### PR TITLE
perf(render): cull foliage buckets without square roots

### DIFF
--- a/src/render/foliage.ts
+++ b/src/render/foliage.ts
@@ -40,8 +40,8 @@ import {
   insideGrassHubExclusion,
 } from './foliage_core';
 import {
-  type BucketWindowInput,
-  bucketVisible,
+  type BucketWindowSquaredInput,
+  bucketVisibleSquared,
   foliageDistanceScale,
   foliageFogLimit,
   type InstanceCullWindows,
@@ -3055,8 +3055,8 @@ export function buildFoliage(seed: number): FoliageView {
   // Reused by the per-frame bucket cull below. Allocating this input inside the
   // loop generated one short-lived object per foliage bucket per frame (well
   // over 100 MB of garbage in a 12-second gameplay sample).
-  const bucketWindow: BucketWindowInput = {
-    centerDist: 0,
+  const bucketWindow: BucketWindowSquaredInput = {
+    centerDistSq: 0,
     radius: 0,
     minDist: undefined,
     maxDist: undefined,
@@ -3162,7 +3162,7 @@ export function buildFoliage(seed: number): FoliageView {
             : 1;
         const dx = b.x - camX;
         const dz = b.z - camZ;
-        bucketWindow.centerDist = Math.sqrt(dx * dx + dz * dz);
+        bucketWindow.centerDistSq = dx * dx + dz * dz;
         bucketWindow.radius = b.radius;
         bucketWindow.minDist = b.minDist;
         bucketWindow.maxDist = b.maxDist;
@@ -3172,7 +3172,7 @@ export function buildFoliage(seed: number): FoliageView {
         bucketWindow.detailFar = detailFar;
         bucketWindow.revealScale = revealScale;
         bucketWindow.fogLimit = fogLimit;
-        b.mesh.visible = bucketVisible(bucketWindow);
+        b.mesh.visible = bucketVisibleSquared(bucketWindow);
         // "Visible" counts SUBMITTED instances: shader-collapsed ones still
         // count here (the collapse saves raster work, not submission).
         if (b.mesh.visible) {

--- a/src/render/foliage_lod.ts
+++ b/src/render/foliage_lod.ts
@@ -196,6 +196,11 @@ export interface BucketWindowInput {
   fogLimit: number;
 }
 
+export type BucketWindowSquaredInput = Omit<BucketWindowInput, 'centerDist'> & {
+  /** squared distance from the camera to the bucket's CENTER */
+  centerDistSq: number;
+};
+
 /**
  * The build-time caps (the near-fill density cull, rocks, dressing, the early bark
  * cull) are measured against the bucket's CENTER, as they always have been. They
@@ -227,4 +232,35 @@ export function bucketVisible(w: BucketWindowInput): boolean {
   if (w.maxAtDetail && nearEdge >= w.detailFar) return false;
 
   return nearEdge < w.fogLimit;
+}
+
+/**
+ * Allocation-free hot-path variant of bucketVisible. The renderer already has
+ * the camera-to-bucket vector, so keeping the distance squared avoids a sqrt
+ * for every foliage bucket on every frame. All thresholds are non-negative in
+ * the live renderer, which makes the comparisons equivalent to bucketVisible.
+ */
+export function bucketVisibleSquared(w: BucketWindowSquaredInput): boolean {
+  if (Number.isNaN(w.centerDistSq)) return false;
+
+  const minCap = (w.minDist ?? 0) * w.distanceScale;
+  if (minCap > 0 && w.centerDistSq < minCap * minCap) return false;
+
+  const maxCap =
+    w.maxDist === undefined
+      ? Number.POSITIVE_INFINITY
+      : w.maxDist * w.distanceScale * w.revealScale;
+  if (maxCap <= 0 || w.centerDistSq >= maxCap * maxCap) return false;
+
+  if (w.minAtDetail) {
+    const maxCenter = w.detailFar - w.radius;
+    if (maxCenter > 0 && w.centerDistSq < maxCenter * maxCenter) return false;
+  }
+  if (w.maxAtDetail) {
+    const minCenter = w.detailFar + w.radius;
+    if (minCenter <= 0 || w.centerDistSq >= minCenter * minCenter) return false;
+  }
+
+  const fogCenter = w.fogLimit + w.radius;
+  return fogCenter > 0 && w.centerDistSq < fogCenter * fogCenter;
 }

--- a/tests/foliage_lod.test.ts
+++ b/tests/foliage_lod.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   type BucketWindowInput,
   bucketVisible,
+  bucketVisibleSquared,
   fogBlendAt,
   foliageDistanceScale,
   foliageFogLimit,
@@ -348,6 +349,57 @@ describe('foliage LOD: the real-model and impostor windows cover the world', () 
     const rock = windowFor({ centerDist: 200, maxDist: LOD_HIGH.rockFar, distanceScale: 0.5 });
     expect(bucketVisible(rock)).toBe(false);
     expect(bucketVisible({ ...rock, distanceScale: 1 })).toBe(true);
+  });
+});
+
+describe('foliage LOD: squared bucket culling preserves visibility decisions', () => {
+  it('matches linear culling across caps, detail bands, and fog boundaries', () => {
+    const cases: BucketWindowInput[] = [
+      windowFor({ centerDist: 0, radius: 0 }),
+      windowFor({ centerDist: 117.5, radius: 60, minDist: 80 }),
+      windowFor({ centerDist: 309, radius: 120, maxDist: 310 }),
+      realTrees(368 + 120, { detailFar: 368, radius: 120 }),
+      impostors(368 - 120, { detailFar: 368, radius: 120 }),
+      windowFor({ centerDist: 399, radius: 20, fogLimit: 400 }),
+      windowFor({ centerDist: 400, radius: 0, fogLimit: 400 }),
+      windowFor({
+        centerDist: 205,
+        radius: 35,
+        minDist: 40,
+        maxDist: 360,
+        minAtDetail: true,
+        maxAtDetail: true,
+        detailFar: 240,
+        revealScale: 0.97,
+        fogLimit: 430,
+      }),
+    ];
+
+    for (const input of cases) {
+      const { centerDist, ...rest } = input;
+      expect(
+        bucketVisibleSquared({ ...rest, centerDistSq: centerDist * centerDist }),
+        `center distance ${centerDist}`,
+      ).toBe(bucketVisible(input));
+    }
+  });
+
+  it('keeps strict boundary behavior at the detail and fog edges', () => {
+    const detailFar = 368;
+    const radius = 120;
+    const cases = [
+      impostors(detailFar - radius, { detailFar, radius }),
+      realTrees(detailFar + radius, { detailFar, radius }),
+      windowFor({ centerDist: 400, fogLimit: 400 }),
+      windowFor({ centerDist: 399.999, fogLimit: 400 }),
+    ];
+
+    for (const input of cases) {
+      const { centerDist, ...rest } = input;
+      expect(bucketVisibleSquared({ ...rest, centerDistSq: centerDist * centerDist })).toBe(
+        bucketVisible(input),
+      );
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- replace the per-frame foliage bucket sqrt with squared-distance comparisons
- preserve numeric caps, detail-band, and fog-boundary behavior
- add equivalence coverage for caps, impostor bands, and strict boundaries

## Type of change

- [x] Refactor or performance (no behavior change)
- [x] Tests

## How was this tested?

- `npx vitest run tests/foliage_lod.test.ts` (115 passed)
- related render and foliage suites (157 passed)
- `npm run check:ts` (passed)
- `npm run ci:changed` (passed)
- pre-push QA floor (77 passed, 3 skipped)
- `npm run gate` reached the full suite: 1,937 files passed, 8 skipped; 24,640 tests passed, 74 skipped; 6 unrelated timeout failures listed below

## Full gate result

The gate stopped at the full Vitest phase with exit 1 after 1,171.74 seconds. The failures are outside the changed render and foliage files:

- `tests/eastbrook_gameplay_integration.test.ts`: fixed-seed world projection timeout at 90 seconds
- `tests/escort_quest.test.ts`: escort loot-window timeout at 20 seconds
- `tests/fire_short_fight_tuning.test.ts`: talented burst guard timeout at 20 seconds
- `tests/mail_expiry.test.ts`: expiry-boundary return timeout at 20 seconds
- `tests/professions_trend_guild_letter.test.ts`: two real-Sim timeout failures at 40 seconds each

## Scope

High graphics profile foliage culling only. No simulation, persistence, database, or player-visible behavior changes.

## Checklist

- [ ] Full gate passes. The full gate was run and is blocked by the unrelated timeouts above.
- [x] N/A. This PR adds no player-visible strings.
- [x] No generated files or dependencies changed.
