### PR TITLE
fix(sim): gate delve-shop purchases and companion upgrades on proximity

### DIFF
--- a/src/sim/delves/runs.ts
+++ b/src/sim/delves/runs.ts
@@ -1545,12 +1545,33 @@ export function delveRiteChoose(ctx: SimContext, intensity: RiteIntensity, pid?:
 
 // ----- companion economy + shop + wire getters -------------------------------
 
+// Reach for Brother Halven's Marks shop and the companion upgrade board: the
+// same 12-yard radius around the delve door the WS dispatch handler already
+// pre-gates on (server/game.ts 'delve_buy' / 'companion_upgrade'), enforced
+// here too as defense-in-depth, matching every other location-gated spend in
+// the sim (market.ts nearMerchant, bank.ts nearBanker, mail/post_office.ts
+// nearMailbox, items.ts buyItem's dist2d check, instances/heroic_vendor.ts
+// heroicVendorInRange, professions/training.ts isAtStation).
+const DELVE_SHOP_RANGE = 12;
+
+function nearDelveDoor(pos: Pick<Vec3, 'x' | 'z'>, delve: DelveDef): boolean {
+  return Math.hypot(pos.x - delve.doorPos.x, pos.z - delve.doorPos.z) <= DELVE_SHOP_RANGE;
+}
+
 export function companionUpgrade(ctx: SimContext, companionId: string, pid?: number): void {
   const r = ctx.resolve(pid);
   if (!r) return;
   const def = DELVE_COMPANIONS[companionId];
   if (!def) {
     ctx.error(r.meta.entityId, 'Unknown companion.');
+    return;
+  }
+  // The companion is ranked up at Brother Halven, not from anywhere in the
+  // world: find the delve this companion belongs to and require the player
+  // stand at its door.
+  const delve = Object.values(DELVES).find((d) => d.autoCompanionId === companionId);
+  if (!delve || !nearDelveDoor(r.e.pos, delve)) {
+    ctx.error(r.meta.entityId, 'Too far away.');
     return;
   }
   const rank = r.meta.companionUpgrades[companionId] ?? 1;
@@ -1608,10 +1629,11 @@ export function delveClearsFor(ctx: SimContext, pid: number): Record<string, num
   return { ...(ctx.players.get(pid)?.delveClears ?? {}) };
 }
 
-// Server-authoritative Marks-vendor purchase. Re-validates the gate + balance
-// here regardless of what the client shows; the client only sends intent. The
-// server geo-gates this to the board NPC (see the `delve_buy` command) so a
-// player must be standing at Brother Halven, mirroring `enter_delve`.
+// Server-authoritative Marks-vendor purchase. Re-validates the door range, the
+// gate, and the balance here regardless of what the client shows; the client
+// only sends intent. The WS dispatch (see the `delve_buy` command) pre-gates
+// the same 12-yard door range so a player must be standing at Brother Halven,
+// mirroring `enter_delve`; the check below is defense-in-depth.
 export function delveBuyShopItem(
   ctx: SimContext,
   delveId: string,
@@ -1629,6 +1651,11 @@ export function delveBuyShopItem(
   const def = ITEMS[itemId];
   if (!def) {
     ctx.error(meta.entityId, 'That item is not for sale.');
+    return;
+  }
+  const delve = DELVES[delveId];
+  if (!delve || !nearDelveDoor(r.e.pos, delve)) {
+    ctx.error(meta.entityId, 'Too far away.');
     return;
   }
   if (!delveShopGateMet(meta, delveId, entry.gate)) {

--- a/tests/delve_companion.test.ts
+++ b/tests/delve_companion.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-
+import { DELVES } from '../src/sim/data';
 import { updateDelveCompanion } from '../src/sim/delves/companion';
 import { Sim } from '../src/sim/sim';
 import { terrainHeight } from '../src/sim/world';
@@ -15,6 +15,11 @@ function teleport(sim: Sim, x: number, z: number) {
   p.pos.y = terrainHeight(x, z, sim.cfg.seed);
   p.prevPos = { ...p.pos };
 }
+
+// Rank-up is gated to the delve door, like the shop and enter_delve; every
+// companionUpgrade test below must stand the player there first.
+const reliquaryDoor = DELVES.collapsed_reliquary.doorPos;
+const teleportToReliquaryDoor = (sim: Sim) => teleport(sim, reliquaryDoor.x, reliquaryDoor.z);
 
 describe('delve companions', () => {
   it('solo enter spawns Acolyte Tessa', () => {
@@ -326,6 +331,7 @@ describe('delve companions', () => {
 
   it('companion upgrade rank 2 costs 3 marks (Marks only, no copper)', () => {
     const sim = makeSim();
+    teleportToReliquaryDoor(sim);
     const meta = (sim as any).players.get(sim.playerId);
     meta.delveMarks = 10;
     meta.copper = 100;
@@ -337,6 +343,7 @@ describe('delve companions', () => {
 
   it('companion upgrade is a no-op without enough marks or for an unknown companion', () => {
     const sim = makeSim();
+    teleportToReliquaryDoor(sim);
     const meta = (sim as any).players.get(sim.playerId);
     meta.companionUpgrades.companion_tessa = 1;
     meta.delveMarks = 2; // rank 2 costs 3 Marks, so this is short
@@ -346,6 +353,19 @@ describe('delve companions', () => {
     sim.companionUpgrade('no_such_companion');
     expect(meta.companionUpgrades.companion_tessa).toBe(1);
     expect(meta.delveMarks).toBe(2);
+  });
+
+  it('companion upgrade is rejected far from the delve door, no debit (defense-in-depth: the WS dispatch already geo-gates this, but the sim must refuse it too)', () => {
+    const sim = makeSim();
+    teleport(sim, reliquaryDoor.x + 200, reliquaryDoor.z + 200);
+    const meta = (sim as any).players.get(sim.playerId);
+    meta.delveMarks = 10;
+    sim.drainEvents();
+    sim.companionUpgrade('companion_tessa');
+    expect(meta.companionUpgrades.companion_tessa ?? 1).toBe(1); // rank unchanged
+    expect(meta.delveMarks, 'the Marks must survive the refusal').toBe(10);
+    const ev = sim.drainEvents();
+    expect(ev.some((e) => e.type === 'error' && e.text === 'Too far away.')).toBe(true);
   });
 
   it('companion damages hostile mobs in combat', () => {

--- a/tests/delve_shop.test.ts
+++ b/tests/delve_shop.test.ts
@@ -1,10 +1,12 @@
 // Delve Marks vendor (Brother Halven's shop): gate unlock logic + the
-// server-authoritative buy path (gate + balance re-validated in the Sim).
+// server-authoritative buy path (gate, door range, and balance re-validated
+// in the Sim).
 import { describe, expect, it } from 'vitest';
 import { bagCapacity } from '../src/sim/bags';
-import { DELVE_SHOPS, ITEMS } from '../src/sim/data';
+import { DELVE_SHOPS, DELVES, ITEMS } from '../src/sim/data';
 import { Sim } from '../src/sim/sim';
 import type { PlayerClass } from '../src/sim/types';
+import { terrainHeight } from '../src/sim/world';
 
 // autoEquip:false so a bought wearable stays in the bags where we can count it
 // (mirrors the chest-loot test in delves.test.ts).
@@ -13,6 +15,19 @@ const makeSim = (cls: PlayerClass = 'warrior', seed = 7) =>
 const metaOf = (sim: Sim) => (sim as any).players.get(sim.playerId);
 const countOf = (sim: Sim, id: string) =>
   sim.inventory.filter((s) => s.itemId === id).reduce((n, s) => n + s.count, 0);
+
+function teleport(sim: Sim, x: number, z: number) {
+  const p = sim.player;
+  p.pos.x = x;
+  p.pos.z = z;
+  p.pos.y = terrainHeight(x, z, sim.cfg.seed);
+  p.prevPos = { ...p.pos };
+}
+
+// Brother Halven's shop is gated to the delve door, like enter_delve; every
+// buying test below must stand the player there first.
+const reliquaryDoor = DELVES.collapsed_reliquary.doorPos;
+const teleportToReliquaryDoor = (sim: Sim) => teleport(sim, reliquaryDoor.x, reliquaryDoor.z);
 
 const shop = DELVE_SHOPS.collapsed_reliquary;
 const availableEntry = shop.find((e) => e.gate === 'available')!;
@@ -52,6 +67,7 @@ describe('delve shop, gate logic', () => {
 describe('delve shop, buying', () => {
   it('grants the item and debits Marks on a valid purchase', () => {
     const sim = makeSim();
+    teleportToReliquaryDoor(sim);
     metaOf(sim).delveMarks = 100;
     const before = countOf(sim, availableEntry.itemId);
     sim.delveBuyShopItem('collapsed_reliquary', availableEntry.itemId);
@@ -61,11 +77,25 @@ describe('delve shop, buying', () => {
 
   it('rejects when Marks are insufficient, no item, no debit', () => {
     const sim = makeSim();
+    teleportToReliquaryDoor(sim);
     metaOf(sim).delveMarks = availableEntry.marks - 1;
     const before = countOf(sim, availableEntry.itemId);
     sim.delveBuyShopItem('collapsed_reliquary', availableEntry.itemId);
     expect(countOf(sim, availableEntry.itemId)).toBe(before);
     expect(sim.delveMarks).toBe(availableEntry.marks - 1);
+  });
+
+  it('rejects a purchase made far from the delve door, no debit (defense-in-depth: the WS dispatch already geo-gates this, but the sim must refuse it too)', () => {
+    const sim = makeSim();
+    teleport(sim, reliquaryDoor.x + 200, reliquaryDoor.z + 200);
+    const meta = metaOf(sim);
+    meta.delveMarks = 100;
+    sim.drainEvents();
+    sim.delveBuyShopItem('collapsed_reliquary', availableEntry.itemId);
+    expect(countOf(sim, availableEntry.itemId)).toBe(0);
+    expect(sim.delveMarks, 'the Marks must survive the refusal').toBe(100);
+    const ev = sim.drainEvents();
+    expect(ev.some((e) => e.type === 'error' && e.text === 'Too far away.')).toBe(true);
   });
 
   it('rejects a full-bag purchase BEFORE the spend: no Marks debit, no overflow grant', () => {
@@ -74,6 +104,7 @@ describe('delve shop, buying', () => {
     // without the gate the purchase landed past capacity and the counter was
     // an overflow loophole.
     const sim = makeSim();
+    teleportToReliquaryDoor(sim);
     const meta = metaOf(sim);
     meta.delveMarks = 100;
     const capacity = bagCapacity(meta.bags);
@@ -97,6 +128,7 @@ describe('delve shop, buying', () => {
 
   it('rejects a locked clears:3 item until the clears requirement is met', () => {
     const sim = makeSim();
+    teleportToReliquaryDoor(sim);
     const meta = metaOf(sim);
     meta.delveMarks = 100;
     sim.delveBuyShopItem('collapsed_reliquary', clearsEntry.itemId);
@@ -111,6 +143,7 @@ describe('delve shop, buying', () => {
 
   it('rejects a Heroic-gated rare until a heroic clear is recorded', () => {
     const sim = makeSim();
+    teleportToReliquaryDoor(sim);
     const meta = metaOf(sim);
     meta.delveMarks = 100;
     sim.delveBuyShopItem('collapsed_reliquary', heroicEntry.itemId);
@@ -125,6 +158,7 @@ describe('delve shop, buying', () => {
 
   it('rejects an item that is not in the shop / wrong delve, no debit', () => {
     const sim = makeSim();
+    teleportToReliquaryDoor(sim);
     metaOf(sim).delveMarks = 100;
     sim.delveBuyShopItem('collapsed_reliquary', 'worn_sword');
     sim.delveBuyShopItem('no_such_delve', availableEntry.itemId);

--- a/tests/delves.test.ts
+++ b/tests/delves.test.ts
@@ -1444,6 +1444,10 @@ describe('Tessa percent-of-health heal + rank cap', () => {
     meta.delveMarks = 100;
     meta.copper = 100;
     meta.companionUpgrades = { companion_tessa: 1 };
+    // Rank-up happens at Brother Halven's board (the delve door), not from
+    // inside the run: step back to the door before spending.
+    const door = DELVES.collapsed_reliquary.doorPos;
+    teleport(sim, door.x, door.z);
     sim.companionUpgrade('companion_tessa');
     expect(meta.companionUpgrades.companion_tessa).toBe(2);
     expect(meta.delveMarks).toBe(97);

--- a/tests/parity/golden/delve_progression.json
+++ b/tests/parity/golden/delve_progression.json
@@ -303,7 +303,7 @@
       "tick": 7,
       "time": 0.35,
       "nextId": 967,
-      "state": "9e0c9ba8",
+      "state": "030ce161",
       "events": "4a81857f",
       "rng": {
         "draws": 3,
@@ -422,8 +422,8 @@
           "overpowerUntil": -1,
           "petMode": "defensive",
           "pos": {
-            "x": 104200,
-            "z": -1127
+            "x": -5,
+            "z": -52
           },
           "potionCooldownUntil": -1,
           "resourceType": "rage",
@@ -454,7 +454,7 @@
       "tick": 9,
       "time": 0.45,
       "nextId": 967,
-      "state": "8bc6d077",
+      "state": "60ee2880",
       "events": "741638a5",
       "rng": {
         "draws": 3,
@@ -569,12 +569,12 @@
           "maxResource": 100,
           "moveSpeed": 7,
           "offhandItemId": "eastbrook_buckler",
-          "onGround": true,
           "overpowerUntil": -1,
           "petMode": "defensive",
           "pos": {
-            "x": 104200,
-            "z": -1127
+            "x": -5,
+            "y": -0.04,
+            "z": -52
           },
           "potionCooldownUntil": -1,
           "resourceType": "rage",

--- a/tests/parity/scenarios.ts
+++ b/tests/parity/scenarios.ts
@@ -2826,7 +2826,12 @@ function delveProgression(): Scenario {
         rec.tick(3); // walk into the tombstone -> advanceDelveModule to the finale
       }
       rec.snapshot('advanced-to-finale');
-      // Marks shop: an 'available'-gated piece + a companion rank bump.
+      // Marks shop: an 'available'-gated piece + a companion rank bump. Both
+      // are gated to Brother Halven's board at the delve door (12 yards),
+      // like enter_delve, so step back to the door before spending.
+      p.pos = { x: def.doorPos.x, y: p.pos.y, z: def.doorPos.z };
+      p.prevPos = { ...p.pos };
+      sim.rebucket(p);
       const meta = sim.players.get(sim.playerId) as any;
       meta.delveMarks = 100;
       meta.copper = 100000;


### PR DESCRIPTION
## Summary

`delveBuyShopItem` and `companionUpgrade` (`src/sim/delves/runs.ts`) spent Delve
Marks and copper with no in-sim proximity check to the delve door, unlike every
other location-gated spend in the sim (market, bank, mail, `buyItem`, the heroic
vendor, profession training). The only gate was the WS dispatch handler in
`server/game.ts`, which checks a 12-yard radius against the delve door before
calling into the sim, so the sim itself had no defense-in-depth against a
crafted frame that skipped straight to the sim call.

Added a `nearDelveDoor(pos, delve)` helper (`DELVE_SHOP_RANGE = 12`, mirroring
the server's `Math.hypot` check) and wired it into both functions, returning
the existing `"Too far away."` error literal (already recognized by the i18n
S3 matcher, no new key needed) on failure.

```mermaid
sequenceDiagram
    participant Client
    participant Server as server/game.ts (WS handler)
    participant Sim as src/sim/delves/runs.ts

    rect rgb(80, 30, 30)
    Note over Client,Sim: Before: sim trusted the caller
    Client->>Server: buy_delve_item (crafted, no door-range check)
    Note over Server: normal client is gated here (12yd),<br/>but a crafted frame can call the sim directly
    Server->>Sim: delveBuyShopItem(pid, itemId)
    Note over Sim: no proximity check
    Sim-->>Client: item granted, Marks spent
    end

    rect rgb(20, 60, 30)
    Note over Client,Sim: After: sim re-checks proximity itself
    Client->>Server: buy_delve_item (any path)
    Server->>Sim: delveBuyShopItem(pid, itemId)
    Sim->>Sim: nearDelveDoor(playerPos, delve)
    alt within 12yd of delve door
        Sim-->>Client: item granted, Marks spent
    else too far
        Sim-->>Client: error "Too far away."
    end
    end
```

## Related issues

N/A

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [ ] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx tsc --noEmit` (clean)
  - `npx @biomejs/biome check --write` on every changed file (0 errors; only
    pre-existing `noNonNullAssertion`/`noExplicitAny` warnings in test files,
    which CI does not gate on)
  - `npx vitest run tests/delve_shop.test.ts` (16/16)
  - `npx vitest run tests/delve_companion.test.ts` (24/24)
  - `npx vitest run tests/delves.test.ts` (150/150)
  - `npx vitest run tests/world_api_parity.test.ts tests/command_facets.test.ts` (319/319)
  - `npx vitest run tests/architecture.test.ts` (37/37)
  - `npx vitest run tests/localization_fixes.test.ts` (40 passed, 3 skipped)
  - `npx vitest run tests/parity` (192/194 passed, 1 pre-existing skip; the one
    failure, `professions_gather`, was confirmed to be an unrelated host-CPU-
    contention flake and passed cleanly re-run in isolation)
  - `UPDATE_PARITY=1` regen of `tests/parity/golden/delve_progression.json`
    after adjusting that scenario to spend at the door, then re-verified it
    matches on a plain (non-`UPDATE_PARITY`) run
- Manual steps: none (sim-only change, no UI surface)
- The full `npm run gate` was **not** run locally for this change, due to local
  machine resource constraints (many concurrent worktree agents oversubscribing
  CPU/RAM on this host at this batch's scale). CI will run the full gate on
  this PR.

## Screenshots / recordings

N/A. This change has no player-visible UI surface (server-side proximity gate
with an existing, already-localized error message).

---

## Checklist

### Quality

- [ ] **The full gate passes.** `npm run gate` is green. I added or updated decisive
      tests for changed behavior and recorded any manual checks above.

### Cross-platform

- [ ] **Tested on desktop and mobile.** Verified on a desktop and on a
      phone-sized viewport in both portrait and landscape. Touch targets stay at
      least 40x40px and inputs at least 16px font (see `src/ui/CLAUDE.md`).
- [ ] **Accessible.** Keyboard-operable, with visible focus, sensible ARIA, and
      respect for `prefers-reduced-motion` (only if this change adds or edits UI).

### Localization (i18n)

- [x] **New player-visible strings follow the contributor policy.** No new
      strings were added; the change reuses the existing `"Too far away."`
      error literal, already recognized by the S3 i18n matcher.
- [x] Numbers, money, dates, units, and percents go through the i18n formatters
      (`formatNumber`, `formatMoney`, `formatDateTime`, `Intl`). N/A, no such
      values touched.
- [x] Player-facing text emitted from `src/sim/` or `server/` is re-localized at
      the client boundary in this same change, and
      `npx vitest run tests/localization_fixes.test.ts` passes.
- [ ] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.
