### PR TITLE
fix(ui): reprice training Learn rows when the purse moves

### DIFF
--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -5685,14 +5685,7 @@ export class Hud {
     this.targetAurasWindow.relocalize();
     if (this.questlogWindow.isOpen) this.questlogWindow.render();
     if ($('#bags').style.display !== 'none') this.renderBags();
-    if (this.openVendorNpcId !== null && $('#vendor-window').style.display === 'block')
-      this.renderVendor();
-    if (this.openHeroicVendorNpcId !== null && $('#vendor-window').style.display === 'block')
-      this.renderHeroicVendor();
-    if (this.openTrainNpcId !== null && $('#train-window').style.display === 'block')
-      this.renderTrain();
-    if (this.openUnbindNpcId !== null && $('#unbind-window').style.display === 'block')
-      this.renderUnbind();
+    this.repaintOpenServiceWindows();
     // The Town Focus signature is text-independent (the allocation, the budget
     // and the in-town flag), so a language switch alone never moves it and the
     // slow-band probe would leave the panel in the old locale until the player
@@ -14316,18 +14309,14 @@ export class Hud {
     // inventory deltas landed here, but every money-only credit now routes through
     // this hook (#2373), so a hidden window would be rebuilt on each one.
     if (bagsWindowShown($('#bags').style.display)) this.renderBags();
-    if (this.openVendorNpcId !== null) this.renderVendor();
-    // A trainer fee is a money-only self delta online (no inv echo): the
-    // trainResult arm can repaint before the purse mirror moves, so sibling
-    // Learn rows stayed gold-chip ready until a failed click. Re-price the
-    // open ladder (and the unbind fee list) on every purse move, the same
-    // edge the vendor affordability path already uses (#2373).
-    if (this.openTrainNpcId !== null && $('#train-window').style.display === 'block') {
-      this.renderTrain();
-    }
-    if (this.openUnbindNpcId !== null && $('#unbind-window').style.display === 'block') {
-      this.renderUnbind();
-    }
+    // A trainer fee is a money-only self delta online (no inv echo), and the
+    // heroic shop prices rows off a mark COUNT in the bag: every service
+    // window's affordability flag can go stale on a purse or inventory move,
+    // so re-price the whole open family here, the same edge the vendor path
+    // already used (#2373). Offline this hook barely fires (the bank window's
+    // wiring); the train ladder converges there through the Learn click and
+    // trainResult repaints instead.
+    this.repaintOpenServiceWindows();
     this.renderCharIfOpen();
     // The crafting window rides this hook too (#2375): it is the online
     // host's instant edge for an authoritative delta, and offline it is what
@@ -14349,6 +14338,23 @@ export class Hud {
     )
       return;
     this.renderCrafting();
+  }
+
+  /** Repaint every OPEN service window (copper vendor, heroic quartermaster,
+   *  training ladder, unbind list) behind its own open-plus-shown guard. All
+   *  four price their rows against the purse or a bag count, so the language
+   *  switch and the authoritative inventory hook repaint the family through
+   *  this one method; the per-site copies of the guard pack earned the
+   *  extraction (rule of three). */
+  private repaintOpenServiceWindows(): void {
+    if (this.openVendorNpcId !== null && $('#vendor-window').style.display === 'block')
+      this.renderVendor();
+    if (this.openHeroicVendorNpcId !== null && $('#vendor-window').style.display === 'block')
+      this.renderHeroicVendor();
+    if (this.openTrainNpcId !== null && $('#train-window').style.display === 'block')
+      this.renderTrain();
+    if (this.openUnbindNpcId !== null && $('#unbind-window').style.display === 'block')
+      this.renderUnbind();
   }
 
   onCosmeticsChanged(): void {

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -14317,6 +14317,17 @@ export class Hud {
     // this hook (#2373), so a hidden window would be rebuilt on each one.
     if (bagsWindowShown($('#bags').style.display)) this.renderBags();
     if (this.openVendorNpcId !== null) this.renderVendor();
+    // A trainer fee is a money-only self delta online (no inv echo): the
+    // trainResult arm can repaint before the purse mirror moves, so sibling
+    // Learn rows stayed gold-chip ready until a failed click. Re-price the
+    // open ladder (and the unbind fee list) on every purse move, the same
+    // edge the vendor affordability path already uses (#2373).
+    if (this.openTrainNpcId !== null && $('#train-window').style.display === 'block') {
+      this.renderTrain();
+    }
+    if (this.openUnbindNpcId !== null && $('#unbind-window').style.display === 'block') {
+      this.renderUnbind();
+    }
     this.renderCharIfOpen();
     // The crafting window rides this hook too (#2375): it is the online
     // host's instant edge for an authoritative delta, and offline it is what

--- a/src/ui/hud/vendor/CLAUDE.md
+++ b/src/ui/hud/vendor/CLAUDE.md
@@ -17,6 +17,12 @@ thin window painter, exported only through `index.ts`.
   (readable under the disabled opacity); locked rows keep the muted plain
   price; known rows are price-free. Pinned by
   `tests/train_window_painter.test.ts` plus the train/unbind hud suites.
+- Train affordability must stay live against the purse: an open train (and
+  unbind) window re-prices on every inventory/purse delta via
+  `Hud.onInventoryChanged` (the vendor edge, #2373), and a pending Learn
+  reserves its fee in `availableTrainCopper` so sibling rows disable before
+  the authoritative copper mirror lands. Pinned by `tests/train_view.test.ts`
+  and `tests/train_window_hud.test.ts`.
 - Recipe knownness resolves through the shared `train_view.ts` viewer
   predicates (`isRecipeKnownForViewer`); never a second knownness rule.
 

--- a/src/ui/hud/vendor/CLAUDE.md
+++ b/src/ui/hud/vendor/CLAUDE.md
@@ -17,12 +17,31 @@ thin window painter, exported only through `index.ts`.
   (readable under the disabled opacity); locked rows keep the muted plain
   price; known rows are price-free. Pinned by
   `tests/train_window_painter.test.ts` plus the train/unbind hud suites.
-- Train affordability must stay live against the purse: an open train (and
-  unbind) window re-prices on every inventory/purse delta via
-  `Hud.onInventoryChanged` (the vendor edge, #2373), and a pending Learn
-  reserves its fee in `availableTrainCopper` so sibling rows disable before
-  the authoritative copper mirror lands. Pinned by `tests/train_view.test.ts`
+- Train affordability must stay live against the purse. Online, every
+  inventory/purse delta re-prices the whole open service-window family
+  (heroic vendor, train, and unbind included) through
+  `Hud.repaintOpenServiceWindows` on the `Hud.onInventoryChanged` edge
+  (#2373); offline the ladder converges through the Learn click and
+  trainResult repaints instead. `buildTrainView` also reserves the fee of
+  every pending or confirmed Learn the MIRRORED known set does not answer
+  yet (`availableTrainCopper`), so sibling rows disable on the first click
+  and never double-reserve an already-debited purse (mirrored knownness and
+  the copper debit arrive together in both hosts). The unbind list re-prices
+  on the same hook but keeps no in-flight reserve of its own: the confirm
+  dialog narrows the same race without closing it (a second confirm can
+  still beat the first fee's mirror), an accepted gap while the exposure
+  stays a deliberate two-step click. Pinned by `tests/train_view.test.ts`
   and `tests/train_window_hud.test.ts`.
+- Every service painter carries keyboard focus across its full-subtree
+  rebuild (`focus_restore.ts`): required since repaints became uninitiated
+  (an inventory delta can land mid-keyboard-run), restoring the exact
+  `data-focus-key` control, then outward row neighbors, then the close
+  button. The neighbor walk is deliberate for uninitiated repaints too:
+  staying in the ladder beats dropping to Close (the vendor precedent), and
+  every action button's aria-label announces its name and fee before any
+  activation. Pinned by `tests/train_window_painter.test.ts`,
+  `tests/professions_commissions_ui.test.ts`, and
+  `tests/vendor_window_painter.test.ts`.
 - Recipe knownness resolves through the shared `train_view.ts` viewer
   predicates (`isRecipeKnownForViewer`); never a second knownness rule.
 

--- a/src/ui/hud/vendor/heroic_vendor_window.ts
+++ b/src/ui/hud/vendor/heroic_vendor_window.ts
@@ -8,6 +8,7 @@
 
 import { itemDisplayName } from '../../entity_i18n';
 import { esc } from '../../esc';
+import { focusedWithin, restoreFirstEnabled } from '../../focus_restore';
 import { formatNumber, t } from '../../i18n';
 import type { PainterHostPresentation } from '../../painter_host';
 import { svgIcon } from '../../ui_icons';
@@ -29,8 +30,19 @@ export function renderHeroicVendorWindow(
   // The rebuild replaces the hovered row (its mouseleave never fires) and
   // collapses the scrolled list; drop the tooltip and restore the scroll.
   deps.hideTooltip();
+  // Inventory and purse deltas repaint this window uninitiated (#2931), so
+  // carry keyboard focus across the wipe per the focus-across-a-REBUILD
+  // contract (the vendor_window idiom): the exact tile when it survived
+  // enabled, else outward grid neighbors, else the close button.
+  const focused = focusedWithin(el);
+  const focusKey = focused?.dataset.focusKey ?? null;
+  const focusedSlot = focused?.classList.contains('vendor-item')
+    ? [...el.querySelectorAll<HTMLButtonElement>('button.vendor-item')].indexOf(
+        focused as HTMLButtonElement,
+      )
+    : -1;
   const scrollTop = el.scrollTop;
-  el.innerHTML = `<div class="panel-title"><span>${esc(t('itemUi.vendor.goodsTitle', { name: vendorName }))}</span><button type="button" class="x-btn" data-close aria-label="${esc(t('itemUi.vendor.close'))}">${svgIcon('close')}</button></div>`;
+  el.innerHTML = `<div class="panel-title"><span>${esc(t('itemUi.vendor.goodsTitle', { name: vendorName }))}</span><button type="button" class="x-btn" data-close data-focus-key="close" aria-label="${esc(t('itemUi.vendor.close'))}">${svgIcon('close')}</button></div>`;
 
   const balance = document.createElement('div');
   balance.className = 'vendor-section-title';
@@ -50,6 +62,9 @@ export function renderHeroicVendorWindow(
     row.type = 'button';
     row.className = 'vendor-item';
     row.disabled = !affordable;
+    // Its own focus key so the restore ladder can find the same offer tile
+    // across a rebuild (one tile per item id, so the id is the identity).
+    row.dataset.focusKey = `buy:${itemId}`;
     const itemName = itemDisplayName(item);
     const marksLabel = formatNumber(marks, { maximumFractionDigits: 0 });
     row.setAttribute('aria-label', t('heroicShop.buyAria', { item: itemName, marks: marksLabel }));
@@ -69,4 +84,26 @@ export function renderHeroicVendorWindow(
   el.querySelector('[data-close]')?.addEventListener('click', () => deps.onClose());
   el.style.display = 'block';
   el.scrollTop = scrollTop;
+  // Restore focus LAST (a bare focus() may scroll the tile into view, which
+  // must win over the raw scroll restore for a keyboard player; with no
+  // captured key, mouse users keep their exact scroll). Dataset equality
+  // rather than an attribute selector: the keys embed item ids and this
+  // needs no CSS.escape (the vendor_window precedent).
+  if (focusKey) {
+    const keyed = [...el.querySelectorAll<HTMLButtonElement>('[data-focus-key]')];
+    const exact = keyed.find((b) => b.dataset.focusKey === focusKey);
+    // The same-slot ladder: the tile's own slot first (after a sell-out the
+    // grid shifts and it holds the next offer), then outward neighbors,
+    // before the close fallback.
+    const ladder = [...el.querySelectorAll<HTMLButtonElement>('button.vendor-item')];
+    const slot = focusedSlot >= 0 ? Math.min(focusedSlot, ladder.length - 1) : -1;
+    const neighbors: (HTMLButtonElement | undefined)[] = [];
+    if (slot >= 0) {
+      for (let step = 0; step < ladder.length; step++) {
+        if (ladder[slot + step]) neighbors.push(ladder[slot + step]);
+        if (step > 0 && ladder[slot - step]) neighbors.push(ladder[slot - step]);
+      }
+    }
+    restoreFirstEnabled([exact, ...neighbors, keyed.find((b) => b.dataset.focusKey === 'close')]);
+  }
 }

--- a/src/ui/hud/vendor/train_view.ts
+++ b/src/ui/hud/vendor/train_view.ts
@@ -44,7 +44,10 @@ export interface TrainRow {
   pending?: boolean;
   /** Training fee in copper (professions/training.ts TRAINING_FEE_BY_TIER). */
   feeCopper: number;
-  /** Advisory only; the authoritative train path recharges the balance check. */
+  /** Whether the reserved purse covers the fee (availableTrainCopper). The
+   *  painter turns this into the Learn button's disabled state, so it is a
+   *  client-side estimate with teeth, not advisory chrome; the authoritative
+   *  train path still recharges the balance check server-side. */
   affordable: boolean;
   /** Present only on locked rows: the named tier requirement, as the craft id
    *  and the flat skill threshold of the recipe's tier (tier * step). */
@@ -64,43 +67,50 @@ export interface TrainViewDeps {
   knownRecipes: readonly string[];
   /** The viewer's flat per-craft skills (CraftingIdentityView.craftSkills). */
   craftSkills: Readonly<Record<string, number>>;
-  /** The viewer's copper balance, for the advisory affordability flag. */
+  /** The viewer's copper balance, priced through the fee reserve into each
+   *  row's affordable flag (see TrainRow.affordable). */
   copper: number;
   items: Record<string, ItemDef>;
   /** Recipe ids with a learn currently in flight (the HUD's
    *  TrainLearnTracker, issue #2342): a teachable row in this set renders
-   *  pending (disabled, statePending label). Their fees are also reserved
-   *  against the purse so sibling teachable rows flip unaffordable the
-   *  moment a Learn click leaves, never after a failed second click.
-   *  Absent means none. */
+   *  pending (disabled, statePending label). While the mirrored known set
+   *  does not answer for a flight, its fee is also reserved against the
+   *  purse (see buildTrainView's reserve) so sibling teachable rows flip
+   *  unaffordable the moment a Learn click leaves, never after a failed
+   *  second click. Absent means none. */
   pendingRecipes?: ReadonlySet<string>;
   /** Server-confirmed learns (trainResult ok) the mirrored knownRecipes set
    *  may not carry yet: unioned into the known set so the row flips to Known
    *  the moment the result lands, never a repaint behind the cprof mirror.
-   *  Absent means none. */
+   *  Their fees stay reserved until the mirror carries the grant, because
+   *  the cprof grant and the debited copper ride the same self-frame: an
+   *  unmirrored confirm means an unmirrored debit. Absent means none. */
   confirmedRecipes?: ReadonlySet<string>;
 }
 
 /**
- * Purse available for pricing one train row after in-flight Learn fees are
- * reserved. Pending flights already left the client; the authoritative charge
- * lands on trainResult ok, so sibling rows must not advertise gold they cannot
- * still spend. The row under pricing is excluded from the reserve when it is
- * itself pending, so its gold fee chip stays honest under the disabled pending
- * state (the painter's pending arm pins that look). Clamped at 0 so a stale or
- * over-reserved pending set never goes negative. Pure and host-agnostic so the
- * view tests pin it directly.
+ * Purse available for pricing one train row after unsettled Learn fees are
+ * reserved. `reservedRecipes` holds the ids whose fee the purse number does
+ * not answer for yet; buildTrainView derives it as pending flights plus
+ * confirmed-but-unmirrored grants, minus anything the MIRRORED known set
+ * already carries (mirrored knownness and the copper debit arrive together
+ * in both hosts, so a mirror-known learn is a settled fee). The row under
+ * pricing is excluded from the reserve so its own gold fee chip stays honest
+ * under the disabled pending state (the painter's pending arm pins that
+ * look). Clamped at 0: online the debited copper can mirror while a flight
+ * is still open, and a negative purse would wrongly disable free tier-0
+ * rows. Pure and host-agnostic so the view tests pin it directly.
  */
 export function availableTrainCopper(
   copper: number,
-  pendingRecipes?: ReadonlySet<string>,
-  /** Recipe id of the row being priced; its own pending fee is not re-reserved. */
+  reservedRecipes?: ReadonlySet<string>,
+  /** Recipe id of the row being priced; its own reserved fee is not held against it. */
   excludeRecipeId?: string,
 ): number {
-  if (!pendingRecipes || pendingRecipes.size === 0) return copper;
+  if (!reservedRecipes || reservedRecipes.size === 0) return copper;
   let reserved = 0;
-  for (const id of pendingRecipes) {
-    if (excludeRecipeId !== undefined && id === excludeRecipeId) continue;
+  for (const id of reservedRecipes) {
+    if (id === excludeRecipeId) continue;
     const recipe = recipeById(id);
     if (recipe) reserved += trainingFeeFor(recipe);
   }
@@ -159,21 +169,32 @@ export function buildTrainView(masterNpcId: string, deps: TrainViewDeps): TrainV
   const station = deps.stations.find((entry) => entry.masterNpcId === masterNpcId);
   if (!station) return { stationType: null, rows: [] };
   const known = new Set(deps.knownRecipes);
+  // The fee reserve: flights and confirms whose charge the purse number does
+  // not answer for yet. An id the MIRROR already knows is a settled fee:
+  // offline the debit and the grant land synchronously before the click
+  // repaint, and online the cprof grant and the debited copper ride the same
+  // self-frame, so mirrored knownness is exactly the observable that the fee
+  // left the purse. Filtering the reserve on it kills both failure
+  // directions at once: an already-debited purse is never reserved a second
+  // time, and a sibling's gold chip cannot flash back between trainResult ok
+  // and the copper mirror landing.
+  const reserved = new Set<string>();
+  if (deps.pendingRecipes) {
+    for (const id of deps.pendingRecipes) if (!known.has(id)) reserved.add(id);
+  }
+  if (deps.confirmedRecipes) {
+    for (const id of deps.confirmedRecipes) if (!known.has(id)) reserved.add(id);
+  }
   // Confirmed-but-unmirrored learns read Known immediately: knownness wins
   // over any stale pending flag for the same id (resolve() cleared it anyway).
   if (deps.confirmedRecipes) for (const id of deps.confirmedRecipes) known.add(id);
-  // Reserve in-flight Learn fees before pricing each ladder row: online the
-  // purse mirror can lag the click by a frame or more, and even offline a
-  // second Learn before trainResult must not look gold-chip ready on a purse
-  // the first flight already committed. Each row prices against the purse
-  // after every OTHER pending fee is reserved (see availableTrainCopper).
   const rows: TrainRow[] = [];
   for (const recipe of ALL_RECIPES) {
     if (trainingStationTypeFor(recipe) !== station.type) continue;
     const state = rowState(recipe, known, deps.craftSkills);
     if (state === null) continue;
     const feeCopper = trainingFeeFor(recipe);
-    const spendable = availableTrainCopper(deps.copper, deps.pendingRecipes, recipe.id);
+    const spendable = availableTrainCopper(deps.copper, reserved, recipe.id);
     rows.push({
       recipeId: recipe.id,
       professionId: recipe.professionId,

--- a/src/ui/hud/vendor/train_view.ts
+++ b/src/ui/hud/vendor/train_view.ts
@@ -15,7 +15,7 @@
 // unmet. Locked rows are ALWAYS produced (the visible ladder: the player
 // must see what a master will eventually teach), never dropped.
 
-import { ALL_RECIPES } from '../../../sim/content/recipes';
+import { ALL_RECIPES, recipeById } from '../../../sim/content/recipes';
 import type { StationType } from '../../../sim/professions/stations';
 import {
   teachTierMet,
@@ -69,13 +69,42 @@ export interface TrainViewDeps {
   items: Record<string, ItemDef>;
   /** Recipe ids with a learn currently in flight (the HUD's
    *  TrainLearnTracker, issue #2342): a teachable row in this set renders
-   *  pending (disabled, statePending label). Absent means none. */
+   *  pending (disabled, statePending label). Their fees are also reserved
+   *  against the purse so sibling teachable rows flip unaffordable the
+   *  moment a Learn click leaves, never after a failed second click.
+   *  Absent means none. */
   pendingRecipes?: ReadonlySet<string>;
   /** Server-confirmed learns (trainResult ok) the mirrored knownRecipes set
    *  may not carry yet: unioned into the known set so the row flips to Known
    *  the moment the result lands, never a repaint behind the cprof mirror.
    *  Absent means none. */
   confirmedRecipes?: ReadonlySet<string>;
+}
+
+/**
+ * Purse available for pricing one train row after in-flight Learn fees are
+ * reserved. Pending flights already left the client; the authoritative charge
+ * lands on trainResult ok, so sibling rows must not advertise gold they cannot
+ * still spend. The row under pricing is excluded from the reserve when it is
+ * itself pending, so its gold fee chip stays honest under the disabled pending
+ * state (the painter's pending arm pins that look). Clamped at 0 so a stale or
+ * over-reserved pending set never goes negative. Pure and host-agnostic so the
+ * view tests pin it directly.
+ */
+export function availableTrainCopper(
+  copper: number,
+  pendingRecipes?: ReadonlySet<string>,
+  /** Recipe id of the row being priced; its own pending fee is not re-reserved. */
+  excludeRecipeId?: string,
+): number {
+  if (!pendingRecipes || pendingRecipes.size === 0) return copper;
+  let reserved = 0;
+  for (const id of pendingRecipes) {
+    if (excludeRecipeId !== undefined && id === excludeRecipeId) continue;
+    const recipe = recipeById(id);
+    if (recipe) reserved += trainingFeeFor(recipe);
+  }
+  return Math.max(0, copper - reserved);
 }
 
 /** True when a station master with `masterNpcId` exists (the gossip dialog's
@@ -133,12 +162,18 @@ export function buildTrainView(masterNpcId: string, deps: TrainViewDeps): TrainV
   // Confirmed-but-unmirrored learns read Known immediately: knownness wins
   // over any stale pending flag for the same id (resolve() cleared it anyway).
   if (deps.confirmedRecipes) for (const id of deps.confirmedRecipes) known.add(id);
+  // Reserve in-flight Learn fees before pricing each ladder row: online the
+  // purse mirror can lag the click by a frame or more, and even offline a
+  // second Learn before trainResult must not look gold-chip ready on a purse
+  // the first flight already committed. Each row prices against the purse
+  // after every OTHER pending fee is reserved (see availableTrainCopper).
   const rows: TrainRow[] = [];
   for (const recipe of ALL_RECIPES) {
     if (trainingStationTypeFor(recipe) !== station.type) continue;
     const state = rowState(recipe, known, deps.craftSkills);
     if (state === null) continue;
     const feeCopper = trainingFeeFor(recipe);
+    const spendable = availableTrainCopper(deps.copper, deps.pendingRecipes, recipe.id);
     rows.push({
       recipeId: recipe.id,
       professionId: recipe.professionId,
@@ -148,7 +183,7 @@ export function buildTrainView(masterNpcId: string, deps: TrainViewDeps): TrainV
       state,
       ...(state === 'teachable' && deps.pendingRecipes?.has(recipe.id) ? { pending: true } : {}),
       feeCopper,
-      affordable: deps.copper >= feeCopper,
+      affordable: spendable >= feeCopper,
       ...(state === 'locked'
         ? {
             requirement: {

--- a/src/ui/hud/vendor/train_window.ts
+++ b/src/ui/hud/vendor/train_window.ts
@@ -16,6 +16,7 @@ import { craftNameText } from '../../char_window';
 import { markDialogRoot } from '../../dialog_root';
 import { itemDisplayName } from '../../entity_i18n';
 import { esc } from '../../esc';
+import { focusedWithin, restoreFirstEnabled } from '../../focus_restore';
 import { formatMoney, formatNumber, t } from '../../i18n';
 import { QUALITY_COLOR } from '../../icons';
 import type { PainterHostPresentation } from '../../painter_host';
@@ -56,8 +57,19 @@ export function renderTrainWindow(
   // A standalone trapping window (the mailbox shape), not the vendor's docked
   // bags pairing: announce it as a labeled dialog for the focus contract.
   markDialogRoot(el, { label: t('hudChrome.training.title', { name: masterName }) });
+  // Inventory and purse deltas repaint this window uninitiated (#2931), so
+  // carry keyboard focus across the wipe per the focus-across-a-REBUILD
+  // contract (the vendor_window idiom): the exact control when it survived
+  // enabled, else outward ladder neighbors, else the close button.
+  const focused = focusedWithin(el);
+  const focusKey = focused?.dataset.focusKey ?? null;
+  const focusedSlot = focused?.classList.contains('train-teachable')
+    ? [...el.querySelectorAll<HTMLButtonElement>('button.train-teachable')].indexOf(
+        focused as HTMLButtonElement,
+      )
+    : -1;
   const scrollTop = el.scrollTop;
-  el.innerHTML = `<div class="panel-title"><span>${esc(t('hudChrome.training.title', { name: masterName }))}</span><button type="button" class="x-btn" data-close aria-label="${esc(t('hudChrome.training.close'))}">${svgIcon('close')}</button></div>`;
+  el.innerHTML = `<div class="panel-title"><span>${esc(t('hudChrome.training.title', { name: masterName }))}</span><button type="button" class="x-btn" data-close data-focus-key="close" aria-label="${esc(t('hudChrome.training.close'))}">${svgIcon('close')}</button></div>`;
 
   if (view.rows.length === 0) {
     const empty = document.createElement('div');
@@ -101,6 +113,10 @@ export function renderTrainWindow(
       // and the reason a rapid second click can never re-send the command.
       const pending = row.pending === true;
       button.disabled = pending || !row.affordable;
+      // Its own focus key so the restore ladder can find the same recipe row
+      // across a rebuild (locked rows and known divs are never focusable, so
+      // only teachable rows and the close button carry keys).
+      button.dataset.focusKey = `learn:${row.recipeId}`;
       const fee = feeLabel(row);
       button.setAttribute(
         'aria-label',
@@ -146,4 +162,25 @@ export function renderTrainWindow(
   el.querySelector('[data-close]')?.addEventListener('click', () => deps.onClose());
   el.style.display = 'block';
   el.scrollTop = scrollTop;
+  // Restore focus LAST (a bare focus() may scroll the row into view, which
+  // must win over the raw scroll restore for a keyboard player; with no
+  // captured key, mouse users keep their exact scroll). Matched by dataset
+  // equality rather than an attribute selector: the keys embed recipe ids
+  // and this needs no CSS.escape (the vendor_window precedent).
+  if (focusKey) {
+    const keyed = [...el.querySelectorAll<HTMLButtonElement>('[data-focus-key]')];
+    const exact = keyed.find((b) => b.dataset.focusKey === focusKey);
+    // The same-slot ladder: the row's own slot first (after a removal it
+    // holds the next recipe), then outward neighbors, before the close fallback.
+    const ladder = [...el.querySelectorAll<HTMLButtonElement>('button.train-teachable')];
+    const slot = focusedSlot >= 0 ? Math.min(focusedSlot, ladder.length - 1) : -1;
+    const neighbors: (HTMLButtonElement | undefined)[] = [];
+    if (slot >= 0) {
+      for (let step = 0; step < ladder.length; step++) {
+        if (ladder[slot + step]) neighbors.push(ladder[slot + step]);
+        if (step > 0 && ladder[slot - step]) neighbors.push(ladder[slot - step]);
+      }
+    }
+    restoreFirstEnabled([exact, ...neighbors, keyed.find((b) => b.dataset.focusKey === 'close')]);
+  }
 }

--- a/src/ui/hud/vendor/unbind_window.ts
+++ b/src/ui/hud/vendor/unbind_window.ts
@@ -14,6 +14,7 @@
 import { markDialogRoot } from '../../dialog_root';
 import { itemDisplayName } from '../../entity_i18n';
 import { esc } from '../../esc';
+import { focusedWithin, restoreFirstEnabled } from '../../focus_restore';
 import { formatMoney, formatNumber, t } from '../../i18n';
 import { QUALITY_COLOR } from '../../icons';
 import type { PainterHostPresentation } from '../../painter_host';
@@ -44,8 +45,19 @@ export function renderUnbindWindow(
   // A standalone trapping window (the train/mailbox shape): announce it as a
   // labeled dialog for the focus contract.
   markDialogRoot(el, { label: t('hudChrome.unbind.title', { name: masterName }) });
+  // Inventory and purse deltas repaint this window uninitiated (#2931), so
+  // carry keyboard focus across the wipe per the focus-across-a-REBUILD
+  // contract (the train_window idiom): the exact control when it survived
+  // enabled, else outward row neighbors, else the close button.
+  const focused = focusedWithin(el);
+  const focusKey = focused?.dataset.focusKey ?? null;
+  const focusedSlot = focused?.classList.contains('unbind-row')
+    ? [...el.querySelectorAll<HTMLButtonElement>('button.unbind-row')].indexOf(
+        focused as HTMLButtonElement,
+      )
+    : -1;
   const scrollTop = el.scrollTop;
-  el.innerHTML = `<div class="panel-title"><span>${esc(t('hudChrome.unbind.title', { name: masterName }))}</span><button type="button" class="x-btn" data-close aria-label="${esc(t('hudChrome.unbind.close'))}">${svgIcon('close')}</button></div>`;
+  el.innerHTML = `<div class="panel-title"><span>${esc(t('hudChrome.unbind.title', { name: masterName }))}</span><button type="button" class="x-btn" data-close data-focus-key="close" aria-label="${esc(t('hudChrome.unbind.close'))}">${svgIcon('close')}</button></div>`;
 
   const intro = document.createElement('div');
   intro.className = 'vi-sub unbind-intro';
@@ -66,6 +78,9 @@ export function renderUnbindWindow(
     button.type = 'button';
     button.className = 'vendor-item unbind-row';
     button.disabled = !row.affordable;
+    // Its own focus key so the restore ladder can find the same item row
+    // across a rebuild (one row per bound item id, so the id is the identity).
+    button.dataset.focusKey = `unbind:${row.itemId}`;
     button.setAttribute('aria-label', t('hudChrome.unbind.unbindAria', { name, fee }));
     const countSuffix =
       row.boundCount > 1 ? ` x${formatNumber(row.boundCount, { maximumFractionDigits: 0 })}` : '';
@@ -88,4 +103,26 @@ export function renderUnbindWindow(
   el.querySelector('[data-close]')?.addEventListener('click', () => deps.onClose());
   el.style.display = 'block';
   el.scrollTop = scrollTop;
+  // Restore focus LAST (a bare focus() may scroll the row into view, which
+  // must win over the raw scroll restore for a keyboard player; with no
+  // captured key, mouse users keep their exact scroll). Dataset equality
+  // rather than an attribute selector: the keys embed item ids and this
+  // needs no CSS.escape (the vendor_window precedent).
+  if (focusKey) {
+    const keyed = [...el.querySelectorAll<HTMLButtonElement>('[data-focus-key]')];
+    const exact = keyed.find((b) => b.dataset.focusKey === focusKey);
+    // The same-slot ladder: the row's own slot first (after an unbind the
+    // list shifts and it holds the next item), then outward neighbors,
+    // before the close fallback.
+    const ladder = [...el.querySelectorAll<HTMLButtonElement>('button.unbind-row')];
+    const slot = focusedSlot >= 0 ? Math.min(focusedSlot, ladder.length - 1) : -1;
+    const neighbors: (HTMLButtonElement | undefined)[] = [];
+    if (slot >= 0) {
+      for (let step = 0; step < ladder.length; step++) {
+        if (ladder[slot + step]) neighbors.push(ladder[slot + step]);
+        if (step > 0 && ladder[slot - step]) neighbors.push(ladder[slot - step]);
+      }
+    }
+    restoreFirstEnabled([exact, ...neighbors, keyed.find((b) => b.dataset.focusKey === 'close')]);
+  }
 }

--- a/tests/bags_money_refresh.test.ts
+++ b/tests/bags_money_refresh.test.ts
@@ -57,6 +57,7 @@ import { type ClientSession, GameServer } from '../server/game';
 import type { Entity } from '../src/sim/types';
 import { groundHeight } from '../src/sim/world';
 import { bareClient } from './helpers/bare_client';
+import { methodBody } from './helpers/method_body';
 
 const PROCEEDS = 54321;
 
@@ -294,8 +295,11 @@ describe('bag purse-freshness wiring (source pins)', () => {
     // the cold-load-safe form too (issue #1538): every money-only credit now routes
     // through here, so the raw `!== 'none'` compare would rebuild a window the
     // player has never opened on each one.
-    expect(hud).toMatch(
-      /onInventoryChanged\(\): void \{[^}]*if \(bagsWindowShown\(\$\('#bags'\)\.style\.display\)\) this\.renderBags\(\);/,
+    // Sliced to the method body (the shared two-space-close bound) rather
+    // than a flat [^}]* reach from the opener: brace-bearing sibling arms
+    // inside onInventoryChanged broke that shape once (#2931).
+    expect(methodBody(hud, 'onInventoryChanged(): void {')).toContain(
+      "if (bagsWindowShown($('#bags').style.display)) this.renderBags();",
     );
   });
 

--- a/tests/crafting_reagent_refresh.test.ts
+++ b/tests/crafting_reagent_refresh.test.ts
@@ -332,9 +332,12 @@ describe('crafting window bag-freshness wiring (source pins)', () => {
   });
 
   it('the online authoritative inventory delta converges it on the same frame', () => {
-    expect(hud).toMatch(
-      /onInventoryChanged\(\): void \{[^}]*this\.refreshOpenCraftingIfReagentsChanged\(\);\s*\}/,
-    );
+    // Bounded at the METHOD's own two-space closing brace rather than a flat
+    // [^}]* reach from the opener (#2931 made that break this pin once) or
+    // the next definition (whose gap a future method could squat in): inner
+    // blocks close at deeper indents, so the slice is exactly the hook body.
+    const arm = region('onInventoryChanged(): void {', '\n  }');
+    expect(arm).toContain('this.refreshOpenCraftingIfReagentsChanged();');
   });
 
   it('the offline vendor buy converges it on the click', () => {

--- a/tests/helpers/method_body.ts
+++ b/tests/helpers/method_body.ts
@@ -1,0 +1,19 @@
+// The one shared bound for source pins over a class method's body.
+//
+// Slices `opener` through the method's own two-space closing brace: inner
+// blocks close at deeper indents, so the first `\n  }` after the opener is
+// the method end. Grew out of #2931, where three suites spelled this slice
+// three ways and the flat `[^}]*` shape they replaced broke on the first
+// brace-bearing sibling arm.
+//
+// Stated limit: a two-space-indented `}` inside a template literal would end
+// the slice early. No hud.ts method does that today, and both anchors throw
+// loudly when missing, so a renamed or restructured method fails here with a
+// message instead of slicing an empty, vacuously passing span.
+export function methodBody(source: string, opener: string): string {
+  const start = source.indexOf(opener);
+  if (start === -1) throw new Error(`methodBody: anchor not found: ${opener}`);
+  const end = source.indexOf('\n  }', start);
+  if (end === -1) throw new Error(`methodBody: no two-space close after: ${opener}`);
+  return source.slice(start, end);
+}

--- a/tests/language_fanout_registry.test.ts
+++ b/tests/language_fanout_registry.test.ts
@@ -97,10 +97,11 @@ const FANOUT_ARMS: readonly string[] = [
   'this.targetAurasWindow.relocalize|',
   'this.questlogWindow.render|this.questlogWindow.isOpen',
   "this.renderBags|$('#bags').style.display !== 'none'",
-  "this.renderVendor|this.openVendorNpcId !== null && $('#vendor-window').style.display === 'block'",
-  "this.renderHeroicVendor|this.openHeroicVendorNpcId !== null && $('#vendor-window').style.display === 'block'",
-  "this.renderTrain|this.openTrainNpcId !== null && $('#train-window').style.display === 'block'",
-  "this.renderUnbind|this.openUnbindNpcId !== null && $('#unbind-window').style.display === 'block'",
+  // The four service windows (copper vendor, heroic quartermaster, train,
+  // unbind) repaint through the shared helper; its per-window open-plus-shown
+  // guards are pinned by tests/train_window_hud.test.ts, since this half only
+  // sees refreshLocalizedDynamicUi's OWN statement-position calls.
+  'this.repaintOpenServiceWindows|',
   'this.renderTownFocus|this.townFocusOpen',
   'this.marketWindow.render|this.marketWindow.isOpen',
   'this.bankWindow.render|this.bankWindow.isOpen',

--- a/tests/professions_commissions_ui.test.ts
+++ b/tests/professions_commissions_ui.test.ts
@@ -8,7 +8,7 @@
 
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ALL_RECIPES } from '../src/sim/content/recipes';
 import { ITEMS } from '../src/sim/data';
 import type { InvSlot } from '../src/sim/types';
@@ -196,6 +196,12 @@ describe('buildUnbindView (the service rows mirror the resolver)', () => {
 });
 
 describe('renderUnbindWindow painter', () => {
+  // The focus test attaches to document.body; a mid-test failure must not
+  // leak a focused node into the shared document for later tests.
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
   it('paints an affordable row with the fee and reports the unbind click', () => {
     const el = document.createElement('div');
     const deps = unbindDeps();
@@ -241,5 +247,41 @@ describe('renderUnbindWindow painter', () => {
     );
     (el2.querySelector('[data-close]') as HTMLButtonElement).click();
     expect(deps.onClose).toHaveBeenCalled();
+  });
+
+  it('carries keyboard focus across a repaint (uninitiated rebuilds)', () => {
+    // Inventory and purse deltas repaint an open window uninitiated (#2931):
+    // the focus-across-a-REBUILD contract, train_window idiom. Attached to
+    // document.body because focus() is inert on a detached tree.
+    const el = document.createElement('div');
+    document.body.appendChild(el);
+    const deps = unbindDeps();
+    const twoBound: InvSlot[] = [
+      { itemId: SWORD, count: 1, instance: { bindOnTrade: true, boundTo: 5 } },
+      { itemId: VESTMENTS, count: 1, instance: { bindOnTrade: true, boundTo: 5 } },
+    ];
+    const view = buildUnbindView({ inventory: twoBound, copper: 50000, items: ITEMS });
+    renderUnbindWindow(el, 'Darva', view, deps);
+    el.querySelector<HTMLButtonElement>(`[data-focus-key="unbind:${SWORD}"]`)?.focus();
+    renderUnbindWindow(el, 'Darva', view, deps);
+    expect((document.activeElement as HTMLElement).dataset.focusKey).toBe(`unbind:${SWORD}`);
+    // ONLY the focused row coming back disabled (its fee now short) falls to
+    // the row neighbor, never to <body> and never straight to close: this is
+    // the rung the uninitiated purse repaint actually exercises.
+    const focusedShort = view.rows.map((row) =>
+      row.itemId === SWORD ? { ...row, affordable: false } : row,
+    );
+    renderUnbindWindow(el, 'Darva', { rows: focusedShort }, deps);
+    expect((document.activeElement as HTMLElement).dataset.focusKey).not.toBe(`unbind:${SWORD}`);
+    expect((document.activeElement as HTMLElement).dataset.focusKey).toMatch(/^unbind:/);
+    // Every row coming back disabled falls to the close button.
+    renderUnbindWindow(
+      el,
+      'Darva',
+      { rows: view.rows.map((row) => ({ ...row, affordable: false })) },
+      deps,
+    );
+    expect((document.activeElement as HTMLElement).dataset.focusKey).toBe('close');
+    el.remove();
   });
 });

--- a/tests/train_view.test.ts
+++ b/tests/train_view.test.ts
@@ -10,6 +10,7 @@ import { STATIONS } from '../src/sim/content/professions';
 import { COMBO_RECIPES } from '../src/sim/content/recipes';
 import { ITEMS } from '../src/sim/data';
 import {
+  availableTrainCopper,
   buildTrainView,
   isRecipeKnownForViewer,
   isStationMasterNpc,
@@ -181,6 +182,58 @@ describe('buildTrainView', () => {
     // Grandfathered (known) rows are free.
     const known = poor.rows.find((row) => row.recipeId === 'recipe_eastbrook_arming_sword');
     expect(known?.feeCopper).toBe(0);
+  });
+
+  it('availableTrainCopper reserves every pending fee except the priced row', () => {
+    // Pure helper pin: one ironlink fee (2500) in flight against a 2500 purse
+    // leaves 0 for a sibling and the full 2500 when the pending row prices
+    // itself (so its gold chip stays under the disabled pending opacity).
+    const pending = new Set(['recipe_ironlink_hauberk']);
+    expect(availableTrainCopper(2500, pending, 'recipe_ironlink_legguards')).toBe(0);
+    expect(availableTrainCopper(2500, pending, 'recipe_ironlink_hauberk')).toBe(2500);
+    expect(availableTrainCopper(2500, undefined)).toBe(2500);
+    expect(availableTrainCopper(2500, new Set())).toBe(2500);
+  });
+
+  it('a pending Learn reserves its fee so sibling teachable rows reprice immediately', () => {
+    // Two ironlink-rung armor recipes cost 25 silver each. With exactly one
+    // fee on hand, learning the first must not leave the second gold-chip
+    // ready while the flight is open (the click-then-cannot-afford trap).
+    const pendingId = 'recipe_ironlink_hauberk';
+    const siblingId = 'recipe_ironlink_legguards';
+    const bothTeachable = {
+      craftSkills: { armorcrafting: 25 },
+      copper: 2500,
+      knownRecipes: [] as string[],
+    };
+    // Baseline without a flight: both teachable rows advertise affordable
+    // even though the purse covers only one fee (the pre-fix trap).
+    const open = buildTrainView('forgemistress_darva', deps(bothTeachable));
+    const openPending = open.rows.find((row) => row.recipeId === pendingId);
+    const openSibling = open.rows.find((row) => row.recipeId === siblingId);
+    expect(openPending?.state).toBe('teachable');
+    expect(openPending?.feeCopper).toBe(2500);
+    expect(openPending?.affordable).toBe(true);
+    expect(openSibling?.state).toBe('teachable');
+    expect(openSibling?.feeCopper).toBe(2500);
+    expect(openSibling?.affordable).toBe(true);
+
+    const inFlight = buildTrainView(
+      'forgemistress_darva',
+      deps({
+        ...bothTeachable,
+        pendingRecipes: new Set([pendingId]),
+      }),
+    );
+    const flightPending = inFlight.rows.find((row) => row.recipeId === pendingId);
+    const flightSibling = inFlight.rows.find((row) => row.recipeId === siblingId);
+    // The row in flight keeps its own affordability (gold chip under pending
+    // opacity) and carries the pending flag.
+    expect(flightPending?.pending).toBe(true);
+    expect(flightPending?.affordable).toBe(true);
+    // The sibling no longer advertises a fee the reserved purse cannot cover.
+    expect(flightSibling?.pending).toBeUndefined();
+    expect(flightSibling?.affordable).toBe(false);
   });
 
   it('the apothecary master lists the alchemy ladder with its combo teachable at tier 1', () => {

--- a/tests/train_view.test.ts
+++ b/tests/train_view.test.ts
@@ -193,6 +193,22 @@ describe('buildTrainView', () => {
     expect(availableTrainCopper(2500, pending, 'recipe_ironlink_hauberk')).toBe(2500);
     expect(availableTrainCopper(2500, undefined)).toBe(2500);
     expect(availableTrainCopper(2500, new Set())).toBe(2500);
+    // EVERY fee sums: two 2500 flights against a 10000 purse leave 5000 for a
+    // third row (an accumulator downgraded to plain assignment fails here).
+    expect(
+      availableTrainCopper(
+        10000,
+        new Set(['recipe_ironlink_hauberk', 'recipe_ironlink_legguards']),
+        'recipe_riveted_copper_girdle',
+      ),
+    ).toBe(5000);
+    // The clamp is a LIVE arm, not defensive: online the debited copper can
+    // mirror while a flight is still open, and an unclamped negative purse
+    // would wrongly disable free tier-0 rows (fee 0 needs spendable >= 0).
+    expect(availableTrainCopper(1000, pending)).toBe(0);
+    // An id recipeById cannot resolve reserves nothing: a stale entry must
+    // neither throw mid-ladder nor distort the purse.
+    expect(availableTrainCopper(2500, new Set(['recipe_not_a_real_id']))).toBe(2500);
   });
 
   it('a pending Learn reserves its fee so sibling teachable rows reprice immediately', () => {
@@ -234,6 +250,64 @@ describe('buildTrainView', () => {
     // The sibling no longer advertises a fee the reserved purse cannot cover.
     expect(flightSibling?.pending).toBeUndefined();
     expect(flightSibling?.affordable).toBe(false);
+  });
+
+  it('a mirror-known learn stops reserving: the debited purse is never double-counted', () => {
+    // Offline shape: Sim.trainRecipe debits AND grants synchronously before
+    // the click repaint, so the flight is still open while the mirror already
+    // knows the recipe. The purse covered two fees (5000), one was debited
+    // (2500 left): the sibling must stay affordable, not be priced at the
+    // debited purse minus the same fee a second time.
+    const view = buildTrainView(
+      'forgemistress_darva',
+      deps({
+        craftSkills: { armorcrafting: 25 },
+        copper: 2500,
+        knownRecipes: ['recipe_ironlink_hauberk'],
+        pendingRecipes: new Set(['recipe_ironlink_hauberk']),
+      }),
+    );
+    const learned = view.rows.find((row) => row.recipeId === 'recipe_ironlink_hauberk');
+    const sibling = view.rows.find((row) => row.recipeId === 'recipe_ironlink_legguards');
+    expect(learned?.state).toBe('known');
+    expect(sibling?.state).toBe('teachable');
+    expect(sibling?.affordable).toBe(true);
+  });
+
+  it('a confirmed-but-unmirrored learn keeps its fee reserved until the mirror lands', () => {
+    // Online shape: trainResult ok cleared the flight and joined the confirmed
+    // overlay, but neither the cprof grant nor the copper debit has mirrored
+    // yet. The sibling must NOT flash back to a gold chip on the stale purse.
+    const confirmed = buildTrainView(
+      'forgemistress_darva',
+      deps({
+        craftSkills: { armorcrafting: 25 },
+        copper: 2500,
+        knownRecipes: [],
+        confirmedRecipes: new Set(['recipe_ironlink_hauberk']),
+      }),
+    );
+    expect(confirmed.rows.find((row) => row.recipeId === 'recipe_ironlink_hauberk')?.state).toBe(
+      'known',
+    );
+    expect(
+      confirmed.rows.find((row) => row.recipeId === 'recipe_ironlink_legguards')?.affordable,
+    ).toBe(false);
+    // Once the self-frame lands (grant mirrored, copper debited) the reserve
+    // must drop even if a stale confirmed entry lingers: the mirror-known
+    // filter, not confirmedIds' pruning, is what guarantees no double-count.
+    const settled = buildTrainView(
+      'forgemistress_darva',
+      deps({
+        craftSkills: { armorcrafting: 25 },
+        copper: 2500,
+        knownRecipes: ['recipe_ironlink_hauberk'],
+        confirmedRecipes: new Set(['recipe_ironlink_hauberk']),
+      }),
+    );
+    expect(
+      settled.rows.find((row) => row.recipeId === 'recipe_ironlink_legguards')?.affordable,
+    ).toBe(true);
   });
 
   it('the apothecary master lists the alchemy ladder with its combo teachable at tier 1', () => {

--- a/tests/train_window_hud.test.ts
+++ b/tests/train_window_hud.test.ts
@@ -13,8 +13,21 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
+import { methodBody } from './helpers/method_body';
 
-const hudSource = readFileSync(resolve(__dirname, '../src/ui/hud.ts'), 'utf8');
+// Comment-stripped (the crafting_reagent_refresh idiom, `://` preserved):
+// prose alone must never satisfy a pin, and a commented-out call must never
+// keep one green.
+function stripComments(src: string): string {
+  return src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+}
+
+const hudSource = stripComments(readFileSync(resolve(__dirname, '../src/ui/hud.ts'), 'utf8'));
+
+/** One hud.ts method's body, via the shared two-space-close bound. */
+function hudMethod(opener: string): string {
+  return methodBody(hudSource, opener);
+}
 
 function trainResultArm(): string {
   const start = hudSource.indexOf("case 'trainResult': {");
@@ -152,25 +165,57 @@ describe('hud.ts train window wiring (source pins)', () => {
     );
   });
 
-  it('reprices an open train (and unbind) window on every inventory/purse delta', () => {
-    // Online a trainer fee is a money-only self delta: trainResult can repaint
-    // before ClientWorld mirrors the new copper, so sibling Learn rows stayed
-    // gold-chip ready until a failed click. onInventoryChanged is the same
-    // edge that keeps vendor affordability honest (#2373); pin both service
-    // windows so a future edit cannot drop the train arm alone.
-    const start = hudSource.indexOf('onInventoryChanged(): void {');
-    expect(start, 'onInventoryChanged method present').toBeGreaterThan(-1);
-    const end = hudSource.indexOf('\n  onCosmeticsChanged()', start);
-    expect(end, 'onInventoryChanged precedes onCosmeticsChanged').toBeGreaterThan(start);
-    const arm = hudSource.slice(start, end);
-    expect(arm).toContain('this.openTrainNpcId !== null');
-    expect(arm).toContain("$('#train-window').style.display === 'block'");
-    expect(arm).toContain('this.renderTrain();');
-    expect(arm).toContain('this.openUnbindNpcId !== null');
-    expect(arm).toContain("$('#unbind-window').style.display === 'block'");
-    expect(arm).toContain('this.renderUnbind();');
-    // Vendor stays on the same hook (regression guard for the family).
-    expect(arm).toContain('this.renderVendor();');
+  it('reprices every open service window on an inventory/purse delta', () => {
+    // Online a trainer fee is a money-only self delta and heroic marks are a
+    // bag count: trainResult can repaint before ClientWorld mirrors the new
+    // copper, so stale rows advertised fees the purse no longer covered.
+    // onInventoryChanged is the edge that keeps vendor affordability honest
+    // (#2373); it must dispatch the whole family through the shared helper.
+    const hook = hudMethod('onInventoryChanged(): void {');
+    expect(hook).toContain('this.repaintOpenServiceWindows();');
+    // The helper carries one open-plus-shown guard per service window, so a
+    // future edit cannot drop the train arm alone (the language fan-out
+    // registry pins the relocalize call site; THIS pins the membership).
+    // The vendor/heroic guards are pinned as their FULL condition lines: the
+    // display half is the behavior that changed when the old unguarded
+    // renderVendor arm moved into the helper.
+    const helper = hudMethod('private repaintOpenServiceWindows(): void {');
+    expect(helper).toContain(
+      "this.openVendorNpcId !== null && $('#vendor-window').style.display === 'block'",
+    );
+    expect(helper).toContain('this.renderVendor();');
+    expect(helper).toContain(
+      "this.openHeroicVendorNpcId !== null && $('#vendor-window').style.display === 'block'",
+    );
+    expect(helper).toContain('this.renderHeroicVendor();');
+    expect(helper).toContain('this.openTrainNpcId !== null');
+    expect(helper).toContain("$('#train-window').style.display === 'block'");
+    expect(helper).toContain('this.renderTrain();');
+    expect(helper).toContain('this.openUnbindNpcId !== null');
+    expect(helper).toContain("$('#unbind-window').style.display === 'block'");
+    expect(helper).toContain('this.renderUnbind();');
+  });
+
+  it("the guards' display sentinel matches what every service painter sets", () => {
+    // The helper's `=== 'block'` guards and each painter's
+    // `el.style.display = 'block'` are independent literals with nothing else
+    // tying them: a painter moved to 'flex' (as #crafting-window uses) would
+    // silently stop its window repainting on this edge while both sides'
+    // separate pins stayed green. Painter sources are comment-stripped for
+    // the same reason hud.ts is: prose must never satisfy the pin.
+    const helper = hudMethod('private repaintOpenServiceWindows(): void {');
+    expect(helper.match(/=== 'block'/g)).toHaveLength(4);
+    for (const painter of [
+      'vendor_window.ts',
+      'heroic_vendor_window.ts',
+      'train_window.ts',
+      'unbind_window.ts',
+    ]) {
+      const src = stripComments(
+        readFileSync(resolve(__dirname, `../src/ui/hud/vendor/${painter}`), 'utf8'),
+      );
+      expect(src, painter).toContain("el.style.display = 'block';");
+    }
   });
 });
 

--- a/tests/train_window_hud.test.ts
+++ b/tests/train_window_hud.test.ts
@@ -151,6 +151,27 @@ describe('hud.ts train window wiring (source pins)', () => {
       'confirmedRecipes: this.trainLearns.confirmedIds(identity.knownRecipes)',
     );
   });
+
+  it('reprices an open train (and unbind) window on every inventory/purse delta', () => {
+    // Online a trainer fee is a money-only self delta: trainResult can repaint
+    // before ClientWorld mirrors the new copper, so sibling Learn rows stayed
+    // gold-chip ready until a failed click. onInventoryChanged is the same
+    // edge that keeps vendor affordability honest (#2373); pin both service
+    // windows so a future edit cannot drop the train arm alone.
+    const start = hudSource.indexOf('onInventoryChanged(): void {');
+    expect(start, 'onInventoryChanged method present').toBeGreaterThan(-1);
+    const end = hudSource.indexOf('\n  onCosmeticsChanged()', start);
+    expect(end, 'onInventoryChanged precedes onCosmeticsChanged').toBeGreaterThan(start);
+    const arm = hudSource.slice(start, end);
+    expect(arm).toContain('this.openTrainNpcId !== null');
+    expect(arm).toContain("$('#train-window').style.display === 'block'");
+    expect(arm).toContain('this.renderTrain();');
+    expect(arm).toContain('this.openUnbindNpcId !== null');
+    expect(arm).toContain("$('#unbind-window').style.display === 'block'");
+    expect(arm).toContain('this.renderUnbind();');
+    // Vendor stays on the same hook (regression guard for the family).
+    expect(arm).toContain('this.renderVendor();');
+  });
 });
 
 describe('#train-window container exists in both HTML entries', () => {

--- a/tests/train_window_painter.test.ts
+++ b/tests/train_window_painter.test.ts
@@ -11,7 +11,7 @@
 
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ITEMS } from '../src/sim/data';
 import type { TrainRow, TrainView } from '../src/ui/hud/vendor/train_view';
 import { renderTrainWindow } from '../src/ui/hud/vendor/train_window';
@@ -173,5 +173,107 @@ describe('train/unbind card hover restores (CSS source pins)', () => {
     const rule = css.slice(start, css.indexOf('}', start));
     expect(rule).toContain('background: rgba(0, 0, 0, 0.24)');
     expect(rule).not.toContain('background: transparent');
+  });
+});
+
+describe('renderTrainWindow keyboard focus carry (uninitiated rebuilds)', () => {
+  // Inventory and purse deltas repaint an open window uninitiated (#2931), so
+  // the painter must carry keyboard focus across its full-subtree wipe (the
+  // focus-across-a-REBUILD contract, vendor_window idiom). Roots attach to
+  // document.body: focus() and activeElement are inert on a detached tree.
+  function paintInto(el: HTMLElement, rows: TrainRow[]): void {
+    renderTrainWindow(el, 'Darva', { stationType: 'forge', rows }, deps());
+  }
+  function attachedRoot(): HTMLElement {
+    const el = document.createElement('div');
+    document.body.appendChild(el);
+    return el;
+  }
+  // A mid-test failure must not leak a focused node into the shared document
+  // for later tests in the file.
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('keeps focus on the same recipe row across a repaint', () => {
+    const el = attachedRoot();
+    paintInto(el, [row({ recipeId: 'recipe_a' }), row({ recipeId: 'recipe_b' })]);
+    const first = el.querySelector<HTMLButtonElement>('[data-focus-key="learn:recipe_a"]');
+    first?.focus();
+    expect(document.activeElement).toBe(first);
+    paintInto(el, [row({ recipeId: 'recipe_a' }), row({ recipeId: 'recipe_b' })]);
+    // The node was rebuilt, so identity moved; the key must not.
+    expect((document.activeElement as HTMLElement).dataset.focusKey).toBe('learn:recipe_a');
+    el.remove();
+  });
+
+  it('falls to the ladder neighbor when the focused row came back disabled', () => {
+    const el = attachedRoot();
+    paintInto(el, [row({ recipeId: 'recipe_a' }), row({ recipeId: 'recipe_b' })]);
+    el.querySelector<HTMLButtonElement>('[data-focus-key="learn:recipe_a"]')?.focus();
+    // The disabling repaint IS the new edge: a purse delta reserved away the
+    // focused row's fee.
+    paintInto(el, [
+      row({ recipeId: 'recipe_a', affordable: false }),
+      row({ recipeId: 'recipe_b' }),
+    ]);
+    expect((document.activeElement as HTMLElement).dataset.focusKey).toBe('learn:recipe_b');
+    el.remove();
+  });
+
+  it('walks BACKWARD to the nearer earlier neighbor when the later side is exhausted', () => {
+    // Focus the LAST row, disable it: the forward walk finds nothing past the
+    // ladder end, so the backward rung must catch (deleting the slot - step
+    // arm would drop this to the close button).
+    const el = attachedRoot();
+    const three = [
+      row({ recipeId: 'recipe_a' }),
+      row({ recipeId: 'recipe_b' }),
+      row({ recipeId: 'recipe_c' }),
+    ];
+    paintInto(el, three);
+    el.querySelector<HTMLButtonElement>('[data-focus-key="learn:recipe_c"]')?.focus();
+    paintInto(el, [three[0], three[1], row({ recipeId: 'recipe_c', affordable: false })]);
+    expect((document.activeElement as HTMLElement).dataset.focusKey).toBe('learn:recipe_b');
+    el.remove();
+  });
+
+  it('lands on the nearest surviving row when the ladder came back shorter', () => {
+    // Focus the third row, repaint with two: the exact key is gone and the
+    // remembered slot is out of range, so the slot fallback must land on the
+    // new last row, never skip the ladder for the close button. (The
+    // Math.min clamp itself is outcome-equivalent to the out-of-range walk;
+    // what this decides is that the slot fallback survives a shrink at all.)
+    const el = attachedRoot();
+    paintInto(el, [
+      row({ recipeId: 'recipe_a' }),
+      row({ recipeId: 'recipe_b' }),
+      row({ recipeId: 'recipe_c' }),
+    ]);
+    el.querySelector<HTMLButtonElement>('[data-focus-key="learn:recipe_c"]')?.focus();
+    paintInto(el, [row({ recipeId: 'recipe_a' }), row({ recipeId: 'recipe_b' })]);
+    expect((document.activeElement as HTMLElement).dataset.focusKey).toBe('learn:recipe_b');
+    el.remove();
+  });
+
+  it('falls to the close button when every row came back disabled', () => {
+    const el = attachedRoot();
+    paintInto(el, [row({ recipeId: 'recipe_a' })]);
+    el.querySelector<HTMLButtonElement>('[data-focus-key="learn:recipe_a"]')?.focus();
+    paintInto(el, [row({ recipeId: 'recipe_a', affordable: false })]);
+    expect((document.activeElement as HTMLElement).dataset.focusKey).toBe('close');
+    el.remove();
+  });
+
+  it('never steals focus that was outside the window', () => {
+    const el = attachedRoot();
+    const outside = document.createElement('button');
+    document.body.appendChild(outside);
+    paintInto(el, [row({ recipeId: 'recipe_a' })]);
+    outside.focus();
+    paintInto(el, [row({ recipeId: 'recipe_a' })]);
+    expect(document.activeElement).toBe(outside);
+    outside.remove();
+    el.remove();
   });
 });

--- a/tests/vendor_window_painter.test.ts
+++ b/tests/vendor_window_painter.test.ts
@@ -9,7 +9,7 @@
 // has no rows.
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import type { ItemDef } from '../src/sim/types';
 import type { VendorBuyOptions } from '../src/sim/vendor_buy_stack';
 import { dismissBuyQuantityPrompts } from '../src/ui/hud/vendor/buy_quantity_prompt_window';
@@ -577,6 +577,47 @@ describe('renderHeroicVendorWindow: goods grid wrapping', () => {
     renderHeroicVendorWindow(el, 'Quartermaster', view, heroicDeps());
 
     expect(el.querySelectorAll('.vendor-goods-grid').length).toBe(0);
+  });
+
+  it('carries keyboard focus across a repaint (uninitiated rebuilds, #2931)', () => {
+    // Marks are a bag count, so ANY inventory delta repaints this window
+    // uninitiated through Hud.repaintOpenServiceWindows; the
+    // focus-across-a-REBUILD contract applies (the train/unbind idiom).
+    // Attached to document.body: focus() is inert on a detached tree.
+    const rows: HeroicShopRow[] = [
+      { itemId: 'trinket', item: item('trinket'), marks: 10, affordable: true },
+      { itemId: 'charm', item: item('charm'), marks: 10, affordable: true },
+    ];
+    const el = document.createElement('div');
+    document.body.appendChild(el);
+    renderHeroicVendorWindow(el, 'Quartermaster', { rows, balance: 20 }, heroicDeps());
+    el.querySelector<HTMLButtonElement>('[data-focus-key="buy:trinket"]')?.focus();
+    renderHeroicVendorWindow(el, 'Quartermaster', { rows, balance: 20 }, heroicDeps());
+    expect((document.activeElement as HTMLElement).dataset.focusKey).toBe('buy:trinket');
+    // The focused tile going disabled falls to the grid neighbor, never to
+    // <body>: the rung an uninitiated marks repaint actually exercises.
+    renderHeroicVendorWindow(
+      el,
+      'Quartermaster',
+      { rows: [{ ...rows[0], affordable: false }, rows[1]], balance: 5 },
+      heroicDeps(),
+    );
+    expect((document.activeElement as HTMLElement).dataset.focusKey).toBe('buy:charm');
+    // Every tile disabled falls to the close button.
+    renderHeroicVendorWindow(
+      el,
+      'Quartermaster',
+      { rows: rows.map((r) => ({ ...r, affordable: false })), balance: 0 },
+      heroicDeps(),
+    );
+    expect((document.activeElement as HTMLElement).dataset.focusKey).toBe('close');
+    el.remove();
+  });
+
+  // The focus test attaches to document.body; a mid-test failure must not
+  // leak a focused node into the shared document for later tests.
+  afterEach(() => {
+    document.body.innerHTML = '';
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes the trainer window bug where a Learn row stayed clickable after the purse no longer covered its fee: buy one training, run out of coin for the next, still see a gold Learn chip, click it, get "You cannot afford that training," and only then see the row disable.

### Root cause

Online, a successful `train_recipe` charge is a **money-only** self delta. The HUD repainted the ladder from the `trainResult` event, which can land **before** `ClientWorld` mirrors the new copper. `onInventoryChanged` already re-priced the vendor for that class of purse move (#2373), but the open train and unbind windows (and the heroic quartermaster, whose marks balance is a bag count) were not on that edge. Sibling teachable rows therefore kept advertising affordable until a failed click forced another repaint.

### Fix

1. **`Hud.repaintOpenServiceWindows`**: `onInventoryChanged` and the language fan-out dispatch all four service windows (copper vendor, heroic quartermaster, train, unbind) through one shared helper, each behind its open-plus-shown guard. The fourth per-site copy of the guard pack earned the extraction (rule of three).
2. **Fee reserve in `train_view.ts`**: `buildTrainView` reserves the fee of every pending or confirmed Learn that the MIRRORED known set does not answer yet (`availableTrainCopper`), so sibling rows flip to the disabled unaffordable look on the first click. The mirror-known filter is the load-bearing half: mirrored knownness and the copper debit arrive together in both hosts (synchronously offline, same self-frame online), so an already-debited purse is never reserved a second time, and a sibling cannot flash back to a gold chip between `trainResult ok` and the copper mirror landing.
3. **Focus across uninitiated rebuilds**: any inventory delta now repaints an open train, unbind, or heroic quartermaster window, so all three painters adopt the focus-across-a-rebuild contract (`focus_restore.ts`, the vendor_window idiom): the exact `data-focus-key` control, then outward ladder neighbors, then the close button. A keyboard player no longer drops to `<body>` mid-ladder on a loot delta. The neighbor walk on an uninitiated repaint is a recorded ruling (vendor precedent; every action button's aria-label announces name and fee).

Existing UX language is preserved: unaffordable teachable rows stay visible as disabled cards with the plain error-tint fee (never a hidden ladder rung); the row in flight keeps its own gold chip under the pending disabled state.

### Known limits (deliberate)

- A `trainResult` that is both denied and lost to a disconnect keeps siblings conservatively reserved for the 5s flight TTL (the outcome is unknowable client-side; the clicked row itself sits disabled-pending the same way).
- The unbind window re-prices on the hook but keeps no in-flight reserve of its own; its fee clicks are confirm-gated, so the exposure is far smaller (documented in `src/ui/hud/vendor/CLAUDE.md`).

### Tests

- `tests/train_view.test.ts`: helper pins (per-fee sum, self-exclusion, live zero clamp, unknown id) plus ladder pins for the pending reserve, the mirror-known no-double-count arm, and the confirmed-but-unmirrored reservation arm.
- `tests/train_window_hud.test.ts`: comment-stripped, method-bounded pins that `onInventoryChanged` dispatches the helper and that the helper carries all four guarded arms, plus a display-sentinel coherence check across the four service painters.
- `tests/train_window_painter.test.ts` / `tests/professions_commissions_ui.test.ts` / `tests/vendor_window_painter.test.ts`: focus carry (exact key, neighbor fallback both directions, shorter-ladder fallback, close fallback, no focus steal) for all three newly uninitiated painters.
- Hardened the two pre-existing `[^}]*` pins over `onInventoryChanged` (`crafting_reagent_refresh`, `bags_money_refresh`) onto the new shared `tests/helpers/method_body.ts` bound; the fan-out registry rows for the four service windows collapse into the helper row (`language_fanout_registry`).

## Test plan

- [x] `npm run gate` (full pre-merge gate)
- [x] Targeted: train/unbind/vendor/focus/perf-budget/architecture/fan-out suites green
- [ ] Manual: open a station master Training window online with just enough copper for one ironlink-rung recipe; Learn it; confirm remaining same-fee rows immediately lose the gold Learn chip (disabled + unaffordable price) without a failed click
- [ ] Manual: with a pending Learn still in flight, confirm the clicked row shows Learning and stays non-clickable

Tracked under release #2923.
