### PR TITLE
perf(render): reduce streamed world stalls

### DIFF
--- a/scripts/freeze_walk_debug.mjs
+++ b/scripts/freeze_walk_debug.mjs
@@ -16,6 +16,7 @@ const BASE_URL = process.env.GAME_URL ?? 'http://localhost:5173';
 const GFX = process.env.PERF_GFX ?? 'ultra';
 const KLASS = process.env.PERF_CLASS ?? 'warrior';
 const WALK_MS = Number(process.env.WALK_MS ?? 14000);
+const SETTLE_MS = Number(process.env.PERF_SETTLE_MS ?? 3500);
 const HEADLESS = process.env.HEADED === '1' ? false : 'new';
 const OUT =
   process.env.PERF_OUT ??
@@ -51,6 +52,59 @@ async function boot(page) {
   // fast without every frame being a multi-second rasterisation "freeze".
   await page.setViewport({ width: 480, height: 320 });
   await page.evaluateOnNewDocument(() => {
+    window.__slowGfxCalls = [];
+    window.__mainLongTasks = [];
+    const observeLongTasks = () => {
+      if (typeof PerformanceObserver === 'undefined') return;
+      try {
+        const observer = new PerformanceObserver((list) => {
+          for (const entry of list.getEntries()) {
+            if (entry.duration >= 20) {
+              window.__mainLongTasks.push({
+                name: entry.name,
+                durationMs: Math.round(entry.duration),
+                startTimeMs: Math.round(entry.startTime),
+              });
+            }
+          }
+        });
+        observer.observe({ type: 'longtask', buffered: true });
+      } catch {}
+    };
+    const wrapSlowGraphicsCall = (prototype, name) => {
+      const original = prototype?.[name];
+      if (typeof original !== 'function') return;
+      prototype[name] = function (...args) {
+        const started = performance.now();
+        try {
+          return original.apply(this, args);
+        } finally {
+          const durationMs = performance.now() - started;
+          if (durationMs >= 20) {
+            window.__slowGfxCalls.push({
+              name,
+              durationMs: Math.round(durationMs),
+              atMs: Math.round(started),
+            });
+          }
+        }
+      };
+    };
+    for (const prototype of [WebGLRenderingContext.prototype, WebGL2RenderingContext.prototype]) {
+      for (const name of [
+        'bufferData',
+        'bufferSubData',
+        'texImage2D',
+        'texSubImage2D',
+        'compileShader',
+        'linkProgram',
+        'drawElements',
+        'drawArrays',
+      ]) {
+        wrapSlowGraphicsCall(prototype, name);
+      }
+    }
+    observeLongTasks();
     window.__armFreeze = () => {
       const g = window.__game,
         r = g.renderer,
@@ -80,13 +134,19 @@ async function boot(page) {
           try {
             lf = g.perf.report()?.renderer?.lastFrame ?? null;
           } catch {}
+          const renderer = g.renderer;
           const pp = g.sim.player.pos;
           window.__freezes.push({
+            atMs: Math.round(now),
             dtMs: Math.round(dt),
             dProg,
             x: Math.round(pp.x),
             z: Math.round(pp.z),
             createdViewTypes: lf?.createdViewTypes ?? null,
+            phaseMs: lf?.phaseMs ?? null,
+            worldPhaseMs: lf?.worldPhaseMs ?? null,
+            zonePrepare: renderer?.lastZonePrepareStats ?? null,
+            zonePrewarm: renderer?.lastZonePrewarmStats ?? null,
             newKeys,
           });
         }
@@ -111,7 +171,7 @@ async function boot(page) {
       Boolean(window.__game?.sim?.player && window.__game?.renderer && window.__game?.perf?.report),
     { timeout: 120000 },
   );
-  await sleep(3500); // let prewarm finish + settle
+  await sleep(SETTLE_MS); // let prewarm/initial terrain settle
 }
 
 async function run() {
@@ -128,6 +188,8 @@ async function run() {
     args,
   });
   const page = await browser.newPage();
+  const profiler =
+    process.env.PERF_CPU_PROFILE === '1' ? await page.target().createCDPSession() : null;
   const errors = [];
   page.on('pageerror', (e) => errors.push(`PAGEERROR: ${e.message}`));
   try {
@@ -145,6 +207,10 @@ async function run() {
     // in. Teleport-stepping (vs real walking) is reliable on slow swiftshader and
     // still triggers the same lazy material/program builds; we want the program
     // SET that compiles, not the streaming dynamics.
+    if (profiler) {
+      await profiler.send('Profiler.enable');
+      await profiler.send('Profiler.start');
+    }
     await page.evaluate(() => window.__armFreeze());
     const startZ = -10;
     const endZ = 170;
@@ -163,6 +229,9 @@ async function run() {
 
     const freezes = await page.evaluate(() => window.__freezes ?? []);
     const baseKeys = await page.evaluate(() => window.__benchBaseKeys ?? []);
+    const slowGfxCalls = await page.evaluate(() => window.__slowGfxCalls ?? []);
+    const mainLongTasks = await page.evaluate(() => window.__mainLongTasks ?? []);
+    const cpuProfile = profiler ? (await profiler.send('Profiler.stop')).profile : null;
 
     // Classify.
     const byClass = {};
@@ -181,10 +250,14 @@ async function run() {
       startZ,
       endZ,
       walkMs: WALK_MS,
+      settleMs: SETTLE_MS,
       totalNewPrograms: totalNew,
       byClass,
       baseKeys,
       freezes,
+      slowGfxCalls,
+      mainLongTasks,
+      cpuProfile,
       errors,
     };
     fs.writeFileSync(OUT, `${JSON.stringify(artifact, null, 2)}\n`);
@@ -210,8 +283,28 @@ async function run() {
         .map(([c, n]) => `${n}x ${c}`)
         .join(', ');
       console.log(
-        `  ${String(f.dtMs).padStart(5)}ms @${f.x},${f.z} +${f.dProg}prog  views=${f.createdViewTypes?.join('|') ?? '-'}  ${cs}`,
+        `  ${String(f.dtMs).padStart(5)}ms @${f.x},${f.z} +${f.dProg}prog ` +
+          `views=${f.createdViewTypes?.join('|') ?? '-'} ` +
+          `phases=${formatPhases(f.phaseMs, f.worldPhaseMs)}  ${cs}`,
       );
+    }
+    console.log(`\nslow WebGL calls >=20ms: ${slowGfxCalls.length}`);
+    for (const call of slowGfxCalls.slice(-20)) console.log(`  ${call.name} ${call.durationMs}ms`);
+    console.log(`main long tasks >=20ms: ${mainLongTasks.length}`);
+    for (const task of mainLongTasks.slice(-20)) console.log(`  ${task.name} ${task.durationMs}ms`);
+    if (cpuProfile) {
+      const nodeById = new Map(cpuProfile.nodes.map((node) => [node.id, node]));
+      const samples = new Map();
+      for (const id of cpuProfile.samples ?? []) {
+        const node = nodeById.get(id);
+        const key = node
+          ? `${node.callFrame.functionName || '(anonymous)'} @ ${node.callFrame.url}`
+          : String(id);
+        samples.set(key, (samples.get(key) ?? 0) + 1);
+      }
+      console.log('\nCPU profile top samples:');
+      for (const [key, count] of [...samples].sort((a, b) => b[1] - a[1]).slice(0, 20))
+        console.log(`  ${String(count).padStart(4)} ${key}`);
     }
     console.log(`\nwrote ${OUT}`);
     if (errors.length)
@@ -220,6 +313,23 @@ async function run() {
     await page.close();
     await browser.close();
   }
+}
+
+function formatPhases(phases, worldPhases) {
+  if (!phases) return '-';
+  const top = Object.entries(phases)
+    .filter(([, value]) => Number.isFinite(value?.max ?? value))
+    .sort((a, b) => (b[1]?.max ?? b[1]) - (a[1]?.max ?? a[1]))
+    .slice(0, 3)
+    .map(([name, value]) => `${name}:${(value?.max ?? value).toFixed(1)}`);
+  const world = worldPhases
+    ? Object.entries(worldPhases)
+        .filter(([, value]) => Number.isFinite(value?.max ?? value))
+        .sort((a, b) => (b[1]?.max ?? b[1]) - (a[1]?.max ?? a[1]))
+        .slice(0, 2)
+        .map(([name, value]) => `${name}:${(value?.max ?? value).toFixed(1)}`)
+    : [];
+  return [...top, ...world.map((entry) => `world.${entry}`)].join(',') || '-';
 }
 
 run().catch((e) => {

--- a/src/render/prewarm_pass.ts
+++ b/src/render/prewarm_pass.ts
@@ -32,6 +32,8 @@ export interface BackgroundPrewarmHooks {
   warmChild?: (group: PrewarmGroupLike, child: unknown) => void;
   /** The synchronous warm pass; the groups are visible exactly for this call. */
   renderWarmPass: () => void;
+  /** Skip all shader work when a streamed zone is not yet interactive. */
+  runWarmPass?: boolean;
 }
 
 export async function runBackgroundPrewarm(
@@ -40,7 +42,7 @@ export async function runBackgroundPrewarm(
 ): Promise<void> {
   for (const group of groups) group.visible = false;
   try {
-    if (hooks.supportsAsyncCompile) {
+    if (hooks.runWarmPass !== false && hooks.supportsAsyncCompile) {
       for (const group of groups) {
         for (const child of [...group.children]) {
           await hooks.idleSlot();
@@ -58,8 +60,10 @@ export async function runBackgroundPrewarm(
       }
       await hooks.idleSlot();
     }
-    for (const group of groups) group.visible = true;
-    hooks.renderWarmPass();
+    if (hooks.runWarmPass !== false) {
+      for (const group of groups) group.visible = true;
+      hooks.renderWarmPass();
+    }
   } finally {
     for (const group of groups) group.visible = false;
   }

--- a/src/render/prewarm_policy.ts
+++ b/src/render/prewarm_policy.ts
@@ -34,6 +34,32 @@ export const CONSTRAINED_TEXTURE_MAX_MS = 1200;
 export const CONSTRAINED_ENTRY_VIEW_RAMP_MS = 300;
 export const NEARBY_LANDMARK_STREAM_RADIUS = 16;
 
+/** Size a character pool to authored demand with a bounded entry cost. */
+export function prewarmMobCopies(
+  commonTemplate: boolean,
+  authoredSpawnCount: number,
+  baseCopies: number,
+  maxCopies: number,
+): number {
+  const base = Math.max(1, Math.floor(baseCopies));
+  if (!commonTemplate) return 1;
+  const authored = Number.isFinite(authoredSpawnCount)
+    ? Math.max(0, Math.floor(authoredSpawnCount))
+    : 0;
+  const cap = Math.max(base, Math.floor(maxCopies));
+  return Math.min(cap, Math.max(base, authored));
+}
+
+/** A template is fully warmed only when every requested pool copy exists. */
+export function prewarmTemplateCompleted(requestedCopies: number, builtCopies: number): boolean {
+  return (
+    Number.isFinite(requestedCopies) &&
+    Number.isFinite(builtCopies) &&
+    requestedCopies > 0 &&
+    builtCopies >= requestedCopies
+  );
+}
+
 export interface MandatoryLandmarkCandidate {
   kind: string;
   templateId: string | null;

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -3149,6 +3149,9 @@ export class Renderer {
   // per-frame distance cull in updateZoneFeatureVisibility. Measured ONCE here:
   // these groups are static and matrix-frozen, so the bounds never move.
   private zoneFeatureGroups: { group: THREE.Group; footprint: FeatureFootprint | null }[] = [];
+  private zoneFeatureVisibilityX = Number.NaN;
+  private zoneFeatureVisibilityZ = Number.NaN;
+  private zoneFeatureVisibilityFar = Number.NaN;
 
   private attachZoneFeature(
     view: { group: THREE.Group; glowLights?: THREE.PointLight[]; cullGroups?: THREE.Group[] },
@@ -3198,6 +3201,9 @@ export class Renderer {
         footprint: measureFeatureFootprint(cullGroup),
       });
     }
+    // A newly attached group must be evaluated even when camera and fog are
+    // unchanged from the previous frame.
+    this.zoneFeatureVisibilityX = Number.NaN;
   }
 
   // Hide feature groups the fog has already swallowed. Terrain and foliage both
@@ -3207,6 +3213,16 @@ export class Renderer {
   private updateZoneFeatureVisibility(fogFar: number): void {
     const camX = this.camera.position.x;
     const camZ = this.camera.position.z;
+    if (
+      camX === this.zoneFeatureVisibilityX &&
+      camZ === this.zoneFeatureVisibilityZ &&
+      fogFar === this.zoneFeatureVisibilityFar
+    ) {
+      return;
+    }
+    this.zoneFeatureVisibilityX = camX;
+    this.zoneFeatureVisibilityZ = camZ;
+    this.zoneFeatureVisibilityFar = fogFar;
     for (const entry of this.zoneFeatureGroups) {
       entry.group.visible = isZoneFeatureVisible(entry.footprint, camX, camZ, fogFar);
     }

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -271,6 +271,8 @@ import {
   type PrewarmPolicy,
   partitionMandatoryLandmarkCandidates,
   prewarmEntryRuns,
+  prewarmMobCopies,
+  prewarmTemplateCompleted,
   remainingPrewarmViewBudget,
   resolvePrewarmPolicy,
 } from './prewarm_policy';
@@ -413,6 +415,11 @@ const PREWARM_COMPILE_MAX_MS = 10000;
 // A background prewarm waits for a browser idle slot between its per-group
 // compile chunks; the timeout forces progress under sustained frame load.
 const IDLE_PREWARM_TIMEOUT_MS = 250;
+// Feature builders contain authored geometry (stairs, piers, rails and hulls)
+// that cannot be split after construction. Do not pay that one-shot cost for a
+// zone whose entry is still outside the interactive neighborhood; terrain and
+// sky can stream ahead safely, while the feature queue catches up near entry.
+const ZONE_STREAM_START_DISTANCE = 120;
 // Safety ceiling for the per-view async-compile gate: if KHR_parallel_shader_compile
 // somehow never reports a program ready, show the view anyway (degrading to the old
 // synchronous first-use compile) rather than stranding an entity invisible.
@@ -652,6 +659,7 @@ const PREWARM_OBJECT_ITEM_IDS = [
   'crypt_ritual_circle',
 ] as const;
 const PREWARM_MOB_POOL_COPIES = 3;
+const PREWARM_MOB_POOL_MAX_COPIES = 8;
 const PREWARM_OBJECT_POOL_COPIES = 2;
 // The common templates above are pooled several-deep (they spawn in groups); every
 // OTHER mob model is still built once so its shader program compiles at load.
@@ -1665,6 +1673,7 @@ export class Renderer {
   private shakeElapsed = 0;
   private fiestaRing: THREE.Mesh | null = null;
   private fiestaPowerupMeshes = new Map<number, THREE.Mesh>();
+  private readonly fiestaPowerupSeen = new Set<number>();
   // Per-entity power-up glow: emits a coloured swirl around the carrier until it expires.
   private fiestaGlows = new Map<number, { color: number; until: number; nextSwirl: number }>();
   // Per-target heal-glow throttle (ms since a target last bloomed a heal glow). A
@@ -2807,12 +2816,15 @@ export class Renderer {
       return;
     }
     // A DataTexture upload is synchronous even from requestIdleCallback.
-    // Split HDRIs into bounded row batches, then run the much smaller 512px
-    // PMREM between idle slots. This keeps background zone preparation from
-    // turning a future biome's sky into one 30+ MB gameplay frame.
+    // Split HDRIs into bounded row batches. The loading-screen path runs the
+    // much smaller 512px PMREM; the background lane only warms source pixels,
+    // so it cannot turn a future biome's sky into a 30+ MB gameplay frame.
     await this.prewarmTextureInIdle(envSource);
-    await idleSlot(IDLE_PREWARM_TIMEOUT_MS);
-    this.ensureEnvironmentBiome(zone.biome);
+    // PMREM generation is synchronous GPU work despite being started from an
+    // idle callback. On a real GPU it produced 300-400ms long tasks while the
+    // player crossed into Mirefen. Keep the raw HDRI warm for the dome, but
+    // leave the IBL on the already resident biome during gameplay; the
+    // loading-screen path above still builds every required entry PMREM.
     await this.prewarmTextureInIdle(domeSource);
   }
 
@@ -2833,14 +2845,21 @@ export class Renderer {
     opts?: { pace?: 'fast' | 'idle' },
   ): Promise<void> {
     const zoneId = this.zoneIdAt(x, z);
-    if (zoneId === null || this.preparedZones.has(zoneId)) {
+    if (zoneId === null) {
+      onProgress?.(1, 1);
+      return Promise.resolve();
+    }
+    const zone = zoneAt(x, z);
+    const idlePace = opts?.pace === 'idle';
+    const needsNearbyFeatures =
+      this.zoneNeedsFeaturePrepare(zone) &&
+      (!idlePace || this.zoneEntryIsNear(zone, this.camera.position.x, this.camera.position.z));
+    if (this.preparedZones.has(zoneId) && !needsNearbyFeatures) {
       onProgress?.(1, 1);
       return Promise.resolve();
     }
     const pending = this.pendingZonePrepares.get(zoneId);
     if (pending) return pending;
-    const zone = zoneAt(x, z);
-    const idlePace = opts?.pace === 'idle';
     const task = (async () => {
       const started = performance.now();
       onProgress?.(0, 100);
@@ -2869,10 +2888,10 @@ export class Renderer {
         (done, total) => onProgress?.(5 + Math.round((done / Math.max(1, total)) * 83), 100),
         { priority: { x, z }, pace: opts?.pace },
       );
-      // The group itself was frozen while still empty in the constructor.
-      // Freeze the children added by this zone as well; subsequent zones are
-      // handled by their own prepare pass.
-      freezeStaticMatrices(this.terrainView.group);
+      // Each streamed chunk freezes its own matrix in attachChunk(). Do not
+      // walk the whole world terrain group here: once several zones are
+      // resident that redundant updateMatrixWorld traversal becomes a visible
+      // long task exactly when a new zone finishes streaming.
       const terrainDone = performance.now();
       onProgress?.(89, 100);
       const waterMeshes = await this.waterView.ensureZone(zone, { pace: opts?.pace });
@@ -2880,13 +2899,12 @@ export class Renderer {
       const waterDone = performance.now();
       onProgress?.(96, 100);
       this.lastAttachedFeatureGroups = [];
-      this.ensureZoneFeatures(zone);
-      // A background prepare precompiles every program this zone just added
-      // (water lakes, bespoke biome features), one idle slot apart: a program
-      // whose driver link has not finished BLOCKS the main thread at its first
-      // draw (getUniforms queries ACTIVE_UNIFORMS synchronously), which was a
-      // measured multi-hundred-ms stall per new biome. compileAsync resolves
-      // only once the programs report ready, so the live render never pays it.
+      if (needsNearbyFeatures) this.ensureZoneFeatures(zone);
+      // The loading-screen path precompiles every program this zone just added
+      // (water lakes, bespoke biome features), one idle slot apart. The live
+      // streaming path deliberately leaves shader work to the per-view compile
+      // gate: compileAsync has a synchronous Three.js prologue that can still
+      // block a gameplay frame even when the driver supports parallel compile.
       if (opts?.pace === 'idle') {
         try {
           if (this.asyncCompileSupported) {
@@ -2943,11 +2961,12 @@ export class Renderer {
 
   async prewarmZoneAt(x: number, z: number, opts?: { background?: boolean }): Promise<void> {
     const zoneId = this.zoneIdAt(x, z);
-    if (zoneId === null || this.prewarmedZonePrograms.has(zoneId)) return;
+    if (zoneId === null) return;
+    const zone = zoneAt(x, z);
+    if (this.prewarmedZonePrograms.has(zoneId) && !this.zoneNeedsEntityPrewarm(zone)) return;
     const pending = this.pendingZonePrewarms.get(zoneId);
     if (pending) return pending;
     const task = (async () => {
-      const zone = zoneAt(x, z);
       const deadline = performance.now() + 5000;
       const t0 = performance.now();
       const mobPrewarm = this.buildEntityPrewarmGroup(zone);
@@ -2958,46 +2977,19 @@ export class Renderer {
       const tBuild = performance.now();
       let tCompile = tBuild;
       try {
-        // A background prewarm (the visible-zone streaming lane) links the new
-        // programs off-thread BEFORE the warm pass renders with them, so the
-        // pass never compiles inside a live gameplay frame. Compile the PREWARM
-        // GROUPS, one idle slot apart, never the whole scene: compileAsync's
-        // synchronous prologue walks and re-initializes every material it is
-        // handed, and a full-scene walk was a measured multi-hundred-ms stall
-        // per streamed zone. Live frames keep rendering across that whole
-        // awaited window, so runBackgroundPrewarm keeps both groups invisible
-        // until the synchronous warm pass (a visible group is a grid of T-posed
-        // rigs stacked next to the player). The gating path (behind the loading
-        // screen) keeps render-first, which also covers renderers without
-        // KHR_parallel_shader_compile.
+        // A background prewarm (the visible-zone streaming lane) only builds
+        // and pools visuals. Even compileAsync has a synchronous Three.js
+        // prologue, and the real-GPU freeze walk measured multi-second tasks
+        // while a neighbouring zone was being prepared. Streamed entities use
+        // their existing per-view compile gate when they become interactive;
+        // the full shader/warm pass remains on the loading-screen path.
         if (opts?.background) {
           await runBackgroundPrewarm([mobGroup, npcGroup], {
-            supportsAsyncCompile: this.asyncCompileSupported,
+            supportsAsyncCompile: false,
+            runWarmPass: false,
             idleSlot: () => idleSlot(IDLE_PREWARM_TIMEOUT_MS),
-            compileChild: async (child) => {
-              await Promise.race([
-                this.webgl.compileAsync(child as THREE.Object3D, this.camera, this.scene),
-                sleep(PREWARM_COMPILE_MAX_MS),
-              ]);
-              await this.compileSkinnedShadowPrograms(child as THREE.Object3D);
-            },
-            warmChild: (groupLike, child) => {
-              const group = groupLike as THREE.Group;
-              const target = child as THREE.Object3D;
-              const visibility = group.children.map((entry) => entry.visible);
-              try {
-                for (const entry of group.children) entry.visible = entry === target;
-                this.renderPrewarmPass(1 / 60, { offscreen: true });
-              } finally {
-                for (let i = 0; i < group.children.length; i++) {
-                  group.children[i].visible = visibility[i];
-                }
-              }
-            },
-            renderWarmPass: () => {
-              tCompile = performance.now();
-              this.renderPrewarmPass(1 / 60, { offscreen: true });
-            },
+            compileChild: async () => {},
+            renderWarmPass: () => {},
           });
         } else {
           tCompile = performance.now();
@@ -3010,13 +3002,13 @@ export class Renderer {
             ]);
           }
         }
-        this.prewarmedZonePrograms.add(zoneId);
+        if (!this.zoneNeedsEntityPrewarm(zone)) this.prewarmedZonePrograms.add(zoneId);
       } finally {
         mobGroup.removeFromParent();
         npcGroup.removeFromParent();
-        // Only publish visuals to the live pool after the warm pass. Background
-        // gameplay can otherwise take one out of its T-pose grid while the
-        // prewarm awaits idle compile slots, leaving its shadow variant cold.
+        // Publish the built visuals only after the prewarm group is detached.
+        // Background streaming has no warm pass, so its per-view compile gate
+        // remains responsible for first-use shader readiness.
         for (const item of mobPrewarm.pooled) this.storePooledVisual(item.key, item.visual);
         for (const item of npcPrewarm.pooled) this.storePooledVisual(item.key, item.visual);
         this.lastZonePrewarmStats = {
@@ -3086,7 +3078,14 @@ export class Renderer {
       horizon,
       forwardX,
       forwardZ,
-    ).filter((zone) => !this.preparedZones.has(zone.id) && !this.pendingZonePrepares.has(zone.id));
+    ).filter(
+      (zone) =>
+        this.zoneEntryIsNear(zone, cameraX, cameraZ) &&
+        (!this.preparedZones.has(zone.id) ||
+          !this.prewarmedZonePrograms.has(zone.id) ||
+          this.zoneNeedsFeaturePrepare(zone)) &&
+        !this.pendingZonePrepares.has(zone.id),
+    );
     this.pumpVisibleZonePrepareQueue();
   }
 
@@ -3094,7 +3093,12 @@ export class Renderer {
     if (this.visibleZonePrepareActive) return;
     const zone = this.visibleZonePrepareQueue.shift();
     if (!zone) return;
-    if (this.preparedZones.has(zone.id) || this.pendingZonePrepares.has(zone.id)) {
+    if (
+      (this.preparedZones.has(zone.id) &&
+        this.prewarmedZonePrograms.has(zone.id) &&
+        !this.zoneNeedsFeaturePrepare(zone)) ||
+      this.pendingZonePrepares.has(zone.id)
+    ) {
       this.pumpVisibleZonePrepareQueue();
       return;
     }
@@ -3281,6 +3285,38 @@ export class Renderer {
       default:
         break;
     }
+  }
+
+  private zoneNeedsFeaturePrepare(zone: ZoneDef): boolean {
+    switch (zone.biome) {
+      case 'dusk':
+        return !this.realmFlora;
+      case 'ember':
+        return !this.emberFeatures || !this.castleFeatures;
+      case 'frost':
+        return !this.frostSky;
+      case 'fen':
+        return !this.fenFeatures;
+      case 'amber':
+        return !this.amberFeatures;
+      case 'night':
+        return !this.nightFeatures;
+      case 'haunt':
+        return !this.hauntFeatures;
+      case 'jungle':
+        return !this.jungleFeatures;
+      case 'garden':
+        return !this.gardenFeatures;
+      case 'gale':
+        return !this.galeFeatures;
+      default:
+        return false;
+    }
+  }
+
+  private zoneEntryIsNear(zone: ZoneDef, cameraX: number, cameraZ: number): boolean {
+    const entry = zoneEntryPoint(zone, cameraX, cameraZ);
+    return Math.hypot(entry.x - cameraX, entry.z - cameraZ) <= ZONE_STREAM_START_DISTANCE;
   }
 
   /** Toggle biome-driven ambient precipitation (snow/rain). */
@@ -4348,6 +4384,28 @@ export class Renderer {
     return [...ids].sort();
   }
 
+  private authoredMobSpawnCountInZone(zone: ZoneDef, templateId: string): number {
+    let count = 0;
+    for (const camp of CAMPS) {
+      if (camp.mobId === templateId && zoneAt(camp.center.x, camp.center.z).id === zone.id) {
+        count += camp.count;
+      }
+    }
+    return count;
+  }
+
+  private zoneNeedsEntityPrewarm(zone: ZoneDef): boolean {
+    if (this.templateIdsInZone(zone, 'mob').some((id) => !this.prewarmedMobTemplates.has(id))) {
+      return true;
+    }
+    return this.templateIdsInZone(zone, 'npc').some((id) => {
+      const npc = NPCS[id];
+      if (!npc) return false;
+      const entity = this.prewarmEntity('npc', npc.id, npc.color, 1);
+      return !this.prewarmedNpcModels.has(visualKeyFor(entity));
+    });
+  }
+
   private buildEntityPrewarmGroup(zone: ZoneDef): {
     group: THREE.Group;
     pooled: { key: string; visual: CharacterVisual }[];
@@ -4363,9 +4421,10 @@ export class Renderer {
       group.add(obj);
       idx++;
     };
-    const build = (templateId: string, copies: number): void => {
+    const build = (templateId: string, copies: number): number => {
       const template = MOBS[templateId];
-      if (!template) return;
+      if (!template) return 0;
+      let built = 0;
       for (let i = 0; i < copies; i++) {
         const entity = this.prewarmEntity('mob', template.id, template.color, template.scale);
         const visual = createCharacterVisual(entity);
@@ -4375,15 +4434,26 @@ export class Renderer {
         if (poolKey) pooled.push({ key: poolKey, visual });
         visual.root.visible = true;
         place(visual.root);
+        built++;
       }
+      return built;
     };
     // Warm only templates that can appear in this zone. The per-template set
     // persists across transitions, so shared families are paid once per session.
     for (const templateId of this.templateIdsInZone(zone, 'mob')) {
       if (this.prewarmedMobTemplates.has(templateId)) continue;
-      const copies = PREWARM_MOB_COMMON_IDS.has(templateId) ? PREWARM_MOB_POOL_COPIES : 1;
-      build(templateId, copies);
-      this.prewarmedMobTemplates.add(templateId);
+      const copies = prewarmMobCopies(
+        PREWARM_MOB_COMMON_IDS.has(templateId),
+        this.authoredMobSpawnCountInZone(zone, templateId),
+        PREWARM_MOB_POOL_COPIES,
+        PREWARM_MOB_POOL_MAX_COPIES,
+      );
+      const built = build(templateId, copies);
+      // Do not permanently suppress a retry when a streamed/failed asset made
+      // the first build empty. A later zone-prewarm pass can then seed the pool.
+      if (prewarmTemplateCompleted(copies, built)) {
+        this.prewarmedMobTemplates.add(templateId);
+      }
     }
     return { group, pooled };
   }
@@ -5606,7 +5676,9 @@ export class Renderer {
       diagnosticsBaseline,
     };
     this.lastPrewarmStats = stats;
-    this.prewarmedZonePrograms.add(activeZone.id);
+    if (!this.zoneNeedsEntityPrewarm(activeZone)) {
+      this.prewarmedZonePrograms.add(activeZone.id);
+    }
     // Dev-channel diagnostic (pairs with main.ts's "[entry-guard] scene built"): one
     // line naming where the entry-time main-thread budget went, for isolating
     // world-entry process kills on real devices.
@@ -6174,7 +6246,8 @@ export class Renderer {
   private updateFiestaPowerups(dt: number): void {
     const match = this.sim.arenaInfo?.match;
     const list = match?.fiesta && match.state === 'active' ? match.fiesta.powerups : [];
-    const seen = new Set<number>();
+    const seen = this.fiestaPowerupSeen;
+    seen.clear();
     for (const p of list) {
       seen.add(p.id);
       let m = this.fiestaPowerupMeshes.get(p.id);

--- a/src/render/zone_feature_visibility_core.ts
+++ b/src/render/zone_feature_visibility_core.ts
@@ -45,9 +45,13 @@ export function featureEdgeDistance(
   camX: number,
   camZ: number,
 ): number {
+  return Math.sqrt(featureEdgeDistanceSq(footprint, camX, camZ));
+}
+
+function featureEdgeDistanceSq(footprint: FeatureFootprint, camX: number, camZ: number): number {
   const dx = Math.max(Math.abs(camX - footprint.centerX) - footprint.halfX, 0);
   const dz = Math.max(Math.abs(camZ - footprint.centerZ) - footprint.halfZ, 0);
-  return Math.hypot(dx, dz);
+  return dx * dx + dz * dz;
 }
 
 /**
@@ -63,7 +67,9 @@ export function isZoneFeatureVisible(
   drawDistance: number,
 ): boolean {
   if (!footprint) return true;
-  return featureEdgeDistance(footprint, camX, camZ) < drawDistance;
+  // This is a hot per-frame path. Compare squared distances so each registered
+  // feature avoids a sqrt while preserving the strict fog boundary.
+  return featureEdgeDistanceSq(footprint, camX, camZ) < drawDistance * drawDistance;
 }
 
 /**

--- a/tests/eastbrook_polish_capture_contract.test.ts
+++ b/tests/eastbrook_polish_capture_contract.test.ts
@@ -364,11 +364,13 @@ describe('Eastbrook polish capture contract', () => {
       // version sync moved every GLB source-fingerprint leaf (#2729), the
       // graphics overhaul and the ability-VFX integration each changed the
       // renderer-integration and view-priority leaves, and this branch edits
-      // src/render/renderer.ts for the compile gates. So the composite mints
+      // src/render/renderer.ts and src/render/prewarm_policy.ts for the compile
+      // gates, then the streaming/feature pacing work changed the renderer
+      // integration leaf again. So the composite mints
       // fresh and matches no parent's literal. No pipeline input or geometry
       // value changed, and no capture was retaken (the five per-asset seal
       // suites stay green untouched).
-      fingerprint: '2172d6960ce3057f6b64d2a1d178ab2b7df5f6802636010b1fa06e57a452106a',
+      fingerprint: '25caad85480b1805357021d9817b15485ed63e27f81365eef4cbe68df5137b8a',
       components: {
         captureContract: {
           id: 'polish-v2',

--- a/tests/prewarm_pass.test.ts
+++ b/tests/prewarm_pass.test.ts
@@ -101,6 +101,28 @@ describe('runBackgroundPrewarm', () => {
     expect(groups[0].visible).toBe(false);
   });
 
+  it('can defer streamed shader work until the zone becomes interactive', async () => {
+    const groups = [group(2)];
+    let compileCalls = 0;
+    let passRan = false;
+    await runBackgroundPrewarm(groups, {
+      supportsAsyncCompile: true,
+      runWarmPass: false,
+      idleSlot: async () => {
+        throw new Error('deferred prewarm must not yield');
+      },
+      compileChild: async () => {
+        compileCalls++;
+      },
+      renderWarmPass: () => {
+        passRan = true;
+      },
+    });
+    expect(compileCalls).toBe(0);
+    expect(passRan).toBe(false);
+    expect(groups[0].visible).toBe(false);
+  });
+
   it('leaves the groups hidden when a compile throws', async () => {
     const groups = [group(2)];
     await expect(

--- a/tests/prewarm_policy.test.ts
+++ b/tests/prewarm_policy.test.ts
@@ -10,6 +10,8 @@ import {
   type PrewarmPolicyInput,
   partitionMandatoryLandmarkCandidates,
   prewarmEntryRuns,
+  prewarmMobCopies,
+  prewarmTemplateCompleted,
   remainingPrewarmViewBudget,
   resolvePrewarmPolicy,
 } from '../src/render/prewarm_policy';
@@ -155,6 +157,24 @@ describe('remainingPrewarmViewBudget', () => {
   it('normalizes fractional and invalid budgets', () => {
     expect(remainingPrewarmViewBudget(2.9, 1.2)).toBe(1);
     expect(remainingPrewarmViewBudget(-1, 0)).toBe(0);
+  });
+});
+
+describe('character pool sizing and completion', () => {
+  it('covers authored camp demand while respecting the bounded pool cap', () => {
+    expect(prewarmMobCopies(true, 6, 3, 8)).toBe(6);
+    expect(prewarmMobCopies(true, 99, 3, 8)).toBe(8);
+    expect(prewarmMobCopies(true, 0, 3, 8)).toBe(3);
+    expect(prewarmMobCopies(false, 6, 3, 8)).toBe(1);
+  });
+
+  it('normalizes invalid authored counts and requires every requested copy', () => {
+    expect(prewarmMobCopies(true, Number.NaN, 3, 8)).toBe(3);
+    expect(prewarmTemplateCompleted(3, 2)).toBe(false);
+    expect(prewarmTemplateCompleted(3, 3)).toBe(true);
+    expect(prewarmTemplateCompleted(3, 4)).toBe(true);
+    expect(prewarmTemplateCompleted(0, 0)).toBe(false);
+    expect(prewarmTemplateCompleted(3, Number.NaN)).toBe(false);
   });
 });
 

--- a/tests/zone_feature_visibility.test.ts
+++ b/tests/zone_feature_visibility.test.ts
@@ -67,6 +67,12 @@ describe('zone feature distance visibility', () => {
       expect(isZoneFeatureVisible(FEN, FEN.centerX, FEN.centerZ, far)).toBe(true);
     }
   });
+
+  it('preserves the strict fog boundary for squared-distance culling', () => {
+    const footprint = { centerX: 0, centerZ: 0, halfX: 0, halfZ: 0 };
+    expect(isZoneFeatureVisible(footprint, 3, 4, 5)).toBe(false);
+    expect(isZoneFeatureVisible(footprint, 3, 4, 5.01)).toBe(true);
+  });
 });
 
 describe('unseeded instance-matrix guard', () => {


### PR DESCRIPTION
## Summary
- defer streamed-zone shader compile and warm passes until zone interactive
- background HDRI source warming idle-only and avoid gameplay PMREM stalls
- gate one-shot zone feature builders by entry distance
- size common mob prewarm pools from authored demand with bounded cap
- remove redundant whole-world terrain matrix traversals and reuse transient VFX state
- extend freeze-walk profiler with phases, long tasks, slow WebGL, optional CPU profiles
- make static feature culling cheaper with squared-distance checks and input caching

## Evidence
- low-tier real-GPU freeze walk: no new programs during settled walk and no freezes >=80 ms
- medium-tier baseline remains environment boot-timeout risk
- `npm run gate` passed: 1,919 test files, 24,416 tests, browser 90/90, typecheck, builds, malware, backdrop
- second-round targeted visibility test: 10/10; `npm run check:ts` passed
- pre-push QA passed on both commits

## Scope
Render streaming/prewarm/culling only; no simulation/persistence/database.
