### PR TITLE
perf(render): sleep offscreen character work on high load

### DIFF
--- a/docs/screenshots/eastbrook-vale-rebuild/polish/metadata/after-desktop-ultra.json
+++ b/docs/screenshots/eastbrook-vale-rebuild/polish/metadata/after-desktop-ultra.json
@@ -11,7 +11,7 @@
     "mode": "composite-sha256",
     "algorithm": "sha256",
     "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-    "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+    "fingerprint": "11cff55ee87ff7e065dd9945e576f7777ea27b07b02ebe9df7da379991bb3118",
     "components": {
       "townAsset": {
         "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -40,7 +40,7 @@
         },
         "renderer": {
           "path": "src/render/renderer.ts",
-          "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+          "sha256": "36f60e80d06556e36efafcd47199b7f33a80774aa1451310b1b60070076b4e51"
         },
         "viewPriorityPolicy": {
           "path": "src/render/prewarm_policy.ts",
@@ -85,7 +85,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "11cff55ee87ff7e065dd9945e576f7777ea27b07b02ebe9df7da379991bb3118",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -114,7 +114,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "36f60e80d06556e36efafcd47199b7f33a80774aa1451310b1b60070076b4e51"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -1380,7 +1380,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "11cff55ee87ff7e065dd9945e576f7777ea27b07b02ebe9df7da379991bb3118",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -1409,7 +1409,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "36f60e80d06556e36efafcd47199b7f33a80774aa1451310b1b60070076b4e51"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -2675,7 +2675,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "11cff55ee87ff7e065dd9945e576f7777ea27b07b02ebe9df7da379991bb3118",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -2704,7 +2704,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "36f60e80d06556e36efafcd47199b7f33a80774aa1451310b1b60070076b4e51"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -3970,7 +3970,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "11cff55ee87ff7e065dd9945e576f7777ea27b07b02ebe9df7da379991bb3118",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -3999,7 +3999,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "36f60e80d06556e36efafcd47199b7f33a80774aa1451310b1b60070076b4e51"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -5265,7 +5265,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "11cff55ee87ff7e065dd9945e576f7777ea27b07b02ebe9df7da379991bb3118",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -5294,7 +5294,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "36f60e80d06556e36efafcd47199b7f33a80774aa1451310b1b60070076b4e51"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -6560,7 +6560,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "11cff55ee87ff7e065dd9945e576f7777ea27b07b02ebe9df7da379991bb3118",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -6589,7 +6589,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "36f60e80d06556e36efafcd47199b7f33a80774aa1451310b1b60070076b4e51"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -7855,7 +7855,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "11cff55ee87ff7e065dd9945e576f7777ea27b07b02ebe9df7da379991bb3118",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -7884,7 +7884,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "36f60e80d06556e36efafcd47199b7f33a80774aa1451310b1b60070076b4e51"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -9150,7 +9150,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "11cff55ee87ff7e065dd9945e576f7777ea27b07b02ebe9df7da379991bb3118",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -9179,7 +9179,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "36f60e80d06556e36efafcd47199b7f33a80774aa1451310b1b60070076b4e51"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -10445,7 +10445,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "11cff55ee87ff7e065dd9945e576f7777ea27b07b02ebe9df7da379991bb3118",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -10474,7 +10474,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "36f60e80d06556e36efafcd47199b7f33a80774aa1451310b1b60070076b4e51"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -11740,7 +11740,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "11cff55ee87ff7e065dd9945e576f7777ea27b07b02ebe9df7da379991bb3118",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -11769,7 +11769,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "36f60e80d06556e36efafcd47199b7f33a80774aa1451310b1b60070076b4e51"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -13035,7 +13035,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "11cff55ee87ff7e065dd9945e576f7777ea27b07b02ebe9df7da379991bb3118",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -13064,7 +13064,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "36f60e80d06556e36efafcd47199b7f33a80774aa1451310b1b60070076b4e51"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -14330,7 +14330,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "11cff55ee87ff7e065dd9945e576f7777ea27b07b02ebe9df7da379991bb3118",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -14359,7 +14359,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "36f60e80d06556e36efafcd47199b7f33a80774aa1451310b1b60070076b4e51"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -15625,7 +15625,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "11cff55ee87ff7e065dd9945e576f7777ea27b07b02ebe9df7da379991bb3118",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -15654,7 +15654,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "36f60e80d06556e36efafcd47199b7f33a80774aa1451310b1b60070076b4e51"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -16920,7 +16920,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "11cff55ee87ff7e065dd9945e576f7777ea27b07b02ebe9df7da379991bb3118",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -16949,7 +16949,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "36f60e80d06556e36efafcd47199b7f33a80774aa1451310b1b60070076b4e51"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -19180,7 +19180,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "11cff55ee87ff7e065dd9945e576f7777ea27b07b02ebe9df7da379991bb3118",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -19209,7 +19209,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "36f60e80d06556e36efafcd47199b7f33a80774aa1451310b1b60070076b4e51"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -20475,7 +20475,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "11cff55ee87ff7e065dd9945e576f7777ea27b07b02ebe9df7da379991bb3118",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -20504,7 +20504,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "36f60e80d06556e36efafcd47199b7f33a80774aa1451310b1b60070076b4e51"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -21770,7 +21770,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "11cff55ee87ff7e065dd9945e576f7777ea27b07b02ebe9df7da379991bb3118",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -21799,7 +21799,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "36f60e80d06556e36efafcd47199b7f33a80774aa1451310b1b60070076b4e51"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -23065,7 +23065,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "11cff55ee87ff7e065dd9945e576f7777ea27b07b02ebe9df7da379991bb3118",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -23094,7 +23094,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "36f60e80d06556e36efafcd47199b7f33a80774aa1451310b1b60070076b4e51"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -24360,7 +24360,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "11cff55ee87ff7e065dd9945e576f7777ea27b07b02ebe9df7da379991bb3118",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -24389,7 +24389,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "36f60e80d06556e36efafcd47199b7f33a80774aa1451310b1b60070076b4e51"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -25655,7 +25655,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "11cff55ee87ff7e065dd9945e576f7777ea27b07b02ebe9df7da379991bb3118",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -25684,7 +25684,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "36f60e80d06556e36efafcd47199b7f33a80774aa1451310b1b60070076b4e51"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -26950,7 +26950,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "11cff55ee87ff7e065dd9945e576f7777ea27b07b02ebe9df7da379991bb3118",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -26979,7 +26979,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "36f60e80d06556e36efafcd47199b7f33a80774aa1451310b1b60070076b4e51"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -28298,7 +28298,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "11cff55ee87ff7e065dd9945e576f7777ea27b07b02ebe9df7da379991bb3118",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -28327,7 +28327,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "36f60e80d06556e36efafcd47199b7f33a80774aa1451310b1b60070076b4e51"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -29593,7 +29593,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "11cff55ee87ff7e065dd9945e576f7777ea27b07b02ebe9df7da379991bb3118",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -29622,7 +29622,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "36f60e80d06556e36efafcd47199b7f33a80774aa1451310b1b60070076b4e51"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",

--- a/docs/screenshots/eastbrook-vale-rebuild/polish/metadata/after-mobile-low.json
+++ b/docs/screenshots/eastbrook-vale-rebuild/polish/metadata/after-mobile-low.json
@@ -11,7 +11,7 @@
     "mode": "composite-sha256",
     "algorithm": "sha256",
     "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-    "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+    "fingerprint": "11cff55ee87ff7e065dd9945e576f7777ea27b07b02ebe9df7da379991bb3118",
     "components": {
       "townAsset": {
         "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -40,7 +40,7 @@
         },
         "renderer": {
           "path": "src/render/renderer.ts",
-          "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+          "sha256": "36f60e80d06556e36efafcd47199b7f33a80774aa1451310b1b60070076b4e51"
         },
         "viewPriorityPolicy": {
           "path": "src/render/prewarm_policy.ts",
@@ -85,7 +85,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "11cff55ee87ff7e065dd9945e576f7777ea27b07b02ebe9df7da379991bb3118",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -114,7 +114,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "36f60e80d06556e36efafcd47199b7f33a80774aa1451310b1b60070076b4e51"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -1363,7 +1363,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "11cff55ee87ff7e065dd9945e576f7777ea27b07b02ebe9df7da379991bb3118",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -1392,7 +1392,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "36f60e80d06556e36efafcd47199b7f33a80774aa1451310b1b60070076b4e51"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -2641,7 +2641,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "11cff55ee87ff7e065dd9945e576f7777ea27b07b02ebe9df7da379991bb3118",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -2670,7 +2670,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "36f60e80d06556e36efafcd47199b7f33a80774aa1451310b1b60070076b4e51"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -3919,7 +3919,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "11cff55ee87ff7e065dd9945e576f7777ea27b07b02ebe9df7da379991bb3118",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -3948,7 +3948,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "36f60e80d06556e36efafcd47199b7f33a80774aa1451310b1b60070076b4e51"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -5197,7 +5197,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "11cff55ee87ff7e065dd9945e576f7777ea27b07b02ebe9df7da379991bb3118",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -5226,7 +5226,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "36f60e80d06556e36efafcd47199b7f33a80774aa1451310b1b60070076b4e51"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -6475,7 +6475,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "11cff55ee87ff7e065dd9945e576f7777ea27b07b02ebe9df7da379991bb3118",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -6504,7 +6504,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "36f60e80d06556e36efafcd47199b7f33a80774aa1451310b1b60070076b4e51"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -7753,7 +7753,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "11cff55ee87ff7e065dd9945e576f7777ea27b07b02ebe9df7da379991bb3118",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -7782,7 +7782,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "36f60e80d06556e36efafcd47199b7f33a80774aa1451310b1b60070076b4e51"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -9031,7 +9031,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "11cff55ee87ff7e065dd9945e576f7777ea27b07b02ebe9df7da379991bb3118",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -9060,7 +9060,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "36f60e80d06556e36efafcd47199b7f33a80774aa1451310b1b60070076b4e51"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -10309,7 +10309,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "11cff55ee87ff7e065dd9945e576f7777ea27b07b02ebe9df7da379991bb3118",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -10338,7 +10338,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "36f60e80d06556e36efafcd47199b7f33a80774aa1451310b1b60070076b4e51"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -11587,7 +11587,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "11cff55ee87ff7e065dd9945e576f7777ea27b07b02ebe9df7da379991bb3118",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -11616,7 +11616,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "36f60e80d06556e36efafcd47199b7f33a80774aa1451310b1b60070076b4e51"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -12865,7 +12865,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "11cff55ee87ff7e065dd9945e576f7777ea27b07b02ebe9df7da379991bb3118",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -12894,7 +12894,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "36f60e80d06556e36efafcd47199b7f33a80774aa1451310b1b60070076b4e51"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -14143,7 +14143,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "11cff55ee87ff7e065dd9945e576f7777ea27b07b02ebe9df7da379991bb3118",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -14172,7 +14172,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "36f60e80d06556e36efafcd47199b7f33a80774aa1451310b1b60070076b4e51"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -15421,7 +15421,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "11cff55ee87ff7e065dd9945e576f7777ea27b07b02ebe9df7da379991bb3118",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -15450,7 +15450,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "36f60e80d06556e36efafcd47199b7f33a80774aa1451310b1b60070076b4e51"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -16699,7 +16699,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "11cff55ee87ff7e065dd9945e576f7777ea27b07b02ebe9df7da379991bb3118",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -16728,7 +16728,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "36f60e80d06556e36efafcd47199b7f33a80774aa1451310b1b60070076b4e51"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -18942,7 +18942,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "11cff55ee87ff7e065dd9945e576f7777ea27b07b02ebe9df7da379991bb3118",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -18971,7 +18971,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "36f60e80d06556e36efafcd47199b7f33a80774aa1451310b1b60070076b4e51"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -20220,7 +20220,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "11cff55ee87ff7e065dd9945e576f7777ea27b07b02ebe9df7da379991bb3118",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -20249,7 +20249,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "36f60e80d06556e36efafcd47199b7f33a80774aa1451310b1b60070076b4e51"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -21498,7 +21498,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "11cff55ee87ff7e065dd9945e576f7777ea27b07b02ebe9df7da379991bb3118",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -21527,7 +21527,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "36f60e80d06556e36efafcd47199b7f33a80774aa1451310b1b60070076b4e51"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -22776,7 +22776,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "11cff55ee87ff7e065dd9945e576f7777ea27b07b02ebe9df7da379991bb3118",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -22805,7 +22805,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "36f60e80d06556e36efafcd47199b7f33a80774aa1451310b1b60070076b4e51"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -24054,7 +24054,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "11cff55ee87ff7e065dd9945e576f7777ea27b07b02ebe9df7da379991bb3118",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -24083,7 +24083,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "36f60e80d06556e36efafcd47199b7f33a80774aa1451310b1b60070076b4e51"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -25332,7 +25332,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "11cff55ee87ff7e065dd9945e576f7777ea27b07b02ebe9df7da379991bb3118",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -25361,7 +25361,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "36f60e80d06556e36efafcd47199b7f33a80774aa1451310b1b60070076b4e51"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -26610,7 +26610,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "11cff55ee87ff7e065dd9945e576f7777ea27b07b02ebe9df7da379991bb3118",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -26639,7 +26639,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "36f60e80d06556e36efafcd47199b7f33a80774aa1451310b1b60070076b4e51"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -27941,7 +27941,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "11cff55ee87ff7e065dd9945e576f7777ea27b07b02ebe9df7da379991bb3118",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -27970,7 +27970,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "36f60e80d06556e36efafcd47199b7f33a80774aa1451310b1b60070076b4e51"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -29219,7 +29219,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+        "fingerprint": "11cff55ee87ff7e065dd9945e576f7777ea27b07b02ebe9df7da379991bb3118",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -29248,7 +29248,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+              "sha256": "36f60e80d06556e36efafcd47199b7f33a80774aa1451310b1b60070076b4e51"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",

--- a/docs/screenshots/eastbrook-vale-rebuild/polish/performance/after-desktop-ultra-town.json
+++ b/docs/screenshots/eastbrook-vale-rebuild/polish/performance/after-desktop-ultra-town.json
@@ -14,7 +14,7 @@
     "mode": "composite-sha256",
     "algorithm": "sha256",
     "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-    "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+    "fingerprint": "11cff55ee87ff7e065dd9945e576f7777ea27b07b02ebe9df7da379991bb3118",
     "components": {
       "townAsset": {
         "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -43,7 +43,7 @@
         },
         "renderer": {
           "path": "src/render/renderer.ts",
-          "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+          "sha256": "36f60e80d06556e36efafcd47199b7f33a80774aa1451310b1b60070076b4e51"
         },
         "viewPriorityPolicy": {
           "path": "src/render/prewarm_policy.ts",

--- a/docs/screenshots/eastbrook-vale-rebuild/polish/performance/after-mobile-low-town.json
+++ b/docs/screenshots/eastbrook-vale-rebuild/polish/performance/after-mobile-low-town.json
@@ -14,7 +14,7 @@
     "mode": "composite-sha256",
     "algorithm": "sha256",
     "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-    "fingerprint": "9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9",
+    "fingerprint": "11cff55ee87ff7e065dd9945e576f7777ea27b07b02ebe9df7da379991bb3118",
     "components": {
       "townAsset": {
         "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -43,7 +43,7 @@
         },
         "renderer": {
           "path": "src/render/renderer.ts",
-          "sha256": "abc8c3c3067e6d99c5e24967ef172750dcdba8811476934ae70a14cfef99965e"
+          "sha256": "36f60e80d06556e36efafcd47199b7f33a80774aa1451310b1b60070076b4e51"
         },
         "viewPriorityPolicy": {
           "path": "src/render/prewarm_policy.ts",

--- a/src/render/characters/visual.ts
+++ b/src/render/characters/visual.ts
@@ -716,6 +716,30 @@ export class CharacterVisual {
   }
 
   /**
+   * Advance only clocks that must not stall while this cosmetic rig is outside
+   * the camera frustum. The next visible update consumes the bounded mixer
+   * debt, while the expensive state machine, pose writes, and bone palette work
+   * stay asleep. Renderer-owned actionable rigs never use this path.
+   */
+  advanceOffscreen(dt: number): void {
+    this.hitCooldown = Math.max(0, this.hitCooldown - dt);
+    if (this.holdCooldown > 0) this.holdCooldown = Math.max(0, this.holdCooldown - dt);
+    const stowTick = tickStow(this.stow, dt);
+    if (stowTick !== 'none') {
+      if (stowTick === 'swap') this.applyStowSwap();
+      this.endStowGesture();
+    }
+    this.pendingDt = Math.min(
+      MIXER_DT_CAP,
+      this.pendingDt + (this.holdT > 0 ? dt * this.holdScale : dt),
+    );
+    if (this.holdT > 0) {
+      this.holdT -= dt;
+      if (this.holdT <= 0) this.holdCooldown = HOLD_REFRACTORY_S;
+    }
+  }
+
+  /**
    * The baked half of the climb, on the rigs that ship the clips (all player
    * archetypes): the REACH rides Spellcast_Raise scrubbed up to its
    * arms-overhead crest and held, and the TOP-OUT rides Sit_Floor_Down played

--- a/src/render/crowd_lod.ts
+++ b/src/render/crowd_lod.ts
@@ -104,6 +104,15 @@ export function animatesEveryFrame(
 }
 
 /**
+ * Whether the character presentation needs its full per-frame visual work.
+ * Off-screen cosmetic rigs may accumulate mixer time without rebuilding their
+ * pose, but anything the player can act on stays live even when frustum-culled.
+ */
+export function shouldRunCharacterVisualWork(onScreen: boolean, actionable: boolean): boolean {
+  return onScreen || actionable;
+}
+
+/**
  * How often a rig in the animated far band advances its mixer, in frames: every
  * 4th in a calm scene, stretching to every 6th once the crowd is dense. Slower
  * than the mid band on purpose (a pose that small is read as motion, not as

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -121,6 +121,7 @@ import {
   characterLodBandsInto,
   crowdLodScaleSq,
   midAnimCadence,
+  shouldRunCharacterVisualWork,
   showsStaticFarMesh,
 } from './crowd_lod';
 import { daisVisualLift } from './dais_lift';
@@ -8911,10 +8912,15 @@ export class Renderer {
         const cadence = animCadenceFrames(d2, lodBands);
         animate = cadence <= 1 || (this.frameIdx + e.id) % cadence === 0;
       }
-      active.update(dt, st, animate);
+      // Frustum-culled rigs still receive the gameplay-safe state derivation
+      // above, but cosmetic pose, mount, and weapon VFX work can sleep until
+      // they re-enter the view. The actionable predicate is the hard carve-out.
+      const fullVisualWork = shouldRunCharacterVisualWork(charOnScreen, actionablePose);
+      if (fullVisualWork) active.update(dt, st, animate);
+      else active.advanceOffscreen(dt);
       // weapon-skin VFX ride the humanoid rig's held weapon; advancing them is a
       // few uniform writes per handle, so they stay smooth at every LOD tier
-      v.visual.updateWeaponVfx(dt);
+      if (fullVisualWork) v.visual.updateWeaponVfx(dt);
       // The sheathe swap is deferred to the gesture midpoint, so the rig (and any
       // skin VFX point light on it) is rebuilt inside update(), not at the diff.
       if (v.visual.consumeWeaponGraphDirty()) this.reconcileViewLights(v);
@@ -8933,7 +8939,8 @@ export class Renderer {
         mst.airborne = airborne;
         mst.backwards = st.backwards;
         mst.swimming = st.swimming;
-        v.mountVisual.update(dt, mst, animate);
+        if (fullVisualWork) v.mountVisual.update(dt, mst, animate);
+        else v.mountVisual.advanceOffscreen(dt);
         // the rider floats WITH the procedural bob (the hover cycle's idle
         // float), not just the mount body
         const bob = mountBobY(mountSpec, this.time, moving);

--- a/tests/crowd_lod.test.ts
+++ b/tests/crowd_lod.test.ts
@@ -11,6 +11,7 @@ import {
   farAnimCadence,
   farAnimRangeScale,
   midAnimCadence,
+  shouldRunCharacterVisualWork,
   showsStaticFarMesh,
 } from '../src/render/crowd_lod';
 import { assertAllocationStable } from './util/alloc_probe';
@@ -133,6 +134,20 @@ describe('animatesEveryFrame', () => {
 
   it('does not exempt a stranger just because the player has no target', () => {
     expect(animatesEveryFrame(STRANGER, SELF, null, null)).toBe(false);
+  });
+});
+
+describe('shouldRunCharacterVisualWork', () => {
+  it('sleeps cosmetic rigs outside the frustum', () => {
+    expect(shouldRunCharacterVisualWork(false, false)).toBe(false);
+  });
+
+  it('keeps visible rigs on the full presentation path', () => {
+    expect(shouldRunCharacterVisualWork(true, false)).toBe(true);
+  });
+
+  it('keeps actionable off-screen rigs live', () => {
+    expect(shouldRunCharacterVisualWork(false, true)).toBe(true);
   });
 });
 

--- a/tests/eastbrook_polish_artifact_integrity.test.ts
+++ b/tests/eastbrook_polish_artifact_integrity.test.ts
@@ -615,9 +615,9 @@ const ACCEPTED_POLISH_V2_METADATA_PATH = path.join(
   'metadata/after-desktop-ultra.json',
 );
 const ACCEPTED_POLISH_V2_METADATA_SHA256 =
-  '1276ca6bb0f63f19cd8f76ee1f4999d616b2bb006c69152713ab58752de0f623';
+  '79ee1d79033872ec1c644f42ec476cc4ebc16587018baa3b2720a9c10f233b96';
 const ACCEPTED_POLISH_V2_COMPOSITE_PROVENANCE =
-  '9d38235f6a16ce60925c0faa28567775cbdb640f1749686c866ffeb9e5a10cb9';
+  '11cff55ee87ff7e065dd9945e576f7777ea27b07b02ebe9df7da379991bb3118';
 const ACCEPTED_POLISH_V2_METADATA = readJsonFile<CaptureMetadata>(ACCEPTED_POLISH_V2_METADATA_PATH);
 const ACCEPTED_POLISH_V2_PROVENANCE = ACCEPTED_POLISH_V2_METADATA.polishProvenance;
 const ACCEPTED_POLISH_V2_TOWN_CONTRACT = ACCEPTED_POLISH_V2_METADATA.records[0]?.townContract;
@@ -1479,7 +1479,7 @@ describe('Eastbrook polish performance and contact evidence', () => {
     // Every measured value (frame timings, draw stats, triangle and scenario
     // numbers) is byte-identical, and no capture was retaken.
     expect(fingerprint.digest('hex')).toBe(
-      '7c4dac9b0aca7cb191d8ab90feb0eb987eba9b1dcb70c4ff3cfee7e34aaeef26',
+      '61af056f7271eaaeab603150a92b46509ef93f220175799af7779425cf52eac8',
     );
   });
 

--- a/tests/eastbrook_polish_capture_contract.test.ts
+++ b/tests/eastbrook_polish_capture_contract.test.ts
@@ -368,7 +368,7 @@ describe('Eastbrook polish capture contract', () => {
       // fresh and matches no parent's literal. No pipeline input or geometry
       // value changed, and no capture was retaken (the five per-asset seal
       // suites stay green untouched).
-      fingerprint: '2172d6960ce3057f6b64d2a1d178ab2b7df5f6802636010b1fa06e57a452106a',
+      fingerprint: '11cff55ee87ff7e065dd9945e576f7777ea27b07b02ebe9df7da379991bb3118',
       components: {
         captureContract: {
           id: 'polish-v2',

--- a/tests/renderer_cpu_hot_path.test.ts
+++ b/tests/renderer_cpu_hot_path.test.ts
@@ -121,4 +121,13 @@ describe('renderer CPU hot path', () => {
     expect(nameplates).toContain('name === v.nameplateStaticName');
     expect(nameplates).not.toContain("e.auras.some((a) => a.kind === 'stealth')");
   });
+
+  it('sleeps off-screen cosmetic rigs while preserving the actionable carve-out', () => {
+    expect(renderer).toContain(
+      'const fullVisualWork = shouldRunCharacterVisualWork(charOnScreen, actionablePose);',
+    );
+    expect(renderer).toContain('else active.advanceOffscreen(dt);');
+    expect(renderer).toContain('else v.mountVisual.advanceOffscreen(dt);');
+    expect(renderer).toContain('if (fullVisualWork) v.visual.updateWeaponVfx(dt);');
+  });
 });


### PR DESCRIPTION
## Summary

- Skip expensive `CharacterVisual.update`, mount animation, and weapon-skin VFX updates for frustum-culled cosmetic rigs.
- Preserve mixer debt and transition clocks through `advanceOffscreen`, so re-entry catches up without stale stow, hit, or hold state.
- Keep the local player, current target, casts, and combat-linked entities on the full path through the existing actionable-pose policy.
- Refresh deterministic Eastbrook provenance pins with the official remint script because renderer source fingerprints changed.

## Related issues

N/A

## Type of change

- [ ] Feature
- [ ] Bug fix
- [x] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Other (please describe):

## How was this tested?

- `npx vitest run tests/architecture.test.ts tests/crowd_lod.test.ts tests/renderer_cpu_hot_path.test.ts tests/character_anim_state.test.ts tests/character_tpose_repair.test.ts tests/character_visual_fail_soft.test.ts` (123 passed)
- `npx vitest run tests/eastbrook_polish_capture_contract.test.ts tests/eastbrook_polish_artifact_integrity.test.ts` (29 passed)
- `npm run check:ts` (passed)
- `npm run ci:changed` (passed, existing warning inventory only)
- `npm run gate` (all pre-test stages passed; initial full Vitest run passed 1,941 files and 24,647 tests, with one stale Eastbrook fingerprint pin; official remint followed, and focused provenance contracts passed 29/29)
- Push preflight (passed: 77 tests, 3 skipped; typecheck; changed-file QA; copy rules)
- `node scripts/assets/eastbrook_grand_armoury/remint_polish_provenance.mjs`

Manual steps: N/A, presentation-only CPU scheduling change.

## Screenshots / recordings

N/A, no UI output changes.

## Checklist

- [x] I have read and agree to follow the CONTRIBUTING.md guidelines.
- [x] I have performed a self-review of my own code and corrected any misspellings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have run the relevant validation commands for this change.
- [x] Any required documentation has been updated.
- [x] I have checked this change does not introduce player-visible strings requiring translation.
