### PR TITLE
fix(render): gate shapeshift-form visual creation on shader compile

### DIFF
--- a/docs/screenshots/eastbrook-vale-rebuild/polish/metadata/after-desktop-ultra.json
+++ b/docs/screenshots/eastbrook-vale-rebuild/polish/metadata/after-desktop-ultra.json
@@ -11,7 +11,7 @@
     "mode": "composite-sha256",
     "algorithm": "sha256",
     "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-    "fingerprint": "fd1b2a46947d588aa6c0e62a04885a8039ed3fb1c2d1e281342f80168b16d590",
+    "fingerprint": "2d4e6e0ee7168a0bf25a13ba1a2754f39e8c8f168e6f369ceb6588fe2bb9b2bb",
     "components": {
       "townAsset": {
         "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -40,7 +40,7 @@
         },
         "renderer": {
           "path": "src/render/renderer.ts",
-          "sha256": "fcf820a6818c80a6017adf3540c7169e6b76376bafa1d65e7a8077b37f0d98c7"
+          "sha256": "8e04c90b2fba4b157cac9f520ab3a95cf22b6d9fb96fc129e0b75905d70c4b17"
         },
         "viewPriorityPolicy": {
           "path": "src/render/prewarm_policy.ts",
@@ -85,7 +85,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "fd1b2a46947d588aa6c0e62a04885a8039ed3fb1c2d1e281342f80168b16d590",
+        "fingerprint": "2d4e6e0ee7168a0bf25a13ba1a2754f39e8c8f168e6f369ceb6588fe2bb9b2bb",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -114,7 +114,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "fcf820a6818c80a6017adf3540c7169e6b76376bafa1d65e7a8077b37f0d98c7"
+              "sha256": "8e04c90b2fba4b157cac9f520ab3a95cf22b6d9fb96fc129e0b75905d70c4b17"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -1380,7 +1380,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "fd1b2a46947d588aa6c0e62a04885a8039ed3fb1c2d1e281342f80168b16d590",
+        "fingerprint": "2d4e6e0ee7168a0bf25a13ba1a2754f39e8c8f168e6f369ceb6588fe2bb9b2bb",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -1409,7 +1409,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "fcf820a6818c80a6017adf3540c7169e6b76376bafa1d65e7a8077b37f0d98c7"
+              "sha256": "8e04c90b2fba4b157cac9f520ab3a95cf22b6d9fb96fc129e0b75905d70c4b17"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -2675,7 +2675,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "fd1b2a46947d588aa6c0e62a04885a8039ed3fb1c2d1e281342f80168b16d590",
+        "fingerprint": "2d4e6e0ee7168a0bf25a13ba1a2754f39e8c8f168e6f369ceb6588fe2bb9b2bb",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -2704,7 +2704,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "fcf820a6818c80a6017adf3540c7169e6b76376bafa1d65e7a8077b37f0d98c7"
+              "sha256": "8e04c90b2fba4b157cac9f520ab3a95cf22b6d9fb96fc129e0b75905d70c4b17"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -3970,7 +3970,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "fd1b2a46947d588aa6c0e62a04885a8039ed3fb1c2d1e281342f80168b16d590",
+        "fingerprint": "2d4e6e0ee7168a0bf25a13ba1a2754f39e8c8f168e6f369ceb6588fe2bb9b2bb",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -3999,7 +3999,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "fcf820a6818c80a6017adf3540c7169e6b76376bafa1d65e7a8077b37f0d98c7"
+              "sha256": "8e04c90b2fba4b157cac9f520ab3a95cf22b6d9fb96fc129e0b75905d70c4b17"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -5265,7 +5265,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "fd1b2a46947d588aa6c0e62a04885a8039ed3fb1c2d1e281342f80168b16d590",
+        "fingerprint": "2d4e6e0ee7168a0bf25a13ba1a2754f39e8c8f168e6f369ceb6588fe2bb9b2bb",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -5294,7 +5294,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "fcf820a6818c80a6017adf3540c7169e6b76376bafa1d65e7a8077b37f0d98c7"
+              "sha256": "8e04c90b2fba4b157cac9f520ab3a95cf22b6d9fb96fc129e0b75905d70c4b17"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -6560,7 +6560,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "fd1b2a46947d588aa6c0e62a04885a8039ed3fb1c2d1e281342f80168b16d590",
+        "fingerprint": "2d4e6e0ee7168a0bf25a13ba1a2754f39e8c8f168e6f369ceb6588fe2bb9b2bb",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -6589,7 +6589,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "fcf820a6818c80a6017adf3540c7169e6b76376bafa1d65e7a8077b37f0d98c7"
+              "sha256": "8e04c90b2fba4b157cac9f520ab3a95cf22b6d9fb96fc129e0b75905d70c4b17"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -7855,7 +7855,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "fd1b2a46947d588aa6c0e62a04885a8039ed3fb1c2d1e281342f80168b16d590",
+        "fingerprint": "2d4e6e0ee7168a0bf25a13ba1a2754f39e8c8f168e6f369ceb6588fe2bb9b2bb",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -7884,7 +7884,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "fcf820a6818c80a6017adf3540c7169e6b76376bafa1d65e7a8077b37f0d98c7"
+              "sha256": "8e04c90b2fba4b157cac9f520ab3a95cf22b6d9fb96fc129e0b75905d70c4b17"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -9150,7 +9150,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "fd1b2a46947d588aa6c0e62a04885a8039ed3fb1c2d1e281342f80168b16d590",
+        "fingerprint": "2d4e6e0ee7168a0bf25a13ba1a2754f39e8c8f168e6f369ceb6588fe2bb9b2bb",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -9179,7 +9179,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "fcf820a6818c80a6017adf3540c7169e6b76376bafa1d65e7a8077b37f0d98c7"
+              "sha256": "8e04c90b2fba4b157cac9f520ab3a95cf22b6d9fb96fc129e0b75905d70c4b17"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -10445,7 +10445,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "fd1b2a46947d588aa6c0e62a04885a8039ed3fb1c2d1e281342f80168b16d590",
+        "fingerprint": "2d4e6e0ee7168a0bf25a13ba1a2754f39e8c8f168e6f369ceb6588fe2bb9b2bb",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -10474,7 +10474,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "fcf820a6818c80a6017adf3540c7169e6b76376bafa1d65e7a8077b37f0d98c7"
+              "sha256": "8e04c90b2fba4b157cac9f520ab3a95cf22b6d9fb96fc129e0b75905d70c4b17"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -11740,7 +11740,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "fd1b2a46947d588aa6c0e62a04885a8039ed3fb1c2d1e281342f80168b16d590",
+        "fingerprint": "2d4e6e0ee7168a0bf25a13ba1a2754f39e8c8f168e6f369ceb6588fe2bb9b2bb",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -11769,7 +11769,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "fcf820a6818c80a6017adf3540c7169e6b76376bafa1d65e7a8077b37f0d98c7"
+              "sha256": "8e04c90b2fba4b157cac9f520ab3a95cf22b6d9fb96fc129e0b75905d70c4b17"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -13035,7 +13035,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "fd1b2a46947d588aa6c0e62a04885a8039ed3fb1c2d1e281342f80168b16d590",
+        "fingerprint": "2d4e6e0ee7168a0bf25a13ba1a2754f39e8c8f168e6f369ceb6588fe2bb9b2bb",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -13064,7 +13064,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "fcf820a6818c80a6017adf3540c7169e6b76376bafa1d65e7a8077b37f0d98c7"
+              "sha256": "8e04c90b2fba4b157cac9f520ab3a95cf22b6d9fb96fc129e0b75905d70c4b17"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -14330,7 +14330,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "fd1b2a46947d588aa6c0e62a04885a8039ed3fb1c2d1e281342f80168b16d590",
+        "fingerprint": "2d4e6e0ee7168a0bf25a13ba1a2754f39e8c8f168e6f369ceb6588fe2bb9b2bb",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -14359,7 +14359,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "fcf820a6818c80a6017adf3540c7169e6b76376bafa1d65e7a8077b37f0d98c7"
+              "sha256": "8e04c90b2fba4b157cac9f520ab3a95cf22b6d9fb96fc129e0b75905d70c4b17"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -15625,7 +15625,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "fd1b2a46947d588aa6c0e62a04885a8039ed3fb1c2d1e281342f80168b16d590",
+        "fingerprint": "2d4e6e0ee7168a0bf25a13ba1a2754f39e8c8f168e6f369ceb6588fe2bb9b2bb",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -15654,7 +15654,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "fcf820a6818c80a6017adf3540c7169e6b76376bafa1d65e7a8077b37f0d98c7"
+              "sha256": "8e04c90b2fba4b157cac9f520ab3a95cf22b6d9fb96fc129e0b75905d70c4b17"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -16920,7 +16920,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "fd1b2a46947d588aa6c0e62a04885a8039ed3fb1c2d1e281342f80168b16d590",
+        "fingerprint": "2d4e6e0ee7168a0bf25a13ba1a2754f39e8c8f168e6f369ceb6588fe2bb9b2bb",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -16949,7 +16949,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "fcf820a6818c80a6017adf3540c7169e6b76376bafa1d65e7a8077b37f0d98c7"
+              "sha256": "8e04c90b2fba4b157cac9f520ab3a95cf22b6d9fb96fc129e0b75905d70c4b17"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -19180,7 +19180,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "fd1b2a46947d588aa6c0e62a04885a8039ed3fb1c2d1e281342f80168b16d590",
+        "fingerprint": "2d4e6e0ee7168a0bf25a13ba1a2754f39e8c8f168e6f369ceb6588fe2bb9b2bb",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -19209,7 +19209,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "fcf820a6818c80a6017adf3540c7169e6b76376bafa1d65e7a8077b37f0d98c7"
+              "sha256": "8e04c90b2fba4b157cac9f520ab3a95cf22b6d9fb96fc129e0b75905d70c4b17"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -20475,7 +20475,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "fd1b2a46947d588aa6c0e62a04885a8039ed3fb1c2d1e281342f80168b16d590",
+        "fingerprint": "2d4e6e0ee7168a0bf25a13ba1a2754f39e8c8f168e6f369ceb6588fe2bb9b2bb",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -20504,7 +20504,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "fcf820a6818c80a6017adf3540c7169e6b76376bafa1d65e7a8077b37f0d98c7"
+              "sha256": "8e04c90b2fba4b157cac9f520ab3a95cf22b6d9fb96fc129e0b75905d70c4b17"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -21770,7 +21770,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "fd1b2a46947d588aa6c0e62a04885a8039ed3fb1c2d1e281342f80168b16d590",
+        "fingerprint": "2d4e6e0ee7168a0bf25a13ba1a2754f39e8c8f168e6f369ceb6588fe2bb9b2bb",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -21799,7 +21799,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "fcf820a6818c80a6017adf3540c7169e6b76376bafa1d65e7a8077b37f0d98c7"
+              "sha256": "8e04c90b2fba4b157cac9f520ab3a95cf22b6d9fb96fc129e0b75905d70c4b17"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -23065,7 +23065,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "fd1b2a46947d588aa6c0e62a04885a8039ed3fb1c2d1e281342f80168b16d590",
+        "fingerprint": "2d4e6e0ee7168a0bf25a13ba1a2754f39e8c8f168e6f369ceb6588fe2bb9b2bb",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -23094,7 +23094,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "fcf820a6818c80a6017adf3540c7169e6b76376bafa1d65e7a8077b37f0d98c7"
+              "sha256": "8e04c90b2fba4b157cac9f520ab3a95cf22b6d9fb96fc129e0b75905d70c4b17"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -24360,7 +24360,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "fd1b2a46947d588aa6c0e62a04885a8039ed3fb1c2d1e281342f80168b16d590",
+        "fingerprint": "2d4e6e0ee7168a0bf25a13ba1a2754f39e8c8f168e6f369ceb6588fe2bb9b2bb",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -24389,7 +24389,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "fcf820a6818c80a6017adf3540c7169e6b76376bafa1d65e7a8077b37f0d98c7"
+              "sha256": "8e04c90b2fba4b157cac9f520ab3a95cf22b6d9fb96fc129e0b75905d70c4b17"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -25655,7 +25655,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "fd1b2a46947d588aa6c0e62a04885a8039ed3fb1c2d1e281342f80168b16d590",
+        "fingerprint": "2d4e6e0ee7168a0bf25a13ba1a2754f39e8c8f168e6f369ceb6588fe2bb9b2bb",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -25684,7 +25684,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "fcf820a6818c80a6017adf3540c7169e6b76376bafa1d65e7a8077b37f0d98c7"
+              "sha256": "8e04c90b2fba4b157cac9f520ab3a95cf22b6d9fb96fc129e0b75905d70c4b17"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -26950,7 +26950,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "fd1b2a46947d588aa6c0e62a04885a8039ed3fb1c2d1e281342f80168b16d590",
+        "fingerprint": "2d4e6e0ee7168a0bf25a13ba1a2754f39e8c8f168e6f369ceb6588fe2bb9b2bb",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -26979,7 +26979,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "fcf820a6818c80a6017adf3540c7169e6b76376bafa1d65e7a8077b37f0d98c7"
+              "sha256": "8e04c90b2fba4b157cac9f520ab3a95cf22b6d9fb96fc129e0b75905d70c4b17"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -28298,7 +28298,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "fd1b2a46947d588aa6c0e62a04885a8039ed3fb1c2d1e281342f80168b16d590",
+        "fingerprint": "2d4e6e0ee7168a0bf25a13ba1a2754f39e8c8f168e6f369ceb6588fe2bb9b2bb",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -28327,7 +28327,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "fcf820a6818c80a6017adf3540c7169e6b76376bafa1d65e7a8077b37f0d98c7"
+              "sha256": "8e04c90b2fba4b157cac9f520ab3a95cf22b6d9fb96fc129e0b75905d70c4b17"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -29593,7 +29593,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "fd1b2a46947d588aa6c0e62a04885a8039ed3fb1c2d1e281342f80168b16d590",
+        "fingerprint": "2d4e6e0ee7168a0bf25a13ba1a2754f39e8c8f168e6f369ceb6588fe2bb9b2bb",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -29622,7 +29622,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "fcf820a6818c80a6017adf3540c7169e6b76376bafa1d65e7a8077b37f0d98c7"
+              "sha256": "8e04c90b2fba4b157cac9f520ab3a95cf22b6d9fb96fc129e0b75905d70c4b17"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",

--- a/docs/screenshots/eastbrook-vale-rebuild/polish/metadata/after-mobile-low.json
+++ b/docs/screenshots/eastbrook-vale-rebuild/polish/metadata/after-mobile-low.json
@@ -11,7 +11,7 @@
     "mode": "composite-sha256",
     "algorithm": "sha256",
     "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-    "fingerprint": "fd1b2a46947d588aa6c0e62a04885a8039ed3fb1c2d1e281342f80168b16d590",
+    "fingerprint": "2d4e6e0ee7168a0bf25a13ba1a2754f39e8c8f168e6f369ceb6588fe2bb9b2bb",
     "components": {
       "townAsset": {
         "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -40,7 +40,7 @@
         },
         "renderer": {
           "path": "src/render/renderer.ts",
-          "sha256": "fcf820a6818c80a6017adf3540c7169e6b76376bafa1d65e7a8077b37f0d98c7"
+          "sha256": "8e04c90b2fba4b157cac9f520ab3a95cf22b6d9fb96fc129e0b75905d70c4b17"
         },
         "viewPriorityPolicy": {
           "path": "src/render/prewarm_policy.ts",
@@ -85,7 +85,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "fd1b2a46947d588aa6c0e62a04885a8039ed3fb1c2d1e281342f80168b16d590",
+        "fingerprint": "2d4e6e0ee7168a0bf25a13ba1a2754f39e8c8f168e6f369ceb6588fe2bb9b2bb",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -114,7 +114,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "fcf820a6818c80a6017adf3540c7169e6b76376bafa1d65e7a8077b37f0d98c7"
+              "sha256": "8e04c90b2fba4b157cac9f520ab3a95cf22b6d9fb96fc129e0b75905d70c4b17"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -1363,7 +1363,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "fd1b2a46947d588aa6c0e62a04885a8039ed3fb1c2d1e281342f80168b16d590",
+        "fingerprint": "2d4e6e0ee7168a0bf25a13ba1a2754f39e8c8f168e6f369ceb6588fe2bb9b2bb",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -1392,7 +1392,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "fcf820a6818c80a6017adf3540c7169e6b76376bafa1d65e7a8077b37f0d98c7"
+              "sha256": "8e04c90b2fba4b157cac9f520ab3a95cf22b6d9fb96fc129e0b75905d70c4b17"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -2641,7 +2641,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "fd1b2a46947d588aa6c0e62a04885a8039ed3fb1c2d1e281342f80168b16d590",
+        "fingerprint": "2d4e6e0ee7168a0bf25a13ba1a2754f39e8c8f168e6f369ceb6588fe2bb9b2bb",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -2670,7 +2670,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "fcf820a6818c80a6017adf3540c7169e6b76376bafa1d65e7a8077b37f0d98c7"
+              "sha256": "8e04c90b2fba4b157cac9f520ab3a95cf22b6d9fb96fc129e0b75905d70c4b17"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -3919,7 +3919,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "fd1b2a46947d588aa6c0e62a04885a8039ed3fb1c2d1e281342f80168b16d590",
+        "fingerprint": "2d4e6e0ee7168a0bf25a13ba1a2754f39e8c8f168e6f369ceb6588fe2bb9b2bb",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -3948,7 +3948,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "fcf820a6818c80a6017adf3540c7169e6b76376bafa1d65e7a8077b37f0d98c7"
+              "sha256": "8e04c90b2fba4b157cac9f520ab3a95cf22b6d9fb96fc129e0b75905d70c4b17"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -5197,7 +5197,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "fd1b2a46947d588aa6c0e62a04885a8039ed3fb1c2d1e281342f80168b16d590",
+        "fingerprint": "2d4e6e0ee7168a0bf25a13ba1a2754f39e8c8f168e6f369ceb6588fe2bb9b2bb",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -5226,7 +5226,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "fcf820a6818c80a6017adf3540c7169e6b76376bafa1d65e7a8077b37f0d98c7"
+              "sha256": "8e04c90b2fba4b157cac9f520ab3a95cf22b6d9fb96fc129e0b75905d70c4b17"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -6475,7 +6475,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "fd1b2a46947d588aa6c0e62a04885a8039ed3fb1c2d1e281342f80168b16d590",
+        "fingerprint": "2d4e6e0ee7168a0bf25a13ba1a2754f39e8c8f168e6f369ceb6588fe2bb9b2bb",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -6504,7 +6504,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "fcf820a6818c80a6017adf3540c7169e6b76376bafa1d65e7a8077b37f0d98c7"
+              "sha256": "8e04c90b2fba4b157cac9f520ab3a95cf22b6d9fb96fc129e0b75905d70c4b17"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -7753,7 +7753,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "fd1b2a46947d588aa6c0e62a04885a8039ed3fb1c2d1e281342f80168b16d590",
+        "fingerprint": "2d4e6e0ee7168a0bf25a13ba1a2754f39e8c8f168e6f369ceb6588fe2bb9b2bb",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -7782,7 +7782,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "fcf820a6818c80a6017adf3540c7169e6b76376bafa1d65e7a8077b37f0d98c7"
+              "sha256": "8e04c90b2fba4b157cac9f520ab3a95cf22b6d9fb96fc129e0b75905d70c4b17"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -9031,7 +9031,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "fd1b2a46947d588aa6c0e62a04885a8039ed3fb1c2d1e281342f80168b16d590",
+        "fingerprint": "2d4e6e0ee7168a0bf25a13ba1a2754f39e8c8f168e6f369ceb6588fe2bb9b2bb",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -9060,7 +9060,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "fcf820a6818c80a6017adf3540c7169e6b76376bafa1d65e7a8077b37f0d98c7"
+              "sha256": "8e04c90b2fba4b157cac9f520ab3a95cf22b6d9fb96fc129e0b75905d70c4b17"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -10309,7 +10309,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "fd1b2a46947d588aa6c0e62a04885a8039ed3fb1c2d1e281342f80168b16d590",
+        "fingerprint": "2d4e6e0ee7168a0bf25a13ba1a2754f39e8c8f168e6f369ceb6588fe2bb9b2bb",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -10338,7 +10338,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "fcf820a6818c80a6017adf3540c7169e6b76376bafa1d65e7a8077b37f0d98c7"
+              "sha256": "8e04c90b2fba4b157cac9f520ab3a95cf22b6d9fb96fc129e0b75905d70c4b17"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -11587,7 +11587,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "fd1b2a46947d588aa6c0e62a04885a8039ed3fb1c2d1e281342f80168b16d590",
+        "fingerprint": "2d4e6e0ee7168a0bf25a13ba1a2754f39e8c8f168e6f369ceb6588fe2bb9b2bb",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -11616,7 +11616,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "fcf820a6818c80a6017adf3540c7169e6b76376bafa1d65e7a8077b37f0d98c7"
+              "sha256": "8e04c90b2fba4b157cac9f520ab3a95cf22b6d9fb96fc129e0b75905d70c4b17"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -12865,7 +12865,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "fd1b2a46947d588aa6c0e62a04885a8039ed3fb1c2d1e281342f80168b16d590",
+        "fingerprint": "2d4e6e0ee7168a0bf25a13ba1a2754f39e8c8f168e6f369ceb6588fe2bb9b2bb",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -12894,7 +12894,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "fcf820a6818c80a6017adf3540c7169e6b76376bafa1d65e7a8077b37f0d98c7"
+              "sha256": "8e04c90b2fba4b157cac9f520ab3a95cf22b6d9fb96fc129e0b75905d70c4b17"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -14143,7 +14143,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "fd1b2a46947d588aa6c0e62a04885a8039ed3fb1c2d1e281342f80168b16d590",
+        "fingerprint": "2d4e6e0ee7168a0bf25a13ba1a2754f39e8c8f168e6f369ceb6588fe2bb9b2bb",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -14172,7 +14172,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "fcf820a6818c80a6017adf3540c7169e6b76376bafa1d65e7a8077b37f0d98c7"
+              "sha256": "8e04c90b2fba4b157cac9f520ab3a95cf22b6d9fb96fc129e0b75905d70c4b17"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -15421,7 +15421,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "fd1b2a46947d588aa6c0e62a04885a8039ed3fb1c2d1e281342f80168b16d590",
+        "fingerprint": "2d4e6e0ee7168a0bf25a13ba1a2754f39e8c8f168e6f369ceb6588fe2bb9b2bb",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -15450,7 +15450,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "fcf820a6818c80a6017adf3540c7169e6b76376bafa1d65e7a8077b37f0d98c7"
+              "sha256": "8e04c90b2fba4b157cac9f520ab3a95cf22b6d9fb96fc129e0b75905d70c4b17"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -16699,7 +16699,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "fd1b2a46947d588aa6c0e62a04885a8039ed3fb1c2d1e281342f80168b16d590",
+        "fingerprint": "2d4e6e0ee7168a0bf25a13ba1a2754f39e8c8f168e6f369ceb6588fe2bb9b2bb",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -16728,7 +16728,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "fcf820a6818c80a6017adf3540c7169e6b76376bafa1d65e7a8077b37f0d98c7"
+              "sha256": "8e04c90b2fba4b157cac9f520ab3a95cf22b6d9fb96fc129e0b75905d70c4b17"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -18942,7 +18942,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "fd1b2a46947d588aa6c0e62a04885a8039ed3fb1c2d1e281342f80168b16d590",
+        "fingerprint": "2d4e6e0ee7168a0bf25a13ba1a2754f39e8c8f168e6f369ceb6588fe2bb9b2bb",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -18971,7 +18971,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "fcf820a6818c80a6017adf3540c7169e6b76376bafa1d65e7a8077b37f0d98c7"
+              "sha256": "8e04c90b2fba4b157cac9f520ab3a95cf22b6d9fb96fc129e0b75905d70c4b17"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -20220,7 +20220,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "fd1b2a46947d588aa6c0e62a04885a8039ed3fb1c2d1e281342f80168b16d590",
+        "fingerprint": "2d4e6e0ee7168a0bf25a13ba1a2754f39e8c8f168e6f369ceb6588fe2bb9b2bb",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -20249,7 +20249,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "fcf820a6818c80a6017adf3540c7169e6b76376bafa1d65e7a8077b37f0d98c7"
+              "sha256": "8e04c90b2fba4b157cac9f520ab3a95cf22b6d9fb96fc129e0b75905d70c4b17"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -21498,7 +21498,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "fd1b2a46947d588aa6c0e62a04885a8039ed3fb1c2d1e281342f80168b16d590",
+        "fingerprint": "2d4e6e0ee7168a0bf25a13ba1a2754f39e8c8f168e6f369ceb6588fe2bb9b2bb",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -21527,7 +21527,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "fcf820a6818c80a6017adf3540c7169e6b76376bafa1d65e7a8077b37f0d98c7"
+              "sha256": "8e04c90b2fba4b157cac9f520ab3a95cf22b6d9fb96fc129e0b75905d70c4b17"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -22776,7 +22776,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "fd1b2a46947d588aa6c0e62a04885a8039ed3fb1c2d1e281342f80168b16d590",
+        "fingerprint": "2d4e6e0ee7168a0bf25a13ba1a2754f39e8c8f168e6f369ceb6588fe2bb9b2bb",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -22805,7 +22805,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "fcf820a6818c80a6017adf3540c7169e6b76376bafa1d65e7a8077b37f0d98c7"
+              "sha256": "8e04c90b2fba4b157cac9f520ab3a95cf22b6d9fb96fc129e0b75905d70c4b17"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -24054,7 +24054,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "fd1b2a46947d588aa6c0e62a04885a8039ed3fb1c2d1e281342f80168b16d590",
+        "fingerprint": "2d4e6e0ee7168a0bf25a13ba1a2754f39e8c8f168e6f369ceb6588fe2bb9b2bb",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -24083,7 +24083,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "fcf820a6818c80a6017adf3540c7169e6b76376bafa1d65e7a8077b37f0d98c7"
+              "sha256": "8e04c90b2fba4b157cac9f520ab3a95cf22b6d9fb96fc129e0b75905d70c4b17"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -25332,7 +25332,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "fd1b2a46947d588aa6c0e62a04885a8039ed3fb1c2d1e281342f80168b16d590",
+        "fingerprint": "2d4e6e0ee7168a0bf25a13ba1a2754f39e8c8f168e6f369ceb6588fe2bb9b2bb",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -25361,7 +25361,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "fcf820a6818c80a6017adf3540c7169e6b76376bafa1d65e7a8077b37f0d98c7"
+              "sha256": "8e04c90b2fba4b157cac9f520ab3a95cf22b6d9fb96fc129e0b75905d70c4b17"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -26610,7 +26610,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "fd1b2a46947d588aa6c0e62a04885a8039ed3fb1c2d1e281342f80168b16d590",
+        "fingerprint": "2d4e6e0ee7168a0bf25a13ba1a2754f39e8c8f168e6f369ceb6588fe2bb9b2bb",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -26639,7 +26639,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "fcf820a6818c80a6017adf3540c7169e6b76376bafa1d65e7a8077b37f0d98c7"
+              "sha256": "8e04c90b2fba4b157cac9f520ab3a95cf22b6d9fb96fc129e0b75905d70c4b17"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -27941,7 +27941,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "fd1b2a46947d588aa6c0e62a04885a8039ed3fb1c2d1e281342f80168b16d590",
+        "fingerprint": "2d4e6e0ee7168a0bf25a13ba1a2754f39e8c8f168e6f369ceb6588fe2bb9b2bb",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -27970,7 +27970,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "fcf820a6818c80a6017adf3540c7169e6b76376bafa1d65e7a8077b37f0d98c7"
+              "sha256": "8e04c90b2fba4b157cac9f520ab3a95cf22b6d9fb96fc129e0b75905d70c4b17"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -29219,7 +29219,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "fd1b2a46947d588aa6c0e62a04885a8039ed3fb1c2d1e281342f80168b16d590",
+        "fingerprint": "2d4e6e0ee7168a0bf25a13ba1a2754f39e8c8f168e6f369ceb6588fe2bb9b2bb",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -29248,7 +29248,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "fcf820a6818c80a6017adf3540c7169e6b76376bafa1d65e7a8077b37f0d98c7"
+              "sha256": "8e04c90b2fba4b157cac9f520ab3a95cf22b6d9fb96fc129e0b75905d70c4b17"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",

--- a/docs/screenshots/eastbrook-vale-rebuild/polish/performance/after-desktop-ultra-town.json
+++ b/docs/screenshots/eastbrook-vale-rebuild/polish/performance/after-desktop-ultra-town.json
@@ -14,7 +14,7 @@
     "mode": "composite-sha256",
     "algorithm": "sha256",
     "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-    "fingerprint": "fd1b2a46947d588aa6c0e62a04885a8039ed3fb1c2d1e281342f80168b16d590",
+    "fingerprint": "2d4e6e0ee7168a0bf25a13ba1a2754f39e8c8f168e6f369ceb6588fe2bb9b2bb",
     "components": {
       "townAsset": {
         "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -43,7 +43,7 @@
         },
         "renderer": {
           "path": "src/render/renderer.ts",
-          "sha256": "fcf820a6818c80a6017adf3540c7169e6b76376bafa1d65e7a8077b37f0d98c7"
+          "sha256": "8e04c90b2fba4b157cac9f520ab3a95cf22b6d9fb96fc129e0b75905d70c4b17"
         },
         "viewPriorityPolicy": {
           "path": "src/render/prewarm_policy.ts",

--- a/docs/screenshots/eastbrook-vale-rebuild/polish/performance/after-mobile-low-town.json
+++ b/docs/screenshots/eastbrook-vale-rebuild/polish/performance/after-mobile-low-town.json
@@ -14,7 +14,7 @@
     "mode": "composite-sha256",
     "algorithm": "sha256",
     "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-    "fingerprint": "fd1b2a46947d588aa6c0e62a04885a8039ed3fb1c2d1e281342f80168b16d590",
+    "fingerprint": "2d4e6e0ee7168a0bf25a13ba1a2754f39e8c8f168e6f369ceb6588fe2bb9b2bb",
     "components": {
       "townAsset": {
         "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -43,7 +43,7 @@
         },
         "renderer": {
           "path": "src/render/renderer.ts",
-          "sha256": "fcf820a6818c80a6017adf3540c7169e6b76376bafa1d65e7a8077b37f0d98c7"
+          "sha256": "8e04c90b2fba4b157cac9f520ab3a95cf22b6d9fb96fc129e0b75905d70c4b17"
         },
         "viewPriorityPolicy": {
           "path": "src/render/prewarm_policy.ts",

--- a/src/render/compile_gate.ts
+++ b/src/render/compile_gate.ts
@@ -87,3 +87,22 @@ export class CompileGateQueue {
     return result;
   }
 }
+
+/**
+ * Clears a shared "which target is this pending swap for" token, but only if it
+ * still names `owner`. Some renderer.ts call sites reuse ONE EntityView field
+ * across a family of mutually exclusive gated swaps instead of one pending flag
+ * per swap target (e.g. shapeshift-form creation: sheep/bear/cat/travel share a
+ * single formCompilePending token because at most one of them is ever active or
+ * newly built per entity per frame). The shared CompileGateQueue runs gates one
+ * at a time, but a NEWER swap can still be registered while an OLDER one is
+ * still in flight (a fast form-to-form reswap before the first compile settles).
+ * Without this guard, the older gate's onSettled would clear the token as soon
+ * as it resolves, revealing the newer target before its own compile is done:
+ * exactly the freeze this gate exists to prevent. Passing the raw setter
+ * (`current => null`) instead of this guard is only safe when the field is
+ * dedicated to a single target, as mountCompilePending/visualCompilePending are.
+ */
+export function settlePendingSwap<T>(current: T | null, owner: T): T | null {
+  return current === owner ? null : current;
+}

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -113,7 +113,7 @@ import { attackAbilityId, isSpinAttackAbility } from './characters/weapon_attack
 import { fogFarForBuiltGround } from './chunk_residency_core';
 import { CLICK_MARKER_LIFETIME, clickMarkerAnim, clickMarkerColor } from './click_marker';
 import { buildCliffScree, type CliffScreeView } from './cliff_scree';
-import { CompileGateQueue } from './compile_gate';
+import { CompileGateQueue, settlePendingSwap } from './compile_gate';
 import { trackWebGLContext } from './context_release';
 import {
   animatesEveryFrame,
@@ -962,6 +962,13 @@ export interface EntityView {
   // in so a plain hide would not be overwritten later the same frame. See #2571.
   mountCompilePending: boolean;
   visualCompilePending: boolean;
+  // Same gate shape as mountCompilePending/visualCompilePending (the lazy form roots'
+  // .visible is also recomputed every tick, see the "lazy form visuals" block), but
+  // shared across sheep/bear/cat/travel as ONE token instead of four flags: at most
+  // one form is ever active or newly built per entity per frame (see the mutually
+  // exclusive polyed/bear/cat/travel booleans), so a single field naming the pending
+  // form's root, cleared via settlePendingSwap, is enough. See #2571.
+  formCompilePending: THREE.Object3D | null;
   lastOverheadEmoteKey: string | null;
   recklessOn?: boolean;
   // render-space position last frame, for true u/s locomotion speed
@@ -6850,6 +6857,7 @@ export class Renderer {
       compileReady: null,
       mountCompilePending: false,
       visualCompilePending: false,
+      formCompilePending: null,
       lastOverheadEmoteKey: null,
       lastX: e.pos.x,
       lastZ: e.pos.z,
@@ -8554,11 +8562,18 @@ export class Renderer {
 
       // lazy form visuals, swapped by visibility like the old sheep/bear rigs
       // A null build leaves the field unset; the shared gate retries after its cooldown.
+      // A freshly built form root is exactly a brand-new rig's materials linking for
+      // the first time (same as a race/mech base-visual swap), so it is gated the
+      // same way instead of freezing the frame the form lands on (#2571).
       if (polyed && !v.sheepVisual) {
         const built = this.createCharacterVisualWithRetry(e, 'form_sheep', 'form_sheep');
         if (built) {
           v.sheepVisual = built;
           v.group.add(built.root); // group.scale already carries e.scale
+          v.formCompilePending = built.root;
+          this.gateSwapFlagOnCompile(built.root, () => {
+            v.formCompilePending = settlePendingSwap(v.formCompilePending, built.root);
+          });
         }
       }
       if (bear && !v.bearVisual) {
@@ -8566,6 +8581,10 @@ export class Renderer {
         if (built) {
           v.bearVisual = built;
           v.group.add(built.root);
+          v.formCompilePending = built.root;
+          this.gateSwapFlagOnCompile(built.root, () => {
+            v.formCompilePending = settlePendingSwap(v.formCompilePending, built.root);
+          });
         }
       }
       if (cat && !v.catVisual) {
@@ -8573,6 +8592,10 @@ export class Renderer {
         if (built) {
           v.catVisual = built;
           v.group.add(built.root);
+          v.formCompilePending = built.root;
+          this.gateSwapFlagOnCompile(built.root, () => {
+            v.formCompilePending = settlePendingSwap(v.formCompilePending, built.root);
+          });
         }
       }
       if (travel && !v.travelVisual) {
@@ -8580,12 +8603,27 @@ export class Renderer {
         if (built) {
           v.travelVisual = built;
           v.group.add(built.root);
+          v.formCompilePending = built.root;
+          this.gateSwapFlagOnCompile(built.root, () => {
+            v.formCompilePending = settlePendingSwap(v.formCompilePending, built.root);
+          });
         }
       }
-      if (v.sheepVisual) v.sheepVisual.root.visible = polyed;
-      if (v.bearVisual) v.bearVisual.root.visible = bear;
-      if (v.catVisual) v.catVisual.root.visible = cat;
-      if (v.travelVisual) v.travelVisual.root.visible = travel;
+      // Gated per form root: the per-frame recompute below AND the pending token
+      // both drive .visible, so a still-linking form pops in a frame or two late
+      // instead of stalling the frame it is entered on.
+      if (v.sheepVisual) {
+        v.sheepVisual.root.visible = polyed && v.formCompilePending !== v.sheepVisual.root;
+      }
+      if (v.bearVisual) {
+        v.bearVisual.root.visible = bear && v.formCompilePending !== v.bearVisual.root;
+      }
+      if (v.catVisual) {
+        v.catVisual.root.visible = cat && v.formCompilePending !== v.catVisual.root;
+      }
+      if (v.travelVisual) {
+        v.travelVisual.root.visible = travel && v.formCompilePending !== v.travelVisual.root;
+      }
       // rideable mount under the player (the lazy form-visual pattern). Mount
       // GLBs are lazyPreload: the first sight of a rider kicks the fetch and
       // the visual appears once ready. A druid form replaces the whole body,

--- a/tests/compile_gate.test.ts
+++ b/tests/compile_gate.test.ts
@@ -3,6 +3,7 @@ import {
   awaitCompileGate,
   CompileGateQueue,
   type CompileGateScheduler,
+  settlePendingSwap,
 } from '../src/render/compile_gate';
 
 function fakeScheduler(): CompileGateScheduler & {
@@ -152,5 +153,33 @@ describe('CompileGateQueue', () => {
       timedOut: false,
     });
     expect(priorities).toEqual([40]);
+  });
+});
+
+describe('settlePendingSwap', () => {
+  it('clears the token when it still names the settling owner', () => {
+    const root = { id: 'bear' };
+    expect(settlePendingSwap(root, root)).toBeNull();
+  });
+
+  it('leaves an already-clear token alone', () => {
+    expect(settlePendingSwap(null, { id: 'bear' })).toBeNull();
+  });
+
+  it('does not clobber a newer pending swap: the classic druid form-dance race', () => {
+    // Bear form is built and gated first (token = bearRoot). Before its compile
+    // settles, the player reswaps to cat form, which is built and gated second
+    // (token = catRoot, overwriting bearRoot). When bear's gate finally settles,
+    // its callback must NOT clear cat's still-pending token, or cat would reveal
+    // one frame before its own shader actually finished linking: the exact
+    // freeze this gate exists to prevent, just relocated to a rapid form swap.
+    const bearRoot = { id: 'bear' };
+    const catRoot = { id: 'cat' };
+    let pending: typeof bearRoot | typeof catRoot | null = bearRoot;
+    pending = catRoot; // cat's build reassigns the shared token before bear settles
+    pending = settlePendingSwap(pending, bearRoot); // bear's onSettled fires late
+    expect(pending).toBe(catRoot);
+    pending = settlePendingSwap(pending, catRoot); // cat's own onSettled fires next
+    expect(pending).toBeNull();
   });
 });

--- a/tests/eastbrook_polish_artifact_integrity.test.ts
+++ b/tests/eastbrook_polish_artifact_integrity.test.ts
@@ -614,10 +614,15 @@ const ACCEPTED_POLISH_V2_METADATA_PATH = path.join(
   POLISH_ROOT,
   'metadata/after-desktop-ultra.json',
 );
+// Re-pinned: src/render/renderer.ts is the rendererIntegration leaf of the polish
+// composite provenance, so gating the shapeshift-form visual swap on async compile
+// (#2571) in that file moves the metadata file's bytes (its polishProvenance block)
+// and the composite fingerprint it carries, the same way the compile-storm
+// gear/mount/base-visual gate fix re-pinned these before it.
 const ACCEPTED_POLISH_V2_METADATA_SHA256 =
-  '7e15cc4c6b8c5b5bbf066129aa59f21f3f93a5125816918ea5814aa2cf31e59d';
+  '33c844c2f31361c377506f384718ee2310da2bf1607b4c8724a56303beceff38';
 const ACCEPTED_POLISH_V2_COMPOSITE_PROVENANCE =
-  'fd1b2a46947d588aa6c0e62a04885a8039ed3fb1c2d1e281342f80168b16d590';
+  '2d4e6e0ee7168a0bf25a13ba1a2754f39e8c8f168e6f369ceb6588fe2bb9b2bb';
 const ACCEPTED_POLISH_V2_METADATA = readJsonFile<CaptureMetadata>(ACCEPTED_POLISH_V2_METADATA_PATH);
 const ACCEPTED_POLISH_V2_PROVENANCE = ACCEPTED_POLISH_V2_METADATA.polishProvenance;
 const ACCEPTED_POLISH_V2_TOWN_CONTRACT = ACCEPTED_POLISH_V2_METADATA.records[0]?.townContract;
@@ -1474,15 +1479,13 @@ describe('Eastbrook polish performance and contact evidence', () => {
     expect(acceptedFiles).toHaveLength(4);
     // Second-order seal, recomputed LAST in the re-mint recipe: it hashes the
     // performance evidence files, which carry the composite polish provenance.
-    // The lockfile leaf is pnpm-lock.yaml after the local-gate-perf migration (0.33.1 previously used package-lock.json), a hashed input to every
-    // GLB source fingerprint, so the town/mailbox/noticeboard leaves moved, the
-    // composite polish provenance followed (also folding in the v0.33 render
-    // recovery's renderer leaf, which re-pinned the capture contract without
-    // re-sweeping this evidence), and this seal follows the composite. Every
-    // measured value (frame timings, draw stats, triangle and scenario
-    // numbers) is byte-identical, and no capture was retaken.
+    // src/render/renderer.ts is the rendererIntegration leaf of that composite,
+    // so gating the shapeshift-form visual swap on async compile (#2571) moved
+    // the composite fingerprint and, with it, this seal follows. Every measured
+    // value (frame timings, draw stats, triangle and scenario numbers) is
+    // byte-identical, and no capture was retaken.
     expect(fingerprint.digest('hex')).toBe(
-      '71d3f6fc676687032023477349393654690706dbfe0bd25106dca32a13d1de3c',
+      'e6115e14fe78b1bc52616624a72b0837858282c74bd3a3feab9fdd312a576454',
     );
   });
 

--- a/tests/eastbrook_polish_capture_contract.test.ts
+++ b/tests/eastbrook_polish_capture_contract.test.ts
@@ -360,12 +360,13 @@ describe('Eastbrook polish capture contract', () => {
       mode: 'composite-sha256',
       algorithm: 'sha256',
       baselineRevision: EASTBROOK_POLISH_BASELINE_REVISION,
-      // Deliberately re-pinned: the lockfile leaf is pnpm-lock.yaml after the local-gate-perf migration (previously package-lock.json at 0.33.1),
-      // a hashed input to every GLB source fingerprint, so the town, mailbox and
-      // noticeboard leaves all moved and this composite mints fresh (atop the v0.33
-      // render recovery's renderer integration leaf). Not one pipeline input or
-      // geometry value changed, and no capture was retaken.
-      fingerprint: 'fd1b2a46947d588aa6c0e62a04885a8039ed3fb1c2d1e281342f80168b16d590',
+      // Deliberately re-pinned: src/render/renderer.ts is the rendererIntegration
+      // leaf of this composite, and editing it to gate the shapeshift-form visual
+      // swap on async compile (#2571) moves the leaf's own sha256 and, with it,
+      // the composite fingerprint. No GLB source fingerprint moved and no
+      // capture was retaken, following the identical precedent this composite
+      // already carries from the compile-storm gear/mount/base-visual gate fix.
+      fingerprint: '2d4e6e0ee7168a0bf25a13ba1a2754f39e8c8f168e6f369ceb6588fe2bb9b2bb',
       components: {
         captureContract: {
           id: 'polish-v2',

--- a/tests/shapeshift_form_compile_gate.test.ts
+++ b/tests/shapeshift_form_compile_gate.test.ts
@@ -1,0 +1,84 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+// Renderer.ts is a coordinator that needs a live WebGL/DOM context to instantiate
+// (see tests/CLAUDE.md), so its wiring is pinned by scanning the actual source, the
+// same pattern tests/prewarm_policy.test.ts and tests/prewarm_resume.test.ts use for
+// the sibling compile-gate/prewarm wiring in this file. settlePendingSwap's own
+// behavior (including the rapid form-swap race this gate exists to survive) is
+// covered directly in tests/compile_gate.test.ts.
+const renderer = () => readFileSync(new URL('../src/render/renderer.ts', import.meta.url), 'utf8');
+
+describe('shapeshift-form compile gate (#2571)', () => {
+  it('declares one shared pending-root token on EntityView, not one flag per form', () => {
+    const source = renderer();
+    const fieldStart = source.indexOf('formCompilePending: THREE.Object3D | null;');
+    expect(fieldStart).toBeGreaterThan(-1);
+    // Sits beside the two existing per-frame-recomputed gate flags this mirrors.
+    const mountFlagAt = source.indexOf('mountCompilePending: boolean;');
+    const visualFlagAt = source.indexOf('visualCompilePending: boolean;');
+    expect(mountFlagAt).toBeGreaterThan(-1);
+    expect(visualFlagAt).toBeGreaterThan(mountFlagAt);
+    expect(fieldStart).toBeGreaterThan(visualFlagAt);
+    // Initialized to null (no form pending) on every new EntityView.
+    expect(source).toContain('formCompilePending: null,');
+  });
+
+  it('gates all four lazy form-visual builds (sheep, bear, cat, travel) on compile', () => {
+    const source = renderer();
+    const blockStart = source.indexOf('// lazy form visuals, swapped by visibility');
+    const blockEnd = source.indexOf('// rideable mount under the player', blockStart);
+    expect(blockStart).toBeGreaterThan(-1);
+    expect(blockEnd).toBeGreaterThan(blockStart);
+    const block = source.slice(blockStart, blockEnd);
+
+    for (const form of ['sheepVisual', 'bearVisual', 'catVisual', 'travelVisual']) {
+      const visualAt = block.indexOf(`v.${form} = built;`);
+      expect(visualAt, `${form} assignment`).toBeGreaterThan(-1);
+      const addAt = block.indexOf('v.group.add(built.root)', visualAt);
+      expect(addAt, `${form} group.add`).toBeGreaterThan(visualAt);
+      const pendingAt = block.indexOf('v.formCompilePending = built.root;', addAt);
+      expect(pendingAt, `${form} pending set`).toBeGreaterThan(addAt);
+      const gateAt = block.indexOf('this.gateSwapFlagOnCompile(built.root, () => {', pendingAt);
+      expect(gateAt, `${form} gate call`).toBeGreaterThan(pendingAt);
+      const settleAt = block.indexOf(
+        'v.formCompilePending = settlePendingSwap(v.formCompilePending, built.root);',
+        gateAt,
+      );
+      expect(settleAt, `${form} settle callback`).toBeGreaterThan(gateAt);
+    }
+
+    // Uses the flag shape (gateSwapFlagOnCompile), not the direct-hide shape
+    // (gateSwapOnCompile): the visibility lines right below recompute every tick.
+    expect(block).not.toContain('this.gateSwapOnCompile(built.root)');
+  });
+
+  it('consults the pending token, keyed per form root, in the per-frame visibility recompute', () => {
+    const source = renderer();
+    const blockStart = source.indexOf('// Gated per form root: the per-frame recompute below');
+    const blockEnd = source.indexOf('// rideable mount under the player', blockStart);
+    expect(blockStart).toBeGreaterThan(-1);
+    expect(blockEnd).toBeGreaterThan(blockStart);
+    const block = source.slice(blockStart, blockEnd);
+
+    expect(block).toContain(
+      'v.sheepVisual.root.visible = polyed && v.formCompilePending !== v.sheepVisual.root;',
+    );
+    expect(block).toContain(
+      'v.bearVisual.root.visible = bear && v.formCompilePending !== v.bearVisual.root;',
+    );
+    expect(block).toContain(
+      'v.catVisual.root.visible = cat && v.formCompilePending !== v.catVisual.root;',
+    );
+    expect(block).toContain(
+      'v.travelVisual.root.visible = travel && v.formCompilePending !== v.travelVisual.root;',
+    );
+  });
+
+  it('imports settlePendingSwap from the shared compile_gate core', () => {
+    const source = renderer();
+    expect(source).toContain(
+      "import { CompileGateQueue, settlePendingSwap } from './compile_gate';",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

PR #2710 gated live gear, mount, and base-visual swaps on
`KHR_parallel_shader_compile` to stop the mid-play shader-compile-storm freeze
(issue #2571), but its commit message explicitly deferred one case: "shapeshift-
form creation (sheep/bear/cat/travel) is left for a later prewarm-manifest fix
rather than four more per-form pending flags." This PR closes that gap.

Building a druid form's `CharacterVisual` for the first time (sheep/polymorph,
bear, cat, travel) still links its shader program synchronously on the next
draw call: the same freeze the issue describes, just triggered by a form change
instead of a gear swap or streaming.

Each lazy form root's `.visible` is recomputed every frame from the sim's
current form (`src/render/renderer.ts`'s per-entity sync loop), the same shape
as the mount root and the base-visual root after a race/mech swap, so a direct
hide-then-restore (`gateSwapOnCompile`) would be overwritten the same frame.
This reuses `gateSwapFlagOnCompile` instead, the pending-flag gate already
established for those two cases.

Because `polyed`/`bear`/`cat`/`travel` are computed as mutually exclusive
booleans in that same loop, at most one form is ever active or newly built per
entity per frame. That makes a single `EntityView.formCompilePending` token
(naming the currently pending form's root) sufficient for all four forms,
instead of one pending flag per form, which is exactly what PR #2710 declined
to add. A new `settlePendingSwap` helper in `src/render/compile_gate.ts` clears
that shared token only when it still names the swap that is settling, so a fast
form-to-form reswap before the first compile resolves cannot let an older
gate's callback reveal the newer, still-compiling form one frame early.

This is a render-timing fix only: the steady-state visuals are unchanged, only
the timing of when a not-yet-compiled form becomes visible changes (it now
waits for the async compile, or reveals immediately on a renderer without
`KHR_parallel_shader_compile` support, matching the existing gates' fallback
behavior).

```mermaid
flowchart TD
    A[Shapeshift form requested\ne.g. druid enters Bear Form] --> B{Form visual\nalready built?}
    B -- yes, already visible --> Z[Per-frame visibility recompute\nshows the existing form root]
    B -- no, first time this entity\ntakes this form --> C[Build the form's CharacterVisual\nv.bearVisual = built; group.add]
    C --> D[Set EntityView.formCompilePending\nto the new form root]
    D --> E{Shader program\nalready compiled?\nKHR_parallel_shader_compile}
    E -- yes / unsupported browser --> F[gateSwapFlagOnCompile settles\nimmediately: onSettled fires sync]
    E -- no, still linking --> G[Hide via the per-frame recompute:\nvisible = wanted && pending !== root]
    G --> H[compileAsync resolves off the main thread]
    H --> I[onSettled: settlePendingSwap clears\nthe token only if it still names\nthis form's root]
    F --> J[Next frame: pending token clear]
    I --> J
    J --> K[Form root becomes visible,\nshader already linked: no freeze]
```

## Related issues

Contributes to #2571.

## Type of change

- [x] Bug fix
- [ ] Feature: new functionality
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx vitest run tests/compile_gate.test.ts tests/shapeshift_form_compile_gate.test.ts`
  - `npx vitest run tests/eastbrook_polish_capture_contract.test.ts tests/eastbrook_polish_artifact_integrity.test.ts` (re-pinned the renderer-integration provenance seal this edit moves, same as PR #2710's own precedent)
  - `npx vitest run tests/architecture.test.ts tests/prewarm_policy.test.ts tests/prewarm_resume.test.ts`
  - `npx tsc --noEmit`
  - `npm run gate` (full CI-equivalent gate)
- Manual steps: none; this is a render-timing-only change with no steady-state visual difference, covered by the pure-core test (`settlePendingSwap`, including the rapid form-to-form reswap race) plus a renderer-source wiring pin (`tests/shapeshift_form_compile_gate.test.ts`), following the same test shape `tests/prewarm_policy.test.ts`/`tests/prewarm_resume.test.ts` already use for this file's other compile-gate/prewarm wiring.

## Screenshots / recordings

Not included. This is a render-timing fix with no visible behavior change in the
steady state (same end visuals for every shapeshift form; only the timing of
when a not-yet-compiled form becomes visible changes), so a before/after
screenshot would not show anything different.

---

## Checklist

### Quality

- [x] **The full gate passes.** `npm run gate` is green. Added `settlePendingSwap`
      coverage (including the rapid form-swap race) to `tests/compile_gate.test.ts`
      and a renderer wiring pin in the new `tests/shapeshift_form_compile_gate.test.ts`.

### Cross-platform

- [x] N/A for the desktop/mobile viewport checklist item: no UI/HUD surface changed,
      only renderer shader-compile timing for the three offline/online/headless hosts
      that already share this renderer path.
- [ ] Accessible. N/A, no UI change.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files. The two `docs/screenshots/eastbrook-vale-rebuild/polish/`
      seal JSON updates were produced by
      `node scripts/assets/eastbrook_grand_armoury/remint_polish_provenance.mjs`,
      the checked-in re-mint tool for exactly this situation (editing
      `src/render/renderer.ts`, the pinned `rendererIntegration` provenance leaf),
      not hand-edited.
