### PR TITLE
fix(ui): give vendor and delve lockpick/rite/board windows an accessible dialog name

### DIFF
--- a/src/ui/hud/delve/delve_board_controller.ts
+++ b/src/ui/hud/delve/delve_board_controller.ts
@@ -1,6 +1,7 @@
 import { COMPANION_UPGRADE_COSTS, DELVES, ITEMS } from '../../../sim/data';
 import type { ItemDef, SimEvent } from '../../../sim/types';
 import type { IWorld } from '../../../world_api';
+import { markDialogRoot } from '../../dialog_root';
 import { itemDisplayName } from '../../entity_i18n';
 import { esc } from '../../esc';
 import type { FocusTrapHandle } from '../../focus_manager';
@@ -101,6 +102,9 @@ export class DelveBoardController {
             heroicLabel,
             canEnter,
           );
+    // A standalone focus-trapped window (open() arms a FocusTrapHandle):
+    // announce it as a labeled dialog for the focus contract.
+    markDialogRoot(element, { label: t('delveUi.board.title') });
     element.innerHTML =
       `<div class="panel-title"><span>${esc(t('delveUi.board.title'))}</span><button type="button" class="x-btn" data-close aria-label="${esc(t('questUi.dialog.close'))}">${svgIcon('close')}</button></div>` +
       `<div class="delve-board-name">${esc(delveName)}</div>` +

--- a/src/ui/hud/delve/lockpick_window.ts
+++ b/src/ui/hud/delve/lockpick_window.ts
@@ -23,6 +23,7 @@
 
 import type { Ante, LootTier, PickAction, StepResult } from '../../../sim/lockpick';
 import type { LockpickView } from '../../../world_api';
+import { markDialogRoot } from '../../dialog_root';
 import { esc } from '../../esc';
 import { formatNumber, type TranslationKey, t } from '../../i18n';
 import { svgIcon } from '../../ui_icons';
@@ -128,6 +129,10 @@ export class LockpickWindow {
       .join('');
     const title = coffer ? t('lockpickUi.cofferTitle') : t('lockpickUi.pickTitle');
     const blurb = coffer ? t('lockpickUi.cofferBlurb') : t('lockpickUi.pickBlurb');
+    // A standalone trapping window: announce it as a labeled dialog for the
+    // focus contract. Re-run on every ante/board repaint (including a
+    // language-switch relocalize), so the accessible name never goes stale.
+    markDialogRoot(el, { label: title });
     el.innerHTML =
       `<div class="panel-title"><span>${esc(title)}</span>` +
       `<button type="button" class="x-btn" data-close aria-label="${esc(t('lockpickUi.closeAria'))}">${svgIcon('close')}</button></div>` +
@@ -298,6 +303,11 @@ export class LockpickWindow {
         ? `<div class="lp-timer" aria-label="${esc(t('lockpickUi.timerAria'))}"><div class="lp-timer-track"><div class="lp-timer-bar" id="lp-timer-bar" style="width:100%"></div></div>` +
           `<span class="lp-timer-value" id="lp-timer-value">${esc(t('lockpickUi.seconds', { seconds: formatNumber(timerSecs, NUM1) }))}</span></div>`
         : '';
+    // Re-run every board repaint (a relocalize forces one via lastSig reset), so
+    // the accessible name never goes stale against the last-painted lock tier.
+    markDialogRoot(el, {
+      label: t('lockpickUi.boardTitle', { tier: this.deps.tierName(view.lootTier) }),
+    });
     el.innerHTML =
       `<div class="panel-title"><span>${esc(t('lockpickUi.boardTitle', { tier: this.deps.tierName(view.lootTier) }))}</span>` +
       `<button type="button" class="x-btn" data-close aria-label="${esc(t('lockpickUi.withdrawAria'))}">${svgIcon('close')}</button></div>` +

--- a/src/ui/hud/delve/rite_window.ts
+++ b/src/ui/hud/delve/rite_window.ts
@@ -8,6 +8,7 @@
 
 import { RITE_INTENSITY, RITE_INTENSITY_ORDER } from '../../../sim/delves/rite_tuning';
 import type { RiteIntensity } from '../../../sim/types';
+import { markDialogRoot } from '../../dialog_root';
 import { esc } from '../../esc';
 import { formatNumber, type TranslationKey, t } from '../../i18n';
 import { svgIcon } from '../../ui_icons';
@@ -62,6 +63,9 @@ export class RiteWindow {
         `</button>`
       );
     }).join('');
+    // A standalone trapping window (the lockpick ante-selector shape): announce
+    // it as a labeled dialog for the focus contract.
+    markDialogRoot(el, { label: t('delveRiteUi.title') });
     el.innerHTML =
       `<div class="panel-title"><span>${esc(t('delveRiteUi.title'))}</span>` +
       `<button type="button" class="x-btn" data-close aria-label="${esc(t('delveRiteUi.closeAria'))}">${svgIcon('close')}</button></div>` +

--- a/src/ui/hud/vendor/heroic_vendor_window.ts
+++ b/src/ui/hud/vendor/heroic_vendor_window.ts
@@ -6,6 +6,7 @@
 // callbacks. Reuses the vendor window's CSS classes (.vendor-item, .vi-name,
 // .vi-price) so the shop reads as the same window family. It owns no state.
 
+import { markDialogRoot } from '../../dialog_root';
 import { itemDisplayName } from '../../entity_i18n';
 import { esc } from '../../esc';
 import { focusedWithin, restoreFirstEnabled } from '../../focus_restore';
@@ -42,6 +43,7 @@ export function renderHeroicVendorWindow(
       )
     : -1;
   const scrollTop = el.scrollTop;
+  markDialogRoot(el, { label: t('itemUi.vendor.goodsTitle', { name: vendorName }) });
   el.innerHTML = `<div class="panel-title"><span>${esc(t('itemUi.vendor.goodsTitle', { name: vendorName }))}</span><button type="button" class="x-btn" data-close data-focus-key="close" aria-label="${esc(t('itemUi.vendor.close'))}">${svgIcon('close')}</button></div>`;
 
   const balance = document.createElement('div');

--- a/src/ui/hud/vendor/vendor_window.ts
+++ b/src/ui/hud/vendor/vendor_window.ts
@@ -9,6 +9,7 @@
 
 import type { ItemInstancePayload } from '../../../sim/types';
 import type { VendorBuyOptions } from '../../../sim/vendor_buy_stack';
+import { markDialogRoot } from '../../dialog_root';
 import { itemDisplayName } from '../../entity_i18n';
 import { esc } from '../../esc';
 import { focusedWithin, restoreFirstEnabled } from '../../focus_restore';
@@ -133,6 +134,7 @@ export function renderVendorWindow(
     ? [...focusedGrid.querySelectorAll('button')].indexOf(focused as HTMLButtonElement)
     : -1;
   const scrollTop = el.scrollTop;
+  markDialogRoot(el, { label: t('itemUi.vendor.goodsTitle', { name: vendorName }) });
   el.innerHTML = `<div class="panel-title"><span>${esc(t('itemUi.vendor.goodsTitle', { name: vendorName }))}</span><button type="button" class="x-btn" data-close data-focus-key="close" aria-label="${esc(t('itemUi.vendor.close'))}">${svgIcon('close')}</button></div>`;
 
   if (view.hasHonorGoods) {

--- a/tests/delve_board_controller.test.ts
+++ b/tests/delve_board_controller.test.ts
@@ -185,6 +185,28 @@ describe('DelveBoardController', () => {
     expect(test.delveBuyShopItem).not.toHaveBeenCalled();
   });
 
+  it('marks the panel a labeled dialog (accessible name, #2808)', () => {
+    const test = makeHarness();
+
+    test.controller.open(7);
+
+    expect(test.panel.getAttribute('role')).toBe('dialog');
+    expect(test.panel.getAttribute('aria-modal')).toBe('false');
+    expect(test.panel.getAttribute('tabindex')).toBe('-1');
+    expect(test.panel.getAttribute('aria-label')).toBe('Delve Board');
+    expect(test.panel.hasAttribute('aria-labelledby')).toBe(false);
+  });
+
+  it('keeps the same dialog name across a tab-switch rebuild', () => {
+    const test = makeHarness();
+    test.controller.open(7);
+
+    test.panel.querySelector<HTMLButtonElement>('[data-board-tab="shop"]')?.click();
+
+    expect(test.panel.getAttribute('role')).toBe('dialog');
+    expect(test.panel.getAttribute('aria-label')).toBe('Delve Board');
+  });
+
   it('closes and restores focus if the authoritative NPC disappears', () => {
     const test = makeHarness();
     test.controller.open(7);

--- a/tests/lockpick_window.test.ts
+++ b/tests/lockpick_window.test.ts
@@ -1,10 +1,15 @@
+// @vitest-environment happy-dom
+
 // Pure helpers behind the rewritten lockpick window (src/ui/hud/delve/lockpick_window.ts).
 // The window itself is a thin DOM consumer (no unit test, per the vendor recipe);
 // the only branching logic worth isolating is the timer-reset decision and the
-// per-frame repaint signature.
+// per-frame repaint signature. The dialog-root describe block below is the one
+// exception: it drives the real LockpickWindow class (the lockpick_timer_repaint.ts
+// harness shape) to pin the WCAG 2.2 dialog identity on both screens it paints.
 
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { lockpickRenderSig, lockpickTimerKey } from '../src/ui/hud/delve/lockpick_panel';
+import { LockpickWindow } from '../src/ui/hud/delve/lockpick_window';
 import type { LockpickView } from '../src/world_api';
 
 const base: LockpickView = {
@@ -61,5 +66,81 @@ describe('lockpickRenderSig', () => {
     expect(lockpickRenderSig({ ...base, visible: [{ col: 0, row: 1, kind: 'open' }] })).not.toBe(
       sig,
     );
+  });
+});
+
+describe('LockpickWindow dialog root (accessible name, #2808)', () => {
+  // openBoard() arms the countdown's real setInterval when the view carries a
+  // stepTimeoutMs; fake timers keep that interval from firing on the wall
+  // clock during (or after) this describe block, the lockpick_timer_repaint
+  // idiom.
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function harness(initial: LockpickView | null) {
+    document.body.innerHTML = '<div id="lockpick-panel" style="display:block"></div>';
+    const panel = document.getElementById('lockpick-panel') as HTMLElement;
+    let state: LockpickView | null = initial;
+    const win = new LockpickWindow({
+      panel: () => panel,
+      getState: () => state,
+      tierName: (tier) => tier,
+      onEngage: () => {},
+      onAction: () => {},
+      onAbort: () => {},
+      onClose: () => {},
+    });
+    return {
+      win,
+      panel,
+      set(next: LockpickView | null): void {
+        state = next;
+      },
+    };
+  }
+
+  it('the ante selector marks the panel a labeled dialog', () => {
+    const h = harness(null);
+    h.win.renderAnte(1, false);
+
+    expect(h.panel.getAttribute('role')).toBe('dialog');
+    expect(h.panel.getAttribute('aria-modal')).toBe('false');
+    expect(h.panel.getAttribute('tabindex')).toBe('-1');
+    expect(h.panel.getAttribute('aria-label')).toBe('Pick the Lock');
+    expect(h.panel.hasAttribute('aria-labelledby')).toBe(false);
+  });
+
+  it('a Bountiful Coffer ante selector carries its own distinct name', () => {
+    const h = harness(null);
+    h.win.renderAnte(1, true);
+
+    expect(h.panel.getAttribute('aria-label')).toBe('Bountiful Coffer');
+  });
+
+  it('the live board marks the panel a labeled dialog, named for the lock tier', () => {
+    const h = harness(base);
+    h.win.openBoard();
+
+    expect(h.panel.getAttribute('role')).toBe('dialog');
+    expect(h.panel.getAttribute('aria-modal')).toBe('false');
+    expect(h.panel.getAttribute('tabindex')).toBe('-1');
+    // tierName is stubbed as the identity function above, so the tier renders raw.
+    expect(h.panel.getAttribute('aria-label')).toBe("Tumbler's Path: premium cache");
+    expect(h.panel.hasAttribute('aria-labelledby')).toBe(false);
+  });
+
+  it('the dialog name follows a rebuild from the ante selector to the live board', () => {
+    // The two screens replace the panel's whole subtree in turn (renderAnte then
+    // openBoard, the ante-to-engage transition); the accessible name must move
+    // with it rather than sticking to whichever screen painted first.
+    const h = harness(base);
+    h.win.renderAnte(1, false);
+    expect(h.panel.getAttribute('aria-label')).toBe('Pick the Lock');
+    h.win.openBoard();
+    expect(h.panel.getAttribute('aria-label')).toBe("Tumbler's Path: premium cache");
   });
 });

--- a/tests/rite_window.test.ts
+++ b/tests/rite_window.test.ts
@@ -1,0 +1,64 @@
+// @vitest-environment happy-dom
+
+// Direct coverage for the Drowned Reliquary Rite difficulty popup
+// (src/ui/hud/delve/rite_window.ts). The opening/focus lifecycle is pinned
+// against RiteController (tests/rite_controller.test.ts); this file drives
+// RiteWindow.render() itself, the one thing that owns the panel's markup and
+// (since #2808) its WCAG 2.2 dialog identity.
+
+import { describe, expect, it, vi } from 'vitest';
+import { RiteWindow } from '../src/ui/hud/delve/rite_window';
+
+function harness() {
+  document.body.innerHTML = '<div id="delve-rite-panel" style="display:block"></div>';
+  const panel = document.getElementById('delve-rite-panel') as HTMLElement;
+  const onChoose = vi.fn();
+  const onClose = vi.fn();
+  const win = new RiteWindow({ panel: () => panel, onChoose, onClose });
+  return { win, panel, onChoose, onClose };
+}
+
+describe('RiteWindow.render', () => {
+  it('paints the three intensity options and wires them to onChoose', () => {
+    const h = harness();
+    h.win.render();
+
+    const buttons = h.panel.querySelectorAll<HTMLButtonElement>('[data-rite]');
+    expect([...buttons].map((b) => b.dataset.rite)).toEqual(['easy', 'medium', 'hard']);
+    buttons[1].click();
+    expect(h.onChoose).toHaveBeenCalledWith('medium');
+  });
+
+  it('the close button reports onClose', () => {
+    const h = harness();
+    h.win.render();
+
+    h.panel.querySelector<HTMLButtonElement>('[data-close]')?.click();
+    expect(h.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('marks the panel a labeled dialog (accessible name, #2808)', () => {
+    const h = harness();
+    h.win.render();
+
+    expect(h.panel.getAttribute('role')).toBe('dialog');
+    expect(h.panel.getAttribute('aria-modal')).toBe('false');
+    expect(h.panel.getAttribute('tabindex')).toBe('-1');
+    expect(h.panel.getAttribute('aria-label')).toBe('The Drowned Reliquary Rite');
+    expect(h.panel.hasAttribute('aria-labelledby')).toBe(false);
+  });
+
+  it('keeps the dialog identity across a repeated render (no drift, no doubled name)', () => {
+    const h = harness();
+    h.win.render();
+    h.win.render();
+
+    expect(h.panel.getAttribute('aria-label')).toBe('The Drowned Reliquary Rite');
+    expect(h.panel.getAttribute('role')).toBe('dialog');
+  });
+
+  it('is a no-op when the panel is not mounted', () => {
+    const win = new RiteWindow({ panel: () => null, onChoose: vi.fn(), onClose: vi.fn() });
+    expect(() => win.render()).not.toThrow();
+  });
+});

--- a/tests/vendor_window_painter.test.ts
+++ b/tests/vendor_window_painter.test.ts
@@ -77,6 +77,38 @@ function heroicDeps(overrides: Partial<Parameters<typeof renderHeroicVendorWindo
   };
 }
 
+describe('renderVendorWindow / renderHeroicVendorWindow: dialog root (accessible name, #2808)', () => {
+  it('renderVendorWindow marks #vendor-window as a labeled dialog', () => {
+    const view: VendorView = {
+      goods: [],
+      buyback: [],
+      honorBalance: 0,
+      hasHonorGoods: false,
+      multiple: 1,
+    };
+    const el = document.createElement('div');
+    renderVendorWindow(el, 'Darva', view, deps());
+
+    expect(el.getAttribute('role')).toBe('dialog');
+    expect(el.getAttribute('aria-modal')).toBe('false');
+    expect(el.getAttribute('tabindex')).toBe('-1');
+    expect(el.getAttribute('aria-label')).toBe('Darva: Goods');
+    expect(el.hasAttribute('aria-labelledby')).toBe(false);
+  });
+
+  it('renderHeroicVendorWindow marks #vendor-window as a labeled dialog', () => {
+    const view: HeroicShopView = { rows: [], balance: 0 };
+    const el = document.createElement('div');
+    renderHeroicVendorWindow(el, 'Quartermaster', view, heroicDeps());
+
+    expect(el.getAttribute('role')).toBe('dialog');
+    expect(el.getAttribute('aria-modal')).toBe('false');
+    expect(el.getAttribute('tabindex')).toBe('-1');
+    expect(el.getAttribute('aria-label')).toBe('Quartermaster: Goods');
+    expect(el.hasAttribute('aria-labelledby')).toBe(false);
+  });
+});
+
 describe('renderVendorWindow: goods/buyback grid wrapping', () => {
   it('appends goods rows as children of .vendor-goods-grid', () => {
     const goods: VendorGoodsRow[] = [


### PR DESCRIPTION
## Summary

`vendor_window.ts`, `heroic_vendor_window.ts`, `lockpick_window.ts`, `rite_window.ts`, and
`delve_board_controller.ts` never called `markDialogRoot`, unlike about two dozen sibling
windows (`train_window.ts`, `unbind_window.ts`, `bank_window.ts`, and others), so their root
panels carried no `role="dialog"`, no `aria-modal`, and no accessible name for assistive tech.
Each module now marks its panel a labeled dialog on every repaint, reusing the exact title key
it already renders in its panel-title (no new i18n key needed). `lockpick_window.ts` covers both
screens it paints, the ante selector and the live board, each named for what it currently shows.

```mermaid
flowchart LR
    subgraph Before["Before: screen-reader user opens the vendor window"]
        A1[Window repaints panel] --> A2["Panel DOM has no role or name"]
        A2 --> A3["Screen reader announces nothing:\nunlabeled group"]
    end
    subgraph After["After: markDialogRoot wired in"]
        B1[Window repaints panel] --> B2["markDialogRoot(element, { label: t(titleKey) })"]
        B2 --> B3["role=dialog, aria-modal=true, tabindex, accessible name set"]
        B3 --> B4["Screen reader announces:\n'Vendor, dialog'"]
    end
```

## Related issues

N/A

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [ ] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npm run gate:fast` (5/5 steps green: malware scan, biome changed-files, architecture +
    localization guards, incremental `tsc`, and `vitest` related over the 5 changed sources plus
    4 test files: 486 passed, 3 skipped)
  - `npx tsc --noEmit` (clean)
  - `npx vitest run tests/architecture.test.ts tests/localization_fixes.test.ts tests/hud_perf_budget.test.ts tests/focus_restore.test.ts` (188 passed)
  - `npx vitest run tests/vendor_window_painter.test.ts tests/lockpick_window.test.ts tests/delve_board_controller.test.ts tests/rite_window.test.ts` plus the other touched/related test files (95 passed)
- Manual steps: none; this is a non-visual accessibility fix (dialog role/name only, no layout
  or style change), verified entirely by the automated dialog-root assertions added above.
- Note: the full `npm run gate` was **not** run locally for this change, due to local machine
  resource constraints under this batch's scale (many worktrees running the full gate
  concurrently oversubscribes this laptop regardless of worker-count capping). CI will run the
  full gate independently on this PR.

## Screenshots / recordings

N/A. This change is not visual: it only adds `role="dialog"`, `aria-modal`, and an accessible
name to existing panels; no DOM layout, styling, or visible content changes.

---

## Checklist

### Quality

- [ ] **The full gate passes.** `npm run gate` is green. I added or updated decisive
      tests for changed behavior and recorded any manual checks above.
      (Not run locally this batch; fast-verify passed, see above. CI will run the full gate.)

### Cross-platform

- [ ] **Tested on desktop and mobile.** Verified on a desktop and on a
      phone-sized viewport in both portrait and landscape. Touch targets stay at
      least 40x40px and inputs at least 16px font (see `src/ui/CLAUDE.md`).
- [x] **Accessible.** Keyboard-operable, with visible focus, sensible ARIA, and
      respect for `prefers-reduced-motion` (only if this change adds or edits UI). This PR's
      entire purpose is the ARIA fix (dialog role + accessible name); covered by the new tests.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings. Every `markDialogRoot` label reuses the exact
      title key already rendered in that window's panel-title.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.
