### PR TITLE
fix(server): rate-limit DELETE /api/assets/:id like its DELETE /api/maps/:id sibling

### DIFF
--- a/server/http/middleware/rate_limit.ts
+++ b/server/http/middleware/rate_limit.ts
@@ -387,8 +387,10 @@ export const MAP_MUTATION_POLICY: RateLimitPolicy = {
   tier2: 'global',
 };
 
-// The GLB asset upload limiter (v0.20.0 merge migration). Same posture as
-// MAP_MUTATION_POLICY: fused bucket shared with the legacy POST /api/assets arm,
+// The GLB asset mutation limiter (v0.20.0 merge migration). Same posture as
+// MAP_MUTATION_POLICY: ONE fused bucket shared across every /api/assets
+// mutation (the legacy POST /api/assets upload arm AND the legacy DELETE
+// /api/assets/:id arm both check the same assetUploadRateLimited function),
 // coded 429 on the new path recorded as the same deviation class.
 export const ASSET_UPLOAD_POLICY: RateLimitPolicy = {
   name: 'asset_upload',

--- a/server/main.ts
+++ b/server/main.ts
@@ -2549,6 +2549,9 @@ async function handleApi(req: http.IncomingMessage, res: http.ServerResponse): P
     if (req.method === 'DELETE' && assetIdMatch) {
       const accountId = await bearerActiveAccount(req, res);
       if (accountId === null) return;
+      if (!assetUploadRateLimited(req, accountId).allowed) {
+        return json(res, 429, { error: 'rate_limited' });
+      }
       return assetDeleteCore(res, accountId, Number(assetIdMatch[1]));
     }
     json(res, 404, { error: 'unknown endpoint' });

--- a/server/ratelimit.ts
+++ b/server/ratelimit.ts
@@ -353,11 +353,12 @@ export function resetCardUploadRateLimits(): void {
   cardUploadAccountAttempts.clear();
 }
 
-// GLB asset uploads (POST /api/assets) get their own per-IP AND per-account
-// bucket, mirroring the player-card upload throttle above: an upload flood can
-// never burn a player's login budget (these maps are separate from the shared
-// `attempts` map, so STRICTEST_RATE_LIMIT is unaffected), and a single account
-// spraying uploads through many IPs is still capped by the account key.
+// GLB asset mutations (POST /api/assets upload, DELETE /api/assets/:id) share
+// one per-IP AND per-account bucket, mirroring the player-card upload throttle
+// above: a flood of either can never burn a player's login budget (these maps
+// are separate from the shared `attempts` map, so STRICTEST_RATE_LIMIT is
+// unaffected), and a single account spraying requests through many IPs is
+// still capped by the account key.
 export const ASSET_UPLOAD_MAX_PER_MINUTE = 10;
 // Map saves are bigger writes (up to 2 MiB JSONB) but honest editors autosave;
 // 30/min leaves headroom for rapid save-as/fork flows while bounding floods.

--- a/server/user_assets_routes.ts
+++ b/server/user_assets_routes.ts
@@ -204,10 +204,12 @@ async function deleteHandler(ctx: Ctx): Promise<void> {
 
 // ---------------------------------------------------------------------------
 // The route table. registry.ts spreads this into apiRoutes. /api/assets/mine is
-// static, so the router prefers it over the dynamic :file byte read. The legacy
-// DELETE arm mounts no limiter (matching legacy exactly); the byte GET carries
-// the public-read policy like its legacy arm's publicReadRateLimited check (the
-// coded-vs-prose 429 deviation, recorded).
+// static, so the router prefers it over the dynamic :file byte read. DELETE
+// shares the fused ASSET_UPLOAD_POLICY bucket with the upload lane, mirroring
+// how DELETE /api/maps/:id shares MAP_MUTATION_POLICY with its own create/save
+// lane (maps_routes.ts); the byte GET carries the public-read policy like its
+// legacy arm's publicReadRateLimited check (the coded-vs-prose 429 deviation,
+// recorded).
 // ---------------------------------------------------------------------------
 
 export const routes: RouteDef[] = [
@@ -242,7 +244,7 @@ export const routes: RouteDef[] = [
     method: 'DELETE',
     path: '/api/assets/:id',
     surface: 'api',
-    middleware: [activeGuard, requireOwnedAsset],
+    middleware: [activeGuard, rateLimit(ASSET_UPLOAD_POLICY), requireOwnedAsset],
     meta: { requireOwned: { kind: 'user_asset', ownerScope: 'account' } },
     handler: deleteHandler,
   },

--- a/tests/server/http/known_deviations.ts
+++ b/tests/server/http/known_deviations.ts
@@ -1324,6 +1324,7 @@ export const KNOWN_DEVIATIONS: readonly KnownDeviation[] = [
       '/api/maps/:id/publish',
       '/api/maps/:id/unpublish',
       '/api/assets',
+      '/api/assets/:id',
       '/api/assets/:file',
     ],
     currentBehavior:
@@ -1332,7 +1333,9 @@ export const KNOWN_DEVIATIONS: readonly KnownDeviation[] = [
       'their fused ip+account bucket inline in server/main.ts, and the two public reads ' +
       '(GET /api/maps/public, the GET /api/assets byte read) plus the anonymous leg of ' +
       'GET /api/maps/:id check the tier-1 publicReadRateLimited bucket, each returning ' +
-      'the same snake_case prose body.',
+      'the same snake_case prose body. DELETE /api/assets/:id shares the same ' +
+      'assetUploadRateLimited fused ip+account bucket as the POST /api/assets upload, so it ' +
+      'carries the identical old-vs-new 429 body/header divergence described below.',
     intendedBehavior:
       'The v0.20.0 in-merge migration serves these routes through the new pipeline, where ' +
       'the throttle is a rateLimit(policy) middleware (MAP_MUTATION_POLICY / ' +
@@ -1342,7 +1345,8 @@ export const KNOWN_DEVIATIONS: readonly KnownDeviation[] = [
       'Retry-After, instead of the bare { error: "rate_limited" } prose. The tier-1 buckets ' +
       'are SHARED with the legacy arms (the policies wrap the same ratelimit.ts functions), ' +
       'so limits land identically; only the 429 body shape and headers differ, plus EVERY ' +
-      'policy-mounted lane (the mutations and upload included, not just the public reads) ' +
+      'policy-mounted lane (the mutations, the upload, and the DELETE /api/assets/:id ' +
+      'ASSET_UPLOAD_POLICY arm included, not just the public reads) ' +
       'gains the pg tier-2 global backstop the legacy tier-1-only checks lack. The GET ' +
       '/api/assets/:file byte read keeps the surface-default problem+json ERROR envelope ' +
       '(its success body is binary but its meta sets no envelope, the POST /api/card ' +

--- a/tests/server/http/surface_inventory.ts
+++ b/tests/server/http/surface_inventory.ts
@@ -1411,7 +1411,7 @@ export const SURFACE_INVENTORY: readonly SurfaceRoute[] = [
     handler: 'assetIdMatch',
     contentType: PROBLEM_JSON,
     authScope: AUTH_SCOPE.full,
-    limiter: null,
+    limiter: 'assetUploadRateLimited',
     requireOwnedExpected: REQUIRE_OWNED.bola404,
     match: /^\/api\/assets\/(\d+)$/,
   },

--- a/tests/server/user_assets_routes.test.ts
+++ b/tests/server/user_assets_routes.test.ts
@@ -2,9 +2,10 @@
 // (server/user_assets_routes.ts). Sibling of tests/server/maps_routes.test.ts:
 // the RouteDefs and the legacy handleApi lanes share the same cores, so this
 // file pins the route-layer contract the parity corpus cannot reach db-free:
-// the guards, the pre-auth 413, the coded 429 on the shared upload bucket, the
-// requireOwnedAsset deny (resolved through the caller's own bounded list), the
-// binary byte-read response headers, and the in-handler :file shape parity.
+// the guards, the pre-auth 413, the coded 429 on the shared upload/delete
+// mutation bucket, the requireOwnedAsset deny (resolved through the caller's
+// own bounded list), the binary byte-read response headers, and the
+// in-handler :file shape parity.
 process.env.DATABASE_URL ||= 'postgres://test:test@127.0.0.1:5433/wocc_assets_routes';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -247,8 +248,8 @@ describe('auth guards + the pre-auth 413', () => {
   });
 });
 
-describe('the shared upload limiter (coded 429, shared bucket)', () => {
-  it('throws the coded rate_limit.exceeded once the legacy bucket is drained', async () => {
+describe('the shared upload/delete mutation limiter (coded 429, shared bucket)', () => {
+  it('throws the coded rate_limit.exceeded once the legacy bucket is drained (upload)', async () => {
     const req = { headers: {}, socket: { remoteAddress: '10.8.8.8' } } as http.IncomingMessage;
     for (let i = 0; i < ASSET_UPLOAD_MAX_PER_MINUTE; i++) {
       assetUploadRateLimited(req, CALLER);
@@ -260,6 +261,27 @@ describe('the shared upload limiter (coded 429, shared bucket)', () => {
     expect(res.status).toBe(429);
     expect(res.body.code).toBe('rate_limit.exceeded');
     expect(res.headers['retry-after']).toBeDefined();
+  });
+
+  it('throws the coded rate_limit.exceeded once the shared bucket is drained (delete), like DELETE /api/maps/:id', async () => {
+    // DELETE /api/assets/:id had NO rate limiter at all (regression coverage):
+    // it now shares the SAME fused ip+account bucket as the upload lane, the
+    // same posture DELETE /api/maps/:id has with its own create/save lane.
+    const req = { headers: {}, socket: { remoteAddress: '10.8.8.9' } } as http.IncomingMessage;
+    for (let i = 0; i < ASSET_UPLOAD_MAX_PER_MINUTE; i++) {
+      assetUploadRateLimited(req, CALLER);
+    }
+    const deleteAsset = vi.fn();
+    fakeService({ listMine: async () => [assetRecord()], deleteAsset });
+    const res = await runRoute('DELETE', '/api/assets/:id', {
+      headers: { authorization: BEARER },
+      params: { id: '3' },
+      url: '/api/assets/3',
+    });
+    expect(res.status).toBe(429);
+    expect(res.body.code).toBe('rate_limit.exceeded');
+    expect(res.headers['retry-after']).toBeDefined();
+    expect(deleteAsset).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary

`DELETE /api/assets/:id` mounted no rate limiter on either dispatch arm (the
migrated `RouteDef` in `server/user_assets_routes.ts`, and the legacy fallback
in `server/main.ts`), unlike its structurally identical sibling
`DELETE /api/maps/:id`, which shares `MAP_MUTATION_POLICY` with its
create/save lane. An account could delete uploaded GLB assets in an unbounded
loop.

Both dispatch arms now share the existing `ASSET_UPLOAD_POLICY` fused
ip+account bucket (`assetUploadRateLimited`) with the upload lane, mirroring
how the maps family already shares one mutation bucket across
create/save/fork/publish/delete. The `surface_inventory.ts` characterization
row is updated to match (`limiter: null` -> `'assetUploadRateLimited'`), and a
test-first regression test in `tests/server/user_assets_routes.test.ts`
reproduces the gap (it fails against the pre-fix code: 404 where a drained
bucket should 429) and passes with the fix.

```mermaid
sequenceDiagram
    participant Client
    participant Route as DELETE /api/assets/:id
    participant Limiter as ASSET_UPLOAD_POLICY bucket
    participant Store as Asset store

    rect rgb(255, 230, 230)
    Note over Client,Store: Before: no limiter on either dispatch arm
    loop unbounded
        Client->>Route: DELETE /api/assets/:id
        Route->>Store: delete (no rate check)
        Store-->>Client: 200 / 404
    end
    end

    rect rgb(225, 245, 225)
    Note over Client,Store: After: shares ASSET_UPLOAD_POLICY with the upload lane
    Client->>Route: DELETE /api/assets/:id
    Route->>Limiter: assetUploadRateLimited(account)
    alt bucket has capacity
        Limiter-->>Route: allowed
        Route->>Store: delete
        Store-->>Client: 200 / 404
    else bucket drained
        Limiter-->>Route: denied
        Route-->>Client: 429 rate_limited
    end
    end
```

## Related issues

N/A

## Type of change

- [x] Bug fix
- [ ] Feature: new functionality
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [ ] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx tsc --noEmit` (clean)
  - `npx @biomejs/biome check --write` on all 6 changed files (0 errors, only
    pre-existing unrelated warnings, no fixes needed)
  - Targeted: `npx vitest run tests/server/user_assets_routes.test.ts
    tests/server/http/surface_inventory.test.ts
    tests/server/http/known_deviations.test.ts tests/server/tunables.test.ts
    tests/server/ownership_coverage.test.ts tests/server/http/parity.test.ts
    tests/server/http/completeness.test.ts tests/server/maps_routes.test.ts`
    (all green, 517 tests)
  - Full `tests/server/` directory: 139 files, 2979 passed / 7 skipped, 0 failed
  - `tests/architecture.test.ts` + `tests/localization_fixes.test.ts` (after
    `npm run i18n:gen`): both green
  - `node scripts/malware_scan.mjs --gate`: PASS (0 high after priors)
  - Repro-verified the regression test: stashed the fix and re-ran the new
    test to confirm it fails (404 instead of 429) against the pre-fix code,
    then restored the fix and confirmed it passes
- The full `npm run gate` was not run locally for this change, due to local
  machine resource constraints (multiple concurrent worktrees on this host at
  this batch's scale make the shared gate step take an unreasonable amount of
  wall time). CI will run the full gate on this PR.

## Screenshots / recordings

N/A. This is a server-side rate-limiting fix with no player- or
operator-visible UI surface.

---

## Checklist

### Quality

- [ ] **The full gate passes.** `npm run gate` is green. I added or updated decisive
      tests for changed behavior and recorded any manual checks above.
      (Not run locally this batch; see "How was this tested?" above. Targeted
      typecheck, changed-file biome, architecture/localization guards, malware
      scan, and a superset of the relevant vitest suite were run instead and
      all passed. CI will run the full gate.)

### Cross-platform

- [ ] Tested on desktop and mobile.
- [ ] Accessible.

(No UI surface in this change; not applicable.)

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.
