### PR TITLE
fix(ui): reconcile the finder own-listing pins after #2714 and #2724

### DIFF
--- a/src/ui/dungeon_finder_view.ts
+++ b/src/ui/dungeon_finder_view.ts
@@ -448,14 +448,14 @@ export function buildDungeonFinderView(input: DungeonFinderViewInput): DungeonFi
     // Issue #2030: a listing for a dungeon/raid I am currently locked out of
     // is not something I can usefully apply to, and showing it invites a
     // player to join a group only to discover the lockout at the door. Hide
-    // it from the browse list. The board payload is viewer-independent, so
-    // my own listing DOES pass through this loop (it also renders in the
-    // separate `myListing` panel): exempt it the same as `applied`, or a
-    // leader who takes the lockout mid-run loses their own row from Open
-    // Listings. A listing I have already applied to stays visible even
-    // while locked out, so its row (and withdraw control) keep existing:
-    // otherwise a pending application could never be withdrawn once the
-    // lockout landed.
+    // it from the browse list. A listing I have already applied to stays
+    // visible even while locked out, so its row (and withdraw control) keep
+    // existing: otherwise a pending application could never be withdrawn
+    // once the lockout landed. My OWN listing no longer reaches this filter
+    // (the issue-2031 alreadyInGroup skip above hides it from browse
+    // entirely); a locked-out leader keeps managing theirs through the
+    // separate `myListing` panel, which no lockout ever filters. The `!mine`
+    // guard stays as belt and braces should the skip above ever narrow.
     if (!applied && !mine && lockoutMinutesFor(activity, input.lockouts) > 0) continue;
     const blocked = blockReasonFor(activity, level, specRole);
     const roleFit =

--- a/tests/dungeon_finder_view.test.ts
+++ b/tests/dungeon_finder_view.test.ts
@@ -424,7 +424,13 @@ describe('dungeon finder view core', () => {
     expect(view.board.listings[0].canApply).toBe(false);
   });
 
-  it('keeps a leader listing visible in Open listings when its OWN dungeon goes locked (#2030 followup)', () => {
+  it('keeps a locked-out leader in charge of their listing via the myListing panel (#2030 followup, reconciled with issue 2031)', () => {
+    // Originally this pinned the leader's own row staying in Open listings
+    // when their dungeon went locked. Issue 2031 then hid the own listing
+    // from browse results altogether (it lives in the myListing panel), which
+    // supersedes that row. The #2030 concern it protected still holds and is
+    // pinned here in its reconciled form: a lockout landing mid-run must not
+    // strip the leader of their listing, so the myListing panel survives it.
     const heroicListing = {
       id: 8,
       activityId: 'hollow_crypt_heroic',
@@ -448,8 +454,15 @@ describe('dungeon finder view core', () => {
         }),
       ),
     );
-    expect(view.board.listings.map((l) => l.id)).toEqual([8]);
-    expect(view.board.listings[0].mine).toBe(true);
+    // Browse hides my own group (issue 2031), lockout or not.
+    expect(view.board.listings).toEqual([]);
+    // The lockout must not filter the leader's own management panel.
+    expect(view.board.myListing).toEqual({
+      id: 8,
+      activityId: 'hollow_crypt_heroic',
+      tags: [],
+      applicants: [],
+    });
   });
 
   it('does not hide a listing over a lockout on a DIFFERENT dungeon or a lockout-free difficulty (#2030 followup)', () => {


### PR DESCRIPTION
## Summary

Un-reds the release branch CI. PR #2714 pinned a locked-out leader's own row staying visible in Open listings (the #2030 followup test), and PR #2724, whose branch predates that test, then hid the player's own listing from browse results altogether (issue 2031). Both merged green on their own; combined, every CI run on `release/v0.34.0` since has failed the #2030-followup test (reproducible on a clean base checkout, and the red shard on every open PR against this base).

Issue 2031's behavior is the adopted design: the own listing lives in the `myListing` panel, not the browse list. This reconciles the stale test to pin what actually protects the leader now (the `myListing` panel survives a mid-run lockout instead of the browse row), and updates the lockout-filter comment in `dungeon_finder_view.ts` that still claimed the own row passes through that filter.

No behavior changes: the diff is one test reworked and one comment corrected.

## Related issues

Follow-up to #2714 and #2724 (issues #2030 / #2031).

## Type of change

- [x] Bug fix

## How was this tested?

- `npx vitest run tests/dungeon_finder_view.test.ts` (24 passed, including the reconciled pin; fails on the base without this change)
- `npx tsc --noEmit` clean
- The reconciled test pins both halves: browse hides the own group under a lockout, and the lockout does not filter `board.myListing`.

## Screenshots / recordings

N/A: no visual change (a test and a comment).

---

## Checklist

### Quality

- [x] **The full gate passes.** The touched suite and typecheck are green locally; this PR exists to make the branch-wide gate green again.

### Cross-platform

- [x] **Tested on desktop and mobile.** N/A: no runtime change.
- [x] **Accessible.** N/A: no runtime change.

### Localization (i18n)

- [ ] ~New player-visible strings~ N/A: no strings.
- [ ] ~Numbers, money, dates, units, and percents~ N/A.
- [ ] ~Player-facing text emitted from `src/sim/` or `server/`~ N/A.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files.
