### PR TITLE
fix(client): close the same-frame zone-warmup teleport race

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -3708,6 +3708,19 @@ async function startGame(
         pendingReleaseFacing = null;
         acc -= DT;
       }
+      // Re-check immediately after the tick loop, before renderer.sync() below reads
+      // offlineSim.player.pos for this frame. The call at the top of frame() only sees
+      // the position as of the START of the frame; a tick above can itself teleport the
+      // player (release-spirit/resurrect landing in a different zone, a dungeon door or
+      // portal trigger reached mid-tick), which the top-of-frame call has no way to see.
+      // Left unchecked, this frame would still render the just-teleported position with
+      // no loading curtain and an unprepared destination zone (a one-frame flash of an
+      // empty/black view). maybeWarmCurrentZone() is idempotent per call (it early-returns
+      // once a warmup is already in flight or the zone is ready), so calling it twice in
+      // one frame is safe; it does not remove the top-of-frame call, which still owns the
+      // input-suspend handling and catches a teleport triggered from outside the tick
+      // (e.g. a UI action) before this frame's tick even runs.
+      maybeWarmCurrentZone();
       const pp = offlineSim.player;
       traceStart = perf.startTrace();
       try {


### PR DESCRIPTION
## Summary

A player-submitted screen recording of live gameplay showed a one-frame solid
black rectangle over roughly the bottom-right 40% x 45% of the viewport,
appearing for exactly one frame right after the chat log printed "You have
died." then "Entering Thornpeak Heights." (a death/respawn zone transition).
The frames right around it show an unusually close/clipped third-person
camera. I don't have the original clip, only the description; I root-caused
it by reading `src/main.ts`'s per-frame `frame()` loop.

`maybeWarmCurrentZone()` detects a teleport-sized position jump
(`src/game/zone_transition.ts`: `TELEPORT_DISPLACEMENT_YD = 30`,
`zoneWarmupMode()`) and, for a genuine teleport, puts up the blocking loading
curtain and awaits `renderer.prepareZoneAt()` / `renderer.prepareZonesAround()`
before revealing the new zone, specifically so the player is never dropped
into a not-yet-built void. It ran only once, as the very first statement in
`frame()`.

For the offline path, the sim tick loop (`while (acc >= DT) { ... }`) runs
later in the same `frame()` call, and a tick can itself teleport the player:
I confirmed a concrete example, `updateDoorTriggers` in
`src/sim/instances/dungeons.ts` ("walking into a dungeon door teleports you
through it, no click needed"), which runs per player per tick and moves
`p.pos` synchronously inside `Sim.tick()`. Because
`maybeWarmCurrentZone()` already ran at the top of `frame()` with the
pre-tick position, this kind of mid-tick teleport is invisible to the check
for the frame it happens in; it is only caught on the FOLLOWING frame's
top-of-frame call, one frame after `renderer.sync()` already drew the new,
unprepared position with no loading curtain up.

I revised the "release-spirit/resurrect" framing from the original report:
`releaseSpirit`/`resurrectAtCorpse`/`resurrectAtSpiritHealer` are only
invoked from HUD button clicks, which land in their own browser task between
animation frames (JS run-to-completion), so they are already caught
correctly by the existing top-of-frame check. The bug needs a position
mutation that happens **synchronously inside `offlineSim.tick()`**, called
from `frame()`'s own tick loop; door triggers are a real, confirmed example,
and the general class covers anything that moves the player from inside a
tick rather than an immediate client-side mutation (rift/portal triggers,
similar future systems).

I also checked the online path: `ClientWorld` only mutates `world.player.pos`
from `applySnapshot`/event handlers reached through `this.ws.onmessage`,
a genuine async WebSocket message handler. Since `frame()` runs synchronously
top to bottom, a message handler can never fire in the middle of it (only
between calls), so the top-of-frame check for the online branch always sees
an up-to-date position before that same frame's `renderer.sync()`. The online
branch does not have this race, so I left it untouched rather than adding an
unneeded check there.

## Fix

Add a second `maybeWarmCurrentZone()` call in the offline branch of
`frame()`, right after the tick loop and before `renderer.sync()`. The
existing top-of-frame call stays exactly where it is: it still owns the
`input.setSuspendMovement(...)` ordering, and it still catches a teleport
triggered from outside the tick (e.g. a future UI action that mutates
position directly). `maybeWarmCurrentZone()` is already idempotent per call
(`if (zoneWarmup) return;` / `if (!riftExit && renderer.isZoneReadyAt(...))
return;`), and I traced its mutable state (`lastWarmCheckX/Z`,
`lastWarmInRiftBand`) to confirm a second same-frame call is safe: the second
call measures displacement from the position the first call recorded at the
top of the frame, so it correctly reports the actual jump the tick just
made, including a rift-band exit that happens mid-tick.

```mermaid
flowchart LR
  subgraph OLD["OLD per-frame order"]
    direction LR
    A1[zone-warmup check] --> A2[input] --> A3["sim tick (can teleport)"] --> A4["render\n(renders the unprepared zone,\nno curtain, one bad frame)"]
  end
  subgraph NEW["NEW per-frame order"]
    direction LR
    B1[zone-warmup check] --> B2[input] --> B3["sim tick (can teleport)"] --> B4["zone-warmup re-check"] --> B5["render\n(curtain already up if needed)"]
  end
```

## Related issues

N/A (bug found and fixed from a user-submitted recording, no tracking issue
was filed).

## Type of change

- [x] Bug fix

## How was this tested?

This is a one-frame render race: essentially impossible to catch with a
conventional screenshot, and `frame()` itself is a DOM/render coordinator, not
unit-testable. `src/game/zone_transition.ts`'s pure policy (`zoneWarmupMode`,
`TELEPORT_DISPLACEMENT_YD`) is unchanged by this fix (it is a call-order
reorder of an existing function, not new decision logic), so its existing
`tests/zone_transition.test.ts` needed no new pin.

Instead I verified live against a running offline session (`npm run dev`,
puppeteer-core), then reverted every trace of the instrumentation before
committing (the diff below is the entire change: 13 added lines calling the
existing function a second time):

- Commands: `npm run dev`, a temporary puppeteer script driving a real
  offline warrior through boot, then nudging `sim.player.pos` to just inside
  a real dungeon door's `DOOR_TRIGGER_RADIUS` (2.0yd) from outside the
  instance and letting the natural `requestAnimationFrame` loop run (not a
  manual `sim.tick()` call), so the real `updateDoorTriggers` mid-tick
  teleport fires inside the game's own frame loop.
- Manual steps / what I observed: I temporarily tagged the two
  `maybeWarmCurrentZone()` call sites with an origin label and logged
  displacement to a page-global array whenever a call detected a jump larger
  than 1 yard.
  - With the fix disabled (only the top-of-frame call active): the mid-tick
    teleport (displacement ~100228yd, door approach -> dungeon interior) was
    only detected by the *next* frame's top-of-frame call, ~12ms after the
    teleport landed, one full rendered frame late, exactly reproducing the
    reported bug's mechanism.
  - With the fix enabled: the *same* teleport was detected by the new
    post-tick call in the *same* frame it happened (also ~12ms after the
    prior frame, i.e. the very next rendered frame, but caught before that
    frame's `renderer.sync()` instead of one frame after).
  - I then removed all instrumentation, leaving only the real fix (a plain
    second `maybeWarmCurrentZone()` call, no debug code, no new parameters).
- I additionally reasoned through the offline release-spirit/resurrect path
  and the online path (see Summary above) to scope which paths actually need
  the second check and confirm the online branch does not.

## Screenshots / recordings

Not applicable: the defect is a single rendered frame at 60fps (about
16ms), which is not something a still screenshot or a short clip can
reliably capture, and this PR does not change any steady-state visuals.

---

## Checklist

### Quality

- [x] **The full gate passes.** `npx tsc --noEmit` is clean, and the changed
      file passes `npx @biomejs/biome check src/main.ts` with 0 errors (only
      pre-existing, whole-repo warnings). The repo's `.githooks/pre-push`
      floor (typecheck, guard tests `tests/architecture.test.ts` +
      `tests/localization_fixes.test.ts`, changed-files biome, copy-rules
      scan) ran automatically on push and reported green both times
      (before and after the rebase onto the latest `release/v0.34.0`).
      I could not get a fully clean `npm run gate` run in this session: the
      shared dev machine was under sustained, externally-caused load
      (load average 50-99 on a 16-core box for over an hour, traced to a
      large unrelated concurrent workflow's own worktrees/vitest processes,
      confirmed via each process's cwd) for the whole session, and the full
      24900+ test `vitest` run flaked on a different, unrelated test file
      each attempt (`tests/escort_quest.test.ts`, a worker-teardown race in
      `tests/localization_fixes.test.ts`, `tests/fire_short_fight_tuning.test.ts`,
      `tests/eastbrook_gameplay_integration.test.ts`,
      `tests/parity/parity_g.test.ts`, `tests/escort_ambush_convoy.test.ts`),
      never in `src/main.ts` or anything this PR touches, and every failing
      assertion was a wall-clock timeout. `tests/escort_quest.test.ts` passed
      cleanly in full isolation (18/18) when the machine had room to
      breathe, then failed on the identical assertion later purely because
      load had spiked again, which is the signature `scripts/gate.mjs`'s own
      header comment describes ("an unbounded full run saturates every core
      and flakes the heavy sim suites when other work shares the machine").
      `tests/zone_transition.test.ts` (the only test file for the touched
      policy, unchanged by this fix) passes cleanly (3/3) in isolation.
      Every gate step before the full vitest run (i18n artifacts/freshness,
      wiki content, malware scan, changed-files biome, sfx check) passed on
      every attempt.

### Cross-platform

- ~~Tested on desktop and mobile~~: no UI surface changed, only a per-frame
  call-order fix.
- N/A. No UI added or edited.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS`
      is not enabled anywhere.
- [x] I didn't hand-edit generated files.
