### PR TITLE
perf(render): fold high-tier weapon aura scan

### DIFF
--- a/docs/screenshots/eastbrook-vale-rebuild/polish/metadata/after-desktop-ultra.json
+++ b/docs/screenshots/eastbrook-vale-rebuild/polish/metadata/after-desktop-ultra.json
@@ -11,7 +11,7 @@
     "mode": "composite-sha256",
     "algorithm": "sha256",
     "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-    "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+    "fingerprint": "c4ff5868169ffecb708e1e60528af788a70c48366f0ce0e29f2f0995894d6749",
     "components": {
       "townAsset": {
         "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -40,7 +40,7 @@
         },
         "renderer": {
           "path": "src/render/renderer.ts",
-          "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+          "sha256": "a52cdfa0394c318df0b36cc63715dfaa457178f39fe869a4520a54537078a074"
         },
         "viewPriorityPolicy": {
           "path": "src/render/prewarm_policy.ts",
@@ -85,7 +85,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "c4ff5868169ffecb708e1e60528af788a70c48366f0ce0e29f2f0995894d6749",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -114,7 +114,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "a52cdfa0394c318df0b36cc63715dfaa457178f39fe869a4520a54537078a074"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -1380,7 +1380,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "c4ff5868169ffecb708e1e60528af788a70c48366f0ce0e29f2f0995894d6749",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -1409,7 +1409,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "a52cdfa0394c318df0b36cc63715dfaa457178f39fe869a4520a54537078a074"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -2675,7 +2675,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "c4ff5868169ffecb708e1e60528af788a70c48366f0ce0e29f2f0995894d6749",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -2704,7 +2704,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "a52cdfa0394c318df0b36cc63715dfaa457178f39fe869a4520a54537078a074"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -3970,7 +3970,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "c4ff5868169ffecb708e1e60528af788a70c48366f0ce0e29f2f0995894d6749",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -3999,7 +3999,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "a52cdfa0394c318df0b36cc63715dfaa457178f39fe869a4520a54537078a074"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -5265,7 +5265,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "c4ff5868169ffecb708e1e60528af788a70c48366f0ce0e29f2f0995894d6749",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -5294,7 +5294,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "a52cdfa0394c318df0b36cc63715dfaa457178f39fe869a4520a54537078a074"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -6560,7 +6560,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "c4ff5868169ffecb708e1e60528af788a70c48366f0ce0e29f2f0995894d6749",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -6589,7 +6589,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "a52cdfa0394c318df0b36cc63715dfaa457178f39fe869a4520a54537078a074"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -7855,7 +7855,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "c4ff5868169ffecb708e1e60528af788a70c48366f0ce0e29f2f0995894d6749",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -7884,7 +7884,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "a52cdfa0394c318df0b36cc63715dfaa457178f39fe869a4520a54537078a074"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -9150,7 +9150,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "c4ff5868169ffecb708e1e60528af788a70c48366f0ce0e29f2f0995894d6749",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -9179,7 +9179,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "a52cdfa0394c318df0b36cc63715dfaa457178f39fe869a4520a54537078a074"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -10445,7 +10445,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "c4ff5868169ffecb708e1e60528af788a70c48366f0ce0e29f2f0995894d6749",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -10474,7 +10474,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "a52cdfa0394c318df0b36cc63715dfaa457178f39fe869a4520a54537078a074"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -11740,7 +11740,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "c4ff5868169ffecb708e1e60528af788a70c48366f0ce0e29f2f0995894d6749",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -11769,7 +11769,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "a52cdfa0394c318df0b36cc63715dfaa457178f39fe869a4520a54537078a074"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -13035,7 +13035,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "c4ff5868169ffecb708e1e60528af788a70c48366f0ce0e29f2f0995894d6749",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -13064,7 +13064,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "a52cdfa0394c318df0b36cc63715dfaa457178f39fe869a4520a54537078a074"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -14330,7 +14330,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "c4ff5868169ffecb708e1e60528af788a70c48366f0ce0e29f2f0995894d6749",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -14359,7 +14359,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "a52cdfa0394c318df0b36cc63715dfaa457178f39fe869a4520a54537078a074"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -15625,7 +15625,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "c4ff5868169ffecb708e1e60528af788a70c48366f0ce0e29f2f0995894d6749",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -15654,7 +15654,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "a52cdfa0394c318df0b36cc63715dfaa457178f39fe869a4520a54537078a074"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -16920,7 +16920,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "c4ff5868169ffecb708e1e60528af788a70c48366f0ce0e29f2f0995894d6749",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -16949,7 +16949,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "a52cdfa0394c318df0b36cc63715dfaa457178f39fe869a4520a54537078a074"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -19180,7 +19180,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "c4ff5868169ffecb708e1e60528af788a70c48366f0ce0e29f2f0995894d6749",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -19209,7 +19209,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "a52cdfa0394c318df0b36cc63715dfaa457178f39fe869a4520a54537078a074"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -20475,7 +20475,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "c4ff5868169ffecb708e1e60528af788a70c48366f0ce0e29f2f0995894d6749",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -20504,7 +20504,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "a52cdfa0394c318df0b36cc63715dfaa457178f39fe869a4520a54537078a074"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -21770,7 +21770,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "c4ff5868169ffecb708e1e60528af788a70c48366f0ce0e29f2f0995894d6749",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -21799,7 +21799,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "a52cdfa0394c318df0b36cc63715dfaa457178f39fe869a4520a54537078a074"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -23065,7 +23065,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "c4ff5868169ffecb708e1e60528af788a70c48366f0ce0e29f2f0995894d6749",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -23094,7 +23094,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "a52cdfa0394c318df0b36cc63715dfaa457178f39fe869a4520a54537078a074"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -24360,7 +24360,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "c4ff5868169ffecb708e1e60528af788a70c48366f0ce0e29f2f0995894d6749",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -24389,7 +24389,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "a52cdfa0394c318df0b36cc63715dfaa457178f39fe869a4520a54537078a074"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -25655,7 +25655,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "c4ff5868169ffecb708e1e60528af788a70c48366f0ce0e29f2f0995894d6749",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -25684,7 +25684,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "a52cdfa0394c318df0b36cc63715dfaa457178f39fe869a4520a54537078a074"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -26950,7 +26950,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "c4ff5868169ffecb708e1e60528af788a70c48366f0ce0e29f2f0995894d6749",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -26979,7 +26979,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "a52cdfa0394c318df0b36cc63715dfaa457178f39fe869a4520a54537078a074"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -28298,7 +28298,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "c4ff5868169ffecb708e1e60528af788a70c48366f0ce0e29f2f0995894d6749",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -28327,7 +28327,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "a52cdfa0394c318df0b36cc63715dfaa457178f39fe869a4520a54537078a074"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -29593,7 +29593,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "c4ff5868169ffecb708e1e60528af788a70c48366f0ce0e29f2f0995894d6749",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -29622,7 +29622,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "a52cdfa0394c318df0b36cc63715dfaa457178f39fe869a4520a54537078a074"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",

--- a/docs/screenshots/eastbrook-vale-rebuild/polish/metadata/after-mobile-low.json
+++ b/docs/screenshots/eastbrook-vale-rebuild/polish/metadata/after-mobile-low.json
@@ -11,7 +11,7 @@
     "mode": "composite-sha256",
     "algorithm": "sha256",
     "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-    "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+    "fingerprint": "c4ff5868169ffecb708e1e60528af788a70c48366f0ce0e29f2f0995894d6749",
     "components": {
       "townAsset": {
         "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -40,7 +40,7 @@
         },
         "renderer": {
           "path": "src/render/renderer.ts",
-          "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+          "sha256": "a52cdfa0394c318df0b36cc63715dfaa457178f39fe869a4520a54537078a074"
         },
         "viewPriorityPolicy": {
           "path": "src/render/prewarm_policy.ts",
@@ -85,7 +85,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "c4ff5868169ffecb708e1e60528af788a70c48366f0ce0e29f2f0995894d6749",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -114,7 +114,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "a52cdfa0394c318df0b36cc63715dfaa457178f39fe869a4520a54537078a074"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -1363,7 +1363,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "c4ff5868169ffecb708e1e60528af788a70c48366f0ce0e29f2f0995894d6749",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -1392,7 +1392,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "a52cdfa0394c318df0b36cc63715dfaa457178f39fe869a4520a54537078a074"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -2641,7 +2641,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "c4ff5868169ffecb708e1e60528af788a70c48366f0ce0e29f2f0995894d6749",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -2670,7 +2670,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "a52cdfa0394c318df0b36cc63715dfaa457178f39fe869a4520a54537078a074"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -3919,7 +3919,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "c4ff5868169ffecb708e1e60528af788a70c48366f0ce0e29f2f0995894d6749",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -3948,7 +3948,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "a52cdfa0394c318df0b36cc63715dfaa457178f39fe869a4520a54537078a074"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -5197,7 +5197,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "c4ff5868169ffecb708e1e60528af788a70c48366f0ce0e29f2f0995894d6749",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -5226,7 +5226,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "a52cdfa0394c318df0b36cc63715dfaa457178f39fe869a4520a54537078a074"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -6475,7 +6475,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "c4ff5868169ffecb708e1e60528af788a70c48366f0ce0e29f2f0995894d6749",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -6504,7 +6504,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "a52cdfa0394c318df0b36cc63715dfaa457178f39fe869a4520a54537078a074"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -7753,7 +7753,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "c4ff5868169ffecb708e1e60528af788a70c48366f0ce0e29f2f0995894d6749",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -7782,7 +7782,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "a52cdfa0394c318df0b36cc63715dfaa457178f39fe869a4520a54537078a074"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -9031,7 +9031,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "c4ff5868169ffecb708e1e60528af788a70c48366f0ce0e29f2f0995894d6749",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -9060,7 +9060,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "a52cdfa0394c318df0b36cc63715dfaa457178f39fe869a4520a54537078a074"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -10309,7 +10309,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "c4ff5868169ffecb708e1e60528af788a70c48366f0ce0e29f2f0995894d6749",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -10338,7 +10338,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "a52cdfa0394c318df0b36cc63715dfaa457178f39fe869a4520a54537078a074"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -11587,7 +11587,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "c4ff5868169ffecb708e1e60528af788a70c48366f0ce0e29f2f0995894d6749",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -11616,7 +11616,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "a52cdfa0394c318df0b36cc63715dfaa457178f39fe869a4520a54537078a074"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -12865,7 +12865,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "c4ff5868169ffecb708e1e60528af788a70c48366f0ce0e29f2f0995894d6749",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -12894,7 +12894,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "a52cdfa0394c318df0b36cc63715dfaa457178f39fe869a4520a54537078a074"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -14143,7 +14143,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "c4ff5868169ffecb708e1e60528af788a70c48366f0ce0e29f2f0995894d6749",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -14172,7 +14172,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "a52cdfa0394c318df0b36cc63715dfaa457178f39fe869a4520a54537078a074"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -15421,7 +15421,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "c4ff5868169ffecb708e1e60528af788a70c48366f0ce0e29f2f0995894d6749",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -15450,7 +15450,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "a52cdfa0394c318df0b36cc63715dfaa457178f39fe869a4520a54537078a074"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -16699,7 +16699,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "c4ff5868169ffecb708e1e60528af788a70c48366f0ce0e29f2f0995894d6749",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -16728,7 +16728,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "a52cdfa0394c318df0b36cc63715dfaa457178f39fe869a4520a54537078a074"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -18942,7 +18942,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "c4ff5868169ffecb708e1e60528af788a70c48366f0ce0e29f2f0995894d6749",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -18971,7 +18971,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "a52cdfa0394c318df0b36cc63715dfaa457178f39fe869a4520a54537078a074"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -20220,7 +20220,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "c4ff5868169ffecb708e1e60528af788a70c48366f0ce0e29f2f0995894d6749",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -20249,7 +20249,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "a52cdfa0394c318df0b36cc63715dfaa457178f39fe869a4520a54537078a074"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -21498,7 +21498,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "c4ff5868169ffecb708e1e60528af788a70c48366f0ce0e29f2f0995894d6749",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -21527,7 +21527,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "a52cdfa0394c318df0b36cc63715dfaa457178f39fe869a4520a54537078a074"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -22776,7 +22776,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "c4ff5868169ffecb708e1e60528af788a70c48366f0ce0e29f2f0995894d6749",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -22805,7 +22805,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "a52cdfa0394c318df0b36cc63715dfaa457178f39fe869a4520a54537078a074"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -24054,7 +24054,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "c4ff5868169ffecb708e1e60528af788a70c48366f0ce0e29f2f0995894d6749",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -24083,7 +24083,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "a52cdfa0394c318df0b36cc63715dfaa457178f39fe869a4520a54537078a074"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -25332,7 +25332,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "c4ff5868169ffecb708e1e60528af788a70c48366f0ce0e29f2f0995894d6749",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -25361,7 +25361,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "a52cdfa0394c318df0b36cc63715dfaa457178f39fe869a4520a54537078a074"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -26610,7 +26610,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "c4ff5868169ffecb708e1e60528af788a70c48366f0ce0e29f2f0995894d6749",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -26639,7 +26639,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "a52cdfa0394c318df0b36cc63715dfaa457178f39fe869a4520a54537078a074"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -27941,7 +27941,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "c4ff5868169ffecb708e1e60528af788a70c48366f0ce0e29f2f0995894d6749",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -27970,7 +27970,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "a52cdfa0394c318df0b36cc63715dfaa457178f39fe869a4520a54537078a074"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -29219,7 +29219,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "c4ff5868169ffecb708e1e60528af788a70c48366f0ce0e29f2f0995894d6749",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -29248,7 +29248,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "a52cdfa0394c318df0b36cc63715dfaa457178f39fe869a4520a54537078a074"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",

--- a/docs/screenshots/eastbrook-vale-rebuild/polish/performance/after-desktop-ultra-town.json
+++ b/docs/screenshots/eastbrook-vale-rebuild/polish/performance/after-desktop-ultra-town.json
@@ -14,7 +14,7 @@
     "mode": "composite-sha256",
     "algorithm": "sha256",
     "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-    "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+    "fingerprint": "c4ff5868169ffecb708e1e60528af788a70c48366f0ce0e29f2f0995894d6749",
     "components": {
       "townAsset": {
         "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -43,7 +43,7 @@
         },
         "renderer": {
           "path": "src/render/renderer.ts",
-          "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+          "sha256": "a52cdfa0394c318df0b36cc63715dfaa457178f39fe869a4520a54537078a074"
         },
         "viewPriorityPolicy": {
           "path": "src/render/prewarm_policy.ts",

--- a/docs/screenshots/eastbrook-vale-rebuild/polish/performance/after-mobile-low-town.json
+++ b/docs/screenshots/eastbrook-vale-rebuild/polish/performance/after-mobile-low-town.json
@@ -14,7 +14,7 @@
     "mode": "composite-sha256",
     "algorithm": "sha256",
     "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-    "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+    "fingerprint": "c4ff5868169ffecb708e1e60528af788a70c48366f0ce0e29f2f0995894d6749",
     "components": {
       "townAsset": {
         "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -43,7 +43,7 @@
         },
         "renderer": {
           "path": "src/render/renderer.ts",
-          "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+          "sha256": "a52cdfa0394c318df0b36cc63715dfaa457178f39fe869a4520a54537078a074"
         },
         "viewPriorityPolicy": {
           "path": "src/render/prewarm_policy.ts",

--- a/src/render/character_effects.ts
+++ b/src/render/character_effects.ts
@@ -19,6 +19,19 @@ export interface CharacterWeaponAura {
   tip: boolean;
 }
 
+/** Resolve one aura without requiring a second scan of the entity's aura list. */
+export function characterWeaponAuraFromAura(
+  aura: Pick<Entity['auras'][number], 'id'>,
+  out: CharacterWeaponAura,
+): boolean {
+  const buff = ABILITY_VFX_FULL_SPECS[aura.id]?.buff;
+  const tint = buff?.weaponAura;
+  if (tint === undefined) return false;
+  out.color = abilityHexColor(tint);
+  out.tip = buff?.weaponAuraScope === 'tip';
+  return true;
+}
+
 /** The held weapon's imbued-overlay color + scope, filled into the caller's
  *  scratch (allocation-free per frame), or null when no worn aura asks for
  *  one. Data-driven off the full spec's buff.weaponAura knob (aura id ==
@@ -33,11 +46,7 @@ export function characterWeaponAuraInto(
   out: CharacterWeaponAura,
 ): CharacterWeaponAura | null {
   for (const a of e.auras) {
-    const buff = ABILITY_VFX_FULL_SPECS[a.id]?.buff;
-    const tint = buff?.weaponAura;
-    if (tint !== undefined) {
-      out.color = abilityHexColor(tint);
-      out.tip = buff?.weaponAuraScope === 'tip';
+    if (characterWeaponAuraFromAura(a, out)) {
       return out;
     }
   }

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -70,7 +70,7 @@ import {
 } from './camera_feel_core';
 import { canopyDetailPrewarmTextures } from './canopy_detail';
 import { buildCastleFeatures, type CastleFeaturesView } from './castle_features';
-import { type CharacterWeaponAura, characterWeaponAuraInto } from './character_effects';
+import { type CharacterWeaponAura, characterWeaponAuraFromAura } from './character_effects';
 import {
   addCharacterEffectAura,
   CHARACTER_EFFECT_RECKLESSNESS,
@@ -8042,8 +8042,10 @@ export class Renderer {
       let hasFrostNovaRoot = false;
       let mageBarrierState: MageBarrierState | null = null;
       let characterEffects = 0;
+      let hasWeaponAura = false;
       for (const a of e.auras) {
         characterEffects = addCharacterEffectAura(characterEffects, a);
+        if (!hasWeaponAura) hasWeaponAura = characterWeaponAuraFromAura(a, this.weaponAuraScratch);
         if (a.kind === 'polymorph') hasPoly = true;
         if (a.kind === 'form_bear') hasBear = true;
         if (a.id === 'ghost_wolf') hasGhostWolf = true;
@@ -8386,8 +8388,10 @@ export class Renderer {
         if (changed) for (const node of changed) this.gateSwapOnCompile(node);
         this.reconcileViewLights(v);
       }
-      const weaponAura = characterWeaponAuraInto(e, this.weaponAuraScratch);
-      v.visual.setWeaponAura(weaponAura ? weaponAura.color : null, weaponAura?.tip ?? false);
+      v.visual.setWeaponAura(
+        hasWeaponAura ? this.weaponAuraScratch.color : null,
+        hasWeaponAura && this.weaponAuraScratch.tip,
+      );
 
       // live sheathe toggle (Z key): the sim's weaponStowed bit moves held
       // props between the hands and the on-back pose (self or a peer)

--- a/tests/character_effects.test.ts
+++ b/tests/character_effects.test.ts
@@ -244,7 +244,7 @@ describe('character visual effects', () => {
     // and unread. The overlay's own coverage lives in the cases above.
     expect(renderer).not.toContain('hasSanguineAura');
     expect(renderer).toContain(
-      'v.visual.setWeaponAura(weaponAura ? weaponAura.color : null, weaponAura?.tip ?? false);',
+      'v.visual.setWeaponAura(\n        hasWeaponAura ? this.weaponAuraScratch.color : null,',
     );
     expect(renderer).toContain('active.setSoulRend(hasSoulRend);');
     expect(renderer).toContain("if (hasSoulRend) {\n        this.vfx.castSparkle(e.id, 'shadow'");

--- a/tests/eastbrook_polish_artifact_integrity.test.ts
+++ b/tests/eastbrook_polish_artifact_integrity.test.ts
@@ -615,9 +615,9 @@ const ACCEPTED_POLISH_V2_METADATA_PATH = path.join(
   'metadata/after-desktop-ultra.json',
 );
 const ACCEPTED_POLISH_V2_METADATA_SHA256 =
-  '1276ca6bb0f63f19cd8f76ee1f4999d616b2bb006c69152713ab58752de0f623';
+  'f2e8b90c0b1124b302b305d71ae26f97e1eba93ab6ac61e613546d0e92160185';
 const ACCEPTED_POLISH_V2_COMPOSITE_PROVENANCE =
-  '9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9';
+  'c4ff5868169ffecb708e1e60528af788a70c48366f0ce0e29f2f0995894d6749';
 const ACCEPTED_POLISH_V2_METADATA = readJsonFile<CaptureMetadata>(ACCEPTED_POLISH_V2_METADATA_PATH);
 const ACCEPTED_POLISH_V2_PROVENANCE = ACCEPTED_POLISH_V2_METADATA.polishProvenance;
 const ACCEPTED_POLISH_V2_TOWN_CONTRACT = ACCEPTED_POLISH_V2_METADATA.records[0]?.townContract;
@@ -1479,7 +1479,7 @@ describe('Eastbrook polish performance and contact evidence', () => {
     // Every measured value (frame timings, draw stats, triangle and scenario
     // numbers) is byte-identical, and no capture was retaken.
     expect(fingerprint.digest('hex')).toBe(
-      '7c4dac9b0aca7cb191d8ab90feb0eb987eba9b1dcb70c4ff3cfee7e34aaeef26',
+      'd0caa7f75459c604b7b3fe958b01f52724149f74251718f93ba3ddf7c537f0f2',
     );
   });
 

--- a/tests/eastbrook_polish_capture_contract.test.ts
+++ b/tests/eastbrook_polish_capture_contract.test.ts
@@ -368,7 +368,7 @@ describe('Eastbrook polish capture contract', () => {
       // fresh and matches no parent's literal. No pipeline input or geometry
       // value changed, and no capture was retaken (the five per-asset seal
       // suites stay green untouched).
-      fingerprint: '2172d6960ce3057f6b64d2a1d178ab2b7df5f6802636010b1fa06e57a452106a',
+      fingerprint: 'c4ff5868169ffecb708e1e60528af788a70c48366f0ce0e29f2f0995894d6749',
       components: {
         captureContract: {
           id: 'polish-v2',


### PR DESCRIPTION
## Summary
- fold weapon-aura detection into the renderer's existing per-entity aura pass
- remove the second aura-list traversal from the high-tier character frame path
- preserve first-match selection, tip scope, and clear behavior
- refresh the Eastbrook polish provenance seals required when renderer.ts changes

## Type of change

- [x] Refactor or performance (no behavior change)
- [x] Tests

## How was this tested?

- `npx vitest run tests/character_effects.test.ts` (9 passed)
- `npx vitest run tests/eastbrook_polish_capture_contract.test.ts tests/eastbrook_polish_artifact_integrity.test.ts` (29 passed)
- `npm run check:ts` (passed)
- pre-push QA floor (77 passed, 3 skipped)
- targeted Biome (no errors, pre-existing warnings only)

## Scope

High graphics profile character rendering only; no simulation, persistence, database, or player-visible behavior changes. The Eastbrook files are deterministic provenance updates for the renderer hash contract, with no capture or geometry changes.

## Checklist

- [ ] Full gate passes. The gate is delegated to remote CI; the prior shard failed only because the renderer hash invalidated stale evidence pins, now refreshed in this PR.
- [x] N/A. This PR adds no player-visible strings.
- [x] No dependencies changed.
