### PR TITLE
fix(ui): fix the delve minimap arrow direction and locale relocalize

### DIFF
--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -5559,6 +5559,10 @@ export class Hud {
     // string, so a switch can never draw the old language; clearing is about not
     // carrying dead rasters in the sprite budget.
     this.mapPainter.relocalize();
+    // The delve minimap/world-map schematic bakes the localized compass-north
+    // glyph into its cached background canvas, keyed only on module id; a
+    // language switch alone never busts that cache, so force one rebuild.
+    this.delvePainter.relocalize();
     // The unit-frame move/lock buttons' labels are set once at construction + on
     // toggle, so re-localize them in place on a language switch (same reason as
     // the party rows above).

--- a/src/ui/hud/delve/delve_map.ts
+++ b/src/ui/hud/delve/delve_map.ts
@@ -79,7 +79,10 @@ export interface SchematicArrow {
   kind: 'arrow';
   cx: number;
   cy: number;
-  /** canvas rotation in radians (matches -p.facing convention in hud.ts) */
+  /** canvas rotation in radians. Unlike the overworld map (-facing), this
+   *  schematic's localZ-to-canvas-Y mapping is NOT flipped (see
+   *  delveLocalToCanvas), so the arrow needs `facing + PI` to point the
+   *  same way the player is actually walking. */
   angle: number;
   size: number;
   fill: string;
@@ -369,7 +372,12 @@ export function delveSchematicPlayer(
     kind: 'arrow',
     cx,
     cy,
-    angle: -facing, // matches the convention in updateMinimap / updateMapWindow
+    // The overworld map (map_window_view.ts toMap) flips world Z onto canvas Y,
+    // so its arrow uses -facing. This schematic's delveLocalToCanvas maps
+    // localZ to canvas Y WITHOUT flipping it (localZ - zMin, not maxZ - localZ),
+    // so the same -facing formula pointed the arrow backwards at north/south;
+    // facing + PI is the correct rotation for this unflipped mapping.
+    angle: facing + Math.PI,
     size: Math.max(5, canvasSize * 0.045),
     fill: '#fff',
     stroke: '#000',

--- a/src/ui/hud/delve/delve_map_painter.ts
+++ b/src/ui/hud/delve/delve_map_painter.ts
@@ -206,6 +206,21 @@ export class DelveMapPainter {
     private readonly classColor: (cls: string) => string,
   ) {}
 
+  /** Drop the cached static-schematic backgrounds on a language switch: the
+   *  baked compass-north glyph (northLabel, resolved from `hudChrome.compass.N`)
+   *  is drawn INTO the cached canvas, so it never re-resolves on its own like a
+   *  write-elided string would. Cleared rather than cleared-and-rebuilt so the
+   *  next paint rebuilds through the ordinary cache-miss path (same idiom as
+   *  MapWindowPainter.relocalize, its sibling in the write-elision writeup).
+   *  Hud calls this from its woc:languagechange fan-out, alongside
+   *  mapPainter.relocalize(). */
+  relocalize(): void {
+    this.minimapBg = null;
+    this.minimapBgModuleId = '';
+    this.worldMapBg = null;
+    this.worldMapBgModuleId = '';
+  }
+
   /** Resolve the player-facing delve + module names (the only i18n the painter
    *  does; the pure model takes them already localized). */
   private resolveNames(run: DelveRunInfo): { delveName: string; moduleName: string } {

--- a/tests/delve_map.test.ts
+++ b/tests/delve_map.test.ts
@@ -232,10 +232,25 @@ describe('delveSchematicPlayer', () => {
     expect(arrow.cy).toBeLessThanOrEqual(162);
   });
 
-  it('passes facing as negated angle (matches hud.ts -p.facing convention)', () => {
+  it('rotates the arrow by facing + PI (this schematic maps localZ to canvas Y unflipped, unlike the overworld -facing convention)', () => {
     const layout = DELVE_MODULE_LAYOUTS.reliquary_sunken_ossuary;
     const facing = Math.PI / 4;
     const arrow = delveSchematicPlayer(0, 20, facing, layout, 162, 8);
-    expect(arrow.angle).toBeCloseTo(-facing, 5);
+    expect(arrow.angle).toBeCloseTo(facing + Math.PI, 5);
+  });
+
+  it('points north (canvas -Y, up) when facing 0 = world +Z, matching delveLocalToCanvas', () => {
+    // facing 0 means the player moves toward +Z (world north), and this
+    // schematic's Z maps DIRECTLY to canvas Y (localZ - zMin, unflipped), so
+    // +Z is canvas-DOWN. The arrow tip (drawn at local (0, -size) before
+    // rotation) must therefore point canvas-down at facing 0, the opposite of
+    // the overworld's -facing convention (which would point it canvas-up).
+    const layout = DELVE_MODULE_LAYOUTS.reliquary_sunken_ossuary;
+    const arrow = delveSchematicPlayer(0, 20, 0, layout, 162, 8);
+    // Tip after rotation: (size*sin(angle), -size*cos(angle)).
+    const tipX = Math.sin(arrow.angle);
+    const tipY = -Math.cos(arrow.angle);
+    expect(tipX).toBeCloseTo(0, 5);
+    expect(tipY).toBeCloseTo(1, 5); // +Y = canvas-down = world +Z here
   });
 });

--- a/tests/delve_map_painter.test.ts
+++ b/tests/delve_map_painter.test.ts
@@ -5,16 +5,19 @@
 //
 // The write-elision facet (makeWriterFacet) is exercised in painter_host.test.ts
 // (grew to six writers); this file keeps only the delve-specific path.
-// The painter's canvas/DOM methods (paintMinimapDelve / paintWorldMapDelve) need a
-// real 2D context + getComputedStyle, so they are NOT exercised here; this Node
-// suite drives the PURE path (delveDrawModel), which is exactly the contract the
-// per-frame painters lean on.
+// Full pixel-level rendering of paintMinimapDelve / paintWorldMapDelve needs a
+// real 2D context + getComputedStyle, so that end-to-end coverage lives in the
+// opt-in tests/browser/delve_map_painter.browser.test.ts. This Node suite mostly
+// drives the PURE path (delveDrawModel), the contract the per-frame painters lean
+// on, plus one narrow behavioral pin (relocalize's cache-bust) over a hand-rolled
+// fake 2D context, mirroring tests/map_window_painter.test.ts's fake-context idiom.
 
 import { readFileSync } from 'node:fs';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { DELVE_MODULE_LAYOUTS } from '../src/sim/delve_layout';
 import { delveLocalToCanvas, delveSchematicStatic } from '../src/ui/hud/delve/delve_map';
-import { delveDrawModel } from '../src/ui/hud/delve/delve_map_painter';
+import { DelveMapPainter, delveDrawModel } from '../src/ui/hud/delve/delve_map_painter';
+import type { PainterHostWriters } from '../src/ui/painter_host';
 import type { IWorld } from '../src/world_api';
 
 // --- Pure draw model: Sim-vs-ClientWorld parity + both-sites determinism --------
@@ -170,6 +173,135 @@ describe('delveDrawModel (pure draw model)', () => {
     // ...but the schematic scales with the viewport (different size + pad).
     expect(world.schematic).toEqual(delveSchematicStatic(LAYOUT, WORLDMAP.size, WORLDMAP.pad));
     expect(world.schematic).not.toEqual(mini.schematic);
+  });
+});
+
+// --- relocalize(): the cached schematic background (incl. the baked compass-N
+// glyph) is keyed only on module id, never locale, so a language switch alone can
+// never bust it; relocalize() must force exactly one rebuild. ------------------
+
+/** A minimal 2D-context stub covering every call drawSchematic/paintMinimapDelve
+ *  makes for the non-litany reliquary module (no clipToOutline prims -> no
+ *  Path2D). Mirrors the hand-rolled fake in tests/map_window_painter.test.ts;
+ *  this file only needs it not to throw, not to record draws. */
+function fakeDelveCtx(): CanvasRenderingContext2D {
+  const ctx = {
+    fillStyle: '',
+    strokeStyle: '',
+    lineWidth: 1,
+    font: '',
+    textAlign: 'start',
+    textBaseline: 'alphabetic',
+    imageSmoothingEnabled: false,
+    globalAlpha: 1,
+    save(): void {},
+    restore(): void {},
+    beginPath(): void {},
+    moveTo(): void {},
+    lineTo(): void {},
+    closePath(): void {},
+    ellipse(): void {},
+    arc(): void {},
+    clip(): void {},
+    fill(): void {},
+    stroke(): void {},
+    fillRect(): void {},
+    strokeRect(): void {},
+    clearRect(): void {},
+    drawImage(): void {},
+    translate(): void {},
+    rotate(): void {},
+    strokeText(): void {},
+    fillText(): void {},
+  };
+  return ctx as unknown as CanvasRenderingContext2D;
+}
+
+/** Stubs `document`/`getComputedStyle` for the painter's offscreen-canvas cache
+ *  and color resolution, counting every `document.createElement('canvas')` so a
+ *  cache hit vs. a rebuild is observable without inspecting private fields. */
+function installDelveStyleGlobals(): { canvasesCreated: () => number } {
+  let created = 0;
+  vi.stubGlobal('document', {
+    documentElement: {},
+    createElement(tag: string): unknown {
+      if (tag !== 'canvas') throw new Error(`unexpected createElement(${tag})`);
+      created++;
+      const bg = fakeDelveCtx();
+      return { width: 0, height: 0, getContext: (kind: string) => (kind === '2d' ? bg : null) };
+    },
+  });
+  vi.stubGlobal('getComputedStyle', () => ({
+    getPropertyValue: (): string => 'paint:token',
+  }));
+  return { canvasesCreated: () => created };
+}
+
+function delveWorldForPainter(): IWorld {
+  const p = { id: 1, kind: 'player', dead: false, pos: { x: 0, z: 20 }, facing: 0 };
+  return {
+    player: p,
+    entities: new Map([[1, p]]),
+    partyInfo: null,
+    delveRun: {
+      delveId: 'collapsed_reliquary',
+      modules: [MODULE_ID],
+      moduleIndex: 0,
+      origin: { x: 0, z: 0 },
+    },
+  } as unknown as IWorld;
+}
+
+describe('DelveMapPainter.relocalize', () => {
+  it('busts the cached minimap background so the next paint rebuilds it exactly once', () => {
+    const trace = installDelveStyleGlobals();
+    try {
+      const writers = {
+        setText: (el: HTMLElement, text: string): void => {
+          (el as unknown as { textContent: string }).textContent = text;
+        },
+      } as unknown as PainterHostWriters;
+      const painter = new DelveMapPainter(writers, () => 'white');
+      const world = delveWorldForPainter();
+      const zoneLabel = { textContent: '' } as unknown as HTMLElement;
+      const ctx = fakeDelveCtx();
+
+      painter.paintMinimapDelve(ctx, world, zoneLabel, MINIMAP.size);
+      expect(trace.canvasesCreated()).toBe(1); // first paint bakes the bg canvas
+
+      painter.paintMinimapDelve(ctx, world, zoneLabel, MINIMAP.size);
+      expect(trace.canvasesCreated()).toBe(1); // same module: cache hit, no rebuild
+
+      painter.relocalize();
+      painter.paintMinimapDelve(ctx, world, zoneLabel, MINIMAP.size);
+      expect(trace.canvasesCreated()).toBe(2); // relocalize forced exactly one rebuild
+
+      painter.paintMinimapDelve(ctx, world, zoneLabel, MINIMAP.size);
+      expect(trace.canvasesCreated()).toBe(2); // re-latched: no further rebuild
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it('busts the world-map background cache independently of the minimap one', () => {
+    const trace = installDelveStyleGlobals();
+    try {
+      const writers = { setText: (): void => {} } as unknown as PainterHostWriters;
+      const painter = new DelveMapPainter(writers, () => 'white');
+      const world = delveWorldForPainter();
+      const ctx = fakeDelveCtx();
+
+      painter.paintWorldMapDelve(ctx, world, WORLDMAP.size);
+      expect(trace.canvasesCreated()).toBe(1);
+      painter.paintWorldMapDelve(ctx, world, WORLDMAP.size);
+      expect(trace.canvasesCreated()).toBe(1);
+
+      painter.relocalize();
+      painter.paintWorldMapDelve(ctx, world, WORLDMAP.size);
+      expect(trace.canvasesCreated()).toBe(2);
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 });
 

--- a/tests/language_fanout_registry.test.ts
+++ b/tests/language_fanout_registry.test.ts
@@ -91,6 +91,7 @@ const FANOUT_ARMS: readonly string[] = [
   'this.riftTracker.relocalize|',
   'this.partyFramesPainter.relocalize|',
   'this.mapPainter.relocalize|',
+  'this.delvePainter.relocalize|',
   'this.targetFrameMover.relocalize|',
   'this.playerFrameMover.relocalize|',
   'this.partyFrameMover.relocalize|',


### PR DESCRIPTION
## Summary

The delve minimap/world-map player arrow reused the overworld map's `-facing`
rotation convention, but `delveLocalToCanvas` maps `localZ` onto canvas Y
without flipping it (unlike the overworld's `toMap`, which does `maxZ - localZ`).
That mismatch pointed the delve arrow backwards whenever the player faced
north or south. Fixed `delveSchematicPlayer`'s angle to `facing + Math.PI`,
the correct rotation for this schematic's unflipped mapping.

Separately, `DelveMapPainter` baked its localized compass-north glyph into two
cached background canvases (`minimapBg`, `worldMapBg`) keyed only on module
id, never on locale, and had no `relocalize()` wired into
`Hud.refreshLocalizedDynamicUi()` the way its sibling `MapWindowPainter`
already does. Added `DelveMapPainter.relocalize()` to bust both caches and
wired it into the language fan-out alongside the existing
`mapPainter.relocalize()` call, with a matching entry added to the language
fan-out registry test.

```mermaid
flowchart TB
    subgraph before["Before: arrow angle"]
        direction TB
        A1["overworld toMap flips Z:\ncanvasY = maxZ - localZ\narrow angle = -facing"] --> A2["delve schematic COPIES\nthe same -facing formula"]
        A2 --> A3["delveLocalToCanvas does NOT\nflip Z: canvasY = localZ - zMin"]
        A3 --> A4["arrow points BACKWARDS\nwhen player faces north/south"]
    end
    subgraph after["After: arrow angle"]
        direction TB
        B1["delveLocalToCanvas: unflipped\ncanvasY = localZ - zMin"] --> B2["arrow angle =\nfacing + Math.PI"]
        B2 --> B3["arrow correctly points the\nway the player is walking"]
    end
    subgraph locale["Locale relocalize wiring"]
        direction TB
        C1["Hud.refreshLocalizedDynamicUi()"] --> C2["mapPainter.relocalize()\n(overworld, existing)"]
        C1 --> C3["DelveMapPainter.relocalize()\n(NEW)"]
        C3 --> C4["busts minimapBg + worldMapBg\ncaches so compass-north glyph\nre-bakes in the new locale"]
    end
```

## Related issues

N/A

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [ ] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx tsc --noEmit` (clean)
  - `npx vitest run tests/delve_map.test.ts tests/delve_map_painter.test.ts tests/language_fanout_registry.test.ts` (61/61 passed)
  - `npm run gate:fast` (PASS: malware scan clean, changed-file biome no errors, architecture + localization guard tests 77 passed / 3 skipped, incremental tsc clean)
- Manual steps: none (no live dev server run in this pass, see note below).

The full `npm run gate` was not run locally for this change, due to local
machine resource constraints under this batch's scale (many worktrees running
concurrently on one host). CI will run the full gate on this PR.

## Screenshots / recordings

Not captured in this automated batch run (avoiding concurrent dev-server/port
contention across a large parallel PR batch); this is a small, localized
change, please verify visually on review.

---

## Checklist

### Quality

- [ ] **The full gate passes.** `npm run gate` is green. I added or updated decisive
      tests for changed behavior and recorded any manual checks above.

(Not run locally this pass; targeted tsc/vitest and `gate:fast` were run and
are green, see "How was this tested?" above. Added/updated tests for the
angle fix and the new `relocalize()` cache-busting in
`tests/delve_map.test.ts` and `tests/delve_map_painter.test.ts`.)

### Cross-platform

- [ ] **Tested on desktop and mobile.** Verified on a desktop and on a
      phone-sized viewport in both portrait and landscape. Touch targets stay at
      least 40x40px and inputs at least 16px font (see `src/ui/CLAUDE.md`).
- [ ] **Accessible.** Keyboard-operable, with visible focus, sensible ARIA, and
      respect for `prefers-reduced-motion` (only if this change adds or edits UI).

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.
