### PR TITLE
fix(server): unbreak the release gate after the Seeker merge

### DIFF
--- a/server/seeker_entitlement.ts
+++ b/server/seeker_entitlement.ts
@@ -27,13 +27,24 @@ interface SeekerEntitlementRuntime {
   verifySeekerSolanaArtifactAttestation: typeof verifySeekerSolanaArtifactAttestation;
 }
 
+// Each entry FORWARDS at call time instead of capturing the imported binding here.
+// Capturing eagerly made this module-scope literal read every import the moment the
+// module loaded, which is fine in production but detonates under Vitest: a suite that
+// mocks `./db` with an explicit factory throws on the first export its factory happens
+// to omit, at IMPORT time, so the whole test file fails to collect. Adding
+// `walletForAccount` to db broke 37 unrelated suites that way (xp, markers,
+// ip_block_kick, ...), none of which touch Seeker at all. Deferring the read scopes that
+// blast radius to the tests that actually call the path, and the next db export added
+// here cannot repeat it. The arrows also survive the `{ ...REAL_RUNTIME }` spread below,
+// which a getter-based version would not (spreading reads getters).
 const REAL_RUNTIME: SeekerEntitlementRuntime = {
-  walletForAccount,
-  findSeekerGenesisToken,
-  findSeekerGenesisTokens,
-  claimAvailableSeekerEntitlement,
-  seekerEntitlementForAccount,
-  verifySeekerSolanaArtifactAttestation,
+  walletForAccount: (...args) => walletForAccount(...args),
+  findSeekerGenesisToken: (...args) => findSeekerGenesisToken(...args),
+  findSeekerGenesisTokens: (...args) => findSeekerGenesisTokens(...args),
+  claimAvailableSeekerEntitlement: (...args) => claimAvailableSeekerEntitlement(...args),
+  seekerEntitlementForAccount: (...args) => seekerEntitlementForAccount(...args),
+  verifySeekerSolanaArtifactAttestation: (...args) =>
+    verifySeekerSolanaArtifactAttestation(...args),
 };
 
 let runtime = REAL_RUNTIME;

--- a/tests/native_immersive_mode.test.ts
+++ b/tests/native_immersive_mode.test.ts
@@ -1,11 +1,38 @@
-import { readFileSync } from 'node:fs';
+import { readdirSync, readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
 const root = new URL('../', import.meta.url);
 const read = (path: string) => readFileSync(new URL(path, root), 'utf8').replace(/\r\n/g, '\n');
 
+// PR #2423 split the Android app into product flavors (play, solanaStore): the shared
+// behavior moved to BaseMainActivity, and each flavor now ships its own thin MainActivity
+// that only overrides plugin registration. The immersive-mode code this suite guards lives
+// in the base, so that is what it reads; the old single-activity path stopped existing and
+// took this file's whole collection down with it.
+const ACTIVITY_DIR = 'android/app/src/main/java/com/worldofclaudecraft';
+
+/** Every flavor that ships its own MainActivity, discovered rather than listed. */
+function flavorActivities(): { flavor: string; source: string }[] {
+  const srcDir = new URL('android/app/src/', root);
+  return readdirSync(srcDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && entry.name !== 'main')
+    .map((entry) => ({
+      flavor: entry.name,
+      path: `android/app/src/${entry.name}/java/com/worldofclaudecraft/MainActivity.java`,
+    }))
+    .filter(({ path }) => {
+      try {
+        readFileSync(new URL(path, root));
+        return true;
+      } catch {
+        return false; // test-only and androidTest source sets have no activity
+      }
+    })
+    .map(({ flavor, path }) => ({ flavor, source: read(path) }));
+}
+
 describe('Android immersive mode', () => {
-  const activity = read('android/app/src/main/java/com/worldofclaudecraft/MainActivity.java');
+  const activity = read(`${ACTIVITY_DIR}/BaseMainActivity.java`);
 
   it('hides every system bar while preserving transient swipe access', () => {
     expect(activity).toContain('WindowCompat.getInsetsController(');
@@ -21,5 +48,19 @@ describe('Android immersive mode', () => {
       /onWindowFocusChanged\(boolean hasFocus\)[\s\S]*?super\.onWindowFocusChanged\(hasFocus\);[\s\S]*?if \(hasFocus\) \{[\s\S]*?enterImmersiveMode\(\);/,
     );
     expect(activity.match(/enterImmersiveMode\(\);/g)).toHaveLength(2);
+  });
+
+  it('reaches every shipped flavor, not just the base class it is written in', () => {
+    // The guard above reads ONE file. After the flavor split that only proves the shipped
+    // app enters immersive mode if every flavor's activity actually inherits it: a new
+    // flavor extending BridgeActivity directly would ship without immersive mode while
+    // this suite stayed green over a surface that no longer matched it.
+    const flavors = flavorActivities();
+    expect(flavors.map((f) => f.flavor).sort()).toEqual(['play', 'solanaStore']);
+    for (const { flavor, source } of flavors) {
+      expect(source, `${flavor} MainActivity must inherit the immersive base`).toMatch(
+        /class MainActivity extends BaseMainActivity/,
+      );
+    }
   });
 });

--- a/tests/server/seeker_entitlement_import_isolation.test.ts
+++ b/tests/server/seeker_entitlement_import_isolation.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// Regression pin for the import-time blast radius (release/v0.34.0, PR #2423).
+//
+// `server/seeker_entitlement.ts` builds its REAL_RUNTIME table at module scope. When the
+// entries captured the imported bindings eagerly, loading the module read every one of
+// them, so ANY suite whose `vi.mock('../server/db')` factory omitted a single export threw
+// on import and failed to collect. Adding `walletForAccount` to db that way broke 37
+// unrelated suites (xp, markers, ip_block_kick, playtime_grant, ...), none of which touch
+// Seeker: the failures read as 37 broken features rather than one missing mock line.
+//
+// This file mocks db with a factory that deliberately omits EVERY seeker-related export,
+// mimicking the ordinary server suite that has no idea this module exists, then imports
+// the module. It passes only while the runtime defers its reads to call time.
+//
+// Deliberately NOT fixed by adding the export to this factory: doing that here would pin
+// the opposite of the invariant. The point is that an unrelated suite must be able to
+// under-specify the db mock and still load.
+vi.mock('../../server/db', () => ({
+  // The two exports a generic server suite actually mocks, and nothing else.
+  accountAndScopeForToken: vi.fn(),
+  moderationStatusForAccount: vi.fn(),
+  pool: {},
+}));
+
+describe('seeker_entitlement import isolation', () => {
+  it('loads under a db mock that omits its exports, without touching them', async () => {
+    // A throw here is the regression: it means module scope read a binding the mock does
+    // not define. The assertions after it are secondary to the import surviving at all.
+    const mod = await import('../../server/seeker_entitlement');
+
+    expect(typeof mod.handleSeekerEntitlementStatus).toBe('function');
+    expect(typeof mod.setSeekerEntitlementRuntimeForTests).toBe('function');
+  });
+
+  it('survives the spread the test-override helper performs', async () => {
+    // The other half of the design choice. `setSeekerEntitlementRuntimeForTests` does
+    // `{ ...REAL_RUNTIME, ...overrides }`, and a spread READS every property: a
+    // getter-based deferral would throw right here under this same under-specified mock,
+    // which is why the entries are forwarding arrows instead. Forwarding itself is
+    // already covered by the Seeker suites that call these paths for real.
+    const mod = await import('../../server/seeker_entitlement');
+    expect(() => mod.setSeekerEntitlementRuntimeForTests({})).not.toThrow();
+    mod.resetSeekerEntitlementRuntimeForTests();
+  });
+});


### PR DESCRIPTION
## Summary

`release/v0.34.0` fails its own release gate across all 8 shards. Two independent breakages
arrived with #2423 (`feature/optimaization_for_solanaSeeker`), and this PR fixes both. After
it, a full local gate on the release tip is green (all 10 steps, 2068 files).

### 1. The Seeker runtime captured its db bindings at module scope (37 suites)

`server/seeker_entitlement.ts` builds `REAL_RUNTIME` in a module-scope object literal. Written
as `{ walletForAccount, ... }` it reads every imported binding the instant the module loads.
That is harmless in production and fatal under Vitest: a suite that mocks `./db` with an
explicit factory throws on the first export its factory happens to omit, at IMPORT time, so the
file never collects.

#2423 added `walletForAccount` to `server/db`, and 37 suites that mock db without it went red:
`xp`, `markers`, `ip_block_kick`, `playtime_grant` and more, none of which touch Seeker. That is
why the gate reads as dozens of broken features rather than one missing mock line, and why every
shard is red (Vitest shards by file, so the broken files land in all 8 partitions).

Each entry now forwards at call time, so an under-specified db mock only affects a test that
actually exercises the path, and the next export added here cannot repeat the outage.

Forwarding arrows rather than getters, deliberately: `setSeekerEntitlementRuntimeForTests` does
`{ ...REAL_RUNTIME, ...overrides }`, and a spread READS getters, landing straight back in the
same throw. There is a test pinning that, so the choice cannot be undone by accident.

### 2. The Android immersive-mode suite read a path the flavor split deleted

#2423 also split the Android app into `play` and `solanaStore` product flavors: shared behavior
moved to `BaseMainActivity`, and each flavor ships a thin `MainActivity` overriding only plugin
registration. `tests/native_immersive_mode.test.ts` still read the old single-activity path, so
it failed to collect.

I checked which side was wrong before touching it, because `AndroidManifest.xml` still declares
`android:name=".MainActivity"` and a genuinely missing class there would be a broken app launch
rather than a stale test. It is not: the manifest resolves per flavor and both flavors ship the
class. The test was stale.

Repointed at `BaseMainActivity`, plus the assertion the split now requires: reading one file
only proves the shipped app enters immersive mode IF every flavor's activity inherits it. A new
flavor extending `BridgeActivity` directly would ship without immersive mode while this suite
stayed green over a surface that no longer matched it. Flavors are discovered from the source
sets rather than listed, so a third one cannot join quietly.

## Related issues

Unblocks the release branch; no issue filed, since the fix landed faster than the report would
have. Same family as #2820 (two merged changes that were each green alone).

## Type of change

- [x] Bug fix
- [ ] Feature: new functionality
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands: `npm run gate` green on the current release tip (all 10 steps, 2068 files, run solo
  so the result is not contention-coloured), `npx tsc --noEmit`, `npx @biomejs/biome check` on
  changed files.
- Reproduction first, on a pristine checkout of the release tip with none of this branch's code:
  `tests/xp.test.ts` failed with the exact `No "walletForAccount" export is defined` error, and
  `native_immersive_mode` with `ENOENT ... MainActivity.java`.
- Blast radius measured rather than estimated: 101 suites mock `../server/db`, 37 of them
  without the new export.
- Spot-checked the previously broken suites (`xp`, `markers`, `ip_block_kick`) and the four
  Seeker suites, all green, before running the full gate.
- New `tests/server/seeker_entitlement_import_isolation.test.ts` fails without the source fix,
  with the original error.

## Screenshots / recordings

N/A. Server binding shape and a test path; no player-visible surface.

---

## Checklist

### Quality

- [x] **The full gate passes.** Green on the current release tip, with a regression test for the
      import-time invariant and a widened flavor assertion for the Android suite.

### Cross-platform

- [x] **Tested on desktop and mobile.** No client surface changes. The Android half is a test
      correction; the shipped activities are untouched, and the new assertion checks both
      flavors inherit the immersive base.
- [x] **Accessible.** N/A, no UI.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in
      any production path.
- [x] I didn't hand-edit generated files.

## Notes for the reviewer

The regression test deliberately mocks `../../server/db` WITHOUT the Seeker exports. Adding them
to that factory would have pinned the opposite of the invariant: the point is that an unrelated
suite must be able to under-specify the db mock and still load. Please keep it under-specified
if this file is ever touched.

Worth considering separately: 101 suites hand-roll a db mock factory, so any new `server/db`
export can break an arbitrary subset of them. A shared `fakeDb()` factory (the
`tests/server/helpers/` pattern) would make that class of breakage structural rather than
recurring. Out of scope here, and it wants its own discussion.
