### PR TITLE
fix(render): guard the shader pow() bases that NaN into a black rectangle

### DIFF
--- a/scripts/asset_pipeline/weapon_vfx.js
+++ b/scripts/asset_pipeline/weapon_vfx.js
@@ -2358,8 +2358,8 @@ function makeAurora(b, c) {
         float t = fract(vUv.x * 1.4 - uTime * 0.1);
         float tri = 1.0 - abs(2.0 * t - 1.0);
         vec3 c = tri < 0.5 ? mix(uColA, uColB, tri * 2.0) : mix(uColB, uColC, tri * 2.0 - 1.0);
-        float ends = pow(sin(3.14159 * vUv.x), 0.75);
-        float edge = pow(1.0 - abs(vUv.y * 2.0 - 1.0), 1.6);
+        float ends = pow(max(0.0, sin(3.14159 * vUv.x)), 0.75);
+        float edge = pow(max(0.0, 1.0 - abs(vUv.y * 2.0 - 1.0)), 1.6);
         float shim = 0.72 + 0.28 * sin(uTime * 1.1 + vUv.x * 8.0);
         float a = ends * edge * shim * uOpacity;
         gl_FragColor = vec4(c * a, a);
@@ -2393,7 +2393,10 @@ function makeShell(root, shellSpec) {
       uniform vec3 uColor; uniform float uStr; uniform float uPow; uniform float uTime;
       varying vec3 vN; varying vec3 vV;
       void main() {
-        float f = pow(1.0 - abs(dot(normalize(vN), normalize(vV))), uPow);
+        // max() is load-bearing: normalized dot products overshoot 1.0 by an ulp
+        // on the silhouette, and pow() of a negative base is NaN. One NaN pixel
+        // here becomes a hard-edged black rectangle after the bloom blur.
+        float f = pow(max(0.0, 1.0 - abs(dot(normalize(vN), normalize(vV)))), uPow);
         float a = f * uStr * (0.85 + 0.15 * sin(uTime * 1.7));
         gl_FragColor = vec4(uColor * a, a);
       }`,

--- a/scripts/asset_pipeline/weapon_vfx.js
+++ b/scripts/asset_pipeline/weapon_vfx.js
@@ -2232,7 +2232,11 @@ function makeTwinkles(root, b, c) {
       uniform float uTime; uniform float uScale;
       varying float vI;
       void main() {
-        float w = 0.5 + 0.5 * sin(uTime * aRate * 6.2831 + aSeed * 6.2831);
+        // clamp() is load-bearing: GLSL leaves the precision of sin() to the
+        // implementation, so 0.5 + 0.5 * sin(x) is only non-negative in exact
+        // arithmetic. pow() of a negative base is NaN, and one NaN here is a
+        // hard-edged black rectangle once the bloom blurs it.
+        float w = clamp(0.5 + 0.5 * sin(uTime * aRate * 6.2831 + aSeed * 6.2831), 0.0, 1.0);
         vI = pow(w, 9.0);
         vec4 mv = modelViewMatrix * vec4(position, 1.0);
         gl_PointSize = aSize * uScale * (0.55 + 0.45 * vI) / max(0.15, -mv.z);
@@ -2393,9 +2397,12 @@ function makeShell(root, shellSpec) {
       uniform vec3 uColor; uniform float uStr; uniform float uPow; uniform float uTime;
       varying vec3 vN; varying vec3 vV;
       void main() {
-        // max() is load-bearing: normalized dot products overshoot 1.0 by an ulp
-        // on the silhouette, and pow() of a negative base is NaN. One NaN pixel
-        // here becomes a hard-edged black rectangle after the bloom blur.
+        // max() is load-bearing: abs(dot(...)) of two vectors normalized in
+        // shader overshoots 1.0 by an ulp where they are aligned or
+        // anti-aligned, i.e. where the surface faces the camera head-on, so the
+        // base goes an ulp NEGATIVE there and pow() of a negative base is NaN.
+        // One NaN pixel here becomes a hard-edged black rectangle after the
+        // bloom blur.
         float f = pow(max(0.0, 1.0 - abs(dot(normalize(vN), normalize(vV)))), uPow);
         float a = f * uStr * (0.85 + 0.15 * sin(uTime * 1.7));
         gl_FragColor = vec4(uColor * a, a);

--- a/src/render/ability_vfx/shells.ts
+++ b/src/render/ability_vfx/shells.ts
@@ -45,7 +45,10 @@ export class BuffShells {
         varying vec3 vNormal;
         varying vec3 vView;
         void main() {
-          float fres = pow(1.0 - abs(dot(normalize(vNormal), normalize(vView))), 2.2);
+          // max() guards pow() against a normalized dot product that overshoots
+          // 1.0 by an ulp: a negative base is NaN, and one NaN pixel spreads
+          // into a hard-edged black rectangle through the bloom blur.
+          float fres = pow(max(0.0, 1.0 - abs(dot(normalize(vNormal), normalize(vView)))), 2.2);
           float pulse = 0.85 + 0.15 * sin(uTime * 5.0);
           vec3 col = uColor * (0.25 + 1.9 * fres) * pulse;
           gl_FragColor = vec4(col, uOpacity * (0.12 + 0.88 * fres));

--- a/src/render/ability_vfx/shells.ts
+++ b/src/render/ability_vfx/shells.ts
@@ -45,9 +45,10 @@ export class BuffShells {
         varying vec3 vNormal;
         varying vec3 vView;
         void main() {
-          // max() guards pow() against a normalized dot product that overshoots
-          // 1.0 by an ulp: a negative base is NaN, and one NaN pixel spreads
-          // into a hard-edged black rectangle through the bloom blur.
+          // max() guards pow() where the surface faces the camera head-on: there
+          // abs(dot(...)) of two vectors normalized in shader overshoots 1.0 by
+          // an ulp, so the base goes negative and pow() returns NaN. One NaN
+          // pixel spreads into a hard-edged black rectangle through the bloom.
           float fres = pow(max(0.0, 1.0 - abs(dot(normalize(vNormal), normalize(vView)))), 2.2);
           float pulse = 0.85 + 0.15 * sin(uTime * 5.0);
           vec3 col = uColor * (0.25 + 1.9 * fres) * pulse;

--- a/src/render/water.ts
+++ b/src/render/water.ts
@@ -297,7 +297,10 @@ const WATER_FRAG = /* glsl */ `
     }
     vec3 N = normalize(vec3(nm + waveSlope * 9.5, 3.1).xzy);
     vec3 V = normalize(cameraPosition - vWPos);
-    float fresnel = 0.05 + 0.95 * pow(1.0 - max(dot(N, V), 0.0), 4.0);
+    // clamp(), not max(): max() leaves the upper bound open, and a normalized
+    // dot product that overshoots 1.0 by an ulp makes the pow() base negative,
+    // which is NaN. One NaN pixel becomes a black rectangle after the bloom blur.
+    float fresnel = 0.05 + 0.95 * pow(1.0 - clamp(dot(N, V), 0.0, 1.0), 4.0);
     // The seabed is hard clamped at ${WATER_SEABED_CLAMP_YARDS} yards. A linear ramp spends the
     // whole palette in the shallows, and an exponential is still climbing when
     // it reaches the clamp, which creases the colour field along the clamp

--- a/src/render/weapon_vfx.ts
+++ b/src/render/weapon_vfx.ts
@@ -2613,8 +2613,8 @@ function makeAurora(b: THREE.Box3, c: WeaponVfxAurora): VfxPart | null {
         float t = fract(vUv.x * 1.4 - uTime * 0.1);
         float tri = 1.0 - abs(2.0 * t - 1.0);
         vec3 c = tri < 0.5 ? mix(uColA, uColB, tri * 2.0) : mix(uColB, uColC, tri * 2.0 - 1.0);
-        float ends = pow(sin(3.14159 * vUv.x), 0.75);
-        float edge = pow(1.0 - abs(vUv.y * 2.0 - 1.0), 1.6);
+        float ends = pow(max(0.0, sin(3.14159 * vUv.x)), 0.75);
+        float edge = pow(max(0.0, 1.0 - abs(vUv.y * 2.0 - 1.0)), 1.6);
         float shim = 0.72 + 0.28 * sin(uTime * 1.1 + vUv.x * 8.0);
         float a = ends * edge * shim * uOpacity;
         gl_FragColor = vec4(c * a, a);
@@ -2648,7 +2648,10 @@ function makeShell(root: THREE.Object3D, shellSpec: WeaponVfxShellSpec): VfxPart
       uniform vec3 uColor; uniform float uStr; uniform float uPow; uniform float uTime;
       varying vec3 vN; varying vec3 vV;
       void main() {
-        float f = pow(1.0 - abs(dot(normalize(vN), normalize(vV))), uPow);
+        // max() is load-bearing: normalized dot products overshoot 1.0 by an ulp
+        // on the silhouette, and pow() of a negative base is NaN. One NaN pixel
+        // here becomes a hard-edged black rectangle after the bloom blur.
+        float f = pow(max(0.0, 1.0 - abs(dot(normalize(vN), normalize(vV)))), uPow);
         float a = f * uStr * (0.85 + 0.15 * sin(uTime * 1.7));
         gl_FragColor = vec4(uColor * a, a);
       }`,

--- a/src/render/weapon_vfx.ts
+++ b/src/render/weapon_vfx.ts
@@ -2487,7 +2487,11 @@ function makeTwinkles(root: THREE.Object3D, b: THREE.Box3, c: WeaponVfxTwinkles)
       uniform float uTime; uniform float uScale;
       varying float vI;
       void main() {
-        float w = 0.5 + 0.5 * sin(uTime * aRate * 6.2831 + aSeed * 6.2831);
+        // clamp() is load-bearing: GLSL leaves the precision of sin() to the
+        // implementation, so 0.5 + 0.5 * sin(x) is only non-negative in exact
+        // arithmetic. pow() of a negative base is NaN, and one NaN here is a
+        // hard-edged black rectangle once the bloom blurs it.
+        float w = clamp(0.5 + 0.5 * sin(uTime * aRate * 6.2831 + aSeed * 6.2831), 0.0, 1.0);
         vI = pow(w, 9.0);
         vec4 mv = modelViewMatrix * vec4(position, 1.0);
         gl_PointSize = aSize * uScale * (0.55 + 0.45 * vI) / max(0.15, -mv.z);
@@ -2648,9 +2652,12 @@ function makeShell(root: THREE.Object3D, shellSpec: WeaponVfxShellSpec): VfxPart
       uniform vec3 uColor; uniform float uStr; uniform float uPow; uniform float uTime;
       varying vec3 vN; varying vec3 vV;
       void main() {
-        // max() is load-bearing: normalized dot products overshoot 1.0 by an ulp
-        // on the silhouette, and pow() of a negative base is NaN. One NaN pixel
-        // here becomes a hard-edged black rectangle after the bloom blur.
+        // max() is load-bearing: abs(dot(...)) of two vectors normalized in
+        // shader overshoots 1.0 by an ulp where they are aligned or
+        // anti-aligned, i.e. where the surface faces the camera head-on, so the
+        // base goes an ulp NEGATIVE there and pow() of a negative base is NaN.
+        // One NaN pixel here becomes a hard-edged black rectangle after the
+        // bloom blur.
         float f = pow(max(0.0, 1.0 - abs(dot(normalize(vN), normalize(vV)))), uPow);
         float a = f * uStr * (0.85 + 0.15 * sin(uTime * 1.7));
         gl_FragColor = vec4(uColor * a, a);

--- a/tests/asset_pipeline.test.ts
+++ b/tests/asset_pipeline.test.ts
@@ -761,6 +761,50 @@ describe('asset library registry parsers', () => {
     expect(Object.fromEntries(parsed)).toEqual(WORLD_TUNING);
   });
 
+  it('the viewer twin shell POWERS match src/render/weapon_vfx.ts, and stay above zero', async () => {
+    // The exponent half of the pow() domain, on the offline mirror. The base
+    // half is guarded tree-wide by tests/shader_pow_domain.test.ts, and the
+    // runtime exponents by tests/weapon_vfx_specs.test.ts, but that suite
+    // imports src/ and so says nothing about this file: with the base now
+    // clamped, a mirror shell power edited to 0 makes the offline makeShell
+    // path evaluate pow(0.0, 0.0), which is undefined exactly as a negative
+    // base is, and every other suite stays green.
+    const { TIERS } = await import('../src/render/weapon_vfx');
+    const twinSrc = readFileSync(join(ROOT, 'scripts/asset_pipeline/weapon_vfx.js'), 'utf8');
+    const block = twinSrc.match(/export const TIERS = \{([\s\S]*?)\n\};/);
+    expect(block, 'weapon_vfx.js twin must export TIERS').toBeTruthy();
+    const body = block?.[1] ?? '';
+
+    // Keyed by tier name rather than by position, so a reordered twin compares
+    // the rows a reader would expect it to compare.
+    const headers = [...body.matchAll(/^ {2}(\w+): \{$/gm)];
+    const twinPowers: Record<string, number> = {};
+    for (const [index, header] of headers.entries()) {
+      const end = headers[index + 1]?.index ?? body.length;
+      const section = body.slice(header.index ?? 0, end);
+      const power = section.match(/shell: \{[^}]*\bpower: (-?[\d.]+)/);
+      if (power) twinPowers[header[1]] = Number(power[1]);
+    }
+
+    const realPowers = Object.fromEntries(
+      Object.entries(TIERS).map(([name, tier]) => [name, tier.shell.power]),
+    );
+    expect(twinPowers).toEqual(realPowers);
+    // Vacuity floor: an equality against an empty object passes, and a parser
+    // that silently matched nothing is the way this pin dies quietly.
+    expect(Object.keys(twinPowers).length).toBe(Object.keys(TIERS).length);
+    for (const [name, power] of Object.entries(twinPowers)) {
+      expect(power, `twin tier ${name}: shell power must be > 0`).toBeGreaterThan(0);
+    }
+    // Every shell row in the WHOLE twin, not only the tier table: a per-weapon
+    // override added below WEAPON_VFX reaches the same makeShell.
+    const everyPower = [...twinSrc.matchAll(/shell: \{[^}]*\bpower: (-?[\d.]+)/g)].map((m) =>
+      Number(m[1]),
+    );
+    expect(everyPower.length).toBeGreaterThanOrEqual(Object.keys(TIERS).length);
+    for (const power of everyPower) expect(power).toBeGreaterThan(0);
+  });
+
   it('parses WEAPON_VFX_TUNING into weaponKey -> channel multipliers, ignoring comments', async () => {
     const library = await libraryImport;
     const src = [

--- a/tests/helpers/source_files_under.test.ts
+++ b/tests/helpers/source_files_under.test.ts
@@ -1,0 +1,168 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { SOURCE_EXTENSIONS, sourceFilesUnder } from './source_files_under';
+
+// The paired test for the shared source walk, and the producer fixture the
+// guards that consume it cannot supply themselves: every scan root in this repo
+// is shallow enough that a consumer's own assertions read identically whether
+// this walk descends or stops at the top level (#2485, #2489). Only a fixture
+// tree separates them, so the contract is pinned here once.
+//
+// The symlink cases are not hypothetical hygiene. This walk follows links on
+// both arms by design, so a cycle is a hang that takes the whole suite's
+// collection down with it, and a link out of the root is a corpus quietly
+// holding files nobody reviewing this repo can see.
+
+describe('sourceFilesUnder', () => {
+  let root = '';
+
+  beforeEach(() => {
+    root = mkdtempSync(path.join(tmpdir(), 'woc-source-files-under-'));
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  const write = (relative: string, body = 'export const x = 1;\n'): void => {
+    const full = path.join(root, ...relative.split('/'));
+    mkdirSync(path.dirname(full), { recursive: true });
+    writeFileSync(full, body);
+  };
+
+  it('finds source files at every depth, labeled relative to the root', () => {
+    write('top.ts');
+    write('one/mid.js');
+    write('one/two/three/deep.mjs');
+    // Three levels, not two: a walk with any depth cap fails here rather than
+    // passing on a shallower fixture.
+    expect(sourceFilesUnder(root).map((f) => f.file)).toEqual([
+      'one/mid.js',
+      'one/two/three/deep.mjs',
+      'top.ts',
+    ]);
+  });
+
+  it('covers the whole declared extension policy, and nothing outside it', () => {
+    // Every extension SOURCE_EXTENSIONS declares, driven off the constant, so
+    // adding one there without teaching the walk about it fails here. The
+    // shader extensions have no file in the tree today: this is the only place
+    // that can prove they would be scanned the day one lands.
+    for (const extension of SOURCE_EXTENSIONS) write(`kept${extension}`);
+    write('notes.md');
+    write('data.json');
+    write('shader.txt');
+    write('types.d.ts');
+    write('legacy.d.mts');
+    expect(
+      sourceFilesUnder(root)
+        .map((f) => f.file)
+        .sort(),
+    ).toEqual(SOURCE_EXTENSIONS.map((extension) => `kept${extension}`).sort());
+  });
+
+  it('sorts within each directory, so the order does not depend on the filesystem', () => {
+    // Written in an order that is neither sorted nor reversed, so a walk
+    // returning raw readdir order would have to be lucky to pass. CI is ext4
+    // (readdir in hash order) and a dev checkout is APFS (byte-lexicographic).
+    write('zulu.ts');
+    write('alpha.ts');
+    write('mike/zulu.js');
+    write('mike/alpha.js');
+    expect(sourceFilesUnder(root).map((f) => f.file)).toEqual([
+      'alpha.ts',
+      'mike/alpha.js',
+      'mike/zulu.js',
+      'zulu.ts',
+    ]);
+  });
+
+  it('labels with forward slashes, and returns a full path that reads back', () => {
+    write('a/dupe.ts', 'export const a = 1;\n');
+    write('b/dupe.ts', 'export const b = 2;\n');
+    const found = sourceFilesUnder(root);
+    // Bare names would collide, and a per-file count map keyed on them would
+    // silently merge two files into one row.
+    expect(found.map((f) => f.file)).toEqual(['a/dupe.ts', 'b/dupe.ts']);
+    // `full` is what every consumer hands to readFileSync. Read the file rather
+    // than re-deriving the path with the same path.join the walk used, which
+    // would compare the implementation to itself.
+    expect(path.isAbsolute(found[0].full)).toBe(true);
+    expect(readFileSync(found[0].full, 'utf8')).toBe('export const a = 1;\n');
+  });
+
+  it('skips only the named directories, at any depth', () => {
+    write('kept.ts');
+    write('node_modules/dep.ts');
+    write('one/node_modules/nested_dep.ts');
+    write('one/kept_too.ts');
+    expect(
+      sourceFilesUnder(root, { skipDirectories: ['node_modules'] }).map((f) => f.file),
+    ).toEqual(['kept.ts', 'one/kept_too.ts']);
+    // Without the option nothing is skipped: the exclusion is the caller's
+    // decision, never a default the caller cannot see.
+    expect(sourceFilesUnder(root).map((f) => f.file)).toContain('node_modules/dep.ts');
+  });
+
+  it('follows a symlinked source FILE (a Dirent reads false for one)', () => {
+    // The reason there is no `entry.isFile()` gate: Dirent is lstat-based, so
+    // gating on it drops a symlinked module that a flat readdirSync().filter()
+    // would have read. That is the silent narrowing this walk exists to stop.
+    write('real/module.ts');
+    symlinkSync(path.join(root, 'real', 'module.ts'), path.join(root, 'linked.ts'));
+    expect(sourceFilesUnder(root).map((f) => f.file)).toEqual(['linked.ts', 'real/module.ts']);
+  });
+
+  it('walks a DIRECTORY named like a source file instead of returning it', () => {
+    // The shape the hand-rolled walk exists for: readdirSync's `recursive: true`
+    // emits directory entries into its result, so `namespace.ts` would come back
+    // as a file and reach a consumer's readFileSync as an EISDIR crash.
+    write('namespace.ts/child.ts');
+    expect(sourceFilesUnder(root).map((f) => f.file)).toEqual(['namespace.ts/child.ts']);
+  });
+
+  it('descends a symlinked directory ONCE, rather than returning its files twice', () => {
+    // The other half of the symlink decision: `entry.isDirectory()` is
+    // lstat-based, so taking it at face value drops an entire linked subtree.
+    // Following it means two links to one subtree can double-count, which
+    // silently doubles any per-file count a consumer pins.
+    write('real/inside.ts');
+    write('real/deeper/lower.ts');
+    symlinkSync(path.join(root, 'real'), path.join(root, 'link_a'));
+    symlinkSync(path.join(root, 'real'), path.join(root, 'link_b'));
+    const files = sourceFilesUnder(root).map((f) => f.file);
+    // The first link reached in sorted order wins; `real/` itself is then a
+    // revisit of the same realpath.
+    expect(files).toEqual(['link_a/deeper/lower.ts', 'link_a/inside.ts']);
+    expect(new Set(files).size).toBe(files.length);
+  });
+
+  it('terminates on a symlink cycle instead of recursing until the process dies', () => {
+    // A link pointing at its own ancestor. Without the visited-realpath set this
+    // case does not fail, it HANGS, and it takes the collection of every other
+    // suite in the run with it.
+    write('one/two/kept.ts');
+    symlinkSync(path.join(root, 'one'), path.join(root, 'one', 'two', 'loop'));
+    expect(sourceFilesUnder(root).map((f) => f.file)).toEqual(['one/two/kept.ts']);
+  });
+
+  it('throws on a directory link that escapes the root, rather than silently deciding', () => {
+    // Refuses rather than filtering (#2499). Skipping it narrows the scan with
+    // no diff to notice; following it puts files from outside the tree into a
+    // corpus pinned as a file set.
+    const outside = mkdtempSync(path.join(tmpdir(), 'woc-source-files-outside-'));
+    try {
+      writeFileSync(path.join(outside, 'stranger.ts'), 'export const s = 1;\n');
+      symlinkSync(outside, path.join(root, 'escape'));
+      expect(() => sourceFilesUnder(root)).toThrow(/links outside the scan root/);
+    } finally {
+      rmSync(outside, { recursive: true, force: true });
+    }
+  });
+
+  it('is empty for an empty root rather than throwing', () => {
+    expect(sourceFilesUnder(root)).toEqual([]);
+  });
+});

--- a/tests/helpers/source_files_under.ts
+++ b/tests/helpers/source_files_under.ts
@@ -1,0 +1,132 @@
+import { readdirSync, realpathSync, statSync } from 'node:fs';
+import path from 'node:path';
+
+// The shared recursive walk for guards whose corpus is SOURCE files rather than
+// the `.ts` modules helpers/ts_files_under.ts returns. Same contract, same
+// reasoning (a single-level `readdirSync().filter()` is silent-coverage debt:
+// #2485, #2489, #2502), different extension set.
+//
+// A sibling rather than a knob on ts_files_under.ts, which is `.ts`-only by
+// explicit ruling and directs a caller wanting another extension to write its
+// own walk. Writing that walk per caller is how the extension policy ends up
+// restated, and drifting, in each guard, so the policy lives HERE, once: the
+// shader-domain guard needs the `.js`/`.mjs` half of the tree because the
+// offline asset-pipeline inspector ships its own JS copy of the weapon shaders,
+// and it needs standalone shader files because a `.frag` that never existed on
+// the day a guard was written is exactly the file that leaves the scan silently.
+//
+// SOURCE_EXTENSIONS is therefore the complete policy, deliberately wider than
+// today's tree: every GLSL string in this repo currently lives in a TS/JS
+// template literal, and no `.glsl`, `.frag` or `.vert` file exists yet. Listing
+// them costs nothing and means the first one added is scanned rather than
+// ignored.
+
+/** The complete source-extension policy for guards that scan a source tree. */
+export const SOURCE_EXTENSIONS = [
+  // The JS/TS module family, in every spelling this repo's toolchain resolves.
+  '.ts',
+  '.mts',
+  '.cts',
+  '.js',
+  '.mjs',
+  '.cjs',
+  // Standalone shader sources. None exist today; see the header.
+  '.glsl',
+  '.frag',
+  '.vert',
+] as const;
+
+/** One source file found by {@link sourceFilesUnder}. */
+export interface SourceFile {
+  /** Path relative to the scan root, joined with forward slashes at every depth. */
+  readonly file: string;
+  /** Absolute path, for `readFileSync`. */
+  readonly full: string;
+}
+
+/** Options for {@link sourceFilesUnder}. */
+export interface SourceWalkOptions {
+  /**
+   * Directory NAMES never descended into, matched at any depth. Only for
+   * directories a scan must not read at all (`node_modules`, generated bundles);
+   * a caller that merely wants fewer results filters the returned list.
+   */
+  readonly skipDirectories?: Iterable<string>;
+}
+
+/** `.d.ts` is a declaration, never a shader host, and its `pow` is a type. */
+const DECLARATION = /\.d\.[cm]?ts$/;
+
+function hasSourceExtension(name: string): boolean {
+  if (DECLARATION.test(name)) return false;
+  return SOURCE_EXTENSIONS.some((extension) => name.endsWith(extension));
+}
+
+function contains(root: string, candidate: string): boolean {
+  return candidate === root || candidate.startsWith(root + path.sep);
+}
+
+/**
+ * Every source file under `root`, RECURSIVELY, sorted by name within each
+ * directory. See {@link SOURCE_EXTENSIONS} for what counts as a source file.
+ *
+ * The sort matters: readdir returns byte-lexicographic order on a dev APFS
+ * checkout and hash order on the ext4 CI runner, so an unsorted walk pins a
+ * label list that only holds on one of them.
+ *
+ * Symlinks are followed on BOTH arms, for the reason ts_files_under.ts spells
+ * out: a `Dirent` reports lstat, so `isFile()` and `isDirectory()` both read
+ * false for one, and gating on either drops a linked module or a whole linked
+ * subtree out of the scan. Two things this walk adds on top, because following
+ * links unconditionally is what makes them possible:
+ *
+ * - A directory's resolved realpath is visited AT MOST ONCE. Without that, a
+ *   link pointing at one of its own ancestors recurses until the process dies,
+ *   taking the whole suite's collection with it, and two links to one subtree
+ *   return every file in it twice, which double-counts any per-file pin.
+ * - A directory link resolving OUTSIDE the root THROWS, naming both paths. It
+ *   refuses rather than filtering, the ruling of #2499: silently skipping it
+ *   would narrow the scan invisibly, and silently following it would put files
+ *   no reviewer of this repo can see into a corpus pinned as a file set.
+ *
+ * Walks by hand rather than through `readdirSync`'s `recursive: true`, which
+ * emits directory entries into its own result (so a directory named `x.ts`
+ * reaches `readFileSync` and throws EISDIR), returns platform-separator paths,
+ * and does not sort.
+ */
+export function sourceFilesUnder(root: string, options: SourceWalkOptions = {}): SourceFile[] {
+  const skip = new Set(options.skipDirectories ?? []);
+  const rootReal = realpathSync(root);
+  const visited = new Set<string>([rootReal]);
+
+  const walk = (dir: string, prefix: string): SourceFile[] => {
+    const out: SourceFile[] = [];
+    const entries = readdirSync(dir, { withFileTypes: true }).sort((a, b) =>
+      a.name < b.name ? -1 : a.name > b.name ? 1 : 0,
+    );
+    for (const entry of entries) {
+      if (skip.has(entry.name)) continue;
+      const full = path.join(dir, entry.name);
+      const isDir =
+        entry.isDirectory() ||
+        (entry.isSymbolicLink() &&
+          (statSync(full, { throwIfNoEntry: false })?.isDirectory() ?? false));
+      if (isDir) {
+        const real = realpathSync(full);
+        if (!contains(rootReal, real)) {
+          throw new Error(
+            `sourceFilesUnder: ${full} links outside the scan root (${real} is not under ${rootReal})`,
+          );
+        }
+        if (visited.has(real)) continue;
+        visited.add(real);
+        out.push(...walk(full, `${prefix}${entry.name}/`));
+      } else if (hasSourceExtension(entry.name)) {
+        out.push({ file: `${prefix}${entry.name}`, full });
+      }
+    }
+    return out;
+  };
+
+  return walk(root, '');
+}

--- a/tests/shader_pow_domain.test.ts
+++ b/tests/shader_pow_domain.test.ts
@@ -1,16 +1,10 @@
-import {
-  mkdirSync,
-  mkdtempSync,
-  readdirSync,
-  readFileSync,
-  rmSync,
-  statSync,
-  writeFileSync,
-} from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join, relative } from 'node:path';
+import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { afterAll, describe, expect, it } from 'vitest';
+import { expectScansOnlyThroughSharedWalkers } from './helpers/scan_guard_self_audit';
+import { sourceFilesUnder } from './helpers/source_files_under';
 
 // GLSL pow(x, y) is UNDEFINED for x < 0, and every shipping compiler lowers it
 // to exp2(y * log2(x)), so a negative base returns NaN rather than a clamped
@@ -21,20 +15,30 @@ import { afterAll, describe, expect, it } from 'vitest';
 // before ACES, and GLSL max(x, y) returns x when y is NaN, so the whole
 // rectangle collapses to black rather than to garbage.
 //
-// The bases that bite are the fresnel-style ones: `1.0 - dot(n, v)` where both
-// vectors were normalized IN SHADER. A normalized dot product overshoots 1.0 by
-// an ulp on the silhouette, the base goes to -1e-7, and the frame gets a black
-// box. That shipped as the weapon-skin black square (the Hoarfrost shell, whose
-// uPow is 2.6). This gate keeps every pow() base in the tree provably >= 0.
+// The bases that bite are the fresnel-style ones: `1.0 - abs(dot(n, v))` where
+// both vectors were normalized IN SHADER. That base is near 1 along the
+// silhouette (abs(dot) near 0) and near 0 where the two vectors are ALIGNED or
+// ANTI-ALIGNED, i.e. where the surface faces the camera head-on. It is the
+// near-zero end that bites: a normalized dot product overshoots 1.0 by an ulp,
+// so the base lands at about -1e-7 and the frame gets a black box. That shipped
+// as the weapon-skin black square (the Hoarfrost shell, whose uPow is 2.6).
+// This gate keeps every pow() base in the tree provably >= 0.
 //
 // Recognized-safe base forms, no allowlist entry needed:
 //   abs(x) / saturate(x) / clamp(x, 0.0, hi) / max(x, 0.0)   the whole base IS
 //                                                            the clamping call
-//   any of the above scaled by a positive literal
+//   any of the above scaled by a positive FINITE literal, multiplied or divided
 //   1.0 - saturate(x) and 1.0 - clamp(x, lo, 1.0)            x is bounded to 1
 // Deliberately NOT recognized: `1.0 - max(x, 0.0)`, which clamps the LOW side
 // only and leaves the high side open. That is exactly how the water fresnel used
 // to spell this bug.
+//
+// Every bound the classifier leans on has to be a FINITE literal it can order,
+// because two of the ways to write a "clamped" expression are not clamps at
+// all: `clamp(x, 0.0, -1.0)` has its bounds reversed, which GLSL leaves
+// undefined rather than defining as either bound, and `max(x, 0.0) / 0.0` wraps
+// a genuinely non-negative term in a division whose result is undefined and, on
+// the shipping lowering, NaN or Inf. Both used to classify safe here.
 //
 // The classifier is whole-expression, never prefix-matched: `abs(x) - 1.0` and
 // `1.0 - saturate(x) * 2.0` both START with a safe-looking token and are both
@@ -79,15 +83,21 @@ const PROVEN_SAFE_BASES: ProvenSafeBase[] = [
     file: 'src/render/weapon_vfx.ts',
     base: 'w',
     sites: 1,
-    anchor: /float w = 0\.5 \+ 0\.5 \* sin\(/,
-    why: 'GLSL sin() is bounded to [-1, 1], so w = 0.5 + 0.5 * sin(...) is >= 0',
+    // The anchor pins the WHOLE guarded expression, clamp included. The
+    // mathematical range of sin() is not the proof it looks like: GLSL leaves
+    // the precision of the trigonometric functions to the implementation, so
+    // 0.5 + 0.5 * sin(x) is only provably >= 0 in exact arithmetic. The clamp is
+    // what makes the claim hold on a real compiler, so the row stands or falls
+    // with it rather than with the sin().
+    anchor: /float w = clamp\(0\.5 \+ 0\.5 \* sin\([^;]*, 0\.0, 1\.0\);/,
+    why: 'w is the result of a clamp(..., 0.0, 1.0), read one line above the pow()',
   },
   {
     file: 'scripts/asset_pipeline/weapon_vfx.js',
     base: 'w',
     sites: 1,
-    anchor: /float w = 0\.5 \+ 0\.5 \* sin\(/,
-    why: 'the offline inspector copy of the same twinkles shader',
+    anchor: /float w = clamp\(0\.5 \+ 0\.5 \* sin\([^;]*, 0\.0, 1\.0\);/,
+    why: 'the offline inspector copy of the same clamped twinkles shader',
   },
   {
     file: 'src/render/water.ts',
@@ -132,29 +142,6 @@ const POW_SITES_PER_FILE: Record<string, number> = {
 // Generated locale bundles are megabytes of prose with no shader in them; a
 // stray "pow(" in lore text would be classified as GLSL.
 const SKIPPED_DIRS = new Set(['node_modules', 'dist', 'i18n.locales', 'i18n.resolved.generated']);
-
-// Hand-rolled rather than helpers/ts_files_under.ts, which is .ts-only by
-// explicit ruling and whose header directs a caller wanting another extension to
-// write its own walk. This corpus must include .js and .mjs, because the offline
-// asset-pipeline mirror of the weapon shader is JS and carries the same shader
-// text. (expectScansOnlyThroughSharedWalkers is therefore inapplicable: it bans
-// every directory read outright.) The recursion is pinned below by a mkdtemp
-// fixture driving this same producer, per tests/CLAUDE.md. The two behaviors
-// that walker learned the hard way are kept: sort, because readdir returns hash
-// order on the ext4 CI runner and byte order on a dev checkout, and resolve
-// symlinks through statSync rather than trusting a Dirent's lstat, so a
-// symlinked module or subtree cannot silently leave the scan.
-function walk(dir: string): string[] {
-  const out: string[] = [];
-  for (const name of readdirSync(dir).sort()) {
-    if (SKIPPED_DIRS.has(name)) continue;
-    const full = join(dir, name);
-    const stat = statSync(full, { throwIfNoEntry: false });
-    if (stat?.isDirectory()) out.push(...walk(full));
-    else if (/\.(?:ts|js|mjs)$/.test(name) && !name.endsWith('.d.ts')) out.push(full);
-  }
-  return out;
-}
 
 /** Strip block and line comments so commented-out or explanatory pow() text is
  *  ignored. The line arm keeps a `://` in a URL from eating the rest of its
@@ -216,15 +203,37 @@ function wholeCallArguments(expr: string, name: string): string[] | null {
   return null;
 }
 
-const ZERO = /^(?:vec[234]\s*\(\s*)?0(?:\.0*)?\s*\)?$/;
-const ONE = /^(?:vec[234]\s*\(\s*)?1(?:\.0*)?\s*\)?$/;
+const NUMBER = /^[+-]?(?:[0-9]+(?:\.[0-9]*)?|\.[0-9]+)(?:[eE][+-]?[0-9]+)?$/;
+
+/** The finite scalar an expression denotes, or null when it is not one. Accepts
+ *  a `vecN(x)` splat, which GLSL bounds are routinely written as. Anything else,
+ *  a uniform or a computed term included, is null: a bound this cannot read is a
+ *  bound this cannot ORDER, and an unordered clamp is the undefined case below. */
+function literalValue(expr: string): number | null {
+  const splat = /^vec[234]\s*\(([^()]*)\)$/.exec(expr.trim());
+  const scalar = (splat ? splat[1] : expr).trim();
+  if (!NUMBER.test(scalar)) return null;
+  const value = Number(scalar);
+  return Number.isFinite(value) ? value : null;
+}
+
+/** Arguments of a whole-expression `clamp(x, lo, hi)` whose bounds are finite
+ *  literals in the RIGHT ORDER, else null. GLSL leaves clamp(x, lo, hi) with
+ *  lo > hi undefined, so a reversed pair proves nothing about either end. */
+function orderedClampBounds(expr: string): { lo: number; hi: number } | null {
+  const clamp = wholeCallArguments(expr, 'clamp');
+  if (clamp === null || clamp.length !== 3) return null;
+  const lo = literalValue(clamp[1]);
+  const hi = literalValue(clamp[2]);
+  if (lo === null || hi === null || lo > hi) return null;
+  return { lo, hi };
+}
 
 /** True when the expression cannot exceed 1.0, so `1.0 - it` stays >= 0. */
 function boundedAboveByOne(expr: string): boolean {
   const e = expr.trim();
   if (wholeCallArguments(e, 'saturate') !== null) return true;
-  const clamp = wholeCallArguments(e, 'clamp');
-  return clamp !== null && clamp.length === 3 && ONE.test(clamp[2]);
+  return orderedClampBounds(e)?.hi === 1;
 }
 
 /** True when the expression cannot go below 0.0, so pow() is well defined. */
@@ -237,23 +246,32 @@ function boundedBelowByZero(expr: string): boolean {
   const additive = topLevelOperators(e, '+-');
   if (additive.length > 0) {
     if (additive.length !== 1 || e[additive[0]] !== '-') return false;
-    if (!ONE.test(e.slice(0, additive[0]).trim())) return false;
+    if (literalValue(e.slice(0, additive[0])) !== 1) return false;
     const right = e.slice(additive[0] + 1).trim();
     if (topLevelOperators(right, '*/').length > 0) return false;
     return boundedAboveByOne(right);
   }
 
-  // No additive term: a trailing scale by a POSITIVE literal cannot change the
-  // sign, so drop it and require what remains to BE a clamping call. Any other
-  // top-level product (`abs(a) * sign`, `max(a, 0.0) * -1.0`) stays unproven.
-  const scaled = e.replace(/\s*[*/]\s*[0-9]+(?:\.[0-9]*)?\s*$/, '');
+  // No additive term: a trailing scale by a POSITIVE FINITE literal cannot
+  // change the sign, so drop it and require what remains to BE a clamping call.
+  // Multiplication and division are split rather than sharing one arm: `* 0.0`
+  // is a degenerate but non-negative zero while `/ 0.0` is undefined and NaN or
+  // Inf on the shipping lowering, so the divisor has to be strictly positive and
+  // the two cannot be proven by the same rule. Any other top-level product
+  // (`abs(a) * sign`, `max(a, 0.0) * -1.0`, `max(a, 0.0) / scale`) is unproven.
+  const trailing = /\s*([*/])\s*([^\s*/]+)\s*$/.exec(e);
+  let scaled = e;
+  if (trailing !== null && topLevelOperators(e, '*/').length === 1) {
+    const factor = literalValue(trailing[2]);
+    if (factor === null || factor <= 0) return false;
+    scaled = e.slice(0, trailing.index).trim();
+  }
   if (topLevelOperators(scaled, '*/').length > 0) return false;
   if (wholeCallArguments(scaled, 'abs') !== null) return true;
   if (wholeCallArguments(scaled, 'saturate') !== null) return true;
-  const clamp = wholeCallArguments(scaled, 'clamp');
-  if (clamp !== null) return clamp.length === 3 && ZERO.test(clamp[1]);
+  if (wholeCallArguments(scaled, 'clamp') !== null) return orderedClampBounds(scaled)?.lo === 0;
   const max = wholeCallArguments(scaled, 'max');
-  return (max ?? []).some((arg) => ZERO.test(arg));
+  return (max ?? []).some((arg) => literalValue(arg) === 0);
 }
 
 interface PowSite {
@@ -280,12 +298,20 @@ function firstArgument(source: string, open: number): string | null {
 // a site. Sticky so the scan can resume after each match.
 const POW_CALL = /(^|[^.A-Za-z0-9_])pow\s*\(/g;
 
+// The corpus is read through helpers/source_files_under.ts, not a walk of this
+// guard's own: this scan needs the .js and .mjs half of the tree (the offline
+// asset-pipeline inspector ships its own JS copy of the weapon shaders) and any
+// standalone shader file, and the extension policy behind that belongs in one
+// shared place rather than restated per guard. The recursion is still pinned
+// below by a mkdtemp fixture driving THIS producer, per tests/CLAUDE.md, since
+// the fixture is what proves the guard consumes the walk correctly, and the
+// self-audit pins that no second, hand-rolled read was added beside it.
 function powSites(roots: string[], base: string): PowSite[] {
   const sites: PowSite[] = [];
   for (const root of roots) {
-    for (const full of walk(join(base, root))) {
-      const file = relative(base, full).split('\\').join('/');
-      const raw = readFileSync(full, 'utf8');
+    for (const entry of sourceFilesUnder(join(base, root), { skipDirectories: SKIPPED_DIRS })) {
+      const file = `${root}/${entry.file}`;
+      const raw = readFileSync(entry.full, 'utf8');
       if (!raw.includes('pow')) continue;
       const source = withoutComments(raw);
       POW_CALL.lastIndex = 0;
@@ -392,6 +418,23 @@ describe('GLSL pow() bases stay non-negative', () => {
     expect(boundedBelowByZero('max(a, 0.0) / scale')).toBe(false);
   });
 
+  it('rejects a wrapper that LOOKS like a clamp and is not one', () => {
+    // The two shapes that used to classify safe here. Neither is a clamped
+    // term: `/ 0.0` is undefined in GLSL and NaN or Inf on the shipping
+    // lowering, and a clamp whose bounds are reversed is undefined outright, so
+    // nothing about either end of it is proven.
+    expect(boundedBelowByZero('max(x, 0.0) / 0.0')).toBe(false);
+    expect(boundedBelowByZero('clamp(x, 0.0, -1.0)')).toBe(false);
+    expect(boundedBelowByZero('1.0 - clamp(x, 2.0, 1.0)')).toBe(false);
+    // And the same rule applied per dimension: a negative divisor flips the
+    // sign, a non-literal one cannot be ordered at all, and a bound that is not
+    // a literal is a bound this classifier must not pretend to have read.
+    expect(boundedBelowByZero('max(x, 0.0) / -2.0')).toBe(false);
+    expect(boundedBelowByZero('max(x, 0.0) / uScale')).toBe(false);
+    expect(boundedBelowByZero('clamp(x, 0.0, uHi)')).toBe(false);
+    expect(boundedBelowByZero('1.0 - clamp(x, uLo, 1.0)')).toBe(false);
+  });
+
   it('accepts the guarded spellings the fix introduced', () => {
     expect(boundedBelowByZero('max(0.0, 1.0 - abs(dot(normalize(vN), normalize(vV))))')).toBe(true);
     expect(boundedBelowByZero('max(0.0, sin(3.14159 * vUv.x))')).toBe(true);
@@ -410,11 +453,23 @@ describe('GLSL pow() bases stay non-negative', () => {
     expect(withoutComments('/* pow(commented, 2.0) */ real')).toBe(' real');
   });
 
+  it('reads the tree only through the shared walker', () => {
+    // The other half of the tests/CLAUDE.md contract: the fixture below pins
+    // that this producer consumes the walk correctly, and this pins that no
+    // second, hand-rolled directory read was added beside it. Over a corpus
+    // pinned as a file set, a stray flat read is invisible until the day
+    // something moves down a level.
+    expectScansOnlyThroughSharedWalkers(import.meta.url, ['source_files_under']);
+  });
+
   describe('the producer itself', () => {
-    // tests/CLAUDE.md: a guard with its own walk pins the recursion with a
-    // mkdtemp fixture driving that walk, because every real scan root here is
-    // already deep enough to pass either way, so no assertion over the real tree
-    // can tell a recursive walk from a flat one.
+    // tests/CLAUDE.md: a guard that scans a directory pins the recursion with a
+    // mkdtemp fixture driving its OWN producer, because every real scan root
+    // here is already deep enough to pass either way, so no assertion over the
+    // real tree can tell a recursive walk from a flat one. The walk itself is
+    // helpers/source_files_under.ts and has its own paired test; what this
+    // fixture pins is that THIS producer drives it over the whole corpus, at
+    // every depth and every extension, and classifies what comes back.
     const fixture = mkdtempSync(join(tmpdir(), 'shader-pow-'));
     afterAll(() => rmSync(fixture, { recursive: true, force: true }));
 
@@ -425,6 +480,10 @@ describe('GLSL pow() bases stay non-negative', () => {
     writeFileSync(join(fixture, 'root', 'nested', 'deeper', 'low.mjs'), 'z = pow (c, 2.0);\n');
     writeFileSync(join(fixture, 'root', 'nested', 'skip.txt'), 'w = pow(d, 2.0);\n');
     writeFileSync(join(fixture, 'root', 'node_modules', 'dep.ts'), 'v = pow(e, 2.0);\n');
+    // A standalone shader file. None exists in the tree today, which is exactly
+    // why it is pinned here: the first one added must land INSIDE this scan
+    // rather than beside it.
+    writeFileSync(join(fixture, 'root', 'nested', 'shader.frag'), 'float q = pow(j, 2.0);\n');
     writeFileSync(
       join(fixture, 'root', 'nested', 'tricky.ts'),
       'const url = "https://x.dev/y"; u = pow(f, 2.0);\n' +
@@ -436,13 +495,14 @@ describe('GLSL pow() bases stay non-negative', () => {
     const found = powSites(['root'], fixture);
 
     it('recurses, so a file one level down cannot leave the scan', () => {
-      expect(found.map((site) => site.base).sort()).toEqual(['a', 'b', 'c', 'f']);
+      expect(found.map((site) => site.base).sort()).toEqual(['a', 'b', 'c', 'f', 'j']);
     });
 
-    it('keeps the .js and .mjs half of the corpus the shared .ts walker drops', () => {
+    it('keeps the .js, .mjs and shader half of the corpus a .ts-only walk drops', () => {
       expect(found.map((site) => site.file).sort()).toEqual([
         'root/nested/deeper/low.mjs',
         'root/nested/mid.js',
+        'root/nested/shader.frag',
         'root/nested/tricky.ts',
         'root/top.ts',
       ]);

--- a/tests/shader_pow_domain.test.ts
+++ b/tests/shader_pow_domain.test.ts
@@ -1,0 +1,461 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterAll, describe, expect, it } from 'vitest';
+
+// GLSL pow(x, y) is UNDEFINED for x < 0, and every shipping compiler lowers it
+// to exp2(y * log2(x)), so a negative base returns NaN rather than a clamped
+// value. That NaN is not a local blemish: the VFX materials are additive, so it
+// poisons the HDR scene texel, the bloom high-pass carries it into the mip
+// chain, and the separable blur (horizontal then vertical) smears one bad texel
+// into a HARD-EDGED AXIS-ALIGNED RECTANGLE. OutputGradePass folds the bloom in
+// before ACES, and GLSL max(x, y) returns x when y is NaN, so the whole
+// rectangle collapses to black rather than to garbage.
+//
+// The bases that bite are the fresnel-style ones: `1.0 - dot(n, v)` where both
+// vectors were normalized IN SHADER. A normalized dot product overshoots 1.0 by
+// an ulp on the silhouette, the base goes to -1e-7, and the frame gets a black
+// box. That shipped as the weapon-skin black square (the Hoarfrost shell, whose
+// uPow is 2.6). This gate keeps every pow() base in the tree provably >= 0.
+//
+// Recognized-safe base forms, no allowlist entry needed:
+//   abs(x) / saturate(x) / clamp(x, 0.0, hi) / max(x, 0.0)   the whole base IS
+//                                                            the clamping call
+//   any of the above scaled by a positive literal
+//   1.0 - saturate(x) and 1.0 - clamp(x, lo, 1.0)            x is bounded to 1
+// Deliberately NOT recognized: `1.0 - max(x, 0.0)`, which clamps the LOW side
+// only and leaves the high side open. That is exactly how the water fresnel used
+// to spell this bug.
+//
+// The classifier is whole-expression, never prefix-matched: `abs(x) - 1.0` and
+// `1.0 - saturate(x) * 2.0` both START with a safe-looking token and are both
+// genuinely negative-capable, so every arm below parses to the end of the
+// expression and settles the top-level operator structure first.
+//
+// It FAILS CLOSED by design, and the list above is the whole recognized set:
+// `length(v)`, `exp(x)`, `x * x`, `smoothstep(a, b, x)`, `1.0 - min(d, 1.0)` and
+// even a redundantly parenthesized `(1.0 - saturate(x))` are all non-negative and
+// all classified unsafe. A new one of those wants a PROVEN_SAFE_BASES row or a
+// new arm here, deliberately: a red is loud and a miss is silent.
+//
+// Scope is pow() alone. sqrt/log/inversesqrt of a bad argument, and normalize()
+// of a zero vector, reach the same additive-then-bloom path (rings.ts already
+// carries an `atan(0,0) would NaN into bloom` guard from an earlier incident).
+// None of those is unguarded in the tree today; widening this gate to them is a
+// separate change.
+
+const repoRoot = fileURLToPath(new URL('..', import.meta.url));
+
+/** Roots holding any shader source. Wider than src/ because the offline
+ *  asset-pipeline viewer ships its own JS copy of the weapon shaders. */
+const SCAN_ROOTS = ['src', 'scripts', 'server', 'headless', 'electron', 'bot'];
+
+interface ProvenSafeBase {
+  file: string;
+  base: string;
+  /** How many sites in that file may carry this base. Pinned so a SECOND, and
+   *  entirely different, `pow(w, ...)` in the same file is not blessed by the
+   *  row that was written for the first one. */
+  sites: number;
+  /** Regex asserted against the file's own text: the provenance is a claim about
+   *  code elsewhere in that file, so it has to be pinned to that code or it
+   *  keeps blessing the site after the line it names is gone. */
+  anchor: RegExp;
+  why: string;
+}
+
+/** Bases that are non-negative by provenance rather than by syntax. */
+const PROVEN_SAFE_BASES: ProvenSafeBase[] = [
+  {
+    file: 'src/render/weapon_vfx.ts',
+    base: 'w',
+    sites: 1,
+    anchor: /float w = 0\.5 \+ 0\.5 \* sin\(/,
+    why: 'GLSL sin() is bounded to [-1, 1], so w = 0.5 + 0.5 * sin(...) is >= 0',
+  },
+  {
+    file: 'scripts/asset_pipeline/weapon_vfx.js',
+    base: 'w',
+    sites: 1,
+    anchor: /float w = 0\.5 \+ 0\.5 \* sin\(/,
+    why: 'the offline inspector copy of the same twinkles shader',
+  },
+  {
+    file: 'src/render/water.ts',
+    base: 'sunAlign',
+    sites: 3,
+    anchor: /float sunAlign = max\(dot\(reflect\(-uSunDir, N\), V\), 0\.0\)/,
+    why: 'sunAlign is itself a max(..., 0.0), reused by the three sun-lobe powers',
+  },
+  {
+    file: 'src/render/worn_stone.ts',
+    base: 'wornAxis',
+    sites: 1,
+    anchor: /vec3 wornAxis = abs\( wornUnitN \)/,
+    why: 'wornAxis is an abs() of a normalized vector',
+  },
+  {
+    file: 'src/render/ability_vfx/rings.ts',
+    base: '1.0 - uProgress',
+    sites: 1,
+    anchor: /uniforms\.uProgress\.value = easeOutQuart\(/,
+    why: 'uProgress is written from JS as easeOutQuart(min(1, age / dur)), never above 1',
+  },
+];
+
+/** Every file that currently holds at least one pow(), and how many. Pinned as a
+ *  SET with counts, not as a floor: a floor sitting under the real total is what
+ *  lets a whole directory leave the scan while the guard stays green. */
+const POW_SITES_PER_FILE: Record<string, number> = {
+  'scripts/asset_pipeline/weapon_vfx.js': 4,
+  'src/render/ability_vfx/rings.ts': 1,
+  'src/render/ability_vfx/shells.ts': 1,
+  'src/render/dungeon.ts': 1,
+  'src/render/foliage_shader_core.ts': 1,
+  'src/render/pbr_fragment_shader.ts': 1,
+  'src/render/post_output_grade.ts': 1,
+  'src/render/sky.ts': 1,
+  'src/render/water.ts': 4,
+  'src/render/weapon_vfx.ts': 4,
+  'src/render/worn_stone.ts': 1,
+};
+
+// Generated locale bundles are megabytes of prose with no shader in them; a
+// stray "pow(" in lore text would be classified as GLSL.
+const SKIPPED_DIRS = new Set(['node_modules', 'dist', 'i18n.locales', 'i18n.resolved.generated']);
+
+// Hand-rolled rather than helpers/ts_files_under.ts, which is .ts-only by
+// explicit ruling and whose header directs a caller wanting another extension to
+// write its own walk. This corpus must include .js and .mjs, because the offline
+// asset-pipeline mirror of the weapon shader is JS and carries the same shader
+// text. (expectScansOnlyThroughSharedWalkers is therefore inapplicable: it bans
+// every directory read outright.) The recursion is pinned below by a mkdtemp
+// fixture driving this same producer, per tests/CLAUDE.md. The two behaviors
+// that walker learned the hard way are kept: sort, because readdir returns hash
+// order on the ext4 CI runner and byte order on a dev checkout, and resolve
+// symlinks through statSync rather than trusting a Dirent's lstat, so a
+// symlinked module or subtree cannot silently leave the scan.
+function walk(dir: string): string[] {
+  const out: string[] = [];
+  for (const name of readdirSync(dir).sort()) {
+    if (SKIPPED_DIRS.has(name)) continue;
+    const full = join(dir, name);
+    const stat = statSync(full, { throwIfNoEntry: false });
+    if (stat?.isDirectory()) out.push(...walk(full));
+    else if (/\.(?:ts|js|mjs)$/.test(name) && !name.endsWith('.d.ts')) out.push(full);
+  }
+  return out;
+}
+
+/** Strip block and line comments so commented-out or explanatory pow() text is
+ *  ignored. The line arm keeps a `://` in a URL from eating the rest of its
+ *  line, which this repo has already shipped once as a live bug (#2499). */
+function withoutComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+}
+
+/** Indices of `ops` characters that sit at paren depth 0 in `expr`. Skips the
+ *  sign of an exponent literal (1.0e-5) and any leading unary sign. */
+function topLevelOperators(expr: string, ops: string): number[] {
+  const out: number[] = [];
+  let depth = 0;
+  for (let i = 0; i < expr.length; i++) {
+    const ch = expr[i];
+    if (ch === '(') depth++;
+    else if (ch === ')') depth--;
+    else if (depth === 0 && ops.includes(ch) && i > 0) {
+      const isExponentSign =
+        (ch === '-' || ch === '+') && /[eE]/.test(expr[i - 1]) && /[0-9.]/.test(expr[i - 2] ?? '');
+      if (!isExponentSign) out.push(i);
+    }
+  }
+  return out;
+}
+
+/** Split a call's arguments at depth 0, e.g. `clamp(a, b, 1.0)` -> [a, b, 1.0]. */
+function splitArguments(inner: string): string[] {
+  const args: string[] = [];
+  let depth = 0;
+  let start = 0;
+  for (let i = 0; i < inner.length; i++) {
+    const ch = inner[i];
+    if (ch === '(') depth++;
+    else if (ch === ')') depth--;
+    else if (ch === ',' && depth === 0) {
+      args.push(inner.slice(start, i).trim());
+      start = i + 1;
+    }
+  }
+  args.push(inner.slice(start).trim());
+  return args;
+}
+
+/** Arguments of `expr` when the WHOLE expression is a call to `name`, else null.
+ *  Whole-expression, so `abs(x) - 1.0` does not read as an `abs` call. */
+function wholeCallArguments(expr: string, name: string): string[] | null {
+  const e = expr.trim();
+  const head = new RegExp(`^${name}\\s*\\(`).exec(e);
+  if (!head || !e.endsWith(')')) return null;
+  const open = head[0].length - 1;
+  let depth = 0;
+  for (let i = open; i < e.length; i++) {
+    if (e[i] === '(') depth++;
+    else if (e[i] === ')' && --depth === 0) {
+      return i === e.length - 1 ? splitArguments(e.slice(open + 1, -1)) : null;
+    }
+  }
+  return null;
+}
+
+const ZERO = /^(?:vec[234]\s*\(\s*)?0(?:\.0*)?\s*\)?$/;
+const ONE = /^(?:vec[234]\s*\(\s*)?1(?:\.0*)?\s*\)?$/;
+
+/** True when the expression cannot exceed 1.0, so `1.0 - it` stays >= 0. */
+function boundedAboveByOne(expr: string): boolean {
+  const e = expr.trim();
+  if (wholeCallArguments(e, 'saturate') !== null) return true;
+  const clamp = wholeCallArguments(e, 'clamp');
+  return clamp !== null && clamp.length === 3 && ONE.test(clamp[2]);
+}
+
+/** True when the expression cannot go below 0.0, so pow() is well defined. */
+function boundedBelowByZero(expr: string): boolean {
+  const e = expr.trim();
+
+  // Additive structure binds loosest, so it settles first. Exactly one shape is
+  // provably non-negative, and its right side must be a BARE bounded term: a
+  // scaled one (`1.0 - saturate(x) * 2.0`) reaches -1.
+  const additive = topLevelOperators(e, '+-');
+  if (additive.length > 0) {
+    if (additive.length !== 1 || e[additive[0]] !== '-') return false;
+    if (!ONE.test(e.slice(0, additive[0]).trim())) return false;
+    const right = e.slice(additive[0] + 1).trim();
+    if (topLevelOperators(right, '*/').length > 0) return false;
+    return boundedAboveByOne(right);
+  }
+
+  // No additive term: a trailing scale by a POSITIVE literal cannot change the
+  // sign, so drop it and require what remains to BE a clamping call. Any other
+  // top-level product (`abs(a) * sign`, `max(a, 0.0) * -1.0`) stays unproven.
+  const scaled = e.replace(/\s*[*/]\s*[0-9]+(?:\.[0-9]*)?\s*$/, '');
+  if (topLevelOperators(scaled, '*/').length > 0) return false;
+  if (wholeCallArguments(scaled, 'abs') !== null) return true;
+  if (wholeCallArguments(scaled, 'saturate') !== null) return true;
+  const clamp = wholeCallArguments(scaled, 'clamp');
+  if (clamp !== null) return clamp.length === 3 && ZERO.test(clamp[1]);
+  const max = wholeCallArguments(scaled, 'max');
+  return (max ?? []).some((arg) => ZERO.test(arg));
+}
+
+interface PowSite {
+  file: string;
+  line: number;
+  base: string;
+}
+
+/** First argument of the pow(...) call whose paren sits at `open`. */
+function firstArgument(source: string, open: number): string | null {
+  let depth = 0;
+  for (let i = open; i < source.length; i++) {
+    const ch = source[i];
+    if (ch === '(') depth++;
+    else if (ch === ')') {
+      depth--;
+      if (depth === 0) return source.slice(open + 1, i).trim();
+    } else if (ch === ',' && depth === 1) return source.slice(open + 1, i).trim();
+  }
+  return null;
+}
+
+// `pow \n (` is legal GLSL, and Math.pow / a name merely ending in "pow" is not
+// a site. Sticky so the scan can resume after each match.
+const POW_CALL = /(^|[^.A-Za-z0-9_])pow\s*\(/g;
+
+function powSites(roots: string[], base: string): PowSite[] {
+  const sites: PowSite[] = [];
+  for (const root of roots) {
+    for (const full of walk(join(base, root))) {
+      const file = relative(base, full).split('\\').join('/');
+      const raw = readFileSync(full, 'utf8');
+      if (!raw.includes('pow')) continue;
+      const source = withoutComments(raw);
+      POW_CALL.lastIndex = 0;
+      let match = POW_CALL.exec(source);
+      while (match !== null) {
+        const open = match.index + match[0].length - 1;
+        const argument = firstArgument(source, open);
+        if (argument !== null) {
+          sites.push({
+            file,
+            line: source.slice(0, match.index).split('\n').length,
+            base: argument,
+          });
+        }
+        match = POW_CALL.exec(source);
+      }
+    }
+  }
+  return sites;
+}
+
+describe('GLSL pow() bases stay non-negative', () => {
+  const sites = powSites(SCAN_ROOTS, repoRoot);
+
+  it('scans every file that currently holds a pow(), at its real site count', () => {
+    // A file-SET pin with per-file counts, so a shader leaving the corpus (a
+    // moved file, a dropped root, a walk that stops recursing) fails HERE rather
+    // than quietly shrinking the surface this guard covers.
+    const found: Record<string, number> = {};
+    for (const site of sites) found[site.file] = (found[site.file] ?? 0) + 1;
+    expect(found).toEqual(POW_SITES_PER_FILE);
+  });
+
+  it('never raises a base that a normalized dot product can push negative', () => {
+    const unguarded = sites
+      .filter((site) => !boundedBelowByZero(site.base))
+      .filter(
+        (site) =>
+          !PROVEN_SAFE_BASES.some((safe) => safe.file === site.file && safe.base === site.base),
+      )
+      .map((site) => `${site.file}:${site.line} -> pow(${site.base}, ...)`);
+    expect(unguarded).toEqual([]);
+  });
+
+  it('holds each provenance row to its real site count and its source anchor', () => {
+    const mismatched: string[] = [];
+    for (const safe of PROVEN_SAFE_BASES) {
+      const matching = sites.filter(
+        (site) => site.file === safe.file && site.base === safe.base,
+      ).length;
+      if (matching !== safe.sites) {
+        mismatched.push(`${safe.file} -> ${safe.base}: ${matching} sites, row says ${safe.sites}`);
+      }
+      // The row's reason is a claim about code elsewhere in the file. Pin it, or
+      // the row keeps blessing the base after that code is gone.
+      const text = readFileSync(join(repoRoot, safe.file), 'utf8');
+      if (!safe.anchor.test(text)) {
+        mismatched.push(`${safe.file} -> ${safe.base}: anchor ${safe.anchor} no longer matches`);
+      }
+    }
+    expect(mismatched).toEqual([]);
+  });
+
+  it('reproduces the NaN the guard exists to stop', () => {
+    // JS Math.pow uses the same exp2(y * log2(x)) lowering as every GLSL
+    // compiler, so this IS the shipped failure rather than an analogy for it: an
+    // ulp of overshoot in a normalized dot product against Hoarfrost's 2.6.
+    const overshoot = Math.abs(1 + Number.EPSILON);
+    expect(1 - overshoot).toBeLessThan(0);
+    expect((1 - overshoot) ** 2.6).toBeNaN();
+    expect(Math.max(0, 1 - overshoot) ** 2.6).toBe(0);
+    // And the guard is a no-op on every well-formed input, the silhouette limit
+    // included: max() only engages once the base is already negative.
+    for (const base of [0, 1e-7, 0.5, 1]) {
+      expect(Math.max(0, base) ** 2.6).toBe(base ** 2.6);
+    }
+  });
+
+  it('rejects the exact spellings that shipped the black rectangle', () => {
+    // Per-dimension negatives: each is a base the classifier MUST call unsafe, so
+    // a loosened rule cannot quietly re-admit the bug.
+    expect(boundedBelowByZero('1.0 - abs(dot(normalize(vN), normalize(vV)))')).toBe(false);
+    expect(boundedBelowByZero('1.0 - max(dot(N, V), 0.0)')).toBe(false);
+    expect(boundedBelowByZero('sin(3.14159 * vUv.x)')).toBe(false);
+    expect(boundedBelowByZero('1.0 - abs(vUv.y * 2.0 - 1.0)')).toBe(false);
+    expect(boundedBelowByZero('1.0 - clamp(V.y, 0.0, 2.0)')).toBe(false); // upper bound not 1
+    expect(boundedBelowByZero('max(dot(N, V), 0.001)')).toBe(false); // max arg not 0
+    expect(boundedBelowByZero('clamp(x, -1.0, 1.0)')).toBe(false); // lower bound not 0
+    expect(boundedBelowByZero('0.5 - saturate(x)')).toBe(false); // subtrahend base not 1
+  });
+
+  it('is whole-expression, so a safe-looking prefix does not pass', () => {
+    // Each opens with a clamping call or a `1.0 -` and still reaches a negative
+    // value. A prefix test, or a trailing-scale strip applied before the
+    // subtraction rule, admits all of them.
+    expect(boundedBelowByZero('abs(x) - 1.0')).toBe(false);
+    expect(boundedBelowByZero('abs(x) - 0.5')).toBe(false);
+    expect(boundedBelowByZero('saturate(x) - 0.5')).toBe(false);
+    expect(boundedBelowByZero('1.0 - saturate(x) * 2.0')).toBe(false);
+    expect(boundedBelowByZero('1.0 - clamp(d, 0.0, 1.0) * 3.0')).toBe(false);
+    expect(boundedBelowByZero('1.0 - saturate(x) - saturate(y)')).toBe(false);
+    expect(boundedBelowByZero('abs(a) * sign')).toBe(false);
+    expect(boundedBelowByZero('max(0.0, x) * -1.0')).toBe(false);
+    expect(boundedBelowByZero('max(a, 0.0) / scale')).toBe(false);
+  });
+
+  it('accepts the guarded spellings the fix introduced', () => {
+    expect(boundedBelowByZero('max(0.0, 1.0 - abs(dot(normalize(vN), normalize(vV))))')).toBe(true);
+    expect(boundedBelowByZero('max(0.0, sin(3.14159 * vUv.x))')).toBe(true);
+    expect(boundedBelowByZero('max(0.0, 1.0 - abs(vUv.y * 2.0 - 1.0))')).toBe(true);
+    expect(boundedBelowByZero('1.0 - clamp(dot(N, V), 0.0, 1.0)')).toBe(true);
+    expect(boundedBelowByZero('1.0 - saturate(dot(normal, geometryViewDir))')).toBe(true);
+    expect(boundedBelowByZero('max(c, vec3(0.0)) / 0.8')).toBe(true);
+    expect(boundedBelowByZero('max(vec3(0.0), c * GAIN + LIFT)')).toBe(true);
+    expect(boundedBelowByZero('abs( canopyGN )')).toBe(true);
+    expect(boundedBelowByZero('clamp(V.y, 0.0, 1.0)')).toBe(true);
+  });
+
+  it('strips comments without letting a URL eat its line', () => {
+    expect(withoutComments('a // see https://x.dev/y and pow(bad, 2.0)\nb')).toBe('a \nb');
+    expect(withoutComments('x = pow(u, 2.0); // https://x.dev')).toBe('x = pow(u, 2.0); ');
+    expect(withoutComments('/* pow(commented, 2.0) */ real')).toBe(' real');
+  });
+
+  describe('the producer itself', () => {
+    // tests/CLAUDE.md: a guard with its own walk pins the recursion with a
+    // mkdtemp fixture driving that walk, because every real scan root here is
+    // already deep enough to pass either way, so no assertion over the real tree
+    // can tell a recursive walk from a flat one.
+    const fixture = mkdtempSync(join(tmpdir(), 'shader-pow-'));
+    afterAll(() => rmSync(fixture, { recursive: true, force: true }));
+
+    mkdirSync(join(fixture, 'root', 'nested', 'deeper'), { recursive: true });
+    mkdirSync(join(fixture, 'root', 'node_modules'), { recursive: true });
+    writeFileSync(join(fixture, 'root', 'top.ts'), 'x = pow(a, 2.0);\n');
+    writeFileSync(join(fixture, 'root', 'nested', 'mid.js'), 'y = pow(b, 2.0);\n');
+    writeFileSync(join(fixture, 'root', 'nested', 'deeper', 'low.mjs'), 'z = pow (c, 2.0);\n');
+    writeFileSync(join(fixture, 'root', 'nested', 'skip.txt'), 'w = pow(d, 2.0);\n');
+    writeFileSync(join(fixture, 'root', 'node_modules', 'dep.ts'), 'v = pow(e, 2.0);\n');
+    writeFileSync(
+      join(fixture, 'root', 'nested', 'tricky.ts'),
+      'const url = "https://x.dev/y"; u = pow(f, 2.0);\n' +
+        '/* commented = pow(g, 2.0); */\n' +
+        'const n = Math.pow(h, 2.0);\n' +
+        'const s = lowpow(i);\n',
+    );
+
+    const found = powSites(['root'], fixture);
+
+    it('recurses, so a file one level down cannot leave the scan', () => {
+      expect(found.map((site) => site.base).sort()).toEqual(['a', 'b', 'c', 'f']);
+    });
+
+    it('keeps the .js and .mjs half of the corpus the shared .ts walker drops', () => {
+      expect(found.map((site) => site.file).sort()).toEqual([
+        'root/nested/deeper/low.mjs',
+        'root/nested/mid.js',
+        'root/nested/tricky.ts',
+        'root/top.ts',
+      ]);
+    });
+
+    it('finds a spaced call, and skips Math.pow, lowpow, comments and node_modules', () => {
+      // `pow (c, 2.0)` is legal GLSL: a startsWith('pow(') scan drops it silently.
+      expect(found.some((site) => site.file.endsWith('low.mjs') && site.base === 'c')).toBe(true);
+      expect(found.some((site) => site.base === 'd')).toBe(false); // .txt
+      expect(found.some((site) => site.base === 'e')).toBe(false); // node_modules
+      expect(found.some((site) => site.base === 'g')).toBe(false); // block comment
+      expect(found.some((site) => site.base === 'h')).toBe(false); // Math.pow
+      expect(found.some((site) => site.base === 'i')).toBe(false); // lowpow
+    });
+  });
+});

--- a/tests/weapon_vfx_specs.test.ts
+++ b/tests/weapon_vfx_specs.test.ts
@@ -22,6 +22,22 @@ describe('WEAPON_VFX specs', () => {
     }
   });
 
+  it('keeps every shell power strictly positive, on the tier and on any override', () => {
+    // The rim shell raises its fresnel term to this exponent. Since the domain
+    // guard landed, that base reaches EXACTLY 0.0 on the silhouette instead of a
+    // tiny epsilon, and pow(0.0, y) is undefined for y <= 0 the same way a
+    // negative base is: it would NaN a whole rim band into the bloom, which is
+    // the black rectangle this pair of pins exists to keep shut. See
+    // tests/shader_pow_domain.test.ts for the base half.
+    for (const [name, tier] of Object.entries(TIERS)) {
+      expect(tier.shell.power, `tier ${name}: shell.power must be > 0`).toBeGreaterThan(0);
+    }
+    for (const [key, spec] of Object.entries(WEAPON_VFX)) {
+      if (spec.shell?.power === undefined) continue;
+      expect(spec.shell.power, `${key}: shell.power override must be > 0`).toBeGreaterThan(0);
+    }
+  });
+
   it('uses only known fx component kinds', () => {
     for (const [key, spec] of Object.entries(WEAPON_VFX)) {
       expect(spec.fx.length, `${key}: empty fx array`).toBeGreaterThan(0);


### PR DESCRIPTION
## Summary

Players report a black rectangle flashing for a single frame, most reliably when
the camera is close to another player carrying a Hoarfrost weapon skin (Ice Fang,
Rime Needle). This fixes it and closes the same defect where it is spelled
differently elsewhere.

**Root cause.** GLSL `pow(x, y)` is undefined for `x < 0`, and every shipping
compiler lowers it to `exp2(y * log2(x))`, so a negative base returns NaN rather
than clamping. The weapon-skin fresnel shell computed

```glsl
float f = pow(1.0 - abs(dot(normalize(vN), normalize(vV))), uPow);
```

Both vectors are normalized in shader, so `abs(dot(...))` overshoots `1.0` by an
ulp wherever the two are aligned or anti-aligned, i.e. wherever the surface faces
the camera head-on. That is the end of the range where the base is already near
zero: it lands at about `-1e-7` and `pow` returns NaN. `uPow` is 2.6 on the
Hoarfrost tier.

**Why one bad fragment becomes a rectangle.** The shell material is additive, so
the NaN poisons the HDR scene texel instead of staying in one fragment. The bloom
high-pass carries it into the mip chain, and `UnrealBloomPass` blurs separably,
horizontal then vertical: one contaminated texel becomes a hard-edged,
axis-aligned rectangle the size of the blur kernel. `OutputGradePass` adds bloom
into the scene colour before ACES, and its `max(vec3(0.0), ...)` returns the
first argument when the second is NaN, so the rectangle resolves to black rather
than to garbage. It lasts one frame because the head-on condition is transient.

Measured on the reported capture, the artifact is exactly `x [1546, 2554]`,
`y [785, 1405]`, edges straight to within a pixel over their whole length, and
the interior a single uniform colour across 210,000 pixels. Hard edges plus a
uniform interior are the signature of NaN contamination, not of a misplaced or
overscaled object.

**The fix** is `pow(max(0.0, base), k)`, plus `clamp()` in place of a
lower-bound-only `max()` for the water fresnel and in place of an unguarded
`0.5 + 0.5 * sin(...)` for the twinkles weight. It is a numerical no-op on every
well formed input: each guard engages only on the case that was already returning
NaN, and every exponent involved is strictly positive, so `pow(0.0, y)` at the
head-on limit is well defined and equals the same 0 the un-guarded expression was
approaching.

| File | Base that could go negative | Status |
|---|---|---|
| `src/render/weapon_vfx.ts` | `1.0 - abs(dot(normalize(vN), normalize(vV)))`, the weapon-skin shell on every tier | the reported defect |
| `src/render/ability_vfx/shells.ts` | the same base, on ability barrier and buff shells | same defect, same spelling |
| `src/render/water.ts` | `1.0 - max(dot(N, V), 0.0)`; `max()` bounds only the low side, so the overshoot still lands negative | same defect, different spelling |
| `src/render/weapon_vfx.ts` | `w = 0.5 + 0.5 * sin(...)`, the twinkles point sprite | hardening. The mathematical range of `sin()` is not a guarantee: GLSL leaves its precision to the implementation, so the term is only provably non-negative in exact arithmetic |
| `src/render/weapon_vfx.ts` | `sin(3.14159 * vUv.x)` and `1.0 - abs(vUv.y * 2.0 - 1.0)`, the aurora ribbon | hardening, not a confirmed defect: both hold over the authored UV range, and the literal `3.14159` sits below pi. Guarded so the whole family has one spelling |
| `scripts/asset_pipeline/weapon_vfx.js` | the offline inspector's documented mirror of the weapon shell, twinkles, and aurora shaders | kept in sync |

**Guard.** `tests/shader_pow_domain.test.ts` walks every `pow()` under `src/`,
`scripts/`, `server/`, `headless/`, `electron/`, and `bot/` and requires the base
to be provably non-negative. It recognizes `abs()`, `saturate()`,
`clamp(x, 0.0, hi)`, `max(x, 0.0)`, any of those scaled by a positive finite
literal, and `1.0 - saturate(x)` / `1.0 - clamp(x, lo, 1.0)`. It deliberately
does NOT recognize `1.0 - max(x, 0.0)`, which is how the water fresnel used to
spell the bug. Classification is whole-expression rather than prefix-based,
because `abs(x) - 1.0` and `1.0 - saturate(x) * 2.0` both open with a
safe-looking token and both reach negative values. Every bound it leans on has to
be a finite literal it can ORDER, because two ways of writing a clamped
expression are not clamps at all: `clamp(x, 0.0, -1.0)` has reversed bounds,
which GLSL leaves undefined, and `max(x, 0.0) / 0.0` wraps a non-negative term in
a division that is undefined and NaN or Inf on the shipping lowering; both are
per-dimension negative cases. Five bases are non-negative by provenance rather
than syntax; each carries a row naming the reason, its site count, and a regex
anchored to the source line the reason cites, so the row stops blessing the site
if that line changes, and the two twinkles rows anchor the whole guarded
expression, `clamp` included. The corpus is pinned as a file set with per-file
counts, not as a floor.

The corpus is read through `tests/helpers/source_files_under.ts`, a new sibling of
the shared `.ts` walker: this scan needs the `.js`/`.mjs` half of the tree (the
offline inspector ships its own JS copy of the weapon shaders) plus standalone
shader files, and that extension policy belongs in one shared place rather than
restated per guard. It follows symlinks on both arms like its sibling, and adds
the two things that makes necessary: a directory realpath is visited at most
once, so a link to an ancestor terminates instead of hanging collection, and a
link resolving outside the root throws rather than silently narrowing or widening
the corpus. It has its own paired fixture test; this guard keeps its own
`mkdtemp` fixture over its producer and adds
`expectScansOnlyThroughSharedWalkers`, so no second hand-rolled read can appear
beside it.

The other half of the domain is the exponent, since the clamps make an exact
`0.0` base reachable where it used to be a tiny epsilon, and `pow(0.0, y)` is
undefined for `y <= 0` just as a negative base is.
`tests/weapon_vfx_specs.test.ts` pins every runtime shell exponent `> 0`, on the
tier and on any per-weapon override. That suite imports `src/`, so it says
nothing about the offline mirror: `tests/asset_pipeline.test.ts` therefore pins
the mirror's shell powers equal to the runtime tiers, keyed by tier name, and
`> 0` for every `shell` row in that file.

## Related issues

N/A. Reported in-game, no tracking issue filed.

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands, all on the branch rebased onto `release/v0.34.0` (tip `7c3ec64c1`):
  - `npx vitest run` (whole suite): **1990 files passed, 8 skipped; 25208 tests
    passed, 74 skipped**. One failure, `tests/dungeon_finder_view.test.ts >
    keeps a leader listing visible in Open listings when its OWN dungeon goes
    locked (#2030 followup)`, which is PRE-EXISTING on the base: it fails
    identically on `upstream/release/v0.34.0` with neither of this branch's
    commits applied (verified in a clean worktree at that tip, 1 failed |
    23 passed). Untouched here, it is not in this change's area.
  - `npx tsc --noEmit` (clean)
  - `npm run build` (exit 0, all five entries, no generated-artifact drift)
  - `node scripts/malware_scan.mjs --gate` (PASS, 4920 files, 0 high after priors)
  - `npx @biomejs/biome check` on the changed files (no errors, no format diffs)
  - Mutation check, per site: reverting the guard on each of the four shader
    files individually turns `tests/shader_pow_domain.test.ts` red naming that
    exact line (and, for the two `weapon_vfx` files, the provenance anchor as
    well). Editing the offline mirror's rare-tier `shell.power` to `0` turns
    `tests/asset_pipeline.test.ts` red at 56/57. Each pin is decisive per file,
    not only in aggregate.
- Manual steps:
  - Reproduced in the browser against a live realm, standing close to a player
    carrying an Ice Fang skin. The artifact recurs within seconds in that
    situation, but on an unpredictable frame: it can be observed on demand and
    cannot be captured deterministically.
  - Instrumented the frame by wrapping the post chain and reading back the
    smallest bloom mip each frame, decoding it as half floats and scanning for
    the NaN and Inf bit patterns. NaN texels appear on precisely the frames that
    show the rectangle, and their mip coordinates map onto the rectangle's
    measured screen bounds.
  - Applied the same clamp as a live shader hot-patch in that session. The NaN
    counter goes to zero and the rectangle stops occurring; removing the patch
    brings both back.


## Screenshots / recordings

**Before**

<img width="2554" height="1405" alt="Screenshot from 2026-08-03 01-28-02" src="https://github.com/user-attachments/assets/c42715ae-7b90-4049-a529-43feada69f07" />


**After**

<img width="2504" height="1324" alt="image" src="https://github.com/user-attachments/assets/55164f00-e951-419a-b5c4-eefa8bf3ec7d" />


<img width="1323" height="996" alt="Screenshot from 2026-08-03 11-22-36" src="https://github.com/user-attachments/assets/386108c8-f36a-45f9-afeb-b8bc37c7eb87" />


---

## Checklist

### Quality

- [x] **The full gate passes.** Every gate step was run on the rebased branch and
      is green (full vitest suite, `tsc`, all five builds, malware scan, biome on
      the changed files).

### Cross-platform

- [ ] ~**Tested on desktop and mobile.**~ Desktop only, and deliberately: this is
      a set of shader domain guards with no layout or input surface, and the
      bloom chain that turns the NaN into a rectangle is composer-tier only,
      which phones do not run.
- [ ] ~**Accessible.** Keyboard-operable, with visible focus, sensible ARIA, and
      respect for `prefers-reduced-motion`.~ No UI added or edited.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.

## Remaining verification

- A CI run on this PR (the workflows need maintainer approval).

## Follow-ups, deliberately not in this PR

- **`gl_PointSize` is unbounded in `weapon_vfx.ts`.** It is the only point-sprite
  system in the tree with no upper clamp, and it floors the divisor at
  `max(0.15, -mv.z)` where every sibling uses `max(1.0, -mv.z)`: `vfx.ts` clamps
  at 110px, `ability_vfx/overlay_sprites.ts` at 96px, `props.ts` at an implicit
  95. With `uScale` near 1217 at a 1405px canvas and `drift` sprites authored up
  to 0.26yd, a particle 0.15yd from the camera rasterizes about 2100px across.
  Real defect when the camera is close to a weapon, but capping it changes what
  near-camera particles look like, so it wants its own PR and its own screenshots
  rather than riding along with a numerical no-op.
- **`normalize()` of a degenerate vector is the same defect class.** `vN` in the
  shell shader and `V = normalize(cameraPosition - vWPos)` in the water shader
  both reach the same additive-then-bloom path. Note that the two fixes differ
  here: `max(0.0, NaN)` returns `0.0` and scrubs, while `clamp(NaN, 0.0, 1.0)`
  propagates NaN, so the water spelling closes the domain overshoot but not a
  camera sitting exactly on the surface point. A drop-in `max()` there is not
  available because it would change the fresnel for `dot < 0`.
- **The `scripts/asset_pipeline/weapon_vfx.js` mirror is still only pinned field
  by field.** `tests/asset_pipeline.test.ts` now pins `WORLD_TUNING` and the shell
  powers, and the domain guard covers every `pow()` in it, but the shader BODIES
  are still hand-applied twice. Pinning the `makeShell` / `makeAurora` bodies
  equal across the two files, or generating one from the other, would close it.
- **The fresnel rim term now has six spellings** across `weapon_vfx.ts`,
  `shells.ts`, `water.ts`, `dungeon.ts`, and `pbr_fragment_shader.ts`. Past the
  rule of three, a shared GLSL snippet would give it one spelling to fix.