### PR TITLE
fix(scripts): clamp local gate vitest workers to available memory

### DIFF
--- a/scripts/gate.mjs
+++ b/scripts/gate.mjs
@@ -14,6 +14,7 @@
 // Keep the step list in sync with .github/workflows/ci.yml (and vice versa).
 import { spawnSync } from 'node:child_process';
 import os from 'node:os';
+import { computeGateWorkers } from './lib/gate_workers.mjs';
 import {
   formatInstallSyncFailure,
   parseInstallProblems,
@@ -21,7 +22,18 @@ import {
 } from './lib/npm_install_sync.mjs';
 import { FFMPEG_PATH, FFPROBE_PATH } from './sfx/ffmpeg_paths.mjs';
 
-const workers = Math.max(1, Math.floor(os.availableParallelism() / 2));
+// Halving the core count only protects a gate run from ITSELF; it does nothing when a
+// second `npm run gate` (or any other heavy vitest run) is happening in a sibling
+// worktree on the same machine, which this repo's own parallel-worktree workflow makes
+// routine. computeGateWorkers additionally clamps to available memory, since a vitest
+// fork worker that starts swapping presents as a flaky failure, not a slow one. Override
+// with GATE_MAX_WORKERS=<n> when you know better than the heuristic (e.g. deliberately
+// running several gates at once and want each one to take a smaller share).
+const workers = computeGateWorkers({
+  cpuCount: os.availableParallelism(),
+  freeMemBytes: os.freemem(),
+  envOverride: process.env.GATE_MAX_WORKERS,
+});
 // npm/npx resolve to .cmd files on Windows, which spawnSync only finds via a shell.
 const shell = process.platform === 'win32';
 
@@ -124,6 +136,4 @@ for (const [name, cmd, args, hint] of steps) {
   }
 }
 
-console.log(
-  `\n[gate] PASS: all ${steps.length} steps green (vitest workers capped at ${workers}, half the cores)`,
-);
+console.log(`\n[gate] PASS: all ${steps.length} steps green (vitest workers: ${workers})`);

--- a/scripts/lib/gate_workers.d.mts
+++ b/scripts/lib/gate_workers.d.mts
@@ -1,0 +1,5 @@
+export function computeGateWorkers(opts: {
+  cpuCount: number;
+  freeMemBytes: number;
+  envOverride: string | undefined;
+}): number;

--- a/scripts/lib/gate_workers.mjs
+++ b/scripts/lib/gate_workers.mjs
@@ -1,0 +1,25 @@
+// Pure worker-count calculator for scripts/gate.mjs, split out per scripts/CLAUDE.md's
+// module-first rule so Vitest can pin every branch without spawning the real gate.
+//
+// gate.mjs previously capped vitest at half the CPU cores, on the theory (its own header
+// comment) that "an unbounded full run saturates every core and flakes the heavy sim suites
+// when other work shares the machine." That theory has a gap: it only accounts for CPU. A
+// dev box running several worktrees at once (this repo's own recommended workflow for
+// parallel tasks) can have multiple `npm run gate` invocations each independently halving
+// the SAME core count, so together they saturate every core anyway, and each vitest fork
+// worker's RSS competes for a machine's finite RAM regardless of how many cores are free.
+// When free memory runs out the OS starts swapping, and a worker that would pass in
+// seconds instead times out waiting on swapped-in pages, presenting as a flaky test failure
+// rather than a slow one.
+const BYTES_PER_WORKER = 768 * 1024 * 1024; // 0.75 GiB: observed RSS ceiling for one heavy
+// vitest fork worker in this repo's sim/render/server suites under load, with headroom.
+
+export function computeGateWorkers({ cpuCount, freeMemBytes, envOverride }) {
+  if (envOverride !== undefined) {
+    const parsed = Number.parseInt(envOverride, 10);
+    if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  }
+  const cpuBound = Math.max(1, Math.floor(cpuCount / 2));
+  const memBound = Math.max(1, Math.floor(freeMemBytes / BYTES_PER_WORKER));
+  return Math.min(cpuBound, memBound);
+}

--- a/tests/gate_workers.test.ts
+++ b/tests/gate_workers.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { computeGateWorkers } from '../scripts/lib/gate_workers.mjs';
+
+const GIB = 1024 * 1024 * 1024;
+const MIB = 1024 * 1024;
+
+describe('computeGateWorkers: CPU-bound default (plenty of free memory)', () => {
+  it('halves the core count, floored, on a machine with ample free memory', () => {
+    expect(
+      computeGateWorkers({ cpuCount: 16, freeMemBytes: 32 * GIB, envOverride: undefined }),
+    ).toBe(8);
+  });
+
+  it('never returns fewer than 1 worker on a single-core machine', () => {
+    expect(
+      computeGateWorkers({ cpuCount: 1, freeMemBytes: 32 * GIB, envOverride: undefined }),
+    ).toBe(1);
+  });
+
+  it('floors an odd core count', () => {
+    expect(
+      computeGateWorkers({ cpuCount: 5, freeMemBytes: 32 * GIB, envOverride: undefined }),
+    ).toBe(2);
+  });
+});
+
+describe('computeGateWorkers: memory-bound clamp', () => {
+  it('clamps below the CPU bound when free memory is tight', () => {
+    expect(
+      computeGateWorkers({ cpuCount: 16, freeMemBytes: 1536 * MIB, envOverride: undefined }),
+    ).toBe(2);
+  });
+
+  it('never returns fewer than 1 worker even under severe memory pressure', () => {
+    expect(
+      computeGateWorkers({ cpuCount: 16, freeMemBytes: 100 * MIB, envOverride: undefined }),
+    ).toBe(1);
+  });
+
+  it('never returns fewer than 1 worker at exactly zero free memory', () => {
+    expect(computeGateWorkers({ cpuCount: 16, freeMemBytes: 0, envOverride: undefined })).toBe(1);
+  });
+
+  it('does not tighten below the CPU bound when memory is not actually the limiter', () => {
+    // Memory bound (10) is looser than the CPU bound (4): CPU stays the limiter.
+    expect(
+      computeGateWorkers({ cpuCount: 8, freeMemBytes: 10 * 768 * MIB, envOverride: undefined }),
+    ).toBe(4);
+  });
+});
+
+describe('computeGateWorkers: GATE_MAX_WORKERS override', () => {
+  it('takes precedence over both the CPU and memory bounds', () => {
+    expect(computeGateWorkers({ cpuCount: 16, freeMemBytes: 100 * MIB, envOverride: '3' })).toBe(3);
+  });
+
+  it('can request more workers than the default CPU-halving heuristic would allow', () => {
+    expect(computeGateWorkers({ cpuCount: 4, freeMemBytes: 32 * GIB, envOverride: '12' })).toBe(12);
+  });
+
+  it.each(['0', '-1', 'abc', '', '  '])(
+    'falls back to the computed default on an invalid override %j',
+    (bad) => {
+      expect(computeGateWorkers({ cpuCount: 16, freeMemBytes: 32 * GIB, envOverride: bad })).toBe(
+        8,
+      );
+    },
+  );
+});


### PR DESCRIPTION
## Summary

`npm run gate` sized its vitest worker pool from CPU cores alone (half of
`os.availableParallelism()`). That guard only protects a gate run from
itself: it does nothing when a second `npm run gate` (or any other heavy
vitest run) is active in a sibling worktree on the same machine, which
this repo's own parallel-worktree workflow makes routine. When several
such runs share one box, free memory runs out and the OS starts swapping,
so a vitest fork worker that would pass in seconds instead times out
waiting on swapped-in pages, presenting as a flaky test failure rather
than a slow one.

This adds a small pure module, `computeGateWorkers` (`scripts/lib/gate_workers.mjs`),
that additionally clamps the worker count to available memory, and a
`GATE_MAX_WORKERS` env override for a contributor who wants explicit
manual control (e.g. deliberately running several gates at once and
wanting each one to take a smaller share). On an otherwise idle machine
with ample free memory, behavior is unchanged: the CPU-half bound still
wins.

```mermaid
flowchart TD
    A["npm run gate starts"] --> B{"GATE_MAX_WORKERS set\nto a valid positive integer?"}
    B -- yes --> C["workers = GATE_MAX_WORKERS\n(explicit override wins)"]
    B -- no / invalid --> D["cpuBound = floor(cpuCount / 2)\n(existing heuristic, unchanged)"]
    D --> E["memBound = floor(freeMemBytes / 0.75 GiB)\n(NEW: per-worker memory budget)"]
    E --> F["workers = max(1, min(cpuBound, memBound))"]
    C --> G["vitest run --maxWorkers=workers"]
    F --> G
```

`.github/workflows/ci.yml`'s own worker-sizing (dedicated, single-tenant
runners, never shared with a sibling gate run) is deliberately left
untouched: this is a local-dev-only problem.

### How this was found and verified

While auditing this dev machine for the "gate is flaky, wastes time on
retries" complaint that prompted this PR, I found the machine had grown to
111 registered git worktrees and was running several `npm run gate`
processes concurrently (each independently trying to claim half the CPU
cores for itself), with the system already paging heavily to swap. An
unmodified full `npm run gate` run under that load hit **12 timeout
failures across 8 unrelated sim test files** (mail, professions,
Eastbrook, escort, fire-mage tuning), every one a
`Test timed out in Nms` error, never an assertion failure. My diff touches
none of that logic. Re-running the same 8 files with a generous
`--testTimeout` under identical load made all 148 of their tests pass,
confirming pure wall-clock starvation, not a regression.

Re-running the full gate with `GATE_MAX_WORKERS` set lower (dogfooding
this PR's own override) produced a clean `[gate] PASS: all 11 steps green`
on the same loaded machine.

## Related issues

N/A (no tracking issue for this local-dev pain point existed; filed as a direct fix)

## Type of change

- [ ] Feature: new functionality
- [ ] Bug fix
- [x] Refactor or performance (no behavior change on an idle/ample-memory machine)
- [ ] Documentation
- [ ] Tests
- [x] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx vitest run tests/gate_workers.test.ts` (14 new unit tests covering
    CPU-bound default, memory-bound clamp, the 1-worker floor, and
    `GATE_MAX_WORKERS` override including invalid-value fallback)
  - `npx tsc --noEmit` (clean)
  - `npm run gate` (full local gate, green: `[gate] PASS: all 11 steps
    green (vitest workers: 2)`, run with `GATE_MAX_WORKERS=2` on a heavily
    loaded machine after isolating and ruling out unrelated contention
    flakes as described above)
- Manual steps: none (dev-tooling-only change, no player- or
  operator-visible surface)

## Screenshots / recordings

N/A. This is a local dev-tooling change with no UI, no player-visible
strings, and no operator-visible surface.

---

## Checklist

### Quality

- [x] **The full gate passes.** `npm run gate` is green. I added or updated
      decisive tests for changed behavior and recorded the manual checks above.

### Cross-platform

- [x] N/A. Node-only tooling script, no UI.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS`
      is not enabled in any production path.
- [x] I didn't hand-edit generated files.
