### PR TITLE
fix(ui): format rank/level/prestige as numbers in High Scores and Leaderboard

### DIFF
--- a/src/ui/highscore_board.ts
+++ b/src/ui/highscore_board.ts
@@ -15,7 +15,7 @@ import { CLASSES } from '../sim/data';
 import type { LeaderboardEntry } from '../world_api';
 import { classDisplayName } from './entity_i18n';
 import { esc } from './esc';
-import { t } from './i18n';
+import { formatNumber, t } from './i18n';
 import { formatXp } from './xp_bar';
 
 /** The board header row (hidden on the mobile stacked layout). */
@@ -50,15 +50,15 @@ export function highscoreRowHtml(r: LeaderboardEntry): string {
   const known = Boolean(CLASSES[r.cls]);
   const star =
     r.prestigeRank > 0
-      ? `<span class="hs-prestige" title="${esc(`${t('game.prestige.rank')} ${r.prestigeRank}`)}">&starf;${r.prestigeRank}</span>`
+      ? `<span class="hs-prestige" title="${esc(`${t('game.prestige.rank')} ${formatNumber(r.prestigeRank, { maximumFractionDigits: 0 })}`)}">&starf;${formatNumber(r.prestigeRank, { maximumFractionDigits: 0 })}</span>`
       : '';
   return (
     `<div class="hs-row${r.rank <= 3 ? ' hs-top' : ''}">` +
-    `<span class="hs-rank">${r.rank}</span>` +
+    `<span class="hs-rank">${formatNumber(r.rank, { maximumFractionDigits: 0 })}</span>` +
     `<span class="hs-name"${known ? ` title="${esc(classDisplayName(r.cls))}"` : ''}>${star}${esc(r.name)}${guildTagHtml(r.guild)}</span>` +
     `<span class="hs-realm" data-label="${esc(realmLabel)}">${esc(r.realm ?? '')}</span>` +
-    `<span class="hs-lvl" data-label="${esc(levelLabel)}">${r.level}</span>` +
-    `<span class="hs-vlvl" data-label="${esc(virtualLevelLabel)}">${r.virtualLevel}</span>` +
+    `<span class="hs-lvl" data-label="${esc(levelLabel)}">${formatNumber(r.level, { maximumFractionDigits: 0 })}</span>` +
+    `<span class="hs-vlvl" data-label="${esc(virtualLevelLabel)}">${formatNumber(r.virtualLevel, { maximumFractionDigits: 0 })}</span>` +
     `<span class="hs-xp" data-label="${esc(lifetimeXpLabel)}">${formatXp(r.lifetimeXp)}</span></div>`
   );
 }

--- a/src/ui/leaderboard_window.ts
+++ b/src/ui/leaderboard_window.ts
@@ -538,10 +538,10 @@ export class LeaderboardWindow {
 
   private guildRowHtml(r: GuildLeaderboardRow): string {
     return (
-      `<div class="lb-row lb-row-guild"><span class="lb-rank">${r.rank}</span>` +
+      `<div class="lb-row lb-row-guild"><span class="lb-rank">${formatNumber(r.rank, { maximumFractionDigits: 0 })}</span>` +
       `<span class="lb-name">${esc(r.name)}</span>` +
       `<span class="lb-members">${formatNumber(r.memberCount, { maximumFractionDigits: 0 })}</span>` +
-      `<span class="lb-vlvl">${r.topLevel}</span>` +
+      `<span class="lb-vlvl">${formatNumber(r.topLevel, { maximumFractionDigits: 0 })}</span>` +
       `<span class="lb-xp">${formatXp(r.totalLifetimeXp)}</span></div>`
     );
   }
@@ -568,7 +568,7 @@ export class LeaderboardWindow {
     const tierName = def ? devTierDisplayName(def) : '';
     const you = r.me ? ` <span class="lb-you">(${esc(t('game.leaderboard.you'))})</span>` : '';
     return (
-      `<div class="lb-row lb-row-dev${r.me ? ' lb-mine' : ''}"><span class="lb-rank">${r.rank}</span>` +
+      `<div class="lb-row lb-row-dev${r.me ? ' lb-mine' : ''}"><span class="lb-rank">${formatNumber(r.rank, { maximumFractionDigits: 0 })}</span>` +
       `<span class="lb-name">${badge}@${esc(r.login)}${you}</span>` +
       `<span class="lb-dev-tier">${esc(tierName)}</span>` +
       `<span class="lb-commits">${formatNumber(r.mergedPrs, { maximumFractionDigits: 0 })}</span></div>`
@@ -607,7 +607,7 @@ export class LeaderboardWindow {
     const you = r.me ? ` <span class="lb-you">(${esc(t('game.leaderboard.you'))})</span>` : '';
     const titleText = r.title ? deedTitleText(r.title) : '';
     return (
-      `<div class="lb-row lb-row-deeds${r.me ? ' lb-mine' : ''}"><span class="lb-rank">${r.rank}</span>` +
+      `<div class="lb-row lb-row-deeds${r.me ? ' lb-mine' : ''}"><span class="lb-rank">${formatNumber(r.rank, { maximumFractionDigits: 0 })}</span>` +
       `<span class="lb-name"${clsTitle}>${esc(r.name)}${you} <span class="lb-realm">${esc(r.realm)}</span></span>` +
       `<span class="lb-renown">${formatNumber(r.renown, { maximumFractionDigits: 0 })}</span>` +
       `<span class="lb-deed-title">${esc(titleText)}</span></div>`
@@ -651,7 +651,7 @@ export class LeaderboardWindow {
   private dailyRowHtml(r: DailyRewardStatus['leaderboard'][number]): string {
     const you = r.me ? ` <span class="lb-you">(${esc(t('game.leaderboard.you'))})</span>` : '';
     return (
-      `<div class="lb-row lb-daily${r.me ? ' lb-mine' : ''}"><span class="lb-rank">${r.rank}</span>` +
+      `<div class="lb-row lb-daily${r.me ? ' lb-mine' : ''}"><span class="lb-rank">${formatNumber(r.rank, { maximumFractionDigits: 0 })}</span>` +
       `<span class="lb-name">${esc(r.name)}${you}</span>` +
       `<span class="lb-xp">${formatNumber(r.points, { maximumFractionDigits: 0 })}</span></div>`
     );
@@ -672,7 +672,7 @@ export class LeaderboardWindow {
     // &starf; renders the prestige star without a literal symbol glyph in source.
     const star =
       r.prestigeRank > 0
-        ? `<span class="lb-prestige" title="${esc(`${t('game.prestige.rank')} ${r.prestigeRank}`)}">&starf;${r.prestigeRank}</span> `
+        ? `<span class="lb-prestige" title="${esc(`${t('game.prestige.rank')} ${formatNumber(r.prestigeRank, { maximumFractionDigits: 0 })}`)}">&starf;${formatNumber(r.prestigeRank, { maximumFractionDigits: 0 })}</span> `
         : '';
     const title = r.knownClass ? ` title="${esc(classDisplayName(r.cls))}"` : '';
     const you = r.me ? ` <span class="lb-you">(${esc(t('game.leaderboard.you'))})</span>` : '';
@@ -680,9 +680,9 @@ export class LeaderboardWindow {
     // localized here; '' (untitled/stale) renders an empty cell.
     const deedTitle = r.title ? deedTitleText(r.title) : '';
     return (
-      `<div class="lb-row lb-row-players${r.me ? ' lb-mine' : ''}"><span class="lb-rank">${r.rank}</span>` +
+      `<div class="lb-row lb-row-players${r.me ? ' lb-mine' : ''}"><span class="lb-rank">${formatNumber(r.rank, { maximumFractionDigits: 0 })}</span>` +
       `<span class="lb-name"${title}>${star}${esc(r.name)}${this.guildTagHtml(r.guild)}${you}</span>` +
-      `<span class="lb-lvl">${r.level}</span><span class="lb-vlvl">${r.virtualLevel}</span>` +
+      `<span class="lb-lvl">${formatNumber(r.level, { maximumFractionDigits: 0 })}</span><span class="lb-vlvl">${formatNumber(r.virtualLevel, { maximumFractionDigits: 0 })}</span>` +
       `<span class="lb-xp">${formatXp(r.lifetimeXp)}</span>` +
       `<span class="lb-deed-title">${esc(deedTitle)}</span></div>`
     );
@@ -699,7 +699,7 @@ export class LeaderboardWindow {
     return (
       `<div class="lb-sticky"><div class="lb-row lb-row-players lb-mine"><span class="lb-rank">&mdash;</span>` +
       `<span class="lb-name">${esc(standing.name)}${this.guildTagHtml(standing.guild)} <span class="lb-you">(${esc(t('game.leaderboard.you'))})</span></span>` +
-      `<span class="lb-lvl">${standing.level}</span><span class="lb-vlvl">${standing.virtualLevel}</span>` +
+      `<span class="lb-lvl">${formatNumber(standing.level, { maximumFractionDigits: 0 })}</span><span class="lb-vlvl">${formatNumber(standing.virtualLevel, { maximumFractionDigits: 0 })}</span>` +
       `<span class="lb-xp">${formatXp(standing.lifetimeXp)}</span>` +
       `<span class="lb-deed-title">${esc(deedTitle)}</span></div></div>`
     );

--- a/tests/highscore_board.test.ts
+++ b/tests/highscore_board.test.ts
@@ -114,6 +114,32 @@ describe('highscore_board: the row/head shape the stylesheet depends on', () => 
   });
 });
 
+describe('highscore_board: rank/level/virtual level/prestige render through formatNumber', () => {
+  // A four-digit value is the decisive probe: formatNumber's default grouping
+  // inserts a thousands separator a raw template interpolation never would,
+  // matching how the lifetimeXp column already renders (formatXp).
+  it('formats the rank with digit grouping, not a raw number', () => {
+    const html = highscoreRowHtml(entry({ rank: 1234 }));
+    expect(html).toContain('<span class="hs-rank">1,234</span>');
+    expect(html).not.toContain('<span class="hs-rank">1234</span>');
+  });
+
+  it('formats the level and virtual level with digit grouping', () => {
+    const html = highscoreRowHtml(entry({ level: 1234, virtualLevel: 5678 }));
+    expect(html).toContain('>1,234</span>');
+    expect(html).toContain('>5,678</span>');
+    expect(html).not.toContain('>1234<');
+    expect(html).not.toContain('>5678<');
+  });
+
+  it('formats the prestige rank badge and its tooltip with digit grouping', () => {
+    const html = highscoreRowHtml(entry({ prestigeRank: 1234 }));
+    expect(html).toContain('&starf;1,234</span>');
+    expect(html).toContain(`${t('game.prestige.rank')} 1,234`);
+    expect(html).not.toContain('&starf;1234<');
+  });
+});
+
 describe('highscore_board: loadHighscoresInto (the thin consumer)', () => {
   it('paints the ranked board from the injected fetch', async () => {
     const el = host();

--- a/tests/leaderboard_window.test.ts
+++ b/tests/leaderboard_window.test.ts
@@ -340,6 +340,53 @@ describe('leaderboard_window: Renown (deeds) board tab', () => {
   });
 });
 
+describe('leaderboard_window: rank/level/virtual level/prestige render through formatNumber', () => {
+  // Every other numeric column on these rows (memberCount, mergedPrs, renown,
+  // points, the pager) already routes through formatNumber; rank, level,
+  // virtual level (including the guild board's top-member level, which reuses
+  // the same vlvl column) and prestige rank must match, not render raw.
+  it('formats the rank in every row builder (players, guilds, devs, deeds, daily)', () => {
+    expect(code).toMatch(
+      /class="lb-rank">\$\{formatNumber\(r\.rank, \{ maximumFractionDigits: 0 \}\)\}/,
+    );
+    const matches = code.match(
+      /class="lb-rank">\$\{formatNumber\(r\.rank, \{ maximumFractionDigits: 0 \}\)\}/g,
+    );
+    expect(matches?.length).toBe(5);
+    expect(code).not.toMatch(/class="lb-rank">\$\{r\.rank\}</);
+  });
+
+  it('formats the players-tab level and virtual level (row and sticky standing)', () => {
+    expect(code).toContain(
+      '<span class="lb-lvl">${formatNumber(r.level, { maximumFractionDigits: 0 })}</span>' +
+        '<span class="lb-vlvl">${formatNumber(r.virtualLevel, { maximumFractionDigits: 0 })}</span>',
+    );
+    expect(code).toContain(
+      '<span class="lb-lvl">${formatNumber(standing.level, { maximumFractionDigits: 0 })}</span>' +
+        '<span class="lb-vlvl">${formatNumber(standing.virtualLevel, { maximumFractionDigits: 0 })}</span>',
+    );
+    expect(code).not.toMatch(/\$\{r\.level\}|\$\{r\.virtualLevel\}/);
+    expect(code).not.toMatch(/\$\{standing\.level\}|\$\{standing\.virtualLevel\}/);
+  });
+
+  it('formats the guild board top-member level (the reused vlvl column)', () => {
+    expect(code).toContain(
+      '<span class="lb-vlvl">${formatNumber(r.topLevel, { maximumFractionDigits: 0 })}</span>',
+    );
+    expect(code).not.toMatch(/\$\{r\.topLevel\}/);
+  });
+
+  it('formats the prestige rank badge and its tooltip', () => {
+    expect(code).toMatch(
+      /&starf;\$\{formatNumber\(r\.prestigeRank, \{ maximumFractionDigits: 0 \}\)\}<\/span>/,
+    );
+    expect(code).toMatch(
+      /t\('game\.prestige\.rank'\)\} \$\{formatNumber\(r\.prestigeRank, \{ maximumFractionDigits: 0 \}\)\}/,
+    );
+    expect(code).not.toMatch(/&starf;\$\{r\.prestigeRank\}/);
+  });
+});
+
 describe('players (lifetime-XP) board: the Book of Deeds title column', () => {
   // The view-model carries the deed ID (leaderboard_view.test.ts); these pins
   // hold the players-tab RENDER arm added alongside the Renown tab's: the id


### PR DESCRIPTION
## Summary

Rank, level, virtual level, and prestige rank rendered as raw interpolated numbers in
`highscore_board.ts` and every row builder in `leaderboard_window.ts` (players, guilds,
devs, deeds, daily, plus the sticky standing row), while every sibling numeric column
on the same rows already went through `formatNumber` or `formatXp`. This wraps the raw
fields with `formatNumber(value, { maximumFractionDigits: 0 })`, mirroring the adjacent
already-formatted columns, so a four-digit rank or level gets its locale digit grouping
instead of a bare number. Purely mechanical: no layout or markup structure changed.

```mermaid
flowchart LR
    subgraph Before["Before (bug)"]
        A1["row data: rank, level,\nvirtualLevel, prestigeRank"] --> A2["template literal\ninterpolates raw number"]
        A2 --> A3["'1234' (no grouping)"]
    end
    subgraph After["After (fixed)"]
        B1["row data: rank, level,\nvirtualLevel, prestigeRank"] --> B2["formatNumber(value,\n{ maximumFractionDigits: 0 })"]
        B2 --> B3["'1,234' (locale grouping)"]
    end
    A3 -. "inconsistent with sibling\nXP / renown / member columns" .-> Bug["visual mismatch\nin the same row"]
    B3 -. "matches formatXp/formatNumber\nalready used on siblings" .-> Fixed["consistent row formatting"]
```

## Related issues

N/A

## Type of change

- [x] Bug fix
- [ ] Feature: new functionality
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [ ] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npm run gate:fast` (malware scan clean, architecture + localization guard tests
    77 passed / 3 skipped, incremental `tsc` clean)
  - `npx vitest run tests/highscore_board.test.ts tests/leaderboard_window.test.ts`
    (73/73 passed)
  - `npx @biomejs/biome check` on the 4 changed files (exit 0; 8 pre-existing-style
    lint warnings only, no errors, no format diffs)
- Manual steps: none; covered by the automated assertions above (four-digit values
  must render with digit grouping, e.g. `1,234` not `1234`).

The full `npm run gate` was not run locally for this change: this batch is running many
worktrees in parallel on a resource-constrained laptop, and a full local gate run was
timing out / oversubscribing CPU and RAM rather than adding real signal. CI on this PR
runs the full gate on GitHub's own infrastructure and is the authoritative check.

## Screenshots / recordings

Not captured in this automated batch run (avoiding concurrent dev-server/port contention
across a large parallel PR batch); this is a small, localized change, please verify
visually on review.

---

## Checklist

### Quality

- [ ] **The full gate passes.** `npm run gate` is green. I added or updated decisive
      tests for changed behavior and recorded any manual checks above.

### Cross-platform

- [ ] **Tested on desktop and mobile.** Verified on a desktop and on a
      phone-sized viewport in both portrait and landscape. Touch targets stay at
      least 40x40px and inputs at least 16px font (see `src/ui/CLAUDE.md`).
- [ ] **Accessible.** Keyboard-operable, with visible focus, sensible ARIA, and
      respect for `prefers-reduced-motion` (only if this change adds or edits UI).

### Localization (i18n)

- [ ] **New player-visible strings follow the contributor policy.** Every user-facing
      string is a `t()` key added to the matching English catalog. I did not edit locale
      overlays, except for the five required non-Latin fills when the M16 wordy-copy
      rule applies (see `src/ui/CLAUDE.md`).
- [x] Numbers, money, dates, units, and percents go through the i18n formatters
      (`formatNumber`, `formatMoney`, `formatDateTime`, `Intl`).
- [ ] Player-facing text emitted from `src/sim/` or `server/` is re-localized at
      the client boundary in this same change, and
      `npx vitest run tests/localization_fixes.test.ts` passes.
- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.
