### PR TITLE
fix(input): make swipe-look honor the Touch Look Speed setting

### DIFF
--- a/src/game/input.ts
+++ b/src/game/input.ts
@@ -241,7 +241,8 @@ export class Input {
   // mouselook do, instead of only ever orbiting the free camera.
   private gamepadLookActive = false;
   private touchLookVector = { x: 0, y: 0 };
-  // multiplier on the touch look (camera joystick) rate; setTouchLookSpeed
+  // multiplier on the touch look rate, both the camera joystick (updateTouchLook)
+  // and the default one-finger swipe-drag (applyTouchLookDelta); setTouchLookSpeed
   // drives it from the settings menu. Mouselook uses lookSensitivity instead.
   private touchLookSpeed = 1;
   // +1 normal, -1 when the player inverts the touch camera's vertical axis
@@ -588,7 +589,7 @@ export class Input {
   }
 
   applyTouchLookDelta(dx: number, dy: number): void {
-    const dragSens = this.lookSensitivity * TOUCH_DRAG_SENS_MULT;
+    const dragSens = this.lookSensitivity * TOUCH_DRAG_SENS_MULT * this.touchLookSpeed;
     this.camYaw -= dx * dragSens;
     this.camPitch = Math.min(
       1.35,

--- a/tests/input.test.ts
+++ b/tests/input.test.ts
@@ -1395,6 +1395,20 @@ describe('Input touch invert-look', () => {
 
     expect(dragYawDelta).toBeGreaterThan(rawYawDelta * 1.5);
   });
+
+  it('honors the Touch Look Speed setting on the default one-finger swipe-drag path', () => {
+    const { input } = makeInput();
+    const baseYaw = input.camYaw;
+    input.applyTouchLookDelta(100, 0);
+    const defaultDelta = Math.abs(input.camYaw - baseYaw);
+
+    input.camYaw = baseYaw;
+    input.setTouchLookSpeed(2);
+    input.applyTouchLookDelta(100, 0);
+    const doubledDelta = Math.abs(input.camYaw - baseYaw);
+
+    expect(doubledDelta).toBeCloseTo(defaultDelta * 2);
+  });
 });
 
 describe('Input camera zoom (issue 1657)', () => {


### PR DESCRIPTION
## Summary

The default one-finger swipe-drag touch camera control (`applyTouchLookDelta` in
`src/game/input.ts`) computed its drag sensitivity from `lookSensitivity *
TOUCH_DRAG_SENS_MULT` only, ignoring `touchLookSpeed`. The opt-in touch camera
joystick path (`updateTouchLook`) already multiplied by `touchLookSpeed`, so the
Touch Look Speed setting only ever affected the joystick, not the default
swipe-drag path most touch players actually use. Fixed by multiplying `dragSens`
by `this.touchLookSpeed` too (a no-op at the default value of 1), and updated the
adjoining comment on the `touchLookSpeed` field to note it now governs both touch
look paths.

```mermaid
flowchart TD
    subgraph Before["Before: swipe-drag ignores the setting"]
        A1["Player drags Touch Look Speed slider to 2x"] --> A2["touchLookSpeed = 2"]
        A2 --> A3["One-finger swipe-drag (applyTouchLookDelta)"]
        A3 --> A4["dragSens = lookSensitivity * TOUCH_DRAG_SENS_MULT
(touchLookSpeed never read)"]
        A4 --> A5["Camera turns at the SAME rate as touchLookSpeed=1"]
    end

    subgraph After["After: both touch paths honor the setting"]
        B1["Player drags Touch Look Speed slider to 2x"] --> B2["touchLookSpeed = 2"]
        B2 --> B3["One-finger swipe-drag (applyTouchLookDelta)"]
        B3 --> B4["dragSens = lookSensitivity * TOUCH_DRAG_SENS_MULT * touchLookSpeed"]
        B4 --> B5["Camera turns 2x as fast, matching the joystick path"]
    end
```

## Related issues

N/A

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [ ] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npm run gate:fast` (5/5 day-loop steps green: malware scan, changed-file
    biome exit 0 with no errors/format diffs, architecture+localization guards
    77 passed/3 skipped, incremental `tsc` clean, vitest related 114 passed)
  - `npx vitest run tests/input.test.ts` (94/94 passed, including the new
    "honors the Touch Look Speed setting on the default one-finger swipe-drag
    path" test, which was confirmed to fail without the fix)
  - `npx tsc --noEmit` (clean, no output)
  - The full `npm run gate` was **not** run locally for this change, due to
    local machine resource constraints at this batch's scale (multiple worktree
    agents running concurrently oversubscribe this laptop's CPU/RAM regardless
    of worker-count capping). CI will run the full gate on this PR.
- Manual steps: none beyond the above; this is a non-visual sensitivity-scalar
  fix confirmed via the automated regression test.

## Screenshots / recordings

N/A. This change is not visual: it corrects a sensitivity multiplier used
internally by the touch camera control and has no observable difference in
appearance, only in camera turn rate when the Touch Look Speed setting is
changed from its default.

---

## Checklist

### Quality

- [ ] **The full gate passes.** `npm run gate` is green. I added or updated decisive
      tests for changed behavior and recorded any manual checks above.
      (Not run locally this batch; see "How was this tested?" above. A new
      regression test was added and verified to fail before the fix and pass
      after it.)

### Cross-platform

- [ ] **Tested on desktop and mobile.** Verified on a desktop and on a
      phone-sized viewport in both portrait and landscape. Touch targets stay at
      least 40x40px and inputs at least 16px font (see `src/ui/CLAUDE.md`).
- [ ] **Accessible.** Keyboard-operable, with visible focus, sensible ARIA, and
      respect for `prefers-reduced-motion` (only if this change adds or edits UI).

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.
