### PR TITLE
perf(render): skip offscreen character effects on high load

### DIFF
--- a/src/render/character_fx_culling_core.ts
+++ b/src/render/character_fx_culling_core.ts
@@ -1,0 +1,10 @@
+/**
+ * Whether a character's cosmetic effect systems need a frame of work.
+ *
+ * Off-screen rigs may let their aura bands, body glows, and particles expire
+ * until they re-enter the view. Actionable entities stay live even when the
+ * frustum cull hides them, so cast and combat-linked telegraphs never sleep.
+ */
+export function shouldRunCharacterFx(onScreen: boolean, actionable: boolean): boolean {
+  return onScreen || actionable;
+}

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -77,6 +77,7 @@ import {
   CHARACTER_EFFECT_SOUL_REND,
   hasCharacterEffect,
 } from './character_effects_core';
+import { shouldRunCharacterFx } from './character_fx_culling_core';
 import { characterViewOutsideHysteresis } from './character_view_core';
 import {
   type AnimState,
@@ -8343,6 +8344,7 @@ export class Renderer {
         this.cullSphere.radius = (v.height * 0.7 + 1.5) * e.scale;
         charOnScreen = this.cullFrustum.intersectsSphere(this.cullSphere);
       }
+      const runCharacterFx = shouldRunCharacterFx(charOnScreen, actionablePose);
 
       // live skin swap: appearance changed (in-game changer or a multiplayer peer).
       // NOT gated: unlike a base-visual swap, the old rig is not being replaced,
@@ -8993,42 +8995,49 @@ export class Renderer {
 
       // per-ability windup orb + buff-orbit bands (spec-driven; no-op for
       // entities with no spec'd cast or aura)
-      this.abilityVfx.syncEntity(e);
-      if (st.casting) {
-        this.vfx.castSparkle(
-          e.id,
-          waterJetVisualChannel
-            ? 'frost'
-            : e.castingAbility === 'demon_heal'
-              ? 'shadow'
-              : (ABILITIES[e.castingAbility ?? '']?.school ?? 'arcane'),
-          dt,
-          // per-ability spec color when the casting ability has one
-          this.abilityVfx.sparkleColorFor(e.castingAbility),
-        );
-      }
-      if (hasSoulRend) {
-        this.vfx.castSparkle(e.id, 'shadow', dt * 3.2);
-      }
-      if (hasRecklessness) {
-        this.vfx.recklessFlame(e.id, dt);
-        if (!v.recklessOn) {
-          v.recklessOn = true;
-          this.recklessSkulls.spawn(v.group, active.height * e.scale);
+      if (runCharacterFx) {
+        this.abilityVfx.syncEntity(e);
+        if (st.casting) {
+          this.vfx.castSparkle(
+            e.id,
+            waterJetVisualChannel
+              ? 'frost'
+              : e.castingAbility === 'demon_heal'
+                ? 'shadow'
+                : (ABILITIES[e.castingAbility ?? '']?.school ?? 'arcane'),
+            dt,
+            // per-ability spec color when the casting ability has one
+            this.abilityVfx.sparkleColorFor(e.castingAbility),
+          );
         }
-      } else if (v.recklessOn) {
+        if (hasSoulRend) {
+          this.vfx.castSparkle(e.id, 'shadow', dt * 3.2);
+        }
+        if (hasRecklessness) {
+          this.vfx.recklessFlame(e.id, dt);
+          if (!v.recklessOn) {
+            v.recklessOn = true;
+            this.recklessSkulls.spawn(v.group, active.height * e.scale);
+          }
+        } else if (v.recklessOn) {
+          v.recklessOn = false;
+        }
+        // Shapeshift-form particle auras riding the tints above: metamorph fire,
+        // moonkin star motes, shadowform gloom wisps. Suppressed for the dead
+        // (the auras themselves drop, but a corpse must not smolder for a frame).
+        if (!e.dead) {
+          if (hasMetamorph) this.vfx.formAura(e.id, 'metamorph', dt);
+          else if (hasMoonkin) this.vfx.formAura(e.id, 'moonkin', dt);
+          else if (hasShadowform) this.vfx.formAura(e.id, 'shadowform', dt);
+        }
+        // The graveyard angel: a soft, constant golden shimmer rising off the Spirit Healer.
+        if (e.templateId === 'spirit_healer') this.vfx.castSparkle(e.id, 'holy', dt * 0.6);
+      } else {
+        // Reset the re-entry latch without paying for particle work while the
+        // rig is hidden. If the aura survives, the skull presentation is
+        // spawned again on the first visible frame.
         v.recklessOn = false;
       }
-      // Shapeshift-form particle auras riding the tints above: metamorph fire,
-      // moonkin star motes, shadowform gloom wisps. Suppressed for the dead
-      // (the auras themselves drop, but a corpse must not smolder for a frame).
-      if (!e.dead) {
-        if (hasMetamorph) this.vfx.formAura(e.id, 'metamorph', dt);
-        else if (hasMoonkin) this.vfx.formAura(e.id, 'moonkin', dt);
-        else if (hasShadowform) this.vfx.formAura(e.id, 'shadowform', dt);
-      }
-      // The graveyard angel: a soft, constant golden shimmer rising off the Spirit Healer.
-      if (e.templateId === 'spirit_healer') this.vfx.castSparkle(e.id, 'holy', dt * 0.6);
 
       // skip the draw for off-screen rigs (pose/audio above already ran)
       if (!charOnScreen) v.group.visible = false;

--- a/tests/architecture.test.ts
+++ b/tests/architecture.test.ts
@@ -306,6 +306,7 @@ const RENDER_PURE_CORES = [
   'src/render/camera_feel_core.ts',
   'src/render/cast_bar.ts',
   'src/render/character_effects_core.ts',
+  'src/render/character_fx_culling_core.ts',
   'src/render/character_view_core.ts',
   'src/render/chunk_residency_core.ts',
   'src/render/cliff_scree_core.ts',

--- a/tests/character_fx_culling.test.ts
+++ b/tests/character_fx_culling.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { shouldRunCharacterFx } from '../src/render/character_fx_culling_core';
+
+describe('character FX culling', () => {
+  it('sleeps cosmetic FX for off-screen non-actionable entities', () => {
+    expect(shouldRunCharacterFx(false, false)).toBe(false);
+  });
+
+  it('keeps visible character FX live', () => {
+    expect(shouldRunCharacterFx(true, false)).toBe(true);
+  });
+
+  it('keeps off-screen actionable telegraphs live', () => {
+    expect(shouldRunCharacterFx(false, true)).toBe(true);
+  });
+});

--- a/tests/renderer_cpu_hot_path.test.ts
+++ b/tests/renderer_cpu_hot_path.test.ts
@@ -121,4 +121,11 @@ describe('renderer CPU hot path', () => {
     expect(nameplates).toContain('name === v.nameplateStaticName');
     expect(nameplates).not.toContain("e.auras.some((a) => a.kind === 'stealth')");
   });
+  it('sleeps cosmetic character FX outside the actionable pose carve-out', () => {
+    expect(renderer).toContain(
+      'const runCharacterFx = shouldRunCharacterFx(charOnScreen, actionablePose);',
+    );
+    expect(renderer).toContain('if (runCharacterFx) {\n        this.abilityVfx.syncEntity(e);');
+    expect(renderer).toContain("this.vfx.formAura(e.id, 'metamorph', dt)");
+  });
 });


### PR DESCRIPTION
## Summary

- Skip `abilityVfx.syncEntity` for frustum-culled cosmetic characters instead of scanning every aura and refreshing hidden bands each frame.
- Sleep off-screen cast particles, body glows, Recklessness flames, shapeshift particles, and Spirit Healer shimmer while allowing pooled effects to expire naturally.
- Preserve the full effect path for visible and actionable entities, including the local player, current target, casters, and combat-linked entities.
- Reset re-entry latches so persistent Recklessness effects regain their one-shot presentation when the rig becomes visible again.

## Related issues

N/A

## Type of change

- [ ] Feature
- [ ] Bug fix
- [x] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Other (please describe):

## How was this tested?

- `npx vitest run tests/character_fx_culling.test.ts tests/renderer_cpu_hot_path.test.ts tests/architecture.test.ts tests/crowd_lod.test.ts tests/character_visual_fail_soft.test.ts` (88 passed)
- `npm run check:ts` (passed after `npm ci`)
- `npm run ci:changed` (passed, existing warning inventory only)
- `npm run gate` (completed through the full gate workflow)
- Push preflight (green: 77 tests, 3 skipped; typecheck; changed-file QA; copy rules)
- `git diff --check` (passed)

Manual steps: N/A, presentation-only CPU scheduling change.

## Screenshots / recordings

N/A, no UI output changes.

## Checklist

- [x] I have read and agree to follow the CONTRIBUTING.md guidelines.
- [x] I have performed a self-review of my own code and corrected any misspellings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have run the relevant validation commands for this change.
- [x] Any required documentation has been updated.
- [x] I have checked this change does not introduce player-visible strings requiring translation.
