### PR TITLE
fix(render): give Wraithwood's permanent drizzle its visible rain

### DIFF
--- a/src/render/weather.ts
+++ b/src/render/weather.ts
@@ -209,13 +209,15 @@ export class Weather {
    *              (indoors / underwater / suppressed)
    */
   update(cam: THREE.Vector3, dt: number, biome: BiomeId | null): void {
-    // peaks -> snow, marsh -> rain, everything else clears
+    // peaks -> snow, marsh/haunt -> rain, everything else clears. Wraithwood's
+    // haunt biome keeps the same permanent drizzle the ambient audio already
+    // plays ("the haunted wood drips under a permanent drizzle" in renderer.ts).
     const want: Precip | null =
       !this.enabled || biome === null
         ? null
         : biome === 'peaks' || biome === 'frost'
           ? 'snow'
-          : biome === 'marsh'
+          : biome === 'marsh' || biome === 'haunt'
             ? 'rain'
             : null;
 

--- a/tests/weather.test.ts
+++ b/tests/weather.test.ts
@@ -1,0 +1,83 @@
+import * as THREE from 'three';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { Weather } from '../src/render/weather';
+
+// weather.ts mints its two point textures via document.createElement('canvas')
+// in the constructor; stub just enough canvas surface for that, the same
+// pattern tests/vfx.test.ts uses for the other Three/document-touching
+// render overlay module.
+function installCanvasStub(): void {
+  const context = {
+    fillStyle: '',
+    fillRect: vi.fn(),
+    createRadialGradient: () => ({ addColorStop: vi.fn() }),
+    createLinearGradient: () => ({ addColorStop: vi.fn() }),
+  };
+  vi.stubGlobal('document', {
+    createElement: () => ({
+      width: 0,
+      height: 0,
+      getContext: () => context,
+    }),
+  });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+interface WeatherProbe {
+  material: THREE.PointsMaterial;
+  points: THREE.Points;
+  mode: 'snow' | 'rain';
+  intensity: number;
+  textures: { flake: THREE.CanvasTexture; streak: THREE.CanvasTexture };
+}
+
+// Drive update() for a stretch of simulated time so the eased intensity has
+// settled toward its steady-state target (transitionAlpha never reaches 1).
+function settle(
+  weather: Weather,
+  cam: THREE.Vector3,
+  biome: Parameters<Weather['update']>[2],
+): void {
+  for (let i = 0; i < 200; i++) weather.update(cam, 0.1, biome);
+}
+
+describe('ambient precipitation biome mapping', () => {
+  it('rains over the haunt biome, matching the permanent-drizzle ambience', () => {
+    // Wraithwood's content header ("a drizzle that never quite stops") and
+    // renderer.ts's ambient-audio precip mapping both put haunt under rain;
+    // Weather.update must agree so the drizzle players hear is also visible.
+    installCanvasStub();
+    const scene = new THREE.Scene();
+    const weather = new Weather(scene, false);
+    const probe = weather as unknown as WeatherProbe;
+    const cam = new THREE.Vector3(0, 0, 0);
+
+    settle(weather, cam, 'haunt');
+
+    expect(probe.mode).toBe('rain');
+    expect(probe.points.visible).toBe(true);
+    expect(probe.material.map).toBe(probe.textures.streak);
+    expect(probe.material.color.getHex()).toBe(0x9fc4e0);
+    expect(probe.material.opacity).toBeGreaterThan(0.65);
+  });
+
+  it('keeps snow on the peaks and stays clear on biomes with no weather', () => {
+    installCanvasStub();
+    const scene = new THREE.Scene();
+    const weather = new Weather(scene, false);
+    const probe = weather as unknown as WeatherProbe;
+    const cam = new THREE.Vector3(0, 0, 0);
+
+    settle(weather, cam, 'peaks');
+    expect(probe.mode).toBe('snow');
+    expect(probe.points.visible).toBe(true);
+    expect(probe.material.map).toBe(probe.textures.flake);
+
+    settle(weather, cam, 'vale');
+    expect(probe.points.visible).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

`Weather.update` in `src/render/weather.ts` picks a precipitation effect from the
current biome, but it had no case for the `haunt` biome (Wraithwood). Meanwhile
`renderer.ts`'s ambient-audio precip mapping already routes `haunt` to rain
("the haunted wood drips under a permanent drizzle"), and Wraithwood's content
header (`src/sim/content/wraithwood.ts`) describes "a drizzle that never quite
stops". So the audio and the writing both promised rain in Wraithwood, but the
visual rain particle system never rendered it.

This PR adds `haunt` to the same rain branch as `marsh` in `Weather.update`, so
the visible rain effect now matches the ambient audio and the zone's own copy.

```mermaid
flowchart LR
    subgraph Before["Before: haunt biome falls through"]
        B1[Player enters Wraithwood haunt biome] --> B2{Weather.update biome switch}
        B2 -->|peaks/frost| B3[snow]
        B2 -->|marsh| B4[rain]
        B2 -->|haunt: no case| B5[precip = null, no rain shown]
        B6[renderer.ts ambient audio] -->|haunt -> rain sfx| B7[drizzle sound plays]
        B5 -.mismatch.- B7
    end

    subgraph After["After: haunt joins the rain branch"]
        A1[Player enters Wraithwood haunt biome] --> A2{Weather.update biome switch}
        A2 -->|peaks/frost| A3[snow]
        A2 -->|marsh or haunt| A4[rain]
        A5[renderer.ts ambient audio] -->|haunt -> rain sfx| A6[drizzle sound plays]
        A4 -- matches --> A6
    end
```

## Related issues

N/A

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [ ] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx vitest run tests/weather.test.ts` (2 passed: haunt-biome rain, plus a
    peaks/vale regression check)
  - `npx tsc --noEmit` (clean, no output)
  - `npm run gate:fast` (malware scan PASS: 5017 files scanned, 265 flags, 0
    high; `biome ci --changed` clean of errors, only pre-existing repo-wide
    warnings; `tests/architecture.test.ts` + `tests/localization_fixes.test.ts`:
    77 passed / 3 skipped; incremental `check:ts` clean; overall PASS, exit 0)
- Manual steps: none in this automated batch run (see note below).

The full `npm run gate` (the complete CI-equivalent merge-bar gate) was not run
locally in this batch, because this laptop is running many parallel worktrees
concurrently and a full gate run oversubscribes CPU/RAM and either times out or
takes far longer than it is worth right now. GitHub Actions CI on this PR runs
on GitHub's own infrastructure and will independently run the full gate; relying
on that instead of a redundant local run.

## Screenshots / recordings

Not captured in this automated batch run (avoiding concurrent dev-server/port
contention across a large parallel PR batch); this is a small, localized
change, please verify visually on review.

---

## Checklist

### Quality

- [ ] **The full gate passes.** `npm run gate` is green. I added or updated decisive
      tests for changed behavior and recorded any manual checks above.

### Cross-platform

- [ ] **Tested on desktop and mobile.** Verified on a desktop and on a
      phone-sized viewport in both portrait and landscape. Touch targets stay at
      least 40x40px and inputs at least 16px font (see `src/ui/CLAUDE.md`).
- [ ] **Accessible.** Keyboard-operable, with visible focus, sensible ARIA, and
      respect for `prefers-reduced-motion` (only if this change adds or edits UI).

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.
