### PR TITLE
fix(content): put Collective Reversal on a 5 minute cooldown

### DIFF
--- a/src/sim/content/classes.ts
+++ b/src/sim/content/classes.ts
@@ -2302,6 +2302,10 @@ export const ABILITIES: Record<string, AbilityDef> = {
   // ---- Chronomancy out-of-combat mass resurrection. The base seven-second cast
   // and mana cost are provisional playtest values. It has no target and rewinds all
   // dead members on the authoritative group or raid roster at cast completion.
+  // The five-minute cooldown is the real throttle: requiresOutOfCombat alone is not
+  // one, because a backline caster who never draws aggro drops combat mid-fight the
+  // moment combatTimer passes the 5s linger (see the engagedPids pass in sim.ts), so
+  // a zero-cooldown mass rez could be chained repeatedly inside a single encounter.
   collective_reversal: {
     id: 'collective_reversal',
     name: 'Collective Reversal',
@@ -2310,7 +2314,7 @@ export const ABILITIES: Record<string, AbilityDef> = {
     specs: ['arcane'],
     cost: 250,
     castTime: 7,
-    cooldown: 0,
+    cooldown: 300,
     range: 0,
     school: 'arcane',
     requiresTarget: false,

--- a/tests/collective_reversal.test.ts
+++ b/tests/collective_reversal.test.ts
@@ -45,9 +45,15 @@ describe('Collective Reversal content', () => {
       specs: ['arcane'],
       learnLevel: 8,
       castTime: 7,
+      cooldown: 300,
       requiresTarget: false,
       requiresOutOfCombat: true,
     });
+    // requiresOutOfCombat is not a throttle on its own: a caster who never draws
+    // aggro drops combat mid-fight, so the cooldown is what stops a mass rez from
+    // being chained inside one encounter. It must outlast a cast plus the combat
+    // linger the caster waits out to become eligible again.
+    expect(def.cooldown).toBeGreaterThan(def.castTime + 5);
     expect(def.effects).toContainEqual({ type: 'massResurrectGroup', hpFrac: 0.3 });
 
     const known = (spec: 'arcane' | 'fire' | 'frost') =>
@@ -175,6 +181,41 @@ describe('Collective Reversal behavior', () => {
     expect(fallen.dead).toBe(true);
     expect(mage.resource).toBe(mana);
     expect(events).toContainEqual({ type: 'castStop', entityId: mage.id, success: false });
+  });
+
+  it('refuses a second cast while the cooldown runs, even fully out of combat', () => {
+    const { sim, mage } = chronomancer();
+    const fallen = addToGroup(sim, mage, 'warrior', 'Fallen Twice');
+    killAt(fallen, mage.pos.x + 2, mage.pos.z);
+
+    sim.castAbility(ABILITY_ID);
+    expect(mage.castingAbility).toBe(ABILITY_ID);
+    for (let tick = 0; tick < 141; tick++) sim.tick();
+    expect(mage.castingAbility).toBeNull();
+    sim.respondToResurrection(true, fallen.id);
+    expect(fallen.dead).toBe(false);
+
+    const remaining = mage.cooldowns.get(ABILITY_ID) ?? 0;
+    expect(remaining).toBeGreaterThan(290);
+    expect(remaining).toBeLessThanOrEqual(300);
+
+    // The same group member dies again and the mage is unambiguously out of combat
+    // with a full mana pool: only the cooldown may refuse this cast.
+    killAt(fallen, mage.pos.x + 2, mage.pos.z);
+    mage.inCombat = false;
+    mage.combatTimer = 99;
+    mage.resource = mage.maxResource;
+    const mana = mage.resource;
+    sim.castAbility(ABILITY_ID);
+    expect(mage.castingAbility).toBeNull();
+    expect(mage.resource).toBe(mana);
+    expect(fallen.dead).toBe(true);
+
+    // Clearing only the cooldown lets the identical cast start, proving the refusal
+    // above was the cooldown and not the out-of-combat or dead-member gate.
+    mage.cooldowns.delete(ABILITY_ID);
+    sim.castAbility(ABILITY_ID);
+    expect(mage.castingAbility).toBe(ABILITY_ID);
   });
 
   it('cancels cleanly if another source revives every group member first', () => {


### PR DESCRIPTION
## Summary

`collective_reversal` (Collective Reversal, the Chronomancy group mass resurrection)
shipped with `cooldown: 0`, gated only by `requiresOutOfCombat`. That gate is not a
throttle on its own.

`Entity.inCombat` is recomputed every tick as `engagedPids.has(p.id) || p.combatTimer < 5`
(the `engagedPids` pass in `src/sim/sim.ts`). A backline caster who never draws aggro
therefore drops combat in the middle of a live fight as soon as the 5 second combat linger
passes. Combined with a zero cooldown, that let one mage chain the mass rez several times
inside a single encounter, which is how this surfaced (four resurrections from the same
caster in one fight).

The out-of-combat gate itself is correctly enforced, at cast start and re-checked every
tick during the 7 second cast (`activeCastRestriction` plus the mass-resurrection arm in
`src/sim/combat/casting_lifecycle.ts`), so this is not an enforcement bug. The missing
piece is the cooldown.

This sets `cooldown: 300`. Wipe recovery is unaffected, since a wipe plus a corpse run
runs well past five minutes, but the spell can no longer be chained within one fight.

Deliberately scoped to the one ability. Changing the shared combat rule was considered and
rejected: `inCombat` is read in roughly a hundred places across `src/sim`, `src/net`, and
`server`, gating regen, mounts, fishing, rested XP, `/unstuck`, arena, Vale Cup, delves,
pet and mob AI, and the bot detector, and four other abilities (`stealth`, `prowl`, `sap`,
`fireball_form`) depend on a player being able to drop combat mid-fight.

The cooldown holds up against the usual resets: `src/sim/cooldown_persist.ts` persists
remaining time across a logout, and neither `spirit.ts` nor `entity_roster.ts` clears the
`cooldowns` map on death.

## Related issues

N/A

## Type of change

- [x] Bug fix

## How was this tested?

- Commands:
  - `npx vitest run tests/collective_reversal.test.ts` (9 passed)
  - `npx vitest run tests/parity` (193 passed, 1 skipped; no golden-trace drift)
  - `npx vitest run tests/architecture.test.ts tests/progression.test.ts tests/guide.test.ts tests/chronomancy_buffs.test.ts tests/skill_icons.test.ts` (170 passed)
  - `npx tsc --noEmit` (exit 0)
  - `npx @biomejs/biome check src/sim/content/classes.ts tests/collective_reversal.test.ts` (clean)
  - `npm run gate` (see the note below)
- Tests added, in the existing `tests/collective_reversal.test.ts`:
  - The content record pin now includes `cooldown: 300`, plus an assertion that the
    cooldown outlasts a cast plus the combat linger, so the spell cannot be chained.
  - A new behavior test casts it to completion, confirms the cooldown is armed at roughly
    300s, re-kills the same group member, and re-casts with the caster forced fully out of
    combat (`inCombat = false`, `combatTimer = 99`) at full mana. That cast is refused, and
    no mana is spent. Deleting only the cooldown entry then lets the identical cast start,
    which is what proves the refusal came from the cooldown rather than from the
    out-of-combat or dead-group-member gate.

### Note on the gate: pre-existing failures on `release/v0.34.0`

`npm run gate` does not pass on this branch, and does not pass on the base either. I ran
the full suite twice to attribute it:

| | Files failed | Tests failed | Tests passed |
|---|---|---|---|
| Base `35173822c`, this commit removed | 26 | 2 | 27281 |
| This branch | 26 | 2 | 27282 |

The failure sets are identical. The only delta is one additional passing test, the one
added here. CI is also red on the last several pushes to `release/v0.34.0`, including
`35173822c` itself.

For whoever picks that up, the 26 split into two groups:

- 24 server suites fail to LOAD, running zero tests, on a `vi.mock` hoisting error against
  `server/db` reached through `server/daily_rewards.ts` and `server/seeker_entitlement.ts`.
  Everything that constructs a `GameServer` is caught (`admin`, `bandwidth`, `interest`,
  `xp`, `linkdead`, `arena_online`, `collective_reversal_online`, and others). Worth
  flagging on its own: those suites are currently silently contributing no coverage.
- 2 assertion failures: `tests/pbr_fragment_shader.test.ts` hits
  `ReferenceError: document is not defined` in `src/render/terrain.ts`
  (`buildSplatAlbedoArray`), and `tests/quest_targets.test.ts` fails a gather-node
  clustering golden at the 32yd threshold.

None of these are touched by this change.

## Screenshots / recordings

No screenshots captured. The only player-visible effect is that the ability tooltip now
renders a cooldown line, produced by the existing tooltip path directly from the ability
def. No new strings and no layout change. Happy to add before/after captures if a reviewer
wants them.

---

## Checklist

### Quality

- [ ] **The full gate passes.** Not green, for pre-existing reasons documented above. The
      base branch fails identically with this commit removed, and every check that this
      change can affect (targeted suite, parity golden trace, architecture, progression,
      guide freshness, `tsc`, biome) is green.

### Cross-platform

- ~Tested on desktop and mobile.~ N/A, no UI change.
- ~Accessible.~ N/A, no UI change.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings. The ability description is unchanged and
      the cooldown renders through the existing tooltip formatter.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled
      in any production path.
- [x] I didn't hand-edit generated files. `tests/guide.test.ts` passes, so no wiki content
      regen is required.
