### PR TITLE
fix(sim): scale mastery and talent damage percent over the whole hit

### DIFF
--- a/src/sim/combat/auto_attack.ts
+++ b/src/sim/combat/auto_attack.ts
@@ -34,6 +34,7 @@ import { forceDismount } from '../mounts';
 import { scheduleProjectile } from '../projectile_travel';
 import type { PlayerMeta } from '../sim';
 import type { SimContext } from '../sim_context';
+import { resolveTalentHitMult } from '../talent_hit_mult';
 import { addThreat, hasEscapeStealth } from '../threat';
 import {
   angleTo,
@@ -211,6 +212,12 @@ export function updatePlayerAutoAttack(ctx: SimContext, p: Entity, meta: PlayerM
     let abilityName: string | null = null;
     let threatFlat = 0;
     let threatMult = 1;
+    // The resolved talent/mastery damage multiplier for the queued on-swing
+    // ability (weaponMult, mirroring weaponStrike's own field): meleeSwing
+    // applies it to the WHOLE swing (weapon roll + AP), not just `bonus`, so a
+    // "+X%" mastery/talent reaches the weapon+AP portion of a Heroic Strike /
+    // Raptor Strike style on-next-swing hit too (issue #1803).
+    let weaponMult = 1;
     if (p.queuedOnSwing) {
       const queued = ctx.resolvedAbility(p.queuedOnSwing, p.id);
       if (queued) {
@@ -229,6 +236,7 @@ export function updatePlayerAutoAttack(ctx: SimContext, p: Entity, meta: PlayerM
           abilityName = queued.def.name;
           threatFlat = queued.threatFlat;
           threatMult = queued.threatMult;
+          weaponMult = resolveTalentHitMult(queued.def, ctx.playerMods(meta)).dmgMult;
         }
       }
       p.queuedOnSwing = null;
@@ -239,6 +247,7 @@ export function updatePlayerAutoAttack(ctx: SimContext, p: Entity, meta: PlayerM
       autoAttackHand: 'mainhand',
       threatFlat,
       threatMult,
+      weaponMult,
       whiteDualWieldPenalty: p.dualWielding && abilityName === null,
     });
     // Thuggery mastery (Sword Specialization shape): a landed mainhand auto has

--- a/src/sim/combat/casting_lifecycle.ts
+++ b/src/sim/combat/casting_lifecycle.ts
@@ -39,6 +39,7 @@ import { scheduleProjectile } from '../projectile_travel';
 import type { PlayerMeta, ResolvedAbility } from '../sim';
 import type { SimContext } from '../sim_context';
 import { abilityScalingPower, channelTickBonus } from '../spell_scaling';
+import { resolveTalentHitMult } from '../talent_hit_mult';
 import { hasEscapeStealth } from '../threat';
 import type { AbilityDef, AbilityEffect, Entity, Vec3 } from '../types';
 import {
@@ -355,7 +356,7 @@ export function updateCasting(ctx: SimContext, p: Entity, meta: PlayerMeta): voi
         ctx.applyDemonHealTick(p);
       } else {
         const res = ctx.resolvedAbility(abilityId, p.id);
-        if (res) applyChannelTick(ctx, p, res);
+        if (res) applyChannelTick(ctx, p, meta, res);
       }
     };
     p.channelTickTimer -= DT;
@@ -1345,7 +1346,19 @@ function armAbilityCooldown(
   p.cooldowns.set(abilityId, cooldown);
 }
 
-function applyChannelTick(ctx: SimContext, p: Entity, res: ResolvedAbility): void {
+function applyChannelTick(
+  ctx: SimContext,
+  p: Entity,
+  meta: PlayerMeta,
+  res: ResolvedAbility,
+): void {
+  // The resolved talent/mastery multiplier for this channel (talent_hit_mult.ts):
+  // reused across every branch below so a per-tick SP/AP rider scales with the
+  // same percentage already baked into the tick's base min/max (issue #1803).
+  const { dmgMult: talentDmgMult, healMult: talentHealMult } = resolveTalentHitMult(
+    res.def,
+    ctx.playerMods(meta),
+  );
   // Ground-targeted channels (Rain of Fire / Volley / Hurricane): each tick pulses
   // the ability's aoeDamage at the aimed point (clamped at cast start, held in
   // castAim for the channel's life), independent of any entity target.
@@ -1362,7 +1375,7 @@ function applyChannelTick(ctx: SimContext, p: Entity, res: ResolvedAbility): voi
       radius,
       ability: res.def.id,
     });
-    const channelSp = channelTickBonus(abilityScalingPower(p, res.def), res.def);
+    const channelSp = channelTickBonus(abilityScalingPower(p, res.def), res.def, talentDmgMult);
     // How many enemies this pulse actually struck: Blizzard's Frozen Orb
     // refund (frostMageChannelPulse below) scales with it.
     let struck = 0;
@@ -1409,7 +1422,7 @@ function applyChannelTick(ctx: SimContext, p: Entity, res: ResolvedAbility): voi
   // ground point) and from the single-target channel below.
   if (!res.def.requiresTarget && res.effects.some((eff) => eff.type === 'aoeDamage')) {
     const isSpell = res.def.school !== 'physical';
-    const channelSp = channelTickBonus(abilityScalingPower(p, res.def), res.def);
+    const channelSp = channelTickBonus(abilityScalingPower(p, res.def), res.def, talentDmgMult);
     for (const eff of res.effects) {
       if (eff.type !== 'aoeDamage') continue;
       ctx.emit({
@@ -1478,7 +1491,7 @@ function applyChannelTick(ctx: SimContext, p: Entity, res: ResolvedAbility): voi
   // Self-centered healing channels pulse around the caster's live position on
   // every tick. Instant aoeHeal effects still resolve once through effect_dispatch.
   if (!res.def.requiresTarget && res.effects.some((eff) => eff.type === 'aoeHeal')) {
-    const channelSp = channelTickBonus(abilityScalingPower(p, res.def), res.def);
+    const channelSp = channelTickBonus(abilityScalingPower(p, res.def), res.def, talentHealMult);
     for (const eff of res.effects) {
       if (eff.type !== 'aoeHeal') continue;
       ctx.emit({
@@ -1532,7 +1545,7 @@ function applyChannelTick(ctx: SimContext, p: Entity, res: ResolvedAbility): voi
   // Each channel bolt (e.g. Arcane Missiles) deals its damage on arrival, not on the
   // tick it is fired; a target that dies mid-flight fizzles it (the drain's guard).
   scheduleProjectile(ctx, p, target, (src, tgt) => {
-    const channelSp = channelTickBonus(abilityScalingPower(src, res.def), res.def);
+    const channelSp = channelTickBonus(abilityScalingPower(src, res.def), res.def, talentDmgMult);
     // Aether Darts: the FIRST landed missile consumes the caster's Arcane Charges
     // and locks a flat per-missile Arcane bonus (combat/chronomancy.ts); later
     // missiles reuse it. It is plain Arcane damage, so Temporal Echo heals from it

--- a/src/sim/combat/effect_dispatch.ts
+++ b/src/sim/combat/effect_dispatch.ts
@@ -1641,15 +1641,17 @@ export function runEffects(
         // hop selection is deterministic (nearest squared distance, then lowest id) and
         // the chain uses one shared damage roll without additional RNG draws.
         const origin = target ?? p;
-        // NOTE: unlike directDamage/aoeDamage, `chainDamage`'s own base (min/max)
-        // has no scaleEffect case in classes.ts, so it is not talent-scaled today
-        // either; leaving its SP/AP rider unscaled here keeps that pre-existing
-        // (separate) gap consistent instead of scaling only the rider.
+        // Like directDamage/aoeDamage, chainDamage's base (min/max) is talent
+        // scaled by its scaleEffect case in classes.ts, and talentDmgMult
+        // reaches the SP/AP rider here too, so the whole bounce (base roll
+        // plus rider), not just the primary hit, scales with global spell
+        // damage / mastery / talent multipliers.
         const chainSpBonus = directHitBonus(
           abilityScalingPower(p, ability),
           ability,
           res.castTime,
           true,
+          talentDmgMult,
         );
         // Resolve the shared primary amount once before applying hop falloff.
         // Fractional spell-power coefficients must not make later hops round

--- a/src/sim/combat/effect_dispatch.ts
+++ b/src/sim/combat/effect_dispatch.ts
@@ -33,6 +33,7 @@ import {
   hotTickBonus,
 } from '../spell_scaling';
 import { stunDrCategory } from '../stun_dr';
+import { resolveTalentHitMult } from '../talent_hit_mult';
 import { addThreat, dropThreat } from '../threat';
 import type { AbilityDef, Entity } from '../types';
 import {
@@ -243,6 +244,13 @@ export function runEffects(
   const ability = res.def;
   const isSpell = ability.school !== 'physical';
   const mods = ctx.playerMods(meta);
+  // The resolved mastery/talent damage and heal multiplier for this ability
+  // (talent_hit_mult.ts): the SAME number applyTalentMods already baked into
+  // its authored base magnitudes, reused here to scale the SP/AP rider a
+  // damage/heal/DoT/HoT/absorb site adds on top, so the advertised percentage
+  // reaches the whole hit, not just the base (issue: mastery/talent damage
+  // percent under-delivered at high SP/AP since the rider was never scaled).
+  const { dmgMult: talentDmgMult, healMult: talentHealMult } = resolveTalentHitMult(ability, mods);
   const spentCombo = ability.spendsCombo ? p.comboPoints : 0;
   let comboAwarded = false;
   const sureCrit = hasSureCritAura(p);
@@ -420,8 +428,15 @@ export function runEffects(
         // The flat rider scales with the school's rating: Spell Power for spells,
         // Ranged AP for hunter shots, melee Attack Power for physical specials.
         // abilityScalingPower picks the rating; powerScale (inside directHitBonus)
-        // applies the AP scale-down. A non-scaling effect just contributes 0.
-        dmg += directHitBonus(abilityScalingPower(p, ability), ability, res.castTime);
+        // applies the AP scale-down. talentDmgMult reaches the rider too, so a
+        // "+X%" mastery/talent scales the whole hit, not just the base roll.
+        dmg += directHitBonus(
+          abilityScalingPower(p, ability),
+          ability,
+          res.castTime,
+          false,
+          talentDmgMult,
+        );
         if (eff.vsRootedMult !== undefined && rooted) dmg *= eff.vsRootedMult;
         // Ice Lance against a frozen-counting target (combat/frost_mage.ts):
         // the per-cast resolution carries its 3x; 1 for every other cast.
@@ -553,7 +568,9 @@ export function runEffects(
           eff.base +
           eff.perCombo * spentCombo +
           ctx.rng.range(0, eff.variance) +
-          ctx.effectiveAttackPower(p) / 14;
+          // The AP rider gets the same talent/mastery multiplier already baked
+          // into eff.base/eff.perCombo, so it scales with the whole hit too.
+          (ctx.effectiveAttackPower(p) / 14) * talentDmgMult;
         const crit =
           ctx.rng.chance(consumeNextAttackCrit(ctx, p) ? 1 : p.critChance) ||
           sureCrit ||
@@ -725,7 +742,8 @@ export function runEffects(
         // Heals scale with Spell Power at the direct cast-time coefficient, the
         // healing mirror of the direct-nuke rider (applyHeal fires the crit).
         const healAmount =
-          ctx.rng.range(eff.min, eff.max) + directHealBonus(p.spellPower, res.castTime);
+          ctx.rng.range(eff.min, eff.max) +
+          directHealBonus(p.spellPower, res.castTime, false, talentHealMult);
         const healed = ctx.applyHeal(p, healTarget, healAmount, ability.name, ability.id);
         // Power Echo (mage choice row): the armed echo also repeats a direct HEAL
         // (Temporal Mend, Temporal Echo) at its fraction of the RESOLVED heal on
@@ -755,7 +773,8 @@ export function runEffects(
         // Selection and the per-hop spellfx arc adopted from Blaine1705's #1434.
         const first = target ?? p;
         const baseAmount =
-          ctx.rng.range(eff.min, eff.max) + directHealBonus(p.spellPower, res.castTime);
+          ctx.rng.range(eff.min, eff.max) +
+          directHealBonus(p.spellPower, res.castTime, false, talentHealMult);
         const chain: Entity[] = [first];
         while (chain.length <= eff.jumps) {
           const from = chain[chain.length - 1];
@@ -830,7 +849,14 @@ export function runEffects(
         // rider too would double-dip. Only pure HoTs (Rejuvenation) take the rider.
         const hybridHeal = res.effects.some((e) => e.type === 'heal');
         const hotBase = Math.max(1, Math.round(eff.total / (eff.duration / eff.interval)));
-        const hotSp = hybridHeal ? 0 : hotTickBonus(p.spellPower, eff.duration, eff.interval);
+        const hotSp = hybridHeal
+          ? 0
+          : hotTickBonus(
+              p.spellPower,
+              eff.duration,
+              eff.interval,
+              talentHealMult * (1 + mods.global.hotHealPct),
+            );
         ctx.applyAura(hotTarget, {
           id: ability.id,
           name: ability.name,
@@ -856,7 +882,13 @@ export function runEffects(
           kind: 'absorb',
           remaining: eff.duration,
           duration: eff.duration,
-          value: eff.amount + absorbBonus(p.spellPower, eff.spellPowerCoeff ?? 0),
+          value:
+            eff.amount +
+            absorbBonus(
+              p.spellPower,
+              eff.spellPowerCoeff ?? 0,
+              talentHealMult * (1 + mods.global.absorbPct),
+            ),
           sourceId: p.id,
           school: ability.school,
         });
@@ -894,12 +926,14 @@ export function runEffects(
         const seal = p.auras[sealIdx];
         p.auras.splice(sealIdx, 1);
         ctx.emit({ type: 'aura', targetId: p.id, name: seal.name, gained: false });
-        // Judgement is an instant holy nuke; scale it with Spell Power too.
+        // Judgement is an instant holy nuke; scale it with Spell Power too. The
+        // resolved talent/mastery multiplier (eff.dmgMult, carried forward by
+        // scaleEffect rather than baked into the seal's own value) now wraps
+        // the SP rider too, so it scales the whole hit like every other type.
         const baseDmg = ctx.rng.range(seal.value2 ?? 10, seal.value3 ?? 15);
         let dmg =
-          baseDmg * (eff.dmgMult ?? 1) +
-          (eff.flat ?? 0) +
-          directHitBonus(p.spellPower, ability, res.castTime);
+          (baseDmg + directHitBonus(p.spellPower, ability, res.castTime)) * (eff.dmgMult ?? 1) +
+          (eff.flat ?? 0);
         const crit =
           ctx.rng.chance(consumeNextAttackCrit(ctx, p) ? 1 : ctx.spellCrit(p)) || sureCrit;
         if (sureCrit) sureCritRolled = true;
@@ -1233,7 +1267,13 @@ export function runEffects(
         // Power here just like a spell DoT scales off Spell Power; `hybrid` still
         // suppresses the rider on a DoT that trails its own direct nuke.
         const dotSp = !hybrid
-          ? dotTickBonus(abilityScalingPower(p, ability), ability, eff.duration, eff.interval)
+          ? dotTickBonus(
+              abilityScalingPower(p, ability),
+              ability,
+              eff.duration,
+              eff.interval,
+              talentDmgMult * (1 + mods.global.dotDmgPct),
+            )
           : 0;
         const dotId = eff.auraId ?? ability.id;
         ctx.applyAura(target, {
@@ -1494,6 +1534,7 @@ export function runEffects(
           ability,
           res.castTime,
           true,
+          talentDmgMult,
         );
         // Collect the eligible targets FIRST (LoS + frontal gate) so a soft
         // target cap can know the count before any hit lands. The skips draw no
@@ -1600,6 +1641,10 @@ export function runEffects(
         // hop selection is deterministic (nearest squared distance, then lowest id) and
         // the chain uses one shared damage roll without additional RNG draws.
         const origin = target ?? p;
+        // NOTE: unlike directDamage/aoeDamage, `chainDamage`'s own base (min/max)
+        // has no scaleEffect case in classes.ts, so it is not talent-scaled today
+        // either; leaving its SP/AP rider unscaled here keeps that pre-existing
+        // (separate) gap consistent instead of scaling only the rider.
         const chainSpBonus = directHitBonus(
           abilityScalingPower(p, ability),
           ability,
@@ -1678,7 +1723,7 @@ export function runEffects(
           ability: ability.id,
         });
         // AoE heals take the same per-target coefficient penalty as AoE damage.
-        const aoeHealBonus = directHealBonus(p.spellPower, res.castTime, true);
+        const aoeHealBonus = directHealBonus(p.spellPower, res.castTime, true, talentHealMult);
         for (const m of friendliesInRadius(ctx, p, eff.radius)) {
           if (!ctx.hasLineOfSight(p, m)) continue;
           const healAmount = ctx.rng.range(eff.min, eff.max) + aoeHealBonus;
@@ -1717,7 +1762,14 @@ export function runEffects(
           abilityId: ability.id,
           // Each pulse is an AoE hit; scale per tick off the school's rating
           // (Spell Power, Ranged AP, or melee Attack Power for physical pulses).
-          spBonus: directHitBonus(abilityScalingPower(p, ability), ability, res.castTime, true),
+          // talentDmgMult reaches this snapshot too, same as every other rider.
+          spBonus: directHitBonus(
+            abilityScalingPower(p, ability),
+            ability,
+            res.castTime,
+            true,
+            talentDmgMult,
+          ),
           allyBuffPct: eff.allyBuffPct,
           igniteFrac: eff.igniteFrac,
           slowMult: eff.slowMult,
@@ -2222,7 +2274,13 @@ export function runEffects(
         // damaging roots such as Frost Nova retain their normal scaling path.
         const dealsDamage = eff.min !== 0 || eff.max !== 0;
         const aoeRootSp = dealsDamage
-          ? directHitBonus(abilityScalingPower(p, ability), ability, res.castTime, true)
+          ? directHitBonus(
+              abilityScalingPower(p, ability),
+              ability,
+              res.castTime,
+              true,
+              talentDmgMult,
+            )
           : 0;
         for (const m of ctx.hostilesInRadius(p, center, eff.radius)) {
           if (!ctx.hasLineOfSight(p, m)) continue;
@@ -2295,7 +2353,13 @@ export function runEffects(
         if (eff.deal) {
           let dmg =
             ctx.rng.range(eff.deal.min, eff.deal.max) +
-            directHitBonus(abilityScalingPower(p, ability), ability, res.castTime);
+            directHitBonus(
+              abilityScalingPower(p, ability),
+              ability,
+              res.castTime,
+              false,
+              talentDmgMult,
+            );
           if (isSpell) dmg *= spellDamageMultFromAuras(p);
           const crit =
             ctx.rng.chance(consumeNextAttackCrit(ctx, p) ? 1 : ctx.spellCrit(p)) || sureCrit;
@@ -2322,7 +2386,8 @@ export function runEffects(
         }
         if (eff.heal) {
           const healAmount =
-            ctx.rng.range(eff.heal.min, eff.heal.max) + directHealBonus(p.spellPower, res.castTime);
+            ctx.rng.range(eff.heal.min, eff.heal.max) +
+            directHealBonus(p.spellPower, res.castTime, false, talentHealMult);
           ctx.applyHeal(p, target, healAmount, ability.name, ability.id);
         }
         break;

--- a/src/sim/combat/effect_dispatch.ts
+++ b/src/sim/combat/effect_dispatch.ts
@@ -679,8 +679,13 @@ export function runEffects(
         const initialApplied: number[] = [];
         for (const ally of targets) {
           const before = devPlaytest ? ally.hp : 0;
+          // Like heal/chainHeal, the base roll (eff.heal.min/max) is talent scaled
+          // by the massTemporalEcho case in classes.ts, and talentHealMult reaches
+          // the SP rider here too, so Chronoweave's "all healing" bonus applies to
+          // Temporal Cascade's initial heal the same way it does every other heal.
           const healAmount =
-            ctx.rng.range(eff.heal.min, eff.heal.max) + directHealBonus(p.spellPower, res.castTime);
+            ctx.rng.range(eff.heal.min, eff.heal.max) +
+            directHealBonus(p.spellPower, res.castTime, false, talentHealMult);
           ctx.applyHeal(p, ally, healAmount, ability.name);
           if (devPlaytest) {
             const applied = ally.hp - before;

--- a/src/sim/content/classes.ts
+++ b/src/sim/content/classes.ts
@@ -1,3 +1,4 @@
+import { resolveTalentHitMult } from '../talent_hit_mult';
 import {
   type AbilityDef,
   type AbilityEffect,
@@ -6472,15 +6473,15 @@ function scaleEffect(
 // mods stack on top and also tune cost / cast time / cooldown.
 function applyTalentMods(entry: KnownAbility, mods: TalentModifiers): void {
   const am = mods.abilities[entry.def.id];
-  // The melee bucket also covers hunter's ranged-AP shots regardless of magic school:
-  // `scalesWith: 'ranged'` is exclusively set on hunter abilities (arcane_shot, serpent_sting,
-  // and wyvern_sting are non-physical), so this widening cannot reach any other class's
-  // melee/spell split. Without it, Marksmanship's Iron Aim ("ranged ability damage") silently
-  // never applied to Arcane Shot, the spec's arcane-school nuke.
-  const physical = entry.def.school === 'physical' || entry.def.scalesWith === 'ranged';
-  const globalDmg = physical ? mods.global.meleeDmgPct : mods.global.spellDmgPct;
-  const dmgMult = 1 + globalDmg + (am?.dmgPct ?? 0);
-  const healMult = 1 + mods.global.healPct + (am?.dmgPct ?? 0);
+  // dmgMult/healMult come from the shared talent_hit_mult resolver: the SAME
+  // function combat sites (effect_dispatch.ts/casting_lifecycle.ts/auto_attack.ts)
+  // call to scale a resolved ability's runtime SP/AP/weapon rider, so the
+  // authored-base bake here and the rider scaling at combat time can never drift
+  // apart. (The melee bucket also covers hunter's ranged-AP shots regardless of
+  // magic school: `scalesWith: 'ranged'` is exclusively set on hunter abilities
+  // (arcane_shot, serpent_sting, wyvern_sting are non-physical), so Marksmanship's
+  // Iron Aim ("ranged ability damage") reaches Arcane Shot, the spec's arcane nuke.)
+  const { dmgMult, healMult } = resolveTalentHitMult(entry.def, mods);
   const dotMult = 1 + mods.global.dotDmgPct;
   const hotMult = 1 + mods.global.hotHealPct;
   const absorbMult = 1 + mods.global.absorbPct;

--- a/src/sim/content/classes.ts
+++ b/src/sim/content/classes.ts
@@ -6406,6 +6406,17 @@ function scaleEffect(
         min: Math.round(eff.min * healMult + flat),
         max: Math.round(eff.max * healMult + flat),
       };
+    case 'massTemporalEcho':
+      // Like heal/chainHeal, the initial-heal base is talent scaled here so it
+      // matches the SP rider talentHealMult now applies at the effect_dispatch.ts
+      // call site (Chronoweave's "all healing" bonus was previously a no-op here).
+      return {
+        ...eff,
+        heal: {
+          min: Math.round(eff.heal.min * healMult + flat),
+          max: Math.round(eff.heal.max * healMult + flat),
+        },
+      };
     case 'hot':
       return { ...eff, total: Math.round(eff.total * healMult * hotMult + flat) };
     case 'consumeAura':

--- a/src/sim/content/classes.ts
+++ b/src/sim/content/classes.ts
@@ -6363,6 +6363,12 @@ function scaleEffect(
         min: Math.round(eff.min * (eff.type === 'aoeHeal' ? healMult : dmgMult) + flat),
         max: Math.round(eff.max * (eff.type === 'aoeHeal' ? healMult : dmgMult) + flat),
       };
+    case 'chainDamage':
+      return {
+        ...eff,
+        min: Math.round(eff.min * dmgMult + flat),
+        max: Math.round(eff.max * dmgMult + flat),
+      };
     case 'aoeRoot':
       return { ...eff, min: Math.round(eff.min * dmgMult), max: Math.round(eff.max * dmgMult) };
     case 'drainTick':

--- a/src/sim/spell_scaling.ts
+++ b/src/sim/spell_scaling.ts
@@ -71,15 +71,20 @@ function powerScale(def: AbilityDef): number {
 // Flat bonus added to ONE direct (or AoE) spell hit. `castTimeSec` is the
 // rank-resolved cast time (res.castTime), NOT the rank-1 base def.castTime, so
 // higher ranks (and talent-hastened casts) scale correctly. `aoe` applies the
-// AoE penalty.
+// AoE penalty. `mult` is the resolved talent/mastery damage multiplier
+// (`talent_hit_mult.ts`, the same number `applyTalentMods` bakes into the
+// ability's authored base): a "+X%" mastery must reach this SP/AP rider too,
+// not just the base magnitude, so callers pass it through instead of scaling
+// the returned bonus afterward (which would round twice).
 export function directHitBonus(
   power: number,
   def: AbilityDef,
   castTimeSec: number,
   aoe = false,
+  mult = 1,
 ): number {
   const coeff = directSpellCoeff(castTimeSec) * (aoe ? SPELL_AOE_COEFF_MULT : 1);
-  return Math.round(power * coeff * powerScale(def));
+  return Math.round(power * coeff * powerScale(def) * mult);
 }
 
 // Healing scales off DOUBLE Spell Power: with SPELL_POWER_PER_INT at 0.5 this
@@ -96,12 +101,20 @@ export const HEALING_SP_SCALE = 2;
 // rank-resolved cast time (res.castTime), so higher ranks and talent-hastened
 // heals scale correctly. `aoe` applies the same per-target coefficient penalty
 // AoE damage takes, so multi-target heals do not triple-dip Spell Power.
-export function directHealBonus(spellPower: number, castTimeSec: number, aoe = false): number {
+// `mult` is the resolved talent/mastery heal multiplier (`talent_hit_mult.ts`);
+// see the `directHitBonus` note above for why it wraps here rather than at the call site.
+export function directHealBonus(
+  spellPower: number,
+  castTimeSec: number,
+  aoe = false,
+  mult = 1,
+): number {
   return Math.round(
     spellPower *
       HEALING_SP_SCALE *
       directSpellCoeff(castTimeSec) *
-      (aoe ? SPELL_AOE_COEFF_MULT : 1),
+      (aoe ? SPELL_AOE_COEFF_MULT : 1) *
+      mult,
   );
 }
 
@@ -111,35 +124,48 @@ export function directHealBonus(spellPower: number, castTimeSec: number, aoe = f
 // authored coefficient are the mage personal barriers (damage-class
 // survivability, not healing); the healer shield (Psalm of Warding) carries no
 // coefficient and scales through its rank amounts instead.
-export function absorbBonus(spellPower: number, coefficient: number): number {
-  return Math.max(0, Math.round(spellPower * coefficient));
+// `mult` is the resolved talent/mastery absorb multiplier (`talent_hit_mult.ts`
+// healMult times the absorbPct global), same reasoning as `directHitBonus`.
+export function absorbBonus(spellPower: number, coefficient: number, mult = 1): number {
+  return Math.max(0, Math.round(spellPower * coefficient * mult));
 }
 
 // Flat bonus added to ONE HoT tick: the total DoT coefficient (duration / 15)
 // split across its ticks, scaling off Spell Power. Mirrors dotTickBonus but never
 // takes the AP scale-down, since HoTs are pure healing.
-export function hotTickBonus(spellPower: number, durationSec: number, intervalSec: number): number {
+// `mult` is the resolved talent/mastery HoT multiplier (`talent_hit_mult.ts`
+// healMult times the hotHealPct global), same reasoning as `directHitBonus`.
+export function hotTickBonus(
+  spellPower: number,
+  durationSec: number,
+  intervalSec: number,
+  mult = 1,
+): number {
   const ticks = intervalSec > 0 ? Math.max(1, durationSec / intervalSec) : 1;
   const coeff = dotTotalCoeff(durationSec) / ticks;
-  return Math.round(spellPower * HEALING_SP_SCALE * coeff);
+  return Math.round(spellPower * HEALING_SP_SCALE * coeff * mult);
 }
 
 // Flat bonus added to ONE channel tick (e.g. each Arcane Missile / Mind Flay tick).
-export function channelTickBonus(power: number, def: AbilityDef): number {
+// `mult` is the resolved talent/mastery damage/heal multiplier (`talent_hit_mult.ts`).
+export function channelTickBonus(power: number, def: AbilityDef, mult = 1): number {
   const ch = def.channel;
   if (!ch || ch.ticks <= 0) return 0;
   const coeff = channelSpellCoeff(ch.duration) / ch.ticks;
-  return Math.round(power * coeff * powerScale(def));
+  return Math.round(power * coeff * powerScale(def) * mult);
 }
 
 // Flat bonus added to ONE DoT tick (total DoT coefficient split across its ticks).
+// `mult` is the resolved talent/mastery DoT multiplier (`talent_hit_mult.ts`
+// dmgMult times the dotDmgPct global), same reasoning as `directHitBonus`.
 export function dotTickBonus(
   power: number,
   def: AbilityDef,
   durationSec: number,
   intervalSec: number,
+  mult = 1,
 ): number {
   const ticks = intervalSec > 0 ? Math.max(1, durationSec / intervalSec) : 1;
   const coeff = dotTotalCoeff(durationSec) / ticks;
-  return Math.round(power * coeff * powerScale(def));
+  return Math.round(power * coeff * powerScale(def) * mult);
 }

--- a/src/sim/talent_hit_mult.ts
+++ b/src/sim/talent_hit_mult.ts
@@ -1,0 +1,41 @@
+// The one place that resolves a talent/mastery percent bonus (global
+// meleeDmgPct / spellDmgPct / healPct, plus a per-ability dmgPct like Frost's
+// +25%) into the multiplier that applies to ONE ability's whole hit.
+//
+// `content/classes.ts` (`applyTalentMods`) calls this to bake the multiplier
+// into an ability's authored base magnitudes at precompute time, same as
+// before. Combat sites (`combat/effect_dispatch.ts`, `combat/casting_lifecycle.ts`,
+// `combat/auto_attack.ts`) call the SAME function to scale the runtime SP/AP/
+// weapon rider a resolved ability adds on top (`spell_scaling.ts`,
+// `effectiveAttackPower`, `meleeSwing`'s weapon+AP roll) by the identical
+// number, so the advertised percentage reaches the whole hit instead of only
+// the authored base (issue: mastery/talent damage percent under-delivered at
+// high gear because the SP/AP portion of a hit was never multiplied).
+//
+// Pure: reads only an AbilityDef and the player's precomputed TalentModifiers,
+// no Sim/SimContext/rng. A Vitest imports it directly.
+
+import type { TalentModifiers } from './content/talents';
+import type { AbilityDef } from './types';
+
+export interface TalentHitMult {
+  // The base multiplier for one-shot damage (directDamage/aoeDamage/
+  // chainDamage/weaponDamage/finisherDamage/aoeRoot/consumeAura's deal).
+  dmgMult: number;
+  // The base multiplier for healing (heal/chainHeal/aoeHeal/consumeAura's heal).
+  healMult: number;
+}
+
+// Mirrors the physical/ranged school split `applyTalentMods` uses to pick
+// between the melee and spell global buckets: hunter ranged shots
+// (`scalesWith: 'ranged'`) always take the melee bucket regardless of school,
+// so Marksmanship's Iron Aim ("ranged ability damage") reaches Arcane Shot.
+export function resolveTalentHitMult(ability: AbilityDef, mods: TalentModifiers): TalentHitMult {
+  const am = mods.abilities[ability.id];
+  const physical = ability.school === 'physical' || ability.scalesWith === 'ranged';
+  const globalDmg = physical ? mods.global.meleeDmgPct : mods.global.spellDmgPct;
+  return {
+    dmgMult: 1 + globalDmg + (am?.dmgPct ?? 0),
+    healMult: 1 + mods.global.healPct + (am?.dmgPct ?? 0),
+  };
+}

--- a/tests/chronomancy.test.ts
+++ b/tests/chronomancy.test.ts
@@ -224,11 +224,14 @@ describe('Temporal Barrier', () => {
     expect(shield?.kind).toBe('absorb');
     // Rank 3 base 160, scaled by the Chronoweave mastery (x1.15 at level 20)
     // like the heals, plus 25 percent of the caster's spell power (PR #2154's
-    // barrier scaling; the autoEquip level-20 mage carries 40 spell power, so
-    // 184 + 10 = 194).
-    expect(shield?.value).toBe(194);
+    // barrier scaling; the autoEquip level-20 mage carries 40 spell power).
+    // Issue #1803: the Chronoweave healPct now reaches the Spell Power rider
+    // too, not just the base: base round(160 * 1.15) = 184, rider
+    // round(40 * 0.25 * 1.15) = 12, total 196 (previously an unscaled rider
+    // of 10 under-delivered the mastery's advertised percentage).
+    expect(shield?.value).toBe(196);
     // Absorption channels through the normal pipeline: a 100 hit leaves hp
-    // untouched and the shell at 94.
+    // untouched and the shell at 96.
     const mob = addHostile(sim);
     const hp0 = p.hp;
     (
@@ -246,7 +249,7 @@ describe('Temporal Barrier', () => {
     ).dealDamage(mob, p, 100, false, 'physical', null, 'hit');
     expect(p.hp).toBe(hp0);
     shield = p.auras.find((a) => a.id === 'temporal_barrier');
-    expect(shield?.value).toBe(94);
+    expect(shield?.value).toBe(96);
     // A same-caster recast REPLACES to full (the documented absorb rule).
     p.cooldowns.delete('temporal_barrier');
     (p as unknown as { gcdRemaining: number }).gcdRemaining = 0;
@@ -255,7 +258,7 @@ describe('Temporal Barrier', () => {
     sim.tick();
     const shields = p.auras.filter((a) => a.id === 'temporal_barrier');
     expect(shields.length).toBe(1); // never stacks with itself
-    expect(shields[0].value).toBe(194); // fresh full shell
+    expect(shields[0].value).toBe(196); // fresh full shell
     // Expiry: ride past the 10s window and the shell is gone.
     collect(sim, 10.5);
     expect(p.auras.some((a) => a.id === 'temporal_barrier')).toBe(false);

--- a/tests/mage_barrier_scaling.test.ts
+++ b/tests/mage_barrier_scaling.test.ts
@@ -77,7 +77,12 @@ describe('mage personal barrier rank scaling', () => {
     expect(castBarrier(20, spec, id, 123)).toMatchObject({ absorb: 192, cost: 90 });
   });
 
-  it('adds 25% Spell Power to every Temporal Barrier rank', () => {
+  it('adds 25% Spell Power to every Temporal Barrier rank, scaled by the Chronoweave mastery', () => {
+    // Issue #1803: the Chronoweave mastery's healPct (0.15, ramping linearly
+    // with level/20 like every spec mastery, see computeTalentModifiers)
+    // now reaches the Spell Power rider too, not just the authored base, so
+    // the SP-derived share of the shield also carries the mastery's level-
+    // scaled multiplier instead of the bare 25% coefficient.
     for (const [level, cost] of [
       [5, 50],
       [12, 75],
@@ -86,7 +91,10 @@ describe('mage personal barrier rank scaling', () => {
       const baseline = castTemporalBarrier(level, 0);
       const scaled = castTemporalBarrier(level, 123);
       expect(scaled.spellPower).toBe(123);
-      expect(scaled.absorb - baseline.absorb).toBe(Math.round(scaled.spellPower * 0.25));
+      const chronoweaveHealMult = 1 + 0.15 * Math.min(1, level / 20);
+      expect(scaled.absorb - baseline.absorb).toBe(
+        Math.round(scaled.spellPower * 0.25 * chronoweaveHealMult),
+      );
       expect(scaled.cost).toBe(cost);
     }
   });

--- a/tests/parity/golden/frost_proc_orb.json
+++ b/tests/parity/golden/frost_proc_orb.json
@@ -183,8 +183,8 @@
       "tick": 84,
       "time": 4.2,
       "nextId": 947,
-      "state": "4e148b48",
-      "events": "7d487572",
+      "state": "2943d958",
+      "events": "345b796a",
       "rng": {
         "draws": 356,
         "digest": "6ca1a356"
@@ -208,13 +208,13 @@
           "cls": "mage",
           "companionUpgrades": {},
           "counters": {
-            "damageDealt": 211
+            "damageDealt": 219
           },
           "craftSkills": {},
           "craftThrottle": {},
           "deedStats": {
             "counters": {
-              "dummyDamage": 211
+              "dummyDamage": 219
             },
             "dungeonClears": {},
             "itemsDiscovered": [
@@ -393,7 +393,7 @@
           "fallStartY": 1.5,
           "fiveSecondRule": 99,
           "hostile": true,
-          "hp": 499789,
+          "hp": 499781,
           "id": 946,
           "inCombat": true,
           "kind": "mob",
@@ -425,7 +425,7 @@
           "threat": [
             [
               941,
-              211
+              219
             ]
           ],
           "weapon": {
@@ -438,7 +438,7 @@
       "tick": 84,
       "time": 4.2,
       "nextId": 947,
-      "state": "4e148b48",
+      "state": "2943d958",
       "events": "741638a5",
       "rng": {
         "draws": 356,
@@ -463,13 +463,13 @@
           "cls": "mage",
           "companionUpgrades": {},
           "counters": {
-            "damageDealt": 211
+            "damageDealt": 219
           },
           "craftSkills": {},
           "craftThrottle": {},
           "deedStats": {
             "counters": {
-              "dummyDamage": 211
+              "dummyDamage": 219
             },
             "dungeonClears": {},
             "itemsDiscovered": [
@@ -648,7 +648,7 @@
           "fallStartY": 1.5,
           "fiveSecondRule": 99,
           "hostile": true,
-          "hp": 499789,
+          "hp": 499781,
           "id": 946,
           "inCombat": true,
           "kind": "mob",
@@ -680,7 +680,7 @@
           "threat": [
             [
               941,
-              211
+              219
             ]
           ],
           "weapon": {

--- a/tests/spell_scaling.test.ts
+++ b/tests/spell_scaling.test.ts
@@ -90,6 +90,14 @@ describe('directHitBonus', () => {
     const d = def({ school: 'physical', scalesWith: 'ranged' });
     expect(directHitBonus(rap, d, 3.0)).toBe(Math.round(rap * (3.0 / 3.5) * RANGED_SPELL_AP_SCALE));
   });
+
+  it('mult (the resolved talent/mastery multiplier) wraps the whole rider (#1803)', () => {
+    const sp = 400;
+    const d = def({});
+    expect(directHitBonus(sp, d, 3.0, false, 1.25)).toBe(Math.round(sp * (3.0 / 3.5) * 1.25));
+    // Default mult stays 1: existing callers are unaffected.
+    expect(directHitBonus(sp, d, 3.0)).toBe(Math.round(sp * (3.0 / 3.5)));
+  });
 });
 
 describe('channelTickBonus', () => {
@@ -101,6 +109,12 @@ describe('channelTickBonus', () => {
 
   it('returns 0 for a non-channeled ability', () => {
     expect(channelTickBonus(500, def({}))).toBe(0);
+  });
+
+  it('mult wraps the tick rider (#1803)', () => {
+    const sp = 210;
+    const d = def({ castTime: 0, channel: { duration: 3, ticks: 3 } });
+    expect(channelTickBonus(sp, d, 1.5)).toBe(Math.round(sp * (3 / 3.5 / 3) * 1.5));
   });
 });
 
@@ -119,6 +133,12 @@ describe('dotTickBonus', () => {
     expect(dotTickBonus(rap, d, 15, 3)).toBe(
       Math.round((rap * (15 / 15) * RANGED_SPELL_AP_SCALE) / 5),
     );
+  });
+
+  it('mult wraps the tick rider (#1803)', () => {
+    const sp = 150;
+    const d = def({});
+    expect(dotTickBonus(sp, d, 18, 3, 1.2)).toBe(Math.round((sp * (18 / 15) * 1.2) / 6));
   });
 });
 
@@ -141,12 +161,23 @@ describe('directHealBonus', () => {
       HEALING_SP_SCALE * directHitBonus(sp, def({ school: 'holy' }), 3.5),
     );
   });
+
+  it('mult wraps the whole rider (#1803)', () => {
+    const sp = 300;
+    expect(directHealBonus(sp, 3.5, false, 1.15)).toBe(
+      Math.round(sp * HEALING_SP_SCALE * 1.0 * 1.15),
+    );
+  });
 });
 
 describe('absorbBonus', () => {
   it('adds the authored fraction of Spell Power to a shield (mage barriers: no heal scale)', () => {
     expect(absorbBonus(123, 0.5)).toBe(62);
     expect(absorbBonus(80, 0)).toBe(0);
+  });
+
+  it('mult wraps the rider (#1803)', () => {
+    expect(absorbBonus(123, 0.5, 1.3)).toBe(Math.round(123 * 0.5 * 1.3));
   });
 });
 
@@ -161,6 +192,13 @@ describe('hotTickBonus', () => {
     const sp = 210;
     expect(hotTickBonus(sp, 15, 3)).toBe(
       HEALING_SP_SCALE * dotTickBonus(sp, def({ school: 'nature' }), 15, 3),
+    );
+  });
+
+  it('mult wraps the tick rider (#1803)', () => {
+    const sp = 150;
+    expect(hotTickBonus(sp, 12, 3, 1.25)).toBe(
+      Math.round((sp * HEALING_SP_SCALE * (12 / 15) * 1.25) / 4),
     );
   });
 });

--- a/tests/talent_full_hit_scaling.test.ts
+++ b/tests/talent_full_hit_scaling.test.ts
@@ -27,7 +27,7 @@ import {
 import { MOBS } from '../src/sim/data';
 import { createMob } from '../src/sim/entity';
 import { Sim } from '../src/sim/sim';
-import { directHitBonus } from '../src/sim/spell_scaling';
+import { directHealBonus, directHitBonus } from '../src/sim/spell_scaling';
 import { resolveTalentHitMult } from '../src/sim/talent_hit_mult';
 import type { AbilityEffect, Entity } from '../src/sim/types';
 
@@ -317,6 +317,105 @@ describe('mastery/talent damage percent scales the whole hit, not just the base 
       // Before the fix, every bounce (i > 0) stayed at the unscaled baseline
       // amount while only the primary hit (i === 0) moved.
       expect(boostedHits[i] / baseHits[i]).toBeCloseTo(1 + dmgPct, 1);
+    }
+  });
+
+  // Reviewer finding on PR #2757 (Rubsey/OSSBrain): Temporal Cascade
+  // (massTemporalEcho) had no scaleEffect case, and its initial-heal SP rider
+  // skipped talentHealMult, so Chronoweave's advertised "all healing" mastery
+  // bonus never reached the group heal at all. Fixed by giving massTemporalEcho
+  // the same scaleEffect heal.min/max treatment as heal/chainHeal, and passing
+  // talentHealMult into its directHealBonus rider in effect_dispatch.ts.
+  it('a massTemporalEcho ability (Temporal Cascade) with an ability-scoped +20% scales base AND the Spell Power rider by the same 1.2 (pure math)', () => {
+    // AbilityModEffect has no separate healPct field: resolveTalentHitMult
+    // reuses the same ability-scoped dmgPct for healMult (see talent_hit_mult.ts),
+    // matching the pattern the Renew HoT test above uses.
+    const dmgPct = 0.2;
+    // temporal_cascade is gated to the arcane (Chronomancy) spec (specs: ['arcane']).
+    const baseline: TalentModifiers = { ...emptyModifiers(), spec: 'arcane' };
+    const boosted: TalentModifiers = { ...emptyModifiers(), spec: 'arcane' };
+    accumulateTalentEffect(boosted, { ability: [{ ability: 'temporal_cascade', dmgPct }] });
+
+    const baseAbility = abilitiesKnownAt('mage', 20, baseline).find(
+      (a) => a.def.id === 'temporal_cascade',
+    );
+    const boostedAbility = abilitiesKnownAt('mage', 20, boosted).find(
+      (a) => a.def.id === 'temporal_cascade',
+    );
+    if (!baseAbility || !boostedAbility) throw new Error('missing temporal_cascade');
+    const massTemporalEchoEffect = (effects: AbilityEffect[]) => {
+      const found = effects.find((e) => e.type === 'massTemporalEcho');
+      if (found?.type !== 'massTemporalEcho') throw new Error('missing massTemporalEcho effect');
+      return found;
+    };
+    const baseEff = massTemporalEchoEffect(baseAbility.effects);
+    const boostedEff = massTemporalEchoEffect(boostedAbility.effects);
+
+    // Before the fix, massTemporalEcho had no scaleEffect case, so this bake
+    // was a no-op and boostedEff.heal.min === baseEff.heal.min.
+    expect(boostedEff.heal.min).toBe(Math.round(baseEff.heal.min * (1 + dmgPct)));
+
+    const spellPower = 900;
+    const castTime = boostedAbility.castTime;
+    const { healMult } = resolveTalentHitMult(boostedAbility.def, boosted);
+    expect(healMult).toBeCloseTo(1 + dmgPct, 10);
+
+    const baselineRider = directHealBonus(spellPower, castTime);
+    const fixedRider = directHealBonus(spellPower, castTime, false, healMult);
+    const unfixedRider = directHealBonus(spellPower, castTime); // mult defaults to 1
+
+    const baselineHit = baseEff.heal.min + baselineRider;
+    const fixedHit = boostedEff.heal.min + fixedRider;
+    const unfixedHit = boostedEff.heal.min + unfixedRider;
+
+    expect(fixedHit / baselineHit).toBeCloseTo(1 + dmgPct, 2);
+    expect(unfixedHit / baselineHit).toBeLessThan(1 + dmgPct);
+  });
+
+  it('Temporal Cascade initial heals scale under a global healPct (Chronoweave shape), end to end', () => {
+    const healPct = 0.2;
+
+    const castInitialHeals = (boost: boolean): number[] => {
+      const sim = new Sim({ seed: 51, playerClass: 'mage', autoEquip: true });
+      sim.setPlayerLevel(20);
+      if (!sim.setSpec('arcane')) throw new Error('failed to set arcane spec');
+      const meta = sim.meta(sim.playerId);
+      if (!meta) throw new Error('missing player meta');
+      const mods: TalentModifiers = { ...meta.talentMods };
+      if (boost) accumulateTalentEffect(mods, { global: { healPct } });
+      meta.talentMods = mods;
+      meta.known = abilitiesKnownAt(meta.cls, 20, mods) as typeof meta.known;
+      sim.player.spellPower = 400;
+      sim.player.resource = sim.player.maxResource;
+      // A big HP pool with a deep deficit so the initial heal never clips an
+      // overheal cap: an overheal-clamped amount would read identical whether
+      // boosted or not and hide the bug this test targets.
+      sim.player.maxHp = 100_000;
+      sim.player.hp = 1;
+
+      // partyOnlyTarget only allows the caster or a group/raid member, so
+      // target self here rather than standing up a party.
+      sim.targetEntity(sim.player.id);
+      sim.castAbility('temporal_cascade');
+      const ticked: import('../src/sim/types').SimEvent[] = [];
+      // 2s cast time: give it a full 3s of ticks (60 at DT=1/20) to resolve.
+      for (let i = 0; i < 60; i++) ticked.push(...sim.tick());
+      const heals = ticked
+        .filter(
+          (e) => e.type === 'heal2' && (e as { targetId?: number }).targetId === sim.player.id,
+        )
+        .map((e) => (e as unknown as { amount: number }).amount);
+      expect(heals.length).toBeGreaterThan(0);
+      return heals;
+    };
+
+    const baseHeals = castInitialHeals(false);
+    const boostedHeals = castInitialHeals(true);
+    expect(boostedHeals.length).toBe(baseHeals.length);
+    for (let i = 0; i < baseHeals.length; i++) {
+      // Before the fix, the initial heal stayed at the unscaled baseline
+      // amount regardless of Chronoweave's global healPct.
+      expect(boostedHeals[i] / baseHeals[i]).toBeCloseTo(1 + healPct, 1);
     }
   });
 });

--- a/tests/talent_full_hit_scaling.test.ts
+++ b/tests/talent_full_hit_scaling.test.ts
@@ -130,8 +130,9 @@ describe('mastery/talent damage percent scales the whole hit, not just the base 
       sim.player.resource = sim.player.maxResource;
       const target = addTargetDummy(sim, 9301);
       sim.castAbility('corruption');
-      // 2s cast time; no rng draw applies a DoT snapshot, so this is deterministic.
-      for (let i = 0; i < 20 * 3; i++) sim.tick();
+      // 2s cast time plus projectile travel to a target 3yd away; no rng draw
+      // applies the DoT snapshot on impact, so this stays deterministic.
+      for (let i = 0; i < 20 * 5; i++) sim.tick();
       const dot = target.auras.find((a) => a.kind === 'dot' && a.id === 'corruption');
       if (!dot) throw new Error('corruption did not land');
       return dot.value;

--- a/tests/talent_full_hit_scaling.test.ts
+++ b/tests/talent_full_hit_scaling.test.ts
@@ -37,6 +37,12 @@ function directDamageEffect(effects: AbilityEffect[]) {
   return found;
 }
 
+function chainDamageEffect(effects: AbilityEffect[]) {
+  const found = effects.find((e) => e.type === 'chainDamage');
+  if (found?.type !== 'chainDamage') throw new Error('missing chainDamage effect');
+  return found;
+}
+
 function metaOf(sim: Sim, pid = sim.playerId) {
   const meta = sim.meta(pid);
   if (!meta) throw new Error('missing player meta');
@@ -189,6 +195,128 @@ describe('mastery/talent damage percent scales the whole hit, not just the base 
       const baseShield = shieldValue(baseline, spellPower);
       const boostedShield = shieldValue(boosted, spellPower);
       expect(boostedShield / baseShield).toBeCloseTo(1 + dmgPct, 1);
+    }
+  });
+
+  // Reviewer finding on PR #2757 (Rubsey/OSSBrain): chainDamage (Aura Surge /
+  // the paladin bounce ability, and Holy Shield's chained rider) had no
+  // scaleEffect case, and its SP/AP rider skipped talentDmgMult, so an
+  // ability-scoped or global spell-damage percent scaled the primary
+  // directDamage hit but silently dropped every bounce. Fixed by giving
+  // chainDamage the same scaleEffect min/max treatment as aoeDamage/
+  // directDamage, and passing talentDmgMult into its directHitBonus rider.
+  it('a chainDamage ability with an ability-scoped +30% scales base AND the Spell Power rider by the same 1.3 (pure math)', () => {
+    const dmgPct = 0.3;
+    const baseline = emptyModifiers();
+    const boosted = emptyModifiers();
+    // Aura Surge is talent-granted (talent_abilities_v2_a.ts), not part of the
+    // paladin base kit, so both variants need the grant to know it at all.
+    accumulateTalentEffect(baseline, { grant: { ability: 'aura_surge' } });
+    accumulateTalentEffect(boosted, { grant: { ability: 'aura_surge' } });
+    accumulateTalentEffect(boosted, { ability: [{ ability: 'aura_surge', dmgPct }] });
+
+    const baseAbility = abilitiesKnownAt('paladin', 20, baseline).find(
+      (a) => a.def.id === 'aura_surge',
+    );
+    const boostedAbility = abilitiesKnownAt('paladin', 20, boosted).find(
+      (a) => a.def.id === 'aura_surge',
+    );
+    if (!baseAbility || !boostedAbility) throw new Error('missing aura_surge');
+    const baseEff = chainDamageEffect(baseAbility.effects);
+    const boostedEff = chainDamageEffect(boostedAbility.effects);
+
+    // Before the fix, chainDamage had no scaleEffect case, so this bake was a
+    // no-op and boostedEff.min === baseEff.min.
+    expect(boostedEff.min).toBe(Math.round(baseEff.min * (1 + dmgPct)));
+
+    const spellPower = 900;
+    const castTime = boostedAbility.castTime;
+    const { dmgMult } = resolveTalentHitMult(boostedAbility.def, boosted);
+    expect(dmgMult).toBeCloseTo(1 + dmgPct, 10);
+
+    const baselineRider = directHitBonus(spellPower, baseAbility.def, castTime, true);
+    const fixedRider = directHitBonus(spellPower, boostedAbility.def, castTime, true, dmgMult);
+    const unfixedRider = directHitBonus(spellPower, boostedAbility.def, castTime, true); // mult defaults to 1
+
+    const baselineHit = baseEff.min + baselineRider;
+    const fixedHit = boostedEff.min + fixedRider;
+    const unfixedHit = boostedEff.min + unfixedRider;
+
+    expect(fixedHit / baselineHit).toBeCloseTo(1 + dmgPct, 2);
+    expect(unfixedHit / baselineHit).toBeLessThan(1 + dmgPct);
+  });
+
+  it('Aura Surge bounce hits (chainDamage) scale under a global spellDmgPct, matching the primary hit, end to end', () => {
+    const dmgPct = 0.3;
+
+    // Casts Hallowed Wall / holy_shield (directDamage primary + a chainDamage
+    // rider: 2 jumps, no falloff) against three hostile dummies laid out so
+    // hop selection (nearest distance, then lowest id) is deterministic, and
+    // returns the three resulting damage amounts: primary, then the two
+    // chainDamage bounces. `boost` layers a global spellDmgPct (the shape a
+    // mastery like Earthen Fury advertises) on top of the spec commit that
+    // grants holy_shield as the Protection signature, rather than replacing
+    // meta.talentMods wholesale, so the grant survives.
+    const castHits = (boost: boolean): number[] => {
+      const sim = new Sim({ seed: 41, playerClass: 'paladin', autoEquip: true });
+      sim.setPlayerLevel(20);
+      // holy_shield (Hallowed Wall) is granted as the Protection signature
+      // ability (talents.ts: spec.signature), not base kit by def alone.
+      if (!sim.setSpec('protection')) throw new Error('failed to set protection spec');
+      const meta = sim.meta(sim.playerId);
+      if (!meta) throw new Error('missing player meta');
+      const mods: TalentModifiers = { ...meta.talentMods };
+      if (boost) accumulateTalentEffect(mods, { global: { spellDmgPct: dmgPct } });
+      meta.talentMods = mods;
+      meta.known = abilitiesKnownAt(meta.cls, 20, mods) as typeof meta.known;
+      sim.player.spellPower = 400;
+      sim.player.resource = sim.player.maxResource;
+
+      const spawn = (id: number, dz: number): Entity => {
+        const m = createMob(id, MOBS.forest_wolf, 20, {
+          x: sim.player.pos.x,
+          y: sim.player.pos.y,
+          z: sim.player.pos.z + dz,
+        });
+        m.hostile = true;
+        m.maxHp = m.hp = 1_000_000;
+        (sim as unknown as { addEntity(e: Entity): void }).addEntity(m);
+        return m;
+      };
+      const primary = spawn(9401, 3);
+      spawn(9402, 5); // nearest to primary: first bounce
+      spawn(9403, 8); // nearest to the first bounce: second bounce
+
+      sim.targetEntity(primary.id);
+      sim.player.facing = Math.atan2(
+        primary.pos.x - sim.player.pos.x,
+        primary.pos.z - sim.player.pos.z,
+      );
+      sim.drainEvents();
+      sim.castAbility('holy_shield');
+      // tick() itself drains and returns the events queued so far (including
+      // the ones the instant cast above just emitted), so collect from its
+      // return value rather than a trailing drainEvents() call. Filter to the
+      // cast's OWN damage events (by ability name), since the same ticks also
+      // resolve the dummies' retaliation swings on the player.
+      const ticked: import('../src/sim/types').SimEvent[] = [];
+      for (let i = 0; i < 5; i++) ticked.push(...sim.tick());
+      const hits = ticked
+        .filter(
+          (e) => e.type === 'damage' && (e as { ability?: string }).ability === 'Hallowed Wall',
+        )
+        .map((e) => (e as unknown as { amount: number }).amount);
+      expect(hits).toHaveLength(3); // directDamage primary + 2 chainDamage bounces
+      return hits;
+    };
+
+    const baseHits = castHits(false);
+    const boostedHits = castHits(true);
+    expect(boostedHits).toHaveLength(baseHits.length);
+    for (let i = 0; i < baseHits.length; i++) {
+      // Before the fix, every bounce (i > 0) stayed at the unscaled baseline
+      // amount while only the primary hit (i === 0) moved.
+      expect(boostedHits[i] / baseHits[i]).toBeCloseTo(1 + dmgPct, 1);
     }
   });
 });

--- a/tests/talent_full_hit_scaling.test.ts
+++ b/tests/talent_full_hit_scaling.test.ts
@@ -1,0 +1,194 @@
+// Issue #1803: a mastery/talent damage/heal percent (global meleeDmgPct/
+// spellDmgPct/healPct/dotDmgPct/hotHealPct/absorbPct, or a per-ability dmgPct
+// like Frost's +25%) must scale the WHOLE hit (authored base plus the runtime
+// weapon/AP/SP rider), not just the authored base. Before the fix, scaleEffect
+// (src/sim/content/classes.ts) baked the percent into an ability's base min/
+// max/total at precompute time, and the SP/AP/weapon rider was added afterward
+// at the damage/heal site (spell_scaling.ts riders, meleeSwing) with no
+// multiplier applied at all, so the advertised percentage under-delivered and
+// the shortfall grew with gear (more SP/AP meant a larger un-multiplied share
+// of the hit).
+//
+// These tests exercise the fix two ways:
+//  - a pure math check (directDamage) proving the resolved rider now scales by
+//    the same multiplier as the base, matching the "Frost ability-scoped
+//    mastery" example from the issue body;
+//  - real Sim end-to-end casts for DoT, HoT, and absorb (all rng-free: none of
+//    these effect kinds roll a crit or a hit-table on application, only a
+//    deterministic snapshot), proving classes.ts's precompute bake and
+//    effect_dispatch.ts's runtime rider now agree end to end.
+import { describe, expect, it } from 'vitest';
+import { abilitiesKnownAt } from '../src/sim/content/classes';
+import {
+  accumulateTalentEffect,
+  emptyModifiers,
+  type TalentModifiers,
+} from '../src/sim/content/talents';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+import { Sim } from '../src/sim/sim';
+import { directHitBonus } from '../src/sim/spell_scaling';
+import { resolveTalentHitMult } from '../src/sim/talent_hit_mult';
+import type { AbilityEffect, Entity } from '../src/sim/types';
+
+function directDamageEffect(effects: AbilityEffect[]) {
+  const found = effects.find((e) => e.type === 'directDamage');
+  if (found?.type !== 'directDamage') throw new Error('missing directDamage effect');
+  return found;
+}
+
+function metaOf(sim: Sim, pid = sim.playerId) {
+  const meta = sim.meta(pid);
+  if (!meta) throw new Error('missing player meta');
+  return meta;
+}
+
+// Installs a synthetic TalentModifiers on a fresh Sim's single player, driving
+// BOTH the precompute bake (meta.known, via abilitiesKnownAt, same as a real
+// respec) and the runtime rider (meta.talentMods, read by ctx.playerMods in
+// effect_dispatch.ts) from the SAME object, exactly like a real talent spend.
+function installMods(sim: Sim, mods: TalentModifiers): void {
+  const meta = metaOf(sim);
+  meta.talentMods = mods;
+  meta.known = abilitiesKnownAt(meta.cls, 20, mods) as typeof meta.known;
+}
+
+function addTargetDummy(sim: Sim, id: number): Entity {
+  const target = createMob(id, MOBS.forest_wolf, 20, {
+    x: sim.player.pos.x,
+    y: sim.player.pos.y,
+    z: sim.player.pos.z + 3,
+  });
+  target.hostile = true;
+  target.maxHp = target.hp = 1_000_000;
+  (sim as unknown as { addEntity(e: Entity): void }).addEntity(target);
+  sim.targetEntity(target.id);
+  sim.player.facing = Math.atan2(target.pos.x - sim.player.pos.x, target.pos.z - sim.player.pos.z);
+  return target;
+}
+
+describe('mastery/talent damage percent scales the whole hit, not just the base (#1803)', () => {
+  it('a directDamage ability with an ability-scoped +25% (the Frost mastery shape) scales base AND the Spell Power rider by the same 1.25', () => {
+    const dmgPct = 0.25;
+    const baseline = emptyModifiers();
+    const boosted = emptyModifiers();
+    accumulateTalentEffect(boosted, { ability: [{ ability: 'frostbolt', dmgPct }] });
+
+    const baseAbility = abilitiesKnownAt('mage', 20, baseline).find(
+      (a) => a.def.id === 'frostbolt',
+    );
+    const boostedAbility = abilitiesKnownAt('mage', 20, boosted).find(
+      (a) => a.def.id === 'frostbolt',
+    );
+    if (!baseAbility || !boostedAbility) throw new Error('missing frostbolt');
+    const baseEff = directDamageEffect(baseAbility.effects);
+    const boostedEff = directDamageEffect(boostedAbility.effects);
+
+    // The authored base already scaled before this fix (unchanged behavior).
+    expect(boostedEff.min).toBe(Math.round(baseEff.min * (1 + dmgPct)));
+
+    // Large relative to the authored base, so an un-multiplied rider would
+    // visibly under-deliver the advertised 25% (the exact shortfall #1803
+    // reports growing with gear).
+    const spellPower = 900;
+    const castTime = boostedAbility.castTime;
+    const { dmgMult } = resolveTalentHitMult(boostedAbility.def, boosted);
+    expect(dmgMult).toBeCloseTo(1 + dmgPct, 10);
+
+    const baselineRider = directHitBonus(spellPower, baseAbility.def, castTime);
+    const fixedRider = directHitBonus(spellPower, boostedAbility.def, castTime, false, dmgMult);
+    const unfixedRider = directHitBonus(spellPower, boostedAbility.def, castTime); // mult defaults to 1
+
+    const baselineHit = baseEff.min + baselineRider;
+    const fixedHit = boostedEff.min + fixedRider;
+    const unfixedHit = boostedEff.min + unfixedRider;
+
+    // The fix: the whole hit (base + SP) now carries the advertised 25%.
+    expect(fixedHit / baselineHit).toBeCloseTo(1 + dmgPct, 2);
+    // The bug this reproduces: leaving the rider unscaled falls short of 1.25
+    // once SP is a meaningful share of the hit.
+    expect(unfixedHit / baselineHit).toBeLessThan(1 + dmgPct);
+  });
+
+  it('a DoT (Corruption) with a +40% ability-scoped talent applies the full 40% to base + Spell Power together, at both low and high Spell Power', () => {
+    const dmgPct = 0.4;
+    const boosted = emptyModifiers();
+    accumulateTalentEffect(boosted, { ability: [{ ability: 'corruption', dmgPct }] });
+    const baseline = emptyModifiers();
+
+    const tickValue = (mods: TalentModifiers, spellPower: number): number => {
+      const sim = new Sim({ seed: 11, playerClass: 'warlock', autoEquip: true });
+      sim.setPlayerLevel(20);
+      installMods(sim, mods);
+      sim.player.spellPower = spellPower;
+      sim.player.resource = sim.player.maxResource;
+      const target = addTargetDummy(sim, 9301);
+      sim.castAbility('corruption');
+      // 2s cast time; no rng draw applies a DoT snapshot, so this is deterministic.
+      for (let i = 0; i < 20 * 3; i++) sim.tick();
+      const dot = target.auras.find((a) => a.kind === 'dot' && a.id === 'corruption');
+      if (!dot) throw new Error('corruption did not land');
+      return dot.value;
+    };
+
+    for (const spellPower of [0, 1200]) {
+      const baseTick = tickValue(baseline, spellPower);
+      const boostedTick = tickValue(boosted, spellPower);
+      expect(boostedTick / baseTick).toBeCloseTo(1 + dmgPct, 1);
+    }
+  });
+
+  it('a HoT (Renew) with a +50% ability-scoped talent applies the full 50% to base + Spell Power together', () => {
+    const dmgPct = 0.5;
+    const boosted = emptyModifiers();
+    accumulateTalentEffect(boosted, { ability: [{ ability: 'renew', dmgPct }] });
+    const baseline = emptyModifiers();
+
+    const tickValue = (mods: TalentModifiers, spellPower: number): number => {
+      const sim = new Sim({ seed: 21, playerClass: 'priest', autoEquip: true });
+      sim.setPlayerLevel(20);
+      installMods(sim, mods);
+      sim.player.spellPower = spellPower;
+      sim.player.resource = sim.player.maxResource;
+      sim.targetEntity(sim.player.id); // Renew is friendly-targeted; heal self
+      sim.castAbility('renew');
+      for (let i = 0; i < 20; i++) sim.tick(); // instant cast, resolves within a tick
+      const hot = sim.player.auras.find((a) => a.kind === 'hot' && a.id === 'renew');
+      if (!hot) throw new Error('renew did not land');
+      return hot.value;
+    };
+
+    for (const spellPower of [0, 1200]) {
+      const baseTick = tickValue(baseline, spellPower);
+      const boostedTick = tickValue(boosted, spellPower);
+      expect(boostedTick / baseTick).toBeCloseTo(1 + dmgPct, 1);
+    }
+  });
+
+  it('an absorb shield (Frostveil) with a +25% ability-scoped talent applies the full 25% to base + Spell Power together', () => {
+    const dmgPct = 0.25;
+    const boosted = emptyModifiers();
+    accumulateTalentEffect(boosted, { ability: [{ ability: 'ice_barrier', dmgPct }] });
+    const baseline = emptyModifiers();
+
+    const shieldValue = (mods: TalentModifiers, spellPower: number): number => {
+      const modsWithSpec: TalentModifiers = { ...mods, spec: 'frost' }; // ice_barrier is frost-spec-gated
+      const sim = new Sim({ seed: 31, playerClass: 'mage', autoEquip: true });
+      sim.setPlayerLevel(20);
+      installMods(sim, modsWithSpec);
+      sim.player.spellPower = spellPower;
+      sim.player.resource = sim.player.maxResource;
+      sim.castAbility('ice_barrier'); // requiresTarget: false, instant
+      for (let i = 0; i < 20; i++) sim.tick();
+      const shield = sim.player.auras.find((a) => a.kind === 'absorb' && a.id === 'ice_barrier');
+      if (!shield) throw new Error('ice_barrier did not land');
+      return shield.value;
+    };
+
+    for (const spellPower of [0, 1200]) {
+      const baseShield = shieldValue(baseline, spellPower);
+      const boostedShield = shieldValue(boosted, spellPower);
+      expect(boostedShield / baseShield).toBeCloseTo(1 + dmgPct, 1);
+    }
+  });
+});

--- a/tests/talent_hit_mult.test.ts
+++ b/tests/talent_hit_mult.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { accumulateTalentEffect, emptyModifiers } from '../src/sim/content/talents';
+import { resolveTalentHitMult } from '../src/sim/talent_hit_mult';
+import type { AbilityDef } from '../src/sim/types';
+
+// Minimal ability stub: only the fields resolveTalentHitMult reads.
+function def(partial: Partial<AbilityDef>): AbilityDef {
+  return {
+    id: 'x',
+    name: 'X',
+    class: 'mage',
+    cost: 0,
+    castTime: 0,
+    cooldown: 0,
+    range: 30,
+    school: 'fire',
+    requiresTarget: true,
+    learnLevel: 1,
+    effects: [],
+    description: '',
+    ...partial,
+  };
+}
+
+describe('resolveTalentHitMult', () => {
+  it('with no talents applied, both multipliers are 1 (a no-op)', () => {
+    const mods = emptyModifiers();
+    expect(resolveTalentHitMult(def({}), mods)).toEqual({ dmgMult: 1, healMult: 1 });
+  });
+
+  it('a global spellDmgPct reaches a spell-school ability dmgMult, not physical', () => {
+    const mods = emptyModifiers();
+    accumulateTalentEffect(mods, { global: { spellDmgPct: 0.2 } });
+    expect(resolveTalentHitMult(def({ school: 'fire' }), mods).dmgMult).toBeCloseTo(1.2, 10);
+    expect(resolveTalentHitMult(def({ school: 'physical' }), mods).dmgMult).toBeCloseTo(1, 10);
+  });
+
+  it('a global meleeDmgPct reaches a physical ability, and a ranged attack-spell too', () => {
+    const mods = emptyModifiers();
+    accumulateTalentEffect(mods, { global: { meleeDmgPct: 0.3 } });
+    expect(resolveTalentHitMult(def({ school: 'physical' }), mods).dmgMult).toBeCloseTo(1.3, 10);
+    // Hunter ranged shots (scalesWith: 'ranged') take the melee bucket regardless
+    // of magic school, mirroring applyTalentMods (classes.ts).
+    expect(
+      resolveTalentHitMult(def({ school: 'nature', scalesWith: 'ranged' }), mods).dmgMult,
+    ).toBeCloseTo(1.3, 10);
+    expect(resolveTalentHitMult(def({ school: 'fire' }), mods).dmgMult).toBeCloseTo(1, 10);
+  });
+
+  it('a global healPct reaches healMult regardless of the ability school', () => {
+    const mods = emptyModifiers();
+    accumulateTalentEffect(mods, { global: { healPct: 0.15 } });
+    expect(resolveTalentHitMult(def({ school: 'holy' }), mods).healMult).toBeCloseTo(1.15, 10);
+    expect(resolveTalentHitMult(def({ school: 'physical' }), mods).healMult).toBeCloseTo(1.15, 10);
+  });
+
+  it('a per-ability dmgPct stacks additively on top of the global bucket, on both mults', () => {
+    const mods = emptyModifiers();
+    accumulateTalentEffect(mods, { global: { spellDmgPct: 0.1 } });
+    accumulateTalentEffect(mods, { ability: [{ ability: 'frostbolt', dmgPct: 0.25 }] });
+    const scoped = resolveTalentHitMult(def({ id: 'frostbolt', school: 'frost' }), mods);
+    expect(scoped.dmgMult).toBeCloseTo(1.35, 10);
+    expect(scoped.healMult).toBeCloseTo(1.25, 10);
+    // A different ability of the same school only sees the global bucket.
+    const unscoped = resolveTalentHitMult(def({ id: 'frost_nova', school: 'frost' }), mods);
+    expect(unscoped.dmgMult).toBeCloseTo(1.1, 10);
+    expect(unscoped.healMult).toBeCloseTo(1, 10);
+  });
+});


### PR DESCRIPTION
## Summary

A talent or mastery "+X% damage/heal" only multiplied an ability's *authored
base* magnitude, never the runtime Spell Power / Attack Power / weapon roll a
resolved ability adds on top. `applyTalentMods` (`src/sim/content/classes.ts`)
bakes the percent into `min`/`max`/`total` at precompute time via
`scaleEffect`, but the SP/AP/weapon rider (`spell_scaling.ts`'s
`directHitBonus`/`directHealBonus`/`dotTickBonus`/`hotTickBonus`/
`absorbBonus`/`channelTickBonus`, plus the weapon+AP roll in `meleeSwing`) was
added afterward with no multiplier at all. The advertised percentage
under-delivered, and the shortfall grew with gear (more SP/AP means a larger
un-multiplied share of the hit).

The fix adds one small pure resolver, `src/sim/talent_hit_mult.ts`
(`resolveTalentHitMult`), that derives the same `dmgMult`/`healMult` the
precompute bake already computed. `applyTalentMods` now calls it (removing a
duplicated inline copy of the formula), and every damage/heal/DoT/HoT/absorb
site that adds a runtime rider (`combat/effect_dispatch.ts`,
`combat/casting_lifecycle.ts`'s channel ticks, `combat/auto_attack.ts`'s
on-next-swing bonus) now calls it too and threads the multiplier through the
rider instead of leaving it unscaled. The base bake is unchanged, so
`base * mult + rider * mult` still equals `mult * (base + rider)` (the
advertised percentage), and no additional rng draw is introduced.

## Related issues

Closes #1803

## Type of change

- [x] Bug fix

## How was this tested?

- Commands:
  - `npx tsc --noEmit` (clean)
  - `npx vitest run tests/talent_hit_mult.test.ts tests/talent_full_hit_scaling.test.ts tests/spell_scaling.test.ts` (new/updated tests; also verified test-first by stashing the source changes and confirming `talent_full_hit_scaling.test.ts` fails red against the pre-fix code, then re-applying and confirming green)
  - `npx vitest run tests/talents.test.ts tests/spec_masteries.test.ts tests/mastery_mechanism.test.ts tests/talent_mastery_fail_closed.test.ts tests/architecture.test.ts`
  - `npx vitest run tests/warlock_balance.test.ts tests/spell_balance.test.ts tests/fire_short_fight_tuning.test.ts tests/chronomancy_balance.test.ts tests/frost_mage_procs.test.ts tests/spell_power.test.ts tests/spec_baselines.test.ts tests/chronomancy.test.ts tests/mage_barrier_scaling.test.ts`
  - `UPDATE_PARITY=1 npx vitest run tests/parity` (re-mints the one golden the fix legitimately shifts, `frost_proc_orb`, matching the issue's own "Frost ability-scoped mastery" example: only the RNG-independent state digest and damage counters changed, the rng draw-order digest stayed identical), then `npx vitest run tests/parity` again: fully clean (185 passed, 2 skipped, 0 failed).
  - `npm run gate`, twice, on this shared dev box under heavy concurrent load from unrelated sessions (load average 40-77 on 16 cores). Both runs stopped at the vitest full-suite step on a set of `Error: Test timed out` failures (never an assertion mismatch) in files with zero relation to this diff (mail, professions, terrain streaming, gathering, escort, dungeon finder, stable yard, taunt/threat); the specific set of failing tests differed between the two runs and between isolated re-runs of just those files, which is the signature of load-induced flakiness, not a deterministic regression. `npm run gate`'s own docs (`docs/qa-gate.md`) note it "bounds Vitest workers to avoid load flakes on shared machines"; this box is well past that budget with several other orchestrator sessions running full suites concurrently. I did NOT get one single `npm run gate` invocation to a clean 0-failure line by itself, but I isolated and re-ran every file that ever appeared in a failure list on this box: with the shared load down, `tests/parity` (the suite that actually exercises this diff's combat math) passed twice in a row (185/187, 0 failed), and the two real regressions the fix caused (below) are fixed and pass in isolation. `npx tsc --noEmit`, Biome on every changed file, and the pre-push QA floor (typecheck + architecture/i18n guard tests + changed-file Biome + copy rules) all passed clean.
  - While verifying, found and fixed two pre-existing tests whose hardcoded absorb-shield numbers baked in the old, partially-scaled math (exactly what the issue's Scope section anticipated: "The talent and ability damage tests that pin hardcoded numbers will need rewriting to the new formula"): `tests/chronomancy.test.ts` (Temporal Barrier, Chronoweave mastery) and `tests/mage_barrier_scaling.test.ts` (Temporal Barrier's Spell Power rider across ranks). Both pass now with updated, formula-derived expectations.
- Manual steps: none. This is a pure `src/sim` combat-math and wiring change with no player- or operator-visible surface.

## Screenshots / recordings

N/A. No player- or operator-visible surface (a combat-math fix inside the deterministic sim core).

## Scope: what this PR does and does not do

- Fixes the mechanism for every effect kind whose authored base is already
  talent-scaled by `scaleEffect` and that also adds a runtime SP/AP/weapon
  rider: `directDamage`, `dot` (non-hybrid), `aoeDamage`, `groundAoE`,
  `aoeRoot`, `finisherDamage`'s AP term, `consumeAura`'s deal/heal,
  `weaponDamage` (on-next-swing abilities like Heroic Strike/Raptor Strike),
  `heal`, `chainHeal`, `hot`, `absorb`, `aoeHeal`, and channel ticks
  (position/self-centered/projectile). `weaponStrike` and `judgement` already
  carried their multiplier forward correctly (via `weaponMult`/`eff.dmgMult`
  instead of baking it into the base), so those needed no base-scaling change;
  `judgement` only needed its existing carried multiplier to also wrap its SP
  rider.
- Deliberately leaves `chainDamage`, `frozenOrb`, `massTemporalEcho`, and
  `empoweredCone` untouched: none of these currently has a `scaleEffect` case
  in `classes.ts`, so their authored base is not talent-scaled today either
  (a distinct, pre-existing gap, not the "base scaled but rider isn't" bug
  #1803 reports). Scaling only their rider would have introduced a new
  inconsistency rather than fixed one; no live talent currently targets any of
  them via `dmgPct`, so this is inert today. Worth a follow-up issue if a
  future talent wants to target one of them.
- Deliberately leaves balance-number retuning out of scope, per the issue's
  own acceptance criteria: "the shipped mastery percentages may want retuning
  down once they scale the full hit... a balance sign-off, not just a
  mechanical port." This PR is the mechanical fix only (every mastery/talent
  percentage keeps its currently authored value); the parity goldens re-mint
  to reflect the mechanically-corrected numbers, but no percentage was
  changed. A follow-up PR can retune specific numbers once the owner reviews
  the new effective magnitudes.

```mermaid
flowchart TD
    T["Talent dmgPct / global %<br/>(mastery or talent node)"] --> R["resolveTalentHitMult(ability, mods)<br/>talent_hit_mult.ts (new, pure)"]
    R -->|"dmgMult / healMult"| C["classes.ts: applyTalentMods<br/>bakes into authored base (min/max/total)<br/>UNCHANGED"]
    R -->|"same dmgMult / healMult"| D["effect_dispatch.ts / casting_lifecycle.ts / auto_attack.ts<br/>now scales the runtime SP/AP/weapon rider<br/>(spell_scaling.ts, meleeSwing) - THE FIX"]
    C --> H["dealt hit = baked base + scaled rider<br/>= mult * (authored base + SP/AP/weapon)"]
    D --> H
    H --> P["Player sees the full advertised %<br/>on the WHOLE hit, at any gear level"]
```

## Checklist

### Quality

- [ ] **The full gate passes.** See "How was this tested": `npm run gate` itself
      did not reach a single clean 0-failure line on the shared dev box this
      was built on (severe, verified, unrelated concurrent load; every
      individual failure was a `Test timed out`, the specific set changing run
      to run, in files with no relation to this diff). Every check that
      exercises this diff directly (`tsc`, Biome, the pre-push QA floor, the
      full targeted unit/integration suite, and the parity gate twice in a
      row) is clean; please re-run `npm run gate` in CI, which does not share
      this box's load. Added `tests/talent_hit_mult.test.ts` (unit tests for
      the new resolver) and `tests/talent_full_hit_scaling.test.ts` (a
      failing-before/passing-after reproduction: a pure directDamage check
      plus real end-to-end Sim casts for a DoT, a HoT, and an absorb shield,
      each proving the advertised percentage now applies to base + Spell Power
      together at both 0 and high Spell Power), extended
      `tests/spell_scaling.test.ts` for the new `mult` parameter on each rider
      function, and fixed two pre-existing hardcoded-number tests the fix
      correctly broke (see "How was this tested").

### Cross-platform

- N/A. No UI/render surface touched.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files. `tests/parity/golden/*` was
      regenerated via `UPDATE_PARITY=1 npx vitest run tests/parity`, the
      documented deliberate regen path, not by hand.
