### PR TITLE
fix(sim): dedupe Mass Barrier and Nature's Fury like every other group buff

### DIFF
--- a/src/sim/combat/aura_stacking.ts
+++ b/src/sim/combat/aura_stacking.ts
@@ -21,6 +21,12 @@ export const SOURCE_INDEPENDENT_GROUP_BUFF_AURA_IDS: ReadonlySet<string> = new S
   // two separate 3-charge guaranteed-crit auras on a shared ally.
   'emboldening_roar_crit',
   'mark_of_the_wild',
+  // Mass Barrier (mage aoeAllyAbsorb): two mages must not stack two separate
+  // 130-absorb shields on a shared ally; the later cast replaces the first.
+  'mass_barrier',
+  // Nature's Fury (druid buff_spellcrit pulse): two druids in the same party
+  // pulsing onto a shared ally must not double the 3% spell-crit bonus.
+  'natures_fury',
   'power_word_fortitude',
   'rallying_cry_dr',
   'rallying_cry_hp',

--- a/tests/group_buff_self_stacking.test.ts
+++ b/tests/group_buff_self_stacking.test.ts
@@ -72,6 +72,89 @@ describe('Emboldening Roar never stacks its crit buff with itself', () => {
   });
 });
 
+describe('Mass Barrier never stacks its shield with itself', () => {
+  it('two mages casting on an overlapping group leave exactly one absorb copy per target', () => {
+    const sim = new Sim({ seed: 2026, playerClass: 'mage', noPlayer: true }) as AnySim;
+    const a = sim.addPlayer('mage', 'MageA');
+    const b = sim.addPlayer('mage', 'MageB');
+    for (const pid of [a, b]) {
+      sim.setPlayerLevel(20, pid);
+      expect(sim.applyTalents({ spec: 'frost', rows: { 17: 'mag_r17_mass_barrier' } }, pid)).toBe(
+        true,
+      );
+      const p = sim.entities.get(pid) as Entity;
+      p.resource = p.maxResource;
+    }
+    const entA = sim.entities.get(a) as Entity;
+    const entB = sim.entities.get(b) as Entity;
+    entB.pos = { ...entA.pos };
+    entB.prevPos = { ...entA.pos };
+    sim.partyInvite(b, a);
+    sim.partyAccept(b);
+
+    sim.castAbility('mass_barrier', a);
+    entB.gcdRemaining = 0;
+    sim.castAbility('mass_barrier', b);
+
+    for (const ent of [entA, entB]) {
+      const shield = ent.auras.filter((x) => x.id === 'mass_barrier');
+      expect(shield, 'one Mass Barrier copy').toHaveLength(1);
+      // The later cast owns the surviving copy.
+      expect(shield[0].sourceId).toBe(b);
+    }
+  });
+});
+
+describe("Nature's Fury never stacks its spell-crit pulse with itself", () => {
+  it('two druids in the same party pulsing on a shared ally leave exactly one copy', () => {
+    const sim = new Sim({ seed: 2026, playerClass: 'druid', noPlayer: true }) as AnySim;
+    const a = sim.addPlayer('druid', 'DruidA');
+    const b = sim.addPlayer('druid', 'DruidB');
+    for (const pid of [a, b]) {
+      sim.setPlayerLevel(20, pid);
+      expect(
+        sim.applyTalents({ spec: null, rows: { 20: 'dru_r20_improved_hurricane' } }, pid),
+      ).toBe(true);
+    }
+    const entA = sim.entities.get(a) as Entity;
+    const entB = sim.entities.get(b) as Entity;
+    entB.pos = { ...entA.pos };
+    entB.prevPos = { ...entA.pos };
+    sim.partyInvite(b, a);
+    sim.partyAccept(b);
+
+    // Moonwing Form is the Balance signature (gated behind the balance spec);
+    // the talent under test only needs the form AURA, so apply it directly
+    // like tests/natures_fury.test.ts does, without spending a spec pick.
+    const applyAura = sim as unknown as { applyAura(t: Entity, a: Record<string, unknown>): void };
+    for (const [ent, sourceId] of [
+      [entA, a],
+      [entB, b],
+    ] as const) {
+      applyAura.applyAura(ent, {
+        id: 'moonkin_form',
+        name: 'Moonwing Form',
+        kind: 'form_moonkin',
+        remaining: 3600,
+        duration: 3600,
+        value: 0,
+        sourceId,
+        school: 'arcane',
+      });
+    }
+
+    // Nature's Fury pulses once a second, staggered by pid: run past a full
+    // cycle so both druids have pulsed onto each other at least once.
+    for (let i = 0; i < 40; i++) sim.tick();
+
+    for (const ent of [entA, entB]) {
+      const fury = ent.auras.filter((x) => x.id === 'natures_fury');
+      expect(fury, "one Nature's Fury copy").toHaveLength(1);
+      expect(fury[0].kind).toBe('buff_spellcrit');
+    }
+  });
+});
+
 describe('every group buff is exhaustion-gated or source-independent', () => {
   it('no aoeAlly buff can silently self-stack across casters', () => {
     const offenders: string[] = [];
@@ -95,6 +178,11 @@ describe('every group buff is exhaustion-gated or source-independent', () => {
           // The dispatch stamps this as `${abilityId}_hp` (Rallying Cry).
           if (!SOURCE_INDEPENDENT_GROUP_BUFF_AURA_IDS.has(`${ability.id}_hp`)) {
             offenders.push(`${ability.id} (aoeAllyMaxHp)`);
+          }
+        } else if (eff.type === 'aoeAllyAbsorb') {
+          // The dispatch applies this straight under the ability id (Mass Barrier).
+          if (!SOURCE_INDEPENDENT_GROUP_BUFF_AURA_IDS.has(ability.id)) {
+            offenders.push(`${ability.id} (aoeAllyAbsorb)`);
           }
         }
       }


### PR DESCRIPTION
## Summary

Every source-independent group buff in the sim (Arcane Intellect, Battle Shout,
Wildfang Rally, Emboldening Roar, and so on) is deduped through
`SOURCE_INDEPENDENT_GROUP_BUFF_AURA_IDS` in `src/sim/combat/aura_stacking.ts`,
so a second caster replaces an existing copy on a shared ally instead of
stacking a duplicate. Two group buffs were missing from that set:

- **Mass Barrier** (mage `aoeAllyAbsorb`, id `mass_barrier`): two mages
  covering the same ally each landed a separate 130-absorb shield instead of
  the later cast replacing the earlier one.
- **Nature's Fury** (druid `buff_spellcrit` pulse, id `natures_fury`,
  `src/sim/combat/natures_fury.ts`): two druids in Moonwing Form pulsing onto
  the same ally each landed a separate +3% spell-crit aura instead of one
  replacing the other.

This fixes both ids into the dedupe set (each with a comment explaining the
bug it prevents), and extends the `group_buff_self_stacking` guard test's
scan so it also flags any `aoeAllyAbsorb` ability missing from the set (it
previously only scanned `buffTarget` and `aoeAllyAttackPower` effects), which
is exactly the gap that let Mass Barrier go unnoticed.

```mermaid
sequenceDiagram
    participant MageA as Mage A
    participant MageB as Mage B
    participant Ally
    participant AuraSet as SOURCE_INDEPENDENT_GROUP_BUFF_AURA_IDS

    Note over MageA,Ally: Before fix: 'mass_barrier' missing from the set
    MageA->>Ally: cast Mass Barrier (aoeAllyAbsorb)
    Ally->>Ally: apply aura mass_barrier #1 (130 absorb)
    MageB->>Ally: cast Mass Barrier (aoeAllyAbsorb)
    AuraSet--xAlly: not listed, no replace check
    Ally->>Ally: apply aura mass_barrier #2 (130 absorb)
    Note over Ally: Ally now holds 260 absorb (duplicated)

    Note over MageA,Ally: After fix: 'mass_barrier' added to the set
    MageA->>Ally: cast Mass Barrier (aoeAllyAbsorb)
    Ally->>Ally: apply aura mass_barrier #1 (130 absorb)
    MageB->>Ally: cast Mass Barrier (aoeAllyAbsorb)
    AuraSet->>Ally: listed, replace-across-sources
    Ally->>Ally: replace mass_barrier #1 with #2 (still 130 absorb)
    Note over Ally: Ally holds a single 130 absorb, as intended
```

The same mechanism (and the same before/after) applies to `natures_fury`.

## Related issues

N/A

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [ ] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx tsc --noEmit` (clean)
  - `npx vitest run tests/group_buff_self_stacking.test.ts tests/natures_fury.test.ts tests/mass_barrier_theme.test.ts tests/aura_stacking.test.ts` (18/18 passed, including the 2 new regression tests and the extended scan test)
  - `npx @biomejs/biome check --write src/sim/combat/aura_stacking.ts tests/group_buff_self_stacking.test.ts` (clean; one pre-existing `noExplicitAny` warning on an untouched line, not an error)
  - Verified both new assertions fail without the fix: git-stashed the `aura_stacking.ts` change and reran the two new tests, confirmed red, then restored the change and confirmed green.
- Manual steps: none (sim-only change, covered by automated regression tests).
- The full `npm run gate` was not run locally in this batch due to local machine
  resource constraints (multiple concurrent worktrees oversubscribing the host);
  CI will run the full gate on this PR.

## Screenshots / recordings

N/A. This is a sim-only bug fix with no player-visible UI change.

---

## Checklist

### Quality

- [ ] **The full gate passes.** `npm run gate` is green. I added or updated decisive
      tests for changed behavior and recorded any manual checks above.

### Cross-platform

- [ ] **Tested on desktop and mobile.**
- [ ] **Accessible.**

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.
