### PR TITLE
feat(mounts): make mount reins tradable instead of soulbound

### DIFF
--- a/src/sim/content/items.ts
+++ b/src/sim/content/items.ts
@@ -362,36 +362,42 @@ export const BASE_ITEMS: Record<string, ItemDef> = {
   },
   // The horse's reins: the ONLY purchasable mount, sold by Stablemaster Marla
   // Hitchen for 10 gold after the player has learned Riding (ridingTrained gate
-  // in items.ts buyItem). Soulbound like every reins item, so owning it IS owning
-  // the horse (src/sim/mounts.ts mountOwned) and it never transfers.
-  // sellValue 0: bought, never sold back.
+  // in items.ts buyItem). Not soulbound: owning the item IS owning the horse
+  // (src/sim/mounts.ts mountOwned), and like every player reins it can trade
+  // hands. The buy path's mountOwned gate therefore only stops duplicates in
+  // your own containers: buy, give away, buy again is allowed, making this an
+  // elastic market good with a 10g vendor floor (deliberate; no copper mint,
+  // since it never sells back). noVendorSell + sellValue 0: an accidental
+  // 0-copper sale that buyback rotation could eat would destroy the mount.
   reins_valorsteed: {
     id: 'reins_valorsteed',
     name: 'Reins of the Valorsteed',
     kind: 'mount',
     mount: 'valorsteed',
     quality: 'common',
-    soulbound: true,
+    noVendorSell: true,
     noDiscard: true,
     sellValue: 0,
     buyValue: 100_000, // 10 gold in copper
   },
   // Collectible mount (Morthen the Gravecaller, The Hollow Crypt). Owning the
-  // reins item IS owning the mount (src/sim/mounts.ts mountOwned): soulbound,
-  // so ownership never transfers, and it stays valid from the bank too.
+  // reins item IS owning the mount (src/sim/mounts.ts mountOwned); it stays
+  // valid from the bank too, and it transfers like any other unbound item.
   reins_grag_bear: {
     id: 'reins_grag_bear',
     name: 'Reins of the Goliath Grag-Bear',
     kind: 'mount',
     mount: 'grag_bear',
     quality: 'rare',
-    soulbound: true,
+    noVendorSell: true,
     noDiscard: true,
     sellValue: 0,
   },
   // Developer-only mount. It is intentionally absent from vendors, quests,
   // creature loot, heroic loot, and Rift reward pools. Use /dev mounts or
   // /dev give reins_terrorspark_groundshaker while the feature remains under development.
+  // Unlike the player reins it STAYS soulbound: it has no acquisition path, so
+  // tradability would turn a dev grant into an economy leak.
   reins_terrorspark_groundshaker: {
     id: 'reins_terrorspark_groundshaker',
     name: 'Ignition Key: Terrorspark Groundshaker',

--- a/src/sim/content/temple.ts
+++ b/src/sim/content/temple.ts
@@ -696,15 +696,16 @@ export const TEMPLE_ITEMS: Record<string, ItemDef> = {
     sellValue: 2400,
     requiredClass: WAR,
   },
-  // Collectible mount (Ysolei, Avatar of the Drowned Moon). Soulbound; owning
-  // the ignition key item is owning the mount (src/sim/mounts.ts mountOwned).
+  // Collectible mount (Ysolei, Avatar of the Drowned Moon). Not soulbound;
+  // owning the ignition key item is owning the mount (src/sim/mounts.ts
+  // mountOwned), and the item transfers like any other.
   reins_aether_hover_cycle: {
     id: 'reins_aether_hover_cycle',
     name: 'Ignition Key: Aether-Jouster Hover-Cycle',
     kind: 'mount',
     mount: 'aether_hover_cycle',
     quality: 'epic',
-    soulbound: true,
+    noVendorSell: true,
     noDiscard: true,
     sellValue: 0,
   },

--- a/src/sim/content/zone2.ts
+++ b/src/sim/content/zone2.ts
@@ -1647,15 +1647,16 @@ export const ZONE2_ITEMS: Record<string, ItemDef> = {
     sellValue: 350,
     requiredClass: WAR,
   },
-  // Collectible mount (Vael the Fogbinder, The Sunken Bastion). Soulbound;
-  // owning the reins item is owning the mount (src/sim/mounts.ts mountOwned).
+  // Collectible mount (Vael the Fogbinder, The Sunken Bastion). Not soulbound;
+  // owning the reins item is owning the mount (src/sim/mounts.ts mountOwned),
+  // and the item transfers like any other.
   reins_stalkglider_snail: {
     id: 'reins_stalkglider_snail',
     name: 'Reins of the Moss-Shell Stalk-Glider',
     kind: 'mount',
     mount: 'stalkglider_snail',
     quality: 'rare',
-    soulbound: true,
+    noVendorSell: true,
     noDiscard: true,
     sellValue: 0,
   },

--- a/src/sim/content/zone3.ts
+++ b/src/sim/content/zone3.ts
@@ -3101,17 +3101,18 @@ export const ZONE3_ITEMS: Record<string, ItemDef> = {
       },
     ],
   },
-  // Collectible mounts (src/sim/mounts.ts mountOwned): soulbound reins items;
-  // owning the item is owning the mount. The toad drops from Korzul the
-  // Gravewyrm, the griffin from Nythraxis (the raid pinnacle drop), the
-  // gobbler from Thunzharr the world boss (a personal-loot chase drop).
+  // Collectible mounts (src/sim/mounts.ts mountOwned): unbound reins items;
+  // owning the item is owning the mount, and the item transfers like any
+  // other. The toad drops from Korzul the Gravewyrm, the griffin from
+  // Nythraxis (the raid pinnacle drop), the gobbler from Thunzharr the world
+  // boss (a personal-loot chase drop).
   reins_shadowjump_toad: {
     id: 'reins_shadowjump_toad',
     name: 'Reins of Kama-Kage the Shadow-Jump Toad',
     kind: 'mount',
     mount: 'shadowjump_toad',
     quality: 'uncommon',
-    soulbound: true,
+    noVendorSell: true,
     noDiscard: true,
     sellValue: 0,
   },
@@ -3121,7 +3122,7 @@ export const ZONE3_ITEMS: Record<string, ItemDef> = {
     kind: 'mount',
     mount: 'stormfeather_griffin',
     quality: 'uncommon',
-    soulbound: true,
+    noVendorSell: true,
     noDiscard: true,
     sellValue: 0,
   },
@@ -3131,7 +3132,7 @@ export const ZONE3_ITEMS: Record<string, ItemDef> = {
     kind: 'mount',
     mount: 'thunderstrut_gobbler',
     quality: 'epic',
-    soulbound: true,
+    noVendorSell: true,
     noDiscard: true,
     sellValue: 0,
   },

--- a/src/sim/market_query.ts
+++ b/src/sim/market_query.ts
@@ -188,9 +188,10 @@ function itemMatchesType(item: ItemDef, filter: MarketItemTypeFilter): boolean {
     return !isCosmeticItem(item) && (item.kind === 'junk' || item.kind === 'tool');
   if (filter === 'cosmetic') return isCosmeticItem(item);
   // The catch-all for catalog kinds with no browse category of their own. Mount
-  // reins join quest items here: both are soulbound oddments a player can hold
-  // but never list, so neither earns a filter chip, and neither may be left
-  // reachable through 'All' alone (tests/market_filters.test.ts).
+  // reins join quest items here: quest items are never listable, and reins
+  // (listable now that they are unbound) are too few to earn a filter chip.
+  // Neither may be left reachable through 'All' alone
+  // (tests/market_filters.test.ts).
   if (filter === 'other') return item.kind === 'quest' || item.kind === 'mount';
   // Exhaustive on purpose: a future MARKET_ITEM_TYPE_FILTERS entry with no arm above
   // reddens tsc here instead of silently inheriting the 'other' predicate, which is

--- a/src/sim/mounts.ts
+++ b/src/sim/mounts.ts
@@ -1,10 +1,12 @@
 // Rideable ground mounts: collection + mount/dismount rules, a sibling sim
 // system behind the SimContext seam (module-first; sim.ts keeps thin delegates).
 //
-// Collection model: EVERY catalog mount is owned while its soulbound reins item
-// (ItemDef kind 'mount') sits in the player's bags or bank. The horse
-// (DEFAULT_MOUNT) is no longer free: it has its own reins item too, sold by the
-// stablemaster, so a fresh player owns nothing until they buy or loot a mount.
+// Collection model: EVERY catalog mount is owned while its reins item (ItemDef
+// kind 'mount') sits in the player's bags or bank. Player reins are NOT
+// soulbound: ownership travels with the item, so a reins can be traded,
+// mailed, or listed away (and the mount with it). The horse (DEFAULT_MOUNT)
+// is no longer free: it has its own reins item too, sold by the stablemaster,
+// so a fresh player owns nothing until they buy or loot a mount.
 // There is NO persisted "selected mount": reins are usable items, so you ride by
 // using the reins (summonMountItem, reached through items.ts useItem) and the
 // item you clicked IS the choice. The live "riding X right now" state is
@@ -35,6 +37,14 @@ import { DT, type Entity, FORM_AURA_KINDS, isNonSpellCast } from './types';
 // instant from every path (forceDismount), so there is no matching constant.
 export const MOUNT_SUMMON_SECONDS = 1.5;
 
+// Cadence (in ticks) of the while-mounted ownership re-validation in
+// updateMountTransition. The check is two container scans per mounted player,
+// so it runs on an id-staggered cadence instead of every tick; the worst-case
+// dismount delay (MOUNT_OWNERSHIP_REVALIDATE_TICKS ticks, 200ms) is
+// unobservable next to the 1.5s summon channel. tickCount and entity ids are
+// identical on every host, so the stagger is deterministic.
+export const MOUNT_OWNERSHIP_REVALIDATE_TICKS = 4;
+
 // The reins itemId per catalog mount, derived once from the merged ITEMS table
 // (single source: the item record declares `mount`, nothing re-lists the map).
 // Static content, so the lazy module-level cache is multi-Sim safe.
@@ -54,8 +64,10 @@ export function mountItemId(key: string): string | null {
 }
 
 /** Whether the player owns the mount: any catalog mount (the horse included)
- *  while its reins item sits in bags or bank (soulbound, so ownership never
- *  transfers). Unknown keys are never owned. A fresh player owns nothing. */
+ *  while its reins item sits in bags or bank. Reins are not soulbound, so
+ *  ownership travels with the item (a traded-away reins is a lost mount, and
+ *  a summon channel re-validates ownership at completion). Unknown keys are
+ *  never owned. A fresh player owns nothing. */
 export function mountOwned(meta: PlayerMeta, key: string): boolean {
   if (!mountDef(key)) return false;
   const itemId = mountItemId(key);
@@ -278,8 +290,10 @@ export function toggleMount(ctx: SimContext, pid: number): boolean {
 /** Per-tick driver for the mount summon/dismount channel (called from the
  *  coordinator's per-player loop). `swimming` is whether the entity is in
  *  fishable/deep water this tick. Water and death force an instant dismount;
- *  a summon channel cancels on entering combat or water; a finished channel
- *  applies the mount (re-validating ownership) or the dismount. */
+ *  losing the reins dismounts too (ownership is re-validated while mounted,
+ *  on a short deterministic stagger); a summon channel cancels on entering
+ *  combat or water; a finished channel applies the mount (re-validating
+ *  ownership) or the dismount. */
 export function updateMountTransition(ctx: SimContext, e: Entity, swimming: boolean): void {
   const meta = ctx.players.get(e.id);
   // (a) Water force-dismounts instantly: no ground mount swims. Also clears any
@@ -289,6 +303,22 @@ export function updateMountTransition(ctx: SimContext, e: Entity, swimming: bool
     e.mountCastRemaining = 0;
     e.mountCastKey = '';
     if (meta) recalcFor(ctx, e, meta);
+    return;
+  }
+  // (a2) Ownership re-validation while mounted. Reins are transferable items,
+  // so the ridden mount can leave the player's possession mid-ride (traded,
+  // mailed, listed, deposited): the ride must follow the item, or one reins
+  // could keep a chain of players mounted. The lent training steed is the one
+  // sanctioned unowned ride. Draws no rng (a pure bags+bank scan), and the
+  // id-staggered cadence keeps the per-tick cost flat across mounted players.
+  if (
+    e.mountKey &&
+    meta &&
+    ctx.tickCount % MOUNT_OWNERSHIP_REVALIDATE_TICKS === e.id % MOUNT_OWNERSHIP_REVALIDATE_TICKS &&
+    !mountOwned(meta, e.mountKey) &&
+    !trainingSummon(meta, e.mountKey)
+  ) {
+    forceDismount(ctx, e);
     return;
   }
   // (b) Advance an in-flight summon/dismount channel.

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -914,9 +914,11 @@ export interface OtherItemDef extends BaseItemDef {
 
 // A collectible mount item. Owning the item IS owning the mount: while it sits
 // in the player's bags or bank, the catalog mount it names is selectable and
-// ridable (src/sim/mounts.ts mountOwned). Always soulbound, so ownership can
-// never transfer. Every catalog mount has one, the horse included: five are
-// sub-1% boss drops, the horse's reins comes from the stablemaster.
+// ridable (src/sim/mounts.ts mountOwned). Player reins are NOT soulbound, so
+// ownership transfers with the item (trade, mail, market, guild bank); only
+// the developer-only tank stays bound. Every catalog mount has one, the horse
+// included: five are sub-1% boss drops, the horse's reins comes from the
+// stablemaster.
 export interface MountItemDef extends BaseItemDef {
   kind: 'mount';
   mount: MountKey;

--- a/src/sim/vendor_buy_stack.ts
+++ b/src/sim/vendor_buy_stack.ts
@@ -24,9 +24,9 @@
 // Latent asymmetry, named so it stays deliberate: vendorCountForced treats
 // soulbound as force-1 but bulkEligible (items.ts buyItem) does not exclude
 // soulbound, so a soulbound copper-priced stackable would bulk-multiply while
-// the count path forces it to 1. No such item exists today (the only
-// soulbound row with a buyValue is a mount, force-1 on both paths); a future
-// soulbound consumable must pick ONE rule here.
+// the count path forces it to 1. No such item exists today (no soulbound row
+// carries a buyValue: the purchasable reins is unbound and force-1 via its
+// mount kind); a future soulbound consumable must pick ONE rule here.
 //
 // DOM-free and deterministic so tests/vendor_buy_stack.test.ts drives it directly.
 

--- a/src/world_api/mounts.ts
+++ b/src/world_api/mounts.ts
@@ -9,7 +9,8 @@ import type { MountKey } from '../sim/content/mounts';
 // ownership, combat gate) in src/sim/mounts.ts.
 export interface IWorldMounts {
   /** The owned subset of the catalog, in catalog order: any mount whose
-   *  reins item sits in bags or bank (soulbound). A fresh player owns nothing. */
+   *  reins item sits in bags or bank (ownership travels with the item; reins
+   *  are not soulbound). A fresh player owns nothing. */
   ownedMounts(): readonly MountKey[];
   /** Whether the player has purchased the riding skill from Marla (80g).
    *  Required before summoning any mount. */

--- a/tests/admin.test.ts
+++ b/tests/admin.test.ts
@@ -1376,7 +1376,7 @@ describe('legacy guild administration parity', () => {
       purchasedSlots: 30,
       usedSlots: 1,
       dormantSlots: 1,
-      slots: [{ index: 0, itemId: 'reins_grag_bear', count: 1, dormant: true }],
+      slots: [{ index: 0, itemId: 'final_argument_greatblade', count: 1, dormant: true }],
     };
     fakeGameState.adminGuildBankState.mockReturnValueOnce(state);
 

--- a/tests/guild_bank.test.ts
+++ b/tests/guild_bank.test.ts
@@ -911,13 +911,13 @@ describe('guildBankDepositFor / guildBankWithdrawFor (items)', () => {
   // per dimension, on the deposit side AND the tampered-book withdraw side.
   it('refuses soulbound items on deposit (the anonymous-pipe policy), mutating nothing', () => {
     const sim = makeOfficerSim();
-    expect(ITEMS.reins_grag_bear.soulbound).toBe(true); // fixture guard
-    meta(sim).inventory.push({ itemId: 'reins_grag_bear', count: 1 });
+    expect(ITEMS.final_argument_greatblade.soulbound).toBe(true); // fixture guard
+    meta(sim).inventory.push({ itemId: 'final_argument_greatblade', count: 1 });
     const before = fingerprint(sim);
     sim.drainEvents();
     sim.guildBankDepositFor(
       sim.playerId,
-      meta(sim).inventory.findIndex((s) => s.itemId === 'reins_grag_bear'),
+      meta(sim).inventory.findIndex((s) => s.itemId === 'final_argument_greatblade'),
     );
     expect(fingerprint(sim)).toBe(before);
     expect(hasErr(sim.drainEvents(), 'You cannot store soulbound items in the guild bank.')).toBe(
@@ -959,7 +959,7 @@ describe('guildBankDepositFor / guildBankWithdrawFor (items)', () => {
     // one; the copy must stay dormant in the book, never reach another player.
     const sim = makeOfficerSim();
     book(sim).inventory.push(
-      { itemId: 'reins_grag_bear', count: 1 }, // soulbound def
+      { itemId: 'final_argument_greatblade', count: 1 }, // soulbound def
       { itemId: 'wolf_fang', count: 1, instance: { boundTo: 424242 } }, // bound copy
     );
     const before = fingerprint(sim);
@@ -990,7 +990,7 @@ describe('guildBankDepositFor / guildBankWithdrawFor (items)', () => {
     const out = 'That item cannot be withdrawn from the guild bank.';
     const rows: { slot: Record<string, unknown>; err: string }[] = [
       { slot: { itemId: questItemId, count: 1 }, err: out },
-      { slot: { itemId: 'reins_grag_bear', count: 1 }, err: out },
+      { slot: { itemId: 'final_argument_greatblade', count: 1 }, err: out },
       { slot: { itemId: noListId, count: 1 }, err: out },
       { slot: { itemId: 'wolf_fang', count: 1, instance: { boundTo: 424242 } }, err: out },
       { slot: { itemId: 'wolf_fang', count: 1, instance: { bindOnTrade: true } }, err: out },
@@ -1012,7 +1012,7 @@ describe('guildBankDepositFor / guildBankWithdrawFor (items)', () => {
     if (!questItemId) throw new Error('missing quest fixture');
     const refused = [
       { itemId: questItemId, count: 1 },
-      { itemId: 'reins_grag_bear', count: 1 },
+      { itemId: 'final_argument_greatblade', count: 1 },
       { itemId: 'riding_training', count: 1 },
       { itemId: 'wolf_fang', count: 1, instance: { boundTo: 424242 } },
       { itemId: 'wolf_fang', count: 1, instance: { bindOnTrade: true } },
@@ -2524,7 +2524,7 @@ describe('applyGuildBankDeltasTo / revertGuildBankDeltasTo (the forward + invers
 
 describe('purgeDormantGuildBankSlot (the admin escape hatch)', () => {
   const DORMANT = [
-    { itemId: 'reins_grag_bear', count: 1 }, // soulbound def
+    { itemId: 'final_argument_greatblade', count: 1 }, // soulbound def
     { itemId: 'riding_training', count: 1 }, // noMarketList def
     { itemId: 'wolf_fang', count: 1, instance: { boundTo: 424242 } }, // bound copy
     { itemId: 'wolf_fang', count: 1, instance: { bindOnTrade: true } }, // armed copy
@@ -2568,11 +2568,11 @@ describe('purgeDormantGuildBankSlot (the admin escape hatch)', () => {
     // dormant copy than the one they read.
     const sim = makeOfficerSim();
     book(sim).inventory.push(
-      { itemId: 'reins_grag_bear', count: 1 },
+      { itemId: 'final_argument_greatblade', count: 1 },
       { itemId: 'riding_training', count: 1 },
     );
     const before = fingerprint(sim);
-    expect(sim.purgeDormantGuildBankSlot(GUILD_ID, 1, 'reins_grag_bear')).toBeNull();
+    expect(sim.purgeDormantGuildBankSlot(GUILD_ID, 1, 'final_argument_greatblade')).toBeNull();
     expect(sim.purgeDormantGuildBankSlot(GUILD_ID, 0, '')).toBeNull();
     expect(fingerprint(sim)).toBe(before);
     // The matching name still purges.
@@ -2593,17 +2593,17 @@ describe('purgeDormantGuildBankSlot (the admin escape hatch)', () => {
 
   it('refuses a missing book, and every out-of-range or malformed index, mutating nothing', () => {
     const sim = makeOfficerSim();
-    book(sim).inventory.push({ itemId: 'reins_grag_bear', count: 1 });
+    book(sim).inventory.push({ itemId: 'final_argument_greatblade', count: 1 });
     const before = fingerprint(sim);
     for (const bad of [-1, 1, 99, 0.5, Number.NaN, Number.POSITIVE_INFINITY]) {
       expect(
-        sim.purgeDormantGuildBankSlot(GUILD_ID, bad, 'reins_grag_bear'),
+        sim.purgeDormantGuildBankSlot(GUILD_ID, bad, 'final_argument_greatblade'),
         String(bad),
       ).toBeNull();
     }
     expect(fingerprint(sim)).toBe(before);
     // No book for that guild at all: refuse, never mint one.
-    expect(sim.purgeDormantGuildBankSlot(GUILD_ID + 1, 0, 'reins_grag_bear')).toBeNull();
+    expect(sim.purgeDormantGuildBankSlot(GUILD_ID + 1, 0, 'final_argument_greatblade')).toBeNull();
     expect(sim.guildBanks.has(GUILD_ID + 1)).toBe(false);
   });
 
@@ -2611,15 +2611,15 @@ describe('purgeDormantGuildBankSlot (the admin escape hatch)', () => {
     // The whole reason the hatch exists: guildBankHoldings is the disband
     // guard's read, and a dormant slot keeps it non-zero forever.
     const sim = makeOfficerSim({ treasury: 0 });
-    book(sim).inventory.push({ itemId: 'reins_grag_bear', count: 1 });
+    book(sim).inventory.push({ itemId: 'final_argument_greatblade', count: 1 });
     expect(sim.guildBankHoldings(GUILD_ID)).toEqual({ copper: 0, items: 1 });
-    expect(sim.purgeDormantGuildBankSlot(GUILD_ID, 0, 'reins_grag_bear')).not.toBeNull();
+    expect(sim.purgeDormantGuildBankSlot(GUILD_ID, 0, 'final_argument_greatblade')).not.toBeNull();
     expect(sim.guildBankHoldings(GUILD_ID)).toEqual({ copper: 0, items: 0 });
   });
 
   it('draws no rng (the purge and the operator read are pure book work)', () => {
     const sim = makeOfficerSim();
-    book(sim).inventory.push({ itemId: 'reins_grag_bear', count: 1 });
+    book(sim).inventory.push({ itemId: 'final_argument_greatblade', count: 1 });
     let draws = 0;
     sim.rng.setObserver(() => {
       draws++;
@@ -2628,8 +2628,8 @@ describe('purgeDormantGuildBankSlot (the admin escape hatch)', () => {
     expect(draws).toBe(1); // positive control
     draws = 0;
     sim.guildBankInfoForGuild(GUILD_ID);
-    sim.purgeDormantGuildBankSlot(GUILD_ID, 0, 'reins_grag_bear'); // the success arm
-    sim.purgeDormantGuildBankSlot(GUILD_ID, 0, 'reins_grag_bear'); // and a refusal
+    sim.purgeDormantGuildBankSlot(GUILD_ID, 0, 'final_argument_greatblade'); // the success arm
+    sim.purgeDormantGuildBankSlot(GUILD_ID, 0, 'final_argument_greatblade'); // and a refusal
     expect(draws).toBe(0);
     sim.rng.setObserver(null);
   });

--- a/tests/guild_bank_persistence.test.ts
+++ b/tests/guild_bank_persistence.test.ts
@@ -2142,7 +2142,9 @@ describe('adminPurgeGuildBankSlot (the operator escape hatch)', () => {
     const { session } = joinServer(server, 1, 'Officer');
     officerSetup(server, session);
     seatDormant(server);
-    expect(await server.adminPurgeGuildBankSlot(GUILD_ID, 0, 'reins_grag_bear', OPERATOR)).toEqual({
+    expect(
+      await server.adminPurgeGuildBankSlot(GUILD_ID, 0, 'final_argument_greatblade', OPERATOR),
+    ).toEqual({
       ok: false,
       reason: 'not_dormant',
     });

--- a/tests/market_filters.test.ts
+++ b/tests/market_filters.test.ts
@@ -267,6 +267,17 @@ describe('World Market filters', () => {
     );
   });
 
+  // Mount reins are listable now that they are unbound, so their browse home is
+  // newly load-bearing: a listed reins must be findable under the Other chip,
+  // never stranded where only an exact-name search reaches it.
+  it("routes mount reins through the 'other' chip so a listed reins stays browsable", () => {
+    expect(filterIds(['reins_grag_bear'], { itemType: 'other' })).toEqual(['reins_grag_bear']);
+    // And no narrower chip claims it.
+    for (const t of ['weapon', 'armor', 'consumable', 'bag', 'material', 'cosmetic'] as const) {
+      expect(filterIds(['reins_grag_bear'], { itemType: t }), t).toEqual([]);
+    }
+  });
+
   // The exhaustiveness tail in itemMatchesType is a tsc guard, and tsc is erased in
   // the shipped bundle. This drives what SURVIVES that erasure: an item type with no
   // arm must browse as nothing, never as everything. Returning the asserted `never`

--- a/tests/mounts.test.ts
+++ b/tests/mounts.test.ts
@@ -28,13 +28,16 @@ import {
   mountDef,
   normalizeMountKey,
   normalizeSelectedMount,
+  TRAINING_MOUNT_KEY,
 } from '../src/sim/content/mounts';
 import { ITEMS, MOBS, NPCS, QUESTS } from '../src/sim/data';
 import { createMob } from '../src/sim/entity';
-import { useItem } from '../src/sim/items';
+import { guildBankPipeRefusal } from '../src/sim/guild_bank';
+import { sellItem, useItem } from '../src/sim/items';
 import { MARKET_HOUSE_STOCK } from '../src/sim/market';
 import {
   bagOwnedMounts,
+  MOUNT_OWNERSHIP_REVALIDATE_TICKS,
   MOUNT_SUMMON_SECONDS,
   mountItemId,
   mountOwned,
@@ -53,7 +56,10 @@ import {
   RIFT_GREEN_MOUNT_REINS,
 } from '../src/sim/rift/progression';
 import { Sim } from '../src/sim/sim';
+import type { SimContext } from '../src/sim/sim_context';
+import { tradeSetOffer } from '../src/sim/social/trade';
 import { DT, FORM_AURA_KINDS, type MountItemDef, type SimEvent } from '../src/sim/types';
+import { groundHeight } from '../src/sim/world';
 
 function makeWorld() {
   return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
@@ -162,13 +168,24 @@ describe('mount reins items (the collection: owning the item is owning the mount
   const reinsFor = (key: string) =>
     Object.values(ITEMS).filter((d) => d.kind === 'mount' && d.mount === key) as MountItemDef[];
 
-  it('every mount has exactly one soulbound reins item (the horse now included)', () => {
+  it('every mount has exactly one reins item; player reins are unbound, the dev tank stays bound', () => {
     for (const key of MOUNT_KEYS) {
       const items = reinsFor(key);
       expect(items).toHaveLength(1);
       const item = items[0];
       expect(mountItemId(key)).toBe(item.id);
-      expect(item.soulbound).toBe(true); // never traded, mailed, listed, or destroyed
+      if (key === 'terrorspark_groundshaker') {
+        // The developer-only tank stays soulbound: it has no player acquisition
+        // path, and tradability would turn a dev grant into a leak vector.
+        expect(item.soulbound).toBe(true);
+      } else {
+        // Player reins are NOT soulbound: they trade, mail, list, and store in
+        // the guild bank like any other item (the transfer describe below).
+        expect(item.soulbound).toBeFalsy();
+        // sellValue is 0, so the vendor path stays closed instead of paying
+        // nothing for an accidental sale that buyback rotation could eat.
+        expect(item.noVendorSell).toBe(true);
+      }
       expect(item.noDiscard).toBe(true);
       expect(item.sellValue).toBe(0);
       // The item's name color matches the card's rarity tier.
@@ -415,6 +432,287 @@ describe('mount reins items (the collection: owning the item is owning the mount
     expect(sim.countItem('reins_stormfeather_griffin', pid)).toBe(1);
     expect(mountOwned(sim.players.get(pid)!, 'stormfeather_griffin')).toBe(true);
     expect(e.mountKey).toBe('stormfeather_griffin');
+  });
+});
+
+// Reins are ordinary transferable items now (not soulbound): every anonymous or
+// direct exchange pipe accepts them, while noDiscard and noVendorSell keep the
+// two accidental-loss paths closed. One decisive test per pipe, through the
+// real gate each pipe applies.
+describe('mount reins transfer (not soulbound: the collection trades hands)', () => {
+  it('a reins item is accepted into a trade offer, not filtered as soulbound', () => {
+    // Mirrors the heroic_mark filter test (tests/heroic_soulbound.test.ts),
+    // inverted: the reins must SURVIVE the offer filter.
+    const bags = new Map<number, Map<string, number>>([[1, new Map([['reins_grag_bear', 1]])]]);
+    const session: any = {
+      a: 1,
+      b: 2,
+      offerA: null,
+      offerB: null,
+      acceptedA: true,
+      acceptedB: true,
+    };
+    const ctx = {
+      resolve: (pid?: number) => (pid === 1 ? { meta: { entityId: 1, copper: 0 }, e: {} } : null),
+      trades: new Map<number, any>([[1, session]]),
+      countItem: (itemId: string, pid?: number) => bags.get(pid ?? 1)?.get(itemId) ?? 0,
+    } as unknown as SimContext;
+
+    tradeSetOffer(ctx, [{ itemId: 'reins_grag_bear', count: 1 }], 0, 1);
+
+    expect(session.offerA.items.map((s: any) => s.itemId)).toContain('reins_grag_bear');
+  });
+
+  it('a reins item can be mailed to another character', () => {
+    const sim = makeWorld();
+    const sender = sim.addPlayer('warrior', 'Alice');
+    const recipient = sim.addPlayer('mage', 'Bob');
+    const senderMeta = sim.players.get(sender)!;
+    const recipientMeta = sim.players.get(recipient)!;
+    const box = sim.entities.get(sim.postOffice.mailboxIds[0])!;
+    const senderEntity = sim.entities.get(sender)!;
+    senderMeta.copper = 1_000;
+    sim.addItem('reins_grag_bear', 1, sender);
+    senderEntity.pos = { ...box.pos };
+    senderEntity.prevPos = { ...box.pos };
+    sim.rebucket(senderEntity);
+    sim.drainEvents();
+
+    sim.mailSendResolved(
+      { key: String(recipientMeta.characterId ?? recipient), name: recipientMeta.name },
+      'One careful owner',
+      '',
+      0,
+      [{ itemId: 'reins_grag_bear', count: 1 }],
+      sender,
+    );
+
+    const events = sim.drainEvents();
+    expect(
+      events.some((e) => e.type === 'mailResult' && (e as any).code === 'noMailSoulbound'),
+    ).toBe(false);
+    // Escrowed out of the sender's bags: the parcel really carries the mount.
+    expect(sim.countItem('reins_grag_bear', sender)).toBe(0);
+  });
+
+  it('a reins item can be listed on the World Market', () => {
+    const sim = makeWorld();
+    const seller = sim.addPlayer('warrior', 'Seller');
+    const merchant = [...sim.entities.values()].find((e) => e.templateId === 'the_merchant')!;
+    const e = sim.entities.get(seller)!;
+    e.pos.x = merchant.pos.x;
+    e.pos.z = merchant.pos.z;
+    e.prevPos = { ...e.pos };
+    sim.addItem('reins_grag_bear', 1, seller);
+    sim.drainEvents();
+
+    sim.marketList('reins_grag_bear', 1, 100, seller);
+
+    expect(errorTexts(sim.drainEvents())).toEqual([]);
+    expect(sim.marketListings.some((l) => l.itemId === 'reins_grag_bear' && !l.house)).toBe(true);
+    // Escrowed out of the bags: the listing really carries the mount.
+    expect(sim.countItem('reins_grag_bear', seller)).toBe(0);
+  });
+
+  // Drive the ownership re-validation through its id-staggered cadence: call
+  // the transition for up to one full window, advancing the tick counter so
+  // the stagger is guaranteed to land exactly once.
+  function revalidateWindow(sim: Sim, pid: number, windows = 1): void {
+    const e = sim.entities.get(pid)!;
+    for (let i = 0; i < windows * MOUNT_OWNERSHIP_REVALIDATE_TICKS; i++) {
+      updateMountTransition(sim.ctx, e, false);
+      sim.tickCount++;
+    }
+  }
+
+  it('listing the ridden reins away dismounts within the re-validation window', () => {
+    // The ride follows the item: once the reins leave the player's possession
+    // (here the market escrow, but any pipe), the mounted state must not
+    // outlive ownership, or one reins could keep a chain of players mounted.
+    const sim = makeWorld();
+    const pid = join(sim);
+    sim.addItem('reins_grag_bear', 1, pid);
+    const merchant = [...sim.entities.values()].find((e) => e.templateId === 'the_merchant')!;
+    const e = sim.entities.get(pid)!;
+    e.pos.x = merchant.pos.x;
+    e.pos.z = merchant.pos.z;
+    e.prevPos = { ...e.pos };
+    ride(sim, pid, 'grag_bear');
+    expect(e.mountKey).toBe('grag_bear');
+
+    sim.marketList('reins_grag_bear', 1, 100, pid);
+    expect(sim.countItem('reins_grag_bear', pid)).toBe(0);
+
+    revalidateWindow(sim, pid);
+    expect(e.mountKey).toBe('');
+  });
+
+  it('mailing the ridden reins away dismounts within the re-validation window', () => {
+    // Same rule through the mail escrow: the parcel carries the mount away at
+    // send time, so the rider must come down.
+    const sim = makeWorld();
+    const pid = join(sim);
+    const other = sim.addPlayer('mage', 'Bob');
+    const meta = sim.players.get(pid)!;
+    const otherMeta = sim.players.get(other)!;
+    meta.copper = 1_000;
+    sim.addItem('reins_grag_bear', 1, pid);
+    const box = sim.entities.get(sim.postOffice.mailboxIds[0])!;
+    const e = sim.entities.get(pid)!;
+    e.pos = { ...box.pos };
+    e.prevPos = { ...box.pos };
+    sim.rebucket(e);
+    ride(sim, pid, 'grag_bear');
+    expect(e.mountKey).toBe('grag_bear');
+
+    sim.mailSendResolved(
+      { key: String(otherMeta.characterId ?? other), name: otherMeta.name },
+      'One careful owner',
+      '',
+      0,
+      [{ itemId: 'reins_grag_bear', count: 1 }],
+      pid,
+    );
+    expect(sim.countItem('reins_grag_bear', pid)).toBe(0);
+
+    revalidateWindow(sim, pid);
+    expect(e.mountKey).toBe('');
+  });
+
+  it('trading the ridden reins away dismounts once the trade completes', () => {
+    // The full trade pipe through the real tick loop: items move only at
+    // completion, so the rider stays up until then and comes down within one
+    // re-validation window after.
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('mage', 'Bet');
+    const eA = sim.entities.get(a)!;
+    const eB = sim.entities.get(b)!;
+    eA.pos.x = 0;
+    eA.pos.z = -40;
+    eA.pos.y = groundHeight(eA.pos.x, eA.pos.z, sim.cfg.seed);
+    eA.prevPos = { ...eA.pos };
+    eB.pos.x = 3;
+    eB.pos.z = -40;
+    eB.pos.y = groundHeight(eB.pos.x, eB.pos.z, sim.cfg.seed);
+    eB.prevPos = { ...eB.pos };
+    sim.players.get(a)!.ridingTrained = true;
+    sim.addItem('reins_grag_bear', 1, a);
+    sim.tick();
+    ride(sim, a, 'grag_bear');
+    expect(eA.mountKey).toBe('grag_bear');
+
+    sim.tradeRequest(b, a);
+    sim.tradeAccept(b);
+    sim.tradeSetOffer([{ itemId: 'reins_grag_bear', count: 1 }], 0, a);
+    sim.tradeConfirm(a);
+    sim.tradeConfirm(b);
+    for (let i = 0; i <= MOUNT_OWNERSHIP_REVALIDATE_TICKS + 1 && eA.mountKey; i++) sim.tick();
+
+    expect(sim.countItem('reins_grag_bear', b)).toBe(1);
+    expect(mountOwned(sim.players.get(b)!, 'grag_bear')).toBe(true);
+    expect(eA.mountKey).toBe('');
+  });
+
+  it('a banked reins keeps the ride: ownership spans bags plus bank', () => {
+    // Non-vacuity control for the dismounts above: losing the item dismounts,
+    // merely re-homing it to the bank does not, even across two full windows.
+    const sim = makeWorld();
+    const pid = join(sim);
+    sim.addItem('reins_grag_bear', 1, pid);
+    const e = sim.entities.get(pid)!;
+    ride(sim, pid, 'grag_bear');
+    const meta = sim.players.get(pid)!;
+    const slotIndex = meta.inventory.findIndex((s) => s.itemId === 'reins_grag_bear');
+    meta.bank.inventory.push(meta.inventory.splice(slotIndex, 1)[0]);
+
+    revalidateWindow(sim, pid, 2);
+    expect(e.mountKey).toBe('grag_bear');
+  });
+
+  it('never steals the lent training steed: the one sanctioned unowned ride', () => {
+    // The exemption dimension: a lesson rider owns no reins at all, and the
+    // re-validation must leave the lent steed alone or the level-20 tutorial
+    // breaks on its first window.
+    const sim = makeWorld();
+    const pid = join(sim, 20);
+    const meta = sim.players.get(pid)!;
+    meta.ridingTrained = false;
+    meta.mountTraining = {
+      sessionId: 'test_session',
+      ownerId: pid,
+      anchor: { x: 0, z: 0 },
+      state: 'IN_PROGRESS',
+      phase: 'mount',
+    };
+    const e = sim.entities.get(pid)!;
+    expect(toggleMount(sim.ctx, pid)).toBe(true);
+    finishTransition(sim, pid);
+    expect(e.mountKey).toBe(TRAINING_MOUNT_KEY);
+    expect(mountOwned(meta, TRAINING_MOUNT_KEY)).toBe(false); // truly unowned
+
+    revalidateWindow(sim, pid, 2);
+    expect(e.mountKey).toBe(TRAINING_MOUNT_KEY);
+  });
+
+  it('the re-validation draws no rng, on both the pass and the dismount arm', () => {
+    const sim = makeWorld();
+    const pid = join(sim);
+    sim.addItem('reins_grag_bear', 1, pid);
+    const e = sim.entities.get(pid)!;
+    ride(sim, pid, 'grag_bear');
+    const meta = sim.players.get(pid)!;
+    sim.tickCount = e.id; // align the stagger so the scan runs on this call
+    let draws = 0;
+    sim.rng.setObserver(() => {
+      draws++;
+    });
+    sim.rng.next();
+    expect(draws).toBe(1); // positive control
+    draws = 0;
+    updateMountTransition(sim.ctx, e, false); // owner: the pass arm
+    expect(e.mountKey).toBe('grag_bear');
+    meta.inventory.splice(
+      meta.inventory.findIndex((s) => s.itemId === 'reins_grag_bear'),
+      1,
+    );
+    updateMountTransition(sim.ctx, e, false); // the dismount arm
+    expect(e.mountKey).toBe('');
+    expect(draws).toBe(0);
+    sim.rng.setObserver(null);
+  });
+
+  it('the guild bank pipe accepts reins in both directions', () => {
+    for (const direction of [undefined, 'withdraw'] as const) {
+      expect(
+        guildBankPipeRefusal({ itemId: 'reins_grag_bear', count: 1 }, direction),
+        String(direction),
+      ).toBeNull();
+    }
+  });
+
+  it('the developer tank stays refused by the exchange pipes (still soulbound)', () => {
+    expect(guildBankPipeRefusal({ itemId: 'reins_terrorspark_groundshaker', count: 1 })).not.toBe(
+      null,
+    );
+  });
+
+  it('vendor sell still refuses reins (noVendorSell: sellValue 0 protects the collection)', () => {
+    const sim = makeWorld();
+    const pid = sim.addPlayer('warrior', 'Seller');
+    const marla = [...sim.entities.values()].find(
+      (e) => e.kind === 'npc' && e.templateId === 'stablemaster_marla',
+    )!;
+    const player = sim.entities.get(pid)!;
+    player.pos.x = marla.pos.x;
+    player.pos.z = marla.pos.z;
+    sim.addItem('reins_valorsteed', 1, pid);
+    sim.drainEvents();
+
+    sellItem(sim.ctx, 'reins_valorsteed', 1, pid);
+
+    expect(sim.countItem('reins_valorsteed', pid)).toBe(1);
+    expect(errorTexts(sim.drainEvents())).toContain('That item is not for sale.');
   });
 });
 

--- a/tests/server/admin.test.ts
+++ b/tests/server/admin.test.ts
@@ -3386,7 +3386,7 @@ describe('guild bank operator read', () => {
     dormantSlots: 1,
     slots: [
       { index: 0, itemId: 'wolf_fang', count: 3, dormant: false },
-      { index: 1, itemId: 'reins_grag_bear', count: 1, dormant: true },
+      { index: 1, itemId: 'final_argument_greatblade', count: 1, dormant: true },
     ],
   };
 

--- a/tests/server/admin_guild_bank_view.test.ts
+++ b/tests/server/admin_guild_bank_view.test.ts
@@ -19,7 +19,7 @@ const GUILD_ID = 4242;
 
 // One slot per refusal dimension the anonymous-pipe policy has, matching the
 // hatch's own coverage in tests/guild_bank.test.ts.
-const SOULBOUND = 'reins_grag_bear';
+const SOULBOUND = 'final_argument_greatblade';
 const NO_MARKET = 'riding_training';
 const PLAIN = 'wolf_fang';
 


### PR DESCRIPTION
## Summary

Mount reins are no longer soulbound. The seven player-obtainable reins (valorsteed, grag-bear, stalk-glider snail, shadow-jump toad, stormfeather griffin, thunderstrut gobbler, aether hover-cycle) drop `soulbound: true`, so they now pass every exchange pipe: player trade, mail, World Market listings (browsable under the Other chip), and guild bank deposits. Ownership stays presence-based: whoever holds the reins in bags or bank owns the mount.

Two deliberate guardrails ship with the unbinding:

- **`noVendorSell` on every unbound reins.** They keep `sellValue: 0`, so without it an accidental vendor sale would pay nothing and buyback rotation could destroy the mount. `noDiscard` is retained for the same reason. Merchants refuse reins exactly as before.
- **Ownership re-validation while mounted** (`updateMountTransition`, new a2 clause). Reins can now leave a rider's possession mid-ride, so the sim re-checks ownership on a deterministic id-staggered cadence (`MOUNT_OWNERSHIP_REVALIDATE_TICKS` = 4 ticks, worst case 200ms) and force-dismounts a rider who gave their reins away. Otherwise one reins could keep a chain of players mounted. The lent training steed (the one sanctioned unowned ride) is exempt, and the clause draws zero rng (parity gate green, no golden re-mint).

The developer-only Terrorspark Groundshaker **stays soulbound**: it has no player acquisition path, and tradability would turn a dev grant into an economy leak. Pinned by test on both the def and the guild bank pipe.

### Economy consequences for owner sign-off

Unbinding is a real supply-side change, called out here rather than buried:

- Rift-farmed mounts become marketable: duplicate reins from repeatable rift clears (0.5% B / 0.1% A / 0.3% S) were previously inert and can now be listed. The S-tier epics (hover-cycle, gobbler) are the largest change: still rift-exclusive to MINT, no longer rift-exclusive to OWN.
- `reins_valorsteed` becomes an elastic market good with a 10g vendor floor (buy, give away, buy again). No copper mint exists since reins never sell back.
- If either is unwanted, the per-item revert is one `soulbound: true` line.

## Type of change

- [x] Feature: new functionality

## How was this tested?

- Commands: TDD (pins flipped red first, then content). `npx vitest run tests/mounts.test.ts` (71 tests: catalog pin, one decisive test per exchange pipe through its real gate, mounted-rider dismount through market escrow, mail escrow and full trade completion, banked-reins and training-steed non-vacuity controls, rng-observer pin, vendor sell and discard still refused). Full suite green (2139 files / 28893 tests) including `tests/parity`, `tests/architecture.test.ts`, `tests/server/tick_perf_capture.test.ts`, and the S3 i18n guard. `tsc --noEmit` clean; all five builds green; i18n freshness, malware scan, changed-files biome, and SFX conformance green via `npm run gate` (its one vitest failure was the known `new_endpoint` porcelain-check contention flake, green standalone and in a clean full-suite run).
- Manual steps: none needed; no UI file changed (tooltips, bag staging gates, and market browse are all flag-driven and follow the content change).

## Screenshots / recordings

N/A: no visual change.

---

## Checklist

### Quality

- [x] **The full gate passes.** Steps verified as above; decisive tests added for every changed behavior.

### Cross-platform

- [x] No `IWorld` member changed (one doc comment updated). The dismount reaches clients through the existing `mnt` identity mirror; item defs are shared static content, so all three hosts agree by construction.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings. The refusal lines the new paths surface are pre-registered sim strings (S3 guard green).

### Hygiene

- [x] No secrets, no `.env`, no generated files hand-edited.

Review notes: the soulbound test fixtures that previously used `reins_grag_bear` (guild bank suites, admin operator view) now use `final_argument_greatblade`, a clean soulbound-only def. Two optional follow-ups deliberately not taken here: a player-facing toast for the ownership dismount (a two-file sim_i18n change), and a guide copy touch-up naming why merchants refuse reins (would trip the M16 five-locale rule).