### PR TITLE
fix(render): dispose the shadowform/moonkin/metamorph material clone caches

### DIFF
--- a/src/render/characters/visual.ts
+++ b/src/render/characters/visual.ts
@@ -1590,6 +1590,9 @@ export class CharacterVisual {
     disposeOwnedWeaponSkinMaterials(this.model, this.originalMaterials, [
       this.ghostMaterials,
       this.soulRendMaterials,
+      this.shadowformMaterials,
+      this.moonkinMaterials,
+      this.metamorphMaterials,
       this.auraGlowMaterials,
     ]);
   }
@@ -1598,11 +1601,17 @@ export class CharacterVisual {
     const materials = new Set<THREE.Material>([
       ...this.ghostMaterials.values(),
       ...this.soulRendMaterials.values(),
+      ...this.shadowformMaterials.values(),
+      ...this.moonkinMaterials.values(),
+      ...this.metamorphMaterials.values(),
       ...this.auraGlowMaterials.values(),
     ]);
     for (const material of materials) material.dispose();
     this.ghostMaterials.clear();
     this.soulRendMaterials.clear();
+    this.shadowformMaterials.clear();
+    this.moonkinMaterials.clear();
+    this.metamorphMaterials.clear();
     this.auraGlowMaterials.clear();
   }
 

--- a/tests/character_visual_fail_soft.test.ts
+++ b/tests/character_visual_fail_soft.test.ts
@@ -87,6 +87,76 @@ describe('createCharacterVisual happy path (issue 2079)', () => {
   });
 });
 
+describe('CharacterVisual dispose() clears every cosmetic-overlay material cache', () => {
+  it('releases the ghost, soulRend, shadowform, moonkin, metamorph, and auraGlow clones', async () => {
+    vi.resetModules();
+    // Same minimally real GLTF stub as the happy-path build above: a
+    // MeshStandardMaterial (has both `color` and `emissive`, so every
+    // overlay's tint/glow write actually runs) plus every named clip.
+    const stubGltf = () => {
+      const scene = new THREE.Group();
+      const mesh = new THREE.Mesh(new THREE.BoxGeometry(1, 2, 1), new THREE.MeshStandardMaterial());
+      mesh.name = 'body';
+      scene.add(mesh);
+      const clip = (name: string) => new THREE.AnimationClip(name, 1, []);
+      return { scene, animations: ['Idle', 'Walk', 'Run', 'Attack', 'Hit', 'Death'].map(clip) };
+    };
+    vi.doMock('../src/render/assets/loader', () => ({
+      loadGltf: vi.fn(() => Promise.resolve(stubGltf())),
+      loadHdr: vi.fn(() => new Promise(() => undefined)),
+      loadTexture: vi.fn(() => new Promise(() => undefined)),
+      releaseGltf: vi.fn(),
+    }));
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const { preloadTrainingDummyAssets } = await import('../src/render/characters/assets');
+    await preloadTrainingDummyAssets();
+    const { createCharacterVisual } = await import('../src/render/characters/index');
+
+    const visual = createCharacterVisual(dummyEntity);
+    expect(visual).not.toBeNull();
+    if (!visual) return;
+
+    // Cycle each overlay on then off in turn: applyVisualMaterials() always
+    // recomputes from the ORIGINAL material against the flags live at that
+    // moment, so switching one off before the next turns on still lands one
+    // clone in each overlay's own cache, and no earlier cache is cleared by
+    // a later overlay taking priority.
+    visual.setGhost(true);
+    visual.setGhost(false);
+    visual.setSoulRend(true);
+    visual.setSoulRend(false);
+    visual.setShadowform(true);
+    visual.setShadowform(false);
+    visual.setMoonkin(true);
+    visual.setMoonkin(false);
+    visual.setMetamorph(true);
+    visual.setMetamorph(false);
+    visual.setAuraGlow(0xffffff, 0.5);
+    visual.setAuraGlow(0xffffff, 0);
+
+    const cacheNames = [
+      'ghostMaterials',
+      'soulRendMaterials',
+      'shadowformMaterials',
+      'moonkinMaterials',
+      'metamorphMaterials',
+      'auraGlowMaterials',
+    ] as const;
+    const caches = visual as unknown as Record<string, Map<unknown, unknown>>;
+    for (const name of cacheNames) {
+      expect(caches[name].size, `${name} should have cached a clone`).toBeGreaterThan(0);
+    }
+
+    visual.dispose();
+
+    for (const name of cacheNames) {
+      expect(caches[name].size, `${name} should be cleared on dispose`).toBe(0);
+    }
+
+    errSpy.mockRestore();
+  });
+});
+
 describe('logAssetMissOnce (issue 2079)', () => {
   it('logs a key the first time only, independently per key', async () => {
     vi.resetModules();


### PR DESCRIPTION
## Summary

`CharacterVisual` (`src/render/characters/visual.ts`) clones body materials into six
per-overlay caches when a form/effect overlay is applied: `ghostMaterials`,
`soulRendMaterials`, `shadowformMaterials`, `moonkinMaterials`, `metamorphMaterials`,
and `auraGlowMaterials`. On teardown, `disposeWeaponSkinMaterials()`'s `variantMaps`
array and `disposeEffectMaterials()`'s cleared `Set` only ever covered three of the
six caches (ghost, soulRend, auraGlow). The other three, shadowform, moonkin, and
metamorph, were never disposed or cleared, so every character that had worn one of
those overlays leaked its cloned materials (and their GPU program/texture handles)
on despawn or model teardown.

This adds `shadowformMaterials`, `moonkinMaterials`, and `metamorphMaterials` to
both `variantMaps` in `disposeWeaponSkinMaterials()` and the cleared `Set` in
`disposeEffectMaterials()`, mirroring the existing three entries exactly.

```mermaid
flowchart TD
    subgraph before["Before: dispose() sweeps only 3 of 6 caches"]
        A1[Apply overlay: set*Ghost/SoulRend/Shadowform/Moonkin/Metamorph/AuraGlow] --> A2[Clone body material into matching cache]
        A2 --> A3[dispose called on teardown]
        A3 --> A4[ghost, soulRend, auraGlow: cleared and GPU-disposed]
        A3 --> A5["shadowform, moonkin, metamorph: SKIPPED (leaked)"]
    end

    subgraph after["After: dispose() sweeps all 6 caches"]
        B1[Apply overlay: set*Ghost/SoulRend/Shadowform/Moonkin/Metamorph/AuraGlow] --> B2[Clone body material into matching cache]
        B2 --> B3[dispose called on teardown]
        B3 --> B4[All six caches cleared and GPU-disposed]
    end
```

## Related issues

N/A

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [ ] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx tsc --noEmit` (clean, no errors)
  - `npx vitest run tests/character_visual_fail_soft.test.ts tests/weapon_skin_materials.test.ts tests/architecture.test.ts tests/localization_fixes.test.ts` (4 files, 83 passed / 3 skipped)
  - `npx @biomejs/biome check --write src/render/characters/visual.ts tests/character_visual_fail_soft.test.ts` (clean, no fixes needed)
  - `node scripts/malware_scan.mjs --gate` (PASS, 0 high after priors)
  - Manually verified the new dispose-coverage test fails on pre-fix code (shadowformMaterials size 1 instead of 0) and passes after the fix.
- Manual steps: none beyond the above; this is a non-visual leak fix in material lifecycle bookkeeping.

The full `npm run gate` was not run locally for this change due to local machine
resource constraints (many worktrees on this batch running concurrently on a
resource-constrained laptop), so it was intentionally skipped in favor of the
targeted checks above. CI will run the full gate independently on this PR.

## Screenshots / recordings

N/A. This change has no visual effect: it only fixes disposal of materials that
were already being cloned and applied identically before and after; it changes
memory lifecycle, not rendered output.

---

## Checklist

### Quality

- [ ] **The full gate passes.** `npm run gate` is green. I added or updated decisive
      tests for changed behavior and recorded any manual checks above.
      (Not run locally this batch; targeted tsc/vitest/biome/malware-scan checks above
      passed and CI will run the full gate.)

### Cross-platform

- [ ] Tested on desktop and mobile.
- [ ] Accessible.

N/A: no UI or rendered-output change, only a render-internal memory lifecycle fix.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.
