### PR TITLE
fix(styles): fix mobile move-zone safe-area-inset and tablet left-handed frame nudge

### DIFF
--- a/src/styles/hud.mobile.css
+++ b/src/styles/hud.mobile.css
@@ -223,11 +223,15 @@
   }
   /* Floating move joystick: a lower-left capture zone lets the thumb land
      anywhere; the joystick rests dimmed at home until touched, then springs to
-     the touch point with a gold "engaged" glow. */
+     the touch point with a gold "engaged" glow. Anchored with the same
+     env(safe-area-inset-left)/env(safe-area-inset-bottom) offsets as the
+     .mobile-joystick rule it hosts (every other touch control already does
+     this), so the capture zone itself does not sit under a notch or the home
+     indicator gesture strip; the zone's own width/height stay untouched. */
   body.mobile-touch #mobile-move-zone {
     position: absolute;
-    left: 0;
-    bottom: 0;
+    left: max(18px, env(safe-area-inset-left));
+    bottom: calc(26px + env(safe-area-inset-bottom));
     width: min(30vw, 132px);
     min-width: 112px;
     max-width: 132px;
@@ -5459,6 +5463,12 @@
     body.mobile-touch.hud-mobile-tablet #castbar,
     body.mobile-touch.hud-mobile-tablet #swingbar {
       left: calc(50% - 10px);
+    }
+    /* Left-handed mirror of the nudge above, same magnitude, opposite side. */
+    body.mobile-touch.hud-mobile-tablet.mobile-left-handed #player-frame,
+    body.mobile-touch.hud-mobile-tablet.mobile-left-handed #castbar,
+    body.mobile-touch.hud-mobile-tablet.mobile-left-handed #swingbar {
+      left: calc(50% + 10px);
     }
   }
 

--- a/src/styles/hud.mobile.css
+++ b/src/styles/hud.mobile.css
@@ -2333,7 +2333,7 @@
      under the mirrored action ring on the left). */
   body.mobile-touch.mobile-left-handed #mobile-move-zone {
     left: auto;
-    right: 0;
+    right: max(18px, env(safe-area-inset-right));
   }
   /* The paged action ring (Phase 1) lives bottom-right, the same corner the
      move joystick mirrors to above. Pin the ring to the LEFT in left-handed

--- a/tests/client_shell.test.ts
+++ b/tests/client_shell.test.ts
@@ -2120,7 +2120,7 @@ describe('client HTML shell', () => {
     // a child of the move joystick, so it follows that mirror without its own
     // satellite placement rules.
     expect(hudMobileCss).toContain(
-      'body.mobile-touch.mobile-left-handed #mobile-move-zone {\n    left: auto;\n    right: 0;\n  }',
+      'body.mobile-touch.mobile-left-handed #mobile-move-zone {\n    left: auto;\n    right: max(18px, env(safe-area-inset-right));\n  }',
     );
   });
 

--- a/tests/client_shell.test.ts
+++ b/tests/client_shell.test.ts
@@ -2124,6 +2124,26 @@ describe('client HTML shell', () => {
     );
   });
 
+  // #mobile-move-zone is the floating capture zone the joystick above rests
+  // in; every other touch control anchors off env(safe-area-inset-*), but
+  // this one was still pinned to the literal device corner (left: 0; bottom:
+  // 0), so on a notched/rounded-corner phone it could sit under the home
+  // indicator gesture strip. Mirror the same left/bottom offsets the
+  // adjacent .mobile-joystick rule uses, without touching the zone's own
+  // width/height (it must not shrink the capture area).
+  it('anchors the move-zone capture area off the safe-area insets like its sibling joystick', () => {
+    expect(hudMobileCss).toContain(
+      'body.mobile-touch #mobile-move-zone {\n' +
+        '    position: absolute;\n' +
+        '    left: max(18px, env(safe-area-inset-left));\n' +
+        '    bottom: calc(26px + env(safe-area-inset-bottom));\n' +
+        '    width: min(30vw, 132px);',
+    );
+    expect(hudMobileCss).toContain(
+      'min-width: 112px;\n    max-width: 132px;\n    height: min(36vh, 172px);',
+    );
+  });
+
   it('keeps the Target swap, Use, Jump and page toggle in the action ring markup', () => {
     for (const [name, entry] of [
       ['index.html', html],

--- a/tests/mobile_window_transform.test.ts
+++ b/tests/mobile_window_transform.test.ts
@@ -274,4 +274,20 @@ describe('tier player-frame nudges are landscape-gated (hud.mobile.css)', () => 
   it('keys the tablet -10px seat to landscape', () => {
     expect(mediaPrelude('left: calc(50% - 10px)')).toContain('(orientation: landscape)');
   });
+
+  // The compact tier mirrors its narrow-width nudge for .mobile-left-handed
+  // (flipping the sign, same magnitude); the tablet nudge above was missing
+  // that mirror entirely, so left-handed players on a tablet kept the
+  // right-handed -10px seat and the frame stayed pushed into the mirrored
+  // Jump crescent on the left instead of being cleared from it.
+  it('mirrors the tablet -10px seat into a left-handed +10px seat in the same landscape block', () => {
+    expect(mediaPrelude('left: calc(50% + 10px)')).toContain('(orientation: landscape)');
+    expect(css).toContain(
+      'body.mobile-touch.hud-mobile-tablet.mobile-left-handed #player-frame,\n' +
+        '    body.mobile-touch.hud-mobile-tablet.mobile-left-handed #castbar,\n' +
+        '    body.mobile-touch.hud-mobile-tablet.mobile-left-handed #swingbar {\n' +
+        '      left: calc(50% + 10px);\n' +
+        '    }',
+    );
+  });
 });


### PR DESCRIPTION
## Summary

Two independent mobile HUD touch-zone fixes:

1. `#mobile-move-zone` (the floating lower-left move joystick's capture area)
   was pinned to the literal device corner (`left: 0; bottom: 0`) instead of
   the `env(safe-area-inset)` offsets every other touch control uses, so on a
   notched or rounded-corner phone the capture zone could sit under the home
   indicator gesture strip. It now mirrors the same
   `left: max(18px, env(safe-area-inset-left))` /
   `bottom: calc(26px + env(safe-area-inset-bottom))` offsets as the adjacent
   `.mobile-joystick` rule it hosts. The zone's own width/height are untouched.
2. The `hud-mobile-tablet` player-frame anti-overlap nudge (which shifts
   `#player-frame`, `#castbar`, and `#swingbar` by 10px in landscape so they
   clear the Jump crescent) had a left-handed mirror in the compact tier but
   not the tablet tier, so a left-handed tablet player kept the right-handed
   seat and stayed pushed toward the mirrored Jump crescent. Added the
   `.mobile-left-handed` mirror rule for the tablet tier, matching the
   compact tier's existing sign-flip pattern.

```mermaid
flowchart LR
  subgraph Before["Before (buggy)"]
    A1["#mobile-move-zone\nleft:0; bottom:0"] --> A2["Sits under notch /\nhome-indicator gesture strip"]
    A3["hud-mobile-tablet\nplayer-frame nudge: -10px"] --> A4["mobile-left-handed\nno mirror rule"] --> A5["Left-handed tablet player\nstill pushed toward\nmirrored Jump crescent"]
  end
  subgraph After["After (fixed)"]
    B1["#mobile-move-zone\nleft: max(18px, env(safe-area-inset-left))\nbottom: calc(26px + env(safe-area-inset-bottom))"] --> B2["Clears safe area,\nmatches .mobile-joystick"]
    B3["hud-mobile-tablet\nplayer-frame nudge: -10px"] --> B4["+ mobile-left-handed\nmirror: +10px"] --> B5["Left-handed tablet player\nframe clears the\nmirrored Jump crescent"]
  end
```

## Related issues

N/A

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [ ] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx vitest run tests/client_shell.test.ts tests/mobile_window_transform.test.ts` (110/110 passed, including the new pinned assertions for both fixes)
  - `npm run gate:fast` (malware scan, changed-file biome, architecture + localization guard tests: 77 passed / 3 skipped, incremental `tsc --noEmit` clean)
  - The repo's `.githooks/pre-push` floor (tsc, guard tests, changed-file biome, copy-rule scan) ran automatically on `git push` and reported green.
  - The full `npm run gate` was **not** run locally in this batch, due to local machine resource constraints (many worktrees running the full gate concurrently on this host was oversubscribing CPU/RAM and causing timeouts). CI will run the full gate on this PR.
- Manual steps: none beyond reading the diff against the adjacent `.mobile-joystick` and compact-tier `.mobile-left-handed` rules to confirm the mirrored values are correct by construction.

## Screenshots / recordings

Not captured in this automated batch run (avoiding concurrent dev-server/port contention across a large parallel PR batch); this is a small, localized change, please verify visually on review.

---

## Checklist

### Quality

- [ ] **The full gate passes.** `npm run gate` is green. I added or updated decisive
      tests for changed behavior and recorded any manual checks above.

### Cross-platform

- [ ] **Tested on desktop and mobile.** Verified on a desktop and on a
      phone-sized viewport in both portrait and landscape. Touch targets stay at
      least 40x40px and inputs at least 16px font (see `src/ui/CLAUDE.md`).
- [ ] **Accessible.** Keyboard-operable, with visible focus, sensible ARIA, and
      respect for `prefers-reduced-motion` (only if this change adds or edits UI).

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.
