### PR TITLE
fix(sim): make the recovery sicknesses undispellable

### DIFF
--- a/server/game.ts
+++ b/server/game.ts
@@ -957,6 +957,11 @@ interface WireAura {
   src?: number;
   // Encounter-owned control marker. Omitted for ordinary auras.
   ub?: 1;
+  // No-player-counter-may-shed marker (the recovery sicknesses). Presence only: the
+  // client reads it through the same isPlayerRemovableAura predicate the sim uses, so
+  // the buff bar never offers a right-click cancel the server would refuse. Omitted for
+  // ordinary auras, and an old server's omission decodes to undefined, as before.
+  und?: 1;
   // Break-threshold ARMED marker (Lingering Dread's soak-before-snap fear):
   // presence only, never the live soak value - the number decrements per hit
   // and would churn the stable aura cache, while the client (the victim-worn
@@ -1108,6 +1113,7 @@ function wireAura(a: Aura): WireAura {
   // (auras_view ownFirst). Omitted for the rare 0/absent source, which decodes to 0.
   if (a.sourceId) w.src = a.sourceId;
   if (a.unbreakableControl) w.ub = 1;
+  if (a.undispellable) w.und = 1;
   if (a.breakThreshold !== undefined) w.bt = 1;
   return w;
 }

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -176,6 +176,7 @@ interface ClientWireAura {
   emp?: Aura['empowerAbilities'];
   src?: number;
   ub?: 1;
+  und?: 1;
   bt?: 1;
 }
 
@@ -2878,6 +2879,9 @@ export class ClientWorld implements IWorld {
             // (auras_view ownFirst). An old server omits it; 0 matches no player id.
             rec.sourceId = a.src ?? 0;
             rec.unbreakableControl = a.ub === 1 ? true : undefined;
+            // Presence-only mirror of the undispellable marker, so the client's
+            // isPlayerRemovableAura answers exactly as the server's does.
+            rec.undispellable = a.und === 1 ? true : undefined;
             // Presence-only mirror of the break-threshold armed marker (the
             // server emits bt = 1 when breakThreshold is defined): the one
             // client reader is the Lingering Dread victim-band alias, which
@@ -2903,6 +2907,7 @@ export class ClientWorld implements IWorld {
             charges: a.charges,
             empowerAbilities: a.emp,
             unbreakableControl: a.ub === 1 ? true : undefined,
+            undispellable: a.und === 1 ? true : undefined,
             breakThreshold: a.bt === 1 ? 1 : undefined,
           }));
         }

--- a/src/sim/aura_classify.ts
+++ b/src/sim/aura_classify.ts
@@ -45,15 +45,29 @@ export function isDebuffAura(kind: AuraKind, value: number): boolean {
   return DEBUFF_AURA_KINDS.has(kind) || (kind.startsWith('buff_') && value < 0);
 }
 
+// The one rule for "may a player counter take this aura off at all", ahead of any
+// question of school or polarity. Two aura classes answer no: encounter-authored
+// unbreakable control (the script owns its release) and `undispellable` penalties
+// (the recovery sicknesses, which only their own timer clears). Every removal path a
+// player can drive routes through here so the answer cannot drift between them: the
+// dispel executor and its requiresDispellable cast gate (isDispellableAura below),
+// the cleanseSelf executor (combat/effect_dispatch.ts), and the right-click buff
+// cancel (combat/aura_cancel.ts).
+export function isPlayerRemovableAura(
+  aura: Pick<Aura, 'kind' | 'unbreakableControl' | 'undispellable'>,
+): boolean {
+  return !isUnbreakableControlAura(aura) && aura.undispellable !== true;
+}
+
 // The dispel eligibility rule, shared by the dispel executor and the
-// requiresDispellable cast gate so the two can never drift: magic-school only,
-// and the cast's direction picks the polarity (an OFFENSIVE dispel strips a
-// benefit off an enemy; a friendly one strips a harmful effect off an ally).
+// requiresDispellable cast gate so the two can never drift: player-removable and
+// magic-school only, and the cast's direction picks the polarity (an OFFENSIVE dispel
+// strips a benefit off an enemy; a friendly one strips a harmful effect off an ally).
 export function isDispellableAura(
-  aura: Pick<Aura, 'kind' | 'value' | 'school' | 'unbreakableControl'>,
+  aura: Pick<Aura, 'kind' | 'value' | 'school' | 'unbreakableControl' | 'undispellable'>,
   offensive: boolean,
 ): boolean {
-  if (isUnbreakableControlAura(aura)) return false;
+  if (!isPlayerRemovableAura(aura)) return false;
   if (aura.school === 'physical') return false;
   const harmful = isDebuffAura(aura.kind, aura.value);
   return offensive ? !harmful : harmful;

--- a/src/sim/combat/aura_cancel.ts
+++ b/src/sim/combat/aura_cancel.ts
@@ -5,9 +5,8 @@
 // debuff and which expose the right-click affordance). Keeping the classification
 // in one leaf means "rendered as a helpful buff" and "right-click cancelable" are
 // provably the same set and can never drift apart.
-import { isDebuffAura as classifyDebuffAura } from '../aura_classify';
+import { isDebuffAura as classifyDebuffAura, isPlayerRemovableAura } from '../aura_classify';
 import type { Aura } from '../types';
-import { isUnbreakableControlAura } from './cc';
 
 // A debuff is anything in the harmful set, OR a stat aura riding a `buff_*` kind
 // with a negative value (an enfeeble / wither drain reuses a buff_* kind but saps
@@ -18,9 +17,11 @@ export function isDebuffAura(a: Aura): boolean {
 
 // A player may voluntarily cancel any helpful aura they carry; debuffs never. The
 // classic right-click-cancel includes forms, stances, and stealth (canceling a
-// form aura reverts to caster form) since none of those are harmful.
+// form aura reverts to caster form) since none of those are harmful. The
+// player-removable test is the same one the dispel and cleanse executors answer to,
+// so an aura no counter may shed is no more cancelable than it is dispellable.
 export function isCancelableAura(a: Aura): boolean {
-  return !isUnbreakableControlAura(a) && !isDebuffAura(a);
+  return isPlayerRemovableAura(a) && !isDebuffAura(a);
 }
 
 // Whether removing this aura changes derived stats and so needs a recalc to

--- a/src/sim/combat/effect_dispatch.ts
+++ b/src/sim/combat/effect_dispatch.ts
@@ -15,7 +15,7 @@
 // `src/sim`-pure: no DOM/Three, no Math.random/Date.now; all randomness is the
 // shared `ctx.rng` stream, drawn in the exact pre-move order.
 
-import { isDebuffAura, isDispellableAura } from '../aura_classify';
+import { isDebuffAura, isDispellableAura, isPlayerRemovableAura } from '../aura_classify';
 import { ABILITIES, isDelvePos, MOBS } from '../data';
 import { logCascadeCast, recordCascadeInitial } from '../dev/cascade_playtest';
 import { recalcPlayerStats } from '../entity';
@@ -1078,10 +1078,12 @@ export function runEffects(
         // Ice Block strips every player-removable debuff off the caster (control,
         // DoTs, stat saps, ...), broader than breakRoots and breakControl.
         // Encounter-authored unbreakable control stays until its owning script
-        // releases it.
+        // releases it, and an undispellable penalty (the recovery sicknesses) stays
+        // until its own timer runs out: isPlayerRemovableAura is the shared rule this
+        // and the dispel executor both answer to.
         for (let i = p.auras.length - 1; i >= 0; i--) {
           const aura = p.auras[i];
-          if (isDebuffAura(aura.kind, aura.value) && !isUnbreakableControlAura(aura)) {
+          if (isDebuffAura(aura.kind, aura.value) && isPlayerRemovableAura(aura)) {
             p.auras.splice(i, 1);
             ctx.emit({ type: 'aura', targetId: p.id, name: aura.name, gained: false });
           }

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -902,6 +902,11 @@ export interface ArenaReturnPools {
   cooldowns: Map<string, number>;
   abilityCharges: Record<string, AbilityChargeState>;
   ccDr: Map<CrowdControlDrCategory, CrowdControlDrState>;
+  // The recovery sickness the fighter owed on the way in, by id and remaining
+  // seconds. The bout runs on the arena clean slate, but the debt follows them out
+  // (restoreArenaReturnPools), so queueing is not a way to shed the penalty.
+  // Absent when they entered healthy.
+  sickness?: { id: string; remaining: number };
 }
 
 export interface ArenaMatch {

--- a/src/sim/social/arena.ts
+++ b/src/sim/social/arena.ts
@@ -25,8 +25,10 @@ import * as deedsMod from '../deeds';
 import { arenaMapForSlot } from '../dungeon_layout';
 import { recalcPlayerStats } from '../entity';
 import { awardFiestaCompletionHonor, awardRankedArenaWinHonor, honorTeamIdentity } from '../pvp';
+import { SICKNESS_AURA_IDS, UNSTUCK_SICKNESS_ID } from '../resurrection';
 import type { ArenaMatch, ArenaQueueUnit, ArenaReturnPools, PlayerMeta } from '../sim';
 import type { SimContext } from '../sim_context';
+import { applyResurrectionSickness, applyUnstuckSickness } from '../spirit';
 import {
   type ArenaCombatant,
   type ArenaFormat,
@@ -64,13 +66,43 @@ export function cloneAbilityCharges(
 }
 
 export function snapshotArenaReturnPools(e: Entity): ArenaReturnPools {
+  const sickness = e.auras.find((a) => SICKNESS_AURA_IDS.has(a.id));
   return {
     hp: e.hp,
     resource: e.resource,
     cooldowns: new Map(e.cooldowns),
     abilityCharges: cloneAbilityCharges(e.abilityCharges),
     ccDr: cloneCcDr(e.ccDr),
+    // A recovery sickness is owed, not carried: the bout itself runs on the clean
+    // slate (nobody fights a normalized match at a quarter of their stats), but the
+    // remaining seconds come back on the way out. Without this the wipe in
+    // readyArenaFighter laundered the whole penalty for the price of one queue.
+    sickness: sickness ? { id: sickness.id, remaining: sickness.remaining } : undefined,
   };
+}
+
+// Hand back exactly what a fighter carried in. Shared by every arena-shaped mode's
+// return path (ranked arena and Fiesta via returnFromArena, Yumi through the same,
+// and Vale Cup), which is what keeps "a match is a parenthesis, not a rest stop"
+// (issue #1600) from drifting between them.
+//
+// Order is load-bearing: the sickness goes back FIRST because applyAura recalcs the
+// player, so the hp/resource clamp below has to see the drained maxHp, not the
+// healthy one. Everything else is a straight restore.
+export function restoreArenaReturnPools(ctx: SimContext, e: Entity, pools: ArenaReturnPools): void {
+  e.cooldowns = new Map(pools.cooldowns);
+  e.abilityCharges =
+    Object.keys(pools.abilityCharges).length > 0
+      ? cloneAbilityCharges(pools.abilityCharges)
+      : undefined;
+  e.ccDr = cloneCcDr(pools.ccDr);
+  if (pools.sickness) {
+    const { id, remaining } = pools.sickness;
+    if (id === UNSTUCK_SICKNESS_ID) applyUnstuckSickness(ctx, e, remaining);
+    else applyResurrectionSickness(ctx, e, remaining);
+  }
+  e.hp = Math.max(0, Math.min(pools.hp, e.maxHp));
+  e.resource = Math.max(0, Math.min(pools.resource, e.maxResource));
 }
 
 // Ashen Coliseum 1v1 arena tuning consts (moved with the slice). FIESTA_COUNTDOWN
@@ -1161,19 +1193,11 @@ export function returnFromArena(ctx: SimContext, match: ArenaMatch): void {
     // restore and hand back exactly the HP, resource, cooldowns, and CC DR the fighter
     // carried in, so an arena match can never be farmed as a free heal, mana
     // refill, or cooldown reset (issue #1600). recalcPlayerStats already ran
-    // inside resetForArena, so maxHp/maxResource are current for the clamp. Auras
-    // stay cleared (the documented arena clean-slate).
+    // inside resetForArena, so maxHp/maxResource are current for the clamp. Ordinary
+    // auras stay cleared (the documented arena clean-slate); a recovery sickness is
+    // the one exception and rides back through the shared restore.
     const pools = match.preMatchPools?.get(pid);
-    if (pools) {
-      e.cooldowns = new Map(pools.cooldowns);
-      e.abilityCharges =
-        Object.keys(pools.abilityCharges).length > 0
-          ? cloneAbilityCharges(pools.abilityCharges)
-          : undefined;
-      e.ccDr = cloneCcDr(pools.ccDr);
-      e.hp = Math.max(0, Math.min(pools.hp, e.maxHp));
-      e.resource = Math.max(0, Math.min(pools.resource, e.maxResource));
-    }
+    if (pools) restoreArenaReturnPools(ctx, e, pools);
     e.pos = ctx.groundPos(ret.x, ret.z);
     e.prevPos = { ...e.pos };
     e.facing = ret.facing;

--- a/src/sim/social/vale_cup.ts
+++ b/src/sim/social/vale_cup.ts
@@ -79,9 +79,8 @@ import {
 } from '../vale_cup_layout';
 import {
   arenaCombatants,
-  cloneAbilityCharges,
-  cloneCcDr,
   isArenaQueued,
+  restoreArenaReturnPools,
   snapshotArenaReturnPools,
 } from './arena';
 import { duelFor } from './duel';
@@ -1314,16 +1313,7 @@ function teardownCupMatch(ctx: SimContext, match: VcMatch): void {
     // returnFromArena, issue #1600). recalcPlayerStats already ran inside
     // resetForArena, so maxHp/maxResource are current for the clamp.
     const pools = match.preMatchPools?.get(pid);
-    if (pools) {
-      e.cooldowns = new Map(pools.cooldowns);
-      e.abilityCharges =
-        Object.keys(pools.abilityCharges).length > 0
-          ? cloneAbilityCharges(pools.abilityCharges)
-          : undefined;
-      e.ccDr = cloneCcDr(pools.ccDr);
-      e.hp = Math.max(0, Math.min(pools.hp, e.maxHp));
-      e.resource = Math.max(0, Math.min(pools.resource, e.maxResource));
-    }
+    if (pools) restoreArenaReturnPools(ctx, e, pools);
     const ret = match.returns.get(pid);
     if (ret) {
       e.pos = ctx.groundPos(ret.x, ret.z);

--- a/src/sim/spirit.ts
+++ b/src/sim/spirit.ts
@@ -417,6 +417,11 @@ function applySickness(
     value,
     sourceId: p.id,
     school: 'shadow',
+    // The penalty is the whole point of both sicknesses, so no player counter may take
+    // it off: a dispel (warlock Voidfeast, paladin Cleansing Verdict), a cleanse (mage
+    // Cold Coffin), and the buff-bar right-click all skip it, exactly as dying and
+    // relogging already do (aurasSurvivingDeath). Only the timer clears it.
+    undispellable: true,
   });
 }
 

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -470,10 +470,11 @@ export interface Aura {
   // removed by player counters. Natural expiry and encounter cleanup still own it.
   unbreakableControl?: true;
   // A penalty no player counter may shed: dispel, purge, and cleanse all skip it, and
-  // it is never right-click cancelable. Only its own timer takes it off. The two
-  // recovery sicknesses (src/sim/resurrection.ts) carry it, matching the fact that they
-  // already survive death and relogging; without it a single dispel erased the entire
-  // Pale Keeper / unstuck penalty. See isPlayerRemovableAura in ./aura_classify.ts.
+  // it is never right-click cancelable. Only its own timer takes it off. Set today at
+  // exactly one site, applySickness in ./spirit.ts, which serves both recovery
+  // sicknesses, matching the fact that they already survive death and relogging;
+  // without it a single dispel erased the entire Pale Keeper / unstuck penalty. The
+  // rule itself is isPlayerRemovableAura in ./aura_classify.ts.
   undispellable?: true;
   breaksOnDamage?: boolean;
   // Lingering Dread lets a break-on-damage fear absorb this much damage before

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -469,6 +469,12 @@ export interface Aura {
   // Encounter-authored control that must land through immunity and cannot be
   // removed by player counters. Natural expiry and encounter cleanup still own it.
   unbreakableControl?: true;
+  // A penalty no player counter may shed: dispel, purge, and cleanse all skip it, and
+  // it is never right-click cancelable. Only its own timer takes it off. The two
+  // recovery sicknesses (src/sim/resurrection.ts) carry it, matching the fact that they
+  // already survive death and relogging; without it a single dispel erased the entire
+  // Pale Keeper / unstuck penalty. See isPlayerRemovableAura in ./aura_classify.ts.
+  undispellable?: true;
   breaksOnDamage?: boolean;
   // Lingering Dread lets a break-on-damage fear absorb this much damage before
   // breaking. Undefined retains the normal break-on-any-damage behavior.

--- a/src/ui/auras_view.ts
+++ b/src/ui/auras_view.ts
@@ -27,7 +27,11 @@
 // same as 1 (no stacks badge), and a Sim-shaped aura {stacks:1} and a ClientWorld
 // mirror aura {stacks:undefined} derive identical output.
 
-import { isDebuffAura as classifyDebuffAura, DEBUFF_AURA_KINDS } from '../sim/aura_classify';
+import {
+  isDebuffAura as classifyDebuffAura,
+  DEBUFF_AURA_KINDS,
+  isPlayerRemovableAura,
+} from '../sim/aura_classify';
 import type { AuraKind } from '../sim/types';
 import type { AuraSchool } from './aura_effect';
 
@@ -122,6 +126,10 @@ export interface AuraInput {
   // Encounter-owned control cannot be canceled by the player. Mirrored over the
   // online aura wire so the cancel affordance matches the authoritative sim.
   unbreakableControl?: true;
+  // The other arm of the same rule: a penalty no player counter may shed (the recovery
+  // sicknesses). Also mirrored over the wire (terse `und`), so the cancel affordance
+  // cannot offer what the sim's cancel path would refuse.
+  undispellable?: true;
 }
 
 /** The entity fields the core reads: just its aura list. */
@@ -358,8 +366,12 @@ export function createAurasView(
         slot.sourceId = a.sourceId;
         // The buff bar (mode 'buffs', the player's own auras) offers right-click-cancel;
         // a helpful buff is cancelable, a debuff never. The target debuff strip
-        // (mode 'debuffs') is read-only, so nothing there is cancelable.
-        slot.cancelable = mode === 'buffs' && !debuff && a.unbreakableControl !== true;
+        // (mode 'debuffs') is read-only, so nothing there is cancelable. The
+        // removability term is isPlayerRemovableAura, the same predicate the sim's
+        // cancel path answers to (combat/aura_cancel.ts), so the affordance can never
+        // offer a cancel the server would refuse: both the encounter-control and the
+        // undispellable arms ride the wire (ub / und) for exactly this reader.
+        slot.cancelable = mode === 'buffs' && !debuff && isPlayerRemovableAura(a);
         const cachedEffect = effectHtmlCache[count];
         if (
           !effectHtmlCacheVersion ||

--- a/tests/auras_view.test.ts
+++ b/tests/auras_view.test.ts
@@ -242,6 +242,28 @@ describe('createAurasView: derivation per mode', () => {
     ).toBe(false);
   });
 
+  // The sibling of the case above, for the other arm of isPlayerRemovableAura. A
+  // helpful (positive-value) aura is the only shape where the removability term
+  // decides the affordance: a debuff is refused by the isDebuff term regardless. The
+  // flag rides the wire as `und` (server/game.ts wireAura), so this is what keeps the
+  // online buff bar from offering a cancel the server would refuse.
+  it('never offers a right-click cancel on an undispellable helpful aura', () => {
+    const ordinaryBoon = aura({ id: 'ordinary_boon', kind: 'buff_ap', value: 50 });
+    const boundBoon = aura({
+      id: 'bound_boon',
+      kind: 'buff_ap',
+      value: 50,
+      undispellable: true,
+    });
+
+    expect(createAurasView('buffs', deps()).tick(entity([ordinaryBoon])).slots[0].cancelable).toBe(
+      true,
+    );
+    expect(createAurasView('buffs', deps()).tick(entity([boundBoon])).slots[0].cancelable).toBe(
+      false,
+    );
+  });
+
   it('emits one slot PER aura even when two share an id (no core-side dedup)', () => {
     // The sim dedups by id+sourceId, so one entity can carry two auras with the same id
     // from different sources. The core must NOT collapse them (that is the painter's job,

--- a/tests/parity/golden/entity_roster.json
+++ b/tests/parity/golden/entity_roster.json
@@ -462,7 +462,7 @@
       "tick": 5,
       "time": 0.25,
       "nextId": 834,
-      "state": "02d76a16",
+      "state": "23d152e0",
       "events": "f7ff5b3a",
       "rng": {
         "draws": 4,
@@ -553,6 +553,7 @@
               "remaining": 60,
               "school": "shadow",
               "sourceId": 827,
+              "undispellable": true,
               "value": -0.75
             }
           ],
@@ -611,7 +612,7 @@
       "tick": 6,
       "time": 0.3,
       "nextId": 834,
-      "state": "71d8f9a0",
+      "state": "9381fe2a",
       "events": "37d25016",
       "rng": {
         "draws": 4,
@@ -622,7 +623,7 @@
       "tick": 7,
       "time": 0.35,
       "nextId": 834,
-      "state": "76177c97",
+      "state": "3ed5ec37",
       "events": "741638a5",
       "rng": {
         "draws": 4,
@@ -713,6 +714,7 @@
               "remaining": 59.9,
               "school": "shadow",
               "sourceId": 827,
+              "undispellable": true,
               "value": -0.75
             },
             {

--- a/tests/sickness_undispellable.test.ts
+++ b/tests/sickness_undispellable.test.ts
@@ -13,14 +13,17 @@
 import { describe, expect, it } from 'vitest';
 import { isDispellableAura, isPlayerRemovableAura } from '../src/sim/aura_classify';
 import { isCancelableAura } from '../src/sim/combat/aura_cancel';
+import { BUILTIN_WORLD } from '../src/sim/data';
 import {
   RES_SICKNESS_STAT_MULT,
   RESURRECTION_SICKNESS_ID,
+  SICKNESS_AURA_IDS,
   UNSTUCK_SICKNESS_ID,
 } from '../src/sim/resurrection';
 import { Sim } from '../src/sim/sim';
 import { applyResurrectionSickness, applyUnstuckSickness } from '../src/sim/spirit';
 import type { Aura, Entity, PlayerClass } from '../src/sim/types';
+import { groundHeight } from '../src/sim/world';
 import { bareClient } from './helpers/bare_client';
 
 type Ev = { type?: string; text?: string };
@@ -250,6 +253,92 @@ describe('warlock Voidfeast cannot devour a sickness', () => {
     for (let i = 0; i < 15; i++) sim.tick();
     expect(has(p, 'test_withering_wail')).toBe(false);
     expect(has(p, RESURRECTION_SICKNESS_ID)).toBe(true);
+  });
+});
+
+// The arena/fiesta clean slate wipes every aura outright (readyArenaFighter), which
+// is deliberate: nobody should fight a normalized bout at a quarter of their stats.
+// But the wipe also meant one queue laundered the whole penalty, so the debt is now
+// stashed in preMatchPools and handed back on the way out (restoreArenaReturnPools).
+
+// Seat a real ranked bout, at a level where a sickness has a non-zero duration
+// (applySickness is a no-op below level 10, which is what makes the level matter here).
+function seatArenaBout(): { sim: AnySim; a: number; b: number } {
+  const sim = new Sim({
+    seed: 42,
+    playerClass: 'warrior',
+    noPlayer: true,
+    world: { ...BUILTIN_WORLD, camps: [], npcs: {}, groundObjects: [] },
+  }) as AnySim;
+  const a = sim.addPlayer('warrior', 'Aleph') as number;
+  const b = sim.addPlayer('mage', 'Bet') as number;
+  for (const [pid, x] of [
+    [a, 0],
+    [b, 6],
+  ] as const) {
+    sim.setPlayerLevel(12, pid);
+    const e = sim.entities.get(pid) as Entity;
+    e.pos.x = x;
+    e.pos.z = -40;
+    e.pos.y = groundHeight(x, -40, sim.cfg.seed);
+    e.prevPos = { ...e.pos };
+    sim.rebucket(e);
+  }
+  return { sim, a, b };
+}
+
+// End the bout decisively and run out the return delay that hands the survivor back
+// to the world. The pre-fight countdown has to run out first: a bout only resolves
+// once it is active, so killing during the countdown just waits out the 150s cap.
+function finishArenaBout(sim: AnySim, winnerPid: number, loserPid: number): void {
+  for (let i = 0; i < 20 * 10; i++) {
+    if (sim.arenaMatchFor(winnerPid)?.state === 'active') break;
+    sim.tick();
+  }
+  expect(sim.arenaMatchFor(winnerPid)?.state).toBe('active');
+  const winner = sim.entities.get(winnerPid) as Entity;
+  const loser = sim.entities.get(loserPid) as Entity;
+  loser.hp = 1;
+  sim.dealDamage(winner, loser, 1000, false, 'physical', 'Test', 'hit');
+  for (let i = 0; i < 20 * 60 && sim.arenaMatchFor(winnerPid); i++) sim.tick();
+  expect(sim.arenaMatchFor(winnerPid)).toBeNull();
+}
+
+describe('an arena bout is a parenthesis, not a way to shed a sickness', () => {
+  it.each(['resurrection', 'unstuck'] as const)(
+    'clears %s sickness for the bout and hands it back on return',
+    (which) => {
+      const { sim, a, b } = seatArenaBout();
+      const sick = sim.entities.get(a) as Entity;
+      sicken(sim, sick, which);
+      const owed = sicknessAura(sick, which).remaining;
+
+      sim.arenaQueueJoin(a);
+      sim.arenaQueueJoin(b);
+      sim.tick(); // matchmaking seats the pair
+      // The clean slate is intact for the bout itself: this half is the pre-existing
+      // behavior the fix deliberately preserves.
+      expect(has(sick, idOf(which))).toBe(false);
+
+      finishArenaBout(sim, a, b);
+
+      // The debt came back, and never more than the fighter owed walking in.
+      expect(has(sick, idOf(which))).toBe(true);
+      const returned = sicknessAura(sick, which);
+      expect(returned.remaining).toBeGreaterThan(0);
+      expect(returned.remaining).toBeLessThanOrEqual(owed);
+      expect(returned.undispellable).toBe(true);
+    },
+  );
+
+  it('leaves a fighter who entered healthy healthy on return', () => {
+    const { sim, a, b } = seatArenaBout();
+    sim.arenaQueueJoin(a);
+    sim.arenaQueueJoin(b);
+    sim.tick();
+    finishArenaBout(sim, a, b);
+    const winner = sim.entities.get(a) as Entity;
+    expect(winner.auras.some((aura) => SICKNESS_AURA_IDS.has(aura.id))).toBe(false);
   });
 });
 

--- a/tests/sickness_undispellable.test.ts
+++ b/tests/sickness_undispellable.test.ts
@@ -1,0 +1,236 @@
+// The two recovery sicknesses (The Keeper's Toll and Unstuck Sickness) are the one
+// debuff class no player counter may shed. They already survive dying and relogging
+// (aurasSurvivingDeath in src/sim/resurrection.ts); before this suite they were still
+// ordinary dispel food, so a warlock Voidfeast, a paladin Cleansing Verdict, or a mage
+// Cold Coffin erased the whole penalty (and Voidfeast healed the caster 6% for it).
+//
+// The rule is enforced in ONE place: the `undispellable` aura flag, honored by
+// isPlayerRemovableAura in src/sim/aura_classify.ts, which both the dispel executor
+// (+ its requiresDispellable cast gate) and the cleanseSelf executor route through.
+// The negative controls below are what keep the fix from becoming "nothing is
+// dispellable": an ordinary magic debuff must still be dispelled and cleansed.
+
+import { describe, expect, it } from 'vitest';
+import { isDispellableAura, isPlayerRemovableAura } from '../src/sim/aura_classify';
+import { isCancelableAura } from '../src/sim/combat/aura_cancel';
+import {
+  RES_SICKNESS_STAT_MULT,
+  RESURRECTION_SICKNESS_ID,
+  UNSTUCK_SICKNESS_ID,
+} from '../src/sim/resurrection';
+import { Sim } from '../src/sim/sim';
+import { applyResurrectionSickness, applyUnstuckSickness } from '../src/sim/spirit';
+import type { Aura, Entity, PlayerClass } from '../src/sim/types';
+
+type Ev = { type?: string; text?: string };
+type AnySim = Sim & Record<string, any>;
+
+// A plain magic debuff: the negative control. Same school as the sicknesses and also a
+// negative-value buff_* stat drain, so it differs from them ONLY by the flag. Anything
+// that stops removing this one has over-reached.
+function witheringWail(sourceId: number): Aura {
+  return {
+    id: 'test_withering_wail',
+    name: 'Withering Wail',
+    kind: 'buff_allstats_pct',
+    remaining: 60,
+    duration: 60,
+    value: -0.1,
+    sourceId,
+    school: 'shadow',
+  };
+}
+
+function sicknessAura(p: Entity, which: 'resurrection' | 'unstuck'): Aura {
+  const aura = p.auras.find((a) => a.id === idOf(which));
+  if (!aura) throw new Error(`no ${which} sickness applied`);
+  return aura;
+}
+
+const idOf = (which: 'resurrection' | 'unstuck') =>
+  which === 'resurrection' ? RESURRECTION_SICKNESS_ID : UNSTUCK_SICKNESS_ID;
+
+// A single-player rig at a level where the sickness has a real duration (both
+// sicknesses are zero-length below level 10), with the row-8 talent allocated.
+function rig(
+  cls: PlayerClass,
+  talentRow: string,
+  level = 12,
+): { sim: AnySim; p: Entity; events: Ev[] } {
+  const sim = new Sim({ seed: 7, playerClass: cls, autoEquip: true }) as AnySim;
+  sim.setPlayerLevel(level);
+  expect(sim.applyTalents({ spec: null, rows: { 8: talentRow } })).toBe(true);
+  const p = sim.player as Entity;
+  p.resource = p.maxResource;
+  const events: Ev[] = [];
+  const emitter = sim as unknown as { emit(e: Ev): void };
+  const orig = emitter.emit.bind(sim);
+  emitter.emit = (e: Ev) => {
+    events.push(e);
+    orig(e);
+  };
+  return { sim, p, events };
+}
+
+const sicken = (sim: AnySim, p: Entity, which: 'resurrection' | 'unstuck') => {
+  if (which === 'resurrection') applyResurrectionSickness(sim.ctx, p);
+  else applyUnstuckSickness(sim.ctx, p);
+  expect(p.auras.some((a) => a.id === idOf(which))).toBe(true);
+};
+
+const has = (p: Entity, id: string) => p.auras.some((a) => a.id === id);
+
+describe('the recovery sicknesses carry the undispellable flag', () => {
+  it.each(['resurrection', 'unstuck'] as const)('%s sickness is flagged on apply', (which) => {
+    const { sim, p } = rig('warlock', 'wlk_r8_voidfeast');
+    sicken(sim, p, which);
+    expect(sicknessAura(p, which).undispellable).toBe(true);
+  });
+
+  it('a flagged aura is removable by nothing, in either dispel direction', () => {
+    const flagged = { ...witheringWail(1), undispellable: true as const };
+    expect(isPlayerRemovableAura(flagged)).toBe(false);
+    expect(isDispellableAura(flagged, false)).toBe(false);
+    expect(isDispellableAura(flagged, true)).toBe(false);
+    // A debuff was never right-click cancelable; the flag must not make it one.
+    expect(isCancelableAura(flagged)).toBe(false);
+  });
+
+  it('an unflagged magic debuff stays dispellable (the fix is not a blanket ban)', () => {
+    const plain = witheringWail(1);
+    expect(isPlayerRemovableAura(plain)).toBe(true);
+    expect(isDispellableAura(plain, false)).toBe(true);
+  });
+});
+
+describe('warlock Voidfeast cannot devour a sickness', () => {
+  it.each(['resurrection', 'unstuck'] as const)(
+    'refuses the self-cast on %s sickness before billing',
+    (which) => {
+      const { sim, p, events } = rig('warlock', 'wlk_r8_voidfeast');
+      sicken(sim, p, which);
+      const manaBefore = p.resource;
+      const hpBefore = p.hp;
+      sim.targetEntity(p.id);
+      sim.castAbility('voidfeast');
+      sim.tick();
+      expect(
+        events.some((e) => e.type === 'error' && /nothing to devour/i.test(e.text ?? '')),
+      ).toBe(true);
+      expect(has(p, idOf(which))).toBe(true);
+      // The gate refuses before billing, so the 6% devour heal never pays out either.
+      expect(p.resource).toBe(manaBefore);
+      expect(p.cooldowns.has('voidfeast')).toBe(false);
+      expect(p.hp).toBe(hpBefore);
+    },
+  );
+
+  it('refuses an ally carrying only Resurrection Sickness', () => {
+    const sim = new Sim({
+      seed: 7,
+      playerClass: 'warlock',
+      autoEquip: true,
+      noPlayer: true,
+    }) as AnySim;
+    const lockId = sim.addPlayer('warlock', 'Lock') as number;
+    const allyId = sim.addPlayer('warrior', 'Ally') as number;
+    sim.setPlayerLevel(12, lockId);
+    sim.setPlayerLevel(12, allyId);
+    expect(sim.applyTalents({ spec: null, rows: { 8: 'wlk_r8_voidfeast' } }, lockId)).toBe(true);
+    const lock = sim.entities.get(lockId) as Entity;
+    const ally = sim.entities.get(allyId) as Entity;
+    ally.pos = { ...lock.pos, x: lock.pos.x + 2 };
+    ally.prevPos = { ...ally.pos };
+    sim.rebucket(ally);
+    lock.resource = lock.maxResource;
+    applyResurrectionSickness(sim.ctx, ally);
+    const manaBefore = lock.resource;
+    sim.targetEntity(allyId, lockId);
+    sim.castAbility('voidfeast', lockId);
+    for (let i = 0; i < 15; i++) sim.tick();
+    expect(has(ally, RESURRECTION_SICKNESS_ID)).toBe(true);
+    expect(lock.resource).toBe(manaBefore);
+    expect(lock.cooldowns.has('voidfeast')).toBe(false);
+  });
+
+  it('still devours an ordinary debuff sitting under a sickness', () => {
+    const { sim, p } = rig('warlock', 'wlk_r8_voidfeast');
+    // Order matters: the dispel executor scans from the END of the aura array and
+    // stops at its `count`, so the sickness must be the FIRST candidate it meets.
+    // With the wail pushed last the test would pass with no fix at all.
+    p.auras.push(witheringWail(p.id));
+    sicken(sim, p, 'resurrection');
+    sim.targetEntity(p.id);
+    sim.castAbility('voidfeast');
+    for (let i = 0; i < 15; i++) sim.tick();
+    expect(has(p, 'test_withering_wail')).toBe(false);
+    expect(has(p, RESURRECTION_SICKNESS_ID)).toBe(true);
+  });
+});
+
+describe('paladin Cleansing Verdict cannot purge a sickness', () => {
+  it.each(['resurrection', 'unstuck'] as const)(
+    'leaves %s sickness on the target and takes the debuff beneath it',
+    (which) => {
+      const { sim, p } = rig('paladin', 'pal_r8_cleansing_verdict');
+      // Wail FIRST, sickness second: Cleansing Verdict carries no requiresDispellable
+      // gate and dispels count 1 scanning from the end, so this ordering is what makes
+      // the case decisive. It must skip the sickness and take the wail underneath.
+      p.auras.push(witheringWail(p.id));
+      sicken(sim, p, which);
+      sim.targetEntity(p.id);
+      sim.castAbility('cleansing_verdict');
+      for (let i = 0; i < 15; i++) sim.tick();
+      expect(has(p, 'test_withering_wail')).toBe(false);
+      expect(has(p, idOf(which))).toBe(true);
+    },
+  );
+
+  it.each(['resurrection', 'unstuck'] as const)(
+    'finds nothing to purge when %s sickness is the only debuff',
+    (which) => {
+      const { sim, p } = rig('paladin', 'pal_r8_cleansing_verdict');
+      sicken(sim, p, which);
+      sim.targetEntity(p.id);
+      sim.castAbility('cleansing_verdict');
+      for (let i = 0; i < 15; i++) sim.tick();
+      expect(has(p, idOf(which))).toBe(true);
+    },
+  );
+});
+
+describe('mage Cold Coffin (cleanseSelf) cannot strip a sickness', () => {
+  it.each(['resurrection', 'unstuck'] as const)('leaves %s sickness on the caster', (which) => {
+    // Cold Coffin is a base mage ability at level 12, so no talent row is needed;
+    // the row-8 allocation just keeps the rig helper uniform.
+    const { sim, p } = rig('mage', 'mag_r8_warded');
+    sicken(sim, p, which);
+    p.auras.push(witheringWail(p.id));
+    sim.castAbility('ice_block');
+    sim.tick();
+    // cleanseSelf still strips every ordinary debuff: that is the whole ability.
+    expect(has(p, 'test_withering_wail')).toBe(false);
+    expect(has(p, idOf(which))).toBe(true);
+  });
+});
+
+describe('the sickness drain survives every counter', () => {
+  it('keeps the full stat penalty folded in after a cleanse attempt', () => {
+    const { sim, p } = rig('mage', 'mag_r8_warded');
+    const healthy = p.maxHp;
+    sicken(sim, p, 'resurrection');
+    const sickened = p.maxHp;
+    expect(sickened).toBeLessThan(healthy);
+    sim.castAbility('ice_block');
+    sim.tick();
+    expect(p.maxHp).toBe(sickened);
+    expect(sicknessAura(p, 'resurrection').value).toBe(RES_SICKNESS_STAT_MULT);
+  });
+
+  it('refuses the right-click cancel a player could try on the buff bar', () => {
+    const { sim, p } = rig('mage', 'mag_r8_warded');
+    sicken(sim, p, 'resurrection');
+    sim.cancelAura(RESURRECTION_SICKNESS_ID);
+    expect(has(p, RESURRECTION_SICKNESS_ID)).toBe(true);
+  });
+});

--- a/tests/sickness_undispellable.test.ts
+++ b/tests/sickness_undispellable.test.ts
@@ -21,6 +21,7 @@ import {
 import { Sim } from '../src/sim/sim';
 import { applyResurrectionSickness, applyUnstuckSickness } from '../src/sim/spirit';
 import type { Aura, Entity, PlayerClass } from '../src/sim/types';
+import { bareClient } from './helpers/bare_client';
 
 type Ev = { type?: string; text?: string };
 type AnySim = Sim & Record<string, any>;
@@ -100,6 +101,90 @@ describe('the recovery sicknesses carry the undispellable flag', () => {
     const plain = witheringWail(1);
     expect(isPlayerRemovableAura(plain)).toBe(true);
     expect(isDispellableAura(plain, false)).toBe(true);
+  });
+
+  // The cancel arms above ride on isDebuffAura: both sicknesses are negative-value
+  // buff_* auras, so they were already refused as debuffs and those assertions hold
+  // with the flag reverted. A POSITIVE-value buff is the only shape where the
+  // removability term is what decides, so this is the case that actually covers it.
+  it('refuses the cancel on a flagged HELPFUL buff, where the flag is the deciding term', () => {
+    const helpful: Aura = {
+      id: 'test_bound_boon',
+      name: 'Bound Boon',
+      kind: 'buff_ap',
+      remaining: 60,
+      duration: 60,
+      value: 50,
+      sourceId: 1,
+      school: 'holy',
+    };
+    expect(isCancelableAura(helpful)).toBe(true);
+    expect(isCancelableAura({ ...helpful, undispellable: true })).toBe(false);
+    // The client's matching buff-bar affordance is covered beside its own module,
+    // in tests/auras_view.test.ts ("never offers a right-click cancel ...").
+  });
+});
+
+describe('the flag reaches the online client', () => {
+  it('round-trips through the wire as und and back to undispellable', () => {
+    const client = bareClient(1);
+    (client as unknown as { applySnapshot(s: unknown): void }).applySnapshot({
+      ents: [
+        {
+          id: 2,
+          k: 'player',
+          nm: 'Sick',
+          lv: 12,
+          x: 0,
+          y: 0,
+          z: 0,
+          f: 0,
+          hp: 40,
+          mhp: 40,
+          auras: [
+            {
+              id: RESURRECTION_SICKNESS_ID,
+              name: 'Resurrection Sickness',
+              kind: 'buff_allstats_pct',
+              rem: 600,
+              dur: 600,
+              value: RES_SICKNESS_STAT_MULT,
+              school: 'shadow',
+              und: 1,
+            },
+          ],
+        },
+      ],
+    });
+    const mirrored = client.entities.get(2)?.auras.find((a) => a.id === RESURRECTION_SICKNESS_ID);
+    expect(mirrored?.undispellable).toBe(true);
+    expect(isPlayerRemovableAura(mirrored as Aura)).toBe(false);
+  });
+
+  it('leaves an ordinary aura unflagged when the server omits und', () => {
+    const client = bareClient(1);
+    (client as unknown as { applySnapshot(s: unknown): void }).applySnapshot({
+      ents: [
+        {
+          id: 3,
+          k: 'player',
+          nm: 'Well',
+          lv: 12,
+          x: 0,
+          y: 0,
+          z: 0,
+          f: 0,
+          hp: 40,
+          mhp: 40,
+          auras: [
+            { id: 'test_buff', name: 'Test Buff', kind: 'buff_ap', rem: 30, dur: 30, value: 5 },
+          ],
+        },
+      ],
+    });
+    const mirrored = client.entities.get(3)?.auras.find((a) => a.id === 'test_buff');
+    expect(mirrored?.undispellable).toBeUndefined();
+    expect(isPlayerRemovableAura(mirrored as Aura)).toBe(true);
   });
 });
 
@@ -226,6 +311,22 @@ describe('the sickness drain survives every counter', () => {
     expect(p.maxHp).toBe(sickened);
     expect(sicknessAura(p, 'resurrection').value).toBe(RES_SICKNESS_STAT_MULT);
   });
+
+  // Persistence stores only the remaining seconds and restores through the same
+  // applySickness funnel, so the flag cannot be lost across a relog by construction.
+  // This pins that construction: a future refactor that rebuilds the aura literal at
+  // the restore site instead of calling applySickness fails here.
+  it.each(['resurrection', 'unstuck'] as const)(
+    'restores %s sickness flagged when a saved remaining is replayed',
+    (which) => {
+      const { sim, p } = rig('mage', 'mag_r8_warded');
+      const restore = which === 'resurrection' ? applyResurrectionSickness : applyUnstuckSickness;
+      restore(sim.ctx, p, 42);
+      const aura = sicknessAura(p, which);
+      expect(aura.remaining).toBe(42);
+      expect(aura.undispellable).toBe(true);
+    },
+  );
 
   it('refuses the right-click cancel a player could try on the buff bar', () => {
     const { sim, p } = rig('mage', 'mag_r8_warded');

--- a/tests/wire_aura.test.ts
+++ b/tests/wire_aura.test.ts
@@ -54,6 +54,8 @@ describe('wireEntity aura serialization', () => {
     expect(w).not.toHaveProperty('stacks');
     expect(w).not.toHaveProperty('charges');
     expect(w).not.toHaveProperty('src');
+    expect(w).not.toHaveProperty('ub');
+    expect(w).not.toHaveProperty('und');
     expect(w).not.toHaveProperty('bt');
   });
 
@@ -70,6 +72,8 @@ describe('wireEntity aura serialization', () => {
         stacks: 4,
         charges: 2,
         sourceId: 7,
+        unbreakableControl: true,
+        undispellable: true,
         breakThreshold: 25,
       }),
     ];
@@ -89,6 +93,8 @@ describe('wireEntity aura serialization', () => {
       stacks: 4,
       charges: 2,
       src: 7,
+      ub: 1,
+      und: 1,
       bt: 1,
     });
     expect(Object.keys(w)).toEqual([
@@ -105,6 +111,8 @@ describe('wireEntity aura serialization', () => {
       'stacks',
       'charges',
       'src',
+      'ub',
+      'und',
       'bt',
     ]);
   });


### PR DESCRIPTION
## Summary

The two recovery sicknesses (The Keeper's Toll and Unstuck Sickness) could be removed
outright by ordinary player counters, which erased the entire penalty in one global.

They are applied as a plain `buff_allstats_pct` aura with a negative value, so
`isDispellableAura` classified them as ordinary harmful magic. That made all of these work:

- warlock Voidfeast devoured one off yourself or an ally, and healed the caster 6% of max
  health for doing it (the `requiresDispellable` gate counted the sickness as food)
- paladin Cleansing Verdict purged one
- mage Cold Coffin stripped one, since `cleanseSelf` removes every debuff
- arena, Fiesta, Yumi and Vale Cup wiped one, since a bout clears every aura on a fighter

The sicknesses already survive death and relogging (`aurasSurvivingDeath`), and the design
comment in `spirit.ts` frames the Pale Keeper resurrection as deliberately the worse option,
so shedding the penalty for a 15 second cooldown undercut the whole mechanic.

This adds an `undispellable` aura flag and one shared predicate, `isPlayerRemovableAura`,
that every player-driven removal path answers to, rather than an id check per ability:

| Path | Module |
|---|---|
| dispel executor | `src/sim/combat/effect_dispatch.ts` |
| `requiresDispellable` cast gate | `src/sim/combat/casting_lifecycle.ts` |
| `cleanseSelf` executor | `src/sim/combat/effect_dispatch.ts` |
| buff-bar right-click cancel | `src/sim/combat/aura_cancel.ts` |
| the client's cancel affordance | `src/ui/auras_view.ts` |

The flag is set at the single `applySickness` funnel in `src/sim/spirit.ts`, so it covers
both sicknesses and both the fresh-apply and relog-restore paths. It rides the wire as `und`
so the online client's predicate agrees with the server's.

The arena family is handled differently, because the clean slate itself is correct: nobody
should fight a normalized bout at a quarter of their stats. Instead the sickness is stashed
in `preMatchPools` and handed back with its remaining seconds on the way out, so a bout stays
fair and queueing is no longer a way to shed the debt. The four return paths already shared a
byte-identical restore block, so this extracts `restoreArenaReturnPools` next to its existing
snapshot half rather than growing a fourth copy of it.

Two things deliberately left alone:

- **Ability copy.** Cold Coffin still says it removes "every harmful effect" and Voidfeast
  "a harmful one from an ally". Both are now slightly imprecise, but rewording English
  ability descriptions marks the locale rows stale across every language at release, and
  classic-era players already expect a resurrection sickness to be undispellable. Happy to
  amend if you would rather have the copy exact.
- **The mid-bout wipe.** `fiestaDownEntity` and `readyArenaFighter` still clear everything
  during a match. That is the behavior the restore-on-exit is built around.

## Related issues

N/A

## Type of change

- [x] Bug fix
- [x] Tests

## How was this tested?

- Commands:
  - `npx vitest run tests/sickness_undispellable.test.ts` (24 cases, new)
  - `npx vitest run tests/auras_view.test.ts tests/wire_aura.test.ts tests/aura_cancel.test.ts tests/aura_classify.test.ts`
  - every arena/fiesta/yumi/vale_cup suite: 35 files, 502 tests
  - `npx vitest run tests/parity` and `tests/architecture.test.ts`
  - `npx tsc --noEmit`
- Manual steps: none. The behavior is server-authoritative sim logic with no visual surface.

Written test-first: 15 of the first 16 cases failed against the unfixed tree. The suite
carries negative controls throughout, so the fix cannot degrade into "nothing is
dispellable": an ordinary shadow-school stat-sap debuff, identical to a sickness except for
the flag, must still be dispelled by Voidfeast and Cleansing Verdict and cleansed by Cold
Coffin, and each of those is asserted.

Two decisiveness details worth knowing when reading the tests:

- The dispel executor scans the aura array backwards and stops at its `count`, so the
  control debuff is pushed **before** the sickness. With the natural ordering those cases
  would pass with no fix at all.
- The cancel arms ride on the debuff term, which already refuses both sicknesses. The
  positive-value case (`buff_ap`, value 50, flagged) is the one shape where the flag is what
  actually decides, and it covers both the sim predicate and the client affordance.

The parity gate reminted `entity_roster.json` only: the rng draw digest and draw count are
unchanged, so no draw site moved, and the only content delta is the new field on the sickness
aura records.

**Gate status:** two full `npm run gate` runs on this tree ended red on 20 second timeouts in
`tests/terrain_streaming.test.ts` and `tests/threat.test.ts`. Both suites pass in isolation
(95 tests green), no failure was an assertion, and nothing in the failure set touches auras,
dispel, arena, or the wire. It reads as local core contention rather than a regression, but I
am flagging it rather than claiming a green gate. CI on this PR is the real check.

## Screenshots / recordings

N/A. No visual surface changes.

---

## Checklist

### Quality

- [ ] **The full gate passes.** See the gate status note above: red locally on unrelated
      timeouts, green on every targeted suite. Deferring to CI.

### Cross-platform

- [x] N/A. No UI layout change. The one `src/ui` edit swaps a hand-rolled predicate for the
      shared one and changes no markup, styling, or interaction.
- [x] N/A. No new or edited interactive UI.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled
      in any production path.
- [x] I didn't hand-edit generated files. The one regenerated artifact is the parity golden,
      reminted with `UPDATE_PARITY=1` in its own commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
