### PR TITLE
fix(sim): let the Wildheart chain pull reach the whole basin

### DIFF
--- a/docs/prd/wildheart-basin-open-field-dungeon.md
+++ b/docs/prd/wildheart-basin-open-field-dungeon.md
@@ -303,6 +303,17 @@ mobs anchor their leash on the puller rather than on where they stood, because t
 reaching the shrine. Draws no rng, so the parity goldens are unaffected. Implementation in
 `src/sim/instances/boss_chain_pull.ts`, pinned by `tests/wildheart_boss_chain_pull.test.ts`.
 
+The puller-anchored leash alone was not enough, and shipping it alone left the mechanic working only
+near the shrine: a mob woken 170 yards away starts outside that same 70-yard sphere, so the leash
+prelude evaded it home on its first engaged tick and thirteen of the nineteen never took a step. A
+pulled mob now also carries a transit grace (`Entity.chainPullInbound`, `src/sim/mob/chain_pull_transit.ts`)
+that suspends the SOFT leash while it crosses and spends itself the moment the mob reaches the
+sphere, after which the ordinary leash governs from the pull point. The hard tether and the
+unreachable-target stall are untouched, so a mob pinned by geometry still evades on the normal
+clock. One deliberate consequence: a group that pulls and immediately runs is chased rather than
+leashed, since a mob kited away from the pull point never reaches the sphere that would spend its
+grace. That stays bounded by the instance, because the exit portal and a wipe both scrub the pull.
+
 Zulgar drops three new epic weapons: Wildheart Tuskblade, Hexwood Staff of the Basin, and
 Fangknife of Zulgar.
 

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -1319,6 +1319,7 @@ function blankEntity(id: number): Entity {
     leashAnchor: null,
     evadeStall: 0,
     chaseStall: 0,
+    chainPullInbound: false,
     fleeTimer: 0,
     fleeReturnTimer: 0,
     hasFled: false,

--- a/src/sim/entity.ts
+++ b/src/sim/entity.ts
@@ -176,6 +176,7 @@ function baseEntity(id: number, pos: Vec3): Entity {
     leashAnchor: null,
     evadeStall: 0,
     chaseStall: 0,
+    chainPullInbound: false,
     fleeTimer: 0,
     fleeReturnTimer: 0,
     hasFled: false,

--- a/src/sim/instances/boss_chain_pull.ts
+++ b/src/sim/instances/boss_chain_pull.ts
@@ -16,7 +16,9 @@
 // already set, and it draws NO rng, so the shared draw order (and the parity
 // goldens) are untouched. Runs once per boss pull: aggroMob early-returns for a
 // boss already in chase/attack, and re-arms if the boss evades and resets.
+
 import { DUNGEONS, MOBS } from '../data';
+import { markChainPullInbound } from '../mob/chain_pull_transit';
 import type { SimContext } from '../sim_context';
 import { addThreat } from '../threat';
 import type { Entity } from '../types';
@@ -60,10 +62,17 @@ export function chainPullInstanceOnBossAggro(
     // DUNGEON_LEASH_DISTANCE is 70, so a mob anchored where it stood would run
     // 70 yards, hit its leash, and evade home without ever reaching the fight,
     // which would quietly turn the whole mechanic into a no-op for the far half
-    // of the dungeon. Anchoring on the puller lets every pulled mob arrive while
-    // still keeping a real leash: it can be dragged 70 yards from the pull
-    // point, so the group cannot walk the dungeon out through the door.
+    // of the dungeon. Anchoring on the puller keeps a real leash around the
+    // FIGHT: once a mob has arrived it can be dragged 70 yards from the pull
+    // point and no further, so the group cannot walk the dungeon out the door.
+    //
+    // The anchor alone is not enough, and shipping it alone is what broke this
+    // mechanic past the shrine: a mob that starts 170 yards from the puller is
+    // already outside that same sphere, so the leash prelude evaded it home on
+    // its first engaged tick. The inbound flag suspends the soft leash for the
+    // crossing and spends itself on arrival (mob/chain_pull_transit.ts).
     mob.leashAnchor = { ...target.pos };
+    markChainPullInbound(mob);
     addThreat(mob, target.id, 1); // seed the hate table, as aggroMob does
     pulled++;
   }

--- a/src/sim/mob/chain_pull_transit.ts
+++ b/src/sim/mob/chain_pull_transit.ts
@@ -1,0 +1,78 @@
+// The transit grace for a chain-pulled mob, the second half of the
+// premature-boss-pull punish (instances/boss_chain_pull.ts).
+//
+// The pull anchors every woken mob's leash on the PULLER, so that after the
+// fight starts the group can drag them 70 yards and no further. That anchor is
+// right for the fight and wrong for the journey: a mob answering the call from
+// the far end of a ~180-yard instance begins already outside its own
+// DUNGEON_LEASH_DISTANCE sphere, and the leash prelude in combat_profile.ts
+// evades it home on its very first engaged tick, before it takes a step. That
+// silently reduced "the whole basin comes for you" to "the packs within 70
+// yards of the shrine come for you".
+//
+// So a pulled mob carries an inbound flag that SUSPENDS the soft leash while it
+// crosses. The flag is self-clearing on arrival rather than on a timer: the
+// moment the mob is inside the leash sphere it is where the pull wanted it, the
+// grace is spent, and the ordinary leash governs from that same anchor. This is
+// the shape the flee-recovery grace (fleeReturnTimer) already uses one branch
+// above, including its one-yard hysteresis, so an arriving mob cannot clear on
+// the boundary and break on the next tick.
+//
+// Deliberately narrow: it holds ONLY the soft leash. The hard tether
+// (MobTemplate.hardLeashRadius) is checked first and measures from the spawn,
+// and the unreachable-target stall (reachability.ts) still runs as a postlude,
+// so a chain-pulled mob pinned by geometry evades home on the normal five-second
+// clock instead of chasing forever.
+//
+// The one deliberate consequence: a group that pulls and immediately runs is
+// chased instead of leashed, because a mob kited AWAY from the pull point never
+// reaches the sphere that would spend its grace. That is the punish working as
+// written, and it stays bounded by the instance, not by the leash: leaving
+// through the exit portal scrubs the leaver from every inside hate table
+// (instances/dungeons.ts), and a wipe drops the pull the same way, so both outs
+// cost the group the attempt.
+//
+// Pure entity-state, draws NO rng: the parity goldens are untouched.
+import { dist2d, type Entity, type Vec3 } from '../types';
+
+// Matches the flee-recovery grace's clearance test (combat_profile.ts): arrival
+// registers one yard INSIDE the leash edge, so the tick that spends the grace
+// can never be a tick that would also break it.
+export const CHAIN_PULL_ARRIVAL_MARGIN = 1;
+
+/** Arm the transit grace: this mob was woken by a chain pull and has to cross. */
+export function markChainPullInbound(mob: Entity): void {
+  mob.chainPullInbound = true;
+}
+
+/**
+ * Drop the grace, at the two seams that end a pull: startEvadeHome
+ * (combat_profile.ts) and the bulk resets (resetEvadingMob in locomotion.ts,
+ * respawnMob in lifecycle.ts) clear it directly alongside chaseStall.
+ *
+ * The third evade entry, retargetMob (targeting.ts), deliberately does not:
+ * that module is a verbatim move held byte-identical for the parity trace, and
+ * the flag is inert on its path anyway. A mob it sends to 'evade' consults no
+ * leash while walking home, aggroMob refuses to re-pull anything already in
+ * 'evade', and resetEvadingMob clears the flag when it arrives.
+ */
+export function clearChainPullInbound(mob: Entity): void {
+  mob.chainPullInbound = false;
+}
+
+/**
+ * Is this mob still crossing to its pull point, and therefore exempt from the
+ * soft leash for this tick?
+ *
+ * Spends the grace (clearing the flag) on the tick the mob first reaches the
+ * leash sphere, so the answer is false from then on and the leash is live.
+ * False for any mob that was never chain-pulled.
+ */
+export function chainPullTransitHoldsLeash(mob: Entity, leashAnchor: Vec3, leash: number): boolean {
+  if (!mob.chainPullInbound) return false;
+  if (dist2d(mob.pos, leashAnchor) <= leash - CHAIN_PULL_ARRIVAL_MARGIN) {
+    mob.chainPullInbound = false;
+    return false;
+  }
+  return true;
+}

--- a/src/sim/mob/combat_profile.ts
+++ b/src/sim/mob/combat_profile.ts
@@ -11,6 +11,7 @@ import {
   LEASH_DISTANCE,
   steadyAngleTo,
 } from '../types';
+import { chainPullTransitHoldsLeash, clearChainPullInbound } from './chain_pull_transit';
 import { NYTHRAXIS_SPIRIT_MENDING_CAST_ID } from './healer_channel';
 import { chaseStalledUnreachable } from './reachability';
 import { retargetMob, updateMobTarget } from './targeting';
@@ -31,6 +32,7 @@ function startEvadeHome(mob: Entity): void {
   mob.aggroTargetId = null;
   clearThreat(mob);
   mob.leashAnchor = null;
+  clearChainPullInbound(mob);
   mob.castingAbility = null;
   mob.castTotal = 0;
   mob.castRemaining = 0;
@@ -98,7 +100,16 @@ export function updateMobCombatProfile(
       mob.fleeReturnTimer = Math.max(0, mob.fleeReturnTimer - DT);
       if (dist2d(mob.pos, leashAnchor) <= leash - 1) mob.fleeReturnTimer = 0;
     }
-    if (dist2d(mob.pos, leashAnchor) > leash && mob.fleeReturnTimer <= 0) {
+    // A chain-pulled mob answering the call from the far end of the instance
+    // starts OUTSIDE its own leash sphere by design (the pull anchors it on the
+    // puller), so the soft leash is suspended until it arrives. Evaluated
+    // unconditionally, like the flee grace above: the call is what SPENDS the
+    // grace on the arrival tick, so short-circuiting it past the distance test
+    // would leave an arrived mob permanently unleashed. It holds nothing else,
+    // so the hard tether above and the stall postlude below still apply. See
+    // mob/chain_pull_transit.ts.
+    const inTransit = chainPullTransitHoldsLeash(mob, leashAnchor, leash);
+    if (dist2d(mob.pos, leashAnchor) > leash && mob.fleeReturnTimer <= 0 && !inTransit) {
       startEvadeHome(mob);
       return 'done';
     }

--- a/src/sim/mob/lifecycle.ts
+++ b/src/sim/mob/lifecycle.ts
@@ -68,6 +68,7 @@ export function respawnMob(ctx: SimContext, mob: Entity): void {
   mob.leashAnchor = null;
   mob.evadeStall = 0;
   mob.chaseStall = 0;
+  mob.chainPullInbound = false;
   mob.fleeTimer = 0;
   mob.fleeReturnTimer = 0;
   mob.hasFled = false;

--- a/src/sim/mob/locomotion.ts
+++ b/src/sim/mob/locomotion.ts
@@ -1017,6 +1017,7 @@ export function resetEvadingMob(ctx: SimContext, mob: Entity): void {
   mob.leashAnchor = null;
   mob.evadeStall = 0;
   mob.chaseStall = 0;
+  mob.chainPullInbound = false;
   mob.fleeTimer = 0;
   mob.fleeReturnTimer = 0;
   mob.hasFled = false;

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -3399,6 +3399,7 @@ export interface Entity extends ClientMirroredEntityFields {
   leashAnchor: Vec3 | null; // refreshed by hostile player/pet actions; spawnPos remains the true home
   evadeStall: number; // seconds an evading mob has failed to get closer to home; snaps it home if it can't path back (e.g. across water)
   chaseStall: number; // seconds an engaged mob has been pinned unable to close on its target; at CHASE_STALL_TIMEOUT (mob/reachability.ts) it evades home like a leash break
+  chainPullInbound: boolean; // woken by a boss chain pull and still crossing to the puller; suspends the soft leash until it arrives (mob/chain_pull_transit.ts)
   fleeTimer: number; // seconds left in a low-HP panic flee; counts down in the 'flee' state
   fleeReturnTimer: number; // grace after a panic flee hits leash edge, letting it run back before normal leash reset resumes
   hasFled: boolean; // a cowardly mob flees only once per pull; cleared when it resets at spawn

--- a/tests/wildheart_boss_chain_pull.test.ts
+++ b/tests/wildheart_boss_chain_pull.test.ts
@@ -7,10 +7,17 @@
 // still alive sends the whole instance at the puller at once.
 
 import { describe, expect, it } from 'vitest';
-import { BUILTIN_WORLD, DUNGEONS } from '../src/sim/data';
+import { BUILTIN_WORLD, DUNGEONS, MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
 import { enterDungeon } from '../src/sim/instances/dungeons';
+import {
+  CHAIN_PULL_ARRIVAL_MARGIN,
+  chainPullTransitHoldsLeash,
+  clearChainPullInbound,
+  markChainPullInbound,
+} from '../src/sim/mob/chain_pull_transit';
 import { type InstanceSlot, Sim } from '../src/sim/sim';
-import type { Entity, WorldContent } from '../src/sim/types';
+import { DUNGEON_LEASH_DISTANCE, dist2d, type Entity, type WorldContent } from '../src/sim/types';
 
 const WILDHEART_TEST_WORLD: WorldContent = {
   ...BUILTIN_WORLD,
@@ -47,6 +54,25 @@ function claim(dungeonId: string, finalBossId: string): Claimed {
   return { sim, instance, player, boss, others: mobs.filter((m) => m.id !== boss.id) };
 }
 
+// Stand the puller at the shrine, where a group that ran the route past every
+// pack actually pulls Zulgar from. claim() leaves the player at the entrance
+// ~210 yards away, which is not where this mechanic is exercised in play.
+function standAtShrine(sim: Sim, player: Entity, boss: Entity): void {
+  player.pos = sim.ctx.groundPos(boss.pos.x, boss.pos.z - 8);
+  player.prevPos = { ...player.pos };
+  sim.ctx.rebucket(player);
+}
+
+// Run the pull forward with a puller who cannot die (devGod nulls incoming
+// damage in combat/damage.ts). Nineteen level-20 mobs delete the reference
+// warrior in a couple of swings, and a dead puller ends the pull through the
+// normal threat-scrub path, which would mask what is actually under test:
+// whether the pulled mobs stay pulled long enough to cross the basin.
+function tickWithImmortalPuller(sim: Sim, player: Entity, ticks: number): void {
+  player.devGod = true;
+  for (let i = 0; i < ticks; i++) sim.tick();
+}
+
 describe('Wildheart Basin premature boss pull', () => {
   it('opts in through content, not through a hardcoded dungeon id in sim logic', () => {
     expect(DUNGEONS.wildheart_basin.bossChainPull).toBe(true);
@@ -74,9 +100,69 @@ describe('Wildheart Basin premature boss pull', () => {
       expect(mob.threat.get(player.id), mob.templateId).toBeGreaterThan(0);
       // Leash anchored on the PULLER, not where the mob stood: the route is
       // ~180 yards end to end against a 70-yard dungeon leash, so a
-      // self-anchored mob would evade home before reaching the shrine and the
-      // mechanic would silently do nothing for the far half of the dungeon.
+      // self-anchored mob would run 70 yards, hit its leash and evade home
+      // without ever reaching the shrine. The anchor governs the FIGHT; the
+      // inbound flag below is what gets the mob there (chain_pull_transit.ts).
       expect(mob.leashAnchor, mob.templateId).toEqual({ ...player.pos });
+      expect(mob.chainPullInbound, mob.templateId).toBe(true);
+    }
+  });
+
+  // The regression this file exists to hold. Flipping every mob to 'chase' is
+  // only half the mechanic: the pulled mob then has to survive its own leash
+  // check long enough to cross the basin. The pull anchors the leash on the
+  // PULLER, and DUNGEON_LEASH_DISTANCE is 70 against a ~180-yard route, so
+  // every mob further out than 70 yards started the fight already outside its
+  // own leash sphere and evaded home on its first engaged tick. Thirteen of the
+  // nineteen never took a step, which read in play as the mechanic only working
+  // near the shrine.
+  it('holds the pull while a far mob is still crossing the basin', () => {
+    const { sim, player, boss, others } = claim('wildheart_basin', 'wildheart_high_priest');
+    standAtShrine(sim, player, boss);
+    const far = others.filter((m) => dist2d(m.pos, player.pos) > DUNGEON_LEASH_DISTANCE);
+    // The authored route really does put most of the roster out past the leash.
+    expect(far.length).toBeGreaterThan(10);
+
+    sim.aggroMob(boss, player, false);
+    tickWithImmortalPuller(sim, player, 1);
+
+    for (const mob of far) {
+      expect(mob.aiState, `${mob.templateId} ${mob.id}`).not.toBe('evade');
+      expect(mob.aggroTargetId, `${mob.templateId} ${mob.id}`).toBe(player.id);
+    }
+  });
+
+  it('lands every pulled mob on the puller, from the entrance packs to the shrine', () => {
+    const { sim, player, boss, others } = claim('wildheart_basin', 'wildheart_high_priest');
+    standAtShrine(sim, player, boss);
+
+    sim.aggroMob(boss, player, false);
+    // 170 yards at chase speed is about 23 seconds; 60 leaves real headroom.
+    tickWithImmortalPuller(sim, player, 20 * 60);
+
+    for (const mob of others) {
+      expect(mob.aiState, `${mob.templateId} ${mob.id}`).toBe('attack');
+      expect(mob.aggroTargetId, `${mob.templateId} ${mob.id}`).toBe(player.id);
+    }
+  });
+
+  it('re-arms the leash once an arriving mob reaches the pull point', () => {
+    const { sim, player, boss, others } = claim('wildheart_basin', 'wildheart_high_priest');
+    standAtShrine(sim, player, boss);
+    const pullPoint = { ...player.pos };
+
+    sim.aggroMob(boss, player, false);
+    tickWithImmortalPuller(sim, player, 20 * 60);
+
+    // Arrived means anchored again: the transit grace is spent and the leash is
+    // live from the pull point, so the group still cannot walk the instance out
+    // through the door one pack at a time.
+    for (const mob of others) {
+      expect(mob.chainPullInbound, `${mob.templateId} ${mob.id}`).toBe(false);
+      expect(mob.leashAnchor, `${mob.templateId} ${mob.id}`).toEqual(pullPoint);
+      expect(dist2d(mob.pos, pullPoint), `${mob.templateId} ${mob.id}`).toBeLessThanOrEqual(
+        DUNGEON_LEASH_DISTANCE,
+      );
     }
   });
 
@@ -126,5 +212,63 @@ describe('Wildheart Basin premature boss pull', () => {
     sim.aggroMob(boss, player, false);
     sim.rng.setObserver(null);
     expect(draws).toBe(0);
+  });
+});
+
+// The transit grace on its own, away from a live instance: the predicate the
+// leash prelude consults every engaged tick.
+describe('chain-pull transit grace', () => {
+  const ANCHOR = { x: 0, y: 0, z: 0 };
+  const LEASH = DUNGEON_LEASH_DISTANCE;
+
+  function mobAt(z: number): Entity {
+    const mob = createMob(1, MOBS.wildheart_ravager, 20, { x: 0, y: 0, z });
+    return mob;
+  }
+
+  it('holds nothing for a mob that was never chain-pulled', () => {
+    // The far-away mob is the interesting case: without the flag it must still
+    // read as leash-broken, or the grace would exempt every dragged pull.
+    const mob = mobAt(150);
+    expect(chainPullTransitHoldsLeash(mob, ANCHOR, LEASH)).toBe(false);
+    expect(mob.chainPullInbound).toBe(false);
+  });
+
+  it('holds the leash while the mob is still outside the sphere', () => {
+    const mob = mobAt(150);
+    markChainPullInbound(mob);
+    expect(chainPullTransitHoldsLeash(mob, ANCHOR, LEASH)).toBe(true);
+    expect(mob.chainPullInbound).toBe(true);
+  });
+
+  it('spends the grace on the tick the mob reaches the sphere', () => {
+    const mob = mobAt(LEASH - CHAIN_PULL_ARRIVAL_MARGIN);
+    markChainPullInbound(mob);
+    expect(chainPullTransitHoldsLeash(mob, ANCHOR, LEASH)).toBe(false);
+    expect(mob.chainPullInbound).toBe(false);
+  });
+
+  it('clears one yard inside the edge, so arrival and a leash break never collide', () => {
+    // Between leash - MARGIN and leash the mob is still inbound but is not far
+    // enough out to break either, which is the whole point of the hysteresis.
+    const mob = mobAt(LEASH - CHAIN_PULL_ARRIVAL_MARGIN + 0.5);
+    markChainPullInbound(mob);
+    expect(chainPullTransitHoldsLeash(mob, ANCHOR, LEASH)).toBe(true);
+    expect(mob.chainPullInbound).toBe(true);
+  });
+
+  it('does not re-arm when an arrived mob is dragged back out', () => {
+    const mob = mobAt(0);
+    markChainPullInbound(mob);
+    expect(chainPullTransitHoldsLeash(mob, ANCHOR, LEASH)).toBe(false);
+    mob.pos = { x: 0, y: 0, z: LEASH + 40 };
+    expect(chainPullTransitHoldsLeash(mob, ANCHOR, LEASH)).toBe(false);
+  });
+
+  it('clears on the shared pull-over reset', () => {
+    const mob = mobAt(150);
+    markChainPullInbound(mob);
+    clearChainPullInbound(mob);
+    expect(chainPullTransitHoldsLeash(mob, ANCHOR, LEASH)).toBe(false);
   });
 });


### PR DESCRIPTION
The Wildheart Basin's premature-boss-pull punish (`DungeonDef.bossChainPull`, #2645) only worked
near the shrine. Pulling Zulgar with the route still standing woke all 19 remaining mobs, and then
13 of them evaded home on the very next tick without taking a step.

## Cause

The pull anchors each woken mob's leash on the PULLER, so that once the fight starts the group can
drag them 70 yards and no further. That anchor is right for the fight and wrong for the journey.
`DUNGEON_LEASH_DISTANCE` is 70 and the basin's route is about 180 yards end to end, so a mob woken
at the entrance packs starts 170 yards from its own leash anchor: already outside its own sphere.
The leash prelude in `mob/combat_profile.ts` therefore evaded it home on its first engaged tick.

Measured on the real instance, puller standing at the shrine (headless, `seed 91`):

| | before | after |
|---|---|---|
| woken by the pull | 19 / 19 | 19 / 19 |
| still engaged one tick later | 6 | 19 |
| reached the puller | 6 | 19 |

The six survivors are exactly the upper-convergence packs inside 70 yards of the shrine, which is
what this read as in play.

## Fix

A pulled mob now carries a transit grace (`Entity.chainPullInbound`, new module
`src/sim/mob/chain_pull_transit.ts`) that suspends the SOFT leash while it crosses. The flag is
self-clearing on arrival rather than on a timer: the moment the mob is inside the leash sphere it
is where the pull wanted it, the grace is spent, and the ordinary leash governs from that same
anchor, so the group still cannot walk the instance out through the door one pack at a time. It
reuses the shape and the one-yard hysteresis of the flee-recovery grace (`fleeReturnTimer`) sitting
one branch above it.

Deliberately narrow: it holds only the soft leash. The hard tether (`hardLeashRadius`) is checked
first and measures from the spawn, and the unreachable-target stall (`mob/reachability.ts`) still
runs as a postlude, so a chain-pulled mob pinned by geometry evades home on the normal 5s clock.

One deliberate consequence, documented in the module and the PRD: a group that pulls and
immediately runs is chased rather than leashed, because a mob kited away from the pull point never
reaches the sphere that would spend its grace. That stays bounded by the instance, since the exit
portal scrubs the leaver from every inside hate table and a wipe drops the pull the same way.

## Scope

Only `bossChainPull` dungeons can ever set the flag, and Wildheart Basin is still the only one.
Every other mob in the game reads `chainPullInbound === false` and takes the identical branch it
took before. The change draws no rng.

## Tests

`tests/wildheart_boss_chain_pull.test.ts`, 15 tests (6 new, all verified to fail without the fix):

- the far packs are not evaded one tick after the pull
- all 19 cross the basin and reach the puller from the entrance packs to the shrine
- an arrived mob has spent its grace and is anchored at the pull point inside the leash
- the grace holds nothing for a mob that was never chain-pulled (the dragged-pull case)
- it spends on the arrival tick, clears one yard inside the edge, and does not re-arm when an
  arrived mob is dragged back out

Verification: `npm run gate` green (full suite, tsc, changed-files biome, all builds). The parity
golden-trace gate is green with no re-mint, as expected for a change that draws no rng.
