### PR TITLE
fix(server): report the correct too-long password error on register

### DIFF
--- a/server/auth_routes.ts
+++ b/server/auth_routes.ts
@@ -36,11 +36,11 @@ import type * as http from 'node:http';
 import { verifyLoginTwoFactor } from './account';
 import {
   hashPassword,
+  MAX_PASSWORD_LENGTH,
   MIN_PASSWORD_LENGTH,
   newToken,
   normalizeEmail,
   offensiveName,
-  validPassword,
   validUsernameShape,
   verifyPassword,
 } from './auth';
@@ -97,9 +97,11 @@ const TOO_MANY_FAILED_ATTEMPTS = 'too many failed attempts, wait a few minutes a
 const INVALID_CREDENTIALS = 'invalid username or password';
 const USERNAME_SHAPE = 'username must be 3-24 chars (letters, digits, _)';
 const USERNAME_NOT_ALLOWED = 'username is not allowed';
-// The literal derives its bound from MIN_PASSWORD_LENGTH so the message and the
-// validator can never disagree (byte-identical to the legacy "at least 6 chars").
+// The literals derive their bounds from MIN_PASSWORD_LENGTH / MAX_PASSWORD_LENGTH so
+// the message and the validator can never disagree (byte-identical to the legacy
+// "at least 6 chars" / "at most 128 chars").
 const PASSWORD_TOO_SHORT = `password must be at least ${MIN_PASSWORD_LENGTH} chars`;
+const PASSWORD_TOO_LONG = `password must be at most ${MAX_PASSWORD_LENGTH} chars`;
 const USERNAME_TAKEN = 'username already taken';
 const INVALID_TWO_FACTOR_CODE = 'invalid authentication code';
 // Mandatory signup-email reject (mirrors the legacy /api/register arm; the shape
@@ -247,8 +249,12 @@ async function registerHandler(ctx: Ctx): Promise<void> {
     json(ctx.res, 400, { error: USERNAME_NOT_ALLOWED, code: 'account.username_not_allowed' });
     return;
   }
-  if (!validPassword(body.password)) {
+  if (typeof body.password !== 'string' || body.password.length < MIN_PASSWORD_LENGTH) {
     json(ctx.res, 400, { error: PASSWORD_TOO_SHORT, code: 'account.password_too_short' });
+    return;
+  }
+  if (body.password.length > MAX_PASSWORD_LENGTH) {
+    json(ctx.res, 400, { error: PASSWORD_TOO_LONG, code: 'account.password_too_long' });
     return;
   }
   // Email is mandatory at signup: it is the recovery address that later proves

--- a/server/main.ts
+++ b/server/main.ts
@@ -71,11 +71,12 @@ import {
 import { pruneApplePendingLogins } from './apple_auth_db';
 import {
   hashPassword,
+  MAX_PASSWORD_LENGTH,
+  MIN_PASSWORD_LENGTH,
   newToken,
   normalizeCharName,
   normalizeEmail,
   offensiveName,
-  validPassword,
   validUsernameShape,
   verifyPassword,
 } from './auth';
@@ -1331,10 +1332,15 @@ async function handleApi(req: http.IncomingMessage, res: http.ServerResponse): P
           error: 'username is not allowed',
           code: 'account.username_not_allowed',
         });
-      if (!validPassword(body.password))
+      if (typeof body.password !== 'string' || body.password.length < MIN_PASSWORD_LENGTH)
         return json(res, 400, {
-          error: 'password must be at least 6 chars',
+          error: `password must be at least ${MIN_PASSWORD_LENGTH} chars`,
           code: 'account.password_too_short',
+        });
+      if (body.password.length > MAX_PASSWORD_LENGTH)
+        return json(res, 400, {
+          error: `password must be at most ${MAX_PASSWORD_LENGTH} chars`,
+          code: 'account.password_too_long',
         });
       // Email is mandatory at signup: it is the recovery address that later proves
       // account ownership on a password reset, so we capture it up front.

--- a/tests/server/auth.register.test.ts
+++ b/tests/server/auth.register.test.ts
@@ -153,6 +153,13 @@ describe('register handler', () => {
     });
   });
 
+  it('rejects a password over the maximum length with 400 (not the too-short error)', async () => {
+    expect(await runHandler({ username: 'newhero', password: 'a'.repeat(129) })).toEqual({
+      status: 400,
+      body: { error: 'password must be at most 128 chars', code: 'account.password_too_long' },
+    });
+  });
+
   it('rejects a missing or invalid email with 400 before any account read or write', async () => {
     // v0.20.0: email is mandatory at signup (the recovery address), gated after
     // the password check and BEFORE the username lookup.


### PR DESCRIPTION
## Summary

`POST /api/register`'s password gate always reported the under-6-char "too short"
error/code, even for a password over the 128-char maximum, in both the migrated
`RouteDef` handler (`server/auth_routes.ts`) and the legacy ladder (`server/main.ts`).
Both call sites used the single `validPassword()` type-guard, which only returns a
boolean and never distinguishes *why* a password failed (too short vs too long), so
every rejection fell through to the "too short" branch regardless of the real cause.

This splits each gate into the same two-branch min/max check that
`server/account.ts`'s `handleAccountChangePassword` and `server/admin.ts`'s
reset-password handler already use: `PASSWORD_TOO_SHORT` /
`account.password_too_short` below `MIN_PASSWORD_LENGTH`, `PASSWORD_TOO_LONG` /
`account.password_too_long` above `MAX_PASSWORD_LENGTH`. The now-unused
`validPassword` import was removed from both files. Both error codes and their
client localization already existed (`server/http/error_codes.ts`,
`src/ui/i18n.catalog/api_error.ts`), so no new i18n work was needed.

```mermaid
flowchart LR
    subgraph before["Before: validPassword() boolean gate"]
        A1["password = 'a'.repeat(129)"] --> A2{"validPassword(pw)"}
        A2 -->|false, any reason| A3["400 account.password_too_short\n'at least 6 chars'"]
        A3 -.->|wrong: password is too LONG, not too short| A4["misleading error"]
    end

    subgraph after["After: explicit min/max branches"]
        B1["password = 'a'.repeat(129)"] --> B2{"length < MIN_PASSWORD_LENGTH?"}
        B2 -->|yes| B3["400 account.password_too_short"]
        B2 -->|no| B4{"length > MAX_PASSWORD_LENGTH?"}
        B4 -->|yes| B5["400 account.password_too_long"]
        B4 -->|no| B6["continue: email/username checks"]
    end
```

## Related issues

N/A

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [ ] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx tsc --noEmit` (clean)
  - `npx vitest run tests/server/auth.register.test.ts` (added a regression test:
    a 129-char password now expects `account.password_too_long`, not
    `account.password_too_short`; fails before the fix, passes after)
  - `npx vitest run tests/server/auth.register.test.ts tests/http_route_parity.test.ts tests/http_characterization.test.ts tests/api_error_code_parity.test.ts tests/error_codes.test.ts tests/architecture.test.ts tests/localization_fixes.test.ts tests/admin_permissions.test.ts tests/server/admin.test.ts` (446 passed)
  - `npx @biomejs/biome check --write server/auth_routes.ts server/main.ts tests/server/auth.register.test.ts`
  - `npm run gate:fast` (5 day-loop steps green: malware scan, changed-file biome,
    architecture + localization guards, incremental tsc, vitest scoped run: 28 test
    files, 1060 passed, 2 skipped)
- Manual steps: none (server-side validation change, no UI surface).
- Note: the full `npm run gate` was not run locally for this batch, due to local
  machine resource constraints (multiple worktrees running the full gate
  concurrently oversubscribes this laptop's CPU/RAM). CI will run the full gate
  on this PR.

## Screenshots / recordings

N/A. This change has no player-visible or admin-visible UI surface (server-side
validation error selection only); the existing error copy and its i18n already
covered both codes.

---

## Checklist

### Quality

- [ ] **The full gate passes.** `npm run gate` is green. I added or updated decisive
      tests for changed behavior and recorded any manual checks above.
      (Not run locally this batch, see "How was this tested?"; `gate:fast` plus the
      targeted suites above passed, and CI runs the full gate on this PR.)

### Cross-platform

- [ ] **Tested on desktop and mobile.**
- [ ] **Accessible.**

### Localization (i18n)

- [ ] New player-visible strings follow the contributor policy.
- [ ] Numbers, money, dates, units, and percents go through the i18n formatters.
- [ ] Player-facing text emitted from `src/sim/` or `server/` is re-localized at
      the client boundary in this same change, and
      `npx vitest run tests/localization_fixes.test.ts` passes.
- [x] N/A. This PR adds no player-visible strings (both error codes and their
      client localization already existed).

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.
