### PR TITLE
fix(sim): stack eating with natural hp regen, retune potion ladder

### DIFF
--- a/src/sim/combat/auras.ts
+++ b/src/sim/combat/auras.ts
@@ -105,7 +105,14 @@ export function updateRegen(ctx: SimContext, p: Entity, meta: PlayerMeta): void 
   } else if (p.resourceType === 'rage' && !p.inCombat) {
     p.resource = Math.max(0, p.resource - 2);
   }
-  if (!p.inCombat && p.hp < p.maxHp && !p.eating) {
+  // Eating STACKS with natural regen (issue #1608), matching how drinking
+  // already stacks with mana regen below: a food tick heals on TOP of this,
+  // not instead of it, so sitting to eat is never worse than standing idle.
+  // The one exception is a zero-hpPer2s "eating" session (p.eating?.hpPer2s
+  // === 0): that shape heals nothing itself and is the sim's documented dev
+  // freeze idiom (see startCascadePlaytest/startDevSandbox in sim.ts), which
+  // still needs natural regen suppressed to hold a scripted hp bar in place.
+  if (!p.inCombat && p.hp < p.maxHp && p.eating?.hpPer2s !== 0) {
     const regen = p.stats.sta * 0.3 + 2;
     p.hp = Math.min(p.maxHp, p.hp + Math.round(regen));
   }

--- a/src/sim/content/items.ts
+++ b/src/sim/content/items.ts
@@ -523,7 +523,16 @@ export const BASE_ITEMS: Record<string, ItemDef> = {
     bagSlots: 14,
     sellValue: 9000,
   },
-  // --- food & drink (vendor) ---
+  // --- food & drink (vendor, fished, conjured; see also zone2.ts/zone3.ts and
+  // profession_items.ts for the higher zone-bracket and crafted-cooking tiers).
+  // #1608: eating now STACKS with natural hp regen instead of replacing it
+  // (combat/auras.ts updateRegen), matching how drinking already stacks with
+  // mana regen, so every tier below is worth sitting down for at any stamina:
+  // there is no longer a crossover stamina past which it loses to standing
+  // still. The foodHp/drinkMana VALUES are unchanged: they already form a
+  // clear vendor -> fished -> conjured -> next-zone upgrade ladder (61 -> 90 ->
+  // 117 here, continuing to 243/432 in zone2 and 552/874 in zone3), and the
+  // stacking fix is what makes every rung of it worth the bag slot.
   baked_bread: {
     id: 'baked_bread',
     name: 'Cottage Loaf',
@@ -1101,12 +1110,27 @@ export const BASE_ITEMS: Record<string, ItemDef> = {
   },
   // --- combat potions (vendor): instant, usable in combat, 2-minute shared cooldown.
   // Restore less than sitting to eat/drink, the price you pay for not sitting (#103).
+  //
+  // Target fraction (#1608): each tier is sized against the LEAST tanky class for
+  // its resource (priest for potionHp, hunter for potionMana; see
+  // tests/consumables.test.ts) at BASE stats (no gear) at the TOP level of its
+  // intended zone bracket (ZONE1/2/3_ZONE.levelRange[1] in content/zone{1,2,3}.ts:
+  // 7/13/20), the hardest point in the bracket for the tier to still feel worth
+  // the cooldown. That lands potionHp around 80-90% and potionMana around 65-70%
+  // of the reference pool: a real, meaningful topper-upper rather than a sliver,
+  // with headroom against a geared character's larger pool (gear only grows the
+  // pool from here, so a geared cast of the same level sees a SMALLER fraction
+  // than the pinned floor, same as any flat-value consumable; the fix is that the
+  // floor itself is now generous, not that it tracks gear). Every tier in this
+  // ladder must stay BELOW the matching profession_items.ts alchemy draught (the
+  // crafted line is a strict upgrade over the vendor equivalent): keep the two in
+  // lockstep if either changes.
   minor_healing_potion: {
     id: 'minor_healing_potion',
     name: 'Minor Healing Potion',
     kind: 'potion',
     quality: 'common',
-    potionHp: 90,
+    potionHp: 110,
     sellValue: 8,
     buyValue: 40,
   },
@@ -1115,7 +1139,7 @@ export const BASE_ITEMS: Record<string, ItemDef> = {
     name: 'Minor Mana Potion',
     kind: 'potion',
     quality: 'common',
-    potionMana: 120,
+    potionMana: 145,
     sellValue: 8,
     buyValue: 40,
   },
@@ -1138,7 +1162,7 @@ export const BASE_ITEMS: Record<string, ItemDef> = {
     name: 'Lesser Healing Potion',
     kind: 'potion',
     quality: 'common',
-    potionHp: 150,
+    potionHp: 190,
     sellValue: 16,
     buyValue: 85,
   },
@@ -1147,7 +1171,7 @@ export const BASE_ITEMS: Record<string, ItemDef> = {
     name: 'Lesser Mana Potion',
     kind: 'potion',
     quality: 'common',
-    potionMana: 200,
+    potionMana: 250,
     sellValue: 16,
     buyValue: 85,
   },
@@ -1156,7 +1180,7 @@ export const BASE_ITEMS: Record<string, ItemDef> = {
     name: 'Healing Potion',
     kind: 'potion',
     quality: 'common',
-    potionHp: 280,
+    potionHp: 320,
     sellValue: 32,
     buyValue: 170,
   },
@@ -1165,7 +1189,7 @@ export const BASE_ITEMS: Record<string, ItemDef> = {
     name: 'Mana Potion',
     kind: 'potion',
     quality: 'common',
-    potionMana: 360,
+    potionMana: 410,
     sellValue: 32,
     buyValue: 170,
   },

--- a/src/sim/content/profession_items.ts
+++ b/src/sim/content/profession_items.ts
@@ -601,11 +601,14 @@ export const PROFESSION_ITEMS: Record<string, ItemDef> = {
   // at skillReq 0/25/50, apothecary-bound at alchemist_verane. Potions reuse the
   // vendor potionHp/potionMana machinery (instant, in-combat, shared cooldown);
   // elixirs reuse the elixir_of_the_bear shape (a temporary buff_sta aura on
-  // use). Every consumable sits inside the existing ceilings: heal <= 280
-  // (healing_potion), mana <= 360 (mana_potion), elixir buff_sta <= 12 for <=
-  // 900s (elixir_of_the_bear). The three elixir aura display names are localized
-  // client-side through the sim_i18n aura matcher (AURA_NAME_KEY), the same path
-  // as 'Might of the Bear'. Never vendor-stocked (no buyValue).
+  // use). Every rung strictly EXCEEDS its vendor-tier equivalent in items.ts
+  // (minor/lesser/healing_potion, minor/lesser/mana_potion; #1608 retuned that
+  // ladder, so this one moved in lockstep to stay a strict upgrade): heal <= 335
+  // (healing_potion's 320 + headroom), mana <= 425 (mana_potion's 410 +
+  // headroom), elixir buff_sta <= 12 for <= 900s (elixir_of_the_bear). The three
+  // elixir aura display names are localized client-side through the sim_i18n
+  // aura matcher (AURA_NAME_KEY), the same path as 'Might of the Bear'. Never
+  // vendor-stocked (no buyValue).
   silverleaf_healing_draught: {
     id: 'silverleaf_healing_draught',
     name: 'Sheenleaf Healing Draught',
@@ -659,7 +662,7 @@ export const PROFESSION_ITEMS: Record<string, ItemDef> = {
     name: 'Sunpetal Healing Draught',
     kind: 'potion',
     quality: 'rare',
-    potionHp: 280,
+    potionHp: 335,
     sellValue: 32,
   },
   sunpetal_mana_draught: {
@@ -667,7 +670,7 @@ export const PROFESSION_ITEMS: Record<string, ItemDef> = {
     name: 'Sunpetal Mana Draught',
     kind: 'potion',
     quality: 'rare',
-    potionMana: 360,
+    potionMana: 425,
     sellValue: 32,
   },
   elixir_of_the_serpent: {

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3426,9 +3426,10 @@ export class Sim {
       e.hp = Math.max(1, Math.round(e.maxHp * CASCADE_SCENARIO.allyHpFraction));
       // Freeze out-of-combat regen so ONLY the Chronomancer's Echo/initial healing
       // moves these bars (the owner wants to isolate the conversion, not watch the
-      // allies self-heal). A zero-value "food" trips the `!p.eating` regen guard in
-      // updateRegen and heals nothing; an idle, unsitting bot never trips standUp,
-      // and the non-damaging dummy never clears it. Dev scenario only.
+      // allies self-heal). A zero-hpPer2s "food" trips the natural-regen freeze
+      // in updateRegen (auras.ts: `p.eating?.hpPer2s !== 0`) and heals nothing
+      // itself; an idle, unsitting bot never trips standUp, and the
+      // non-damaging dummy never clears it. Dev scenario only.
       e.eating = {
         itemId: 'dev_cascade_freeze',
         kind: 'food',

--- a/tests/combat_auras.test.ts
+++ b/tests/combat_auras.test.ts
@@ -266,7 +266,12 @@ describe('auras: updateRegen', () => {
     const p = sim.player;
     const meta = sim.players.get(p.id) as PlayerMeta;
     p.inCombat = false;
-    p.hp = Math.max(1, p.maxHp - 500);
+    // A big synthetic pool: eating now stacks with natural regen (#1608), so a
+    // realistic deficit would cap out (and stop emitting a food-sourced heal)
+    // partway through 9 ticks. Inflate maxHp so the deficit stays open for the
+    // whole window regardless of the stamina-scaled natural tick's own rate.
+    p.maxHp = 10_000;
+    p.hp = p.maxHp - 5000;
     p.eating = {
       itemId: 'food',
       kind: 'food',

--- a/tests/consumables.test.ts
+++ b/tests/consumables.test.ts
@@ -1,0 +1,227 @@
+// Regression coverage for #1608 ("Food and potions are rarely worth using"):
+// eating now stacks with natural hp regen (combat/auras.ts updateRegen) instead
+// of replacing it, and the potionHp/potionMana ladder (content/items.ts) is
+// retuned to a documented target fraction of a reference class's HP/mana pool.
+// See the design comment above `minor_healing_potion` in content/items.ts for
+// the exact methodology this file pins.
+
+import { describe, expect, it } from 'vitest';
+import { updateRegen } from '../src/sim/combat/auras';
+import { ZONE1_ZONE } from '../src/sim/content/zone1';
+import { ZONE2_ZONE } from '../src/sim/content/zone2';
+import { ZONE3_ZONE } from '../src/sim/content/zone3';
+import { ITEMS } from '../src/sim/data';
+import type { PlayerMeta } from '../src/sim/sim';
+import { Sim } from '../src/sim/sim';
+import type { Consuming, Entity } from '../src/sim/types';
+
+function makeSim(cls: 'warrior' | 'priest' | 'hunter' | 'mage' = 'warrior', seed = 4242): Sim {
+  return new Sim({ seed, playerClass: cls, autoEquip: false });
+}
+
+describe('#1608: eating stacks with natural hp regen', () => {
+  // Real ctx.tickCount must be a multiple of 40 (the classic 2s regen tick) for
+  // updateRegen's early-return to pass; build one real Sim per assertion so the
+  // ctx (playerMods, healingTakenMult, ...) is the genuine seam, not a stub.
+  function healOverOneTick(sim: Sim, stamina: number, eating: Consuming | null): number {
+    const p = sim.player;
+    const meta = sim.players.get(p.id) as PlayerMeta;
+    p.stats.sta = stamina;
+    p.inCombat = false;
+    p.maxHp = 1_000_000;
+    p.hp = 500_000;
+    p.eating = eating;
+    sim.tickCount = 40;
+    const hp0 = p.hp;
+    updateRegen(sim.ctx, p, meta);
+    return p.hp - hp0;
+  }
+
+  function foodTier(foodHp: number): Consuming {
+    return {
+      itemId: 'test_food',
+      kind: 'food',
+      hpPer2s: Math.round(foodHp / 9), // CONSUME_TICKS
+      manaPer2s: 0,
+      remaining: 18,
+      ticksElapsed: 0,
+    };
+  }
+
+  // The exact foodHp tiers named in the issue (61 = baked_bread/tier 1, 117 =
+  // the best vendor/fished tier) plus the mid fished tiers and the conjured
+  // ladder, so every content/items.ts foodHp value this fix touches is covered.
+  const FOOD_TIERS = [45, 61, 90, 117, 243, 552, 980];
+
+  it.each(FOOD_TIERS)(
+    'a foodHp:%d tier heals strictly more per tick than standing idle, at every stamina',
+    (foodHp) => {
+      for (const sta of [0, 16, 20, 37, 50, 100, 300]) {
+        const idle = healOverOneTick(makeSim(), sta, null);
+        const eating = healOverOneTick(makeSim(), sta, foodTier(foodHp));
+        expect(eating).toBeGreaterThan(idle);
+      }
+    },
+  );
+
+  // The issue's own reproduction numbers: tier-1 food (61 foodHp, ~7 hp/2s) used
+  // to lose to natural regen from ~16 stamina, and the best vendor/fished tier
+  // (117 foodHp, ~13 hp/2s) from ~37 stamina. Both crossover points, and well
+  // past them, must now favor eating.
+  it('the issue-reported crossover stamina values no longer favor standing idle', () => {
+    for (const sta of [16, 37, 200]) {
+      const idle = healOverOneTick(makeSim(), sta, null);
+      const tier1 = healOverOneTick(makeSim(), sta, foodTier(61));
+      const tierBest = healOverOneTick(makeSim(), sta, foodTier(117));
+      expect(tier1).toBeGreaterThan(idle);
+      expect(tierBest).toBeGreaterThan(idle);
+    }
+  });
+
+  it('drinking already stacks with mana regen (the behavior food now matches)', () => {
+    const sim = makeSim('mage');
+    const p = sim.player;
+    const meta = sim.players.get(p.id) as PlayerMeta;
+    p.resourceType = 'mana';
+    p.maxResource = 1_000_000;
+    p.resource = 500_000;
+    p.fiveSecondRule = 10; // clears the mana-regen gate
+    p.drinking = {
+      itemId: 'test_drink',
+      kind: 'drink',
+      hpPer2s: 0,
+      manaPer2s: 40,
+      remaining: 18,
+      ticksElapsed: 0,
+    };
+    sim.tickCount = 40;
+    const r0 = p.resource;
+    updateRegen(sim.ctx, p, meta);
+    // Natural mana regen alone (no drink) for comparison.
+    const sim2 = makeSim('mage');
+    const p2 = sim2.player;
+    const meta2 = sim2.players.get(p2.id) as PlayerMeta;
+    p2.resourceType = 'mana';
+    p2.maxResource = 1_000_000;
+    p2.resource = 500_000;
+    p2.fiveSecondRule = 10;
+    p2.drinking = null;
+    sim2.tickCount = 40;
+    const r2_0 = p2.resource;
+    updateRegen(sim2.ctx, p2, meta2);
+    // Drinking healed for strictly more than the natural tick alone: the drink
+    // tick landed ON TOP of natural regen, not instead of it.
+    expect(p.resource - r0).toBeGreaterThan(p2.resource - r2_0);
+  });
+
+  // sim.ts's startCascadePlaytest/startDevSandbox freeze scripted allies' hp by
+  // setting a zero-hpPer2s "eating" session (see the comment above updateRegen's
+  // regen gate). That idiom must keep suppressing natural regen, or those dev
+  // scenarios silently start healing on their own.
+  it('a zero-hpPer2s eating session (the dev freeze idiom) still suppresses natural regen', () => {
+    const sim = makeSim();
+    sim.player.stats.sta = 100; // would otherwise regen a large, easily-observed amount
+    const healed = healOverOneTick(sim, 100, {
+      itemId: 'dev_freeze',
+      kind: 'food',
+      hpPer2s: 0,
+      manaPer2s: 0,
+      remaining: 1_000_000,
+      ticksElapsed: 0,
+    });
+    expect(healed).toBe(0);
+  });
+});
+
+describe('#1608: potionHp/potionMana ladder', () => {
+  // The reference class per resource type is the one with the SMALLEST base
+  // (no-gear) pool at that resource, per the design comment above
+  // minor_healing_potion in content/items.ts: priest for hp, hunter for mana.
+  function basePoolAt(
+    cls: 'priest' | 'hunter',
+    level: number,
+  ): { maxHp: number; maxResource: number } {
+    const sim = new Sim({ seed: 1, playerClass: cls, autoEquip: false, noPlayer: true });
+    const pid = sim.addPlayer(cls, 'Ref');
+    sim.setPlayerLevel(level, pid);
+    const p = (sim as unknown as { entities: Map<number, Entity> }).entities.get(pid) as Entity;
+    return { maxHp: p.maxHp, maxResource: p.maxResource };
+  }
+
+  // Non-null reads of the item table's optional potionHp/potionMana fields:
+  // every id below is a real potion in content/items.ts or profession_items.ts,
+  // so a missing field here is itself a real defect worth throwing on.
+  function potionHp(itemId: string): number {
+    const v = ITEMS[itemId].potionHp;
+    if (v == null) throw new Error(`${itemId} has no potionHp`);
+    return v;
+  }
+  function potionMana(itemId: string): number {
+    const v = ITEMS[itemId].potionMana;
+    if (v == null) throw new Error(`${itemId} has no potionMana`);
+    return v;
+  }
+
+  const HP_TIERS: [string, number][] = [
+    ['minor_healing_potion', ZONE1_ZONE.levelRange[1]],
+    ['lesser_healing_potion', ZONE2_ZONE.levelRange[1]],
+    ['healing_potion', ZONE3_ZONE.levelRange[1]],
+  ];
+  const MANA_TIERS: [string, number][] = [
+    ['minor_mana_potion', ZONE1_ZONE.levelRange[1]],
+    ['lesser_mana_potion', ZONE2_ZONE.levelRange[1]],
+    ['mana_potion', ZONE3_ZONE.levelRange[1]],
+  ];
+
+  it.each(HP_TIERS)(
+    "%s restores a meaningful, documented fraction (0.60-1.00) of a priest's base hp pool at its bracket top",
+    (itemId, topLevel) => {
+      const { maxHp } = basePoolAt('priest', topLevel);
+      const fraction = potionHp(itemId) / maxHp;
+      expect(fraction).toBeGreaterThanOrEqual(0.6);
+      expect(fraction).toBeLessThanOrEqual(1.0);
+    },
+  );
+
+  it.each(MANA_TIERS)(
+    "%s restores a meaningful, documented fraction (0.55-0.85) of a hunter's base mana pool at its bracket top",
+    (itemId, topLevel) => {
+      const { maxResource } = basePoolAt('hunter', topLevel);
+      const fraction = potionMana(itemId) / maxResource;
+      expect(fraction).toBeGreaterThanOrEqual(0.55);
+      expect(fraction).toBeLessThanOrEqual(0.85);
+    },
+  );
+
+  it('each hp/mana tier is a strict upgrade over the previous tier', () => {
+    expect(potionHp('lesser_healing_potion')).toBeGreaterThan(potionHp('minor_healing_potion'));
+    expect(potionHp('healing_potion')).toBeGreaterThan(potionHp('lesser_healing_potion'));
+    expect(potionMana('lesser_mana_potion')).toBeGreaterThan(potionMana('minor_mana_potion'));
+    expect(potionMana('mana_potion')).toBeGreaterThan(potionMana('lesser_mana_potion'));
+  });
+
+  // Golden pin: catches an accidental future edit to the tuned ladder without a
+  // deliberate matching change to this test's target-fraction assertions above.
+  it('pins the exact retuned values', () => {
+    expect(potionHp('minor_healing_potion')).toBe(110);
+    expect(potionHp('lesser_healing_potion')).toBe(190);
+    expect(potionHp('healing_potion')).toBe(320);
+    expect(potionMana('minor_mana_potion')).toBe(145);
+    expect(potionMana('lesser_mana_potion')).toBe(250);
+    expect(potionMana('mana_potion')).toBe(410);
+  });
+
+  // The crafted alchemy ladder (profession_items.ts) documents itself as a
+  // strict upgrade over the matching vendor tier; guard that relationship so a
+  // future vendor retune can't silently invert it (#1608 moved both in lockstep).
+  it('the crafted alchemy top tier stays a strict upgrade over the vendor top tier', () => {
+    expect(potionHp('sunpetal_healing_draught')).toBeGreaterThan(potionHp('healing_potion'));
+    expect(potionMana('sunpetal_mana_draught')).toBeGreaterThan(potionMana('mana_potion'));
+    expect(potionHp('silverleaf_healing_draught')).toBeGreaterThan(
+      potionHp('minor_healing_potion'),
+    );
+    expect(potionMana('silverleaf_mana_draught')).toBeGreaterThan(potionMana('minor_mana_potion'));
+    expect(potionHp('goldleaf_healing_draught')).toBeGreaterThan(potionHp('lesser_healing_potion'));
+    expect(potionMana('goldleaf_mana_draught')).toBeGreaterThan(potionMana('lesser_mana_potion'));
+  });
+});

--- a/tests/parity/golden/c3_aura_runner.json
+++ b/tests/parity/golden/c3_aura_runner.json
@@ -10,14 +10,14 @@
     "pulseGroundAoE over 2+ in-radius hostiles: rng.range per target, stable order",
     "class:paladin"
   ],
-  "draws": 1461,
-  "drawDigest": "1ab18d79",
+  "draws": 1453,
+  "drawDigest": "ba7b1538",
   "frames": [
     {
       "tick": 0,
       "time": 0,
-      "nextId": 946,
-      "state": "c55f269f",
+      "nextId": 832,
+      "state": "0b3de38f",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -38,7 +38,6 @@
             null
           ],
           "bank": {},
-          "bgRating": 1500,
           "cls": "paladin",
           "companionUpgrades": {},
           "counters": {},
@@ -56,7 +55,7 @@
           },
           "delveClears": {},
           "delveDaily": {},
-          "entityId": 941,
+          "entityId": 827,
           "equipment": {
             "chest": "recruit_tunic",
             "mainhand": "training_mace"
@@ -95,7 +94,7 @@
           "fallStartY": 1.5,
           "fiveSecondRule": 99,
           "hp": 95,
-          "id": 941,
+          "id": 827,
           "kind": "player",
           "level": 1,
           "lootFfaTimer": "Infinity",
@@ -139,12 +138,12 @@
     {
       "tick": 2,
       "time": 0.1,
-      "nextId": 947,
-      "state": "b0f4d892",
-      "events": "6f070264",
+      "nextId": 833,
+      "state": "2a827fce",
+      "events": "4640e84e",
       "rng": {
         "draws": 2,
-        "digest": "b6b6e0e7"
+        "digest": "b21cd587"
       },
       "label": "dot-guard",
       "players": [
@@ -161,7 +160,6 @@
             null
           ],
           "bank": {},
-          "bgRating": 1500,
           "cls": "paladin",
           "companionUpgrades": {},
           "counters": {},
@@ -205,7 +203,7 @@
           ],
           "delveClears": {},
           "delveDaily": {},
-          "entityId": 941,
+          "entityId": 827,
           "equipment": {
             "chest": "recruit_tunic",
             "mainhand": "training_mace"
@@ -246,7 +244,7 @@
           "fallStartY": 1.5,
           "fiveSecondRule": 99.1,
           "hp": 50000,
-          "id": 941,
+          "id": 827,
           "kind": "player",
           "level": 20,
           "lootFfaTimer": "Infinity",
@@ -294,11 +292,11 @@
           "dead": true,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.05,
-          "facing": -2.167014,
+          "facing": 2.293447,
           "fallStartY": 1.5,
           "fiveSecondRule": 99,
           "hostile": true,
-          "id": 946,
+          "id": 832,
           "kind": "mob",
           "level": 5,
           "lootFfaTimer": "Infinity",
@@ -308,9 +306,9 @@
           "overpowerUntil": -1,
           "petMode": "defensive",
           "pos": {
-            "x": 39.884155,
-            "y": -2.734328,
-            "z": 39.921388
+            "x": 40.105008,
+            "y": -2.725382,
+            "z": 39.907407
           },
           "potionCooldownUntil": -1,
           "respawnTimer": 59.95,
@@ -324,9 +322,9 @@
           },
           "templateId": "forest_wolf",
           "wanderTarget": {
-            "x": 32.702768,
-            "y": -2.844457,
-            "z": 35.048115
+            "x": 43.257682,
+            "y": -2.497502,
+            "z": 37.127479
           },
           "wanderTimer": 30,
           "weapon": {
@@ -340,144 +338,144 @@
     {
       "tick": 5,
       "time": 0.25,
-      "nextId": 947,
-      "state": "f2bf9e5f",
+      "nextId": 833,
+      "state": "64f4c371",
       "events": "741638a5",
       "rng": {
         "draws": 2,
-        "digest": "b6b6e0e7"
+        "digest": "b21cd587"
       }
     },
     {
       "tick": 10,
       "time": 0.5,
-      "nextId": 947,
-      "state": "f5b483e6",
+      "nextId": 833,
+      "state": "6e1bb876",
       "events": "741638a5",
       "rng": {
         "draws": 2,
-        "digest": "b6b6e0e7"
+        "digest": "b21cd587"
       }
     },
     {
       "tick": 15,
       "time": 0.75,
-      "nextId": 947,
-      "state": "502744bb",
+      "nextId": 833,
+      "state": "011ba677",
       "events": "741638a5",
       "rng": {
         "draws": 2,
-        "digest": "b6b6e0e7"
+        "digest": "b21cd587"
       }
     },
     {
       "tick": 20,
       "time": 1,
-      "nextId": 947,
-      "state": "1ae6348b",
-      "events": "5c135d1d",
+      "nextId": 833,
+      "state": "e4d1769b",
+      "events": "5c615462",
       "rng": {
         "draws": 2,
-        "digest": "b6b6e0e7"
+        "digest": "b21cd587"
       }
     },
     {
       "tick": 25,
       "time": 1.25,
-      "nextId": 947,
-      "state": "d0478523",
+      "nextId": 833,
+      "state": "0ee30b7f",
       "events": "741638a5",
       "rng": {
         "draws": 2,
-        "digest": "b6b6e0e7"
+        "digest": "b21cd587"
       }
     },
     {
       "tick": 30,
       "time": 1.5,
-      "nextId": 947,
-      "state": "dda0de3a",
+      "nextId": 833,
+      "state": "3f83a458",
       "events": "741638a5",
       "rng": {
         "draws": 2,
-        "digest": "b6b6e0e7"
+        "digest": "b21cd587"
       }
     },
     {
       "tick": 35,
       "time": 1.75,
-      "nextId": 947,
-      "state": "0089fc3a",
-      "events": "cbf21e9d",
+      "nextId": 833,
+      "state": "2c67dbec",
+      "events": "73ced772",
       "rng": {
         "draws": 2,
-        "digest": "b6b6e0e7"
+        "digest": "b21cd587"
       }
     },
     {
       "tick": 40,
       "time": 2,
-      "nextId": 947,
-      "state": "0ed92ddb",
-      "events": "fb071fae",
+      "nextId": 833,
+      "state": "c086e0d8",
+      "events": "03219e95",
       "rng": {
         "draws": 2,
-        "digest": "b6b6e0e7"
+        "digest": "b21cd587"
       }
     },
     {
       "tick": 45,
       "time": 2.25,
-      "nextId": 947,
-      "state": "43dba0ad",
+      "nextId": 833,
+      "state": "edb044e2",
       "events": "741638a5",
       "rng": {
-        "draws": 38,
-        "digest": "451513e5"
+        "draws": 36,
+        "digest": "a6240530"
       }
     },
     {
       "tick": 50,
       "time": 2.5,
-      "nextId": 947,
-      "state": "15be1dff",
+      "nextId": 833,
+      "state": "cca82ca4",
       "events": "741638a5",
       "rng": {
-        "draws": 80,
-        "digest": "bee558a6"
+        "draws": 78,
+        "digest": "237d8ce0"
       }
     },
     {
       "tick": 55,
       "time": 2.75,
-      "nextId": 947,
-      "state": "14f67911",
+      "nextId": 833,
+      "state": "e8369ad0",
       "events": "741638a5",
       "rng": {
-        "draws": 118,
-        "digest": "816c4fbe"
+        "draws": 114,
+        "digest": "a4d12f3e"
       }
     },
     {
       "tick": 60,
       "time": 3,
-      "nextId": 947,
-      "state": "94aa21af",
+      "nextId": 833,
+      "state": "db115aa6",
       "events": "741638a5",
       "rng": {
-        "draws": 152,
-        "digest": "062bd2ad"
+        "draws": 145,
+        "digest": "2825508b"
       }
     },
     {
       "tick": 62,
       "time": 3.1,
-      "nextId": 947,
-      "state": "a1ad29f7",
+      "nextId": 833,
+      "state": "c6cd8b4e",
       "events": "741638a5",
       "rng": {
-        "draws": 165,
-        "digest": "1d1cca78"
+        "draws": 160,
+        "digest": "cda87888"
       },
       "label": "regen-expiry",
       "players": [
@@ -494,7 +492,6 @@
             null
           ],
           "bank": {},
-          "bgRating": 1500,
           "cls": "paladin",
           "companionUpgrades": {},
           "counters": {},
@@ -541,7 +538,7 @@
           ],
           "delveClears": {},
           "delveDaily": {},
-          "entityId": 941,
+          "entityId": 827,
           "equipment": {
             "chest": "recruit_tunic",
             "mainhand": "training_mace"
@@ -595,8 +592,8 @@
           },
           "fallStartY": 1.5,
           "fiveSecondRule": 102,
-          "hp": 798,
-          "id": 941,
+          "hp": 429,
+          "id": 827,
           "kind": "player",
           "level": 20,
           "lootFfaTimer": "Infinity",
@@ -644,11 +641,11 @@
           "dead": true,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.05,
-          "facing": -2.167014,
+          "facing": 2.293447,
           "fallStartY": 1.5,
           "fiveSecondRule": 99,
           "hostile": true,
-          "id": 946,
+          "id": 832,
           "kind": "mob",
           "level": 5,
           "lootFfaTimer": "Infinity",
@@ -658,9 +655,9 @@
           "overpowerUntil": -1,
           "petMode": "defensive",
           "pos": {
-            "x": 39.884155,
-            "y": -2.734328,
-            "z": 39.921388
+            "x": 40.105008,
+            "y": -2.725382,
+            "z": 39.907407
           },
           "potionCooldownUntil": -1,
           "respawnTimer": 56.95,
@@ -674,9 +671,9 @@
           },
           "templateId": "forest_wolf",
           "wanderTarget": {
-            "x": 32.702768,
-            "y": -2.844457,
-            "z": 35.048115
+            "x": 43.257682,
+            "y": -2.497502,
+            "z": 37.127479
           },
           "wanderTimer": 30,
           "weapon": {
@@ -690,276 +687,276 @@
     {
       "tick": 65,
       "time": 3.25,
-      "nextId": 949,
-      "state": "9bc46865",
-      "events": "71c216d4",
+      "nextId": 835,
+      "state": "456f9612",
+      "events": "a4a1d852",
       "rng": {
         "draws": 192,
-        "digest": "73aae3f5"
+        "digest": "ea4b6e6e"
       }
     },
     {
       "tick": 70,
       "time": 3.5,
-      "nextId": 949,
-      "state": "89ab2abf",
+      "nextId": 835,
+      "state": "d3df14e1",
       "events": "741638a5",
       "rng": {
         "draws": 234,
-        "digest": "1e9e29c3"
+        "digest": "2f1fbe0a"
       }
     },
     {
       "tick": 75,
       "time": 3.75,
-      "nextId": 949,
-      "state": "6a57a236",
+      "nextId": 835,
+      "state": "67bbc6d9",
       "events": "741638a5",
       "rng": {
-        "draws": 270,
-        "digest": "5d5c19b4"
+        "draws": 275,
+        "digest": "5e9c4c7b"
       }
     },
     {
       "tick": 80,
       "time": 4,
-      "nextId": 949,
-      "state": "f0c07605",
+      "nextId": 835,
+      "state": "a91f233c",
       "events": "741638a5",
       "rng": {
-        "draws": 294,
-        "digest": "a5f8da8a"
+        "draws": 298,
+        "digest": "2343d694"
       }
     },
     {
       "tick": 85,
       "time": 4.25,
-      "nextId": 949,
-      "state": "01c2dc5a",
+      "nextId": 835,
+      "state": "994c2e4c",
       "events": "741638a5",
       "rng": {
-        "draws": 339,
-        "digest": "3eacf3d0"
+        "draws": 341,
+        "digest": "a83a9eeb"
       }
     },
     {
       "tick": 90,
       "time": 4.5,
-      "nextId": 949,
-      "state": "6b1b4436",
+      "nextId": 835,
+      "state": "a6af2935",
       "events": "741638a5",
       "rng": {
-        "draws": 390,
-        "digest": "90a37aae"
+        "draws": 386,
+        "digest": "fe3dbb3f"
       }
     },
     {
       "tick": 95,
       "time": 4.75,
-      "nextId": 949,
-      "state": "3cc734bd",
+      "nextId": 835,
+      "state": "84f05c63",
       "events": "741638a5",
       "rng": {
-        "draws": 464,
-        "digest": "d1ddf931"
+        "draws": 457,
+        "digest": "0a296592"
       }
     },
     {
       "tick": 100,
       "time": 5,
-      "nextId": 949,
-      "state": "fe39c5ac",
+      "nextId": 835,
+      "state": "3509ccdb",
       "events": "741638a5",
       "rng": {
-        "draws": 505,
-        "digest": "af6bea56"
+        "draws": 496,
+        "digest": "02f5422d"
       }
     },
     {
       "tick": 105,
       "time": 5.25,
-      "nextId": 949,
-      "state": "ecd6e1a6",
-      "events": "d628aab0",
+      "nextId": 835,
+      "state": "41800896",
+      "events": "98c2f5c2",
       "rng": {
-        "draws": 552,
-        "digest": "229d1c57"
+        "draws": 539,
+        "digest": "59e08d6d"
       }
     },
     {
       "tick": 110,
       "time": 5.5,
-      "nextId": 949,
-      "state": "0be40916",
+      "nextId": 835,
+      "state": "3cf56a2c",
       "events": "741638a5",
       "rng": {
-        "draws": 597,
-        "digest": "f5ec19e9"
+        "draws": 583,
+        "digest": "e65a6710"
       }
     },
     {
       "tick": 115,
       "time": 5.75,
-      "nextId": 949,
-      "state": "5dc329e5",
+      "nextId": 835,
+      "state": "23e29cdd",
       "events": "741638a5",
       "rng": {
-        "draws": 656,
-        "digest": "a9d876e5"
+        "draws": 645,
+        "digest": "5f2cb70c"
       }
     },
     {
       "tick": 120,
       "time": 6,
-      "nextId": 949,
-      "state": "754fc82d",
+      "nextId": 835,
+      "state": "c078b6d3",
       "events": "741638a5",
       "rng": {
-        "draws": 729,
-        "digest": "bd4b35e6"
+        "draws": 708,
+        "digest": "9efb4f19"
       }
     },
     {
       "tick": 125,
       "time": 6.25,
-      "nextId": 949,
-      "state": "94b1743d",
+      "nextId": 835,
+      "state": "5ab3cb55",
       "events": "741638a5",
       "rng": {
-        "draws": 792,
-        "digest": "9d18ed0b"
+        "draws": 770,
+        "digest": "334e7a0a"
       }
     },
     {
       "tick": 130,
       "time": 6.5,
-      "nextId": 949,
-      "state": "2e7ff65f",
+      "nextId": 835,
+      "state": "ed2e2b35",
       "events": "741638a5",
       "rng": {
-        "draws": 844,
-        "digest": "99e9f000"
+        "draws": 821,
+        "digest": "850cd47b"
       }
     },
     {
       "tick": 135,
       "time": 6.75,
-      "nextId": 949,
-      "state": "8e637622",
+      "nextId": 835,
+      "state": "911b1d12",
       "events": "741638a5",
       "rng": {
-        "draws": 901,
-        "digest": "7837db55"
+        "draws": 882,
+        "digest": "bd0eddea"
       }
     },
     {
       "tick": 140,
       "time": 7,
-      "nextId": 949,
-      "state": "436dac7c",
+      "nextId": 835,
+      "state": "6a5f4c3a",
       "events": "741638a5",
       "rng": {
-        "draws": 947,
-        "digest": "7265a410"
+        "draws": 932,
+        "digest": "fa131332"
       }
     },
     {
       "tick": 145,
       "time": 7.25,
-      "nextId": 949,
-      "state": "1547f27d",
-      "events": "ab14dfbc",
+      "nextId": 835,
+      "state": "5bdabe05",
+      "events": "b2a4f590",
       "rng": {
-        "draws": 991,
-        "digest": "ea69076c"
+        "draws": 993,
+        "digest": "9455c862"
       }
     },
     {
       "tick": 150,
       "time": 7.5,
-      "nextId": 949,
-      "state": "d327b353",
+      "nextId": 835,
+      "state": "fb0ff23b",
       "events": "741638a5",
       "rng": {
-        "draws": 1058,
-        "digest": "0afa97c1"
+        "draws": 1050,
+        "digest": "5b102576"
       }
     },
     {
       "tick": 155,
       "time": 7.75,
-      "nextId": 949,
-      "state": "8c4a0f90",
+      "nextId": 835,
+      "state": "63e8987c",
       "events": "741638a5",
       "rng": {
-        "draws": 1124,
-        "digest": "198ff4e6"
+        "draws": 1115,
+        "digest": "2be44937"
       }
     },
     {
       "tick": 160,
       "time": 8,
-      "nextId": 949,
-      "state": "4510654e",
+      "nextId": 835,
+      "state": "bf04aada",
       "events": "741638a5",
       "rng": {
-        "draws": 1165,
-        "digest": "a4a0fc4d"
+        "draws": 1154,
+        "digest": "99528a7e"
       }
     },
     {
       "tick": 165,
       "time": 8.25,
-      "nextId": 949,
-      "state": "e6c771a2",
+      "nextId": 835,
+      "state": "53c9c304",
       "events": "741638a5",
       "rng": {
-        "draws": 1236,
-        "digest": "3b013a35"
+        "draws": 1215,
+        "digest": "f235f9d2"
       }
     },
     {
       "tick": 170,
       "time": 8.5,
-      "nextId": 949,
-      "state": "861d89ee",
+      "nextId": 835,
+      "state": "18066680",
       "events": "741638a5",
       "rng": {
-        "draws": 1307,
-        "digest": "2e7a0579"
+        "draws": 1285,
+        "digest": "46583eef"
       }
     },
     {
       "tick": 175,
       "time": 8.75,
-      "nextId": 949,
-      "state": "08024287",
+      "nextId": 835,
+      "state": "eeb2ed0d",
       "events": "741638a5",
       "rng": {
-        "draws": 1373,
-        "digest": "02bc8cde"
+        "draws": 1359,
+        "digest": "c1d16f06"
       }
     },
     {
       "tick": 180,
       "time": 9,
-      "nextId": 949,
-      "state": "abae019b",
+      "nextId": 835,
+      "state": "a928ead5",
       "events": "741638a5",
       "rng": {
-        "draws": 1441,
-        "digest": "79f64203"
+        "draws": 1431,
+        "digest": "72043e63"
       }
     },
     {
       "tick": 182,
       "time": 9.1,
-      "nextId": 949,
-      "state": "03ff6ca4",
-      "events": "30310dfe",
+      "nextId": 835,
+      "state": "1c229022",
+      "events": "aa52975c",
       "rng": {
-        "draws": 1461,
-        "digest": "1ab18d79"
+        "draws": 1453,
+        "digest": "ba7b1538"
       },
       "label": "final",
       "players": [
@@ -976,18 +973,17 @@
             null
           ],
           "bank": {},
-          "bgRating": 1500,
           "cls": "paladin",
           "companionUpgrades": {},
           "counters": {
-            "damageDealt": 254,
-            "damageTaken": 26
+            "damageDealt": 263,
+            "damageTaken": 34
           },
           "craftSkills": {},
           "craftThrottle": {},
           "deedStats": {
             "counters": {
-              "damageDealt": 254
+              "damageDealt": 263
             },
             "dungeonClears": {},
             "itemsDiscovered": [
@@ -1028,7 +1024,7 @@
           ],
           "delveClears": {},
           "delveDaily": {},
-          "entityId": 941,
+          "entityId": 827,
           "equipment": {
             "chest": "recruit_tunic",
             "mainhand": "training_mace"
@@ -1074,8 +1070,8 @@
           "dodgeChance": 0.068,
           "fallStartY": 1.5,
           "fiveSecondRule": 6,
-          "hp": 772,
-          "id": 941,
+          "hp": 395,
+          "id": 827,
           "inCombat": true,
           "kind": "player",
           "level": 20,
@@ -1092,7 +1088,7 @@
             "z": -2
           },
           "potionCooldownUntil": -1,
-          "resource": 650,
+          "resource": 600,
           "resourceType": "mana",
           "spawnPos": {
             "x": 2,
@@ -1124,11 +1120,11 @@
           "dead": true,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.05,
-          "facing": -2.167014,
+          "facing": 2.293447,
           "fallStartY": 1.5,
           "fiveSecondRule": 99,
           "hostile": true,
-          "id": 946,
+          "id": 832,
           "kind": "mob",
           "level": 5,
           "lootFfaTimer": "Infinity",
@@ -1138,9 +1134,9 @@
           "overpowerUntil": -1,
           "petMode": "defensive",
           "pos": {
-            "x": 39.884155,
-            "y": -2.734328,
-            "z": 39.921388
+            "x": 40.105008,
+            "y": -2.725382,
+            "z": 39.907407
           },
           "potionCooldownUntil": -1,
           "respawnTimer": 50.95,
@@ -1154,9 +1150,9 @@
           },
           "templateId": "forest_wolf",
           "wanderTarget": {
-            "x": 32.702768,
-            "y": -2.844457,
-            "z": 35.048115
+            "x": 43.257682,
+            "y": -2.497502,
+            "z": 37.127479
           },
           "wanderTimer": 30,
           "weapon": {
@@ -1166,7 +1162,7 @@
           }
         },
         {
-          "aggroTargetId": 941,
+          "aggroTargetId": 827,
           "aiState": "attack",
           "combatTimer": 0.05,
           "comboUntil": -1,
@@ -1177,8 +1173,8 @@
           "fallStartY": 1.5,
           "fiveSecondRule": 99,
           "hostile": true,
-          "hp": 39871,
-          "id": 947,
+          "hp": 39873,
+          "id": 833,
           "inCombat": true,
           "kind": "mob",
           "leashAnchor": {
@@ -1205,12 +1201,12 @@
             "armor": 40
           },
           "swingTimer": 0.05,
-          "tappedById": 941,
+          "tappedById": 827,
           "templateId": "forest_wolf",
           "threat": [
             [
-              941,
-              130
+              827,
+              128
             ]
           ],
           "weapon": {
@@ -1220,7 +1216,7 @@
           }
         },
         {
-          "aggroTargetId": 941,
+          "aggroTargetId": 827,
           "aiState": "attack",
           "combatTimer": 0.05,
           "comboUntil": -1,
@@ -1231,8 +1227,8 @@
           "fallStartY": 1.5,
           "fiveSecondRule": 99,
           "hostile": true,
-          "hp": 39875,
-          "id": 948,
+          "hp": 39864,
+          "id": 834,
           "inCombat": true,
           "kind": "mob",
           "leashAnchor": {
@@ -1259,12 +1255,12 @@
             "armor": 40
           },
           "swingTimer": 0.05,
-          "tappedById": 941,
+          "tappedById": 827,
           "templateId": "forest_wolf",
           "threat": [
             [
-              941,
-              126
+              827,
+              137
             ]
           ],
           "weapon": {

--- a/tests/parity/golden/c3_aura_runner.json
+++ b/tests/parity/golden/c3_aura_runner.json
@@ -10,14 +10,14 @@
     "pulseGroundAoE over 2+ in-radius hostiles: rng.range per target, stable order",
     "class:paladin"
   ],
-  "draws": 1453,
-  "drawDigest": "ba7b1538",
+  "draws": 1461,
+  "drawDigest": "1ab18d79",
   "frames": [
     {
       "tick": 0,
       "time": 0,
-      "nextId": 832,
-      "state": "0b3de38f",
+      "nextId": 946,
+      "state": "c55f269f",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -38,6 +38,7 @@
             null
           ],
           "bank": {},
+          "bgRating": 1500,
           "cls": "paladin",
           "companionUpgrades": {},
           "counters": {},
@@ -55,7 +56,7 @@
           },
           "delveClears": {},
           "delveDaily": {},
-          "entityId": 827,
+          "entityId": 941,
           "equipment": {
             "chest": "recruit_tunic",
             "mainhand": "training_mace"
@@ -94,7 +95,7 @@
           "fallStartY": 1.5,
           "fiveSecondRule": 99,
           "hp": 95,
-          "id": 827,
+          "id": 941,
           "kind": "player",
           "level": 1,
           "lootFfaTimer": "Infinity",
@@ -138,12 +139,12 @@
     {
       "tick": 2,
       "time": 0.1,
-      "nextId": 833,
-      "state": "2a827fce",
-      "events": "4640e84e",
+      "nextId": 947,
+      "state": "b0f4d892",
+      "events": "6f070264",
       "rng": {
         "draws": 2,
-        "digest": "b21cd587"
+        "digest": "b6b6e0e7"
       },
       "label": "dot-guard",
       "players": [
@@ -160,6 +161,7 @@
             null
           ],
           "bank": {},
+          "bgRating": 1500,
           "cls": "paladin",
           "companionUpgrades": {},
           "counters": {},
@@ -203,7 +205,7 @@
           ],
           "delveClears": {},
           "delveDaily": {},
-          "entityId": 827,
+          "entityId": 941,
           "equipment": {
             "chest": "recruit_tunic",
             "mainhand": "training_mace"
@@ -244,7 +246,7 @@
           "fallStartY": 1.5,
           "fiveSecondRule": 99.1,
           "hp": 50000,
-          "id": 827,
+          "id": 941,
           "kind": "player",
           "level": 20,
           "lootFfaTimer": "Infinity",
@@ -292,11 +294,11 @@
           "dead": true,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.05,
-          "facing": 2.293447,
+          "facing": -2.167014,
           "fallStartY": 1.5,
           "fiveSecondRule": 99,
           "hostile": true,
-          "id": 832,
+          "id": 946,
           "kind": "mob",
           "level": 5,
           "lootFfaTimer": "Infinity",
@@ -306,9 +308,9 @@
           "overpowerUntil": -1,
           "petMode": "defensive",
           "pos": {
-            "x": 40.105008,
-            "y": -2.725382,
-            "z": 39.907407
+            "x": 39.884155,
+            "y": -2.734328,
+            "z": 39.921388
           },
           "potionCooldownUntil": -1,
           "respawnTimer": 59.95,
@@ -322,9 +324,9 @@
           },
           "templateId": "forest_wolf",
           "wanderTarget": {
-            "x": 43.257682,
-            "y": -2.497502,
-            "z": 37.127479
+            "x": 32.702768,
+            "y": -2.844457,
+            "z": 35.048115
           },
           "wanderTimer": 30,
           "weapon": {
@@ -338,144 +340,144 @@
     {
       "tick": 5,
       "time": 0.25,
-      "nextId": 833,
-      "state": "64f4c371",
+      "nextId": 947,
+      "state": "ec09e488",
       "events": "741638a5",
       "rng": {
         "draws": 2,
-        "digest": "b21cd587"
+        "digest": "b6b6e0e7"
       }
     },
     {
       "tick": 10,
       "time": 0.5,
-      "nextId": 833,
-      "state": "6e1bb876",
+      "nextId": 947,
+      "state": "a31d3441",
       "events": "741638a5",
       "rng": {
         "draws": 2,
-        "digest": "b21cd587"
+        "digest": "b6b6e0e7"
       }
     },
     {
       "tick": 15,
       "time": 0.75,
-      "nextId": 833,
-      "state": "011ba677",
+      "nextId": 947,
+      "state": "108b4768",
       "events": "741638a5",
       "rng": {
         "draws": 2,
-        "digest": "b21cd587"
+        "digest": "b6b6e0e7"
       }
     },
     {
       "tick": 20,
       "time": 1,
-      "nextId": 833,
-      "state": "e4d1769b",
-      "events": "5c615462",
+      "nextId": 947,
+      "state": "0c8506fe",
+      "events": "5c135d1d",
       "rng": {
         "draws": 2,
-        "digest": "b21cd587"
+        "digest": "b6b6e0e7"
       }
     },
     {
       "tick": 25,
       "time": 1.25,
-      "nextId": 833,
-      "state": "0ee30b7f",
+      "nextId": 947,
+      "state": "47eab222",
       "events": "741638a5",
       "rng": {
         "draws": 2,
-        "digest": "b21cd587"
+        "digest": "b6b6e0e7"
       }
     },
     {
       "tick": 30,
       "time": 1.5,
-      "nextId": 833,
-      "state": "3f83a458",
+      "nextId": 947,
+      "state": "8b7797e3",
       "events": "741638a5",
       "rng": {
         "draws": 2,
-        "digest": "b21cd587"
+        "digest": "b6b6e0e7"
       }
     },
     {
       "tick": 35,
       "time": 1.75,
-      "nextId": 833,
-      "state": "2c67dbec",
-      "events": "73ced772",
+      "nextId": 947,
+      "state": "d75398c4",
+      "events": "cbf21e9d",
       "rng": {
         "draws": 2,
-        "digest": "b21cd587"
+        "digest": "b6b6e0e7"
       }
     },
     {
       "tick": 40,
       "time": 2,
-      "nextId": 833,
-      "state": "c086e0d8",
-      "events": "03219e95",
+      "nextId": 947,
+      "state": "fadbe000",
+      "events": "2e66f8b6",
       "rng": {
         "draws": 2,
-        "digest": "b21cd587"
+        "digest": "b6b6e0e7"
       }
     },
     {
       "tick": 45,
       "time": 2.25,
-      "nextId": 833,
-      "state": "edb044e2",
+      "nextId": 947,
+      "state": "e09a8b6a",
       "events": "741638a5",
       "rng": {
-        "draws": 36,
-        "digest": "a6240530"
+        "draws": 38,
+        "digest": "451513e5"
       }
     },
     {
       "tick": 50,
       "time": 2.5,
-      "nextId": 833,
-      "state": "cca82ca4",
+      "nextId": 947,
+      "state": "3efc68ac",
       "events": "741638a5",
       "rng": {
-        "draws": 78,
-        "digest": "237d8ce0"
+        "draws": 80,
+        "digest": "bee558a6"
       }
     },
     {
       "tick": 55,
       "time": 2.75,
-      "nextId": 833,
-      "state": "e8369ad0",
+      "nextId": 947,
+      "state": "c3c9d266",
       "events": "741638a5",
       "rng": {
-        "draws": 114,
-        "digest": "a4d12f3e"
+        "draws": 118,
+        "digest": "816c4fbe"
       }
     },
     {
       "tick": 60,
       "time": 3,
-      "nextId": 833,
-      "state": "db115aa6",
+      "nextId": 947,
+      "state": "693f9974",
       "events": "741638a5",
       "rng": {
-        "draws": 145,
-        "digest": "2825508b"
+        "draws": 152,
+        "digest": "062bd2ad"
       }
     },
     {
       "tick": 62,
       "time": 3.1,
-      "nextId": 833,
-      "state": "c6cd8b4e",
+      "nextId": 947,
+      "state": "3050f2dc",
       "events": "741638a5",
       "rng": {
-        "draws": 160,
-        "digest": "cda87888"
+        "draws": 165,
+        "digest": "1d1cca78"
       },
       "label": "regen-expiry",
       "players": [
@@ -492,6 +494,7 @@
             null
           ],
           "bank": {},
+          "bgRating": 1500,
           "cls": "paladin",
           "companionUpgrades": {},
           "counters": {},
@@ -538,7 +541,7 @@
           ],
           "delveClears": {},
           "delveDaily": {},
-          "entityId": 827,
+          "entityId": 941,
           "equipment": {
             "chest": "recruit_tunic",
             "mainhand": "training_mace"
@@ -593,7 +596,7 @@
           "fallStartY": 1.5,
           "fiveSecondRule": 102,
           "hp": 429,
-          "id": 827,
+          "id": 941,
           "kind": "player",
           "level": 20,
           "lootFfaTimer": "Infinity",
@@ -641,11 +644,11 @@
           "dead": true,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.05,
-          "facing": 2.293447,
+          "facing": -2.167014,
           "fallStartY": 1.5,
           "fiveSecondRule": 99,
           "hostile": true,
-          "id": 832,
+          "id": 946,
           "kind": "mob",
           "level": 5,
           "lootFfaTimer": "Infinity",
@@ -655,9 +658,9 @@
           "overpowerUntil": -1,
           "petMode": "defensive",
           "pos": {
-            "x": 40.105008,
-            "y": -2.725382,
-            "z": 39.907407
+            "x": 39.884155,
+            "y": -2.734328,
+            "z": 39.921388
           },
           "potionCooldownUntil": -1,
           "respawnTimer": 56.95,
@@ -671,9 +674,9 @@
           },
           "templateId": "forest_wolf",
           "wanderTarget": {
-            "x": 43.257682,
-            "y": -2.497502,
-            "z": 37.127479
+            "x": 32.702768,
+            "y": -2.844457,
+            "z": 35.048115
           },
           "wanderTimer": 30,
           "weapon": {
@@ -687,276 +690,276 @@
     {
       "tick": 65,
       "time": 3.25,
-      "nextId": 835,
-      "state": "456f9612",
-      "events": "a4a1d852",
+      "nextId": 949,
+      "state": "90706072",
+      "events": "71c216d4",
       "rng": {
         "draws": 192,
-        "digest": "ea4b6e6e"
+        "digest": "73aae3f5"
       }
     },
     {
       "tick": 70,
       "time": 3.5,
-      "nextId": 835,
-      "state": "d3df14e1",
+      "nextId": 949,
+      "state": "c6df6238",
       "events": "741638a5",
       "rng": {
         "draws": 234,
-        "digest": "2f1fbe0a"
+        "digest": "1e9e29c3"
       }
     },
     {
       "tick": 75,
       "time": 3.75,
-      "nextId": 835,
-      "state": "67bbc6d9",
+      "nextId": 949,
+      "state": "9b552735",
       "events": "741638a5",
       "rng": {
-        "draws": 275,
-        "digest": "5e9c4c7b"
+        "draws": 270,
+        "digest": "5d5c19b4"
       }
     },
     {
       "tick": 80,
       "time": 4,
-      "nextId": 835,
-      "state": "a91f233c",
-      "events": "741638a5",
+      "nextId": 949,
+      "state": "0317af52",
+      "events": "2e66f8b6",
       "rng": {
-        "draws": 298,
-        "digest": "2343d694"
+        "draws": 294,
+        "digest": "a5f8da8a"
       }
     },
     {
       "tick": 85,
       "time": 4.25,
-      "nextId": 835,
-      "state": "994c2e4c",
+      "nextId": 949,
+      "state": "0a29a2e9",
       "events": "741638a5",
       "rng": {
-        "draws": 341,
-        "digest": "a83a9eeb"
+        "draws": 339,
+        "digest": "3eacf3d0"
       }
     },
     {
       "tick": 90,
       "time": 4.5,
-      "nextId": 835,
-      "state": "a6af2935",
+      "nextId": 949,
+      "state": "fdb7d489",
       "events": "741638a5",
       "rng": {
-        "draws": 386,
-        "digest": "fe3dbb3f"
+        "draws": 390,
+        "digest": "90a37aae"
       }
     },
     {
       "tick": 95,
       "time": 4.75,
-      "nextId": 835,
-      "state": "84f05c63",
+      "nextId": 949,
+      "state": "5853cbe2",
       "events": "741638a5",
       "rng": {
-        "draws": 457,
-        "digest": "0a296592"
+        "draws": 464,
+        "digest": "d1ddf931"
       }
     },
     {
       "tick": 100,
       "time": 5,
-      "nextId": 835,
-      "state": "3509ccdb",
+      "nextId": 949,
+      "state": "64733d33",
       "events": "741638a5",
       "rng": {
-        "draws": 496,
-        "digest": "02f5422d"
+        "draws": 505,
+        "digest": "af6bea56"
       }
     },
     {
       "tick": 105,
       "time": 5.25,
-      "nextId": 835,
-      "state": "41800896",
-      "events": "98c2f5c2",
+      "nextId": 949,
+      "state": "916dc45b",
+      "events": "d628aab0",
       "rng": {
-        "draws": 539,
-        "digest": "59e08d6d"
+        "draws": 552,
+        "digest": "229d1c57"
       }
     },
     {
       "tick": 110,
       "time": 5.5,
-      "nextId": 835,
-      "state": "3cf56a2c",
+      "nextId": 949,
+      "state": "b131d46b",
       "events": "741638a5",
       "rng": {
-        "draws": 583,
-        "digest": "e65a6710"
+        "draws": 597,
+        "digest": "f5ec19e9"
       }
     },
     {
       "tick": 115,
       "time": 5.75,
-      "nextId": 835,
-      "state": "23e29cdd",
+      "nextId": 949,
+      "state": "0ed73984",
       "events": "741638a5",
       "rng": {
-        "draws": 645,
-        "digest": "5f2cb70c"
+        "draws": 656,
+        "digest": "a9d876e5"
       }
     },
     {
       "tick": 120,
       "time": 6,
-      "nextId": 835,
-      "state": "c078b6d3",
+      "nextId": 949,
+      "state": "3cb3db44",
       "events": "741638a5",
       "rng": {
-        "draws": 708,
-        "digest": "9efb4f19"
+        "draws": 729,
+        "digest": "bd4b35e6"
       }
     },
     {
       "tick": 125,
       "time": 6.25,
-      "nextId": 835,
-      "state": "5ab3cb55",
+      "nextId": 949,
+      "state": "3e3d8f28",
       "events": "741638a5",
       "rng": {
-        "draws": 770,
-        "digest": "334e7a0a"
+        "draws": 792,
+        "digest": "9d18ed0b"
       }
     },
     {
       "tick": 130,
       "time": 6.5,
-      "nextId": 835,
-      "state": "ed2e2b35",
+      "nextId": 949,
+      "state": "85b2c5d2",
       "events": "741638a5",
       "rng": {
-        "draws": 821,
-        "digest": "850cd47b"
+        "draws": 844,
+        "digest": "99e9f000"
       }
     },
     {
       "tick": 135,
       "time": 6.75,
-      "nextId": 835,
-      "state": "911b1d12",
+      "nextId": 949,
+      "state": "97adf233",
       "events": "741638a5",
       "rng": {
-        "draws": 882,
-        "digest": "bd0eddea"
+        "draws": 901,
+        "digest": "7837db55"
       }
     },
     {
       "tick": 140,
       "time": 7,
-      "nextId": 835,
-      "state": "6a5f4c3a",
+      "nextId": 949,
+      "state": "9ecdcbd5",
       "events": "741638a5",
       "rng": {
-        "draws": 932,
-        "digest": "fa131332"
+        "draws": 947,
+        "digest": "7265a410"
       }
     },
     {
       "tick": 145,
       "time": 7.25,
-      "nextId": 835,
-      "state": "5bdabe05",
-      "events": "b2a4f590",
+      "nextId": 949,
+      "state": "7dff64a5",
+      "events": "ab14dfbc",
       "rng": {
-        "draws": 993,
-        "digest": "9455c862"
+        "draws": 991,
+        "digest": "ea69076c"
       }
     },
     {
       "tick": 150,
       "time": 7.5,
-      "nextId": 835,
-      "state": "fb0ff23b",
+      "nextId": 949,
+      "state": "18ee838b",
       "events": "741638a5",
       "rng": {
-        "draws": 1050,
-        "digest": "5b102576"
+        "draws": 1058,
+        "digest": "0afa97c1"
       }
     },
     {
       "tick": 155,
       "time": 7.75,
-      "nextId": 835,
-      "state": "63e8987c",
+      "nextId": 949,
+      "state": "0e5dd77c",
       "events": "741638a5",
       "rng": {
-        "draws": 1115,
-        "digest": "2be44937"
+        "draws": 1124,
+        "digest": "198ff4e6"
       }
     },
     {
       "tick": 160,
       "time": 8,
-      "nextId": 835,
-      "state": "bf04aada",
+      "nextId": 949,
+      "state": "5a5d6de2",
       "events": "741638a5",
       "rng": {
-        "draws": 1154,
-        "digest": "99528a7e"
+        "draws": 1165,
+        "digest": "a4a0fc4d"
       }
     },
     {
       "tick": 165,
       "time": 8.25,
-      "nextId": 835,
-      "state": "53c9c304",
+      "nextId": 949,
+      "state": "8b7e1336",
       "events": "741638a5",
       "rng": {
-        "draws": 1215,
-        "digest": "f235f9d2"
+        "draws": 1236,
+        "digest": "3b013a35"
       }
     },
     {
       "tick": 170,
       "time": 8.5,
-      "nextId": 835,
-      "state": "18066680",
+      "nextId": 949,
+      "state": "be5a80ca",
       "events": "741638a5",
       "rng": {
-        "draws": 1285,
-        "digest": "46583eef"
+        "draws": 1307,
+        "digest": "2e7a0579"
       }
     },
     {
       "tick": 175,
       "time": 8.75,
-      "nextId": 835,
-      "state": "eeb2ed0d",
+      "nextId": 949,
+      "state": "1ee04fdf",
       "events": "741638a5",
       "rng": {
-        "draws": 1359,
-        "digest": "c1d16f06"
+        "draws": 1373,
+        "digest": "02bc8cde"
       }
     },
     {
       "tick": 180,
       "time": 9,
-      "nextId": 835,
-      "state": "a928ead5",
+      "nextId": 949,
+      "state": "a8c0387b",
       "events": "741638a5",
       "rng": {
-        "draws": 1431,
-        "digest": "72043e63"
+        "draws": 1441,
+        "digest": "79f64203"
       }
     },
     {
       "tick": 182,
       "time": 9.1,
-      "nextId": 835,
-      "state": "1c229022",
-      "events": "aa52975c",
+      "nextId": 949,
+      "state": "7e5da2b4",
+      "events": "30310dfe",
       "rng": {
-        "draws": 1453,
-        "digest": "ba7b1538"
+        "draws": 1461,
+        "digest": "1ab18d79"
       },
       "label": "final",
       "players": [
@@ -973,17 +976,18 @@
             null
           ],
           "bank": {},
+          "bgRating": 1500,
           "cls": "paladin",
           "companionUpgrades": {},
           "counters": {
-            "damageDealt": 263,
-            "damageTaken": 34
+            "damageDealt": 254,
+            "damageTaken": 26
           },
           "craftSkills": {},
           "craftThrottle": {},
           "deedStats": {
             "counters": {
-              "damageDealt": 263
+              "damageDealt": 254
             },
             "dungeonClears": {},
             "itemsDiscovered": [
@@ -1024,7 +1028,7 @@
           ],
           "delveClears": {},
           "delveDaily": {},
-          "entityId": 827,
+          "entityId": 941,
           "equipment": {
             "chest": "recruit_tunic",
             "mainhand": "training_mace"
@@ -1070,8 +1074,8 @@
           "dodgeChance": 0.068,
           "fallStartY": 1.5,
           "fiveSecondRule": 6,
-          "hp": 395,
-          "id": 827,
+          "hp": 493,
+          "id": 941,
           "inCombat": true,
           "kind": "player",
           "level": 20,
@@ -1088,7 +1092,7 @@
             "z": -2
           },
           "potionCooldownUntil": -1,
-          "resource": 600,
+          "resource": 650,
           "resourceType": "mana",
           "spawnPos": {
             "x": 2,
@@ -1120,11 +1124,11 @@
           "dead": true,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.05,
-          "facing": 2.293447,
+          "facing": -2.167014,
           "fallStartY": 1.5,
           "fiveSecondRule": 99,
           "hostile": true,
-          "id": 832,
+          "id": 946,
           "kind": "mob",
           "level": 5,
           "lootFfaTimer": "Infinity",
@@ -1134,9 +1138,9 @@
           "overpowerUntil": -1,
           "petMode": "defensive",
           "pos": {
-            "x": 40.105008,
-            "y": -2.725382,
-            "z": 39.907407
+            "x": 39.884155,
+            "y": -2.734328,
+            "z": 39.921388
           },
           "potionCooldownUntil": -1,
           "respawnTimer": 50.95,
@@ -1150,9 +1154,9 @@
           },
           "templateId": "forest_wolf",
           "wanderTarget": {
-            "x": 43.257682,
-            "y": -2.497502,
-            "z": 37.127479
+            "x": 32.702768,
+            "y": -2.844457,
+            "z": 35.048115
           },
           "wanderTimer": 30,
           "weapon": {
@@ -1162,7 +1166,7 @@
           }
         },
         {
-          "aggroTargetId": 827,
+          "aggroTargetId": 941,
           "aiState": "attack",
           "combatTimer": 0.05,
           "comboUntil": -1,
@@ -1173,8 +1177,8 @@
           "fallStartY": 1.5,
           "fiveSecondRule": 99,
           "hostile": true,
-          "hp": 39873,
-          "id": 833,
+          "hp": 39871,
+          "id": 947,
           "inCombat": true,
           "kind": "mob",
           "leashAnchor": {
@@ -1201,12 +1205,12 @@
             "armor": 40
           },
           "swingTimer": 0.05,
-          "tappedById": 827,
+          "tappedById": 941,
           "templateId": "forest_wolf",
           "threat": [
             [
-              827,
-              128
+              941,
+              130
             ]
           ],
           "weapon": {
@@ -1216,7 +1220,7 @@
           }
         },
         {
-          "aggroTargetId": 827,
+          "aggroTargetId": 941,
           "aiState": "attack",
           "combatTimer": 0.05,
           "comboUntil": -1,
@@ -1227,8 +1231,8 @@
           "fallStartY": 1.5,
           "fiveSecondRule": 99,
           "hostile": true,
-          "hp": 39864,
-          "id": 834,
+          "hp": 39875,
+          "id": 948,
           "inCombat": true,
           "kind": "mob",
           "leashAnchor": {
@@ -1255,12 +1259,12 @@
             "armor": 40
           },
           "swingTimer": 0.05,
-          "tappedById": 827,
+          "tappedById": 941,
           "templateId": "forest_wolf",
           "threat": [
             [
-              827,
-              137
+              941,
+              126
             ]
           ],
           "weapon": {

--- a/tests/parity/scenarios.ts
+++ b/tests/parity/scenarios.ts
@@ -3309,10 +3309,19 @@ function c3AuraRunner(): Scenario {
       // every 40 ticks (the 2s classic tick): the food heal runs ctx.healingTakenMult +
       // the 'heal' emit, the drink restores mana, and the short buff_ap expires inside
       // updateAuras -> statsDirty -> recalcPlayerStats (+ applyNonPlayerStatAura).
+      // The hp deficit is a FRACTION of the beefed maxHp (50000, see `beef` above), not
+      // an absolute amount: recalcPlayerStats preserves the hp/maxHp FRACTION across a
+      // maxHp change (entity.ts `hpFrac`), so once the buff_ap expiry below shrinks
+      // maxHp back down to the real (unbeefed) paladin value, an absolute deficit like
+      // "600 short of 50000" collapses to a tiny few points of the real pool, small
+      // enough that a single stacked natural-regen tick (#1608: eating no longer blocks
+      // it) closes the whole gap before the food tick's own check runs, and the food
+      // heal this phase exists to cover never fires. A fractional deficit survives the
+      // rescale untouched, so the food heal still has real work left to do afterward.
       p.inCombat = false;
       p.combatTimer = 99;
       p.fiveSecondRule = 99;
-      p.hp = Math.max(1, p.maxHp - 600);
+      p.hp = Math.max(1, Math.round(p.maxHp * 0.4));
       p.resource = Math.max(0, p.maxResource - 300);
       p.eating = {
         itemId: 'parity_food',

--- a/tests/sim_quests_economy.test.ts
+++ b/tests/sim_quests_economy.test.ts
@@ -121,7 +121,7 @@ describe('food, drink, vendor', () => {
     sim.player.combatTimer = 99;
 
     sim.useItem('minor_mana_potion');
-    expect(sim.player.resource).toBe(10 + 120); // instant, no sitting
+    expect(sim.player.resource).toBe(10 + (ITEMS.minor_mana_potion.potionMana ?? 0)); // instant, no sitting
     expect(sim.player.sitting).toBe(false);
     expect(sim.countItem('minor_mana_potion')).toBe(1);
 


### PR DESCRIPTION
## Summary

Food and potions were rarely worth using (#1608). Two separate problems, both fixed:

1. **Eating replaced natural HP regen instead of stacking with it.** `updateRegen`
   (`src/sim/combat/auras.ts`) skipped the natural stamina-scaled regen tick while
   `p.eating` was set, so a low tier of food (flat per-tick heal) lost to natural
   regen past a certain stamina, at which point sitting down to eat was strictly
   worse than standing still. Drinking never had this gate, so food and drink
   behaved inconsistently with each other. The fix removes the gate: eating now
   stacks with natural regen the same way drinking already stacks with mana regen,
   so every food tier is always at least as fast as standing idle, at any
   stamina. The sim's one legitimate use of the old "zero-value food blocks
   regen" behavior (`Sim.startCascadePlaytest` / `Sim.startDevSandbox`, which
   freeze scripted allies' hp bars for dev playtesting) is preserved: the guard
   now keys off `p.eating?.hpPer2s !== 0` instead of `!p.eating`, so a real food
   item (always `hpPer2s > 0`) stacks, while the dev freeze idiom (`hpPer2s: 0`)
   still suppresses natural regen.

2. **The potionHp/potionMana ladder restored a shrinking, undocumented fraction of
   the HP/mana pool as levels and gear grew.** The three healing and three mana
   potion tiers in `src/sim/content/items.ts` are retuned to a documented target:
   each tier restores roughly 80-90% (hp) or 65-70% (mana) of the LEAST tanky
   class's base (no-gear) pool for that resource (priest for hp, hunter for mana)
   at the top level of its intended zone bracket. The full methodology is in the
   comment above `minor_healing_potion` in `content/items.ts`, and
   `tests/consumables.test.ts` pins both the fraction band and the exact values.
   The crafted alchemy draught ladder (`content/profession_items.ts`) documents
   itself as a strict upgrade over the matching vendor tier, so its top rung
   (`sunpetal_healing_draught` / `sunpetal_mana_draught`) moved in lockstep to
   stay above the retuned vendor ceiling.

The foodHp/drinkMana VALUES themselves (vendor, fished, conjured tiers) are
unchanged: they already form a clear increasing ladder by zone bracket, and the
regen-stacking fix is what makes every existing tier worth the bag slot, per the
issue's acceptance criteria. Not a duplicate of #1326 (vendor gold price only);
this PR never touches `sellValue`/`buyValue`.

```mermaid
flowchart LR
    subgraph before["Before (#1608)"]
        A1[Eating] -->|replaces| B1[Natural HP regen]
        D1[Drinking] -->|stacks with| C1[Natural mana regen]
    end
    subgraph after["After this PR"]
        A2[Eating] -->|stacks with| B2[Natural HP regen]
        D2[Drinking] -->|stacks with| C2[Natural mana regen]
    end
```

## Related issues

Closes #1608

## Type of change

- [x] Bug fix

## How was this tested?

- Commands:
  - `npx vitest run tests/consumables.test.ts` (new: pins the eat-vs-natural-regen
    stacking behavior per foodHp tier, the issue's own crossover stamina values,
    the dev-freeze idiom, and the potion fraction/monotonic/golden-value pins)
  - `npx vitest run tests/combat_auras.test.ts tests/items.test.ts tests/recipe_economy.test.ts tests/cast_bar.test.ts tests/tank_defensive_cds.test.ts tests/consumable_command.test.ts tests/vendor_stack.test.ts`
  - `UPDATE_PARITY=1 npx vitest run tests/parity` (regenerated the one golden the
    regen-stacking change legitimately affects: `c3_aura_runner`), followed by a
    full `npx vitest run tests/parity` to confirm it's green again
  - `npx tsc --noEmit`
  - `npx @biomejs/biome check` on every changed file
  - `npm run gate`
- Manual steps: none (non-visual sim/balance change).

---

## Checklist

### Quality

- [x] **The full gate passes.** `npm run gate` is green. I added or updated decisive
      tests for changed behavior and recorded any manual checks above.

### Cross-platform

- N/A. Non-visual sim/balance change.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings (numeric item tuning only; no new
      names, tooltips, or copy).

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files.
