### PR TITLE
fix(desktop): allow Discord CDN avatars under the Electron CSP

### DIFF
--- a/electron/shell_guards.cjs
+++ b/electron/shell_guards.cjs
@@ -102,13 +102,20 @@ const CSP_ORIGINS = {
     'https://api.web3modal.org',
     'https://pulse.walletconnect.org',
   ],
-  // tracking-pixel image beacons.
+  // Image origins the web client loads: tracking-pixel beacons, WalletConnect
+  // modal art, and Discord linked profile pictures (nameplates, HUD widget,
+  // target frame, inspect). Discord PFPs use DISCORD_CDN_BASE in
+  // server/discord_oauth.ts (`cdn.discordapp.com`); without that origin here the
+  // desktop CSP blocks every avatar while the browser build (no CSP) still
+  // paints them, which is exactly the desktop-only regression we hit on
+  // release/v0.34.0.
   img: [
     'https://www.google-analytics.com',
     'https://www.facebook.com',
     'https://secure.walletconnect.com',
     'https://secure.walletconnect.org',
     'https://api.web3modal.org',
+    'https://cdn.discordapp.com',
   ],
   // Cloudflare Turnstile: api.js (script) plus the challenge iframe (frame).
   turnstile: 'https://challenges.cloudflare.com',

--- a/tests/electron_shell_guards.test.ts
+++ b/tests/electron_shell_guards.test.ts
@@ -3,6 +3,7 @@ import {
   ALLOWED_PERMISSIONS,
   appNavigationOrigins,
   buildContentSecurityPolicy,
+  CSP_ORIGINS,
   deriveOrigin,
   extractInlineScriptHashes,
   isDevToolsToggleShortcut,
@@ -197,6 +198,15 @@ describe('buildContentSecurityPolicy', () => {
     expect(directive('img-src')).toContain('https://secure.walletconnect.com');
     expect(directive('font-src')).toContain('https://fonts.reown.com');
     expect(directive('frame-src')).toContain('https://verify.walletconnect.com');
+  });
+
+  // Desktop is the only host that ships a CSP. Linked Discord avatars load from
+  // cdn.discordapp.com (server/discord_oauth.ts DISCORD_CDN_BASE) as <img> and
+  // nameplate-canvas badges; without this origin the desktop client silently
+  // drops every PFP while the web client still paints them.
+  it('allows Discord CDN avatars in img-src so linked PFPs paint on desktop', () => {
+    expect(directive('img-src')).toContain('https://cdn.discordapp.com');
+    expect(CSP_ORIGINS.img).toContain('https://cdn.discordapp.com');
   });
 });
 


### PR DESCRIPTION
## Summary

Desktop clients were not loading linked Discord profile pictures after recent releases, while the web client still showed them.

Root cause: the Electron shell serves a strict Content-Security-Policy on every `app://` response, and `img-src` never allowlisted `https://cdn.discordapp.com` (the origin used by `DISCORD_CDN_BASE` in `server/discord_oauth.ts`). Every Discord PFP request was blocked. Failed loads are intentionally silent (`attachAvatarFallback` hides broken DOM imgs; the nameplate canvas skips undrawn badges), so players just saw missing avatars.

This change adds `https://cdn.discordapp.com` to `CSP_ORIGINS.img` and pins the allowlist in `tests/electron_shell_guards.test.ts`.

## Type of change

- [x] Bug fix
- [x] Tests

## How was this tested?

- Commands:
  - `npx vitest run tests/electron_shell_guards.test.ts` (36 passed)
  - Pre-push QA floor green (architecture + localization_fixes + typecheck + biome on changed files)
- Manual steps:
  - N/A for this session (CSP unit pin is decisive). After a desktop rebuild/ship, linked Discord PFPs should paint on nameplates, the Discord window, the target frame, and inspect, matching web.

## Screenshots / recordings

N/A (desktop CSP allowlist only; no visual asset change).

---

## Checklist

### Quality

- [x] Decisive test added for the new `img-src` origin. Scoped vitest and pre-push floor are green.

### Cross-platform

- [x] Fixes desktop-only parity with the web client (browser has no CSP and already loaded Discord CDN avatars).

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or production dev-command enablement are included.