### PR TITLE
fix(content): give Avatar of War's fiesta augment its spell-damage half

### DIFF
--- a/src/sim/content/augments.ts
+++ b/src/sim/content/augments.ts
@@ -205,7 +205,10 @@ export const AUGMENTS: AugmentDef[] = [
     tier: 'prismatic',
     classes: PHYSICAL,
     description: '+25% all damage, +25% maximum health, +300 armor. Walk it down.',
-    effect: { global: { meleeDmgPct: 0.25 }, stats: { maxHpPct: 0.25, armor: 300 } },
+    effect: {
+      global: { meleeDmgPct: 0.25, spellDmgPct: 0.25 },
+      stats: { maxHpPct: 0.25, armor: 300 },
+    },
   },
   {
     id: 'aug_ascendant',

--- a/tests/fiesta_module.test.ts
+++ b/tests/fiesta_module.test.ts
@@ -42,6 +42,26 @@ describe('fiesta module: deterministic offer draw', () => {
   });
 });
 
+describe('fiesta module: "+X% all damage" augments carry both damage halves', () => {
+  it('aug_avatar sets spellDmgPct alongside meleeDmgPct, matching its own tooltip and the aug_bloodhunter/aug_overdrive sibling pattern', () => {
+    for (const id of ['aug_bloodhunter', 'aug_overdrive', 'aug_avatar']) {
+      const aug = AUGMENTS_BY_ID[id];
+      const melee = aug.effect.global?.meleeDmgPct ?? 0;
+      expect(melee).toBeGreaterThan(0);
+      expect(aug.effect.global?.spellDmgPct).toBe(melee);
+    }
+  });
+
+  it('picking aug_avatar raises the merged spellDmgPct by the same amount as meleeDmgPct', () => {
+    const sim = makeWorld();
+    const pid = sim.addPlayer('paladin', 'A');
+    const base = sim.players.get(pid)!.talentMods;
+    const merged = fiesta.mergeAugmentMods(base, ['aug_avatar']);
+    expect(merged.global.spellDmgPct - base.global.spellDmgPct).toBeCloseTo(0.25, 6);
+    expect(merged.global.spellDmgPct).toBeCloseTo(merged.global.meleeDmgPct, 6);
+  });
+});
+
 describe('fiesta module: mergeAugmentMods', () => {
   it('folds an augment effect into a deep clone, never mutating the base', () => {
     const aug = AUGMENTS.find((a) => (a.effect.stats?.crit ?? 0) > 0)!;


### PR DESCRIPTION
## Summary

The Avatar of War prismatic augment's tooltip promises "+25% all damage", but its
`effect.global` only ever set `meleeDmgPct: 0.25`, never `spellDmgPct`. The sibling
prismatic augments `aug_bloodhunter` and `aug_overdrive` use the same "all damage"
wording and already set both halves at equal values. A PHYSICAL-class pick
(paladin, shaman, druid, hunter) that owns a spell-school ability got zero bonus
from the half its own tooltip claims.

This change adds `spellDmgPct: 0.25` to `aug_avatar`'s `effect.global`, reusing the
same 0.25 value already present for the physical half, so the augment now matches
its tooltip and its sibling augments' pattern.

```mermaid
flowchart LR
    subgraph Before["Before: aug_avatar equipped"]
        A1["Tooltip: '+25% all damage'"] --> B1["effect.global.meleeDmgPct = 0.25"]
        B1 --> C1["Melee ability -> +25% damage"]
        B1 -.-> D1["Spell ability -> +0% damage (missing)"]
    end
    subgraph After["After: aug_avatar equipped"]
        A2["Tooltip: '+25% all damage'"] --> B2["effect.global.meleeDmgPct = 0.25\neffect.global.spellDmgPct = 0.25"]
        B2 --> C2["Melee ability -> +25% damage"]
        B2 --> D2["Spell ability -> +25% damage"]
    end
```

## Related issues

N/A

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [ ] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx vitest run tests/fiesta_module.test.ts` (9 passed), including two new
    tests: one pinning the catalog shape (`aug_avatar.effect.global` carries both
    `meleeDmgPct: 0.25` and `spellDmgPct: 0.25`), and one pinning the merged-mods
    behavior when the augment is equipped.
  - The repo's pre-push QA floor (`tsc --noEmit`, `tests/architecture.test.ts`,
    `tests/localization_fixes.test.ts`, changed-files biome) ran automatically on
    `git push` and was green.
- Manual steps: none; this is a data-only content fix covered by the tests above.
- Note: the full `npm run gate` (the complete CI-equivalent merge-bar gate) was
  **not** run locally for this change, due to local machine resource constraints
  under this batch's scale (multiple concurrent worktrees oversubscribing a
  resource-constrained laptop). CI will run the full gate on this PR.

## Screenshots / recordings

N/A. This is a non-visual data/content change (no HUD, window, tooltip layout,
or rendering change; the tooltip text itself is unchanged).

---

## Checklist

### Quality

- [ ] **The full gate passes.** `npm run gate` is green. I added or updated decisive
      tests for changed behavior and recorded any manual checks above.
      (Not run locally this batch, see "How was this tested?"; targeted tests and
      the pre-push QA floor passed. CI will run the full gate.)

### Cross-platform

- [ ] **Tested on desktop and mobile.** N/A: no UI change.
- [ ] **Accessible.** N/A: no UI change.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings. (The augment's tooltip string
      is unchanged; only the underlying numeric effect data changed.)

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.

> Commit messages and PR titles use [Conventional Commits](https://www.conventionalcommits.org/)
> with a required scope (`feat(talents): ...`, `fix(net): ...`).
