### PR TITLE
fix(render): stop ground-object pooling from nulling its own key on a fresh build

### DIFF
--- a/src/render/ground_object_pool.ts
+++ b/src/render/ground_object_pool.ts
@@ -1,0 +1,84 @@
+import type * as THREE from 'three';
+
+// Ground-object pool: Renderer.createView's generic ground-quest-object branch
+// (the `e.kind === 'object'` arm past the bespoke door/rift/mailbox/noticeboard/
+// delve cases) reuses a previously-removed group by item id instead of paying a
+// full build on every spawn. Pulled out of the renderer coordinator so the
+// miss-path decision, which is where a real bug lived, is unit-testable
+// without a WebGL context: THREE.Group/Mesh/Geometry all construct and mutate
+// fine in plain Node, only WebGLRenderer needs a live canvas.
+//
+// The invariant this module holds: `takeOrBuildGroundObject`'s `poolKey` is
+// ALWAYS the key that was looked up, whether the pool hit or missed.
+// Renderer.removeView only returns a view to the pool when its stored
+// objectPoolKey is truthy; nulling the key on a miss sent every freshly-built
+// object down removeView's non-pooled disposal path instead (see PR "stop
+// ground-object pooling from nulling its own key on a fresh build"). That path
+// disposes any non-shared mesh geometry on the view, but buildGroundQuestObject
+// (quest_objects.ts) clones a per-itemId FOREVER-CACHED template with
+// `clone(true)`, which shares geometry/material BY REFERENCE (never marked via
+// markSharedGeometry): disposing it tore down the GPU buffer the cached
+// template still points at, corrupting every future object built from it. This
+// mirrors the character-visual pool's documented "Pool MISS: build a fresh
+// visual but KEEP its pool key" pattern in Renderer.createView.
+
+export interface PooledObjectView {
+  group: THREE.Group;
+  height: number;
+}
+
+export function takePooledObject(
+  pool: Map<string, PooledObjectView[]>,
+  key: string,
+): PooledObjectView | null {
+  const bucket = pool.get(key);
+  const object = bucket?.pop() ?? null;
+  if (!object) return null;
+  object.group.removeFromParent();
+  object.group.visible = true;
+  object.group.position.set(0, 0, 0);
+  object.group.rotation.set(0, 0, 0);
+  object.group.scale.set(1, 1, 1);
+  return object;
+}
+
+export function storePooledObject(
+  pool: Map<string, PooledObjectView[]>,
+  key: string,
+  object: PooledObjectView,
+): void {
+  object.group.removeFromParent();
+  object.group.visible = false;
+  object.group.position.set(0, 0, 0);
+  object.group.rotation.set(0, 0, 0);
+  object.group.scale.set(1, 1, 1);
+  let bucket = pool.get(key);
+  if (!bucket) {
+    bucket = [];
+    pool.set(key, bucket);
+  }
+  bucket.push(object);
+}
+
+export interface GroundObjectPoolResult {
+  object: PooledObjectView;
+  poolKey: string | null;
+  reused: boolean;
+}
+
+/**
+ * Take a ground object from the pool on a hit, or build a fresh one via
+ * `buildFresh` on a miss. Either way `poolKey` echoes the key that was looked
+ * up, never nulled just because this particular call missed: that is what
+ * lets a fresh build return to the pool the next time it is removed instead
+ * of being disposed.
+ */
+export function takeOrBuildGroundObject(
+  pool: Map<string, PooledObjectView[]>,
+  key: string | null,
+  buildFresh: () => PooledObjectView,
+): GroundObjectPoolResult {
+  const pooled = key ? takePooledObject(pool, key) : null;
+  if (pooled) return { object: pooled, poolKey: key, reused: true };
+  return { object: buildFresh(), poolKey: key, reused: false };
+}

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -229,6 +229,11 @@ import {
 import { GlacialFrontVisual } from './glacial_front_visual';
 import { buildGreatTreePrewarmGroup } from './great_tree_prewarm';
 import { GroundAimReticleVisual } from './ground_aim_reticle_visual';
+import {
+  type PooledObjectView,
+  storePooledObject as storeGroundObjectInPool,
+  takeOrBuildGroundObject,
+} from './ground_object_pool';
 import { createGroundTilt, type GroundTiltState, stepGroundTilt } from './ground_tilt_core';
 import { buildHauntFeatures, type HauntFeaturesView } from './haunt_features';
 import { buildHollowGates } from './hollow_gates';
@@ -856,11 +861,6 @@ export interface RendererPrewarmStats {
   timedOutEntryIds: string[];
   failedEntryIds: string[];
   diagnosticsBaseline: RendererPrewarmDiagnosticsBaselineStats | null;
-}
-
-interface PooledObjectView {
-  group: THREE.Group;
-  height: number;
 }
 
 interface ClickMarkerSlot {
@@ -4593,22 +4593,7 @@ export class Renderer {
     return `object:${e.objectItemId}`;
   }
 
-  private takePooledObject(key: string): PooledObjectView | null {
-    const pool = this.objectPool.get(key);
-    const object = pool?.pop() ?? null;
-    if (!object) return null;
-    this.pooledObjectCount = Math.max(0, this.pooledObjectCount - 1);
-    if (pool?.length === 0) this.objectPool.delete(key);
-    object.group.removeFromParent();
-    object.group.visible = true;
-    object.group.position.set(0, 0, 0);
-    object.group.rotation.set(0, 0, 0);
-    object.group.scale.set(1, 1, 1);
-    return object;
-  }
-
   private storePooledObject(key: string, object: PooledObjectView): void {
-    object.group.removeFromParent();
     // Unlike the character-visual pool, an overflow view has nothing to .dispose(): its
     // geometry/materials are shared per-item-template references (owned elsewhere), so
     // simply not pooling it drops the only reference to its Group/Object3D graph and lets
@@ -4617,16 +4602,7 @@ export class Renderer {
     // shouldRetainPooledCharacterVisual is a generic bounded-retention check (currentCount
     // < maxCount, Infinity-safe); reused here rather than duplicating it under a second name.
     if (!shouldRetainPooledCharacterVisual(this.pooledObjectCount, GFX.maxPooledObjects)) return;
-    object.group.visible = false;
-    object.group.position.set(0, 0, 0);
-    object.group.rotation.set(0, 0, 0);
-    object.group.scale.set(1, 1, 1);
-    let pool = this.objectPool.get(key);
-    if (!pool) {
-      pool = [];
-      this.objectPool.set(key, pool);
-    }
-    pool.push(object);
+    storeGroundObjectInPool(this.objectPool, key, object);
     this.pooledObjectCount++;
   }
 
@@ -6877,18 +6853,22 @@ export class Renderer {
       // Ward shard orbit, and no flag carrier ring or lean.
       group.userData.bg = built.group.userData.bg;
     } else if (e.kind === 'object') {
-      objectPoolKey = this.objectPoolKeyFor(e);
-      const pooled = objectPoolKey ? this.takePooledObject(objectPoolKey) : null;
-      if (pooled) {
-        body = pooled.group;
-        height = pooled.height;
-        body.rotation.y = (e.id % 7) * 0.45;
-      } else {
-        const built = buildGroundQuestObject(e.objectItemId ?? '', e.id);
-        body = built.group;
-        height = built.height;
-        objectPoolKey = null;
-      }
+      // Pool MISS keeps its pool key (mirrors the character-visual pool's
+      // "Pool MISS: build a fresh visual but KEEP its pool key" above): see
+      // ground_object_pool.ts for why nulling it here used to corrupt the
+      // forever-cached, geometry-sharing template every ground object clones.
+      const result = takeOrBuildGroundObject(this.objectPool, this.objectPoolKeyFor(e), () =>
+        buildGroundQuestObject(e.objectItemId ?? '', e.id),
+      );
+      // takeOrBuildGroundObject pops through its own internal takePooledObject,
+      // not this class's storePooledObject counterpart, so a HIT here must mirror
+      // storePooledObject's increment by decrementing pooledObjectCount itself;
+      // otherwise the retention cap (GFX.maxPooledObjects) only ever counts up.
+      if (result.reused) this.pooledObjectCount = Math.max(0, this.pooledObjectCount - 1);
+      objectPoolKey = result.poolKey;
+      body = result.object.group;
+      height = result.object.height;
+      if (result.reused) body.rotation.y = (e.id % 7) * 0.45;
       objectMesh = body;
       if (!this.sparkleMat) {
         this.sparkleMat = new THREE.SpriteMaterial({

--- a/tests/ground_object_pool.test.ts
+++ b/tests/ground_object_pool.test.ts
@@ -1,0 +1,109 @@
+// Regression coverage for src/render/ground_object_pool.ts. THREE.Group/Mesh/
+// Geometry construct and mutate fine under plain Node (see quest_objects.test.ts),
+// so this exercises the real pool cycle without a WebGL context.
+//
+// The bug: Renderer.createView's generic ground-object branch nulled its own
+// computed pool key on a pool MISS, before ever storing anything, so the pool
+// never populated and every spawn rebuilt from scratch. Worse, because
+// buildGroundQuestObject clones a per-itemId forever-cached template with
+// `clone(true)` (sharing geometry/material BY REFERENCE, never marked via
+// markSharedGeometry), a null pool key sent every removed view down
+// Renderer.removeView's non-pooled disposal path, which disposes non-shared
+// mesh geometry: that tore down the cached template's GPU buffer, corrupting
+// every future object built from it.
+import { readFileSync } from 'node:fs';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  type PooledObjectView,
+  storePooledObject,
+  takeOrBuildGroundObject,
+  takePooledObject,
+} from '../src/render/ground_object_pool';
+import { buildGroundQuestObject } from '../src/render/quest_objects';
+
+const rendererSource = readFileSync(new URL('../src/render/renderer.ts', import.meta.url), 'utf8');
+
+describe('takePooledObject / storePooledObject', () => {
+  it('misses on an empty pool and returns null', () => {
+    const pool = new Map<string, PooledObjectView[]>();
+    expect(takePooledObject(pool, 'object:royal_seal')).toBeNull();
+  });
+
+  it('stores and recycles the exact same group reference', () => {
+    const pool = new Map<string, PooledObjectView[]>();
+    const built = buildGroundQuestObject('royal_seal', 1);
+    storePooledObject(pool, 'object:royal_seal', built);
+    expect(pool.get('object:royal_seal')).toHaveLength(1);
+
+    const taken = takePooledObject(pool, 'object:royal_seal');
+    expect(taken?.group).toBe(built.group);
+    expect(taken?.height).toBe(built.height);
+    // the bucket is drained, so a second take misses again
+    expect(pool.get('object:royal_seal')).toHaveLength(0);
+    expect(takePooledObject(pool, 'object:royal_seal')).toBeNull();
+  });
+});
+
+describe('takeOrBuildGroundObject', () => {
+  it('keeps the pool key on a MISS instead of nulling it', () => {
+    const pool = new Map<string, PooledObjectView[]>();
+    const key = 'object:royal_seal';
+    const result = takeOrBuildGroundObject(pool, key, () => buildGroundQuestObject(key, 1));
+    expect(result.reused).toBe(false);
+    // This is the regression: the old code forced poolKey to null right here,
+    // on every miss, so removeView could never return the build to the pool.
+    expect(result.poolKey).toBe(key);
+  });
+
+  it('a pool-missed build returns to the pool and is reused by the next spawn', () => {
+    const pool = new Map<string, PooledObjectView[]>();
+    const key = 'object:royal_seal';
+    const build = vi.fn(() => buildGroundQuestObject(key, 1));
+
+    // Spawn 1: pool is empty, so this is a MISS.
+    const first = takeOrBuildGroundObject(pool, key, build);
+    expect(first.reused).toBe(false);
+    expect(build).toHaveBeenCalledTimes(1);
+
+    // Despawn: mirrors Renderer.removeView, which only pools a view when its
+    // stored objectPoolKey survived the miss (v.objectPoolKey is truthy).
+    expect(first.poolKey).toBeTruthy();
+    storePooledObject(pool, first.poolKey as string, first.object);
+    expect(pool.get(key)).toHaveLength(1);
+
+    // Spawn 2: same item id, pool now has one entry, so this is a HIT that
+    // recycles spawn 1's group instead of paying for another clone.
+    const second = takeOrBuildGroundObject(pool, key, build);
+    expect(second.reused).toBe(true);
+    expect(second.object.group).toBe(first.object.group);
+    expect(build).toHaveBeenCalledTimes(1);
+    expect(pool.get(key)).toHaveLength(0);
+  });
+
+  it('a null key (no reusable template) never calls takePooledObject and stays null throughout', () => {
+    const pool = new Map<string, PooledObjectView[]>();
+    const build = vi.fn(() => buildGroundQuestObject('royal_seal', 1));
+    const result = takeOrBuildGroundObject(pool, null, build);
+    expect(result.poolKey).toBeNull();
+    expect(result.reused).toBe(false);
+    expect(build).toHaveBeenCalledTimes(1);
+    expect(pool.size).toBe(0);
+  });
+});
+
+describe('Renderer.createView object branch (source pin)', () => {
+  it('routes the generic ground-object branch through takeOrBuildGroundObject and never re-nulls the key', () => {
+    const objectBranch = rendererSource.slice(
+      rendererSource.indexOf("} else if (e.kind === 'object') {"),
+      rendererSource.indexOf(
+        "} else if (e.kind === 'mob' && e.templateId === VALE_CUP_BALL_TEMPLATE) {",
+      ),
+    );
+    expect(objectBranch).toContain(
+      'const result = takeOrBuildGroundObject(this.objectPool, this.objectPoolKeyFor(e), () =>',
+    );
+    expect(objectBranch).toContain('objectPoolKey = result.poolKey;');
+    // The regression itself: this branch must never null the key it just took.
+    expect(objectBranch).not.toContain('objectPoolKey = null');
+  });
+});


### PR DESCRIPTION
## Summary

`Renderer.createView`'s generic ground-object branch (`e.kind === 'object'`) computed a valid
`objectPoolKey` via `objectPoolKeyFor(e)`, but on a pool MISS it always reassigned
`objectPoolKey = null` before returning. That meant `removeView` never took the
`storePooledObject` path for any ground object, so the pool never actually populated.

`buildGroundQuestObject` (`src/render/quest_objects.ts`) clones a per-`itemId` forever-cached
template with `clone(true)`, which shares geometry/material by reference across every instance
of that item. With the pool key forced to `null`, every removed ground-object view instead went
down `removeView`'s non-pooled disposal branch, which disposes the mesh's geometry, tearing down
the GPU buffer that the cached template (and every other live clone of that item) still points
at. The next spawn of the same quest item would then render broken/missing geometry.

The fix mirrors the already-documented character-visual pool pattern: on a MISS, build a fresh
object but keep its pool key, so a future `removeView` for that entity correctly stores (not
disposes) the reusable group. The take/store/build-or-take mechanics were extracted into a new
sibling module, `src/render/ground_object_pool.ts`, so the miss-path invariant is unit-testable
in plain Node without a WebGL context; `Renderer.createView` is now a thin consumer of it.

```mermaid
flowchart TD
    subgraph before["Before (bug)"]
        A1["createView: e.kind === 'object'"] --> A2["objectPoolKey = objectPoolKeyFor(e)"]
        A2 --> A3{"pool HIT?"}
        A3 -- yes --> A4["reuse pooled group"]
        A3 -- no --> A5["build fresh group via\nbuildGroundQuestObject (shared geometry)"]
        A5 --> A6["objectPoolKey = null"]
        A4 --> A7["entity later removed"]
        A6 --> A7
        A7 --> A8{"objectPoolKey set?"}
        A8 -- "null on MISS path" --> A9["removeView disposes geometry\n(tears down shared GPU buffer)"]
        A8 -- "set on HIT path" --> A10["storePooledObject: recycled"]
        A9 --> A11["next spawn of same item:\nbroken / missing geometry"]
    end

    subgraph after["After (fix)"]
        B1["createView: e.kind === 'object'"] --> B2["takeOrBuildGroundObject(pool, key, build)"]
        B2 --> B3{"pool HIT?"}
        B3 -- yes --> B4["reuse pooled group, keep key"]
        B3 -- no --> B5["build fresh group, KEEP key"]
        B4 --> B6["entity later removed"]
        B5 --> B6
        B6 --> B7["removeView: key always set"]
        B7 --> B8["storePooledObject: recycled\n(shared geometry stays alive)"]
    end
```

## Related issues

N/A

## Type of change

- [x] Bug fix
- [ ] Feature: new functionality
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [ ] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npm run gate:fast` (malware scan, changed-file biome, architecture + localization guard
    tests, incremental `tsc`, and vitest scoped to the 3 changed files): PASS, "5 day-loop steps
    green (vitest workers: 8)". Changed-file biome reported 0 errors (only pre-existing unrelated
    warnings). Architecture + localization guard tests: 77 passed / 3 skipped. Incremental `tsc`:
    clean. Vitest on the changed files: 12 tests passed, including the new
    `tests/ground_object_pool.test.ts` regression suite.
  - `npm run i18n:gen` (regenerate i18n artifacts, gitignored): no diff.
  - Independently verified via `git stash` that the new source-pin regression test in
    `tests/ground_object_pool.test.ts` fails against the pre-fix `renderer.ts` and passes after
    the fix.
  - The repo's `.githooks/pre-push` floor (typecheck, guard tests, changed-file lint, copy rules)
    ran automatically on `git push` and reported green.
  - The full `npm run gate` was **not** run locally for this change, because this laptop is
    resource-constrained and running the full gate across multiple concurrent worktrees at this
    batch's scale has been timing out / taking far longer than it's worth. CI on this PR runs the
    full gate on GitHub's own infrastructure and is the authoritative check.
- Manual steps: none (headless-only fix, no WebGL context involved in the regression test).

## Screenshots / recordings

N/A. This is not a visual change: the bug is a GPU resource lifecycle defect in the object pool,
not a change to what's rendered on screen in a working build.

---

## Checklist

### Quality

- [ ] **The full gate passes.** `npm run gate` is green. I added or updated decisive
      tests for changed behavior and recorded any manual checks above.
      (Not run locally this batch, see "How was this tested?" above; the added
      `tests/ground_object_pool.test.ts` is a decisive, source-pinned regression test that fails
      pre-fix and passes post-fix. `npm run gate:fast` and the pre-push floor are green; CI will
      run the full gate.)

### Cross-platform

- [ ] Tested on desktop and mobile.
- [ ] Accessible.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.
