### PR TITLE
fix(sim): retire the respawn tiers for one 60s delay, and declare Drogmar's cadence

### DIFF
--- a/src/sim/content/zone3.ts
+++ b/src/sim/content/zone3.ts
@@ -331,15 +331,19 @@ export const ZONE3_MOBS: Record<string, MobTemplate> = {
     family: 'ogre',
     elite: true,
     boss: true,
-    // An HOUR, matching Marrowlord Varkas, whose expected value per kill is
-    // within 2% of his. He is boss: true with boss-tier loot (2000 guaranteed
-    // copper plus three gear drops) but declared no cadence, and boss/elite do
-    // not feed the respawn policy: only respawnMult or rare: true do. So he
-    // silently inherited the open-world TRASH timer and was 24% of the whole
-    // Glimmermere corridor's gold by himself, a bigger single lever on that
-    // route's economy than the trash respawn rate ever was. Declaring the
-    // cadence here is what makes him a boss rather than a very rich ogre.
-    respawnMult: 144,
+    // THREE MINUTES (7.2 * 25), the shipped cadence for a quest kill target
+    // (Old Cragmaw, Captain Verlan). He declared no cadence at all before, and
+    // boss/elite do not feed the respawn policy (only respawnMult or rare: true
+    // do), so he silently inherited the open-world TRASH timer and was 24% of
+    // the whole Glimmermere corridor's gold by himself.
+    //
+    // The fix is NOT a long boss cadence, even though his loot is priced with
+    // Marrowlord Varkas (1hr) and Brutok Skullsmasher (3hr): q_drogmar has a
+    // hard kill objective on him at suggestedPlayers 3, so a party would sit
+    // waiting, and queue behind other parties, for a REQUIRED quest step. He
+    // has to stay available, which makes coin rather than cadence the lever
+    // (see the loot table below).
+    respawnMult: 7.2,
     hpBase: 200,
     hpPerLevel: 30,
     dmgBase: 12,
@@ -354,8 +358,14 @@ export const ZONE3_MOBS: Record<string, MobTemplate> = {
     // drawn-out fight snowballs, so burn him down or kite him off you to bleed
     // the stacks back off.
     rampage: { ap: 20, maxStacks: 5, duration: 10, name: 'Mounting Rage', school: 'physical' },
+    // 650 guaranteed copper, matching Marrowlord Varkas. His TOTAL value per
+    // kill was always in line with his neighbours (3285 against Varkas's 3222
+    // and Brutok's 2557); what was out of line was the SPLIT, at 2000 coin
+    // against their 650 and 320. Since he must stay on a quest-friendly three
+    // minutes, this is the knob that keeps the corridor honest, and it leaves
+    // all three unique drops intact so the kill still pays like a boss.
     loot: [
-      { copper: 2000, chance: 1 },
+      { copper: 650, chance: 1 },
       { itemId: 'drogmar_warboots', chance: 0.3 },
       { itemId: 'drogmars_skullcleaver', chance: 0.25 },
       { itemId: 'thunderward_legguards', chance: 0.25 },

--- a/src/sim/content/zone3.ts
+++ b/src/sim/content/zone3.ts
@@ -331,6 +331,15 @@ export const ZONE3_MOBS: Record<string, MobTemplate> = {
     family: 'ogre',
     elite: true,
     boss: true,
+    // An HOUR, matching Marrowlord Varkas, whose expected value per kill is
+    // within 2% of his. He is boss: true with boss-tier loot (2000 guaranteed
+    // copper plus three gear drops) but declared no cadence, and boss/elite do
+    // not feed the respawn policy: only respawnMult or rare: true do. So he
+    // silently inherited the open-world TRASH timer and was 24% of the whole
+    // Glimmermere corridor's gold by himself, a bigger single lever on that
+    // route's economy than the trash respawn rate ever was. Declaring the
+    // cadence here is what makes him a boss rather than a very rich ogre.
+    respawnMult: 144,
     hpBase: 200,
     hpPerLevel: 30,
     dmgBase: 12,

--- a/src/sim/respawn_policy.ts
+++ b/src/sim/respawn_policy.ts
@@ -3,39 +3,59 @@
 // A pure leaf (no SimContext, no state): a Vitest imports it directly, and the
 // one live caller is the death site in combat/damage.ts.
 //
-// WHY THIS EXISTS: every open-world mob used to respawn on one flat 25s timer,
-// so a farmed camp regenerated about three times a minute and dense pack strips
-// paid gold and XP far past what the zone was tuned for. Respawn now scales with
-// the zone's level band, so a low-level starter camp still churns for questing
-// while endgame packs come back on a farm-resistant cadence.
+// WHY THIS EXISTS: this is a deliberate content-tuning knob, not a classic-era
+// formula. It is stated once here and pinned by tests/respawn_policy.test.ts,
+// with the downstream farm ceilings pinned by tests/economy_yield.test.ts.
 //
-// The tiers are a deliberate content-tuning knob, not a classic-era formula:
-// they are stated once here and pinned by tests/respawn_policy.test.ts, with the
-// downstream farm ceilings they protect pinned by tests/economy_yield.test.ts.
+// HISTORY, because this number has now moved twice and the reasoning matters:
+//
+//  1. The world shipped for months on one flat 25s timer for every open-world
+//     mob.
+//  2. That was replaced by three respawn tiers keyed to a zone's level band (60
+//     / 120 / 180s), on the argument that a farmed camp regenerating three times
+//     a minute paid gold and XP past what the zone was tuned for.
+//  3. The tiers are now retired, back to a single 60s delay. Measuring the tiers
+//     against how players actually farm did not support them:
+//
+//     - Respawn was never the binding constraint for a solo player. Even at
+//       180s the densest route in the world (Thornpeak's Glimmermere corridor,
+//       63 standing mobs) supported about 20 kills a minute, and a player who
+//       kills one mob every 8 seconds wants 7. Nobody was ever waiting on a
+//       spawn. The tiers only ever throttled AoE multi-pulls and several players
+//       sharing a route.
+//     - The per-hour ceilings that justified the tiers assume a farmer who
+//       kills every mob the instant it respawns with zero travel: at the top
+//       cluster that is 1.01 kills per SECOND, sustained, across 130 yards. It
+//       is a bound, not a forecast, and the tiers were sized against a pace no
+//       player can reach.
+//     - The one genuine outlier turned out to be a single mob rather than a
+//       tier: Warlord Drogmar is boss: true with boss-tier loot but declared no
+//       cadence, so he inherited the trash timer and was 24% of that corridor's
+//       gold by himself. He now carries an explicit respawnMult (zone3.ts).
+//
+// The thinner zones are what motivated the revisit: the ten expansion zones
+// share the old endgame band but not its density (their largest cluster is
+// Galecrest's 14-mob shipwreck against Glimmermere's 63), so 180s there bought
+// no farm resistance and only made thin country feel empty.
+//
+// ZoneDef.trashRespawnSeconds remains the per-zone escape hatch. If a specific
+// zone ever needs its own cadence, set it there rather than reintroducing bands.
 
 import { zoneContaining } from './data';
 import type { ZoneDef } from './types';
 
 /**
- * Starter bands (zones capped at level 7): quest-paced, still fast.
+ * The open-world trash respawn delay, everywhere, for every level band.
  *
- * 60 rather than the band formula's own logic, and deliberately: this tier lands
- * on a player's first hour, who has no second camp to rotate to and no mount, so
- * it was checked against supply rather than assumed. A starter camp of 5 to 8
- * mobs now returns 5 to 8 kills a minute (down from 12 to 19), while a new
- * character needs 10 to 20 seconds per kill including the walk, so 3 to 6 a
- * minute. Supply still exceeds demand at every authored starter camp, and the
- * paired camps (two forest_wolf, two wild_boar, two vale_bandit) double it
- * again, so a "kill 10" objective never waits on a spawn.
- *
- * If starter-zone feel ever regresses anyway, prefer ZoneDef.trashRespawnSeconds
- * on the one zone over moving this constant, which governs Farshore Isle too.
+ * 60 was already the starter-band value and was checked against SUPPLY rather
+ * than assumed: a starter camp of 5 to 8 mobs returns 5 to 8 kills a minute,
+ * while a new character needs 10 to 20 seconds per kill including the walk, so
+ * 3 to 6 a minute. Supply exceeds demand at every authored camp in the world,
+ * and the paired camps (two forest_wolf, two wild_boar, two vale_bandit) double
+ * it again, so a "kill 10" objective never waits on a spawn. Applying it
+ * world-wide extends that property to every zone rather than only the first two.
  */
-export const TRASH_RESPAWN_SECONDS_LOW = 60;
-/** Mid bands (zones capped at level 14). */
-export const TRASH_RESPAWN_SECONDS_MID = 120;
-/** Endgame bands (everything above level 14). */
-export const TRASH_RESPAWN_SECONDS_HIGH = 180;
+export const TRASH_RESPAWN_SECONDS = 60;
 
 /**
  * Fallback for a mob standing outside every authored zone rect: the far-east
@@ -46,17 +66,18 @@ export const TRASH_RESPAWN_SECONDS_HIGH = 180;
 export const DEFAULT_RESPAWN_SECONDS = 25;
 
 /**
- * The trash respawn delay for one zone, by its level band. A zone may override
- * its tier with ZoneDef.trashRespawnSeconds. A null zone (nowhere in the
- * authored world) takes DEFAULT_RESPAWN_SECONDS.
+ * The trash respawn delay for one zone. Every authored zone takes the single
+ * world delay unless it overrides with ZoneDef.trashRespawnSeconds; a null zone
+ * (nowhere in the authored world) takes DEFAULT_RESPAWN_SECONDS.
+ *
+ * The zone argument is still taken, and the override still honored, precisely so
+ * a future per-zone cadence needs no caller change: the level band is what was
+ * retired, not per-zone control.
  */
 export function trashRespawnSecondsForZone(zone: ZoneDef | null | undefined): number {
   if (!zone) return DEFAULT_RESPAWN_SECONDS;
   if (zone.trashRespawnSeconds !== undefined) return zone.trashRespawnSeconds;
-  const bandCap = zone.levelRange[1];
-  if (bandCap <= 7) return TRASH_RESPAWN_SECONDS_LOW;
-  if (bandCap <= 14) return TRASH_RESPAWN_SECONDS_MID;
-  return TRASH_RESPAWN_SECONDS_HIGH;
+  return TRASH_RESPAWN_SECONDS;
 }
 
 /**

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -2632,9 +2632,11 @@ export interface ZoneDef {
   // to the Pale Causeway's head so the Wyrmgate opens where the road arrives.
   southPassX?: number;
   // Per-zone override of the open-world trash respawn delay (seconds), which
-  // otherwise comes from this zone's level band (src/sim/respawn_policy.ts
-  // trashRespawnSecondsForZone). An explicit SimConfig.respawnSeconds still
-  // wins over it, and a MobTemplate.respawnSeconds still wins over both.
+  // otherwise is the single world delay TRASH_RESPAWN_SECONDS
+  // (src/sim/respawn_policy.ts trashRespawnSecondsForZone; the level-band tiers
+  // that used to decide it are retired, see that file's header). An explicit
+  // SimConfig.respawnSeconds still wins over it, and a MobTemplate.respawnSeconds
+  // still wins over both.
   trashRespawnSeconds?: number;
 }
 

--- a/tests/camp_density.test.ts
+++ b/tests/camp_density.test.ts
@@ -13,14 +13,28 @@ import {
 } from './helpers/farm_yield';
 
 /**
- * The most mobs a single fast-respawning trash cluster may hold. Eastbrook
- * Vale's wolf/spider/bones chain sits exactly at this cap today, so the guard is
- * deliberately tight: adding another mob to any level 1-7 camp near that chain
- * is a decision to be made on purpose, not by accident.
+ * The most farmable trash one cluster may hold.
+ *
+ * This was a FAST-respawn cap back when respawn varied by level band and only
+ * the level 1-7 zones qualified. The band tiers are retired (every zone is now
+ * on one 60s delay, see src/sim/respawn_policy.ts), so every trash cluster in
+ * the world is "fast" and this is simply a trash-density cap now. Re-based to
+ * 25% above Thornpeak's Glimmermere corridor at 59, on the same convention as
+ * the yield ceilings.
+ *
+ * It still measures something the total cap below does not: trash is what a
+ * farmer can actually cycle, so a cluster that is mostly rares reads very
+ * differently here than it does there (the corridor is 59 of 63).
  */
-const MAX_FAST_TRASH_PER_CLUSTER = 30;
+const MAX_TRASH_PER_CLUSTER = 75;
 
-/** Below this a respawn counts as "fast" for density purposes. */
+/**
+ * Below this a respawn counts as "fast" for density purposes. Every authored
+ * zone is under it today, which is the point: the classifier is kept so a future
+ * per-zone ZoneDef.trashRespawnSeconds slower than 100s drops out of the trash
+ * cap automatically, rather than the cap silently governing a cadence nobody
+ * meant it to.
+ */
 const FAST_RESPAWN_SECONDS = 100;
 
 /**
@@ -103,11 +117,18 @@ describe('clusterCamps: the union-find proximity model', () => {
 });
 
 describe('no farm cluster is overdense', () => {
-  it('keeps every fast-respawn trash cluster at or under the cap', () => {
+  it('keeps every farmable-trash cluster at or under the cap', () => {
     const offenders = worldFarmClusters()
       .map((c) => ({ n: fastTrashCount(c.camps), ids: c.mobIds.join(', ') }))
-      .filter((c) => c.n > MAX_FAST_TRASH_PER_CLUSTER);
+      .filter((c) => c.n > MAX_TRASH_PER_CLUSTER);
     expect(offenders).toEqual([]);
+  });
+
+  it('has that trash cap within reach, so it is a real bound', () => {
+    // Same anti-vacuity check the total cap carries: a cap re-based upward has
+    // to stay reachable or it stops being a guard.
+    const largest = Math.max(...worldFarmClusters().map((c) => fastTrashCount(c.camps)));
+    expect(largest).toBeGreaterThan(MAX_TRASH_PER_CLUSTER * 0.7);
   });
 
   it('caps TOTAL mobs per cluster in every band, not just the fast one', () => {
@@ -227,23 +248,22 @@ describe('the Thornpeak corridor is one dense cluster ON PURPOSE', () => {
     expect(merged[0].mobCount).toBe(63);
   });
 
-  it('bounds that cluster by YIELD instead, which is what the tiers fixed', () => {
+  it('bounds that cluster by YIELD instead, since density here is the layout', () => {
     // Density here is inherent to the layout, so the guard that matters is the
-    // economic one: at the old flat 25s this same cluster paid about 189 gold
-    // and 1.29M XP an hour. tests/economy_yield.test.ts owns the ceilings; this
-    // asserts the corridor is the cluster they are protecting against.
+    // economic one. tests/economy_yield.test.ts owns the ceilings; this asserts
+    // the corridor is the cluster they are protecting against.
     const clusters = worldFarmClusters();
     const richest = clusters.reduce((a, b) => (b.copperPerHour > a.copperPerHour ? b : a));
     expect(richest.mobIds).toContain('glimmermere_wader');
     expect(richest.mobIds).toContain('thornpeak_ogre');
-    // Every TRASH camp in it is on the 180s endgame tier (the rares keep their
-    // own shipped cadence, which is why they are excluded here), and nothing in
-    // the cluster is fast-respawn at all.
+    // Every TRASH camp in it now sits on the single 60s world delay (the rares
+    // and Drogmar keep their own declared cadence, which is why isTrash excludes
+    // them), so the corridor IS fast-respawn: that is the decision, and the
+    // yield ceilings rather than the density cap are what bound it.
     for (const y of richest.camps) {
-      if (isTrash(y.template)) expect(y.respawnSeconds, y.camp.mobId).toBe(180);
-      expect(y.respawnSeconds, y.camp.mobId).toBeGreaterThanOrEqual(FAST_RESPAWN_SECONDS);
+      if (isTrash(y.template)) expect(y.respawnSeconds, y.camp.mobId).toBe(60);
     }
-    expect(fastTrashCount(richest.camps)).toBe(0);
+    expect(fastTrashCount(richest.camps)).toBe(59);
   });
 });
 

--- a/tests/economy_yield.test.ts
+++ b/tests/economy_yield.test.ts
@@ -9,13 +9,26 @@ import { mobXpValue } from '../src/sim/types';
 import { coinEvPerKill, itemEvPerKill, worldFarmClusters, xpPerKill } from './helpers/farm_yield';
 
 // Budgets are pinned ~25% above the shipped maxima, so ordinary content tuning
-// has room while a structural regression (a respawn tier cut, a coin fill an
-// order of magnitude off, a camp merge) trips the guard.
+// has room while a structural regression (a coin fill an order of magnitude off,
+// a camp merge, a respawn cut past what was decided) trips the guard.
+//
+// THESE WERE RE-BASED when the respawn tiers were retired for a single 60s world
+// delay (rationale in src/sim/respawn_policy.ts). Read them as recording a
+// decision, not as an independent bound: they were authored ALONGSIDE the tiers
+// they were said to justify, and calibrated to whatever the world produced
+// afterwards. What they honestly protect is "the economy did not move again
+// without someone deciding", which is worth having and is all it is.
+//
+// Worth keeping in view when judging whether a future number is alarming: the
+// model assumes a farmer who kills every mob the instant it respawns with zero
+// travel, which at the top cluster is 1.01 kills per SECOND across 130 yards.
+// Real throughput is a small fraction of it, and respawn does not bind a solo
+// player at any delay this world has shipped.
 
-/** Protects the richest cluster: Thornpeak's Glimmermere corridor at 27.5 gold/hr. */
-const MAX_CLUSTER_COPPER_PER_HOUR = 344_000;
-/** Protects the fastest XP cluster: the same corridor at 183k XP/hr. */
-const MAX_CLUSTER_XP_PER_HOUR = 229_000;
+/** Protects the richest cluster: Thornpeak's Glimmermere corridor at 56.0 gold/hr. */
+const MAX_CLUSTER_COPPER_PER_HOUR = 701_000;
+/** Protects the fastest XP cluster: the same corridor at 525k XP/hr. */
+const MAX_CLUSTER_XP_PER_HOUR = 657_000;
 
 /** Coin-carrying families: things that plausibly hold a purse. */
 const COIN_FAMILIES = new Set([

--- a/tests/respawn_policy.test.ts
+++ b/tests/respawn_policy.test.ts
@@ -12,6 +12,7 @@ import {
   DUNGEON_X_THRESHOLD,
   instanceOrigin,
   MOBS,
+  QUESTS,
   ZONES,
   zoneAt,
   zoneContaining,
@@ -267,7 +268,7 @@ describe('resolveRespawnSeconds: full precedence', () => {
     expect(isSelfScheduled(MOBS.thornpeak_ogre)).toBe(false);
   });
 
-  it('keeps Warlord Drogmar on his declared hour, not the trash delay', () => {
+  it('keeps Warlord Drogmar on the quest-target cadence, not the trash delay', () => {
     // He is boss + elite with boss-tier loot and NO rare flag, the exact shape
     // that silently inherited a trash timer. The explicit multiplier is what
     // fixes that, so both halves are pinned: the flags that do not schedule him,
@@ -275,15 +276,36 @@ describe('resolveRespawnSeconds: full precedence', () => {
     const drogmar = MOBS.warlord_drogmar;
     expect(drogmar.boss).toBe(true);
     expect(drogmar.rare).toBeUndefined();
-    expect(drogmar.respawnMult).toBe(144);
+    expect(drogmar.respawnMult).toBe(7.2);
     expect(isSelfScheduled(drogmar)).toBe(true);
-    // 144 * 25 = one hour, and it holds wherever he stands.
-    expect(resolveRespawnSeconds(drogmar, thornpeak, undefined)).toBe(3600);
-    expect(resolveRespawnSeconds(drogmar, vale, undefined)).toBe(3600);
+    // 7.2 * 25 = three minutes, and it holds wherever he stands.
+    expect(resolveRespawnSeconds(drogmar, thornpeak, undefined)).toBe(180);
+    expect(resolveRespawnSeconds(drogmar, vale, undefined)).toBe(180);
     // Decisive against a regression to the trash delay.
     expect(resolveRespawnSeconds(drogmar, thornpeak, undefined)).not.toBe(TRASH_RESPAWN_SECONDS);
-    // He matches Marrowlord Varkas, the neighbour his value was calibrated to.
+    // He matches Old Cragmaw, the shipped cadence for a quest kill target, and
+    // deliberately NOT Marrowlord Varkas's boss hour: a required quest step
+    // must not make a party wait or queue. This is the assertion that fails if
+    // someone "corrects" him onto a boss cadence without reading q_drogmar.
+    expect(resolveRespawnSeconds(MOBS.old_cragmaw, thornpeak, undefined)).toBe(180);
     expect(resolveRespawnSeconds(MOBS.marrowlord_varkas, thornpeak, undefined)).toBe(3600);
+  });
+
+  it('holds Drogmar to a quest-friendly cadence because a quest requires him', () => {
+    // The premise the cadence rests on, pinned so it cannot rot silently: if
+    // q_drogmar ever stops requiring the kill, the three minutes is free to be
+    // revisited, and whoever revisits it should see this test say so.
+    const objectives = QUESTS.q_drogmar?.objectives ?? [];
+    expect(objectives).toContainEqual(
+      expect.objectContaining({ type: 'kill', targetMobId: 'warlord_drogmar' }),
+    );
+    // Coin held to Varkas parity instead, which is what keeps the corridor
+    // honest now that cadence cannot.
+    const coin = MOBS.warlord_drogmar.loot.find((e) => e.copper)?.copper;
+    expect(coin).toBe(650);
+    expect(MOBS.marrowlord_varkas.loot.find((e) => e.copper)?.copper).toBe(650);
+    // The three unique drops survive, so the kill still pays like a boss.
+    expect(MOBS.warlord_drogmar.loot.filter((e) => e.itemId)).toHaveLength(3);
   });
 
   it('uses the SPAWN position, not the death position', () => {

--- a/tests/respawn_policy.test.ts
+++ b/tests/respawn_policy.test.ts
@@ -1,5 +1,11 @@
-// Pins the open-world respawn policy (src/sim/respawn_policy.ts): the level-band
-// tiers, the precedence chain around them, and the death site that consumes it.
+// Pins the open-world respawn policy (src/sim/respawn_policy.ts): the single
+// world delay, the precedence chain around it, and the death site that consumes
+// it.
+//
+// The level-band tiers this file used to pin were RETIRED (rationale in the
+// policy header). The band cases below are kept, inverted: they now assert that
+// a zone's level band does NOT change its respawn, so reintroducing a band by
+// accident fails here rather than shipping.
 import { describe, expect, it } from 'vitest';
 import { CORPSE_DURATION } from '../src/sim/combat/damage';
 import {
@@ -16,9 +22,7 @@ import {
   isSelfScheduled,
   LEGACY_RESPAWN_SECONDS,
   resolveRespawnSeconds,
-  TRASH_RESPAWN_SECONDS_HIGH,
-  TRASH_RESPAWN_SECONDS_LOW,
-  TRASH_RESPAWN_SECONDS_MID,
+  TRASH_RESPAWN_SECONDS,
   trashRespawnSecondsForZone,
 } from '../src/sim/respawn_policy';
 import { Sim } from '../src/sim/sim';
@@ -43,36 +47,32 @@ function zoneWithBand(bandCap: number, trashRespawnSeconds?: number): ZoneDef {
   };
 }
 
-describe('trashRespawnSecondsForZone: the level-band tiers', () => {
-  it('gives starter bands (cap <= 7) the fast tier', () => {
-    expect(TRASH_RESPAWN_SECONDS_LOW).toBe(60);
-    expect(trashRespawnSecondsForZone(zoneWithBand(7))).toBe(60);
-    expect(trashRespawnSecondsForZone(zoneWithBand(1))).toBe(60);
+describe('trashRespawnSecondsForZone: one delay for every level band', () => {
+  it('is 60 seconds, stated as a literal so the number cannot drift silently', () => {
+    expect(TRASH_RESPAWN_SECONDS).toBe(60);
   });
 
-  it('gives mid bands (cap 8 to 14) the middle tier', () => {
-    expect(TRASH_RESPAWN_SECONDS_MID).toBe(120);
-    expect(trashRespawnSecondsForZone(zoneWithBand(8))).toBe(120);
-    expect(trashRespawnSecondsForZone(zoneWithBand(14))).toBe(120);
+  it('gives EVERY band the same delay, including the old tier boundaries', () => {
+    // The retired tiers split at cap 7|8 and 14|15. Those two boundaries are
+    // checked explicitly because they are exactly where a reintroduced band
+    // would first show up.
+    for (const bandCap of [1, 7, 8, 14, 15, 20]) {
+      expect(trashRespawnSecondsForZone(zoneWithBand(bandCap))).toBe(60);
+    }
   });
 
-  it('gives endgame bands (cap >= 15) the slow tier', () => {
-    expect(TRASH_RESPAWN_SECONDS_HIGH).toBe(180);
-    expect(trashRespawnSecondsForZone(zoneWithBand(15))).toBe(180);
-    expect(trashRespawnSecondsForZone(zoneWithBand(20))).toBe(180);
-  });
-
-  it('crosses each tier boundary at exactly the documented cap', () => {
-    // Decisive on the boundary itself: 7|8 and 14|15 must differ.
-    expect(trashRespawnSecondsForZone(zoneWithBand(7))).not.toBe(
+  it('no longer varies across the old boundaries, the inverse of the retired pin', () => {
+    // Decisive against a band creeping back: 7|8 and 14|15 must now MATCH,
+    // where the tiered policy required them to differ.
+    expect(trashRespawnSecondsForZone(zoneWithBand(7))).toBe(
       trashRespawnSecondsForZone(zoneWithBand(8)),
     );
-    expect(trashRespawnSecondsForZone(zoneWithBand(14))).not.toBe(
+    expect(trashRespawnSecondsForZone(zoneWithBand(14))).toBe(
       trashRespawnSecondsForZone(zoneWithBand(15)),
     );
   });
 
-  it('lets one zone override its tier with trashRespawnSeconds', () => {
+  it('lets one zone override the world delay with trashRespawnSeconds', () => {
     expect(trashRespawnSecondsForZone(zoneWithBand(20, 45))).toBe(45);
     // ...including down past the fast tier, and including an explicit 0.
     expect(trashRespawnSecondsForZone(zoneWithBand(7, 300))).toBe(300);
@@ -96,10 +96,14 @@ describe('trashRespawnSecondsForZone: the level-band tiers', () => {
 describe('the ZoneDef.trashRespawnSeconds override, end to end', () => {
   const overridden = zoneWithBand(20, 45);
 
-  it('beats the level band through the full resolution, not just the tier fn', () => {
+  it('beats the world delay through the full resolution, not just the tier fn', () => {
     expect(trashRespawnSecondsForZone(overridden)).toBe(45);
-    // Same zone with no override would be the 180s endgame tier.
-    expect(trashRespawnSecondsForZone(zoneWithBand(20))).toBe(180);
+    // Same zone with no override takes the single 60s world delay. Asserted
+    // against the other branch so the override is proven to CHANGE something.
+    expect(trashRespawnSecondsForZone(zoneWithBand(20))).toBe(60);
+    expect(trashRespawnSecondsForZone(overridden)).not.toBe(
+      trashRespawnSecondsForZone(zoneWithBand(20)),
+    );
   });
 
   it('still loses to an explicit SimConfig base, as types.ts documents', () => {
@@ -145,16 +149,17 @@ describe('zoneContaining: strict rect containment, no fallback', () => {
   });
 });
 
-describe('baseRespawnSecondsAt: the global override vs the zone tier', () => {
-  it('reads the zone tier at a position when no global base is configured', () => {
-    // Eastbrook Vale [1-7] -> fast, Mirefen Marsh [6-13] -> mid,
-    // Thornpeak Heights [13-20] -> slow.
+describe('baseRespawnSecondsAt: the global override vs the zone delay', () => {
+  it('reads the same 60s at positions in three different level bands', () => {
+    // Eastbrook Vale [1-7], Mirefen Marsh [6-13] and Thornpeak Heights [13-20]
+    // spanned all three retired tiers, so they are the decisive sample: real
+    // world coordinates, not a synthetic ZoneDef, all landing on one number.
     expect(baseRespawnSecondsAt(-27, 71, undefined)).toBe(60);
-    expect(baseRespawnSecondsAt(-40, 230, undefined)).toBe(120);
-    expect(baseRespawnSecondsAt(-90, 700, undefined)).toBe(180);
+    expect(baseRespawnSecondsAt(-40, 230, undefined)).toBe(60);
+    expect(baseRespawnSecondsAt(-90, 700, undefined)).toBe(60);
   });
 
-  it('lets an explicitly configured base win over every zone tier', () => {
+  it('lets an explicitly configured base win over the zone delay', () => {
     expect(baseRespawnSecondsAt(-27, 71, 2)).toBe(2);
     expect(baseRespawnSecondsAt(-90, 700, 2)).toBe(2);
     // 0 is explicit, not absent.
@@ -168,8 +173,10 @@ describe('baseRespawnSecondsAt: the global override vs the zone tier', () => {
 });
 
 describe('resolveRespawnSeconds: full precedence', () => {
-  const thornpeak = { x: -90, z: 700 }; // level band [13, 20] -> 180s
-  const vale = { x: -27, z: 71 }; // level band [1, 7] -> 60s
+  // Both now resolve to the one 60s world delay; they sat in different tiers
+  // before, so keeping both proves the band no longer separates them.
+  const thornpeak = { x: -90, z: 700 }; // level band [13, 20]
+  const vale = { x: -27, z: 71 }; // level band [1, 7]
 
   it('lets a template respawnSeconds win over everything', () => {
     expect(resolveRespawnSeconds({ respawnSeconds: 10 }, thornpeak, undefined)).toBe(10);
@@ -180,8 +187,8 @@ describe('resolveRespawnSeconds: full precedence', () => {
     );
   });
 
-  it('applies the zone tier to plain trash', () => {
-    expect(resolveRespawnSeconds({}, thornpeak, undefined)).toBe(180);
+  it('applies the one world delay to plain trash, wherever it stands', () => {
+    expect(resolveRespawnSeconds({}, thornpeak, undefined)).toBe(60);
     expect(resolveRespawnSeconds({}, vale, undefined)).toBe(60);
     expect(resolveRespawnSeconds(undefined, vale, undefined)).toBe(60);
   });
@@ -213,8 +220,12 @@ describe('resolveRespawnSeconds: full precedence', () => {
     expect(isSelfScheduled({ respawnMult: 4, rare: true })).toBe(true);
     expect(isSelfScheduled({})).toBe(false);
     // Elite and boss status alone do NOT self-schedule: an open-world boss that
-    // never declared a cadence rides the zone tier like the trash around it.
+    // never declares a cadence rides the world delay like the trash around it.
+    // That is exactly how Warlord Drogmar ended up on a trash timer while
+    // carrying boss loot, so the rule is pinned rather than assumed.
     expect(isSelfScheduled({ rare: false })).toBe(false);
+    expect(isSelfScheduled({ boss: true } as never)).toBe(false);
+    expect(isSelfScheduled({ elite: true } as never)).toBe(false);
     expect(isSelfScheduled(undefined)).toBe(false);
   });
 
@@ -240,8 +251,8 @@ describe('resolveRespawnSeconds: full precedence', () => {
   });
 
   it('names exactly the templates whose respawn DID move, so the change is visible', () => {
-    // The complement of the pin above. Only unscheduled open-world bosses and
-    // plain trash may appear here; a rare showing up is the regression.
+    // The complement of the pin above. Only plain trash may appear here; a
+    // self-scheduled template showing up is the regression.
     const moved = Object.values(MOBS)
       .filter((t) => t.respawnSeconds === undefined && isSelfScheduled(t))
       .filter(
@@ -251,22 +262,45 @@ describe('resolveRespawnSeconds: full precedence', () => {
       )
       .map((t) => t.id);
     expect(moved).toEqual([]);
-    // ...while plain trash and unscheduled bosses DO move, so the tier is live.
-    expect(resolveRespawnSeconds(MOBS.warlord_drogmar, thornpeak, undefined)).toBe(180);
-    expect(MOBS.warlord_drogmar.boss).toBe(true);
-    expect(MOBS.warlord_drogmar.respawnMult).toBeUndefined();
+    // ...while plain trash DOES take the world delay, so the policy is live.
+    expect(resolveRespawnSeconds(MOBS.thornpeak_ogre, thornpeak, undefined)).toBe(60);
+    expect(isSelfScheduled(MOBS.thornpeak_ogre)).toBe(false);
+  });
+
+  it('keeps Warlord Drogmar on his declared hour, not the trash delay', () => {
+    // He is boss + elite with boss-tier loot and NO rare flag, the exact shape
+    // that silently inherited a trash timer. The explicit multiplier is what
+    // fixes that, so both halves are pinned: the flags that do not schedule him,
+    // and the multiplier that does.
+    const drogmar = MOBS.warlord_drogmar;
+    expect(drogmar.boss).toBe(true);
+    expect(drogmar.rare).toBeUndefined();
+    expect(drogmar.respawnMult).toBe(144);
+    expect(isSelfScheduled(drogmar)).toBe(true);
+    // 144 * 25 = one hour, and it holds wherever he stands.
+    expect(resolveRespawnSeconds(drogmar, thornpeak, undefined)).toBe(3600);
+    expect(resolveRespawnSeconds(drogmar, vale, undefined)).toBe(3600);
+    // Decisive against a regression to the trash delay.
+    expect(resolveRespawnSeconds(drogmar, thornpeak, undefined)).not.toBe(TRASH_RESPAWN_SECONDS);
+    // He matches Marrowlord Varkas, the neighbour his value was calibrated to.
+    expect(resolveRespawnSeconds(MOBS.marrowlord_varkas, thornpeak, undefined)).toBe(3600);
   });
 
   it('uses the SPAWN position, not the death position', () => {
-    // Same template, two different homes: the band decides.
+    // The world delay is uniform, so an in-world position no longer separates
+    // from another in-world position: the decisive contrast is on-map (60s)
+    // against off-map (the 25s instance-plane fallback).
+    const offMap = instanceOrigin(0, 0);
+    expect(resolveRespawnSeconds({}, vale, undefined)).toBe(TRASH_RESPAWN_SECONDS);
+    expect(resolveRespawnSeconds({}, offMap, undefined)).toBe(DEFAULT_RESPAWN_SECONDS);
     expect(resolveRespawnSeconds({}, vale, undefined)).not.toBe(
-      resolveRespawnSeconds({}, thornpeak, undefined),
+      resolveRespawnSeconds({}, offMap, undefined),
     );
   });
 });
 
 describe('the death site consumes the policy', () => {
-  it('puts a slain open-world mob down for its zone tier, not the old flat 25s', () => {
+  it('puts a slain open-world mob down for the world delay, not the off-map 25s', () => {
     const sim = new Sim({ seed: 20061, playerClass: 'warrior' });
     expect(sim.cfg.respawnSeconds).toBeUndefined();
     const mob = [...sim.entities.values()].find(
@@ -277,7 +311,7 @@ describe('the death site consumes the policy', () => {
     expect(home?.id).toBe('eastbrook_vale');
     sim.dealDamage(null, mob, 99_999, false, 'physical', null, 'hit');
     expect(mob.dead).toBe(true);
-    expect(mob.respawnTimer).toBe(TRASH_RESPAWN_SECONDS_LOW);
+    expect(mob.respawnTimer).toBe(TRASH_RESPAWN_SECONDS);
     expect(mob.respawnTimer).not.toBe(DEFAULT_RESPAWN_SECONDS);
   });
 
@@ -321,14 +355,14 @@ describe('the death site consumes the policy', () => {
     // so the effective delay is max(tier, corpse window). Giving coinless trash
     // harvest tags makes those corpses lootable where they were not, which would
     // silently stretch the delay if the corpse window ever exceeded a tier.
-    // CORPSE_DURATION is 60 and the fastest tier is 60, so the tier still wins
-    // everywhere; farm_yield prices camps on the tier alone and stays correct.
-    expect(CORPSE_DURATION).toBeLessThanOrEqual(TRASH_RESPAWN_SECONDS_LOW);
-    expect(CORPSE_DURATION).toBeLessThanOrEqual(TRASH_RESPAWN_SECONDS_MID);
-    expect(CORPSE_DURATION).toBeLessThanOrEqual(TRASH_RESPAWN_SECONDS_HIGH);
+    // CORPSE_DURATION is 60 and the world delay is 60, so the delay still wins
+    // (they are EQUAL now, which is the tightest this can be without the corpse
+    // window starting to push respawns out); farm_yield prices camps on the
+    // delay alone and stays correct only while this holds.
+    expect(CORPSE_DURATION).toBeLessThanOrEqual(TRASH_RESPAWN_SECONDS);
 
-    // ...and end to end: a harvestable Eastbrook beast is back on the 60s tier,
-    // not 60 plus a corpse window.
+    // ...and end to end: a harvestable Eastbrook beast is back on the 60s
+    // delay, not 60 plus a corpse window.
     const sim = new Sim({ seed: 20061, playerClass: 'warrior', noPlayer: true });
     const wolf = [...sim.entities.values()].find(
       (e) => e.kind === 'mob' && e.templateId === 'forest_wolf',
@@ -337,8 +371,8 @@ describe('the death site consumes the policy', () => {
     expect(MOBS.forest_wolf.componentTags?.length).toBeGreaterThan(0);
     sim.dealDamage(null, wolf, 99_999, false, 'physical', null, 'hit');
     expect(wolf.dead).toBe(true);
-    expect(wolf.respawnTimer).toBe(TRASH_RESPAWN_SECONDS_LOW);
-    const deadline = Math.ceil(TRASH_RESPAWN_SECONDS_LOW / DT) + 4;
+    expect(wolf.respawnTimer).toBe(TRASH_RESPAWN_SECONDS);
+    const deadline = Math.ceil(TRASH_RESPAWN_SECONDS / DT) + 4;
     let revivedAt: number | null = null;
     for (let i = 0; i < deadline && revivedAt === null; i++) {
       sim.tick();
@@ -346,8 +380,8 @@ describe('the death site consumes the policy', () => {
     }
     expect(revivedAt).not.toBeNull();
     // Within one tick of the tier, so no corpse window was added on top.
-    expect(revivedAt as number).toBeGreaterThanOrEqual(TRASH_RESPAWN_SECONDS_LOW);
-    expect(revivedAt as number).toBeLessThan(TRASH_RESPAWN_SECONDS_LOW + 1);
+    expect(revivedAt as number).toBeGreaterThanOrEqual(TRASH_RESPAWN_SECONDS);
+    expect(revivedAt as number).toBeLessThan(TRASH_RESPAWN_SECONDS + 1);
   });
 
   it('still caps corpse decay at a fixed template respawn (the training dummy)', () => {
@@ -361,7 +395,7 @@ describe('the death site consumes the policy', () => {
     // The dummy's whole point is a huge HP pool; overkill it outright.
     sim.dealDamage(null, dummy, dummy.hp, false, 'physical', null, 'hit');
     expect(dummy.dead).toBe(true);
-    // Its fixed schedule beats Thornpeak's 180s tier, and still caps corpse decay.
+    // Its fixed schedule beats the world delay, and still caps corpse decay.
     expect(dummy.respawnTimer).toBe(fixed);
     expect(dummy.corpseTimer).toBeLessThanOrEqual(fixed as number);
   });


### PR DESCRIPTION
## Summary

Retires the open-world respawn tiers for a single 60s delay everywhere, and gives Warlord Drogmar the explicit cadence he was missing.

**The tiers did not do what they were introduced to do.** They were added on July 30 (#2677) on the argument that a farmed camp regenerating three times a minute paid past what its zone was tuned for. Measured against how players actually farm, that does not hold up:

- Respawn was never the binding constraint for a solo player. Even at 180s the densest route in the world (Thornpeak's Glimmermere corridor, 63 standing mobs) supported about 20 kills a minute, while a player killing one mob every 8 seconds wants 7. Nobody was ever waiting on a spawn. The tiers only ever throttled AoE multi-pulls and several players sharing a route.
- The per-hour ceilings that justified them assume a farmer who kills every mob the instant it respawns with zero travel. At the top cluster that is 1.01 kills per **second**, sustained, across 130 yards. It is a bound, not a forecast.
- The ten expansion zones paid the visible cost: they share the endgame band but not its density (their largest cluster is Galecrest's 14-mob shipwreck against Glimmermere's 63), so 180s bought no farm resistance there and only made thin country feel empty.

**Drogmar was the one genuine outlier, and he is a mob, not a tier.** He is `boss: true` with boss-tier loot but declared no cadence, and `boss`/`elite` do not feed the respawn policy: only `respawnMult` or `rare: true` do. So he inherited the trash timer and was 24% of that corridor's gold by himself, a bigger single lever on its economy than the trash respawn rate ever was.

He now carries `respawnMult: 7.2` (three minutes), the cadence Old Cragmaw and Captain Verlan already use for a quest kill target, **not** a boss hour: `q_drogmar` has a hard kill objective on him at `suggestedPlayers: 3`, so a long cadence would make a party wait, and queue behind other parties, for a required quest step.

Since cadence cannot hold his gold down, coin does: **2000 guaranteed copper to 650**, matching Marrowlord Varkas. His TOTAL per-kill value was never the outlier (3285 against Varkas's 3222 and Brutok's 2557); the SPLIT was, at 2000 coin against their 650 and 320. All three unique drops survive, so the kill still pays like a boss.

### What moves

| | Before | After |
|---|---|---|
| Trash respawn, all zones | 60 / 120 / 180s by level band | **60s** |
| Warlord Drogmar, respawn | 180s (inherited) | **3 min** (declared) |
| Warlord Drogmar, guaranteed coin | 2000 | **650** |
| Richest cluster, gold | 27.5 g/hr | 59.6 g/hr |
| Richest cluster, XP | 183k/hr | 525k/hr |

Rares, minibosses, and every template with an authored `respawnMult` are byte-identical: they are self-scheduled and multiply the unchanged 25s legacy base. The off-map 25s fallback for instanced content is unchanged. `ZoneDef.trashRespawnSeconds` survives as the per-zone escape hatch, and `trashRespawnSecondsForZone` still takes a zone, so a future per-zone cadence needs no caller change.

### On the re-based budgets

`MAX_CLUSTER_COPPER_PER_HOUR` (344,000 to 701,000), `MAX_CLUSTER_XP_PER_HOUR` (229,000 to 657,000), and the trash-density cap (30 to 75) are raised on the existing ~25% above-shipped-maxima convention.

Calling this out rather than burying it: those ceilings were authored **in the same PR as the tiers they were said to justify**, and calibrated to whatever the world produced afterwards. They are not independent evidence, and the comments now say so. What they honestly protect is "the economy did not move again without someone deciding."

The fast-respawn density cap needed renaming, not just raising. It was a *fast*-respawn cap when only level 1-7 zones qualified; every zone is fast now, so it is a plain trash-density cap and the old name would have lied.

## Related issues

N/A

## Type of change

- [x] Bug fix
- [x] Tests

## How was this tested?

- Commands:
  - `npx vitest run tests/respawn_policy.test.ts tests/economy_yield.test.ts tests/camp_density.test.ts` (60 passed)
  - `npx vitest run tests/parity` (185 passed, 1 skipped; **no golden re-mint needed**)
  - `npx tsc --noEmit` (clean)
  - `npx @biomejs/biome check` on every changed file (clean)
  - `npm run gate`: green end to end (i18n gen + freshness, wiki content, malware scan, changed-files biome, SFX conformance), full suite **24,940 of 24,941 passed**.
    - The one failure was `tests/i18n_status_registry.test.ts` on a row `sim:groundPickup.objectAlreadyCredited`, which is environmental and cannot reproduce on CI: `src/ui/i18n.status.json` is a generated untracked file, the gate's `i18n:gen` step reported `1 cached, FULL TURBO`, and turbo's cache is shared across local worktrees, so a sibling branch's artifact leaked in. A pristine `release/v0.34.0` worktree passes it, and this worktree passes it too after a real `i18n:gen` (key count 1 to 0). This PR touches no i18n.
- Manual steps: priced every camp in the world through the real model in `tests/helpers/farm_yield.ts` at 180 / 120 / 90 / 60 / 45s, per zone and world-wide, to pick the number and to size the re-based budgets.

The retired band tests are kept and **inverted**: they now assert that a zone's level band does *not* change its respawn, so a tier creeping back fails rather than ships. `isSelfScheduled` additionally pins that `boss: true` and `elite: true` do not schedule a mob, which is the exact gap that put Drogmar on a trash timer.

## Screenshots / recordings

N/A, no visual change.

## Follow-up worth considering, not in this PR

Nineteen named elites still ride the world delay and will now pop every 60s (The Barrow King, The Wreck Warden, The Idol Guardian, Cindraleth, and others). Same root cause as Drogmar, about 0.6 g/hr each, so economically trivial but arguably cheapening. Gorrak the Ruthless is a `boss: true` already on a 60s respawn in Eastbrook today, which predates this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


