### PR TITLE
fix(ui): give the bags window an accessible dialog role and name

### DIFF
--- a/src/ui/bags_window.ts
+++ b/src/ui/bags_window.ts
@@ -61,6 +61,7 @@ import {
   resolveDepositSubmit,
 } from './bags_view';
 import { showQuantityPrompt } from './bank_quantity_prompt';
+import { markDialogRoot } from './dialog_root';
 import { itemDisplayName } from './entity_i18n';
 import { isPaperdollDraggable } from './equip_drop_core';
 import { esc } from './esc';
@@ -390,6 +391,12 @@ export class BagsWindow {
     // rebuild, so capture its scroll offset and reapply it to the fresh grid:
     // otherwise using an item (e.g. a potion) snaps the list back to the top.
     const prevScrollTop = el.querySelector('.bag-grid')?.scrollTop ?? 0;
+    // Bags is a non-modal companion window (vendor / trade / market can be open
+    // alongside it), so it gets the accessible name and role=dialog like every
+    // other window in the family, but NO focus trap: markDialogRoot never installs
+    // one on its own (that is a separate opt-in, see prompt_dialog.ts for the modal
+    // recipe this window's own prompts use).
+    markDialogRoot(el, { label: t('itemUi.bags.title') });
     el.innerHTML = `<div class="panel-title"><span>${esc(t('itemUi.bags.title'))}</span><button type="button" class="x-btn" data-close data-focus-key="close" aria-label="${esc(t('itemUi.bags.close'))}">${svgIcon('close')}</button></div>`;
     el.appendChild(this.buildBagBar());
     // Skip the chip/search row entirely when the bag is empty: a full filter bar

--- a/tests/bags_window.test.ts
+++ b/tests/bags_window.test.ts
@@ -36,6 +36,21 @@ describe('bags_window: no magic values', () => {
   });
 });
 
+describe('bags_window: accessibility contract', () => {
+  // Bags rides alongside vendor / trade / market (a non-modal companion window,
+  // per close()'s own comment), so it must NOT gain a focus trap here: it only
+  // needs the same role=dialog + accessible name every other window family
+  // member gets via markDialogRoot (mirrors bank_window.ts, which already calls
+  // this with its own title key).
+  it('marks the window as a dialog root with the bags title as its accessible name', () => {
+    expect(painter).toContain("markDialogRoot(el, { label: t('itemUi.bags.title') });");
+  });
+
+  it('does not install a focus trap (no modal:true) on the non-modal bags root', () => {
+    expect(painter).not.toMatch(/markDialogRoot\([^)]*modal:\s*true/);
+  });
+});
+
 describe('bags_window: load-bearing behaviors preserved', () => {
   it('uses the branded Claudium icon and matching balance color', () => {
     expect(hud).toContain('src="/claudium/icons/claudium_coin_64.webp"');


### PR DESCRIPTION
## Summary

`bags_window.ts` never called `markDialogRoot`, unlike every other window in its
family, including `bank_window.ts`, which already follows the same non-modal-companion
pattern. Screen readers announced the bags panel with no `role` and no accessible name.

This wires `markDialogRoot(el, { label: t('itemUi.bags.title') })` right before `render()`
rebuilds the panel markup, mirroring `bank_window.ts`. No focus trap is introduced: bags
stays a non-modal companion of vendor/trade/market by design (`modal` is left at its
default `false`).

```mermaid
flowchart LR
    subgraph before["Before"]
        A1["render() rebuilds\nel.innerHTML"] --> A2["el has no role,\nno accessible name"]
        A2 --> A3["Screen reader announces\nan unlabeled generic region"]
    end
    subgraph after["After"]
        B1["render() called"] --> B2["markDialogRoot(el,\n{ label: t('itemUi.bags.title') })"]
        B2 --> B3["el gets role=dialog,\naria-label, tabindex=-1\n(aria-modal=false, no focus trap)"]
        B3 --> B4["render() rebuilds\nel.innerHTML"]
        B4 --> B5["Screen reader announces\n'Bags' dialog"]
    end
```

Added source-level tests in `tests/bags_window.test.ts` pinning the exact
`markDialogRoot` call and asserting no `modal: true` was introduced alongside it
(bags must stay a non-modal companion, unlike a true focus-trapped modal).

## Related issues

N/A

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [ ] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npm run gate:fast` (architecture + localization guard tests: 77 passed / 3 skipped,
    incremental `tsc` clean, changed-file biome clean: "Checked 2 files, No fixes applied")
  - `npx vitest run tests/bags_window.test.ts` (37/37 passed, including the 2 new
    accessibility-contract tests)
- Manual steps: none (source-level test asserts the exact call site and shape; no
  behavior visible to a player changes beyond assistive-technology output).

The full `npm run gate` was not run locally for this change, due to local machine
resource constraints under this batch's scale (many worktrees running the full gate
concurrently oversubscribes this laptop). CI will run the full gate on this PR.

## Screenshots / recordings

N/A. This change only adds ARIA attributes (`role`, `aria-label`, `aria-modal`,
`tabindex`) consumed by assistive technology; there is no visible rendering change.

---

## Checklist

### Quality

- [ ] **The full gate passes.** `npm run gate` is green. I added or updated decisive
      tests for changed behavior and recorded any manual checks above.

### Cross-platform

- [ ] **Tested on desktop and mobile.** Verified on a desktop and on a
      phone-sized viewport in both portrait and landscape. Touch targets stay at
      least 40x40px and inputs at least 16px font (see `src/ui/CLAUDE.md`).
- [x] **Accessible.** Keyboard-operable, with visible focus, sensible ARIA, and
      respect for `prefers-reduced-motion` (only if this change adds or edits UI).

### Localization (i18n)

- [x] **New player-visible strings follow the contributor policy.** Every user-facing
      string is a `t()` key added to the matching English catalog. I did not edit locale
      overlays, except for the five required non-Latin fills when the M16 wordy-copy
      rule applies (see `src/ui/CLAUDE.md`).
- [ ] Numbers, money, dates, units, and percents go through the i18n formatters
      (`formatNumber`, `formatMoney`, `formatDateTime`, `Intl`).
- [ ] Player-facing text emitted from `src/sim/` or `server/` is re-localized at
      the client boundary in this same change, and
      `npx vitest run tests/localization_fixes.test.ts` passes.
- [x] N/A. This PR adds no player-visible strings (it reuses the existing
      `itemUi.bags.title` key already used by the panel's visible title).

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.
