### PR TITLE
fix(android): point the Solana wallet-adapter connection icon at a favicon that exists

### DIFF
--- a/android/app/src/solanaStore/java/com/worldofclaudecraft/NativeSolanaMobilePlugin.kt
+++ b/android/app/src/solanaStore/java/com/worldofclaudecraft/NativeSolanaMobilePlugin.kt
@@ -31,7 +31,7 @@ class NativeSolanaMobilePlugin : Plugin() {
     private val walletAdapter = MobileWalletAdapter(
         connectionIdentity = ConnectionIdentity(
             identityUri = Uri.parse("https://worldofclaudecraft.com"),
-            iconUri = Uri.parse("favicon.svg"),
+            iconUri = Uri.parse("favicon.ico"),
             identityName = "World of ClaudeCraft",
         ),
     )

--- a/tests/android_seeker_distribution.test.ts
+++ b/tests/android_seeker_distribution.test.ts
@@ -199,6 +199,12 @@ describe('Android Seeker distribution boundary', () => {
     expect(main).toContain("? t('wallet.seekerAppHelp')");
   });
 
+  it('points the MWA connection identity icon at a favicon that actually ships', () => {
+    expect(plugin).toContain('iconUri = Uri.parse("favicon.ico")');
+    expect(plugin).not.toContain('favicon.svg');
+    expect(existsSync('public/favicon.ico')).toBe(true);
+  });
+
   it('promotes the existing rewards button below Chat without covering mobile unit frames', () => {
     expect(main).toContain(
       "document.getElementById('mobile-combat-controls')?.appendChild(dailyRewardsButton)",


### PR DESCRIPTION
## Summary

The Android build's Solana wallet-adapter integration
(`android/app/src/solanaStore/java/com/worldofclaudecraft/NativeSolanaMobilePlugin.kt`)
set `ConnectionIdentity.iconUri` to `Uri.parse("favicon.svg")`. That file has never
shipped in `public/`; only `favicon.ico` and the 16x16/32x32 PNGs do, and every other
favicon reference in the codebase already points at `favicon.ico`. This is a one-line
fix to point the icon URI at the file that actually exists, plus a regression test that
pins the fix and confirms the referenced file is really on disk.

```mermaid
flowchart LR
    subgraph Before["Before (bug)"]
        A1[MobileWalletAdapter builds\nConnectionIdentity] --> A2["iconUri = favicon.svg"]
        A2 --> A3[Seeker wallet app requests\nfavicon.svg from public/]
        A3 --> A4[404: file never shipped\nwallet shows no connection icon]
    end

    subgraph After["After (fix)"]
        B1[MobileWalletAdapter builds\nConnectionIdentity] --> B2["iconUri = favicon.ico"]
        B2 --> B3[Seeker wallet app requests\nfavicon.ico from public/]
        B3 --> B4[200: file ships in public/\nwallet shows the real icon]
    end
```

## Related issues

N/A

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [ ] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npm run i18n:gen` (unrelated pre-req: `src/ui/i18n.status.json` was missing in the
    fresh worktree; gitignored generated output, not part of this diff)
  - `npm run gate:fast` (malware scan, changed-file biome check on
    `tests/android_seeker_distribution.test.ts`, `tests/architecture.test.ts` +
    `tests/localization_fixes.test.ts` guard tests, incremental `tsc --noEmit`, and
    `npx vitest run tests/android_seeker_distribution.test.ts`) - all 5 steps passed
    green, 13/13 tests in the target file passed
  - Verified the new regression test actually catches the bug: reproduced it failing
    against the pre-fix source via `git stash` before confirming it passes with the fix
    applied
- Manual steps: none (Kotlin plugin code is not exercised by the web/Vitest toolchain
  beyond the source-pinning regression test; no device build was run)

The full `npm run gate` was not run locally in this batch: this laptop is running many
worktrees concurrently and the full gate has been repeatedly timing out under that
contention, so it would cost far more time than it is worth for a one-line fix already
covered by `gate:fast` and a targeted, verified-failing-before-fix regression test. CI
will run the full gate on this PR.

## Screenshots / recordings

N/A. This change is not visual: it only changes a Kotlin string literal used for a
native wallet-adapter connection metadata field.

---

## Checklist

### Quality

- [ ] **The full gate passes.** `npm run gate` is green. I added or updated decisive
      tests for changed behavior and recorded any manual checks above.

(Not run locally this batch, see "How was this tested?" above; `gate:fast` and the
scoped tests passed, and CI runs the full gate on this PR.)

### Cross-platform

- [ ] **Tested on desktop and mobile.** Verified on a desktop and on a
      phone-sized viewport in both portrait and landscape. Touch targets stay at
      least 40x40px and inputs at least 16px font (see `src/ui/CLAUDE.md`).
- [ ] **Accessible.** Keyboard-operable, with visible focus, sensible ARIA, and
      respect for `prefers-reduced-motion` (only if this change adds or edits UI).

(N/A: no UI surface changed. This is a native Android Kotlin string literal used
internally by the Solana wallet-adapter connection handshake.)

### Localization (i18n)

- [ ] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.
