### PR TITLE
fix(ui): trap focus and mark the dialog role on the crafting window

### DIFF
--- a/src/ui/crafting_window.ts
+++ b/src/ui/crafting_window.ts
@@ -17,6 +17,7 @@ import {
   craftingTabs,
   resolveSelectedCraft,
 } from './crafting_view';
+import { markDialogRoot } from './dialog_root';
 import { itemDisplayName, tEntity } from './entity_i18n';
 import { esc } from './esc';
 import { formatNumber, type TranslationKey, t } from './i18n';
@@ -89,6 +90,10 @@ export function renderCraftingWindow(
   learnHints: ReadonlyMap<string, CraftLearnHint> = new Map(),
 ): void {
   deps.hideTooltip();
+  // A standalone trapping window (the train/professions shape), not the
+  // vendor's docked bags pairing: announce it as a labeled dialog for the
+  // focus contract (src/ui/CLAUDE.md).
+  markDialogRoot(el, { label: t('hudChrome.crafting.title') });
   const scrollTop = el.querySelector('.crafting-body')?.scrollTop ?? 0;
   // The tab strip is its own horizontal scroller on mobile (hud.mobile.css
   // `.crafting-tabs { overflow-x: auto }`) and is rebuilt with everything

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -1559,6 +1559,11 @@ export class Hud {
   private openUnbindNpcId: number | null = null;
   private readonly unbindWindowFocus = this.windowFocus('#unbind-window');
   private unbindOpenerFocus: HTMLElement | null = null;
+  // The crafting window (#1127) was the one standalone-window holdout that
+  // never installed the shared Tab trap or returned focus to its opener: the
+  // same train/unbind shape, added here so it stops being the exception.
+  private readonly craftingWindowFocus = this.windowFocus('#crafting-window');
+  private craftingOpenerFocus: HTMLElement | null = null;
   // Craft tier-up snapshot (Professions 2.0): the last SYNCED
   // craftSkills observation handleEvents diffs for tier crossings. null until
   // the first synced observation, which initializes silently (no toasts for
@@ -14350,16 +14355,19 @@ export class Hud {
     }
     this.closeOtherWindows('#crafting-window');
     this.renderCrafting();
+    // AFTER the paint, the train / unbind ordering (see toggleTownFocus):
+    // captureFocus records the opener and installs the trap over a root that
+    // is by then populated and displayed. #crafting-window now installs its
+    // own trap (this change), so the craftId branch below only needs to move
+    // focus onto the selected tab within that trap, not chase it back from body.
+    this.craftingOpenerFocus = this.craftingWindowFocus.captureFocus();
     if (craftId !== undefined) {
       const scroller = $('#crafting-window').querySelector('.crafting-body');
       if (scroller) scroller.scrollTop = 0;
       // The gossip route reaches here after the dialog released its focus
-      // trap WITHOUT restoring (the successor-window premise), and
-      // #crafting-window installs no trap of its own: land keyboard focus on
-      // the selected tab (onSelectCraft's refocus target) so the handoff
-      // never strands focus on body. Promoting this window into the
-      // windowFocus system proper is the #2525 town-focus precedent, a
-      // separate ruling, not this change.
+      // trap WITHOUT restoring (the successor-window premise): land keyboard
+      // focus on the selected tab (onSelectCraft's refocus target) so the
+      // handoff never strands focus on body.
       ($('#crafting-window').querySelector('.crafting-tab.sel') as HTMLElement | null)?.focus();
     }
   }
@@ -14442,6 +14450,8 @@ export class Hud {
   closeCrafting(): void {
     $('#crafting-window').style.display = 'none';
     this.hideTooltip();
+    this.craftingWindowFocus.restoreFocus(this.craftingOpenerFocus);
+    this.craftingOpenerFocus = null;
     // Commission opt-ins are per-session-of-the-window: closing it drops any
     // armed-but-uncrafted checkboxes, so reopening always starts clean (the
     // off-by-default rule). The selected tab is persisted separately

--- a/tests/crafting_window_focus.test.ts
+++ b/tests/crafting_window_focus.test.ts
@@ -1,0 +1,215 @@
+// @vitest-environment happy-dom
+//
+// The crafting window (#1127) was the one standalone-window holdout that
+// never installed the shared Tab focus trap (windowFocus/FocusManager) or
+// the markDialogRoot dialog role every sibling window (Talents/Social/
+// Market/Deeds/Train/Unbind/...) carries. This drives the REAL
+// renderCraftingWindow painter plus the REAL FocusManager/makeWindowFocus
+// bridge (src/ui/CLAUDE.md's "windowFocus(rootSel)" contract), wired exactly
+// the way Hud.openCrafting/closeCrafting install it, so a regression that
+// drops either half fails here. The hud.ts coordinator itself is not
+// instantiated (no test in this repo does; see train_window_hud.test.ts):
+// its wiring is pinned by source, the established pattern for this
+// monolith.
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { InvSlot, ItemDef } from '../src/sim/types';
+import { buildCraftingView, type RecipeDefLike } from '../src/ui/crafting_view';
+import { type CraftingWindowDeps, renderCraftingWindow } from '../src/ui/crafting_window';
+import { FocusManager } from '../src/ui/focus_manager';
+import { makeWindowFocus } from '../src/ui/window_focus';
+
+function item(id: string): ItemDef {
+  return { id, name: id, quality: 'common', kind: 'junk', sellValue: 0 } as unknown as ItemDef;
+}
+
+function table(...items: ItemDef[]): Record<string, ItemDef> {
+  return Object.fromEntries(items.map((i) => [i.id, i]));
+}
+
+function recipe(id: string, reagents: { itemId: string; count: number }[]): RecipeDefLike {
+  return {
+    id,
+    professionId: 'cooking',
+    resultItemId: `${id}_result`,
+    resultCount: 1,
+    reagents,
+    skillReq: 0,
+  };
+}
+
+/** Dispatch a Tab keydown on document (the FocusManager listens there, capture
+ *  phase) and report whether it was intercepted (preventDefault called). */
+function pressTab(): boolean {
+  return !document.dispatchEvent(
+    new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true }),
+  );
+}
+
+function craftingDeps(): CraftingWindowDeps {
+  return {
+    hideTooltip: () => {},
+    onCraft: () => {},
+    onClose: () => {},
+    itemIcon: () => '',
+    moneyHtml: () => '',
+    itemTooltip: () => '',
+    attachTooltip: () => {},
+    commissionChecked: () => false,
+    onToggleCommission: () => {},
+    selectedCraft: () => null,
+    onSelectCraft: () => {},
+  };
+}
+
+/** A view with one CRAFTABLE recipe, so the painted Craft button is enabled
+ *  (a disabled button is excluded from FOCUSABLE_SELECTOR) and the window
+ *  carries two focusable controls: Close and Craft. */
+function craftableView() {
+  const items = table(item('bone_fragments'), item('recipe_a_result'));
+  const inventory: InvSlot[] = [{ itemId: 'bone_fragments', count: 3 }];
+  return buildCraftingView(
+    [recipe('recipe_a', [{ itemId: 'bone_fragments', count: 2 }])],
+    inventory,
+    items,
+  );
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('renderCraftingWindow: dialog role', () => {
+  it('marks the root role=dialog, aria-modal=false, tabindex=-1, and names it via the crafting title', () => {
+    const el = document.createElement('div');
+    renderCraftingWindow(el, craftableView(), craftingDeps());
+    expect(el.getAttribute('role')).toBe('dialog');
+    expect(el.getAttribute('aria-modal')).toBe('false');
+    expect(el.getAttribute('tabindex')).toBe('-1');
+    expect(el.getAttribute('aria-label')).toBe('Crafting');
+    expect(el.hasAttribute('aria-labelledby')).toBe(false);
+  });
+
+  it('keeps the dialog role after a repaint (re-render is not a one-time stamp)', () => {
+    const el = document.createElement('div');
+    renderCraftingWindow(el, craftableView(), craftingDeps());
+    renderCraftingWindow(el, craftableView(), craftingDeps());
+    expect(el.getAttribute('role')).toBe('dialog');
+    expect(el.getAttribute('aria-label')).toBe('Crafting');
+  });
+});
+
+describe('crafting window: Tab focus trap and restore-on-close', () => {
+  it('installs the trap on open (captureFocus records the opener) and traps Tab within the window', () => {
+    const opener = document.createElement('button');
+    document.body.appendChild(opener);
+    opener.focus();
+    expect(document.activeElement).toBe(opener);
+
+    const el = document.createElement('div');
+    el.id = 'crafting-window';
+    document.body.appendChild(el);
+
+    // The exact bridge Hud.windowFocus() builds: makeWindowFocus(this.focusManager, () => $(rootSel)).
+    const fm = new FocusManager();
+    const bridge = makeWindowFocus(fm, () => el);
+
+    // Mirrors Hud.openCrafting: paint first, THEN capture (the train/unbind/
+    // townFocus ordering), so the trap installs over a populated, displayed root.
+    renderCraftingWindow(el, craftableView(), craftingDeps());
+    const capturedOpener = bridge.captureFocus();
+    expect(capturedOpener).toBe(opener);
+
+    // Document order: Close (panel-title), the craft's tab-strip button
+    // (.crafting-tabs), then the Craft row button (.crafting-body).
+    const closeBtn = el.querySelector<HTMLButtonElement>('[data-close]');
+    const tabBtn = el.querySelector<HTMLButtonElement>('.crafting-tab');
+    const craftBtn = el.querySelector<HTMLButtonElement>('.crafting-recipe-btn');
+    expect(closeBtn).not.toBeNull();
+    expect(tabBtn).not.toBeNull();
+    expect(craftBtn).not.toBeNull();
+    expect(craftBtn?.disabled).toBe(false); // the craftable fixture precondition
+
+    // Walk the full three-control cycle: every Tab is intercepted (the trap
+    // is really installed, not a no-op that happens to leave focus alone),
+    // and it wraps back to Close rather than ever reaching the opener or body.
+    closeBtn?.focus();
+    expect(document.activeElement).toBe(closeBtn);
+    expect(pressTab()).toBe(true);
+    expect(document.activeElement).toBe(tabBtn);
+    expect(pressTab()).toBe(true);
+    expect(document.activeElement).toBe(craftBtn);
+    expect(pressTab()).toBe(true);
+    expect(document.activeElement).toBe(closeBtn); // wraps
+    expect(document.activeElement).not.toBe(opener);
+    expect(document.activeElement).not.toBe(document.body);
+  });
+
+  it('hands focus back to the opener on close, tearing the trap down', async () => {
+    const opener = document.createElement('button');
+    document.body.appendChild(opener);
+    opener.focus();
+
+    const el = document.createElement('div');
+    el.id = 'crafting-window';
+    document.body.appendChild(el);
+
+    const fm = new FocusManager();
+    const bridge = makeWindowFocus(fm, () => el);
+
+    renderCraftingWindow(el, craftableView(), craftingDeps());
+    const capturedOpener = bridge.captureFocus();
+
+    const closeBtn = el.querySelector<HTMLButtonElement>('[data-close]');
+    closeBtn?.focus();
+    expect(document.activeElement).toBe(closeBtn);
+
+    // Mirrors Hud.closeCrafting: restoreFocus(the captured opener).
+    bridge.restoreFocus(capturedOpener);
+    // FocusManager.restore() defers one tick (window.setTimeout(0)).
+    await new Promise((r) => setTimeout(r, 0));
+    expect(document.activeElement).toBe(opener);
+
+    // The trap released too: Tab no longer intercepts inside the (now
+    // closed) crafting window.
+    const stillPrevented = pressTab();
+    expect(stillPrevented).toBe(false);
+  });
+});
+
+describe('hud.ts crafting window wiring (source pins; Hud is a monolith no test instantiates)', () => {
+  const hudSource = readFileSync(resolve(__dirname, '../src/ui/hud.ts'), 'utf8');
+
+  it('builds the shared windowFocus bridge for #crafting-window, the train/unbind shape', () => {
+    expect(hudSource).toContain(
+      "private readonly craftingWindowFocus = this.windowFocus('#crafting-window');",
+    );
+    expect(hudSource).toContain('private craftingOpenerFocus: HTMLElement | null = null;');
+  });
+
+  it('openCrafting captures the opener AFTER the paint, mirroring openTrain/openUnbind', () => {
+    const start = hudSource.indexOf('openCrafting(craftId?: string): void {');
+    const end = hudSource.indexOf('private renderCrafting(): void {');
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+    const body = hudSource.slice(start, end);
+    expect(body).toContain('this.renderCrafting();');
+    expect(body).toContain('this.craftingOpenerFocus = this.craftingWindowFocus.captureFocus();');
+    // AFTER, not before: the render call precedes the capture.
+    expect(body.indexOf('this.renderCrafting();')).toBeLessThan(
+      body.indexOf('this.craftingOpenerFocus = this.craftingWindowFocus.captureFocus();'),
+    );
+  });
+
+  it('closeCrafting restores focus to the opener and clears the field', () => {
+    const start = hudSource.indexOf('closeCrafting(): void {');
+    const end = hudSource.indexOf('private persistCraftingTab(): void {');
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+    const body = hudSource.slice(start, end);
+    expect(body).toContain('this.craftingWindowFocus.restoreFocus(this.craftingOpenerFocus);');
+    expect(body).toContain('this.craftingOpenerFocus = null;');
+  });
+});


### PR DESCRIPTION
## Summary

The crafting window (`src/ui/crafting_window.ts`, opened via `Hud.openCrafting` /
`closeCrafting`) was the one standalone window that never installed the shared
Tab focus trap or announced itself as a dialog, unlike its siblings (Talents,
Social, Market, Deeds, Train, Unbind). `openCrafting` never called the
`windowFocus` bridge, `closeCrafting` never restored focus to the opener, and
`renderCraftingWindow` never called `markDialogRoot`.

Fixed by wiring it exactly like the train/unbind/town-focus standalone windows:
a `craftingWindowFocus` / `craftingOpenerFocus` pair on `Hud` that captures the
opener and installs the trap after the paint in `openCrafting`, and restores
focus plus clears the field in `closeCrafting` (which also covers the
Esc/`closeManagedWindow` path). `renderCraftingWindow` now calls
`markDialogRoot(el, { label: t('hudChrome.crafting.title') })` using the
existing title key, so no new i18n key was needed.

```mermaid
sequenceDiagram
    participant Kbd as Keyboard user
    participant Hud
    participant Win as Crafting window DOM

    rect rgb(80, 30, 30)
    Note over Kbd,Win: Before the fix
    Kbd->>Hud: openCrafting()
    Hud->>Win: paint (no role, no focus trap)
    Kbd->>Win: Tab
    Win-->>Kbd: focus escapes to page behind the window
    Kbd->>Win: Esc / close
    Win-->>Kbd: focus lost, not returned to opener
    end

    rect rgb(20, 60, 30)
    Note over Kbd,Win: After the fix
    Kbd->>Hud: openCrafting()
    Hud->>Win: paint, then markDialogRoot() + install craftingWindowFocus trap
    Win-->>Kbd: role=dialog, labeled, focus enters window
    Kbd->>Win: Tab
    Win-->>Kbd: cycles Close -> tab-strip -> Craft -> wraps (trapped)
    Kbd->>Win: Esc / close
    Win->>Hud: closeCrafting()
    Hud-->>Kbd: focus restored to craftingOpenerFocus (the opener)
    end
```

## Related issues

N/A

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [ ] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npm run gate:fast` (malware scan, changed-files biome, architecture +
    localization guards, incremental `tsc`) - PASSED.
  - `npx tsc --noEmit` - clean.
  - `npx @biomejs/biome check --write` on the two changed non-test files -
    clean after minor import-order fixes.
  - Targeted `vitest` runs: the new `tests/crafting_window_focus.test.ts`
    (7/7 pass), the full pre-existing crafting suite (110 tests across 7
    files), `tests/architecture.test.ts`, `tests/dialog_root.test.ts`,
    `tests/hud_perf_budget.test.ts`, and `tests/localization_fixes.test.ts`
    (after `npm run i18n:gen`, which produced zero diffs since no new i18n
    key was added) - all pass.
- Manual steps: none beyond the automated tests above; this is a keyboard
  focus-management fix and the automated Tab-cycling test exercises the real
  `FocusManager` / `makeWindowFocus` bridge.

The full `npm run gate` was not run locally for this change: this batch is
running many worktrees concurrently on a resource-constrained laptop, and a
full local gate run was oversubscribing CPU/RAM and taking far longer than it
was worth. CI runs the full gate on GitHub's own infrastructure and will
independently verify it; relying on that here.

## Screenshots / recordings

N/A. This is a keyboard-focus and ARIA-attribute change with no visible
rendering difference; the crafting window's appearance is unchanged.

---

## Checklist

### Quality

- [ ] **The full gate passes.** `npm run gate` is green. I added or updated decisive
      tests for changed behavior and recorded any manual checks above.
      (Not run locally this batch, see "How was this tested?"; CI will run it.)

### Cross-platform

- [ ] **Tested on desktop and mobile.** Verified on a desktop and on a
      phone-sized viewport in both portrait and landscape. Touch targets stay at
      least 40x40px and inputs at least 16px font (see `src/ui/CLAUDE.md`).
- [x] **Accessible.** Keyboard-operable, with visible focus, sensible ARIA, and
      respect for `prefers-reduced-motion` (only if this change adds or edits UI).

### Localization (i18n)

- [ ] New player-visible strings follow the contributor policy.
- [ ] Numbers, money, dates, units, and percents go through the i18n formatters.
- [ ] Player-facing text emitted from `src/sim/` or `server/` is re-localized at
      the client boundary in this same change.
- [x] N/A. This PR adds no player-visible strings (reuses the existing
      `hudChrome.crafting.title` key for the new `markDialogRoot` label).

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.
