### PR TITLE
fix(ui): settle the dungeon finder own-listing rule, unbreaking the release

### DIFF
--- a/src/ui/dungeon_finder_view.ts
+++ b/src/ui/dungeon_finder_view.ts
@@ -442,21 +442,24 @@ export function buildDungeonFinderView(input: DungeonFinderViewInput): DungeonFi
     // Hide a listing for the group I am ALREADY part of, whether I lead it
     // (mine) or I am one of the leader's party members browsing the same
     // board (matched by leader name: the board carries no member pids).
+    // Because this drops every `mine` listing, no row that survives the loop
+    // can carry `mine: true`; the field stays on the row view (and in the
+    // repaint signature) as part of its contract, not because it can be set.
     const alreadyInGroup =
       mine || (input.partyLeaderName !== null && listing.leaderName === input.partyLeaderName);
     if (alreadyInGroup) continue;
     // Issue #2030: a listing for a dungeon/raid I am currently locked out of
     // is not something I can usefully apply to, and showing it invites a
     // player to join a group only to discover the lockout at the door. Hide
-    // it from the browse list. The board payload is viewer-independent, so
-    // my own listing DOES pass through this loop (it also renders in the
-    // separate `myListing` panel): exempt it the same as `applied`, or a
-    // leader who takes the lockout mid-run loses their own row from Open
-    // Listings. A listing I have already applied to stays visible even
-    // while locked out, so its row (and withdraw control) keep existing:
-    // otherwise a pending application could never be withdrawn once the
-    // lockout landed.
-    if (!applied && !mine && lockoutMinutesFor(activity, input.lockouts) > 0) continue;
+    // it from the browse list. A listing I have already applied to stays
+    // visible even while locked out, so its row (and withdraw control) keep
+    // existing: otherwise a pending application could never be withdrawn once
+    // the lockout landed. That `applied` exemption is the only one: my OWN
+    // listing never reaches this line, because issue #2031's alreadyInGroup
+    // filter above drops it first, and it keeps its dedicated `myListing`
+    // panel (which no lockout filters), so a leader who takes the lockout
+    // mid-run still sees their listing there.
+    if (!applied && lockoutMinutesFor(activity, input.lockouts) > 0) continue;
     const blocked = blockReasonFor(activity, level, specRole);
     const roleFit =
       activity.composition === null || info.roles.some((r) => (listing.needed?.[r] ?? 0) > 0);

--- a/tests/dungeon_finder_view.test.ts
+++ b/tests/dungeon_finder_view.test.ts
@@ -424,11 +424,54 @@ describe('dungeon finder view core', () => {
     expect(view.board.listings[0].canApply).toBe(false);
   });
 
-  it('keeps a leader listing visible in Open listings when its OWN dungeon goes locked (#2030 followup)', () => {
+  it('keeps a locked-out leader listing in the myListing panel, not the browse list (#2820)', () => {
+    // Two rules meet here, and this pins how they compose. Issue 2031 hides the
+    // group I am already in from the browse list, my own listing included, and
+    // issue 2030 hides listings for a dungeon I am locked out of. So a leader who
+    // takes the lockout mid-run has no row in Open Listings, by BOTH rules. The
+    // #2030 concern (a leader losing sight of their own listing) is answered by
+    // the dedicated myListing panel, which no lockout filters: asserted here, so
+    // hiding the row can never quietly become hiding the listing entirely.
     const heroicListing = {
       id: 8,
       activityId: 'hollow_crypt_heroic',
       leaderName: 'Lead',
+      tags: [],
+      size: 1,
+      capacity: 5,
+      needed: { tank: 0, healer: 1, dps: 3 },
+      members: [{ cls: 'warrior' as const, level: 20, role: 'tank' as const }],
+    };
+    const myListing = {
+      id: 8,
+      activityId: 'hollow_crypt_heroic',
+      tags: [],
+      applicants: [],
+    };
+    const view = live(
+      buildDungeonFinderView(
+        input({
+          tab: 'board',
+          playerLevel: 20,
+          board: [heroicListing],
+          info: makeInfo('sim', { myListing }),
+          lockouts: [{ id: 'hollow_crypt:heroic', msRemaining: 3_600_000 }],
+        }),
+      ),
+    );
+    expect(view.board.listings).toEqual([]);
+    expect(view.board.myListing).toEqual(myListing);
+  });
+
+  it('still shows a locked-out listing I have APPLIED to, so it stays withdrawable (#2030)', () => {
+    // The one surviving exemption in the lockout filter. Distinct from the case
+    // above: not mine, so issue 2031 does not hide it, and applied, so the
+    // lockout does not either. Without this the row (and its withdraw control)
+    // would vanish the moment the lockout landed, stranding the application.
+    const heroicListing = {
+      id: 9,
+      activityId: 'hollow_crypt_heroic',
+      leaderName: 'Someone Else',
       tags: [],
       size: 1,
       capacity: 5,
@@ -441,15 +484,13 @@ describe('dungeon finder view core', () => {
           tab: 'board',
           playerLevel: 20,
           board: [heroicListing],
-          info: makeInfo('sim', {
-            myListing: { id: 8, activityId: 'hollow_crypt_heroic', tags: [], applicants: [] },
-          }),
+          info: makeInfo('sim', { myApplication: { listingId: 9 } }),
           lockouts: [{ id: 'hollow_crypt:heroic', msRemaining: 3_600_000 }],
         }),
       ),
     );
-    expect(view.board.listings.map((l) => l.id)).toEqual([8]);
-    expect(view.board.listings[0].mine).toBe(true);
+    expect(view.board.listings.map((l) => l.id)).toEqual([9]);
+    expect(view.board.listings[0].applied).toBe(true);
   });
 
   it('does not hide a listing over a lockout on a DIFFERENT dungeon or a lockout-free difficulty (#2030 followup)', () => {


### PR DESCRIPTION
## Summary

`release/v0.34.0` is red, and every PR based on it inherits a failing CI run. Two merged
features disagree about whether a player's OWN premade listing appears in the Open Listings
browse board, and each was green on its own base:

- `d7bd08cda` (#2714) added the lockout filter with a `mine` exemption, plus a test asserting
  a leader keeps their row when their dungeon locks mid-run.
- `c79af4715` (#2724, issue #2031) then added the `alreadyInGroup` filter,
  `mine || partyLeaderName match`, a few lines ABOVE it.

`mine` listings now `continue` before ever reaching the lockout filter, so the `!mine`
exemption is dead code and #2714's test asserts behavior the code no longer has. Git merged
both cleanly (they never touch the same lines) and neither PR's own CI could have caught it.

**Settled in favor of #2724: the own listing stays out of the browse board.** Reasoning:

1. The concern behind #2714's exemption is already met elsewhere. It existed so a locked-out
   leader would not lose sight of their listing, but `myListing` is passed through with no
   lockout filtering, so the leader keeps their dedicated panel either way.
2. #2724 is the newer, deliberate decision, with its own issue and a test that pins the panel
   split (hiding the board row must not drop the `myListing` panel).
3. A row you cannot apply to is clutter on a list whose purpose is groups you could join.

No behavior change ships: the code already does this. The change makes the tests and comments
say what the code does. The dead `!mine` term is gone, and the comment that claimed own
listings pass through the loop now records why they cannot.

The contradictory test is replaced by one pinning how the two rules COMPOSE (own listing
absent from `listings`, still present in `myListing`), plus a second test for the `applied`
exemption that survives, which nothing covered on its own before: a listing I have applied to
stays visible while locked out, so its withdraw control keeps existing.

## Related issues

Closes #2820.

## Type of change

- [x] Bug fix
- [ ] Feature: new functionality
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands: `npm run gate` green (all 10 steps, 7 workers), `npx vitest run
  tests/dungeon_finder_view.test.ts tests/dungeon_finder_window.test.ts`, `npx tsc --noEmit`,
  `npx @biomejs/biome check` on the changed files.
- Reproduction first: confirmed the failure on a pristine `origin/release/v0.34.0` worktree
  with a clean `pnpm install --frozen-lockfile` and none of this branch's code present, so the
  fix is aimed at the real cause rather than a local artifact.
- Coverage: the replacement test fails if the `alreadyInGroup` filter stops covering `mine`,
  and the new `applied` test fails if the surviving exemption is dropped, so neither rule can
  regress silently the way this pair did.

## Screenshots / recordings

N/A. No shipped behavior changes: the board already hides the own listing today. This aligns
the tests and comments with it.

---

## Checklist

### Quality

- [x] **The full gate passes.** Green on this branch, with decisive tests for both surviving
      rules.

### Cross-platform

- [x] **Tested on desktop and mobile.** Pure view-core change, no layout or styling; the
      window renders from the same view model on both.
- [x] **Accessible.** No UI structure change.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in
      any production path.
- [x] I didn't hand-edit generated files.

## Notes for the reviewer

One deliberate scope call: `FinderListingRowView.mine` is now always false for rows that
survive the loop, so the `!mine` term in `canApply` and the `l.mine` branch in
`dungeon_finder_window.ts` are also unreachable. I left them and documented the fact where
`mine` is computed, rather than widening a release-unblocking fix into a cleanup of someone
else's feature. Happy to follow up if you would rather they go.
