### PR TITLE
fix(render): scope the dynamic-resolution region to the scene pass

### DIFF
--- a/src/render/post.ts
+++ b/src/render/post.ts
@@ -1,6 +1,5 @@
 import type { N8AOPass } from 'n8ao';
 import * as THREE from 'three';
-import { RenderPass } from 'three/examples/jsm/postprocessing/RenderPass.js';
 import { ShaderPass } from 'three/examples/jsm/postprocessing/ShaderPass.js';
 import { SMAAPass } from 'three/examples/jsm/postprocessing/SMAAPass.js';
 import type { UnrealBloomPass } from 'three/examples/jsm/postprocessing/UnrealBloomPass.js';
@@ -11,6 +10,7 @@ import { PostEffectComposer } from './post_composer';
 import { StaticOpaqueN8AOPass } from './post_n8ao';
 import { OutputGradePass } from './post_output_grade';
 import { postPipelinePlan } from './post_plan_core';
+import { RegionRenderPass } from './post_region_render_pass';
 import { renderLayerDisabled } from './render_dev_flags';
 
 // Post chain: N8AO (high: half-res Low, ultra+insane: full-res Medium)
@@ -161,6 +161,9 @@ export function buildComposer(
   });
   const composer = new PostEffectComposer(webgl, target, width, height, plan.singleComposerBuffer);
 
+  // The scene pass owns the dynamic-resolution region (see post_region_render_pass.ts):
+  // scoping it to this one draw is what keeps every later pass full-extent.
+  let scenePass: RegionRenderPass | null = null;
   let ao: N8AOPass | null = null;
   if (plan.scene.pass === 'n8ao') {
     // N8AOPass replaces RenderPass. A separate scene pass would be discarded.
@@ -198,7 +201,8 @@ export function buildComposer(
     }
     composer.addPass(ao);
   } else {
-    composer.addPass(new RenderPass(scene, camera));
+    scenePass = new RegionRenderPass(scene, camera);
+    composer.addPass(scenePass);
   }
 
   let bloom: UnrealBloomPass | null = null;
@@ -257,13 +261,21 @@ export function buildComposer(
       // logical aspect, not the drawing-buffer extent.
       aspect = width / Math.max(1, height);
       if (gradeOnly) {
-        composer.setRenderRegion(composer.renderTarget1.width, composer.renderTarget1.height);
+        if (scenePass) scenePass.region = null;
         grade.setInputUvRect(1, 1, 1, 1);
       }
     },
     setRenderRegion(region: DynamicResolutionRect): void {
       if (!gradeOnly) return;
-      composer.setRenderRegion(region.renderWidth, region.renderHeight);
+      // Region the scene draw only. The grade then reads that sub-rect and
+      // writes its expansion at the destination's FULL extent, so no pass after
+      // it can emit a partial frame.
+      if (scenePass) {
+        scenePass.region =
+          region.renderWidth < region.targetWidth || region.renderHeight < region.targetHeight
+            ? { width: region.renderWidth, height: region.renderHeight }
+            : null;
+      }
       grade.setInputUvRect(region.uvScaleX, region.uvScaleY, region.uvMaxX, region.uvMaxY);
     },
     render(): void {

--- a/src/render/post_composer.ts
+++ b/src/render/post_composer.ts
@@ -50,19 +50,10 @@ export class PostEffectComposer extends EffectComposer {
     for (const pass of this.passes) pass.setSize(effectiveWidth, effectiveHeight);
   }
 
-  setRenderRegion(width: number, height: number): void {
-    const targets =
-      this.renderTarget1 === this.renderTarget2
-        ? [this.renderTarget1]
-        : [this.renderTarget1, this.renderTarget2];
-    for (const target of targets) {
-      const renderWidth = Math.min(target.width, Math.max(1, Math.floor(width)));
-      const renderHeight = Math.min(target.height, Math.max(1, Math.floor(height)));
-      target.viewport.set(0, 0, renderWidth, renderHeight);
-      target.scissor.set(0, 0, renderWidth, renderHeight);
-      target.scissorTest = renderWidth < target.width || renderHeight < target.height;
-    }
-  }
+  // No setRenderRegion here on purpose. Clamping the ping-pong targets regions
+  // every pass that writes to one, not just the scene draw, which strands a
+  // never-written margin for the tail pass to stretch over the canvas. The
+  // region belongs to the scene pass alone (see post_region_render_pass.ts).
 
   override setSize(width: number, height: number): void {
     const state = this as unknown as EffectComposerSizeState;

--- a/src/render/post_region_render_pass.ts
+++ b/src/render/post_region_render_pass.ts
@@ -1,0 +1,69 @@
+import type { WebGLRenderer, WebGLRenderTarget } from 'three';
+import { RenderPass } from 'three/examples/jsm/postprocessing/RenderPass.js';
+
+/**
+ * Scene pass for the dynamic-resolution (grade-only) path.
+ *
+ * Dynamic resolution never reallocates: it keeps full-size composer targets and
+ * shrinks only the rendered region, leaving OutputGradePass to expand that
+ * sub-rect back to full extent through its input uv rect. The region therefore
+ * belongs to the SCENE draw and to nothing else. Any later pass that inherits it
+ * writes a partial image into a full-size target, and the tail pass then stretches
+ * that target (valid sub-rect plus a never-written margin) across the canvas: the
+ * frame lands scaled into one corner with a frozen margin beside it.
+ *
+ * Owning the region here, applied immediately before the scene draw and removed
+ * immediately after, makes that leak unrepresentable. It holds regardless of
+ * EffectComposer ping-pong parity and of whether the screen-fx pass is enabled on
+ * any given frame, both of which change which physical target each later pass
+ * writes to.
+ */
+
+export interface RenderRegionSize {
+  readonly width: number;
+  readonly height: number;
+}
+
+/**
+ * Clamp `target` to `region`, or restore its full extent when `region` is null.
+ * A region at or beyond the target extent clears the scissor test rather than
+ * leaving a full-coverage one armed.
+ */
+export function applyRenderRegion(
+  target: WebGLRenderTarget,
+  region: RenderRegionSize | null,
+): void {
+  const width = region
+    ? Math.min(target.width, Math.max(1, Math.floor(region.width)))
+    : target.width;
+  const height = region
+    ? Math.min(target.height, Math.max(1, Math.floor(region.height)))
+    : target.height;
+  target.viewport.set(0, 0, width, height);
+  target.scissor.set(0, 0, width, height);
+  target.scissorTest = width < target.width || height < target.height;
+}
+
+export class RegionRenderPass extends RenderPass {
+  /** Live render region, or null to draw the scene at the target's full extent. */
+  region: RenderRegionSize | null = null;
+
+  override render(
+    renderer: WebGLRenderer,
+    writeBuffer: WebGLRenderTarget,
+    readBuffer: WebGLRenderTarget,
+    deltaTime: number,
+    maskActive: boolean,
+  ): void {
+    // RenderPass draws into readBuffer; renderToScreen has no target to carry a
+    // region, and the grade pass always follows this one, so it cannot be last.
+    const target = this.renderToScreen ? null : readBuffer;
+    const region = this.region;
+    if (target && region) applyRenderRegion(target, region);
+    try {
+      super.render(renderer, writeBuffer, readBuffer, deltaTime, maskActive);
+    } finally {
+      if (target && region) applyRenderRegion(target, null);
+    }
+  }
+}

--- a/tests/post_composer.test.ts
+++ b/tests/post_composer.test.ts
@@ -62,7 +62,7 @@ describe('post effect composer', () => {
     expect(setSize).toHaveBeenCalledWith(1280, 720);
   });
 
-  it('floors fixed targets and applies a whole-pixel scene region without reallocating', () => {
+  it('floors fixed targets to whole pixels', () => {
     const target = new THREE.WebGLRenderTarget(320, 180, {
       depthBuffer: false,
       samples: 0,
@@ -72,17 +72,35 @@ describe('post effect composer', () => {
     const resizeTarget = vi.spyOn(target, 'setSize');
 
     composer.setSizeAndPixelRatio(641, 361, 1.5);
+
     expect(resizeTarget).toHaveBeenLastCalledWith(961, 541);
+    expect(target.width).toBe(961);
+    expect(target.height).toBe(541);
+  });
 
-    resizeTarget.mockClear();
-    composer.setRenderRegion(640, 360);
-    expect(target.viewport.toArray()).toEqual([0, 0, 640, 360]);
-    expect(target.scissor.toArray()).toEqual([0, 0, 640, 360]);
-    expect(target.scissorTest).toBe(true);
-    expect(resizeTarget).not.toHaveBeenCalled();
+  it('never clamps a ping-pong target to a render region', () => {
+    // The dynamic-resolution region used to be applied here, to every ping-pong
+    // target. That regions every pass that writes to one, not just the scene
+    // draw, so the grade's expansion landed back inside the sub-rect and the tail
+    // pass stretched a never-written margin over the canvas. The region belongs
+    // to the scene pass alone (see post_region_render_pass.ts).
+    const target = new THREE.WebGLRenderTarget(640, 360, {
+      depthBuffer: false,
+      samples: 0,
+      type: THREE.HalfFloatType,
+    });
+    const composer = new PostEffectComposer(rendererStub(), target, 640, 360, false);
 
-    composer.setRenderRegion(961, 541);
-    expect(target.scissorTest).toBe(false);
+    expect('setRenderRegion' in composer).toBe(false);
+    for (const renderTarget of [composer.renderTarget1, composer.renderTarget2]) {
+      expect(renderTarget.scissorTest).toBe(false);
+      expect(renderTarget.viewport.toArray()).toEqual([
+        0,
+        0,
+        renderTarget.width,
+        renderTarget.height,
+      ]);
+    }
   });
 
   it('keeps independent ping-pong targets when a tail pass needs them', () => {

--- a/tests/post_pipeline.test.ts
+++ b/tests/post_pipeline.test.ts
@@ -1,6 +1,7 @@
 import * as THREE from 'three';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { dynamicResolutionRect } from '../src/render/dynamic_resolution_core';
+import type { RegionRenderPass } from '../src/render/post_region_render_pass';
 
 const disabledLayers = new Set<string>();
 const gfxSettings = vi.hoisted(() => ({
@@ -157,7 +158,7 @@ describe('live post pipeline', () => {
     );
 
     expect(post.composer.passes.map((pass) => pass.constructor.name)).toEqual([
-      'RenderPass',
+      'RegionRenderPass',
       'OutputGradePass',
       'ShaderPass',
       'SMAAPass',
@@ -179,9 +180,21 @@ describe('live post pipeline', () => {
       minRenderScale: 0.68,
     });
     post.setRenderRegion(rect);
-    expect(post.composer.renderTarget1.viewport.toArray()).toEqual([0, 0, 960, 540]);
-    expect(post.composer.renderTarget1.scissor.toArray()).toEqual([0, 0, 960, 540]);
-    expect(post.composer.renderTarget1.scissorTest).toBe(true);
+    // The region rides the scene pass, which applies and drops it around its own
+    // draw. Both composer targets therefore stay full-extent, so the grade's
+    // expansion and the tail SMAA pass each cover the whole frame. Regioning the
+    // targets here is what left a frozen margin for SMAA to stretch to the canvas.
+    const scenePass = post.composer.passes[0] as RegionRenderPass;
+    expect(scenePass.region).toEqual({ width: 960, height: 540 });
+    for (const renderTarget of [post.composer.renderTarget1, post.composer.renderTarget2]) {
+      expect(renderTarget.scissorTest).toBe(false);
+      expect(renderTarget.viewport.toArray()).toEqual([
+        0,
+        0,
+        renderTarget.width,
+        renderTarget.height,
+      ]);
+    }
     expect(post.grade.uniforms.uInputUvRect.value.toArray()).toEqual([
       rect.uvScaleX,
       rect.uvScaleY,

--- a/tests/post_region_render_pass.test.ts
+++ b/tests/post_region_render_pass.test.ts
@@ -1,0 +1,145 @@
+import * as THREE from 'three';
+import { describe, expect, it } from 'vitest';
+import { applyRenderRegion, RegionRenderPass } from '../src/render/post_region_render_pass';
+
+function sceneTarget(width = 1280, height = 720): THREE.WebGLRenderTarget {
+  return new THREE.WebGLRenderTarget(width, height, {
+    depthBuffer: true,
+    samples: 0,
+    type: THREE.HalfFloatType,
+  });
+}
+
+/** Minimal stand-in for the members three's RenderPass touches. */
+function rendererStub(onDraw: () => void): THREE.WebGLRenderer {
+  return {
+    autoClear: true,
+    autoClearColor: true,
+    autoClearDepth: true,
+    autoClearStencil: true,
+    setRenderTarget: () => {},
+    clear: () => {},
+    render: () => onDraw(),
+  } as unknown as THREE.WebGLRenderer;
+}
+
+interface DrawSample {
+  viewport: number[];
+  scissor: number[];
+  scissorTest: boolean;
+}
+
+function renderAndSample(
+  pass: RegionRenderPass,
+  target: THREE.WebGLRenderTarget,
+  onDraw: () => void = () => {},
+): DrawSample | null {
+  let during: DrawSample | null = null;
+  const renderer = rendererStub(() => {
+    during = {
+      viewport: target.viewport.toArray(),
+      scissor: target.scissor.toArray(),
+      scissorTest: target.scissorTest,
+    };
+    onDraw();
+  });
+  pass.render(renderer, sceneTarget(), target, 0, false);
+  return during;
+}
+
+describe('applyRenderRegion', () => {
+  it('clamps to whole pixels inside the target and arms the scissor', () => {
+    const target = sceneTarget(961, 541);
+
+    applyRenderRegion(target, { width: 816.7, height: 459.9 });
+
+    expect(target.viewport.toArray()).toEqual([0, 0, 816, 459]);
+    expect(target.scissor.toArray()).toEqual([0, 0, 816, 459]);
+    expect(target.scissorTest).toBe(true);
+  });
+
+  it('restores the full extent and disarms the scissor when the region is null', () => {
+    const target = sceneTarget(961, 541);
+    applyRenderRegion(target, { width: 640, height: 360 });
+
+    applyRenderRegion(target, null);
+
+    expect(target.viewport.toArray()).toEqual([0, 0, 961, 541]);
+    expect(target.scissor.toArray()).toEqual([0, 0, 961, 541]);
+    expect(target.scissorTest).toBe(false);
+  });
+
+  it('never exceeds the target or collapses below one pixel', () => {
+    const target = sceneTarget(640, 360);
+
+    applyRenderRegion(target, { width: 9999, height: 9999 });
+    expect(target.viewport.toArray()).toEqual([0, 0, 640, 360]);
+    expect(target.scissorTest).toBe(false); // full coverage leaves no scissor armed
+
+    applyRenderRegion(target, { width: 0, height: -12 });
+    expect(target.viewport.toArray()).toEqual([0, 0, 1, 1]);
+    expect(target.scissorTest).toBe(true);
+  });
+});
+
+describe('RegionRenderPass', () => {
+  it('clamps the scene target only while the scene draw is in flight', () => {
+    const target = sceneTarget();
+    const pass = new RegionRenderPass(new THREE.Scene(), new THREE.PerspectiveCamera());
+    pass.region = { width: 1088, height: 612 };
+
+    const during = renderAndSample(pass, target);
+
+    expect(during).toEqual({
+      viewport: [0, 0, 1088, 612],
+      scissor: [0, 0, 1088, 612],
+      scissorTest: true,
+    });
+  });
+
+  it('leaves no region behind for a later pass to inherit', () => {
+    // The regression this pass exists for. Dynamic resolution shrinks the scene
+    // draw and lets OutputGradePass expand it again, so every pass after the
+    // scene MUST see a full-extent target. When the region survived the scene
+    // draw (it used to live on the composer's ping-pong targets), the grade wrote
+    // its expansion into the same sub-rect and the tail pass stretched the whole
+    // target, never-written margin included, across the canvas.
+    const target = sceneTarget();
+    const pass = new RegionRenderPass(new THREE.Scene(), new THREE.PerspectiveCamera());
+    pass.region = { width: 1088, height: 612 };
+
+    renderAndSample(pass, target);
+
+    expect(target.viewport.toArray()).toEqual([0, 0, 1280, 720]);
+    expect(target.scissor.toArray()).toEqual([0, 0, 1280, 720]);
+    expect(target.scissorTest).toBe(false);
+  });
+
+  it('restores the full extent even when the scene draw throws', () => {
+    const target = sceneTarget();
+    const pass = new RegionRenderPass(new THREE.Scene(), new THREE.PerspectiveCamera());
+    pass.region = { width: 1088, height: 612 };
+
+    expect(() =>
+      renderAndSample(pass, target, () => {
+        throw new Error('context lost mid-draw');
+      }),
+    ).toThrow('context lost mid-draw');
+
+    expect(target.viewport.toArray()).toEqual([0, 0, 1280, 720]);
+    expect(target.scissorTest).toBe(false);
+  });
+
+  it('draws at full extent with no scissor when no region is set', () => {
+    const target = sceneTarget();
+    const pass = new RegionRenderPass(new THREE.Scene(), new THREE.PerspectiveCamera());
+
+    const during = renderAndSample(pass, target);
+
+    expect(during).toEqual({
+      viewport: [0, 0, 1280, 720],
+      scissor: [0, 0, 1280, 720],
+      scissorTest: false,
+    });
+  });
+});


### PR DESCRIPTION
Fixes #2746.

## What is broken

On Medium, once the governor drops the render scale below the ceiling, the world lands
scaled into the bottom-left corner of the viewport and the right and top margins keep a
frozen copy of an older frame. Reproduced on an Apple M4 Pro sitting at 119 FPS and 8.4 ms
frame time, still pinned at 85 percent render scale, so a single streaming hitch is enough
to trigger it and Medium's recovery (`recoverStep: 0.05` gated on `recoverStableSeconds: 7`)
leaves it on screen for 20 seconds or more.

Medium is the only tier with `supportsDynamicResolution` (it is the `gradeOnly` path), so
it is the feature's only live consumer, and it was broken.

## Root cause

Dynamic resolution never reallocates. It keeps full-size composer targets and shrinks only
the rendered region, leaving `OutputGradePass` to expand that sub-rect back to full extent
through its input uv rect. That expansion only lands when the grade renders to the canvas,
via `setRenderTarget(null)` and the full canvas viewport.

`PostEffectComposer.setRenderRegion` clamped the viewport and scissor on BOTH ping-pong
targets. Once tail SMAA was extended to Medium the grade stopped being the terminal pass,
so it wrote its expansion back into the same clamped sub-rect (a one to one copy), and the
SMAA blend then stretched the entire target, never-written margin included, across the
canvas.

The pipeline's own plan already recorded the broken precondition:

```
medium as shipped (gradeOnly + tail SMAA)    singleBuffer=false gradeWrites=composer-a  passes=render>output-grade>smaa
medium with ?smaa=off                        singleBuffer=true  gradeWrites=canvas      passes=render>output-grade
```

### How it got in

Two sibling branches, six minutes apart, neither an ancestor of the other:

- `4feea92e95` "perf(render): replace supersampled edge AA with SMAA" moved SMAA from
  `smaa: tier === 'high'` to medium and above, reasoning that "Medium also uses tail SMAA.
  Its grade target already supplies the post seam."
- `4d862378b9` "perf(render): arm the governor on ultra and give it a real resolution
  lever" added dynamic resolution with the terminal-pass assumption.

`4dfc924c86` combined them with no textual conflict. Every existing test was a source-text
pin or a stub-shape check, so nothing flagged the broken cross-pass contract.

## The fix

The region belongs to the scene draw and to nothing else. `RegionRenderPass` applies it
immediately before that draw and removes it immediately after, so no later pass can inherit
it. `PostEffectComposer.setRenderRegion` is removed.

This matters over narrower fixes: `EffectComposer` swaps buffers after every `needsSwap`
pass and `screenFx` toggles its own `enabled` per frame, so ping-pong parity is not stable.
Regioning only the read buffer, or un-regioning only the grade's write buffer, both leak
whenever a ripple or crit flash is live, which would read as "mostly fixed, flickers during
combat". Scoping the region to the pass makes the leak unrepresentable.

The change is fully contained: `useAo` is always false when `gradeOnly` is true, so the
scene pass on the only path with `supportsDynamicResolution` is always a plain
`RenderPass`. High, ultra and insane are untouched.

## Verification

Real Apple M4 Pro GPU, same hardware as the report. Render frame A red at full scale, then
frame B blue at an 85 percent region, and measure the share of each screen area still
showing frame A:

| mechanism | right margin | top margin | interior |
|---|---|---|---|
| current `main` | 100 percent stale | 100 percent stale | 0.3 percent (SMAA edge bleed) |
| this PR | 0 percent | 0 percent | 0 percent |

Also:

- `npm run gate`: PASS, all 11 steps green.
- New `tests/post_region_render_pass.test.ts` (9 assertions across region clamping and pass
  scoping). Mutation-checked: deleting the restore line fails 2 of them.
- `tests/post_composer.test.ts` and `tests/post_pipeline.test.ts` updated. Both previously
  pinned the defective mechanism (they asserted `renderTarget1.scissorTest` was true), so
  they now pin the opposite: targets stay full-extent and the scene pass carries the region.

## Scope note

This is not v0.33.0-specific. The post pipeline files are byte-identical across `main`,
`release/v0.33.0`, `release/v0.33.1` and `release/v0.34.0`, so all of them carry the bug.
Targeting `main`, which is where `release/v0.33.1` is currently cut from.

## Test plan

- [x] `npm run gate` green
- [x] Real-GPU pixel verification, before and after
- [x] Mutation check on the new regression test
- [ ] Confirm on the dev environment at Medium after deploy: force a governor drop and check
      the right edge of the viewport
