### PR TITLE
fix(render): stop Frostveil's aurora from bleeding into neighboring zones

### DIFF
--- a/src/render/frost_sky.ts
+++ b/src/render/frost_sky.ts
@@ -6,6 +6,7 @@ import * as THREE from 'three';
 import { FROSTVEIL_ROADS } from '../sim/content/frostveil';
 import { hash2 } from '../sim/rng';
 import { terrainHeight } from '../sim/world';
+import { auroraFadeBand } from './frost_sky_fade_core';
 
 export interface FrostSkyView {
   group: THREE.Group;
@@ -274,12 +275,10 @@ export function buildFrostSky(seed = 0): FrostSkyView {
       // frost rect's edges: its z band, and (now that the Reach is the
       // center strip with realms on both sides) both x borders, so the
       // aurora never shows over the Drakelands east of x 180 nor the
-      // Amberfall west of x -180.
-      const fadeIn = Math.min(1, Math.max(0, (camZ - 1400) / 80));
-      const fadeOut = 1 - Math.min(1, Math.max(0, (camZ - 1920) / 80));
-      const fadeW = Math.min(1, Math.max(0, (camX + 220) / 80));
-      const fadeE = Math.min(1, Math.max(0, (220 - camX) / 80));
-      const band = Math.min(fadeIn, fadeOut, fadeW, fadeE);
+      // Amberfall west of x -180. The boundary math is the pure core
+      // frost_sky_fade_core.ts, so its zone-edge value stays testable
+      // without a canvas/document.
+      const band = auroraFadeBand(camX, camZ);
       for (const r of ribbons) {
         r.mesh.visible = band > 0.001;
         if (!r.mesh.visible) continue;

--- a/src/render/frost_sky_fade_core.ts
+++ b/src/render/frost_sky_fade_core.ts
@@ -1,0 +1,31 @@
+// Aurora visibility fade for the Frostveil sky. The curtains hang far above
+// the fog (fog: false, additive blending), so without an explicit gate every
+// neighboring realm sees them over its horizon. Fades the aurora out across
+// the frost rect's z band and both x borders, so the ribbons vanish AT and
+// beyond the real zone boundary: the Drakelands' xMin (src/sim/content/
+// drakelands.ts) and the Amberfall's xMax (src/sim/content/amberfall.ts) are
+// both 180 (signed for the west side), so this core's x bound must match
+// that value exactly or the aurora bleeds into the neighboring realm.
+//
+// RENDER_PURE_CORES module: no three.js, no DOM; frost_sky.ts's update() is
+// the thin Three-side consumer that multiplies each ribbon's opacity by the
+// returned band.
+
+export const AURORA_Z_NEAR = 1400;
+export const AURORA_Z_FAR = 1920;
+/** Matches drakelands.ts xMin (180) and amberfall.ts xMax (-180). */
+export const AURORA_X_BOUND = 180;
+export const AURORA_RAMP = 80;
+
+/**
+ * 0 outside the frost rect, ramping linearly to 1 over `AURORA_RAMP` units
+ * inside each of its four edges. At and beyond AURORA_X_BOUND on either side
+ * (and outside the z band) the aurora is fully invisible.
+ */
+export function auroraFadeBand(camX: number, camZ: number): number {
+  const fadeIn = Math.min(1, Math.max(0, (camZ - AURORA_Z_NEAR) / AURORA_RAMP));
+  const fadeOut = 1 - Math.min(1, Math.max(0, (camZ - AURORA_Z_FAR) / AURORA_RAMP));
+  const fadeW = Math.min(1, Math.max(0, (camX + AURORA_X_BOUND) / AURORA_RAMP));
+  const fadeE = Math.min(1, Math.max(0, (AURORA_X_BOUND - camX) / AURORA_RAMP));
+  return Math.min(fadeIn, fadeOut, fadeW, fadeE);
+}

--- a/tests/architecture.test.ts
+++ b/tests/architecture.test.ts
@@ -427,6 +427,7 @@ const RENDER_PURE_CORES = [
   'src/render/fishing_bobber_core.ts',
   'src/render/foliage_core.ts',
   'src/render/foliage_shader_core.ts',
+  'src/render/frost_sky_fade_core.ts',
   'src/render/gfx_aa_policy_core.ts',
   'src/render/gfx_override_core.ts',
   'src/render/ground_aim_reticle_core.ts',

--- a/tests/frost_sky_fade_core.test.ts
+++ b/tests/frost_sky_fade_core.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import {
+  AURORA_RAMP,
+  AURORA_Z_FAR,
+  AURORA_Z_NEAR,
+  auroraFadeBand,
+} from '../src/render/frost_sky_fade_core';
+import { AMBERFALL_ZONE } from '../src/sim/content/amberfall';
+import { DRAKELANDS_ZONE } from '../src/sim/content/drakelands';
+
+// A z well inside the aurora's z band, so only the x edges are under test.
+const MID_Z = (AURORA_Z_NEAR + AURORA_Z_FAR) / 2;
+
+function requireDefined(value: number | undefined, label: string): number {
+  if (value === undefined) throw new Error(`${label} is undefined`);
+  return value;
+}
+
+// Pin the fade boundary against the REAL neighboring-zone bounds, not the
+// module's own constant: this is what a drifted magic number (the bug this
+// covers) would slip past if the test read AURORA_X_BOUND instead.
+const DRAKELANDS_X_MIN = requireDefined(DRAKELANDS_ZONE.xMin, 'DRAKELANDS_ZONE.xMin'); // 180
+const AMBERFALL_X_MAX = requireDefined(AMBERFALL_ZONE.xMax, 'AMBERFALL_ZONE.xMax'); // -180
+
+describe('frost sky aurora fade band', () => {
+  it('is fully visible deep inside the frost rect', () => {
+    expect(auroraFadeBand(0, MID_Z)).toBe(1);
+  });
+
+  it('is zero exactly at the Drakelands boundary (xMin)', () => {
+    expect(auroraFadeBand(DRAKELANDS_X_MIN, MID_Z)).toBe(0);
+  });
+
+  it('is zero exactly at the Amberfall boundary (xMax)', () => {
+    expect(auroraFadeBand(AMBERFALL_X_MAX, MID_Z)).toBe(0);
+  });
+
+  it('stays zero past the east boundary, into the Drakelands', () => {
+    expect(auroraFadeBand(DRAKELANDS_X_MIN + 1, MID_Z)).toBe(0);
+    expect(auroraFadeBand(DRAKELANDS_X_MIN + 40, MID_Z)).toBe(0);
+    expect(auroraFadeBand(540, MID_Z)).toBe(0); // deep in the Drakelands
+  });
+
+  it('stays zero past the west boundary, into the Amberfall', () => {
+    expect(auroraFadeBand(AMBERFALL_X_MAX - 1, MID_Z)).toBe(0);
+    expect(auroraFadeBand(AMBERFALL_X_MAX - 40, MID_Z)).toBe(0);
+    expect(auroraFadeBand(-540, MID_Z)).toBe(0); // deep in the Amberfall
+  });
+
+  it('ramps linearly over the 80-unit edge on both sides', () => {
+    const halfway = DRAKELANDS_X_MIN - AURORA_RAMP / 2;
+    expect(auroraFadeBand(halfway, MID_Z)).toBeCloseTo(0.5, 5);
+    expect(auroraFadeBand(-halfway, MID_Z)).toBeCloseTo(0.5, 5);
+  });
+
+  it('also fades to zero outside the z band', () => {
+    expect(auroraFadeBand(0, AURORA_Z_NEAR - 1)).toBe(0);
+    expect(auroraFadeBand(0, AURORA_Z_FAR + AURORA_RAMP + 1)).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

The Frostveil aurora's camera-based visibility fade used a hardcoded 220-unit x
boundary while the real neighboring zones start 40 units earlier, at 180
(`DRAKELANDS_ZONE.xMin` and `AMBERFALL_ZONE.xMax` are both 180, signed for the
west side). That let the aurora ribbons stay partially visible up to ~40 yards
past the actual zone line, into Drakelands and Amberfall sky.

This extracts the fade-band math (the z-band ramp plus both x-edge ramps, the
80-unit ramp width preserved) into a new pure core,
`src/render/frost_sky_fade_core.ts` (registered in `RENDER_PURE_CORES`), so the
boundary is Vitest-testable without a canvas/document, and corrects the x
bound to 180 to match the real zone data. `src/render/frost_sky.ts` becomes a
thin consumer calling `auroraFadeBand(camX, camZ)`. The new test
(`tests/frost_sky_fade_core.test.ts`) pins zero opacity at and beyond
x = 180 / -180 against the real `DRAKELANDS_ZONE.xMin` / `AMBERFALL_ZONE.xMax`
values (not the module's own constant), so it actually catches future drift
between the two, plus a 0.5 ramp-midpoint check and z-band coverage.

```mermaid
flowchart LR
    subgraph before["Before: stale 220 cutoff"]
        direction TB
        A1["camX crosses real\nzone line at x=180"] --> A2{"|camX| < 220?"}
        A2 -->|yes, 180..220| A3["aurora still rendered\n(bleeds ~40yd into\nDrakelands/Amberfall)"]
        A2 -->|no, beyond 220| A4["aurora hidden"]
    end
    subgraph after["After: auroraFadeBand uses AURORA_X_BOUND=180"]
        direction TB
        B1["camX crosses real\nzone line at x=180"] --> B2{"|camX| < 180?"}
        B2 -->|yes| B3["aurora ramps down,\nfully hidden AT x=180"]
        B2 -->|no| B4["aurora hidden\n(matches zone boundary)"]
    end
```

## Related issues

N/A

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [ ] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npm run gate:fast` (architecture + localization guards, incremental `tsc`) - green:
    `tests/architecture.test.ts` + `tests/localization_fixes.test.ts` = 77 passed / 3 skipped,
    `tsc --noEmit` incremental clean.
  - `npx vitest run tests/frost_sky_fade_core.test.ts` standalone - 7/7 passed.
  - `npx @biomejs/biome check src/render/frost_sky.ts src/render/frost_sky_fade_core.ts
    tests/frost_sky_fade_core.test.ts tests/architecture.test.ts` - zero issues on all four
    changed files.
- Manual steps: none beyond the above; this batch did not run a live dev server (see Screenshots
  note below).

The full `npm run gate` was **not** run locally in this change, due to local machine resource
constraints under this batch's scale (many concurrent worktrees on one host oversubscribe
CPU/RAM regardless of worker-count capping). CI will run the full gate on this PR.

## Screenshots / recordings

Not captured in this automated batch run (avoiding concurrent dev-server/port contention across
a large parallel PR batch); this is a small, localized change, please verify visually on review.

---

## Checklist

### Quality

- [ ] **The full gate passes.** `npm run gate` is green. I added or updated decisive
      tests for changed behavior and recorded any manual checks above.

### Cross-platform

- [ ] **Tested on desktop and mobile.**
- [ ] **Accessible.**

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.
