### PR TITLE
fix(render): sort the point-light budget by the live budget, not just visible-slot count

### DIFF
--- a/src/render/point_light_budget.ts
+++ b/src/render/point_light_budget.ts
@@ -66,7 +66,12 @@ export function applyPointLightBudget(
     const dz = entry.worldPos.z - pz;
     entry.d2 = dx * dx + dz * dz;
   }
-  if (ranked.length > visibleCount) ranked.sort((a, b) => a.d2 - b.d2);
+  // Sort whenever the live budget (which can sit below visibleCount under the
+  // frame-budget governor or on constrained-memory tiers) actually truncates
+  // the ranked list: comparing against visibleCount alone let array order,
+  // not distance, decide which lights shine whenever liveBudget < ranked.length
+  // <= visibleCount.
+  if (ranked.length > liveBudget) ranked.sort((a, b) => a.d2 - b.d2);
   for (let index = 0; index < ranked.length; index++) {
     const entry = ranked[index];
     const counted = index < visibleCount;

--- a/tests/point_light_budget.test.ts
+++ b/tests/point_light_budget.test.ts
@@ -82,13 +82,29 @@ describe('applyPointLightBudget', () => {
     const near = rankedLight(1, 0);
     const mid = rankedLight(5, 0);
     const far = rankedLight(500, 0);
-    // Sorted input: the function skips sorting when everything fits the budget.
+    // Already sorted by distance, so this stays green regardless of the sort guard.
     const ranked = [near, mid, far];
     applyPointLightBudget(ranked, 0, 0, 6, 2, RANGE_SQ);
     expect(near.light.intensity).toBe(5);
     expect(mid.light.intensity).toBe(5);
     expect(far.light.intensity).toBe(0);
     expect(far.light.visible).toBe(true); // counted, but contributes nothing
+  });
+
+  it('sorts by distance when the live budget truncates fewer lights than visibleCount', () => {
+    // liveBudget(2) < ranked.length(3) <= visibleCount(6): a sort guard keyed off
+    // visibleCount alone would skip sorting here even though the live budget still
+    // truncates the ranked list, so array order (not distance) would pick the
+    // winners. All three lights sit inside range so only the live-budget cutoff
+    // is under test.
+    const near = rankedLight(1, 0);
+    const mid = rankedLight(5, 0);
+    const farInRange = rankedLight(50, 0);
+    const ranked = [farInRange, near, mid]; // misordered: farthest listed first
+    applyPointLightBudget(ranked, 0, 0, 6, 2, RANGE_SQ);
+    expect(near.light.intensity).toBe(5);
+    expect(mid.light.intensity).toBe(5);
+    expect(farInRange.light.intensity).toBe(0);
   });
 
   it('leaves base-less (externally driven) light intensity alone while shining', () => {


### PR DESCRIPTION
## Summary

`applyPointLightBudget` only re-sorted its ranked point lights by distance
when `ranked.length` exceeded `visibleCount`, but which lights actually
shine is gated by `index < liveBudget`. `liveBudget` can sit below
`visibleCount` under the frame-budget governor or on constrained-memory
tiers. Whenever the ranked list fit inside `visibleCount` but still
exceeded `liveBudget`, the sort was skipped entirely and array order, not
distance, decided which lights shone.

The fix compares the sort guard against `liveBudget` instead of
`visibleCount`, since the real call site in `renderer.ts` always keeps
`liveBudget <= visibleCount`, so the nearest lights within range shine
regardless of the order fire/view lights land in the ranked array.

```mermaid
flowchart TD
    subgraph Buggy["Before: guard compares against visibleCount"]
        A1["ranked.length = 3, visibleCount = 6, liveBudget = 2"] --> A2{"ranked.length > visibleCount?\n3 > 6 = false"}
        A2 -->|"skip sort"| A3["array order decides\nwhich 2 of 3 lights shine"]
        A3 --> A4["farthest light can shine\ninstead of the 2nd-nearest"]
    end

    subgraph Fixed["After: guard compares against liveBudget"]
        B1["ranked.length = 3, visibleCount = 6, liveBudget = 2"] --> B2{"ranked.length > liveBudget?\n3 > 2 = true"}
        B2 -->|"sort by distance (d2)"| B3["ranked[0..1] = nearest 2 lights"]
        B3 --> B4["index < liveBudget selects\nthe correct nearest lights"]
    end
```

## Related issues

N/A

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [ ] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npm run gate:fast` (PASSED: 5/5 steps -- malware scan, changed-file biome check,
    architecture + localization guard tests, incremental tsc typecheck, vitest related
    to changed files: 21 tests passed)
  - `npx tsc --noEmit` (clean)
  - `npx @biomejs/biome check src/render/point_light_budget.ts tests/point_light_budget.test.ts`
    (clean, no fixes needed)
  - `npx vitest run tests/point_light_budget.test.ts` (12/12 passed with the fix; the new
    regression test was independently verified to FAIL against the pre-fix guard
    (`ranked.length > visibleCount`) and PASS against the fix (`ranked.length > liveBudget`))
- Manual steps: none. The full `npm run gate` was not run locally in this change due to
  local machine resource constraints (many concurrent worktrees on this host under this
  batch's scale make a full gate run unreliable/slow); CI will run the full gate
  independently on this PR.

## Screenshots / recordings

Not captured in this automated batch run (avoiding concurrent dev-server/port contention
across a large parallel PR batch); this is a small, localized change, please verify
visually on review.

---

## Checklist

### Quality

- [ ] **The full gate passes.** `npm run gate` is green. I added or updated decisive
      tests for changed behavior and recorded any manual checks above.

(Not run locally this batch; fast-verify above passed and CI will run the full gate.)

### Cross-platform

- [ ] **Tested on desktop and mobile.** Verified on a desktop and on a
      phone-sized viewport in both portrait and landscape. Touch targets stay at
      least 40x40px and inputs at least 16px font (see `src/ui/CLAUDE.md`).
- [ ] **Accessible.** Keyboard-operable, with visible focus, sensible ARIA, and
      respect for `prefers-reduced-motion` (only if this change adds or edits UI).

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.
