### PR TITLE
feat(perf): Windows client bottleneck diagnostics (GPU timing, ANGLE identity, fleet verdicts)

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "perf:crowd": "node scripts/crowd_fps_bench.mjs",
     "perf:prewarm": "node scripts/prewarm_travel_bench.mjs",
     "perf:baseline": "node scripts/perf_baseline.mjs",
+    "perf:diagnose": "node scripts/perf_diagnose.mjs",
     "ops:cpu-monitor": "node scripts/prod_cpu_monitor.mjs",
     "feel:smoke": "node scripts/feel_smoke.mjs",
     "asset:budget": "node scripts/asset_budget.mjs",

--- a/scripts/perf_diagnose.mjs
+++ b/scripts/perf_diagnose.mjs
@@ -1,0 +1,430 @@
+// One-command local bottleneck diagnosis (headed, real GPU, vsync off).
+//
+// Launches the real game against a running dev server, runs a FIXED scenario
+// (20s town idle at the frozen waypoint, then a 20s forward walk), and folds
+// three signal sources into one verdict: the harness frame collector (wall
+// frame times), the renderer's perfStats() surface (draw counters, phase
+// spans, prewarm, and the GPU section timer where this branch exposes it), and
+// the cross-platform system sampler (whole-system GPU utilization plus the
+// browser process-tree CPU). The verdict logic here is deliberately simple:
+// the authoritative classifier lives client-side (src/render/bottleneck_core.ts).
+//
+//   npm run dev                          # :5173
+//   node scripts/perf_diagnose.mjs      (or: npm run perf:diagnose)
+//
+// Env: WOC_URL game origin (default http://localhost:5173); PERF_PRESET
+// low|medium|high|ultra|insane (default high); BROWSER_PATH as in the other
+// browser scripts. Writes the full JSON report to tmp/perf_diagnose/.
+import fs from 'node:fs';
+import path from 'node:path';
+import { aggregateSystemWindow } from './lib/perf_baseline_store.mjs';
+import { Profiler } from './profiler/harness.mjs';
+import { frameStats } from './profiler/metrics.mjs';
+import { startSystemSampler } from './profiler/system_sampler.mjs';
+
+const GAME_URL = process.env.WOC_URL ?? 'http://localhost:5173';
+const PRESET = process.env.PERF_PRESET ?? 'high';
+// woc_settings numeric values per preset label (src/render/gfx.ts
+// PRESET_LOW..PRESET_INSANE; 5 is the Advanced custom profile, never a bench
+// target). Same mapping as scripts/perf_baseline.mjs and scripts/perf_tour.mjs.
+const PRESET_VALUES = { low: 1, medium: 2, high: 3, ultra: 4, insane: 6 };
+const STEP_MS = 20000;
+const TARGET_FPS = 60;
+// The frozen town-idle waypoint the other perf scripts park at
+// (scripts/perf_attrib.mjs TOWN) and the open-field walk start from
+// scripts/profile.mjs scenarioFps open-run.
+const TOWN = { x: 0, z: -14, facing: 0 };
+const WALK = { x: 0, z: 60, facing: Math.PI };
+
+// Verdict thresholds, mirroring the src/render/bottleneck_core.ts tunables.
+const GPU_DOMINANT_RATIO = 0.8;
+const GPU_MINOR_RATIO = 0.55;
+const SUBMIT_DOMINANT_RATIO = 0.5;
+const COMPILE_STALL_PROGRAM_DELTA = 6;
+const COMPILE_STALL_LONG_TASK_MS = 50;
+
+// The heavy tiers spend well over the profiler's default 30s in boot
+// prewarm/shader compile on a cold cache; widen unless the caller already did.
+if (!process.env.PROF_BOOT_TIMEOUT_MS) process.env.PROF_BOOT_TIMEOUT_MS = '120000';
+
+// Absolute backstop: a wedged browser must never hang the diagnosis silently.
+const WATCHDOG_MS = 10 * 60000;
+setTimeout(() => {
+  console.error(`watchdog: run exceeded ${WATCHDOG_MS / 60000} minutes; force exit`);
+  process.exit(3);
+}, WATCHDOG_MS).unref();
+
+function die(msg) {
+  console.error(msg);
+  process.exit(1);
+}
+
+async function preflight() {
+  let text = '';
+  try {
+    const res = await fetch(GAME_URL, { signal: AbortSignal.timeout(10000) });
+    text = await res.text();
+  } catch (e) {
+    die(`dev server not reachable at ${GAME_URL}; start it with 'npm run dev' (${e.message})`);
+  }
+  if (!/claudecraft/i.test(text)) {
+    die(
+      `the server at ${GAME_URL} does not look like World of ClaudeCraft (another app on this port?); set WOC_URL to the right origin`,
+    );
+  }
+}
+
+// Seed the persisted settings before any app script runs (the same pre-boot
+// woc_settings seeding perf_baseline.mjs and perf_tour.mjs use): fullscreen
+// off so the bench window stays a parked window, and graphicsPreset so the HUD
+// effect profile matches the benched tier (?gfx= forces only the renderer tier).
+async function seedSettings(p) {
+  await p.page.evaluateOnNewDocument((presetValue) => {
+    try {
+      const key = 'woc_settings';
+      const cur = JSON.parse(localStorage.getItem(key) ?? '{}');
+      cur.fullscreen = 0;
+      if (presetValue) cur.graphicsPreset = presetValue;
+      localStorage.setItem(key, JSON.stringify(cur));
+    } catch {
+      /* storage unavailable */
+    }
+  }, PRESET_VALUES[PRESET] ?? 0);
+}
+
+// Narrow read of window.__game.renderer.perfStats() (the same surface the
+// harness collector and perf_tour.mjs read). The gpu block and the
+// gpuTimerSupported flag are being added on this branch; both stay null where
+// the client does not expose them yet, and every failure degrades to null.
+function readPerfStats(page) {
+  return page
+    .evaluate(() => {
+      try {
+        const r = window.__game?.renderer;
+        if (!r || typeof r.perfStats !== 'function') return null;
+        const ps = r.perfStats();
+        if (!ps) return null;
+        return {
+          tier: ps.tier ?? null,
+          calls: ps.calls ?? null,
+          triangles: ps.triangles ?? null,
+          programs: ps.programs ?? null,
+          prewarm: ps.prewarm
+            ? {
+                elapsedMs: ps.prewarm.elapsedMs,
+                maxMs: ps.prewarm.maxMs,
+                timedOut: ps.prewarm.timedOut,
+                budgetUsedRatio: ps.prewarm.budgetUsedRatio,
+                compileMode: ps.prewarm.compileMode,
+                compileMs: ps.prewarm.compileMs,
+                programsBefore: ps.prewarm.programsBefore,
+                programsAfter: ps.prewarm.programsAfter,
+                manifestPlanned: ps.prewarm.manifestPlanned,
+                manifestCompleted: ps.prewarm.manifestCompleted,
+                manifestTimedOut: ps.prewarm.manifestTimedOut,
+                manifestFailed: ps.prewarm.manifestFailed,
+              }
+            : null,
+          phaseMs: ps.phaseMs ?? null,
+          gpu: ps.gpu ?? null,
+          gpuTimerSupported:
+            typeof ps.gpuTimerSupported === 'boolean' ? ps.gpuTimerSupported : null,
+        };
+      } catch {
+        return null;
+      }
+    })
+    .catch(() => null);
+}
+
+// One harness sample plus the raw per-frame deltas behind it. sample() folds
+// frames into stats and drops the raw array; window.__prof.frames still holds
+// the window's deltas until the next start(), so grab them for the combined
+// whole-run frameStats.
+async function runStep(p, rawFrames, opts) {
+  const sample = await p.sample(opts);
+  const frames = await p.page.evaluate(() => (window.__prof?.frames ?? []).slice()).catch(() => []);
+  rawFrames.push(...frames);
+  return sample;
+}
+
+// Local, deliberately simple bottleneck call. Order mirrors the client core:
+// compile stalls trump throughput, then the GPU-timer verdicts, then the
+// inferred low-confidence arm for machines without the timer extension.
+function computeVerdict({ wallP95, gpuP95, programGrowth, longTaskP95, submitP95 }) {
+  const r1 = (v) => Math.round(v * 10) / 10;
+  if (!Number.isFinite(wallP95) || wallP95 <= 0) {
+    return { verdict: 'unknown', confidence: 'low', detail: 'no frame data collected' };
+  }
+  if (programGrowth >= COMPILE_STALL_PROGRAM_DELTA && longTaskP95 >= COMPILE_STALL_LONG_TASK_MS) {
+    return {
+      verdict: 'compile-stalls',
+      confidence: 'high',
+      detail: `${programGrowth} programs linked mid-run with long tasks (p95 ${r1(longTaskP95)}ms)`,
+    };
+  }
+  if (Number.isFinite(gpuP95) && gpuP95 > 0) {
+    if (gpuP95 >= GPU_DOMINANT_RATIO * wallP95) {
+      return {
+        verdict: 'gpu-bound',
+        confidence: 'high',
+        detail: `gpu frame p95 ${r1(gpuP95)}ms of wall p95 ${r1(wallP95)}ms`,
+      };
+    }
+    if (gpuP95 < GPU_MINOR_RATIO * wallP95) {
+      return {
+        verdict: 'cpu-bound',
+        confidence: 'medium',
+        detail: `gpu frame p95 ${r1(gpuP95)}ms well under wall p95 ${r1(wallP95)}ms`,
+      };
+    }
+    return {
+      verdict: 'balanced',
+      confidence: 'medium',
+      detail: `gpu ${r1(gpuP95)}ms and cpu share the ${r1(wallP95)}ms frame`,
+    };
+  }
+  if (Number.isFinite(submitP95) && submitP95 >= SUBMIT_DOMINANT_RATIO * wallP95) {
+    return {
+      verdict: 'inferred-gpu-bound',
+      confidence: 'low',
+      detail: `no gpu timer; submit phase p95 ${r1(submitP95)}ms dominates wall p95 ${r1(wallP95)}ms`,
+    };
+  }
+  return {
+    verdict: 'unknown',
+    confidence: 'low',
+    detail: 'no gpu timer and no dominant submit phase',
+  };
+}
+
+// aggregateSystemWindow folds the four cross-platform keys; the Windows
+// sampler also carries GPU memory, folded here the same way.
+function foldMetric(points, key, t0, t1) {
+  const vals = (points ?? [])
+    .filter((pt) => pt && pt.t >= t0 && pt.t <= t1)
+    .map((pt) => pt[key])
+    .filter((v) => Number.isFinite(v));
+  if (!vals.length) return null;
+  return {
+    avg: Math.round((vals.reduce((a, b) => a + b, 0) / vals.length) * 10) / 10,
+    max: Math.round(Math.max(...vals) * 10) / 10,
+    n: vals.length,
+  };
+}
+
+function frameLine(label, f) {
+  if (!f) return `  ${label.padEnd(12)} no frames`;
+  return (
+    `  ${label.padEnd(12)} fps ${f.fpsMean} (1%low ${f.fpsLow1})  ` +
+    `p50 ${f.p50Ms}ms p95 ${f.p95Ms}ms p99 ${f.p99Ms}ms max ${f.maxMs}ms  jank ${f.jankPct}%`
+  );
+}
+
+function fmtFold(fold, unit = '') {
+  return fold ? `avg ${fold.avg}${unit} max ${fold.max}${unit} (n=${fold.n})` : 'n/a';
+}
+
+function printGpuBlock(gpu, gpuTimerSupported) {
+  if (!gpu || !Number.isFinite(gpu.frameP95Ms)) {
+    const why = gpuTimerSupported === false ? ' (extension unsupported)' : '';
+    console.log(`gpu timer: unavailable${why}`);
+    return;
+  }
+  console.log(
+    `gpu frame: avg ${gpu.frameAvgMs}ms p50 ${gpu.frameP50Ms}ms p95 ${gpu.frameP95Ms}ms ` +
+      `max ${gpu.frameMaxMs}ms (${gpu.frames} frames, ${gpu.disjoints} disjoints, ` +
+      `${gpu.starvedFrames} starved)`,
+  );
+  const sections = gpu.sections ?? [];
+  if (sections.length) {
+    console.log(
+      `  ${'section'.padEnd(16)} ${'avg ms'.padStart(8)} ${'p95 ms'.padStart(8)} ${'samples'.padStart(8)}`,
+    );
+    for (const s of sections) {
+      console.log(
+        `  ${String(s.label).padEnd(16)} ${String(s.avgMs).padStart(8)} ` +
+          `${String(s.p95Ms).padStart(8)} ${String(s.samples).padStart(8)}`,
+      );
+    }
+  }
+}
+
+function stampNow() {
+  const d = new Date();
+  const p2 = (n) => String(n).padStart(2, '0');
+  return (
+    `${d.getFullYear()}${p2(d.getMonth() + 1)}${p2(d.getDate())}-` +
+    `${p2(d.getHours())}${p2(d.getMinutes())}${p2(d.getSeconds())}`
+  );
+}
+
+async function main() {
+  if (!PRESET_VALUES[PRESET]) {
+    die(`PERF_PRESET must be one of: ${Object.keys(PRESET_VALUES).join(', ')} (got '${PRESET}')`);
+  }
+  await preflight();
+  console.log(
+    `perf diagnose: url=${GAME_URL} preset=${PRESET} ` +
+      `(headed, real GPU, vsync off, 2 x ${STEP_MS / 1000}s steps)`,
+  );
+  const p = new Profiler({
+    gameUrl: GAME_URL,
+    width: 1280,
+    height: 720,
+    // Same anti-throttling switches as perf_baseline.mjs: a backgrounded or
+    // occluded headed window stops producing frames and poisons the numbers.
+    extraArgs: [
+      '--disable-backgrounding-occluded-windows',
+      '--disable-background-timer-throttling',
+      '--disable-renderer-backgrounding',
+      '--mute-audio',
+    ],
+  });
+  let sampler = null;
+  const samples = [];
+  const rawFrames = [];
+  let statsBefore = null;
+  let statsAfter = null;
+  let t0 = 0;
+  let t1 = 0;
+  try {
+    await p.launch();
+    await seedSettings(p);
+    await p.page.bringToFront();
+    sampler = startSystemSampler({ browserPid: p.browser?.process()?.pid ?? null });
+    // governor=0 pins the adaptive render governor OFF so it cannot shed
+    // visual density mid-diagnosis (same trade as scripts/perf_baseline.mjs).
+    await p.enter({
+      mode: 'offline',
+      tier: PRESET,
+      selectorTimeoutMs: 60000,
+      extraQuery: '&governor=0',
+    });
+    await p.page.bringToFront();
+    const visible = await p.page
+      .evaluate(() => document.visibilityState === 'visible')
+      .catch(() => false);
+    if (!visible) {
+      console.error('  WARNING: the bench window is hidden or covered; numbers will be dishonest');
+    }
+    statsBefore = await readPerfStats(p.page);
+    t0 = Date.now();
+    console.log(`  sampling town idle (${STEP_MS / 1000}s at the frozen waypoint)`);
+    await p.teleport(TOWN.x, TOWN.z, TOWN.facing);
+    samples.push(await runStep(p, rawFrames, { ms: STEP_MS, label: 'town-idle' }));
+    console.log(`  sampling walk (${STEP_MS / 1000}s forward run)`);
+    await p.teleport(WALK.x, WALK.z, WALK.facing);
+    await p.setMove({ forward: true });
+    samples.push(await runStep(p, rawFrames, { ms: STEP_MS, label: 'walk' }));
+    await p.stopMove();
+    t1 = Date.now();
+    statsAfter = await readPerfStats(p.page);
+  } finally {
+    sampler?.stop();
+    await p.close();
+  }
+
+  const overallFrame = frameStats(rawFrames, TARGET_FPS);
+  const points = sampler?.points ?? [];
+  const sysWindow = aggregateSystemWindow(points, t0, t1);
+  const gpuMemUsed = foldMetric(points, 'gpuMemUsedMb', t0, t1);
+  const gpuMemTotal = foldMetric(points, 'gpuMemTotalMb', t0, t1);
+
+  const newPrograms = samples.flatMap((s) => s.newPrograms ?? []);
+  const progBefore = statsBefore?.programs ?? null;
+  const progAfter = statsAfter?.programs ?? null;
+  const programGrowth =
+    Number.isFinite(progBefore) && Number.isFinite(progAfter)
+      ? Math.max(0, progAfter - progBefore)
+      : newPrograms.length;
+  const longTaskP95 = Math.max(0, ...samples.map((s) => s.longTaskP95 ?? 0));
+  const gpu = statsAfter?.gpu ?? null;
+  const submitP95 = statsAfter?.phaseMs?.submit?.p95 ?? null;
+  const verdict = computeVerdict({
+    wallP95: overallFrame?.p95Ms ?? null,
+    gpuP95: gpu?.frameP95Ms ?? null,
+    programGrowth,
+    longTaskP95,
+    submitP95,
+  });
+
+  console.log('\n========== DIAGNOSIS ==========');
+  for (const s of samples) console.log(frameLine(s.label, s.frame));
+  console.log(frameLine('overall', overallFrame));
+  if (statsAfter) {
+    const tris = Number.isFinite(statsAfter.triangles)
+      ? `${(statsAfter.triangles / 1e6).toFixed(2)}M`
+      : '?';
+    console.log(
+      `renderer: tier ${statsAfter.tier}  calls ${statsAfter.calls}  tris ${tris}  ` +
+        `programs ${statsAfter.programs}`,
+    );
+    const pw = statsAfter.prewarm;
+    if (pw) {
+      console.log(
+        `prewarm: ${pw.elapsedMs}ms of ${pw.maxMs}ms budget (${pw.compileMode} compile ` +
+          `${pw.compileMs}ms), ${pw.manifestCompleted}/${pw.manifestPlanned} entries, ` +
+          `${pw.manifestTimedOut} timed out, ${pw.manifestFailed} failed` +
+          (pw.timedOut ? ', EXCEEDED BUDGET' : ''),
+      );
+    }
+    const phase = statsAfter.phaseMs ?? {};
+    const r1 = (v) => (Number.isFinite(v) ? Math.round(v * 100) / 100 : '?');
+    const ph = (k) => (phase[k] ? `${k} ${r1(phase[k].avg)}/${r1(phase[k].p95)}ms` : `${k} n/a`);
+    console.log(
+      `renderer phases (avg/p95): ${['entities', 'world', 'submit', 'total'].map(ph).join('  ')}`,
+    );
+  } else {
+    console.log('renderer perfStats: unavailable');
+  }
+  printGpuBlock(gpu, statsAfter?.gpuTimerSupported ?? null);
+  console.log(
+    `program growth during run: ${progBefore ?? '?'} -> ${progAfter ?? '?'} ` +
+      `(${newPrograms.length} new shader cacheKeys linked in the sampled windows)`,
+  );
+  for (const key of newPrograms.slice(0, 8)) {
+    console.log(`    - ${String(key).replace(/\s+/g, ' ').slice(0, 140)}`);
+  }
+  console.log(
+    `system: proc-tree cpu ${fmtFold(sysWindow.procCpuPct, '%')}  ` +
+      `system cpu ${fmtFold(sysWindow.cpuPct, '%')}  gpu ${fmtFold(sysWindow.gpuPct, '%')}  ` +
+      `gpu power ${fmtFold(sysWindow.gpuPowerW, 'W')}` +
+      (gpuMemUsed ? `  gpu mem avg ${gpuMemUsed.avg}/${gpuMemTotal?.avg ?? '?'}MB` : ''),
+  );
+  console.log(`\nverdict: ${verdict.verdict} [${verdict.confidence} confidence] ${verdict.detail}`);
+
+  const report = {
+    at: new Date().toISOString(),
+    gameUrl: GAME_URL,
+    preset: PRESET,
+    stepMs: STEP_MS,
+    platform: process.platform,
+    verdict,
+    frame: {
+      perStep: samples.map((s) => ({ label: s.label, ...s.frame })),
+      overall: overallFrame,
+    },
+    renderer: { before: statsBefore, after: statsAfter },
+    programs: { before: progBefore, after: progAfter, growth: programGrowth, newPrograms },
+    gpuTimer: gpu,
+    gpuTimerSupported: statsAfter?.gpuTimerSupported ?? null,
+    system: {
+      window: sysWindow,
+      gpuMemUsedMb: gpuMemUsed,
+      gpuMemTotalMb: gpuMemTotal,
+      points,
+    },
+    samples,
+  };
+  const outDir = path.join('tmp', 'perf_diagnose');
+  fs.mkdirSync(outDir, { recursive: true });
+  const outPath = path.join(outDir, `report-${stampNow()}.json`);
+  fs.writeFileSync(outPath, JSON.stringify(report, null, 2));
+  console.log(`report: ${outPath}`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/profiler/system_sampler.mjs
+++ b/scripts/profiler/system_sampler.mjs
@@ -1,14 +1,25 @@
-// System-level CPU/GPU sampling for the perf baseline harness. macmon
-// (brew install macmon) reads Apple Silicon GPU/CPU utilization without sudo;
-// where it is missing the sampler still runs and reports the browser
-// process-tree CPU via ps, leaving the GPU fields null (the pure aggregation in
-// scripts/lib/perf_baseline_store.mjs treats absent metrics as advisory, never a
-// gate failure). Not pure (child processes + timers): anything testable lives in
-// the store module, per scripts/CLAUDE.md.
+// System-level CPU/GPU sampling for the perf baseline harness, dispatched by
+// platform. darwin (and any other non-Windows platform): macmon (brew install
+// macmon) reads Apple Silicon GPU/CPU utilization without sudo; where it is
+// missing the sampler still runs and reports the browser process-tree CPU via
+// ps, leaving the GPU fields null. win32: delegates to system_sampler_win.mjs
+// (nvidia-smi or typeperf for GPU, PowerShell CIM one-shots for the browser
+// process tree) with the identical return shape. Absent metrics stay advisory
+// either way (the pure aggregation in scripts/lib/perf_baseline_store.mjs never
+// gates on them). Not pure (child processes + timers): anything testable lives
+// in the store module, per scripts/CLAUDE.md.
 import { execFile, spawn } from 'node:child_process';
 import { sumProcessTreeCpu } from '../lib/perf_baseline_store.mjs';
+import { startSystemSamplerWin } from './system_sampler_win.mjs';
 
 export function startSystemSampler({ browserPid = null, intervalMs = 700 } = {}) {
+  // Windows has neither macmon nor `ps -Ao`; the win32 arm fills the same
+  // point fields from nvidia-smi/typeperf and PowerShell CIM instead.
+  if (process.platform === 'win32') return startSystemSamplerWin({ browserPid, intervalMs });
+  return startSystemSamplerPosix({ browserPid, intervalMs });
+}
+
+function startSystemSamplerPosix({ browserPid, intervalMs }) {
   const points = [];
   let macmonState = 'pending';
   let child = null;

--- a/scripts/profiler/system_sampler_win.mjs
+++ b/scripts/profiler/system_sampler_win.mjs
@@ -1,0 +1,283 @@
+// Windows arm of the profiler system sampler. scripts/profiler/system_sampler.mjs
+// dispatches here on win32 and the return shape is identical to the darwin arm:
+// a live `points` array of timestamped partial metrics, `macmonAvailable()`
+// (true once the GPU source has produced a sample), and `stop()`.
+//
+// GPU utilization/memory/power: a long-running `nvidia-smi ... -l 1` poll when
+// the binary exists (checked via `where`); otherwise a vendor-neutral
+// `typeperf "\GPU Engine(*engtype_3D)\Utilization Percentage" -si 1` poll whose
+// per-process engine instances are summed (clamped to 100) per sample line.
+// Browser process-tree CPU: one PowerShell CIM one-shot builds the process tree
+// rooted at the browser pid, then bounded per-interval one-shots over
+// Win32_PerfFormattedData_PerfProc_Process sum PercentProcessorTime across the
+// tree (the counter is per-core scaled, like ps pcpu on the darwin arm).
+// Any failure degrades to missing points (the aggregation in
+// scripts/lib/perf_baseline_store.mjs treats absent metrics as advisory), never
+// a throw. Not pure (child processes + timers), per scripts/CLAUDE.md.
+import { execFile, spawn, spawnSync } from 'node:child_process';
+
+const TREE_QUERY_TIMEOUT_MS = 20000;
+const POLL_TIMEOUT_MS = 8000;
+const PROCESS_TREE_CMD =
+  'Get-CimInstance Win32_Process | Select-Object ProcessId,ParentProcessId,Name | ConvertTo-Json -Compress';
+const PROC_CPU_CMD =
+  'Get-CimInstance Win32_PerfFormattedData_PerfProc_Process | Select-Object IDProcess,PercentProcessorTime | ConvertTo-Json -Compress';
+
+function nvidiaSmiPresent() {
+  try {
+    const probe = spawnSync('where', ['nvidia-smi'], { stdio: 'ignore', windowsHide: true });
+    return probe.status === 0;
+  } catch {
+    return false;
+  }
+}
+
+// Feed complete lines (CRLF tolerated) from a child stdout stream to `handle`.
+function onLines(stream, handle) {
+  let buf = '';
+  stream.on('data', (chunk) => {
+    buf += String(chunk);
+    let nl = buf.indexOf('\n');
+    while (nl >= 0) {
+      const line = buf.slice(0, nl).replace(/\r$/, '').trim();
+      buf = buf.slice(nl + 1);
+      nl = buf.indexOf('\n');
+      if (line) handle(line);
+    }
+  });
+}
+
+// One `nvidia-smi --format=csv,noheader,nounits` line: "41, 2231, 12282, 87.20"
+// (utilization.gpu %, memory.used MiB, memory.total MiB, power.draw W). Power
+// reads "[N/A]" on some boards, which nulls just that field.
+function parseNvidiaSmiLine(line) {
+  const parts = String(line)
+    .split(',')
+    .map((part) => Number(part.trim()));
+  if (parts.length < 4 || !Number.isFinite(parts[0])) return null;
+  return {
+    gpuPct: Math.min(100, Math.max(0, parts[0])),
+    gpuMemUsedMb: Number.isFinite(parts[1]) ? parts[1] : undefined,
+    gpuMemTotalMb: Number.isFinite(parts[2]) ? parts[2] : undefined,
+    gpuPowerW: Number.isFinite(parts[3]) ? parts[3] : undefined,
+  };
+}
+
+// typeperf prints locale-formatted values; tolerate a decimal comma.
+function typeperfNumber(text) {
+  const direct = Number(text);
+  if (Number.isFinite(direct)) return direct;
+  if (/^-?\d+,\d+$/.test(text)) return Number(text.replace(',', '.'));
+  return Number.NaN;
+}
+
+// typeperf emits quoted CSV: a header line of counter paths, then per-second
+// lines of "timestamp","val","val",... with one column per process 3D-engine
+// instance. The header (or a localized error line) has no numeric columns and
+// yields null; a data line sums its instances, clamped to 100 (the instances
+// are per-process utilizations of the shared engine).
+function parseTypeperfLine(line) {
+  const fields = [...String(line).matchAll(/"([^"]*)"/g)].map((m) => m[1]);
+  if (fields.length < 2) return null;
+  let sum = 0;
+  let numeric = 0;
+  for (let i = 1; i < fields.length; i++) {
+    const value = typeperfNumber(fields[i]);
+    if (!Number.isFinite(value)) continue;
+    sum += value;
+    numeric++;
+  }
+  if (!numeric) return null;
+  return Math.min(100, Math.max(0, sum));
+}
+
+// Rows from Win32_Process (ProcessId/ParentProcessId): the set of pids in the
+// tree rooted at rootPid, or null when the root is not in the table.
+function collectTreePids(rows, rootPid) {
+  const root = Number(rootPid);
+  const kids = new Map();
+  let sawRoot = false;
+  for (const row of Array.isArray(rows) ? rows : []) {
+    const pid = Number(row?.ProcessId);
+    if (!Number.isFinite(pid)) continue;
+    if (pid === root) sawRoot = true;
+    const ppid = Number(row?.ParentProcessId);
+    if (!Number.isFinite(ppid)) continue;
+    if (!kids.has(ppid)) kids.set(ppid, []);
+    kids.get(ppid).push(pid);
+  }
+  if (!sawRoot) return null;
+  const seen = new Set();
+  const stack = [root];
+  while (stack.length) {
+    const pid = stack.pop();
+    if (seen.has(pid)) continue;
+    seen.add(pid);
+    for (const kid of kids.get(pid) ?? []) stack.push(kid);
+  }
+  return seen;
+}
+
+// Rows from Win32_PerfFormattedData_PerfProc_Process: total PercentProcessorTime
+// over the tree pids, or null when none matched (e.g. the tree died).
+function sumTreeCpu(rows, treePids) {
+  let total = 0;
+  let matched = 0;
+  for (const row of Array.isArray(rows) ? rows : []) {
+    const pid = Number(row?.IDProcess);
+    const pct = Number(row?.PercentProcessorTime);
+    if (!Number.isFinite(pid) || !Number.isFinite(pct)) continue;
+    if (!treePids.has(pid)) continue;
+    total += pct;
+    matched++;
+  }
+  if (!matched) return null;
+  return Math.round(total * 10) / 10;
+}
+
+export function startSystemSamplerWin({ browserPid = null, intervalMs = 700 } = {}) {
+  const points = [];
+  const children = new Set();
+  let stopped = false;
+  let gpuState = 'pending'; // pending | ok | missing
+  let typeperfStarted = false;
+
+  const track = (child) => {
+    if (!child) return null;
+    children.add(child);
+    child.on('close', () => children.delete(child));
+    child.on('error', () => children.delete(child));
+    return child;
+  };
+
+  // Bounded PowerShell one-shot returning parsed JSON rows; null on any
+  // failure (the timeout kills the child, bad JSON, non-zero exit).
+  const psJsonRows = (command, timeoutMs, cb) => {
+    try {
+      const child = execFile(
+        'powershell',
+        ['-NoProfile', '-NonInteractive', '-Command', command],
+        { timeout: timeoutMs, windowsHide: true, maxBuffer: 64 * 1024 * 1024 },
+        (err, stdout) => {
+          if (err) return cb(null);
+          try {
+            const parsed = JSON.parse(String(stdout));
+            cb(Array.isArray(parsed) ? parsed : parsed ? [parsed] : null);
+          } catch {
+            cb(null);
+          }
+        },
+      );
+      track(child);
+    } catch {
+      cb(null);
+    }
+  };
+
+  const startTypeperf = () => {
+    if (stopped || typeperfStarted) return;
+    typeperfStarted = true;
+    try {
+      const child = spawn(
+        'typeperf',
+        ['\\GPU Engine(*engtype_3D)\\Utilization Percentage', '-si', '1'],
+        { stdio: ['ignore', 'pipe', 'ignore'], windowsHide: true },
+      );
+      track(child);
+      onLines(child.stdout, (line) => {
+        const gpuPct = parseTypeperfLine(line);
+        if (gpuPct == null) return;
+        gpuState = 'ok';
+        points.push({ t: Date.now(), gpuPct });
+      });
+      // A localized or missing counter set makes typeperf error out (often
+      // before any data line): mark the GPU source missing, never throw.
+      child.on('error', () => {
+        if (gpuState !== 'ok') gpuState = 'missing';
+      });
+      child.on('exit', () => {
+        if (gpuState !== 'ok') gpuState = 'missing';
+      });
+    } catch {
+      gpuState = 'missing';
+    }
+  };
+
+  const startNvidiaSmi = () => {
+    try {
+      const child = spawn(
+        'nvidia-smi',
+        [
+          '--query-gpu=utilization.gpu,memory.used,memory.total,power.draw',
+          '--format=csv,noheader,nounits',
+          '-l',
+          '1',
+        ],
+        { stdio: ['ignore', 'pipe', 'ignore'], windowsHide: true },
+      );
+      track(child);
+      onLines(child.stdout, (line) => {
+        const sample = parseNvidiaSmiLine(line);
+        if (!sample) return;
+        gpuState = 'ok';
+        points.push({ t: Date.now(), ...sample });
+      });
+      // A present-but-broken nvidia-smi (driver mismatch, immediate exit)
+      // falls back to the vendor-neutral counter instead of losing GPU data.
+      child.on('error', () => {
+        if (!stopped && gpuState === 'pending') startTypeperf();
+      });
+      child.on('exit', () => {
+        if (!stopped && gpuState === 'pending') startTypeperf();
+      });
+    } catch {
+      startTypeperf();
+    }
+  };
+
+  if (nvidiaSmiPresent()) startNvidiaSmi();
+  else startTypeperf();
+
+  let timer = null;
+  if (browserPid) {
+    psJsonRows(PROCESS_TREE_CMD, TREE_QUERY_TIMEOUT_MS, (rows) => {
+      if (stopped) return;
+      const treePids = collectTreePids(rows, browserPid);
+      if (!treePids) return; // browser pid not in the table: procCpuPct stays absent
+      let inFlight = false;
+      const poll = () => {
+        if (stopped || inFlight) return;
+        inFlight = true;
+        psJsonRows(PROC_CPU_CMD, POLL_TIMEOUT_MS, (perfRows) => {
+          inFlight = false;
+          if (stopped) return;
+          const procCpuPct = sumTreeCpu(perfRows, treePids);
+          if (procCpuPct != null) points.push({ t: Date.now(), procCpuPct });
+        });
+      };
+      // A PowerShell one-shot costs 1 to 3s to start; the inFlight guard makes
+      // a short interval degrade to back-to-back polls instead of a pile-up.
+      timer = setInterval(poll, Math.max(200, intervalMs));
+      poll();
+    });
+  }
+
+  return {
+    points,
+    // Same probe name as the darwin arm so consumers stay platform-blind: true
+    // once the Windows GPU source (nvidia-smi or typeperf) produced a sample.
+    macmonAvailable: () => gpuState === 'ok',
+    stop() {
+      stopped = true;
+      if (timer) clearInterval(timer);
+      for (const child of [...children]) {
+        try {
+          child.kill();
+        } catch {
+          /* already exited */
+        }
+      }
+      return points;
+    },
+  };
+}

--- a/server/db.ts
+++ b/server/db.ts
@@ -739,6 +739,19 @@ ALTER TABLE client_perf_reports ADD COLUMN IF NOT EXISTS worst_10s_frame_p95_ms 
 -- against the server allowlist in perf_report.ts before storage (filter,
 -- dedupe, cap 3). Pre-column and healthy rows both read as the empty array.
 ALTER TABLE client_perf_reports ADD COLUMN IF NOT EXISTS suggestion_ids TEXT[] NOT NULL DEFAULT '{}';
+-- Schema version 3: Windows bottleneck diagnostics (GPU timer percentiles,
+-- ANGLE backend token, post-prewarm program growth, bottleneck verdict).
+-- Deliberately nullable, no defaults: a pre-v3 row, or a client without the
+-- GPU timer extension, reads NULL ("not measured") so fleet aggregates never
+-- fold an unmeasured session into a legitimate zero.
+ALTER TABLE client_perf_reports ADD COLUMN IF NOT EXISTS gpu_frame_p50_ms REAL;
+ALTER TABLE client_perf_reports ADD COLUMN IF NOT EXISTS gpu_frame_p95_ms REAL;
+ALTER TABLE client_perf_reports ADD COLUMN IF NOT EXISTS gpu_timer_supported BOOLEAN;
+ALTER TABLE client_perf_reports ADD COLUMN IF NOT EXISTS angle_backend TEXT;
+ALTER TABLE client_perf_reports ADD COLUMN IF NOT EXISTS parallel_compile BOOLEAN;
+ALTER TABLE client_perf_reports ADD COLUMN IF NOT EXISTS programs_post_prewarm INT;
+ALTER TABLE client_perf_reports ADD COLUMN IF NOT EXISTS bottleneck TEXT;
+ALTER TABLE client_perf_reports ADD COLUMN IF NOT EXISTS bottleneck_confidence TEXT;
 -- Non-custodial Solana wallet links (PRD: docs/prd/woc/wallet-link.md). One
 -- wallet per account (account_id is the PK) and one account per wallet (pubkey
 -- is UNIQUE). The server never holds keys; ownership is proven by a signed
@@ -3519,6 +3532,14 @@ export interface ClientPerfReportInsert {
   visibleViews: number;
   worst10sFrameP95Ms: number;
   suggestionIds: string[];
+  gpuFrameP50Ms: number | null;
+  gpuFrameP95Ms: number | null;
+  gpuTimerSupported: boolean;
+  angleBackend: string | null;
+  parallelCompile: boolean;
+  programsPostPrewarm: number | null;
+  bottleneck: string | null;
+  bottleneckConfidence: string | null;
   rawSummary: Record<string, unknown>;
 }
 
@@ -3533,7 +3554,9 @@ export async function insertClientPerfReport(row: ClientPerfReportInsert): Promi
        dpr, viewport_bucket, device_memory, hardware_concurrency, mobile_touch,
        browser_family, os_family, gl_vendor, gl_renderer_bucket, zone_or_scenario, source,
        crowd_bucket, sim_entities, active_views, visible_views, worst_10s_frame_p95_ms,
-       suggestion_ids, raw_summary
+       suggestion_ids, raw_summary,
+       gpu_frame_p50_ms, gpu_frame_p95_ms, gpu_timer_supported, angle_backend,
+       parallel_compile, programs_post_prewarm, bottleneck, bottleneck_confidence
      ) VALUES (
        $1, $2, $3, $4, $5, $6, $7,
        $8, $9, $10, $11, $12, $13,
@@ -3543,7 +3566,9 @@ export async function insertClientPerfReport(row: ClientPerfReportInsert): Promi
        $27, $28, $29, $30, $31,
        $32, $33, $34, $35, $36, $37,
        $38, $39, $40, $41, $42,
-       $43, $44
+       $43, $44,
+       $45, $46, $47, $48,
+       $49, $50, $51, $52
      )`,
     [
       row.schemaVersion,
@@ -3590,6 +3615,14 @@ export async function insertClientPerfReport(row: ClientPerfReportInsert): Promi
       row.worst10sFrameP95Ms,
       row.suggestionIds,
       JSON.stringify(row.rawSummary),
+      row.gpuFrameP50Ms,
+      row.gpuFrameP95Ms,
+      row.gpuTimerSupported,
+      row.angleBackend,
+      row.parallelCompile,
+      row.programsPostPrewarm,
+      row.bottleneck,
+      row.bottleneckConfidence,
     ],
   );
 }

--- a/server/perf_report.ts
+++ b/server/perf_report.ts
@@ -10,9 +10,10 @@ import { json, readBody } from './http_util';
 import { rateLimitNow, requestIp, windowedRateLimitOutcome } from './ratelimit';
 import { REALM } from './realm';
 
-// Bumped to 2 for the packet 0 report dimensions (zone, crowd, views,
-// worst-10s; ruling R6); the intIn clamp below keeps version-1 clients valid.
-const PERF_REPORT_SCHEMA_VERSION = 2;
+// Bumped to 3 for the Windows bottleneck diagnostics (GPU timer percentiles,
+// ANGLE backend, post-prewarm program growth, bottleneck verdict); the intIn
+// clamp below keeps version-1 and version-2 clients valid.
+const PERF_REPORT_SCHEMA_VERSION = 3;
 
 // Fixed crowd labels (ruling R3). server/ cannot import src/game, so this is
 // a deliberate copy of src/game/crowd_bucket.ts CROWD_BUCKET_LABELS;
@@ -32,6 +33,34 @@ const KNOWN_PERF_SUGGESTION_IDS = [
   'browser-stalls',
   'heap-pressure',
   'context-loss',
+] as const;
+// Bottleneck verdict tokens (schema version 3). Same deliberate-copy pattern
+// as the suggestion ids: server/ cannot import src/render, so this mirrors
+// src/render/bottleneck_core.ts BOTTLENECK_VERDICTS and the cross-boundary
+// pin in tests/bottleneck_verdict_parity.test.ts is the drift guard.
+const KNOWN_BOTTLENECK_VERDICTS = [
+  'compile-stalls',
+  'vsync-capped',
+  'balanced',
+  'gpu-bound',
+  'render-cpu-bound',
+  'cpu-main-bound',
+  'unknown',
+] as const;
+const KNOWN_BOTTLENECK_CONFIDENCES = ['high', 'medium', 'low'] as const;
+// ANGLE backend tokens (schema version 3): the exact angleBackendToken output
+// set from src/render/angle_identity_core.ts (the backend union plus the
+// 'angle-unknown' coarse fallback). Anything else folds to null.
+const KNOWN_ANGLE_BACKENDS = [
+  'd3d11',
+  'd3d11on12',
+  'd3d9',
+  'opengl',
+  'vulkan',
+  'metal',
+  'swiftshader',
+  'warp',
+  'angle-unknown',
 ] as const;
 // The client analyzer caps its output at 3 suggestions per report; the server
 // re-imposes the same ceiling so a hostile payload cannot widen the column.
@@ -137,6 +166,18 @@ function textIn(value: unknown, max: number, fallback = ''): string {
 function choiceIn(value: unknown, choices: readonly string[], fallback: string): string {
   const text = textIn(value, 64);
   return choices.includes(text) ? text : fallback;
+}
+
+// Nullable twin of choiceIn for the schema 3 diagnostics: an unknown or
+// absent token stores as NULL (not measured), never a fabricated default.
+function nullableChoiceIn(value: unknown, choices: readonly string[]): string | null {
+  const text = textIn(value, 64);
+  return choices.includes(text) ? text : null;
+}
+
+function nullableIntIn(value: unknown, min: number, max: number): number | null {
+  const n = nullableNumberIn(value, min, max);
+  return n === null ? null : Math.floor(n);
 }
 
 // Allowlist-filter, dedupe, and cap the client-supplied suggestion ids (ruling
@@ -421,6 +462,14 @@ export async function handlePerfReport(
     visibleViews: intIn(body.visibleViews, 0, 100_000, 0),
     worst10sFrameP95Ms: numberIn(body.worst10sFrameP95Ms, 0, 1000, 0),
     suggestionIds: suggestionIdsIn(body.suggestionIds),
+    gpuFrameP50Ms: nullableNumberIn(body.gpuFrameP50Ms, 0, 10_000),
+    gpuFrameP95Ms: nullableNumberIn(body.gpuFrameP95Ms, 0, 10_000),
+    gpuTimerSupported: Boolean(body.gpuTimerSupported),
+    angleBackend: nullableChoiceIn(body.angleBackend, KNOWN_ANGLE_BACKENDS),
+    parallelCompile: Boolean(body.parallelCompile),
+    programsPostPrewarm: nullableIntIn(body.programsPostPrewarm, 0, 100_000),
+    bottleneck: nullableChoiceIn(body.bottleneck, KNOWN_BOTTLENECK_VERDICTS),
+    bottleneckConfidence: nullableChoiceIn(body.bottleneckConfidence, KNOWN_BOTTLENECK_CONFIDENCES),
     rawSummary: rawSummary(body.rawSummary, devTraceAllowed),
   };
 
@@ -439,5 +488,8 @@ export const perfReportInternalsForTest = {
   suggestionIdsIn,
   CROWD_BUCKET_LABELS,
   KNOWN_PERF_SUGGESTION_IDS,
+  KNOWN_BOTTLENECK_VERDICTS,
+  KNOWN_BOTTLENECK_CONFIDENCES,
+  KNOWN_ANGLE_BACKENDS,
   PERF_REPORT_SCHEMA_VERSION,
 };

--- a/src/game/perf.ts
+++ b/src/game/perf.ts
@@ -1,5 +1,6 @@
 import type { NetPipelineSummary } from '../net/net_pipeline_stats';
 import { type AssetTimingSnapshot, assetTimingSnapshot } from '../render/assets/stats';
+import { type BottleneckReading, classifyBottleneck } from '../render/bottleneck_core';
 import type { Renderer } from '../render/renderer';
 import {
   censusTableLines,
@@ -25,6 +26,14 @@ export interface PerfSnapshot {
   };
   mainMs: Record<string, { count: number; avg: number; p95: number; max: number }>;
   renderer: ReturnType<Renderer['perfStats']> | null;
+  /**
+   * GL programs linked since the entry prewarm settled (cumulative); null
+   * until the prewarm finishes or when no renderer exists. Growth here is
+   * mid-play compile debt, the ANGLE/D3D11 freeze driver (#2571).
+   */
+  programsLinkedPostPrewarm: number | null;
+  /** One-line resource attribution for this window (bottleneck_core). */
+  bottleneck: BottleneckReading | null;
   hud: { hotDomWrites: number; hotDomSkippedWrites: number; hotDomSkipRate: number } | null;
   assets: AssetTimingSnapshot;
   network: { connected: boolean; snapInterval: number; lastSnapAge: number; alpha: number } | null;
@@ -397,6 +406,11 @@ export class PerfMonitor {
   private inputToVisibleMs = new NumberSampleRing(MAX_SAMPLES);
   private longTaskMs = new NumberSampleRing(MAX_SAMPLES);
   private longTaskTotalMs = 0;
+  // 1 Hz post-prewarm GL program counts (ungated, like the heap sawtooth):
+  // the 30 s window delta feeds the bottleneck verdict's compile-stall arm,
+  // and the cumulative count rides every fleet report. 64 slots hold a
+  // minute of samples, twice the widest window read.
+  private programWindow = new TimedNumberSampleRing(64);
   private lastLongTaskAt = 0;
   private longTaskObserver: PerformanceObserver | null = null;
   private readonly traceEnabled: boolean;
@@ -811,6 +825,11 @@ export class PerfMonitor {
       this.frameWindow.entries().map((entry) => ({ at: entry.at, ms: entry.value })),
       now,
     );
+    // 1 Hz program-count sample, ungated, and only once the prewarm settled:
+    // boot compiles are the prewarm's job, mid-play growth is the defect.
+    if (this.renderer && this.renderer.prewarmProgramBaseline() !== null) {
+      this.programWindow.push(now, this.renderer.programCount());
+    }
     // Production telemetry reports on its own 75 s / 5 min cadence. Without a
     // visible diagnostic overlay there is nothing to ASSEMBLE every second:
     // doing so sorted every history and copied renderer stats for no consumer.
@@ -843,6 +862,40 @@ export class PerfMonitor {
       };
     };
     const inputDebug = this.readInputDebug();
+    const rendererStats = this.renderer?.perfStats() ?? null;
+    const last30s = windowSummary(30_000);
+    const longTaskSummary = summarize(this.longTaskMs.toArray());
+    // Post-prewarm program growth: the cumulative count for the beacon, the
+    // 30 s window delta for the verdict. Program counts can shrink when
+    // programs dispose, so both clamp at zero.
+    const programBaseline = this.renderer?.prewarmProgramBaseline() ?? null;
+    const programsLinkedPostPrewarm =
+      programBaseline !== null && rendererStats
+        ? Math.max(0, rendererStats.programs - programBaseline)
+        : null;
+    const programSpan = this.programWindow.snapshotSince(now - MAX_WINDOW_MS);
+    const programDelta30s =
+      programSpan.values.length >= 2
+        ? Math.max(0, programSpan.values[programSpan.values.length - 1] - programSpan.values[0])
+        : 0;
+    // Verdict floor: the GPU ring needs enough resolved frames for a stable
+    // p95 before its number outranks the CPU-side inferences.
+    const gpuStats = rendererStats?.gpu ?? null;
+    const bottleneck = rendererStats
+      ? classifyBottleneck({
+          frameP95Ms: last30s.frameMs.p95,
+          targetFrameMs: 1000 / Math.max(1, rendererStats.budget.targetFps),
+          gpuFrameP95Ms: gpuStats && gpuStats.frames >= 30 ? gpuStats.frameP95Ms : null,
+          submitP95Ms: rendererStats.phaseMs.submit.p95,
+          rendererCpuP95Ms: rendererStats.phaseMs.total.p95,
+          mainOtherAvgMs:
+            (mainMs.sim?.avg ?? 0) + (mainMs.hud?.avg ?? 0) + (mainMs.events?.avg ?? 0),
+          longTaskP95Ms: longTaskSummary.p95,
+          programDelta: programDelta30s,
+          externalFrameCap: rendererStats.renderBudget.externalFrameCap,
+          effectiveRenderScale: rendererStats.effectiveRenderScale,
+        })
+      : null;
     const snapshot: PerfSnapshot = {
       seconds: round(seconds),
       frames: this.frames,
@@ -850,11 +903,13 @@ export class PerfMonitor {
       frameMs: summarizeFrames(this.frameMs.toArray()),
       windows: {
         last10s: windowSummary(10_000),
-        last30s: windowSummary(30_000),
+        last30s,
         worst10s: this.worstWindow.current(),
       },
       mainMs: mainMs as PerfSnapshot['mainMs'],
-      renderer: this.renderer?.perfStats() ?? null,
+      renderer: rendererStats,
+      programsLinkedPostPrewarm,
+      bottleneck,
       hud: this.hud?.perfStats() ?? null,
       assets: assetTimingSnapshot(),
       network: this.network,
@@ -872,7 +927,7 @@ export class PerfMonitor {
       },
       browser: {
         longTasks: {
-          ...summarize(this.longTaskMs.toArray()),
+          ...longTaskSummary,
           totalMs: round(this.longTaskTotalMs),
           lastAge: this.lastLongTaskAt > 0 ? round(now - this.lastLongTaskAt) : -1,
         },
@@ -1029,6 +1084,20 @@ export class PerfMonitor {
       ? `hitch ${h.hitches} (compile ${h.byCause['shader-compile']} tex ${h.byCause['texture-upload']} view ${h.byCause['view-create']} other ${h.byCause.other})  prog +${h.programsAdded}`
       : null;
     const censusLines = this.lastCensusLines;
+    const gpu = r?.gpu ?? null;
+    const gpuLine = gpu
+      ? `gpu ${gpu.frameAvgMs}ms p95 ${gpu.frameP95Ms} (${
+          gpu.sections.map((sec) => `${sec.label} ${sec.avgMs}`).join(' ') || 'no sections'
+        }) dj ${gpu.disjoints}`
+      : `gpu timer ${r?.gpuTimerSupported === false ? 'unsupported' : '-'}`;
+    const verdict = s.bottleneck;
+    const verdictLine = verdict
+      ? `verdict ${verdict.verdict} (${verdict.confidence}): ${verdict.detail}`
+      : null;
+    const progLine =
+      s.programsLinkedPostPrewarm !== null
+        ? `prog post-prewarm +${s.programsLinkedPostPrewarm}  backend ${r?.angleBackend ?? '-'}  pcompile ${r?.parallelCompile ? 'y' : 'n'}`
+        : null;
     this.overlayText.textContent = [
       `fps ${s.fps}  p95 ${s.frameMs.p95}ms  >50 ${s.frameMs.long50}`,
       `10s fps ${s.windows.last10s.fps}  p95 ${s.windows.last10s.frameMs.p95}ms  >50 ${s.windows.last10s.frameMs.long50}`,
@@ -1036,6 +1105,9 @@ export class PerfMonitor {
       `render ${s.mainMs.renderer.avg}/${s.mainMs.renderer.p95}ms  hud ${s.mainMs.hud.avg}/${s.mainMs.hud.p95}ms`,
       `hud writes ${hud?.hotDomWrites ?? 0}  skip ${Math.round((hud?.hotDomSkipRate ?? 0) * 100)}%`,
       `rph e ${rp?.entities.p95 ?? 0} w ${rp?.world.p95 ?? 0} np ${rp?.nameplates.p95 ?? 0} sub ${rp?.submit.p95 ?? 0}ms`,
+      gpuLine,
+      ...(verdictLine ? [verdictLine] : []),
+      ...(progLine ? [progLine] : []),
       `calls ${r?.calls ?? 0}  tris ${r?.triangles ?? 0}  tex ${r?.textures ?? 0}`,
       `scale ${r?.effectiveRenderScale ?? 0}/${r?.renderScale ?? 0}  tier ${r?.tier ?? '-'}`,
       `assets wait ${s.assets.preload.waitMs}ms  gltf ${gltf?.count ?? 0}/${gltf?.p95Ms ?? 0}ms  hdr ${hdr?.count ?? 0}/${hdr?.p95Ms ?? 0}ms  tex ${tex?.count ?? 0}/${tex?.p95Ms ?? 0}ms`,

--- a/src/game/perf_reporter.ts
+++ b/src/game/perf_reporter.ts
@@ -9,9 +9,10 @@ import type { WorldTelemetry } from './world_telemetry';
 declare const __APP_VERSION__: string;
 declare const __APP_BUILD_ID__: string;
 
-// Bumped to 2 for the packet 0 report dimensions (zone, crowd, views,
-// worst-10s; ruling R6). The server's intIn clamp keeps version-1 clients valid.
-const PERF_REPORT_SCHEMA_VERSION = 2;
+// Bumped to 3 for the Windows bottleneck diagnostics (GPU timer percentiles,
+// ANGLE backend, post-prewarm program growth, bottleneck verdict). The
+// server's intIn clamp keeps version-1 and version-2 clients valid.
+const PERF_REPORT_SCHEMA_VERSION = 3;
 
 const FIRST_REPORT_MS = 75_000;
 const REPEAT_REPORT_MS = 5 * 60_000;
@@ -20,6 +21,10 @@ const DEV_TRACE_REPEAT_REPORT_MS = 15_000;
 const MIN_REPORT_SECONDS = 20;
 const MIN_DEV_TRACE_REPORT_SECONDS = 5;
 const MIN_REPORT_FRAMES = 30;
+// GPU whole-frame percentiles ship only once the timer ring holds enough
+// resolved frames for a stable p95; mirrors the verdict floor the monitor
+// applies before a GPU number outranks the CPU-side inferences (perf.ts).
+const MIN_GPU_TIMER_FRAMES = 30;
 const FETCH_KEEPALIVE_MAX_BYTES = 60 * 1024;
 const SESSION_KEY = 'woc_perf_session_id';
 
@@ -267,6 +272,10 @@ function payloadFromSnapshot(
   const suggestionIds = analyzePerfSuggestions(snapshot, location.search, { desktopShell }).map(
     (suggestion) => suggestion.id,
   );
+  // GPU whole-frame percentiles ride only with enough resolved frames for a
+  // stable p95; below the floor (or with no timer at all) they ship null so
+  // fleet aggregates never average a two-frame fluke.
+  const gpu = renderer.gpu && renderer.gpu.frames >= MIN_GPU_TIMER_FRAMES ? renderer.gpu : null;
   return {
     schemaVersion: PERF_REPORT_SCHEMA_VERSION,
     releaseVersion: __APP_VERSION__,
@@ -313,6 +322,16 @@ function payloadFromSnapshot(
     crowdBucket: crowdBucketLabel(activeViews),
     worst10sFrameP95Ms: snapshot.windows.worst10s?.frameMs.p95 ?? null,
     suggestionIds,
+    gpuFrameP50Ms: gpu?.frameP50Ms ?? null,
+    gpuFrameP95Ms: gpu?.frameP95Ms ?? null,
+    gpuTimerSupported: renderer.gpuTimerSupported,
+    angleBackend: renderer.angleBackend,
+    parallelCompile: renderer.parallelCompile,
+    programsPostPrewarm: snapshot.programsLinkedPostPrewarm,
+    // Verdict token and confidence only: bottleneck.detail is dev-only English
+    // prose (the perf-overlay carve-out) and must never ride the wire.
+    bottleneck: snapshot.bottleneck?.verdict ?? null,
+    bottleneckConfidence: snapshot.bottleneck?.confidence ?? null,
     rawSummary: {
       graphicsConfigVersion: renderer.graphicsConfigVersion,
       seconds: snapshot.seconds,
@@ -320,6 +339,7 @@ function payloadFromSnapshot(
       windows: snapshot.windows,
       mainMs: snapshot.mainMs,
       rendererPhaseMs: renderer.phaseMs,
+      rendererGpuSections: renderer.gpu?.sections ?? null,
       rendererFoliage: renderer.foliage,
       rendererBudget: renderer.renderBudget,
       rendererQualityBuckets: renderer.qualityBuckets,

--- a/src/render/angle_identity_core.ts
+++ b/src/render/angle_identity_core.ts
@@ -1,0 +1,145 @@
+// Parses the WEBGL_debug_renderer_info unmasked renderer string into the
+// pieces the perf beacon and the bottleneck classifier care about: whether
+// the context runs through ANGLE, which native backend ANGLE translates to,
+// the adapter name, and the driver version when the string carries one.
+//
+// Why this matters for Windows diagnosis: Chrome on Windows renders WebGL
+// through ANGLE over Direct3D 11, where shader program links are one to three
+// orders of magnitude slower than GL drivers (issue #2243 measured 50 to
+// 1700 ms first-draw links). Telling d3d11 sessions apart from gl/metal/vulkan
+// sessions in fleet data is the difference between "Windows is slow" and
+// "D3D11 shader links are slow".
+//
+// Pure and table-tested: no DOM, no Three. Real-world string shapes covered
+// by tests/angle_identity_core.test.ts.
+
+export type AngleBackend =
+  | 'd3d11on12'
+  | 'd3d11'
+  | 'd3d9'
+  | 'opengl'
+  | 'vulkan'
+  | 'metal'
+  | 'swiftshader'
+  | 'warp';
+
+export interface GlIdentity {
+  raw: string;
+  /** True when the string is ANGLE-shaped ("ANGLE (...)"). */
+  angle: boolean;
+  /**
+   * The native API under the WebGL context. Null when the string does not
+   * say (masked strings, bare adapter names, unknown shapes).
+   */
+  backend: AngleBackend | null;
+  /** Cleaned adapter/device name, null when it cannot be told apart. */
+  deviceName: string | null;
+  /** Driver version when present (the D3D11-<version> suffix shape). */
+  driverVersion: string | null;
+}
+
+// Ordered first-match-wins backend probes. Software rasterizers come first:
+// SwiftShader advertises itself as a Vulkan device and WARP as a D3D11 one,
+// and for diagnosis "software" beats the API it pretends to be.
+const BACKEND_PROBES: ReadonlyArray<readonly [RegExp, AngleBackend]> = [
+  [/swiftshader|subzero|llvmpipe/i, 'swiftshader'],
+  [/microsoft basic render/i, 'warp'],
+  [/direct3d11on12|d3d11on12/i, 'd3d11on12'],
+  [/direct3d\s*11|d3d11/i, 'd3d11'],
+  [/direct3d\s*9|d3d9/i, 'd3d9'],
+  [/vulkan/i, 'vulkan'],
+  [/metal/i, 'metal'],
+  [/opengl|open gl/i, 'opengl'],
+];
+
+// Split "ANGLE (a, b, c)" body on top-level commas only: device segments nest
+// parenthesized ids like "(0x00002704)" that a naive split would cut through.
+function splitTopLevel(body: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let start = 0;
+  for (let i = 0; i < body.length; i++) {
+    const ch = body[i];
+    if (ch === '(') depth++;
+    else if (ch === ')') depth--;
+    else if (ch === ',' && depth === 0) {
+      parts.push(body.slice(start, i).trim());
+      start = i + 1;
+    }
+  }
+  parts.push(body.slice(start).trim());
+  return parts.filter((part) => part.length > 0);
+}
+
+function detectBackend(text: string): AngleBackend | null {
+  for (const [pattern, backend] of BACKEND_PROBES) {
+    if (pattern.test(text)) return backend;
+  }
+  return null;
+}
+
+// The device segment carries API noise the adapter name does not need:
+// PCI-ish hex ids, shader model suffixes, the "ANGLE Metal Renderer:" and
+// "Vulkan 1.x (...)" wrappers.
+function cleanDeviceName(segment: string): string | null {
+  let name = segment;
+  const vulkanWrap = name.match(/vulkan\s[\d.]+\s*\((.*)\)$/i);
+  if (vulkanWrap) name = vulkanWrap[1];
+  name = name.replace(/^angle metal renderer:\s*/i, '');
+  name = name.replace(/\(0x[0-9a-f]+\)/gi, ' ');
+  name = name.replace(/direct3d\s*\d+(on12)?/gi, ' ');
+  name = name.replace(/\b[vp]s_\d_\d\b/gi, ' ');
+  name = name.replace(/\/pcie?\/sse2/gi, ' ');
+  name = name.replace(/\s{2,}/g, ' ').trim();
+  return name.length > 0 ? name : null;
+}
+
+function driverVersionFrom(body: string): string | null {
+  // The trailing ANGLE segment shape: "D3D11-31.0.15.4633". Bare "D3D11" (no
+  // version) is common and yields null.
+  const d3d = body.match(/d3d\d+(?:on12)?-([\d.]+)/i);
+  if (d3d) return d3d[1];
+  return null;
+}
+
+export function parseGlIdentity(glRenderer: string): GlIdentity {
+  const raw = glRenderer.trim();
+  const identity: GlIdentity = {
+    raw,
+    angle: false,
+    backend: null,
+    deviceName: null,
+    driverVersion: null,
+  };
+  if (raw.length === 0) return identity;
+
+  const angleBody = raw.match(/^ANGLE\s*\((.*)\)\s*$/);
+  if (!angleBody) {
+    // Non-ANGLE strings (Firefox GL, Safari, bare adapter names). The whole
+    // string is the device name; backend only when it names one.
+    identity.backend = detectBackend(raw);
+    identity.deviceName = cleanDeviceName(raw);
+    return identity;
+  }
+
+  identity.angle = true;
+  identity.backend = detectBackend(angleBody[1]);
+  identity.driverVersion = driverVersionFrom(angleBody[1]);
+  const segments = splitTopLevel(angleBody[1]);
+  // Canonical modern shape: "vendor, device ..., driver". Two-segment and
+  // one-segment shapes exist in the wild; the device is the widest middle
+  // segment or the only one.
+  const deviceSegment =
+    segments.length >= 2
+      ? segments.slice(1, Math.max(2, segments.length - 1)).join(', ')
+      : segments[0];
+  identity.deviceName = deviceSegment ? cleanDeviceName(deviceSegment) : null;
+  return identity;
+}
+
+/** The short token the perf beacon ships (backend or a coarse fallback). */
+export function angleBackendToken(identity: GlIdentity): string | null {
+  if (identity.backend) return identity.backend;
+  if (identity.angle) return 'angle-unknown';
+  return null;
+}

--- a/src/render/bottleneck_core.ts
+++ b/src/render/bottleneck_core.ts
@@ -1,0 +1,178 @@
+// Fuses the client's existing perf signals into one bottleneck verdict, the
+// pure core. Consumers: the ?perf dev overlay (a one-line diagnosis) and the
+// perf beacon (a stable token the fleet aggregates can group by), so a slow
+// Windows session tells us WHICH resource it starved on instead of just "27
+// fps". Signals come from surfaces that already exist: the frame ring and
+// main-thread buckets (src/game/perf.ts), the renderer phase spans and
+// program counters (renderer.perfStats()), the GPU timer when the extension
+// exists (gpu_timer_core.ts), and the governor's external-frame-cap
+// classification (render_budget.ts).
+//
+// Verdict order is deliberate. Compile stalls trump everything: a session
+// paying mid-play shader links hitches regardless of raw throughput, and on
+// ANGLE/D3D11 those links are the dominant Windows complaint (#2571, #2243).
+// The cap check follows so a healthy vsync-limited session never reads as
+// bound. Only then do the throughput verdicts run.
+
+export type BottleneckVerdict =
+  | 'compile-stalls'
+  | 'vsync-capped'
+  | 'balanced'
+  | 'gpu-bound'
+  | 'render-cpu-bound'
+  | 'cpu-main-bound'
+  | 'unknown';
+
+export type BottleneckConfidence = 'high' | 'medium' | 'low';
+
+export interface BottleneckSignals {
+  /** Wall frame time p95 over the window (ms). */
+  frameP95Ms: number;
+  /** The budget one frame gets at the session's target rate (ms). */
+  targetFrameMs: number;
+  /** GPU whole-frame p95 from the timer extension; null when unsupported. */
+  gpuFrameP95Ms: number | null;
+  /** CPU wall p95 of the renderer submit phase (driver-side sync shows here). */
+  submitP95Ms: number;
+  /** CPU wall p95 of the whole renderer.sync span. */
+  rendererCpuP95Ms: number;
+  /** Average per-frame ms of the non-renderer main buckets (sim, hud, events). */
+  mainOtherAvgMs: number;
+  /** Long task p95 (ms) from the PerformanceObserver window. */
+  longTaskP95Ms: number;
+  /** GL programs linked inside the window, after prewarm settled. */
+  programDelta: number;
+  /** The render-budget governor's external frame cap (vsync) classification. */
+  externalFrameCap: boolean;
+  /** Live render scale after governor backoff (below 1 = already shedding). */
+  effectiveRenderScale: number;
+}
+
+export interface BottleneckReading {
+  verdict: BottleneckVerdict;
+  confidence: BottleneckConfidence;
+  /** Dev-channel English (perf overlay carve-out), never player-facing UI. */
+  detail: string;
+}
+
+// Tunables, exported so the verdict matrix in tests pins them explicitly.
+export const COMPILE_STALL_PROGRAM_DELTA = 6;
+export const COMPILE_STALL_LONG_TASK_MS = 50;
+export const MEETING_TARGET_RATIO = 1.15;
+export const GPU_DOMINANT_RATIO = 0.8;
+export const GPU_MINOR_RATIO = 0.55;
+export const SUBMIT_DOMINANT_RATIO = 0.5;
+export const RENDER_VS_MAIN_RATIO = 1.5;
+
+function round(value: number): number {
+  return Math.round(value * 10) / 10;
+}
+
+export function classifyBottleneck(s: BottleneckSignals): BottleneckReading {
+  const hasFrames = s.frameP95Ms > 0 && s.targetFrameMs > 0;
+  if (!hasFrames) {
+    return { verdict: 'unknown', confidence: 'low', detail: 'no frame window yet' };
+  }
+
+  // 1. Mid-play shader links. Program growth plus long tasks in the same
+  // window is the storm signature regardless of average throughput.
+  if (
+    s.programDelta >= COMPILE_STALL_PROGRAM_DELTA &&
+    s.longTaskP95Ms >= COMPILE_STALL_LONG_TASK_MS
+  ) {
+    return {
+      verdict: 'compile-stalls',
+      confidence: 'high',
+      detail: `${s.programDelta} programs linked mid-window, long task p95 ${round(s.longTaskP95Ms)}ms`,
+    };
+  }
+
+  // 2. A steady external cap (vsync or an OS/driver frame limiter) with the
+  // renderer in headroom is not a bottleneck; calling it one would send a
+  // healthy session to the top of a fleet triage query.
+  if (s.externalFrameCap) {
+    return {
+      verdict: 'vsync-capped',
+      confidence: 'medium',
+      detail: `cadence ${round(s.frameP95Ms)}ms classified as an external frame cap`,
+    };
+  }
+
+  // 3. Meeting target: nothing to attribute.
+  if (s.frameP95Ms <= s.targetFrameMs * MEETING_TARGET_RATIO) {
+    return {
+      verdict: 'balanced',
+      confidence: 'high',
+      detail: `frame p95 ${round(s.frameP95Ms)}ms within target ${round(s.targetFrameMs)}ms`,
+    };
+  }
+
+  // 4. Slow, with a real GPU clock: attribute by share of the wall frame.
+  if (s.gpuFrameP95Ms !== null && s.gpuFrameP95Ms > 0) {
+    const gpuShare = s.gpuFrameP95Ms / s.frameP95Ms;
+    if (gpuShare >= GPU_DOMINANT_RATIO) {
+      const shedding = s.effectiveRenderScale < 1 ? ', governor already shedding resolution' : '';
+      return {
+        verdict: 'gpu-bound',
+        confidence: 'high',
+        detail: `gpu p95 ${round(s.gpuFrameP95Ms)}ms of ${round(s.frameP95Ms)}ms frame${shedding}`,
+      };
+    }
+    if (gpuShare < GPU_MINOR_RATIO) {
+      if (s.rendererCpuP95Ms >= s.mainOtherAvgMs * RENDER_VS_MAIN_RATIO) {
+        return {
+          verdict: 'render-cpu-bound',
+          confidence: 'high',
+          detail: `renderer cpu p95 ${round(s.rendererCpuP95Ms)}ms dominates, gpu only ${round(s.gpuFrameP95Ms)}ms`,
+        };
+      }
+      return {
+        verdict: 'cpu-main-bound',
+        confidence: 'high',
+        detail: `main thread outside renderer ${round(s.mainOtherAvgMs)}ms/frame, gpu only ${round(s.gpuFrameP95Ms)}ms`,
+      };
+    }
+    return {
+      verdict: 'balanced',
+      confidence: 'medium',
+      detail: `gpu ${round(s.gpuFrameP95Ms)}ms and cpu share the ${round(s.frameP95Ms)}ms frame`,
+    };
+  }
+
+  // 5. Slow, no GPU timer (Firefox, Safari, older drivers): infer from the
+  // submit span. A submit-dominated frame usually means the driver made the
+  // CPU wait for the GPU queue, but it is an inference, not a measurement.
+  if (
+    s.submitP95Ms >= s.rendererCpuP95Ms * SUBMIT_DOMINANT_RATIO &&
+    s.submitP95Ms > s.mainOtherAvgMs
+  ) {
+    return {
+      verdict: 'gpu-bound',
+      confidence: 'low',
+      detail: `inferred from submit p95 ${round(s.submitP95Ms)}ms, no GPU timer on this context`,
+    };
+  }
+  if (s.mainOtherAvgMs > s.rendererCpuP95Ms) {
+    return {
+      verdict: 'cpu-main-bound',
+      confidence: 'medium',
+      detail: `main thread outside renderer ${round(s.mainOtherAvgMs)}ms/frame dominates`,
+    };
+  }
+  return {
+    verdict: 'render-cpu-bound',
+    confidence: 'medium',
+    detail: `renderer cpu p95 ${round(s.rendererCpuP95Ms)}ms leads without a GPU timer to confirm`,
+  };
+}
+
+/** The allowlisted beacon tokens (server clamps against this exact set). */
+export const BOTTLENECK_VERDICTS: readonly BottleneckVerdict[] = [
+  'compile-stalls',
+  'vsync-capped',
+  'balanced',
+  'gpu-bound',
+  'render-cpu-bound',
+  'cpu-main-bound',
+  'unknown',
+];

--- a/src/render/gpu_timer.ts
+++ b/src/render/gpu_timer.ts
@@ -1,0 +1,73 @@
+// The Three-facing half of the GPU timer: probes EXT_disjoint_timer_query_webgl2
+// on the live context and owns the composer marker passes that split the frame
+// into named GPU sections. All state-machine logic lives in gpu_timer_core.ts
+// (pure, Node-tested); this file only touches the context and the Pass seam.
+//
+// Section semantics: markers are inserted BEFORE each real pass, and each
+// split closes the previous section, so a section covers everything from its
+// marker to the next one (the last runs to endFrame). The scene section
+// therefore includes three's internal shadow-map pass, which has no seam of
+// its own; the census's frozen-shadow diff remains the tool for shadow share.
+//
+// Never inserted AFTER the final real pass: EffectComposer routes the last
+// enabled pass to the canvas (isLastEnabledPass), and a trailing marker would
+// steal that slot and blank the frame.
+
+import type * as THREE from 'three';
+import { Pass } from 'three/examples/jsm/postprocessing/Pass.js';
+import {
+  createGpuSectionTimer,
+  type GpuSectionTimer,
+  type GpuTimerExt,
+  type GpuTimerGl,
+} from './gpu_timer_core';
+import { renderLayerDisabled } from './render_dev_flags';
+
+export type { GpuSectionTimer, GpuTimerStats } from './gpu_timer_core';
+
+export type GpuTimerUnsupportedReason = 'disabled' | 'webgl1' | 'no-extension';
+
+export interface GpuTimerProbe {
+  timer: GpuSectionTimer | null;
+  supported: boolean;
+  reason: GpuTimerUnsupportedReason | null;
+}
+
+/**
+ * Probe the renderer's context for the timer extension. `?gputimer=off` is the
+ * dev kill switch (render_dev_flags), symmetric with the other layer flags.
+ * Firefox and Safari do not ship the extension; Chrome exposes it on real GPUs
+ * and on ANGLE/D3D11, which is exactly the cohort Windows diagnosis needs.
+ */
+export function probeGpuTimer(webgl: THREE.WebGLRenderer): GpuTimerProbe {
+  if (renderLayerDisabled('gputimer')) return { timer: null, supported: false, reason: 'disabled' };
+  if (!webgl.capabilities.isWebGL2) return { timer: null, supported: false, reason: 'webgl1' };
+  let ext: GpuTimerExt | null = null;
+  try {
+    ext = webgl.getContext().getExtension('EXT_disjoint_timer_query_webgl2') as GpuTimerExt | null;
+  } catch {
+    ext = null;
+  }
+  if (!ext) return { timer: null, supported: false, reason: 'no-extension' };
+  const gl = webgl.getContext() as unknown as GpuTimerGl;
+  return { timer: createGpuSectionTimer(gl, ext), supported: true, reason: null };
+}
+
+/**
+ * A zero-draw composer pass that closes the running GPU section and opens the
+ * named one. needsSwap stays false so the composer's read/write buffers flow
+ * through untouched; render() issues no GL work beyond the query boundary.
+ */
+export class GpuSectionMarkerPass extends Pass {
+  constructor(
+    private readonly split: (label: string) => void,
+    private readonly label: string,
+  ) {
+    super();
+    this.needsSwap = false;
+  }
+
+  override render(): void {
+    this.split(this.label);
+  }
+}

--- a/src/render/gpu_timer_core.ts
+++ b/src/render/gpu_timer_core.ts
@@ -1,0 +1,303 @@
+// GPU frame/section timing over EXT_disjoint_timer_query_webgl2, the pure core.
+// The adapter (gpu_timer.ts) probes the extension and owns the Three-facing
+// marker passes; this module is the query-ring state machine, kept GL-object
+// agnostic (structural interfaces) so a Vitest drives it with a fake context.
+//
+// Model: a frame opens with beginFrame(), split(label) closes the running
+// TIME_ELAPSED query (if any) and opens the next labeled one, endFrame()
+// closes the frame. Timer queries MUST NOT nest, so sequential splits are the
+// only shape this core allows by construction. Results land asynchronously a
+// few frames later; beginFrame() polls non-blockingly and folds resolved
+// frames into the aggregation rings. A disjoint event (GPU clock anomaly:
+// power state change, TDR, tab switch) invalidates every in-flight query, so
+// those frames are dropped rather than recorded wrong.
+
+/** The subset of WebGL2RenderingContext the timer touches (structural). */
+export interface GpuTimerGl {
+  createQuery(): object | null;
+  deleteQuery(query: object): void;
+  beginQuery(target: number, query: object): void;
+  endQuery(target: number): void;
+  getQueryParameter(query: object, pname: number): unknown;
+  getParameter(pname: number): unknown;
+}
+
+/** The two constants EXT_disjoint_timer_query_webgl2 exposes. */
+export interface GpuTimerExt {
+  TIME_ELAPSED_EXT: number;
+  GPU_DISJOINT_EXT: number;
+}
+
+// Core WebGL2 query constants (stable spec values, not extension-specific).
+export const QUERY_RESULT_AVAILABLE = 0x8867;
+export const QUERY_RESULT = 0x8866;
+
+/** Per-section aggregate over the retained window. */
+export interface GpuSectionStats {
+  label: string;
+  avgMs: number;
+  p95Ms: number;
+  samples: number;
+}
+
+export interface GpuTimerStats {
+  /** Resolved whole-frame GPU totals over the retained window. */
+  frames: number;
+  frameAvgMs: number;
+  frameP50Ms: number;
+  frameP95Ms: number;
+  frameMaxMs: number;
+  sections: GpuSectionStats[];
+  /** GPU clock disjoint events seen (each drops the in-flight frames). */
+  disjoints: number;
+  /** Frames that could not open every section because the pool ran dry. */
+  starvedFrames: number;
+}
+
+export interface GpuSectionTimer {
+  beginFrame(): void;
+  /** Close the running section (if any) and open `label`. No-op outside a frame. */
+  split(label: string): void;
+  endFrame(): void;
+  stats(): GpuTimerStats;
+  /** Drop every in-flight query and retained sample (context restore). */
+  reset(): void;
+  dispose(): void;
+}
+
+// Pool and window sizing. A frame uses one query per section (scene plus up
+// to five post passes today); results resolve within a few frames on every
+// driver measured, so 48 pooled queries rides out a deep pipeline without
+// unbounded allocation. The stats window holds four seconds at 60 fps, wide
+// enough for stable p95s at the overlay's 1 Hz cadence.
+const QUERY_POOL_CAP = 48;
+const FRAME_RING_CAP = 240;
+const SECTION_RING_CAP = 240;
+const MAX_SECTIONS = 8;
+const NS_PER_MS = 1e6;
+
+interface PendingSection {
+  query: object;
+  label: string;
+  ns: number;
+  resolved: boolean;
+}
+
+interface PendingFrame {
+  sections: PendingSection[];
+  starved: boolean;
+}
+
+class SampleRing {
+  private readonly values: Float32Array;
+  private next = 0;
+  private filled = 0;
+
+  constructor(capacity: number) {
+    this.values = new Float32Array(capacity);
+  }
+
+  push(value: number): void {
+    this.values[this.next] = value;
+    this.next = (this.next + 1) % this.values.length;
+    if (this.filled < this.values.length) this.filled++;
+  }
+
+  get count(): number {
+    return this.filled;
+  }
+
+  /** Copies the live samples into a sorted scratch array (stats cadence only). */
+  sorted(): number[] {
+    const out: number[] = new Array(this.filled);
+    for (let i = 0; i < this.filled; i++) out[i] = this.values[i];
+    out.sort((a, b) => a - b);
+    return out;
+  }
+
+  clear(): void {
+    this.next = 0;
+    this.filled = 0;
+  }
+}
+
+function percentile(sorted: number[], fraction: number): number {
+  if (sorted.length === 0) return 0;
+  const index = Math.min(sorted.length - 1, Math.floor(fraction * sorted.length));
+  return sorted[index];
+}
+
+function roundMs(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+export function createGpuSectionTimer(gl: GpuTimerGl, ext: GpuTimerExt): GpuSectionTimer {
+  const freeQueries: object[] = [];
+  let allocatedQueries = 0;
+  const pendingFrames: PendingFrame[] = [];
+  let openFrame: PendingFrame | null = null;
+  let openQuery: object | null = null;
+  let disposed = false;
+
+  const frameRing = new SampleRing(FRAME_RING_CAP);
+  const sectionRings = new Map<string, SampleRing>();
+  const sectionTotals = new Map<string, { sum: number; count: number }>();
+  let disjoints = 0;
+  let starvedFrames = 0;
+
+  function takeQuery(): object | null {
+    const pooled = freeQueries.pop();
+    if (pooled) return pooled;
+    if (allocatedQueries >= QUERY_POOL_CAP) return null;
+    const created = gl.createQuery();
+    if (created) allocatedQueries++;
+    return created;
+  }
+
+  function releaseQuery(query: object): void {
+    freeQueries.push(query);
+  }
+
+  function discardPending(): void {
+    for (const frame of pendingFrames) {
+      for (const section of frame.sections) releaseQuery(section.query);
+    }
+    pendingFrames.length = 0;
+  }
+
+  function recordFrame(frame: PendingFrame): void {
+    // A starved frame is missing sections, so its total would understate the
+    // real GPU cost: release its queries but keep it out of the rings. It was
+    // already counted at endFrame time.
+    if (frame.starved) return;
+    let totalNs = 0;
+    for (const section of frame.sections) {
+      totalNs += section.ns;
+      const ms = section.ns / NS_PER_MS;
+      let ring = sectionRings.get(section.label);
+      if (!ring) {
+        if (sectionRings.size >= MAX_SECTIONS) continue;
+        ring = new SampleRing(SECTION_RING_CAP);
+        sectionRings.set(section.label, ring);
+        sectionTotals.set(section.label, { sum: 0, count: 0 });
+      }
+      ring.push(ms);
+      const totals = sectionTotals.get(section.label);
+      if (totals) {
+        totals.sum += ms;
+        totals.count++;
+      }
+    }
+    frameRing.push(totalNs / NS_PER_MS);
+  }
+
+  function poll(): void {
+    // Disjoint first: reading the flag also resets it. When set, every
+    // in-flight query is untrustworthy, so drop them all.
+    if (gl.getParameter(ext.GPU_DISJOINT_EXT) === true) {
+      disjoints++;
+      discardPending();
+      return;
+    }
+    // Frames resolve in submission order; stop at the first incomplete one so
+    // recorded frames stay whole.
+    while (pendingFrames.length > 0) {
+      const frame = pendingFrames[0];
+      let complete = true;
+      for (const section of frame.sections) {
+        if (section.resolved) continue;
+        const available = gl.getQueryParameter(section.query, QUERY_RESULT_AVAILABLE);
+        if (available !== true) {
+          complete = false;
+          break;
+        }
+        section.ns = Number(gl.getQueryParameter(section.query, QUERY_RESULT)) || 0;
+        section.resolved = true;
+        releaseQuery(section.query);
+      }
+      if (!complete) break;
+      pendingFrames.shift();
+      recordFrame(frame);
+    }
+  }
+
+  function closeOpenQuery(): void {
+    if (!openQuery) return;
+    gl.endQuery(ext.TIME_ELAPSED_EXT);
+    openQuery = null;
+  }
+
+  return {
+    beginFrame(): void {
+      if (disposed) return;
+      poll();
+      openFrame = { sections: [], starved: false };
+    },
+    split(label: string): void {
+      // Out-of-band renders (prewarm, census, screenshots) hit marker passes
+      // without a surrounding frame; those splits must stay inert.
+      if (disposed || !openFrame) return;
+      closeOpenQuery();
+      const query = takeQuery();
+      if (!query) {
+        openFrame.starved = true;
+        return;
+      }
+      gl.beginQuery(ext.TIME_ELAPSED_EXT, query);
+      openQuery = query;
+      openFrame.sections.push({ query, label, ns: 0, resolved: false });
+    },
+    endFrame(): void {
+      if (disposed || !openFrame) return;
+      closeOpenQuery();
+      if (openFrame.starved) starvedFrames++;
+      // Even a starved frame's acquired queries are in flight on the GPU, so
+      // they still ride the pending list back to the pool via poll().
+      if (openFrame.sections.length > 0) pendingFrames.push(openFrame);
+      openFrame = null;
+    },
+    stats(): GpuTimerStats {
+      const sortedFrames = frameRing.sorted();
+      let frameSum = 0;
+      for (const ms of sortedFrames) frameSum += ms;
+      const sections: GpuSectionStats[] = [];
+      for (const [label, ring] of sectionRings) {
+        const totals = sectionTotals.get(label);
+        const sorted = ring.sorted();
+        sections.push({
+          label,
+          avgMs: roundMs(totals && totals.count > 0 ? totals.sum / totals.count : 0),
+          p95Ms: roundMs(percentile(sorted, 0.95)),
+          samples: ring.count,
+        });
+      }
+      return {
+        frames: sortedFrames.length,
+        frameAvgMs: roundMs(sortedFrames.length > 0 ? frameSum / sortedFrames.length : 0),
+        frameP50Ms: roundMs(percentile(sortedFrames, 0.5)),
+        frameP95Ms: roundMs(percentile(sortedFrames, 0.95)),
+        frameMaxMs: roundMs(sortedFrames.length > 0 ? sortedFrames[sortedFrames.length - 1] : 0),
+        sections,
+        disjoints,
+        starvedFrames,
+      };
+    },
+    reset(): void {
+      closeOpenQuery();
+      openFrame = null;
+      discardPending();
+      frameRing.clear();
+      sectionRings.clear();
+      sectionTotals.clear();
+    },
+    dispose(): void {
+      if (disposed) return;
+      closeOpenQuery();
+      openFrame = null;
+      discardPending();
+      for (const query of freeQueries) gl.deleteQuery(query);
+      freeQueries.length = 0;
+      disposed = true;
+    },
+  };
+}

--- a/src/render/post.ts
+++ b/src/render/post.ts
@@ -6,6 +6,7 @@ import { SMAAPass } from 'three/examples/jsm/postprocessing/SMAAPass.js';
 import type { UnrealBloomPass } from 'three/examples/jsm/postprocessing/UnrealBloomPass.js';
 import type { DynamicResolutionRect } from './dynamic_resolution_core';
 import { GFX, sharedUniforms } from './gfx';
+import { GpuSectionMarkerPass } from './gpu_timer';
 import { PreparedBloomPass } from './post_bloom';
 import { PostEffectComposer } from './post_composer';
 import { StaticOpaqueN8AOPass } from './post_n8ao';
@@ -130,7 +131,7 @@ export function buildComposer(
   camera: THREE.Camera,
   width: number,
   height: number,
-  opts?: { gradeOnly?: boolean },
+  opts?: { gradeOnly?: boolean; gpuSectionSplit?: (label: string) => void },
 ): PostPipeline {
   // Grade-only mini chain for the medium tier: RenderPass -> OutputGradePass,
   // one fullscreen grade pass over the direct path, followed by SMAA. No AO
@@ -161,7 +162,17 @@ export function buildComposer(
   });
   const composer = new PostEffectComposer(webgl, target, width, height, plan.singleComposerBuffer);
 
+  // GPU section markers (gpu_timer.ts): a zero-draw pass BEFORE each real pass
+  // closes the previous TIME_ELAPSED query and opens the named one. Never
+  // added after the final pass: the composer routes the last enabled pass to
+  // the canvas, and a trailing marker would steal that slot.
+  const split = opts?.gpuSectionSplit;
+  const mark = (label: string): void => {
+    if (split) composer.addPass(new GpuSectionMarkerPass(split, label));
+  };
+
   let ao: N8AOPass | null = null;
+  mark('scene');
   if (plan.scene.pass === 'n8ao') {
     // N8AOPass replaces RenderPass. A separate scene pass would be discarded.
     ao = new StaticOpaqueN8AOPass(scene, camera, size.x, size.y);
@@ -204,12 +215,14 @@ export function buildComposer(
   let bloom: UnrealBloomPass | null = null;
   if (plan.composerPasses.includes('bloom')) {
     bloom = new PreparedBloomPass(size.clone(), BLOOM_STRENGTH, BLOOM_RADIUS, BLOOM_THRESHOLD);
+    mark('bloom');
     composer.addPass(bloom);
   }
   const grade = new OutputGradePass(
     sharedUniforms.uTime,
     bloom instanceof PreparedBloomPass ? bloom.bloomTexture : null,
   );
+  mark('grade');
   composer.addPass(grade);
 
   // Screen-fx pass (display space, straight after the grade and BEFORE the
@@ -219,6 +232,7 @@ export function buildComposer(
   // everything else, then self-disables whenever no ripple/flash is live;
   // EffectComposer simply skips a disabled pass, so toggling is free.
   const screenFx = new ShaderPass(ScreenFxShader);
+  mark('screenfx');
   composer.addPass(screenFx);
   const rippleSlots = Array.from({ length: SCREEN_RIPPLE_SLOTS }, () => ({
     x: 0,
@@ -243,7 +257,10 @@ export function buildComposer(
   // edge pass.
   // ?smaa=off is the dev-only perf-attribution kill switch. It keeps the
   // post-AA cost attributable while comparing the revised tier policy.
-  if (plan.composerPasses.includes('smaa')) composer.addPass(new SMAAPass(size.x, size.y));
+  if (plan.composerPasses.includes('smaa')) {
+    mark('smaa');
+    composer.addPass(new SMAAPass(size.x, size.y));
+  }
 
   return {
     composer,

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -46,6 +46,7 @@ import { AbilityVfx, AbilityVfxFx } from './ability_vfx';
 import { ABILITY_VFX_FULL_SPECS } from './ability_vfx_full_specs';
 import { ABILITY_VFX_SPECS } from './ability_vfx_specs';
 import { type AmberFeaturesView, buildAmberFeatures } from './amber_features';
+import { angleBackendToken, parseGlIdentity } from './angle_identity_core';
 import { isVisuallyDead } from './anim_state';
 import { AOE_RING_LIFETIME, aoeRingAnim } from './aoe_ring';
 import { formatResidencyBudget, residencyBudget } from './assets/residency_budget';
@@ -205,6 +206,7 @@ import {
   urlForcedTier,
 } from './gfx';
 import { GlacialFrontVisual } from './glacial_front_visual';
+import { type GpuSectionTimer, type GpuTimerStats, probeGpuTimer } from './gpu_timer';
 import { buildGreatTreePrewarmGroup } from './great_tree_prewarm';
 import { GroundAimReticleVisual } from './ground_aim_reticle_visual';
 import { createGroundTilt, type GroundTiltState, stepGroundTilt } from './ground_tilt_core';
@@ -1705,6 +1707,9 @@ export class Renderer {
   private nameplateTimer = 0;
   private glVendor = '';
   private glRenderer = '';
+  private angleBackend: string | null = null;
+  private gpuTimer: GpuSectionTimer | null = null;
+  private gpuTimerSupported = false;
   private contextLostCount = 0;
   private contextRestoredCount = 0;
   private phaseSamples: Record<RendererPhase, NumberSampleRing> = {
@@ -1783,8 +1788,21 @@ export class Renderer {
       this.contextRestoredCount++;
       this.captureGlIdentity();
       this.vfx.onContextRestored();
+      // Query objects from the lost context are dead husks: drop the whole
+      // timer and re-probe against the restored context.
+      this.gpuTimer?.dispose();
+      const gpuReprobe = probeGpuTimer(this.webgl);
+      this.gpuTimer = gpuReprobe.timer;
+      this.gpuTimerSupported = gpuReprobe.supported;
     });
     initGfxTier(this.webgl); // software-GL autodetect needs the live context
+    // GPU frame/section timing (EXT_disjoint_timer_query_webgl2): real GPU
+    // milliseconds per frame, split per post pass by the composer markers
+    // below. Cheap (a handful of query objects per frame), so it runs
+    // whenever the extension exists; ?gputimer=off is the kill switch.
+    const gpuProbe = probeGpuTimer(this.webgl);
+    this.gpuTimer = gpuProbe.timer;
+    this.gpuTimerSupported = gpuProbe.supported;
     if (GFX.composer || GFX.gradePass) {
       // three r165's render() resets info per pass (after the shadow pass, see
       // draw_stats_core.ts header), so with the composer's multiple passes every
@@ -2620,7 +2638,13 @@ export class Renderer {
         this.camera,
         this.viewport.width,
         this.viewport.height,
-        { gradeOnly: !GFX.composer },
+        {
+          gradeOnly: !GFX.composer,
+          // Reads the live field so a context-restore re-probe keeps working;
+          // split() outside a beginFrame (prewarm, census, screenshots) is a
+          // no-op by the core's contract.
+          gpuSectionSplit: (label) => this.gpuTimer?.split(label),
+        },
       );
 
     const resize = () => this.resizeViewport();
@@ -2664,9 +2688,11 @@ export class Renderer {
       this.glRenderer = String(
         dbg ? gl.getParameter(dbg.UNMASKED_RENDERER_WEBGL) : gl.getParameter(gl.RENDERER),
       );
+      this.angleBackend = angleBackendToken(parseGlIdentity(this.glRenderer));
     } catch {
       this.glVendor = '';
       this.glRenderer = '';
+      this.angleBackend = null;
     }
   }
 
@@ -3424,6 +3450,19 @@ export class Renderer {
     };
   }
 
+  /**
+   * Cheap live GL program count for the 1 Hz post-prewarm growth tracker
+   * (src/game/perf.ts); perfStats() allocates far too much for that cadence.
+   */
+  programCount(): number {
+    return this.webgl.info.programs?.length ?? 0;
+  }
+
+  /** Program count when the entry prewarm settled; null while it still runs. */
+  prewarmProgramBaseline(): number | null {
+    return this.lastPrewarmStats?.programsAfter ?? null;
+  }
+
   perfStats(): {
     graphicsConfigVersion: number;
     tier: string;
@@ -3464,6 +3503,10 @@ export class Renderer {
     foliage: FoliagePerfStats;
     glVendor: string;
     glRenderer: string;
+    angleBackend: string | null;
+    parallelCompile: boolean;
+    gpu: GpuTimerStats | null;
+    gpuTimerSupported: boolean;
     contextLost: number;
     contextRestored: number;
     phaseMs: RendererPhaseStats;
@@ -3522,6 +3565,10 @@ export class Renderer {
       foliage: this.foliage.perfStats(),
       glVendor: this.glVendor,
       glRenderer: this.glRenderer,
+      angleBackend: this.angleBackend,
+      parallelCompile: this.asyncCompileSupported,
+      gpu: this.gpuTimer ? this.gpuTimer.stats() : null,
+      gpuTimerSupported: this.gpuTimerSupported,
       contextLost: this.contextLostCount,
       contextRestored: this.contextRestoredCount,
       phaseMs: this.rendererPhaseStats(),
@@ -9443,12 +9490,18 @@ export class Renderer {
     this.updateOpaqueDrawOrder(dt);
     if (shakeX !== 0 || shakeY !== 0) this.camera.updateMatrixWorld();
     this.vfx.prepareDraw(this.camera);
+    this.gpuTimer?.beginFrame();
     if (this.post) {
       // screen-fx pass state (ripple re-projection, flash decay) advances
       // with the camera finalized for this frame
       this.post.updateScreenFx(dt);
       this.post.render();
-    } else this.webgl.render(this.scene, this.camera);
+    } else {
+      // No composer (low tier): the whole frame is one GPU section.
+      this.gpuTimer?.split('scene');
+      this.webgl.render(this.scene, this.camera);
+    }
+    this.gpuTimer?.endFrame();
     if (shakeX !== 0 || shakeY !== 0) {
       this.camera.position.x -= shakeX;
       this.camera.position.y -= shakeY;

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -9487,10 +9487,14 @@ export class Renderer {
       this.gatherNodes.updateShadowVisibility(this.camera, this.shadowLightDirection, true);
       this.valeCupStadium.updateShadowVisibility(this.camera, this.shadowLightDirection, true);
     }
+    // GPU frame timing opens here: beginFrame only polls prior results and
+    // opens the frame record (no GL query starts until the first section
+    // split inside the render below), so it sits above the pinned
+    // updateMatrixWorld -> prepareDraw -> render adjacency (tests/vfx.test.ts).
+    this.gpuTimer?.beginFrame();
     this.updateOpaqueDrawOrder(dt);
     if (shakeX !== 0 || shakeY !== 0) this.camera.updateMatrixWorld();
     this.vfx.prepareDraw(this.camera);
-    this.gpuTimer?.beginFrame();
     if (this.post) {
       // screen-fx pass state (ripple re-projection, flash decay) advances
       // with the camera finalized for this frame

--- a/tests/angle_identity_core.test.ts
+++ b/tests/angle_identity_core.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+import { angleBackendToken, parseGlIdentity } from '../src/render/angle_identity_core';
+
+// Real-world unmasked renderer strings, one row per shape the fleet actually
+// sends (see gpuBucket() in src/game/perf.ts for the coarse vendor buckets;
+// this parser answers the finer backend question those buckets cannot).
+describe('angle_identity_core', () => {
+  it('parses the canonical Windows D3D11 shape with a driver version', () => {
+    const id = parseGlIdentity(
+      'ANGLE (NVIDIA, NVIDIA GeForce RTX 4080 (0x00002704) Direct3D11 vs_5_0 ps_5_0, D3D11-31.0.15.4633)',
+    );
+    expect(id.angle).toBe(true);
+    expect(id.backend).toBe('d3d11');
+    expect(id.deviceName).toBe('NVIDIA GeForce RTX 4080');
+    expect(id.driverVersion).toBe('31.0.15.4633');
+  });
+
+  it('parses a laptop adapter without the driver suffix', () => {
+    const id = parseGlIdentity(
+      'ANGLE (NVIDIA, NVIDIA GeForce RTX 3070 Laptop GPU (0x0000249D) Direct3D11 vs_5_0 ps_5_0, D3D11)',
+    );
+    expect(id.backend).toBe('d3d11');
+    expect(id.deviceName).toBe('NVIDIA GeForce RTX 3070 Laptop GPU');
+    expect(id.driverVersion).toBeNull();
+  });
+
+  it('parses Intel integrated D3D11', () => {
+    const id = parseGlIdentity(
+      'ANGLE (Intel, Intel(R) UHD Graphics 630 (0x00003E9B) Direct3D11 vs_5_0 ps_5_0, D3D11-27.20.100.8681)',
+    );
+    expect(id.backend).toBe('d3d11');
+    expect(id.deviceName).toBe('Intel(R) UHD Graphics 630');
+    expect(id.driverVersion).toBe('27.20.100.8681');
+  });
+
+  it('parses the macOS Metal shape', () => {
+    const id = parseGlIdentity(
+      'ANGLE (Apple, ANGLE Metal Renderer: Apple M1 Pro, Unspecified Version)',
+    );
+    expect(id.angle).toBe(true);
+    expect(id.backend).toBe('metal');
+    expect(id.deviceName).toBe('Apple M1 Pro');
+  });
+
+  it('parses ANGLE-over-Vulkan and unwraps the device', () => {
+    const id = parseGlIdentity(
+      'ANGLE (NVIDIA, Vulkan 1.3.277 (NVIDIA GeForce RTX 4080 (0x00002704)), NVIDIA)',
+    );
+    expect(id.backend).toBe('vulkan');
+    expect(id.deviceName).toBe('NVIDIA GeForce RTX 4080');
+  });
+
+  it('classifies SwiftShader as software even though it advertises Vulkan', () => {
+    const id = parseGlIdentity(
+      'ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (Subzero) (0x0000C0DE)), SwiftShader driver)',
+    );
+    expect(id.backend).toBe('swiftshader');
+  });
+
+  it('classifies Microsoft Basic Render (WARP) as warp, not d3d11', () => {
+    const id = parseGlIdentity(
+      'ANGLE (Microsoft, Microsoft Basic Render Driver Direct3D11 vs_5_0 ps_5_0, D3D11)',
+    );
+    expect(id.backend).toBe('warp');
+  });
+
+  it('parses the Android OpenGL ES shape', () => {
+    const id = parseGlIdentity('ANGLE (ARM, Mali-G78 MC14, OpenGL ES 3.2 v1.r32p1-01eac0)');
+    expect(id.backend).toBe('opengl');
+    expect(id.deviceName).toBe('Mali-G78 MC14');
+  });
+
+  it('handles non-ANGLE strings (Firefox GL, bare adapter names)', () => {
+    const firefox = parseGlIdentity('NVIDIA GeForce GTX 1080/PCIe/SSE2');
+    expect(firefox.angle).toBe(false);
+    expect(firefox.backend).toBeNull();
+    expect(firefox.deviceName).toBe('NVIDIA GeForce GTX 1080');
+
+    const bare = parseGlIdentity('Apple M1');
+    expect(bare.angle).toBe(false);
+    expect(bare.deviceName).toBe('Apple M1');
+  });
+
+  it('handles empty and masked strings without throwing', () => {
+    expect(parseGlIdentity('').backend).toBeNull();
+    expect(parseGlIdentity('').deviceName).toBeNull();
+    const masked = parseGlIdentity('WebKit WebGL');
+    expect(masked.angle).toBe(false);
+  });
+
+  it('produces the beacon token: backend, angle-unknown, or null', () => {
+    expect(
+      angleBackendToken(
+        parseGlIdentity(
+          'ANGLE (AMD, AMD Radeon RX 6800 XT (0x000073BF) Direct3D11 vs_5_0 ps_5_0, D3D11)',
+        ),
+      ),
+    ).toBe('d3d11');
+    expect(angleBackendToken(parseGlIdentity('ANGLE (Unheard Of Corp, Mystery Device, v1)'))).toBe(
+      'angle-unknown',
+    );
+    expect(angleBackendToken(parseGlIdentity('Adreno (TM) 640'))).toBeNull();
+  });
+});

--- a/tests/architecture.test.ts
+++ b/tests/architecture.test.ts
@@ -298,8 +298,11 @@ const DOM_GLOBAL_VALUE_ALLOWLIST = new Set([join(repoRoot, 'src/ui/safe_local_st
 // moment of the cycle.
 const RENDER_PURE_CORES = [
   'src/render/ability_vfx_core.ts',
+  'src/render/angle_identity_core.ts',
   'src/render/arena_water_band_core.ts',
   'src/render/blade_grass_dense_core.ts',
+  'src/render/bottleneck_core.ts',
+  'src/render/gpu_timer_core.ts',
   'src/render/camera_boom_core.ts',
   'src/render/compile_gate.ts',
   'src/render/camera_director_core.ts',

--- a/tests/bottleneck_core.test.ts
+++ b/tests/bottleneck_core.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from 'vitest';
+import {
+  BOTTLENECK_VERDICTS,
+  type BottleneckSignals,
+  COMPILE_STALL_LONG_TASK_MS,
+  COMPILE_STALL_PROGRAM_DELTA,
+  classifyBottleneck,
+} from '../src/render/bottleneck_core';
+
+// A healthy 60 fps desktop baseline every case perturbs.
+function signals(overrides: Partial<BottleneckSignals> = {}): BottleneckSignals {
+  return {
+    frameP95Ms: 14,
+    targetFrameMs: 16.7,
+    gpuFrameP95Ms: 8,
+    submitP95Ms: 3,
+    rendererCpuP95Ms: 6,
+    mainOtherAvgMs: 2,
+    longTaskP95Ms: 0,
+    programDelta: 0,
+    externalFrameCap: false,
+    effectiveRenderScale: 1,
+    ...overrides,
+  };
+}
+
+describe('bottleneck_core verdict matrix', () => {
+  it('reads a healthy session as balanced with high confidence', () => {
+    const r = classifyBottleneck(signals());
+    expect(r.verdict).toBe('balanced');
+    expect(r.confidence).toBe('high');
+  });
+
+  it('compile stalls trump throughput verdicts (the ANGLE/D3D11 storm signature)', () => {
+    const r = classifyBottleneck(
+      signals({
+        programDelta: COMPILE_STALL_PROGRAM_DELTA,
+        longTaskP95Ms: COMPILE_STALL_LONG_TASK_MS,
+        frameP95Ms: 45,
+        gpuFrameP95Ms: 40, // even a GPU-heavy window reports the stalls first
+      }),
+    );
+    expect(r.verdict).toBe('compile-stalls');
+    expect(r.confidence).toBe('high');
+  });
+
+  it('program growth without long tasks is not a stall verdict', () => {
+    const r = classifyBottleneck(signals({ programDelta: 30, longTaskP95Ms: 10 }));
+    expect(r.verdict).toBe('balanced');
+  });
+
+  it('an external frame cap reads as vsync-capped, not as a bottleneck', () => {
+    const r = classifyBottleneck(
+      signals({ externalFrameCap: true, frameP95Ms: 34, targetFrameMs: 16.7 }),
+    );
+    expect(r.verdict).toBe('vsync-capped');
+  });
+
+  it('a slow frame dominated by GPU time is gpu-bound with high confidence', () => {
+    const r = classifyBottleneck(
+      signals({ frameP95Ms: 33, gpuFrameP95Ms: 30, targetFrameMs: 16.7 }),
+    );
+    expect(r.verdict).toBe('gpu-bound');
+    expect(r.confidence).toBe('high');
+  });
+
+  it('notes when the governor is already shedding resolution', () => {
+    const r = classifyBottleneck(
+      signals({
+        frameP95Ms: 33,
+        gpuFrameP95Ms: 30,
+        targetFrameMs: 16.7,
+        effectiveRenderScale: 0.72,
+      }),
+    );
+    expect(r.detail).toContain('shedding resolution');
+  });
+
+  it('a slow frame with idle GPU and heavy renderer CPU is render-cpu-bound', () => {
+    const r = classifyBottleneck(
+      signals({
+        frameP95Ms: 36,
+        targetFrameMs: 16.7,
+        gpuFrameP95Ms: 8,
+        rendererCpuP95Ms: 24,
+        mainOtherAvgMs: 4,
+      }),
+    );
+    expect(r.verdict).toBe('render-cpu-bound');
+    expect(r.confidence).toBe('high');
+  });
+
+  it('a slow frame with idle GPU and heavy sim/hud time is cpu-main-bound (the crowd case)', () => {
+    const r = classifyBottleneck(
+      signals({
+        frameP95Ms: 36,
+        targetFrameMs: 16.7,
+        gpuFrameP95Ms: 8,
+        rendererCpuP95Ms: 9,
+        mainOtherAvgMs: 14,
+      }),
+    );
+    expect(r.verdict).toBe('cpu-main-bound');
+  });
+
+  it('without a GPU timer, a dominant submit span infers gpu-bound at low confidence', () => {
+    const r = classifyBottleneck(
+      signals({
+        frameP95Ms: 40,
+        targetFrameMs: 16.7,
+        gpuFrameP95Ms: null,
+        submitP95Ms: 22,
+        rendererCpuP95Ms: 28,
+        mainOtherAvgMs: 3,
+      }),
+    );
+    expect(r.verdict).toBe('gpu-bound');
+    expect(r.confidence).toBe('low');
+    expect(r.detail).toContain('no GPU timer');
+  });
+
+  it('without a GPU timer, main-thread-heavy windows read cpu-main-bound', () => {
+    const r = classifyBottleneck(
+      signals({
+        frameP95Ms: 40,
+        targetFrameMs: 16.7,
+        gpuFrameP95Ms: null,
+        submitP95Ms: 2,
+        rendererCpuP95Ms: 8,
+        mainOtherAvgMs: 20,
+      }),
+    );
+    expect(r.verdict).toBe('cpu-main-bound');
+  });
+
+  it('an empty window is unknown', () => {
+    const r = classifyBottleneck(signals({ frameP95Ms: 0 }));
+    expect(r.verdict).toBe('unknown');
+  });
+
+  it('every produced verdict is in the allowlisted beacon token set', () => {
+    const cases: Partial<BottleneckSignals>[] = [
+      {},
+      { programDelta: 10, longTaskP95Ms: 120 },
+      { externalFrameCap: true },
+      { frameP95Ms: 33, gpuFrameP95Ms: 30 },
+      { frameP95Ms: 36, gpuFrameP95Ms: 8, rendererCpuP95Ms: 24, mainOtherAvgMs: 4 },
+      { frameP95Ms: 36, gpuFrameP95Ms: 8, rendererCpuP95Ms: 9, mainOtherAvgMs: 14 },
+      { frameP95Ms: 40, gpuFrameP95Ms: null, submitP95Ms: 22, rendererCpuP95Ms: 28 },
+      { frameP95Ms: 0 },
+    ];
+    for (const c of cases) {
+      expect(BOTTLENECK_VERDICTS).toContain(classifyBottleneck(signals(c)).verdict);
+    }
+  });
+});

--- a/tests/bottleneck_verdict_parity.test.ts
+++ b/tests/bottleneck_verdict_parity.test.ts
@@ -1,0 +1,25 @@
+// Cross-boundary drift guard for the bottleneck verdict catalog (the Windows
+// bottleneck diagnostics, perf-report schema version 3). server/ cannot
+// import src/render, so the server keeps a deliberate copy of the render
+// catalog as its storage allowlist; this pin is the ONLY thing that keeps the
+// two lists equal (tests/perf_suggestion_id_parity.test.ts is the same
+// pattern for the perf-doctor suggestion ids). It lives in its own file
+// because it is the one test that intentionally imports BOTH sides of the
+// boundary.
+//
+// server/db.ts builds a pg Pool at module load and throws if DATABASE_URL is
+// unset; server/perf_report.ts imports it, so set a dummy URL. Nothing here
+// ever touches the pool.
+process.env.DATABASE_URL ||= 'postgres://test:test@127.0.0.1:5433/wocc_bottleneck_parity';
+
+import { describe, expect, it } from 'vitest';
+import { BOTTLENECK_VERDICTS } from '../src/render/bottleneck_core';
+
+describe('bottleneck verdict parity', () => {
+  it('keeps the server allowlist equal to the render catalog, order included', async () => {
+    const { perfReportInternalsForTest } = await import('../server/perf_report');
+    expect([...perfReportInternalsForTest.KNOWN_BOTTLENECK_VERDICTS]).toEqual([
+      ...BOTTLENECK_VERDICTS,
+    ]);
+  });
+});

--- a/tests/client_perf_reports_db_integration.test.ts
+++ b/tests/client_perf_reports_db_integration.test.ts
@@ -1,5 +1,6 @@
 // Opt-in real-Postgres roundtrip for insertClientPerfReport and the phase 03
-// dimension columns plus the phase 05 suggestion_ids array. The insert's 44
+// dimension columns plus the phase 05 suggestion_ids array and the schema 3
+// bottleneck diagnostics columns. The insert's 52
 // positional parameters are the one place a renumbering slip lands values in
 // the wrong columns while every mocked-pool suite stays green, so this
 // roundtrip is the ONLY decisive guard: it writes a row of pairwise-distinct
@@ -42,7 +43,7 @@ describeDb('client perf report insert roundtrip (real Postgres)', () => {
     // Every value is distinct from every other so ANY positional swap between
     // two columns of a compatible type flips at least one assertion below.
     await db.insertClientPerfReport({
-      schemaVersion: 2,
+      schemaVersion: 3,
       releaseVersion: '0.30.0-test',
       buildId: 'roundtripbuild',
       sessionId: `${MARKER}-row`,
@@ -85,6 +86,14 @@ describeDb('client perf report insert roundtrip (real Postgres)', () => {
       visibleViews: 31,
       worst10sFrameP95Ms: 180.5,
       suggestionIds: ['hardware-acceleration', 'high-dpi'],
+      gpuFrameP50Ms: 6.25,
+      gpuFrameP95Ms: 13.75,
+      gpuTimerSupported: true,
+      angleBackend: 'd3d11',
+      parallelCompile: false,
+      programsPostPrewarm: 17,
+      bottleneck: 'compile-stalls',
+      bottleneckConfidence: 'medium',
       rawSummary: { roundtrip: true, seconds: 77 },
     });
 
@@ -93,7 +102,7 @@ describeDb('client perf report insert roundtrip (real Postgres)', () => {
     ]);
     expect(res.rowCount).toBe(1);
     const r = res.rows[0];
-    expect(r.schema_version).toBe(2);
+    expect(r.schema_version).toBe(3);
     expect(r.release_version).toBe('0.30.0-test');
     expect(r.build_id).toBe('roundtripbuild');
     expect(r.account_id).toBeNull();
@@ -137,6 +146,15 @@ describeDb('client perf report insert roundtrip (real Postgres)', () => {
     // The pg driver maps a JS string array to TEXT[]; order must survive.
     expect(r.suggestion_ids).toEqual(['hardware-acceleration', 'high-dpi']);
     expect(r.raw_summary).toEqual({ roundtrip: true, seconds: 77 });
+    // Schema 3 bottleneck diagnostics columns.
+    expect(r.gpu_frame_p50_ms).toBeCloseTo(6.25, 5);
+    expect(r.gpu_frame_p95_ms).toBeCloseTo(13.75, 5);
+    expect(r.gpu_timer_supported).toBe(true);
+    expect(r.angle_backend).toBe('d3d11');
+    expect(r.parallel_compile).toBe(false);
+    expect(r.programs_post_prewarm).toBe(17);
+    expect(r.bottleneck).toBe('compile-stalls');
+    expect(r.bottleneck_confidence).toBe('medium');
   });
 
   it('serves the row back through clientPerfRaw with the dimensions and suggestion ids mapped', async () => {
@@ -169,7 +187,11 @@ describeDb('client perf report insert roundtrip (real Postgres)', () => {
       [`${MARKER}-legacy`, 'gameplay'],
     );
     const res = await db.pool.query(
-      'SELECT crowd_bucket, sim_entities, active_views, visible_views, worst_10s_frame_p95_ms, suggestion_ids FROM client_perf_reports WHERE session_id = $1',
+      `SELECT crowd_bucket, sim_entities, active_views, visible_views, worst_10s_frame_p95_ms,
+              suggestion_ids, gpu_frame_p50_ms, gpu_frame_p95_ms, gpu_timer_supported,
+              angle_backend, parallel_compile, programs_post_prewarm, bottleneck,
+              bottleneck_confidence
+         FROM client_perf_reports WHERE session_id = $1`,
       [`${MARKER}-legacy`],
     );
     expect(res.rows[0]).toEqual({
@@ -179,6 +201,16 @@ describeDb('client perf report insert roundtrip (real Postgres)', () => {
       visible_views: 0,
       worst_10s_frame_p95_ms: 0,
       suggestion_ids: [],
+      // The schema 3 diagnostics columns are deliberately nullable with no
+      // defaults: a pre-v3 row reads NULL ("not measured"), never zero.
+      gpu_frame_p50_ms: null,
+      gpu_frame_p95_ms: null,
+      gpu_timer_supported: null,
+      angle_backend: null,
+      parallel_compile: null,
+      programs_post_prewarm: null,
+      bottleneck: null,
+      bottleneck_confidence: null,
     });
   });
 

--- a/tests/eastbrook_polish_capture_contract.test.ts
+++ b/tests/eastbrook_polish_capture_contract.test.ts
@@ -360,15 +360,14 @@ describe('Eastbrook polish capture contract', () => {
       mode: 'composite-sha256',
       algorithm: 'sha256',
       baselineRevision: EASTBROOK_POLISH_BASELINE_REVISION,
-      // Deliberately re-pinned. Four independent causes now stack: the 0.33.0
-      // version sync moved every GLB source-fingerprint leaf (#2729), the
-      // graphics overhaul and the ability-VFX integration each changed the
-      // renderer-integration and view-priority leaves, and this branch edits
-      // src/render/renderer.ts for the compile gates. So the composite mints
-      // fresh and matches no parent's literal. No pipeline input or geometry
-      // value changed, and no capture was retaken (the five per-asset seal
-      // suites stay green untouched).
-      fingerprint: '2172d6960ce3057f6b64d2a1d178ab2b7df5f6802636010b1fa06e57a452106a',
+      // Deliberately re-pinned. The renderer-integration leaf moved again:
+      // this branch wires the GPU section timer into src/render/renderer.ts
+      // (probe, beginFrame/endFrame around submit, perfStats gpu block), so
+      // the composite mints fresh. No pipeline input or geometry value
+      // changed, and no capture was retaken (the five per-asset seal suites
+      // stay green untouched). Computed from LF bytes (the repo-normalized
+      // form CI checks out), not a CRLF working tree.
+      fingerprint: '772e53b957e97883198f50cf68af1728b7fb7d8a892c96fe4ffe4789269db9b5',
       components: {
         captureContract: {
           id: 'polish-v2',

--- a/tests/gpu_timer_core.test.ts
+++ b/tests/gpu_timer_core.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createGpuSectionTimer,
+  type GpuTimerGl,
+  QUERY_RESULT,
+  QUERY_RESULT_AVAILABLE,
+} from '../src/render/gpu_timer_core';
+
+// A fake WebGL2 context for the timer state machine. Queries resolve when the
+// test says so, letting the suite model multi-frame result latency, disjoint
+// events, and pool starvation without a GPU.
+const EXT = { TIME_ELAPSED_EXT: 0x88bf, GPU_DISJOINT_EXT: 0x8fbb };
+
+interface FakeQuery {
+  id: number;
+  ns: number;
+  available: boolean;
+  deleted: boolean;
+}
+
+function makeFakeGl() {
+  const queries: FakeQuery[] = [];
+  let active: FakeQuery | null = null;
+  let disjoint = false;
+  const beginOrder: number[] = [];
+  const gl: GpuTimerGl = {
+    createQuery(): object {
+      const q: FakeQuery = { id: queries.length, ns: 0, available: false, deleted: false };
+      queries.push(q);
+      return q;
+    },
+    deleteQuery(query: object): void {
+      (query as FakeQuery).deleted = true;
+    },
+    beginQuery(target: number, query: object): void {
+      expect(target).toBe(EXT.TIME_ELAPSED_EXT);
+      // Timer queries must never nest: the previous one has to be ended first.
+      expect(active).toBeNull();
+      active = query as FakeQuery;
+      beginOrder.push(active.id);
+    },
+    endQuery(target: number): void {
+      expect(target).toBe(EXT.TIME_ELAPSED_EXT);
+      expect(active).not.toBeNull();
+      active = null;
+    },
+    getQueryParameter(query: object, pname: number): unknown {
+      const q = query as FakeQuery;
+      if (pname === QUERY_RESULT_AVAILABLE) return q.available;
+      if (pname === QUERY_RESULT) return q.ns;
+      return null;
+    },
+    getParameter(pname: number): unknown {
+      if (pname === EXT.GPU_DISJOINT_EXT) {
+        const value = disjoint;
+        disjoint = false; // reading resets, like the real extension
+        return value;
+      }
+      return null;
+    },
+  };
+  return {
+    gl,
+    queries,
+    beginOrder,
+    setDisjoint(): void {
+      disjoint = true;
+    },
+    resolveAll(nsPerQuery: (id: number) => number): void {
+      for (const q of queries) {
+        if (!q.available) {
+          q.ns = nsPerQuery(q.id);
+          q.available = true;
+        }
+      }
+    },
+  };
+}
+
+const MS = 1e6; // ns per ms
+
+describe('gpu_timer_core', () => {
+  it('records per-section results and whole-frame totals once queries resolve', () => {
+    const fake = makeFakeGl();
+    const timer = createGpuSectionTimer(fake.gl, EXT);
+
+    timer.beginFrame();
+    timer.split('scene');
+    timer.split('bloom');
+    timer.split('smaa');
+    timer.endFrame();
+
+    // Nothing resolved yet: stats stay empty rather than blocking.
+    expect(timer.stats().frames).toBe(0);
+
+    fake.resolveAll((id) => (id === 0 ? 4 * MS : id === 1 ? 2 * MS : 1 * MS));
+    timer.beginFrame(); // poll happens here
+    timer.endFrame();
+
+    const stats = timer.stats();
+    expect(stats.frames).toBe(1);
+    expect(stats.frameAvgMs).toBeCloseTo(7, 5);
+    expect(stats.frameP95Ms).toBeCloseTo(7, 5);
+    const labels = stats.sections.map((s) => s.label);
+    expect(labels).toEqual(['scene', 'bloom', 'smaa']);
+    expect(stats.sections[0].avgMs).toBeCloseTo(4, 5);
+    expect(stats.sections[1].avgMs).toBeCloseTo(2, 5);
+    expect(stats.sections[2].avgMs).toBeCloseTo(1, 5);
+  });
+
+  it('never nests queries and reuses pooled query objects across frames', () => {
+    const fake = makeFakeGl();
+    const timer = createGpuSectionTimer(fake.gl, EXT);
+
+    for (let frame = 0; frame < 5; frame++) {
+      fake.resolveAll(() => 1 * MS);
+      timer.beginFrame();
+      timer.split('scene');
+      timer.split('post');
+      timer.endFrame();
+    }
+    // 2 queries in flight per frame, resolved before the next begins: the pool
+    // stabilizes instead of growing per frame.
+    expect(fake.queries.length).toBeLessThanOrEqual(4);
+  });
+
+  it('drops in-flight frames on a disjoint event and counts it', () => {
+    const fake = makeFakeGl();
+    const timer = createGpuSectionTimer(fake.gl, EXT);
+
+    timer.beginFrame();
+    timer.split('scene');
+    timer.endFrame();
+
+    fake.setDisjoint();
+    fake.resolveAll(() => 99 * MS); // results exist but are untrustworthy
+    timer.beginFrame();
+    timer.endFrame();
+
+    const stats = timer.stats();
+    expect(stats.disjoints).toBe(1);
+    expect(stats.frames).toBe(0); // the poisoned frame never lands
+  });
+
+  it('starves gracefully when the query pool runs dry', () => {
+    const fake = makeFakeGl();
+    const timer = createGpuSectionTimer(fake.gl, EXT);
+
+    // Never resolve anything: every frame leaks its queries into the pending
+    // list until the pool cap stops new sections.
+    let sawStarvedSplit = false;
+    for (let frame = 0; frame < 40; frame++) {
+      timer.beginFrame();
+      timer.split('scene');
+      timer.split('post');
+      timer.endFrame();
+      if (fake.beginOrder.length < (frame + 1) * 2) sawStarvedSplit = true;
+    }
+    expect(sawStarvedSplit).toBe(true);
+    // Resolve everything: pending frames land, starved ones are counted.
+    fake.resolveAll(() => 1 * MS);
+    timer.beginFrame();
+    timer.endFrame();
+    expect(timer.stats().starvedFrames).toBeGreaterThan(0);
+  });
+
+  it('ignores splits outside a frame (out-of-band census/prewarm renders)', () => {
+    const fake = makeFakeGl();
+    const timer = createGpuSectionTimer(fake.gl, EXT);
+    timer.split('scene'); // no beginFrame: must not begin a GL query
+    expect(fake.beginOrder.length).toBe(0);
+  });
+
+  it('reset drops retained samples and dispose deletes pooled queries', () => {
+    const fake = makeFakeGl();
+    const timer = createGpuSectionTimer(fake.gl, EXT);
+    timer.beginFrame();
+    timer.split('scene');
+    timer.endFrame();
+    fake.resolveAll(() => 3 * MS);
+    timer.beginFrame();
+    timer.endFrame();
+    expect(timer.stats().frames).toBe(1);
+
+    timer.reset();
+    expect(timer.stats().frames).toBe(0);
+
+    timer.dispose();
+    expect(fake.queries.some((q) => q.deleted)).toBe(true);
+    // Disposed timers are inert.
+    timer.beginFrame();
+    timer.split('scene');
+    timer.endFrame();
+    expect(timer.stats().frames).toBe(0);
+  });
+});

--- a/tests/perf_monitor.test.ts
+++ b/tests/perf_monitor.test.ts
@@ -216,6 +216,10 @@ describe('perf monitor scene census wiring', () => {
       }),
       captureSceneCensus: censusReport,
       perfStats: () => null,
+      // The 1 Hz post-prewarm program tracker (perf.ts tick) reads these two
+      // cheap accessors; a null baseline models "prewarm still running".
+      programCount: () => 0,
+      prewarmProgramBaseline: () => null,
     };
   }
 

--- a/tests/perf_report.test.ts
+++ b/tests/perf_report.test.ts
@@ -116,9 +116,9 @@ describe('perf report ingestion', () => {
     expect(insertClientPerfReport).toHaveBeenCalledTimes(1);
     expect(insertClientPerfReport).toHaveBeenCalledWith(
       expect.objectContaining({
-        // 99 clamps to the current schema version (2 since the phase 03
-        // dimensions, ruling R6).
-        schemaVersion: 2,
+        // 99 clamps to the current schema version (3 since the Windows
+        // bottleneck diagnostics).
+        schemaVersion: 3,
         accountId: 10,
         characterId: 55,
         graphicsPreset: 'ultra',
@@ -232,7 +232,7 @@ describe('perf report ingestion', () => {
     expect(perfReportInternalsForTest.PERF_REPORT_SCHEMA_VERSION).toBe(
       perfReporterInternalsForTest.PERF_REPORT_SCHEMA_VERSION,
     );
-    expect(perfReportInternalsForTest.PERF_REPORT_SCHEMA_VERSION).toBe(2);
+    expect(perfReportInternalsForTest.PERF_REPORT_SCHEMA_VERSION).toBe(3);
   });
 
   it('accepts every fixed crowd label and folds hostile crowd input to unknown', async () => {
@@ -408,6 +408,165 @@ describe('perf report ingestion', () => {
     );
     expect(insertClientPerfReport).toHaveBeenCalledWith(
       expect.objectContaining({ suggestionIds: [] }),
+    );
+  });
+
+  it('stores the schema 3 bottleneck diagnostics fields on the row', async () => {
+    await handlePerfReport(
+      fakeReq(
+        {
+          sessionId: 'diag-valid',
+          gpuFrameP50Ms: 5.8,
+          gpuFrameP95Ms: 11.4,
+          gpuTimerSupported: true,
+          angleBackend: 'd3d11',
+          parallelCompile: true,
+          programsPostPrewarm: 12,
+          bottleneck: 'compile-stalls',
+          bottleneckConfidence: 'high',
+          rawSummary: {},
+        },
+        { remoteAddress: '203.0.113.81' },
+      ),
+      fakeRes(),
+    );
+    expect(insertClientPerfReport).toHaveBeenCalledWith(
+      expect.objectContaining({
+        gpuFrameP50Ms: 5.8,
+        gpuFrameP95Ms: 11.4,
+        gpuTimerSupported: true,
+        angleBackend: 'd3d11',
+        parallelCompile: true,
+        programsPostPrewarm: 12,
+        bottleneck: 'compile-stalls',
+        bottleneckConfidence: 'high',
+      }),
+    );
+  });
+
+  it('accepts every allowlisted angle backend, verdict, and confidence token', async () => {
+    const { KNOWN_ANGLE_BACKENDS, KNOWN_BOTTLENECK_VERDICTS, KNOWN_BOTTLENECK_CONFIDENCES } =
+      perfReportInternalsForTest;
+    for (const backend of KNOWN_ANGLE_BACKENDS) {
+      vi.mocked(insertClientPerfReport).mockClear();
+      await handlePerfReport(
+        fakeReq(
+          { sessionId: `diag-backend-${backend}`, angleBackend: backend, rawSummary: {} },
+          { remoteAddress: '203.0.113.82' },
+        ),
+        fakeRes(),
+      );
+      expect(insertClientPerfReport).toHaveBeenCalledWith(
+        expect.objectContaining({ angleBackend: backend }),
+      );
+    }
+    for (const verdict of KNOWN_BOTTLENECK_VERDICTS) {
+      vi.mocked(insertClientPerfReport).mockClear();
+      await handlePerfReport(
+        fakeReq(
+          { sessionId: `diag-verdict-${verdict}`, bottleneck: verdict, rawSummary: {} },
+          { remoteAddress: '203.0.113.83' },
+        ),
+        fakeRes(),
+      );
+      expect(insertClientPerfReport).toHaveBeenCalledWith(
+        expect.objectContaining({ bottleneck: verdict }),
+      );
+    }
+    for (const confidence of KNOWN_BOTTLENECK_CONFIDENCES) {
+      vi.mocked(insertClientPerfReport).mockClear();
+      await handlePerfReport(
+        fakeReq(
+          {
+            sessionId: `diag-confidence-${confidence}`,
+            bottleneckConfidence: confidence,
+            rawSummary: {},
+          },
+          { remoteAddress: '203.0.113.84' },
+        ),
+        fakeRes(),
+      );
+      expect(insertClientPerfReport).toHaveBeenCalledWith(
+        expect.objectContaining({ bottleneckConfidence: confidence }),
+      );
+    }
+  });
+
+  it('folds hostile diagnostics values to null and clamps the numeric ones', async () => {
+    await handlePerfReport(
+      fakeReq(
+        {
+          sessionId: 'diag-hostile',
+          gpuFrameP50Ms: 'not-a-number',
+          gpuFrameP95Ms: 1e9,
+          // Boolean coercion, the same deliberate rule as autoGovernor: any
+          // truthy junk stores true, never a string.
+          gpuTimerSupported: 'yes',
+          angleBackend: 'metal2000; DROP TABLE accounts',
+          parallelCompile: 0,
+          programsPostPrewarm: -5,
+          bottleneck: 'quantum-bound',
+          bottleneckConfidence: 'certain',
+          rawSummary: {},
+        },
+        { remoteAddress: '203.0.113.85' },
+      ),
+      fakeRes(),
+    );
+    expect(insertClientPerfReport).toHaveBeenCalledWith(
+      expect.objectContaining({
+        gpuFrameP50Ms: null,
+        gpuFrameP95Ms: 10_000,
+        gpuTimerSupported: true,
+        angleBackend: null,
+        parallelCompile: false,
+        programsPostPrewarm: 0,
+        bottleneck: null,
+        bottleneckConfidence: null,
+      }),
+    );
+
+    vi.mocked(insertClientPerfReport).mockClear();
+    await handlePerfReport(
+      fakeReq(
+        {
+          sessionId: 'diag-hostile-2',
+          gpuFrameP50Ms: -3,
+          gpuFrameP95Ms: null,
+          programsPostPrewarm: 9e9,
+          bottleneck: 42,
+          rawSummary: {},
+        },
+        { remoteAddress: '203.0.113.86' },
+      ),
+      fakeRes(),
+    );
+    expect(insertClientPerfReport).toHaveBeenCalledWith(
+      expect.objectContaining({
+        gpuFrameP50Ms: 0,
+        gpuFrameP95Ms: null,
+        programsPostPrewarm: 100_000,
+        bottleneck: null,
+      }),
+    );
+  });
+
+  it('defaults the schema 3 diagnostics fields when a v2 client omits them', async () => {
+    await handlePerfReport(
+      fakeReq({ sessionId: 'diag-old-client', rawSummary: {} }, { remoteAddress: '203.0.113.87' }),
+      fakeRes(),
+    );
+    expect(insertClientPerfReport).toHaveBeenCalledWith(
+      expect.objectContaining({
+        gpuFrameP50Ms: null,
+        gpuFrameP95Ms: null,
+        gpuTimerSupported: false,
+        angleBackend: null,
+        parallelCompile: false,
+        programsPostPrewarm: null,
+        bottleneck: null,
+        bottleneckConfidence: null,
+      }),
     );
   });
 

--- a/tests/perf_reporter.test.ts
+++ b/tests/perf_reporter.test.ts
@@ -217,6 +217,12 @@ function snapshot(): PerfSnapshot {
       worst10s: null,
     },
     mainMs: { renderer: { count: 1, avg: 5, p95: 5, max: 5 } },
+    programsLinkedPostPrewarm: 4,
+    bottleneck: {
+      verdict: 'balanced',
+      confidence: 'high',
+      detail: 'frame p95 19ms within target 16.7ms',
+    },
     renderer: {
       graphicsConfigVersion: 16,
       tier: 'high',
@@ -300,6 +306,10 @@ function snapshot(): PerfSnapshot {
       },
       glVendor: 'Apple',
       glRenderer: 'ANGLE (Apple, ANGLE Metal Renderer: Apple M3 Pro)',
+      angleBackend: 'metal',
+      parallelCompile: true,
+      gpu: null,
+      gpuTimerSupported: false,
       contextLost: 0,
       contextRestored: 0,
       phaseMs: {
@@ -677,9 +687,99 @@ describe('perf reporter report dimensions', () => {
     expect(empty.worst10sFrameP95Ms).toBeNull();
   });
 
-  it('stamps schema version 2 on the payload', () => {
+  it('stamps schema version 3 on the payload', () => {
     const body = payloadFromSnapshot(snapshot(), new Settings(), 'sess1', 42)!;
-    expect(body.schemaVersion).toBe(2);
+    expect(body.schemaVersion).toBe(3);
+  });
+});
+
+describe('perf reporter bottleneck diagnostics (schema 3)', () => {
+  const { payloadFromSnapshot } = perfReporterInternalsForTest;
+
+  function gpuStats(frames: number): NonNullable<NonNullable<PerfSnapshot['renderer']>['gpu']> {
+    return {
+      frames,
+      frameAvgMs: 6.2,
+      frameP50Ms: 5.8,
+      frameP95Ms: 11.4,
+      frameMaxMs: 21.9,
+      sections: [
+        { label: 'scene', avgMs: 4.1, p95Ms: 8.2, samples: frames },
+        { label: 'post', avgMs: 2.1, p95Ms: 3.4, samples: frames },
+      ],
+      disjoints: 1,
+      starvedFrames: 2,
+    };
+  }
+
+  it('maps the diagnostics snapshot fields onto the flat v3 payload', () => {
+    const snap = snapshot();
+    snap.renderer!.gpu = gpuStats(120);
+    snap.renderer!.gpuTimerSupported = true;
+    const body = payloadFromSnapshot(snap, new Settings(), 'sess1', 42)!;
+    expect(body.gpuFrameP50Ms).toBe(5.8);
+    expect(body.gpuFrameP95Ms).toBe(11.4);
+    expect(body.gpuTimerSupported).toBe(true);
+    expect(body.angleBackend).toBe('metal');
+    expect(body.parallelCompile).toBe(true);
+    expect(body.programsPostPrewarm).toBe(4);
+    expect(body.bottleneck).toBe('balanced');
+    expect(body.bottleneckConfidence).toBe('high');
+    // The per-section GPU spans ride the nested raw summary, beside the CPU
+    // phase spans, never as flat fleet dimensions.
+    expect(
+      (body.rawSummary as { rendererGpuSections?: Array<{ label: string; avgMs: number }> })
+        .rendererGpuSections,
+    ).toEqual([
+      { label: 'scene', avgMs: 4.1, p95Ms: 8.2, samples: 120 },
+      { label: 'post', avgMs: 2.1, p95Ms: 3.4, samples: 120 },
+    ]);
+  });
+
+  it('nulls the gpu percentiles when the renderer has no gpu timer stats', () => {
+    // The base fixture carries gpu: null, gpuTimerSupported: false.
+    const body = payloadFromSnapshot(snapshot(), new Settings(), 'sess1', 42)!;
+    expect(body.gpuFrameP50Ms).toBeNull();
+    expect(body.gpuFrameP95Ms).toBeNull();
+    expect(body.gpuTimerSupported).toBe(false);
+    expect((body.rawSummary as { rendererGpuSections?: unknown }).rendererGpuSections).toBeNull();
+  });
+
+  it('nulls the gpu percentiles below the 30 resolved-frame floor and ships them at it', () => {
+    const below = snapshot();
+    below.renderer!.gpu = gpuStats(29);
+    const belowBody = payloadFromSnapshot(below, new Settings(), 'sess1', 42)!;
+    expect(belowBody.gpuFrameP50Ms).toBeNull();
+    expect(belowBody.gpuFrameP95Ms).toBeNull();
+    // The sections still ride the raw summary: context, not a percentile claim.
+    expect(
+      (belowBody.rawSummary as { rendererGpuSections?: unknown[] }).rendererGpuSections,
+    ).toHaveLength(2);
+
+    const atFloor = snapshot();
+    atFloor.renderer!.gpu = gpuStats(30);
+    const atFloorBody = payloadFromSnapshot(atFloor, new Settings(), 'sess1', 42)!;
+    expect(atFloorBody.gpuFrameP50Ms).toBe(5.8);
+    expect(atFloorBody.gpuFrameP95Ms).toBe(11.4);
+  });
+
+  it('nulls the verdict and program fields when the snapshot carries none', () => {
+    const snap = snapshot();
+    snap.bottleneck = null;
+    snap.programsLinkedPostPrewarm = null;
+    const body = payloadFromSnapshot(snap, new Settings(), 'sess1', 42)!;
+    expect(body.bottleneck).toBeNull();
+    expect(body.bottleneckConfidence).toBeNull();
+    expect(body.programsPostPrewarm).toBeNull();
+  });
+
+  it('never ships the dev-only bottleneck detail prose', () => {
+    const snap = snapshot();
+    const detail = snap.bottleneck!.detail;
+    expect(detail).toBe('frame p95 19ms within target 16.7ms');
+    const body = payloadFromSnapshot(snap, new Settings(), 'sess1', 42)!;
+    expect(JSON.stringify(body)).not.toContain(detail);
+    expect(body).not.toHaveProperty('bottleneckDetail');
   });
 });
 


### PR DESCRIPTION
## Summary

Windows clients are our worst performers and today the only fleet signal is "low fps". This PR adds the missing measurement layer so a slow session says WHICH resource it starved on, locally and in fleet telemetry:

- **Real GPU frame timing** (`src/render/gpu_timer_core.ts` + `gpu_timer.ts`): `EXT_disjoint_timer_query_webgl2` as a pooled query ring, split per post pass by zero-draw marker passes in the composer (scene / bloom / grade / screenfx / smaa). Disjoint events invalidate in-flight frames; pool starvation degrades gracefully; `?gputimer=off` is the kill switch. The scene section includes the shadow pass (no seam exists there); the census remains the tool for shadow share.
- **ANGLE identity** (`src/render/angle_identity_core.ts`): parses the unmasked renderer string into backend (`d3d11`, `vulkan`, `metal`, `warp`, ...), device, and driver version. D3D11 program links are the documented Windows freeze driver (#2571, #2243); now d3d11 sessions are separable in fleet queries.
- **Bottleneck verdict** (`src/render/bottleneck_core.ts`): fuses GPU ms, CPU buckets, submit stalls, post-prewarm program growth (new 1 Hz tracker in `src/game/perf.ts`), and the governor's external-frame-cap classification into one verdict: `compile-stalls | vsync-capped | balanced | gpu-bound | render-cpu-bound | cpu-main-bound | unknown`, with confidence. Compile stalls outrank throughput verdicts by design.
- **Fleet beacon schema v3** (`src/game/perf_reporter.ts`, `server/perf_report.ts`, `server/db.ts`): ships `gpuFrameP50Ms`, `gpuFrameP95Ms`, `gpuTimerSupported`, `angleBackend`, `parallelCompile`, `programsPostPrewarm`, `bottleneck`, `bottleneckConfidence` into `client_perf_reports` (additive nullable columns; pre-v3 rows read NULL). Server allowlists follow the suggestion-id deliberate-copy pattern, pinned by `tests/bottleneck_verdict_parity.test.ts`. The verdict detail prose never leaves the client.
- **Windows lab tooling** (`scripts/profiler/system_sampler_win.mjs`, `scripts/perf_diagnose.mjs`): the profiler's system sampler now works on Windows (nvidia-smi, typeperf GPU Engine fallback, PowerShell CIM process tree), and `npm run perf:diagnose` is a one-command local diagnosis: fixed idle-plus-walk scenario, frame stats, per-pass GPU table, program growth, verdict, JSON report under `tmp/perf_diagnose/`.

First live run on a Windows machine (Intel UHD, Chrome ANGLE/D3D11) produced this `?perf` overlay during town entry:

```
gpu 119.21ms p95 155.21 (scene 111.54 bloom 1.27 grade 1.89 screenfx 0.04 smaa 4.47) dj 0
verdict compile-stalls (high): 18 programs linked mid-window, long task p95 454ms
prog post-prewarm +26  backend d3d11  pcompile y
```

which is exactly the storm signature #2571 describes, now visible without a dev build.

## Related issues

Part of the #2571 / #2243 / #2445 diagnosis story (tooling, no behavior change to any fix).

## Type of change

- [x] Feature: new functionality
- [x] Tests
- [x] Build, CI, or tooling

## How was this tested?

- Commands: `npx tsc --noEmit` (clean); `npx vitest run` over `gpu_timer_core`, `angle_identity_core`, `bottleneck_core`, `bottleneck_verdict_parity`, `perf_monitor`, `perf_reporter`, `perf_report`, `perf_suggestion_id_parity`, `schema_wiring`, `db_retention_prune`, `client_perf_reports_db_integration` (135 tests, all green; the DB integration suite ran against a real Postgres 16 via `TEST_DATABASE_URL`, covering the new column roundtrip and legacy-row NULL reads). Changed files pass `biome check`.
- Manual steps: entered the offline world on a Windows 11 machine (Chrome, ANGLE/D3D11 on Intel UHD) with `?perf&gfx=high`: GPU section timings live, zero disjoints, verdict and backend lines correct; `?gputimer=off` falls back cleanly ("gpu timer unsupported" line, verdict still computed from CPU-side signals); world entry verified with the timer on and off. `scripts/profiler/system_sampler_win.mjs` produced live nvidia-smi points on the same machine.
- Known Windows-only caveat: `tests/architecture.test.ts` has a pre-existing path-separator failure on Windows checkouts (forward-slash literals vs `path.relative`); unrelated to this diff and green on Linux CI. Follow-up planned.

## Screenshots / recordings

Dev-only `?perf` overlay lines (English by the perf-overlay carve-out); no player-facing UI changed. Overlay sample included in the summary above.

## Checklist

### Quality

- [x] Decisive tests added for every new core and every beacon/server field; commands above. Full `npm run gate` deferred to CI on this Windows machine (see caveat above).

### Cross-platform

- [x] N/A for HUD layout: no player-facing UI changed. Overlay verified on desktop; the GPU timer no-ops where the extension is absent (Firefox, Safari, most mobile), pinned by the probe fallback path.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings (dev `?perf` overlay is the documented English carve-out; server fields are tokens, not prose).

### Hygiene

- [x] No secrets, credentials, or `.env` committed; no generated files hand-edited.

---

Generated with [Claude Code](https://claude.com/claude-code)
