### PR TITLE
perf(render): cache high-tier terrain culling

### DIFF
--- a/src/render/terrain.ts
+++ b/src/render/terrain.ts
@@ -1400,6 +1400,10 @@ export function buildTerrain(seed: number, priorityPoint?: { x: number; z: numbe
     size: number;
     spacing: number;
   }[] = [];
+  let lastVisibilityX = Number.NaN;
+  let lastVisibilityZ = Number.NaN;
+  let lastVisibilityFar = Number.NaN;
+  let lastVisibilityChunkCount = -1;
 
   // True when the chunk cell overlaps a mountain-wall band: an inter-zone
   // ridge line (ZONES[i].zMax) or the world rim. Those chunks always take the
@@ -1779,11 +1783,24 @@ export function buildTerrain(seed: number, priorityPoint?: { x: number; z: numbe
       pool?.dispose();
     },
     update(camX: number, camZ: number, fogFar: number): void {
+      if (
+        camX === lastVisibilityX &&
+        camZ === lastVisibilityZ &&
+        fogFar === lastVisibilityFar &&
+        chunks.length === lastVisibilityChunkCount
+      ) {
+        return;
+      }
+      lastVisibilityX = camX;
+      lastVisibilityZ = camZ;
+      lastVisibilityFar = fogFar;
+      lastVisibilityChunkCount = chunks.length;
       // fully-fogged chunks are pure overdraw; drop them before the frustum
+      const fogFarSq = fogFar * fogFar;
       for (const chunk of chunks) {
         const dx = Math.max(Math.abs(camX - chunk.x) - chunk.half, 0);
         const dz = Math.max(Math.abs(camZ - chunk.z) - chunk.half, 0);
-        chunk.mesh.visible = Math.hypot(dx, dz) < fogFar;
+        chunk.mesh.visible = fogFar > 0 && dx * dx + dz * dz < fogFarSq;
       }
     },
     rebuildRegion(minX: number, minZ: number, maxX: number, maxZ: number): void {

--- a/tests/terrain_streaming.test.ts
+++ b/tests/terrain_streaming.test.ts
@@ -91,13 +91,17 @@ describe('progressive terrain build', () => {
     const { zoneAt } = await import('../src/sim/data');
 
     const terrain = buildTerrain(20061);
+    terrain.update(0, 0, 0);
     const task = terrain.ensureZone(zoneAt(0, 0));
     await vi.runAllTimersAsync();
     await task;
 
-    // update() must not throw once zone chunks (added after the initial
-    // return) are folded into fog culling.
-    expect(() => terrain.update(0, 0, 1000)).not.toThrow();
+    // The first update cached an empty chunk list. Newly streamed chunks must
+    // invalidate that cache, even when camera and fog inputs are unchanged.
+    expect(() => terrain.update(0, 0, 0)).not.toThrow();
+    expect(terrain.group.children.every((child) => !child.visible)).toBe(true);
+    terrain.update(0, 0, 1000);
+    expect(terrain.group.children.some((child) => child.visible)).toBe(true);
   });
 
   it('freezes matrixAutoUpdate on every streamed-in chunk', async () => {


### PR DESCRIPTION
## Summary
- skip unchanged terrain visibility scans once camera, fog, and chunk residency inputs are stable
- replace per-chunk square-root distance checks with squared-distance comparisons
- invalidate the visibility cache when streamed chunks attach
- preserve the existing non-positive fog-range behavior

## Evidence
- `npx vitest run tests/terrain_streaming.test.ts`: 11/11 passed
- `npm run check:ts`: passed
- pre-push QA: passed (77 passed, 3 skipped; Biome completed with existing warnings)
- `npm run gate`: reached the full suite; 1 pre-existing unrelated timeout in `tests/fire_short_fight_tuning.test.ts`, with 24,643 tests passed and 74 skipped (`1,941` files passed, `8` skipped)

## Scope
High graphics profile terrain culling only; no simulation, persistence, or database changes.
