### PR TITLE
feat(sim): scale hunter pets from their owner, and fix the sweep that mismeasured hunters

### DIFF
--- a/scripts/lib/sweep_engagement.d.mts
+++ b/scripts/lib/sweep_engagement.d.mts
@@ -1,0 +1,6 @@
+export declare const MELEE_REACH: number;
+export declare const DEAD_ZONE_MARGIN: number;
+export declare function engagementDistance(
+  abilityDefs: Array<{ minRange?: number; range?: number }> | null | undefined,
+  rangedProfile: { maxRange?: number } | null | undefined,
+): number;

--- a/scripts/lib/sweep_engagement.d.mts
+++ b/scripts/lib/sweep_engagement.d.mts
@@ -4,3 +4,17 @@ export declare function engagementDistance(
   abilityDefs: Array<{ minRange?: number; range?: number }> | null | undefined,
   rangedProfile: { maxRange?: number } | null | undefined,
 ): number;
+export declare const DAMAGE_EFFECTS: Set<string>;
+export declare const STATION_DEAD_BAND: number;
+export declare function station(
+  mover: { pos: { x: number; z: number }; castingAbility?: unknown },
+  target: { pos: { x: number; z: number } },
+  reach: number,
+  speed: number,
+  ticksPerSecond: number,
+): void;
+export declare function attributeSweepDamage(
+  sourceId: number,
+  pid: number,
+  source: { kind?: string; ownerId?: number | null } | null | undefined,
+): 'player' | 'pet' | null;

--- a/scripts/lib/sweep_engagement.mjs
+++ b/scripts/lib/sweep_engagement.mjs
@@ -11,8 +11,29 @@
 // own damaging kit declares a minimum range, so every class whose numbers were
 // already correct keeps standing exactly where it stood.
 
+/**
+ * The effect types that count as damage. Shared with the sweep so the standoff rule
+ * and the sweep's own rotation filter can never disagree about what a damaging
+ * ability is (a divergence would silently evaluate the standoff over a different kit
+ * than the one being measured).
+ */
+export const DAMAGE_EFFECTS = new Set([
+  'aoeDamage',
+  'aoeRoot',
+  'directDamage',
+  'dot',
+  'drainTick',
+  'finisherDamage',
+  'groundAoE',
+  'weaponDamage',
+  'weaponStrike',
+]);
+
 /** Where a class with no minimum-range ability stands. */
 export const MELEE_REACH = 2.25;
+
+/** Yards inside which the mover treats itself as already on station. */
+export const STATION_DEAD_BAND = 0.05;
 
 /**
  * Yards of clearance kept beyond the largest minimum range, so a small positional
@@ -51,4 +72,49 @@ export function engagementDistance(abilityDefs, rangedProfile) {
   // A kit whose ceiling sits under its own floor cannot be stood in at all; hold at
   // the floor rather than returning something inside the dead zone.
   return ceiling <= floor ? stand : Math.min(stand, ceiling);
+}
+
+/**
+ * Move a character toward its engagement distance, closing OR backing off.
+ *
+ * The sweep's old mover only ever closed, which is what parked a hunter inside its
+ * own dead zone. The back-off arm is the new half, so the sign is load-bearing: an
+ * inverted sign walks the character to zero range and reproduces the exact defect
+ * this rule exists to fix, with every other assertion still green.
+ *
+ * Mutates `pos` in place, like the sim does.
+ *
+ * @param {{ pos: { x: number, z: number }, castingAbility?: unknown }} mover
+ * @param {{ pos: { x: number, z: number } }} target
+ * @param {number} reach desired yards from the target
+ * @param {number} speed yards per second
+ * @param {number} ticksPerSecond
+ */
+export function station(mover, target, reach, speed, ticksPerSecond) {
+  const dx = target.pos.x - mover.pos.x;
+  const dz = target.pos.z - mover.pos.z;
+  const dist = Math.hypot(dx, dz);
+  // At exactly zero separation there is no direction to move along.
+  if (dist === 0 || mover.castingAbility) return;
+  const gap = dist - reach;
+  // Dead band, so a character on station does not jitter back and forth forever.
+  if (Math.abs(gap) < STATION_DEAD_BAND) return;
+  const step = Math.sign(gap) * Math.min(Math.abs(gap), speed / ticksPerSecond);
+  mover.pos.x += (dx / dist) * step;
+  mover.pos.z += (dz / dist) * step;
+}
+
+/**
+ * Who a sweep damage event belongs to.
+ *
+ * A controlled pet's damage is its owner's on every real meter, but only for the
+ * measured player's OWN pet: crediting any non-player source would fold a third
+ * party's pet or an environmental hit into the reading.
+ *
+ * @returns {'player' | 'pet' | null} null when the event is not the player's
+ */
+export function attributeSweepDamage(sourceId, pid, source) {
+  if (sourceId === pid) return 'player';
+  if (source && source.kind === 'mob' && source.ownerId === pid) return 'pet';
+  return null;
 }

--- a/scripts/lib/sweep_engagement.mjs
+++ b/scripts/lib/sweep_engagement.mjs
@@ -1,0 +1,54 @@
+// Where a damage sweep should stand its test character.
+//
+// The row-build sweep used to walk EVERY class to melee reach. That is harmless
+// for a caster (no damaging spell in the game has a minimum range) but it silently
+// broke the hunter, whose whole ranged kit carries `minRange: 8`: Auto Shot, Fell
+// Shot, Venom Barb, Long Draw, Splitshot and Hushing Shot all refuse to fire inside
+// eight yards, so the sweep was measuring a hunter as a bad melee class and
+// reporting the result as its DPS.
+//
+// The rule below is deliberately narrow: a class stands at melee reach unless its
+// own damaging kit declares a minimum range, so every class whose numbers were
+// already correct keeps standing exactly where it stood.
+
+/** Where a class with no minimum-range ability stands. */
+export const MELEE_REACH = 2.25;
+
+/**
+ * Yards of clearance kept beyond the largest minimum range, so a small positional
+ * jitter cannot drop the character back inside its own dead zone mid-run.
+ */
+export const DEAD_ZONE_MARGIN = 2;
+
+/**
+ * The distance a sweep should hold against its dummy.
+ *
+ * @param {Array<{ minRange?: number, range?: number }>} abilityDefs
+ *   the damaging ability definitions the class knows at the tested level
+ * @param {{ maxRange?: number } | null | undefined} rangedProfile
+ *   the class `ranged` block, when it has one
+ * @returns {number} yards from the dummy
+ */
+export function engagementDistance(abilityDefs, rangedProfile) {
+  let floor = 0;
+  for (const def of abilityDefs ?? []) {
+    const min = def?.minRange ?? 0;
+    if (min > floor) floor = min;
+  }
+  // No dead zone anywhere in the kit: melee reach, exactly as before.
+  if (floor <= 0) return MELEE_REACH;
+
+  const stand = floor + DEAD_ZONE_MARGIN;
+  // Never step past the shortest ceiling the kit can actually reach at: the class
+  // ranged cap and the shortest range among the abilities that declared the floor.
+  let ceiling = rangedProfile?.maxRange ?? Number.POSITIVE_INFINITY;
+  for (const def of abilityDefs ?? []) {
+    if ((def?.minRange ?? 0) > 0 && typeof def?.range === 'number' && def.range > 0) {
+      if (def.range < ceiling) ceiling = def.range;
+    }
+  }
+  if (!Number.isFinite(ceiling)) return stand;
+  // A kit whose ceiling sits under its own floor cannot be stood in at all; hold at
+  // the floor rather than returning something inside the dead zone.
+  return ceiling <= floor ? stand : Math.min(stand, ceiling);
+}

--- a/scripts/row_build_sweep.mjs
+++ b/scripts/row_build_sweep.mjs
@@ -2,6 +2,7 @@ import { mkdirSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { performance } from 'node:perf_hooks';
 import * as esbuild from 'esbuild';
+import { engagementDistance } from './lib/sweep_engagement.mjs';
 
 const root = process.cwd();
 const outDir = path.join(root, 'docs', 'balance');
@@ -15,7 +16,7 @@ const maxProjectedMs = 10 * 60 * 1000;
 const entrySource = `
   export { CHOICE_ROWS } from './src/sim/content/choice_rows.ts';
   export { TALENTS } from './src/sim/content/talents.ts';
-  export { MOBS } from './src/sim/data.ts';
+  export { CLASSES, MOBS } from './src/sim/data.ts';
   export { createMob } from './src/sim/entity.ts';
   export { Sim } from './src/sim/sim.ts';
   export { ALL_CLASSES, MAX_LEVEL } from './src/sim/types.ts';
@@ -38,9 +39,8 @@ const build = await esbuild.build({
 const dataUrl = `data:text/javascript;base64,${Buffer.from(build.outputFiles[0].text).toString(
   'base64',
 )}`;
-const { ALL_CLASSES, CHOICE_ROWS, MOBS, MAX_LEVEL, Sim, TALENTS, createMob } = await import(
-  dataUrl
-);
+const { ALL_CLASSES, CHOICE_ROWS, CLASSES, MOBS, MAX_LEVEL, Sim, TALENTS, createMob } =
+  await import(dataUrl);
 
 const damageEffects = new Set([
   'aoeDamage',
@@ -54,9 +54,15 @@ const damageEffects = new Set([
   'weaponStrike',
 ]);
 const healingEffects = new Set(['aoeHeal', 'heal', 'hot']);
-const healerClasses = new Set(['paladin', 'priest', 'shaman', 'druid', 'hunter']);
-const meleeReach = 2.25;
+// Real healers only. The hunter was in this set, which pinned it to 60% health every
+// tick and re-pointed its heal abilities at itself, so the sweep spent the hunter's
+// global cooldowns casting the 3s pet heal instead of shooting.
+const healerClasses = new Set(['paladin', 'priest', 'shaman', 'druid']);
 const approachSpeed = 7;
+// The beast a level-20 hunter is assumed to be running. Pet damage belongs to the
+// hunter on any real meter (src/ui/meters.ts folds a pet into its owner's row), so a
+// petless hunter reading is not a hunter reading.
+const sweepTameTemplate = 'terrace_howler';
 
 function face(a, b) {
   a.facing = Math.atan2(b.pos.x - a.pos.x, b.pos.z - a.pos.z);
@@ -116,14 +122,41 @@ function pinDummy(dummy, pos) {
   dummy.vz = 0;
 }
 
-function approach(player, target) {
+// Hold the character at its engagement distance. Closes like the old approach() did,
+// and now also backs off, so a class with a minimum range (the hunter's 8 yd dead
+// zone) is not parked inside it with its whole kit refusing to fire.
+function station(player, target, reach) {
   const dx = target.pos.x - player.pos.x;
   const dz = target.pos.z - player.pos.z;
   const dist = Math.hypot(dx, dz);
-  if (dist <= meleeReach || player.castingAbility) return;
-  const step = Math.min(dist - meleeReach, approachSpeed / ticksPerSecond);
+  if (dist === 0 || player.castingAbility) return;
+  const gap = dist - reach;
+  if (Math.abs(gap) < 0.05) return;
+  const step = Math.sign(gap) * Math.min(Math.abs(gap), approachSpeed / ticksPerSecond);
   player.pos.x += (dx / dist) * step;
   player.pos.z += (dz / dist) * step;
+}
+
+// Give a pet class its pet before the run. Hunters tame through the real ability so
+// the pet goes through completeTame/syncPetLevel exactly as it would in play.
+function equipPet(sim, cls, pid, player) {
+  const summon = { warlock: 'summon_felguard', mage: 'summon_water_elemental' }[cls];
+  if (summon) {
+    sim.castAbility(summon, pid);
+    for (let i = 0; i < 4 * ticksPerSecond; i++) sim.tick();
+    return;
+  }
+  if (cls !== 'hunter') return;
+  const beast = createMob(sim.nextId++, MOBS[sweepTameTemplate], MAX_LEVEL, {
+    x: player.pos.x + 3,
+    y: player.pos.y,
+    z: player.pos.z,
+  });
+  beast.hostile = true;
+  sim.addEntity(beast);
+  sim.targetEntity(beast.id, pid);
+  sim.castAbility('tame_beast', pid);
+  for (let i = 0; i < 7 * ticksPerSecond; i++) sim.tick();
 }
 
 function optionIds(build) {
@@ -139,16 +172,27 @@ function runBuild(cls, build, seconds) {
   const rows = Object.fromEntries(build.map((pick) => [pick.level, pick.optionId]));
   sim.applyTalents({ spec: specId, rows }, pid);
   const player = sim.entities.get(pid);
+  equipPet(sim, cls, pid, player);
   const { dummy, pos } = setupDummy(sim, player);
   sim.targetEntity(dummy.id, pid);
   face(player, dummy);
   sim.startAutoAttack(pid);
 
   let damage = 0;
+  let petDamage = 0;
   let healing = 0;
   sim.emit = (event) => {
-    if (event?.type === 'damage' && event.targetId === dummy.id && event.sourceId === pid) {
-      damage += event.amount || 0;
+    if (event?.type === 'damage' && event.targetId === dummy.id) {
+      if (event.sourceId === pid) {
+        damage += event.amount || 0;
+      } else {
+        // A controlled pet's output is its owner's on every real meter, so count it
+        // here too rather than dropping roughly half of a pet class's damage.
+        const source = sim.entities.get(event.sourceId);
+        if (source && source.kind === 'mob' && source.ownerId === pid) {
+          petDamage += event.amount || 0;
+        }
+      }
     }
     if (
       (event?.type === 'heal' || event?.type === 'heal2') &&
@@ -159,12 +203,16 @@ function runBuild(cls, build, seconds) {
     }
   };
 
-  const actionIds = sim
-    .meta(pid)
-    .known.filter(
+  const known = sim.meta(pid).known;
+  const actionIds = known
+    .filter(
       (ability) => hasAnyEffect(ability, damageEffects) || hasAnyEffect(ability, healingEffects),
     )
     .map((ability) => ability.def.id);
+  const reach = engagementDistance(
+    known.filter((ability) => hasAnyEffect(ability, damageEffects)).map((ability) => ability.def),
+    CLASSES[cls]?.ranged,
+  );
   let actionCursor = 0;
   const totalTicks = seconds * ticksPerSecond;
   const isHealer = healerClasses.has(cls);
@@ -176,7 +224,7 @@ function runBuild(cls, build, seconds) {
       player.hp = Math.floor(player.maxHp * 0.6);
     face(player, dummy);
     sim.targetEntity(dummy.id, pid);
-    approach(player, dummy);
+    station(player, dummy, reach);
 
     if (!player.castingAbility && player.gcdRemaining <= 0 && actionIds.length > 0) {
       for (let scan = 0; scan < actionIds.length; scan++) {
@@ -199,9 +247,10 @@ function runBuild(cls, build, seconds) {
 
   return {
     options: optionIds(build),
-    damage,
+    damage: damage + petDamage,
+    petDamage,
     healing,
-    dps: damage / seconds,
+    dps: (damage + petDamage) / seconds,
     hps: healing / seconds,
   };
 }

--- a/scripts/row_build_sweep.mjs
+++ b/scripts/row_build_sweep.mjs
@@ -2,7 +2,12 @@ import { mkdirSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { performance } from 'node:perf_hooks';
 import * as esbuild from 'esbuild';
-import { engagementDistance } from './lib/sweep_engagement.mjs';
+import {
+  attributeSweepDamage,
+  DAMAGE_EFFECTS,
+  engagementDistance,
+  station,
+} from './lib/sweep_engagement.mjs';
 
 const root = process.cwd();
 const outDir = path.join(root, 'docs', 'balance');
@@ -42,17 +47,6 @@ const dataUrl = `data:text/javascript;base64,${Buffer.from(build.outputFiles[0].
 const { ALL_CLASSES, CHOICE_ROWS, CLASSES, MOBS, MAX_LEVEL, Sim, TALENTS, createMob } =
   await import(dataUrl);
 
-const damageEffects = new Set([
-  'aoeDamage',
-  'aoeRoot',
-  'directDamage',
-  'dot',
-  'drainTick',
-  'finisherDamage',
-  'groundAoE',
-  'weaponDamage',
-  'weaponStrike',
-]);
 const healingEffects = new Set(['aoeHeal', 'heal', 'hot']);
 // Real healers only. The hunter was in this set, which pinned it to 60% health every
 // tick and re-pointed its heal abilities at itself, so the sweep spent the hunter's
@@ -122,31 +116,22 @@ function pinDummy(dummy, pos) {
   dummy.vz = 0;
 }
 
-// Hold the character at its engagement distance. Closes like the old approach() did,
-// and now also backs off, so a class with a minimum range (the hunter's 8 yd dead
-// zone) is not parked inside it with its whole kit refusing to fire.
-function station(player, target, reach) {
-  const dx = target.pos.x - player.pos.x;
-  const dz = target.pos.z - player.pos.z;
-  const dist = Math.hypot(dx, dz);
-  if (dist === 0 || player.castingAbility) return;
-  const gap = dist - reach;
-  if (Math.abs(gap) < 0.05) return;
-  const step = Math.sign(gap) * Math.min(Math.abs(gap), approachSpeed / ticksPerSecond);
-  player.pos.x += (dx / dist) * step;
-  player.pos.z += (dz / dist) * step;
-}
-
 // Give a pet class its pet before the run. Hunters tame through the real ability so
 // the pet goes through completeTame/syncPetLevel exactly as it would in play.
 function equipPet(sim, cls, pid, player) {
   const summon = { warlock: 'summon_felguard', mage: 'summon_water_elemental' }[cls];
   if (summon) {
+    // Spec-gated summons (the mage Water Elemental is frost-only, and this sweep
+    // always runs specs[0]) are simply absent for most builds. Only insist on a pet
+    // when the build can actually cast for one.
+    if (!sim.meta(pid).known.some((ability) => ability.def.id === summon)) return;
     sim.castAbility(summon, pid);
     for (let i = 0; i < 4 * ticksPerSecond; i++) sim.tick();
+    requirePet(sim, cls, pid);
     return;
   }
   if (cls !== 'hunter') return;
+  if (!MOBS[sweepTameTemplate]) throw new Error(`unknown tame template ${sweepTameTemplate}`);
   const beast = createMob(sim.nextId++, MOBS[sweepTameTemplate], MAX_LEVEL, {
     x: player.pos.x + 3,
     y: player.pos.y,
@@ -157,6 +142,15 @@ function equipPet(sim, cls, pid, player) {
   sim.targetEntity(beast.id, pid);
   sim.castAbility('tame_beast', pid);
   for (let i = 0; i < 7 * ticksPerSecond; i++) sim.tick();
+  requirePet(sim, cls, pid);
+}
+
+// A silently petless run reads as a low class score, which is exactly the defect
+// this sweep was fixed for. Fail loudly instead if a cast time, cooldown, or id
+// drifts out from under the fixed tick budgets above.
+function requirePet(sim, cls, pid) {
+  for (const e of sim.entities.values()) if (e.kind === 'mob' && e.ownerId === pid) return;
+  throw new Error(`${cls}: expected a pet after setup, got none`);
 }
 
 function optionIds(build) {
@@ -183,16 +177,11 @@ function runBuild(cls, build, seconds) {
   let healing = 0;
   sim.emit = (event) => {
     if (event?.type === 'damage' && event.targetId === dummy.id) {
-      if (event.sourceId === pid) {
-        damage += event.amount || 0;
-      } else {
-        // A controlled pet's output is its owner's on every real meter, so count it
-        // here too rather than dropping roughly half of a pet class's damage.
-        const source = sim.entities.get(event.sourceId);
-        if (source && source.kind === 'mob' && source.ownerId === pid) {
-          petDamage += event.amount || 0;
-        }
-      }
+      // A controlled pet's output is its owner's on every real meter, so count it
+      // here too rather than dropping roughly half of a pet class's damage.
+      const who = attributeSweepDamage(event.sourceId, pid, sim.entities.get(event.sourceId));
+      if (who === 'player') damage += event.amount || 0;
+      else if (who === 'pet') petDamage += event.amount || 0;
     }
     if (
       (event?.type === 'heal' || event?.type === 'heal2') &&
@@ -206,11 +195,11 @@ function runBuild(cls, build, seconds) {
   const known = sim.meta(pid).known;
   const actionIds = known
     .filter(
-      (ability) => hasAnyEffect(ability, damageEffects) || hasAnyEffect(ability, healingEffects),
+      (ability) => hasAnyEffect(ability, DAMAGE_EFFECTS) || hasAnyEffect(ability, healingEffects),
     )
     .map((ability) => ability.def.id);
   const reach = engagementDistance(
-    known.filter((ability) => hasAnyEffect(ability, damageEffects)).map((ability) => ability.def),
+    known.filter((ability) => hasAnyEffect(ability, DAMAGE_EFFECTS)).map((ability) => ability.def),
     CLASSES[cls]?.ranged,
   );
   let actionCursor = 0;
@@ -224,7 +213,7 @@ function runBuild(cls, build, seconds) {
       player.hp = Math.floor(player.maxHp * 0.6);
     face(player, dummy);
     sim.targetEntity(dummy.id, pid);
-    station(player, dummy, reach);
+    station(player, dummy, reach, approachSpeed, ticksPerSecond);
 
     if (!player.castingAbility && player.gcdRemaining <= 0 && actionIds.length > 0) {
       for (let scan = 0; scan < actionIds.length; scan++) {

--- a/scripts/row_build_sweep.mjs
+++ b/scripts/row_build_sweep.mjs
@@ -125,8 +125,11 @@ function equipPet(sim, cls, pid, player) {
     // always runs specs[0]) are simply absent for most builds. Only insist on a pet
     // when the build can actually cast for one.
     if (!sim.meta(pid).known.some((ability) => ability.def.id === summon)) return;
-    sim.castAbility(summon, pid);
-    for (let i = 0; i < 4 * ticksPerSecond; i++) sim.tick();
+    for (let i = 0; i < 20 * ticksPerSecond && !ownedPet(sim, pid); i++) {
+      player.resource = player.maxResource;
+      if (!player.castingAbility) sim.castAbility(summon, pid);
+      sim.tick();
+    }
     requirePet(sim, cls, pid);
     return;
   }
@@ -137,20 +140,35 @@ function equipPet(sim, cls, pid, player) {
     y: player.pos.y,
     z: player.pos.z,
   });
-  beast.hostile = true;
+  beast.hostile = true; // tameError requires a hostile target
   sim.addEntity(beast);
-  sim.targetEntity(beast.id, pid);
-  sim.castAbility('tame_beast', pid);
-  for (let i = 0; i < 7 * ticksPerSecond; i++) sim.tick();
+  // Wildbond is a 6s cast and the target fights back, so damage pushback routinely
+  // stretches it past any fixed tick budget. Drive it to completion instead: keep
+  // the hunter topped up (this is setup, not the measured window) and re-issue the
+  // cast whenever pushback or a cancel leaves it idle.
+  for (let i = 0; i < 60 * ticksPerSecond && !ownedPet(sim, pid); i++) {
+    player.hp = player.maxHp;
+    if (!player.castingAbility) {
+      sim.targetEntity(beast.id, pid);
+      sim.castAbility('tame_beast', pid);
+    }
+    sim.tick();
+  }
+  // Leave no trace of the setup fight in the measured run.
+  player.hp = player.maxHp;
   requirePet(sim, cls, pid);
 }
 
 // A silently petless run reads as a low class score, which is exactly the defect
 // this sweep was fixed for. Fail loudly instead if a cast time, cooldown, or id
 // drifts out from under the fixed tick budgets above.
+function ownedPet(sim, pid) {
+  for (const e of sim.entities.values()) if (e.kind === 'mob' && e.ownerId === pid) return e;
+  return null;
+}
+
 function requirePet(sim, cls, pid) {
-  for (const e of sim.entities.values()) if (e.kind === 'mob' && e.ownerId === pid) return;
-  throw new Error(`${cls}: expected a pet after setup, got none`);
+  if (!ownedPet(sim, pid)) throw new Error(`${cls}: expected a pet after setup, got none`);
 }
 
 function optionIds(build) {

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -1215,6 +1215,7 @@ function blankEntity(id: number): Entity {
     warcryTimer: 0,
     petPath: [],
     petPathCooldown: 0,
+    petOwnerHpBonus: 0,
     castPushbackReduction: 0,
     knockbackResistance: 0,
     pos: { x: 0, y: 0, z: 0 },

--- a/src/sim/entity.ts
+++ b/src/sim/entity.ts
@@ -176,6 +176,7 @@ function baseEntity(id: number, pos: Vec3): Entity {
     petTauntTimer: 0,
     petPath: [],
     petPathCooldown: 0,
+    petOwnerHpBonus: 0,
     spawnPos: { ...pos },
     leashAnchor: null,
     evadeStall: 0,

--- a/src/sim/pet/pet_ai.ts
+++ b/src/sim/pet/pet_ai.ts
@@ -49,6 +49,7 @@ import {
   RUN_SPEED,
   steadyAngleTo,
 } from '../types';
+import { isTameableFamily, petHeelSpeed, petOwnerScaling } from './pet_scaling';
 import { petCanForceTaunt } from './pet_taunt_gate';
 
 const BODY_RADIUS = PLAYER_BODY_RADIUS;
@@ -78,6 +79,10 @@ export function updatePet(ctx: SimContext, pet: Entity): void {
     ctx.despawnPersistentPet(pet);
     return;
   }
+  // Ahead of the channel/stun early-outs so a gear swap reaches the pet on the very
+  // next tick. Idempotent and rng-free, so it costs a few arithmetic ops when the
+  // owner's stats have not moved.
+  applyPetOwnerScaling(ctx, pet);
   if (updateWaterJetChannel(ctx, pet)) return;
   if (ctx.isStunned(pet)) return;
   ctx.syncPetAspect(pet, owner);
@@ -302,8 +307,54 @@ export function petFollow(ctx: SimContext, pet: Entity, owner: Entity): void {
 
   const routed = pet.petPath.length > 1;
   const aim = routed ? pet.petPath[0] : owner.pos;
-  const speed = Math.max(pet.moveSpeed, RUN_SPEED * 1.1) * ctx.moveSpeedMult(pet);
+  // Heel against the owner's ACTUAL speed, not a fixed RUN_SPEED floor: mounts add
+  // 60 to 80 percent, so the old 7.7 yd/s floor lost ground to every mounted owner
+  // until the 60 yd teleport rescued the pet. moveSpeedMult(owner) already folds in
+  // the mount, speed buffs, and slows; the pet's own multiplier still applies on top
+  // so a snared pet is still snared.
+  const ownerSpeed = RUN_SPEED * ctx.moveSpeedMult(owner);
+  const speed = petHeelSpeed(pet.moveSpeed, ownerSpeed) * ctx.moveSpeedMult(pet);
   ctx.moveToward(pet, aim, speed);
+}
+
+/**
+ * Re-derive the owner-inherited half of a hunter pet's stats (pet/pet_scaling.ts).
+ *
+ * Idempotent, so updatePet can call it every tick and pick up a gear swap the moment
+ * it lands: armor and attack power are recomputed from the template base plus the
+ * current share, while the health share is swapped as a DELTA rather than recomputed,
+ * because the raid stat auras (applyNonPlayerStatAura) write maxHp too and rebuilding
+ * the pool from the template would silently eat their contribution.
+ *
+ * Hunter-only on purpose. A warlock demon and the mage Water Elemental are authored
+ * as pets with their own tuned pools; a tamed beast is a wild mob template that was
+ * never balanced to be a companion, which is the gap this closes.
+ */
+export function applyPetOwnerScaling(ctx: SimContext, pet: Entity): void {
+  if (pet.ownerId === null) return;
+  const meta = ctx.players.get(pet.ownerId);
+  if (!meta || meta.cls !== 'hunter') return;
+  const owner = ctx.entities.get(pet.ownerId);
+  if (!owner) return;
+  const template = MOBS[pet.templateId];
+  // Only a pet the hunter could actually have tamed inherits. The owner-class check
+  // alone would also catch a demon parked on a hunter, which cannot happen in play
+  // but is not what this models.
+  if (!template || !isTameableFamily(template.family)) return;
+  const share = petOwnerScaling({
+    maxHp: owner.maxHp,
+    armor: owner.stats.armor,
+    rangedPower: owner.rangedPower,
+  });
+  pet.attackPower = share.attackPower;
+  pet.stats.armor = Math.round(template.armorPerLevel * (pet.level - 1)) + share.armor;
+  const gained = share.hp - pet.petOwnerHpBonus;
+  if (gained === 0) return;
+  pet.petOwnerHpBonus = share.hp;
+  pet.maxHp = Math.max(1, pet.maxHp + gained);
+  // Growing hands the pet the new headroom outright; shrinking clamps it into the
+  // smaller pool. Either way a dead pet stays dead rather than being revived here.
+  pet.hp = pet.dead ? 0 : Math.max(1, Math.min(pet.maxHp, pet.hp + Math.max(0, gained)));
 }
 
 function petDamageMult(ctx: SimContext, pet: Entity): number {

--- a/src/sim/pet/pet_ai.ts
+++ b/src/sim/pet/pet_ai.ts
@@ -329,6 +329,17 @@ export function petFollow(ctx: SimContext, pet: Entity, owner: Entity): void {
  * Hunter-only on purpose. A warlock demon and the mage Water Elemental are authored
  * as pets with their own tuned pools; a tamed beast is a wild mob template that was
  * never balanced to be a companion, which is the gap this closes.
+ *
+ * KNOWN LIMITATION, pre-existing and deliberately not addressed here: a PERCENT
+ * stamina aura (buff_sta_pct / buff_stats_pct) removes itself by taking a cut of the
+ * pet's CURRENT maxHp (applyNonPlayerStatAura), which is only exact if the pool did
+ * not move while the buff was up. Re-deriving the share inside a buff window
+ * therefore leaves a small residue (measured at 9 hp on a 587 pool). syncPetLevel
+ * already had the same asymmetry, and worse, since it rebuilds the pool from the
+ * template and drops the aura's contribution outright. Making the removal exact
+ * means having that aura record the hp it actually added, which is a change to the
+ * shared non-player aura bookkeeping (warlock pets included) and belongs in its own
+ * commit with its own golden re-mint, not in a hunter balance pass.
  */
 export function applyPetOwnerScaling(ctx: SimContext, pet: Entity): void {
   if (pet.ownerId === null) return;

--- a/src/sim/pet/pet_commands.ts
+++ b/src/sim/pet/pet_commands.ts
@@ -50,7 +50,8 @@ import {
   PET_GROWL_INTERVAL,
   type PetMode,
 } from '../types';
-import { startWaterJet } from './pet_ai';
+import { applyPetOwnerScaling, startWaterJet } from './pet_ai';
+import { isTameableFamily } from './pet_scaling';
 import { petCanForceTaunt } from './pet_taunt_gate';
 
 // Slice-only tuning consts, moved verbatim from sim.ts with the slice.
@@ -209,6 +210,10 @@ export function restorePet(ctx: SimContext, owner: Entity, state: PetState): voi
   pet.lootable = false;
   pet.wanderTarget = null;
   clearThreat(pet);
+  // Grow the pool by the owner's share BEFORE restoring the saved health, so a
+  // pet saved at full comes back at the full inherited pool rather than at the
+  // template pool with the share bolted on afterwards.
+  applyPetOwnerScaling(ctx, pet);
   if (state.dead) {
     pet.dead = true;
     pet.hp = 0;
@@ -235,6 +240,10 @@ export function syncPetLevel(ctx: SimContext, owner: Entity): void {
   pet.scale = scaled.scale;
   pet.color = scaled.color;
   pet.hp = pet.dead ? 0 : Math.max(1, Math.min(pet.maxHp, Math.round(pet.maxHp * hpFrac)));
+  // maxHp/armor were just rebuilt from the template alone, so the owner's share is
+  // gone with them: drop the tracked delta before re-deriving it at the new level.
+  pet.petOwnerHpBonus = 0;
+  applyPetOwnerScaling(ctx, pet);
 }
 
 function cleanPetName(raw: string): string | null {
@@ -245,8 +254,7 @@ function cleanPetName(raw: string): string | null {
 export function tameError(ctx: SimContext, p: Entity, target: Entity): string | null {
   if (target.kind !== 'mob' || !target.hostile) return 'You cannot tame that.';
   const template = MOBS[target.templateId];
-  if (!template || (template.family !== 'beast' && template.family !== 'spider'))
-    return 'Only beasts can be tamed.';
+  if (!template || !isTameableFamily(template.family)) return 'Only beasts can be tamed.';
   if (template.elite || template.boss || template.rare) return 'That beast is too strong to tame.';
   if (target.level > p.level) return 'That beast is too high level for you to tame.';
   if (target.spawnPos.x > DUNGEON_X_THRESHOLD) return 'You cannot tame dungeon creatures.';
@@ -280,6 +288,9 @@ export function completeTame(ctx: SimContext, p: Entity, target: Entity): void {
   pet.inCombat = false;
   pet.tappedById = null;
   pet.auras = [];
+  // Apply the owner's share before the full-health fill so a freshly tamed beast
+  // starts at its inherited pool, not the bare template pool.
+  applyPetOwnerScaling(ctx, pet);
   pet.hp = pet.maxHp;
   pet.loot = null;
   pet.lootable = false;

--- a/src/sim/pet/pet_scaling.ts
+++ b/src/sim/pet/pet_scaling.ts
@@ -28,9 +28,13 @@ import type { MobFamily } from '../types';
  */
 export const TAMEABLE_FAMILIES: readonly MobFamily[] = ['beast', 'spider'];
 
+// Set lookup rather than a scan of the array above: the scaling gate consults this
+// for every hunter pet on every tick.
+const TAMEABLE_FAMILY_SET: ReadonlySet<MobFamily> = new Set(TAMEABLE_FAMILIES);
+
 /** Whether a hunter can tame this family (and so whether its pets inherit). */
 export function isTameableFamily(family: MobFamily): boolean {
-  return TAMEABLE_FAMILIES.includes(family);
+  return TAMEABLE_FAMILY_SET.has(family);
 }
 
 /**

--- a/src/sim/pet/pet_scaling.ts
+++ b/src/sim/pet/pet_scaling.ts
@@ -37,27 +37,47 @@ export function isTameableFamily(family: MobFamily): boolean {
   return TAMEABLE_FAMILY_SET.has(family);
 }
 
+// Provenance of the three ratios, per the rule in docs/design/spell-balance-framework.md
+// that a coefficient needs a classic-era formula, a checked-in reference, or a measured
+// result. Armor and attack power are the classic-era inheritance ratios verbatim. Health
+// is the one adaptation, and is derived below rather than picked.
+
 /**
- * Share of the owner's max health added to the pet's template pool. Sized so a
- * median tameable beast lands in the same durability band as the warlock tank
- * demons it competes with (roughly 600 health at level 20) instead of the
- * roughly 400 it sat at, which is why beast pets died to raid damage that
- * demons survived.
+ * Share of the owner's max health added to the pet's template pool.
+ *
+ * The classic-era rule inherits a share of the hunter's STAMINA, which does not port
+ * directly: a pet here has no stamina stat at all, its pool is the flat template ladder
+ * `hpBase + hpPerLevel * (level - 1)`, so there is nothing for a stamina ratio to apply
+ * to. Re-basing the same rule onto the owner's health is what this is, and at the
+ * level-20 reference the two agree closely: the classic 45% of the hunter's
+ * stamina-derived health is 176, against 181 from 25% of max health (a 3% gap).
+ *
+ * Max health is deliberately the basis rather than the stamina component, because it is
+ * the more CONSERVATIVE of the two once gear is involved: at best-in-slot the
+ * stamina-faithful port would hand the pet 531 health where this hands it 379.
+ *
+ * The measured corroboration, per the framework's third arm: this lands a median
+ * tameable beast in the warlock tank demons' durability band (which is the comparison
+ * that matters, since those are the pets it competes with) instead of well under it,
+ * which is why beast pets were dying to raid damage demons survived.
  */
 export const PET_OWNER_HP_SHARE = 0.25;
 
 /**
- * Share of the owner's armor added to the pet's template armor. Beast templates
- * carry armorPerLevel 8 to 14 against a tank demon's 38 to 55, so this narrows
- * the effective-health gap without turning a damage pet into a tank.
+ * Share of the owner's armor added to the pet's template armor. This is the classic-era
+ * hunter pet armor inheritance ratio, used as-is. Beast templates carry armorPerLevel 8
+ * to 14 against a tank demon's 38 to 55, so it narrows the effective-health gap without
+ * turning a damage pet into a tank.
  */
 export const PET_OWNER_ARMOR_SHARE = 0.35;
 
 /**
- * Share of the owner's ranged attack power the pet inherits as its own attack
- * power. This is the channel that makes a pet scale with hunter gear at all:
- * mob swing damage is `weaponRoll + (attackPower / 14) * weaponSpeed`, and the
- * pet's attackPower was previously always 0.
+ * Share of the owner's ranged attack power the pet inherits as its own attack power.
+ * This is the classic-era hunter pet ranged-attack-power inheritance ratio, used as-is.
+ *
+ * It is also the channel that makes a pet scale with hunter gear at all: mob swing
+ * damage is `weaponRoll + (attackPower / 14) * weaponSpeed`, and a pet's attackPower was
+ * previously 0 for its entire life.
  */
 export const PET_OWNER_AP_SHARE = 0.22;
 

--- a/src/sim/pet/pet_scaling.ts
+++ b/src/sim/pet/pet_scaling.ts
@@ -1,0 +1,109 @@
+// Owner -> pet stat inheritance for hunter beast pets, plus the heel-speed floor.
+//
+// A tamed pet is a clone of the wild mob it came from, so before this module its
+// power was frozen at tame time: health and damage came only from the template's
+// hpBase/dmgBase ladder, and Entity.attackPower stayed 0 for the pet's whole life.
+// Two consequences fell out of that. Gear did nothing for a pet, so a hunter who
+// out-geared their beast kept a level-appropriate but permanently weak companion;
+// and which beast a player happened to tame decided their damage, because the
+// tameable ladder spans roughly 306 to 486 health and 17 to 32 damage per second
+// at level 20 with no way to close the gap.
+//
+// Classic-era hunter pet scaling answers both by making the pet a SHARE of its
+// owner rather than a snapshot of a mob: the pet inherits a fraction of the
+// hunter's attack power, health, and armor, and re-derives whenever the hunter's
+// stats change. The shares below follow that model.
+//
+// This is a pure leaf (no SimContext, no rng, no clock): pet_commands/pet_ai own
+// the application, and tests import these functions directly.
+
+import type { MobFamily } from '../types';
+
+/**
+ * The mob families a hunter can tame, and therefore exactly the pets that inherit
+ * from their owner. Lives here so the tame gate (pet_commands.tameError) and the
+ * scaling gate read ONE list: a family that becomes tameable must start inheriting
+ * in the same change, or a new pet would silently arrive with none of the owner's
+ * stats.
+ */
+export const TAMEABLE_FAMILIES: readonly MobFamily[] = ['beast', 'spider'];
+
+/** Whether a hunter can tame this family (and so whether its pets inherit). */
+export function isTameableFamily(family: MobFamily): boolean {
+  return TAMEABLE_FAMILIES.includes(family);
+}
+
+/**
+ * Share of the owner's max health added to the pet's template pool. Sized so a
+ * median tameable beast lands in the same durability band as the warlock tank
+ * demons it competes with (roughly 600 health at level 20) instead of the
+ * roughly 400 it sat at, which is why beast pets died to raid damage that
+ * demons survived.
+ */
+export const PET_OWNER_HP_SHARE = 0.25;
+
+/**
+ * Share of the owner's armor added to the pet's template armor. Beast templates
+ * carry armorPerLevel 8 to 14 against a tank demon's 38 to 55, so this narrows
+ * the effective-health gap without turning a damage pet into a tank.
+ */
+export const PET_OWNER_ARMOR_SHARE = 0.35;
+
+/**
+ * Share of the owner's ranged attack power the pet inherits as its own attack
+ * power. This is the channel that makes a pet scale with hunter gear at all:
+ * mob swing damage is `weaponRoll + (attackPower / 14) * weaponSpeed`, and the
+ * pet's attackPower was previously always 0.
+ */
+export const PET_OWNER_AP_SHARE = 0.22;
+
+/**
+ * How much faster than its owner a heeling pet may run while catching up. The
+ * pet has to close ground it already lost, so it needs headroom above the
+ * owner's own speed rather than a fixed sprint.
+ */
+export const PET_CATCHUP_SPEED_MULT = 1.1;
+
+/** The owner-derived stats a pet inherits. */
+export interface PetOwnerScaling {
+  /** Health added on top of the pet's template pool. */
+  hp: number;
+  /** Armor added on top of the pet's template armor. */
+  armor: number;
+  /** The pet's attack power, inherited whole from the owner's ranged power. */
+  attackPower: number;
+}
+
+/** The owner fields the inheritance reads. Keeps the math testable without an Entity. */
+export interface PetScalingOwner {
+  maxHp: number;
+  armor: number;
+  rangedPower: number;
+}
+
+/**
+ * The stats a pet inherits from its owner. Pure and idempotent: callers re-derive
+ * from the template base plus this, never accumulate onto a previous result.
+ */
+export function petOwnerScaling(owner: PetScalingOwner): PetOwnerScaling {
+  return {
+    hp: Math.max(0, Math.round(owner.maxHp * PET_OWNER_HP_SHARE)),
+    armor: Math.max(0, Math.round(owner.armor * PET_OWNER_ARMOR_SHARE)),
+    attackPower: Math.max(0, Math.round(owner.rangedPower * PET_OWNER_AP_SHARE)),
+  };
+}
+
+/**
+ * Heel speed for a pet catching up to its owner. The old floor was a fixed
+ * `RUN_SPEED * 1.1` (7.7 yd/s), which a mount beat outright: mounts add 60 to 80
+ * percent, putting a mounted player at 11.2 to 12.6 yd/s, so the pet fell behind
+ * every time until the 60 yd teleport rescued it. Tracking the owner's ACTUAL
+ * speed keeps the pet with its hunter whatever the owner is riding, while a fast
+ * beast still runs at its own higher speed.
+ *
+ * @param petMoveSpeed the pet's own template move speed
+ * @param ownerSpeed the owner's current effective speed, mount and buffs included
+ */
+export function petHeelSpeed(petMoveSpeed: number, ownerSpeed: number): number {
+  return Math.max(petMoveSpeed, ownerSpeed * PET_CATCHUP_SPEED_MULT);
+}

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -3586,6 +3586,10 @@ export interface Entity extends ClientMirroredEntityFields {
   petManualTauntPending?: boolean; // manual Growl command waiting until the pet reaches range
   petPath: Vec3[]; // controlled pet heel route around obstacles; consumed front-to-back (like chargePath)
   petPathCooldown: number; // seconds until this pet may recompute its heel path again
+  // Health this pet currently inherits from its owner (pet/pet_scaling.ts). Tracked
+  // separately from maxHp because the raid stat auras add to maxHp too: re-deriving
+  // the share means swapping THIS delta, never recomputing maxHp from the template.
+  petOwnerHpBonus: number;
   pulseTimer: number; // boss aoe pulse countdown
   stompTimer: number; // boss War Stomp stun-pulse countdown
   bigCastTimer: number; // boss telegraphed-hardcast (bigCast) cadence countdown

--- a/tests/hunter_patch_up_v026.test.ts
+++ b/tests/hunter_patch_up_v026.test.ts
@@ -112,11 +112,20 @@ describe('Hunter Patch Up', () => {
   it('revives the dead owned pet at 35% health', () => {
     const sim = makeHunter();
     const pet = addPet(sim, sim.playerId, 0);
+    // addPet builds the pet by hand rather than through completeTame, so it starts
+    // without the owner's inherited share (pet/pet_scaling.ts). Let that settle while
+    // the pet is still alive, then re-pin the pool: revive takes 35% of the LIVE
+    // maxHp, so a share landing between the fixture and the cast would move the
+    // expected value. Re-deriving is a no-op once settled, so 1000 holds.
+    sim.tick();
+    pet.maxHp = 1_000;
     pet.dead = true;
+    pet.hp = 0;
 
     castPatchUp(sim);
 
     expect(pet.dead).toBe(false);
+    expect(pet.maxHp).toBe(1_000); // the pool really did stay pinned
     expect(pet.hp).toBe(350);
     expect(pet.ownerId).toBe(sim.playerId);
     expect(pet.auras.some((aura) => aura.id === 'revive_pet')).toBe(false);

--- a/tests/parity/golden/pet_commands.json
+++ b/tests/parity/golden/pet_commands.json
@@ -147,7 +147,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 948,
-      "state": "3580475d",
+      "state": "89c0260b",
       "events": "1c683304",
       "rng": {
         "draws": 0,
@@ -268,6 +268,7 @@
         },
         {
           "aiState": "idle",
+          "attackPower": 26,
           "combatTimer": 99,
           "comboUntil": -1,
           "critChance": 0.05,
@@ -275,17 +276,18 @@
           "dodgeChance": 0.05,
           "fallStartY": 1.5,
           "fiveSecondRule": 99,
-          "hp": 194,
+          "hp": 12694,
           "id": 947,
           "kind": "mob",
           "level": 12,
           "lootFfaTimer": "Infinity",
-          "maxHp": 194,
+          "maxHp": 12694,
           "moveSpeed": 8,
           "onGround": true,
           "overpowerUntil": -1,
           "ownerId": 941,
           "petMode": "passive",
+          "petOwnerHpBonus": 12500,
           "pos": {
             "x": 4,
             "y": 1.5,
@@ -298,7 +300,7 @@
             "z": -1
           },
           "stats": {
-            "armor": 110
+            "armor": 202
           },
           "templateId": "forest_wolf",
           "weapon": {
@@ -313,7 +315,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 948,
-      "state": "7a148a27",
+      "state": "dde3bdf1",
       "events": "c95608a6",
       "rng": {
         "draws": 0,
@@ -434,6 +436,7 @@
         },
         {
           "aiState": "idle",
+          "attackPower": 26,
           "auras": [
             {
               "duration": 5,
@@ -455,17 +458,18 @@
           "dodgeChance": 0.05,
           "fallStartY": 1.5,
           "fiveSecondRule": 99,
-          "hp": 97,
+          "hp": 6347,
           "id": 947,
           "kind": "mob",
           "level": 12,
           "lootFfaTimer": "Infinity",
-          "maxHp": 194,
+          "maxHp": 12694,
           "moveSpeed": 8,
           "onGround": true,
           "overpowerUntil": -1,
           "ownerId": 941,
           "petMode": "defensive",
+          "petOwnerHpBonus": 12500,
           "pos": {
             "x": 4,
             "y": 1.5,
@@ -478,7 +482,7 @@
             "z": -1
           },
           "stats": {
-            "armor": 110
+            "armor": 202
           },
           "templateId": "forest_wolf",
           "weapon": {
@@ -493,7 +497,7 @@
       "tick": 20,
       "time": 1,
       "nextId": 948,
-      "state": "0f2c2480",
+      "state": "1f7ada89",
       "events": "4ea5dca7",
       "rng": {
         "draws": 0,
@@ -504,7 +508,7 @@
       "tick": 40,
       "time": 2,
       "nextId": 948,
-      "state": "df1aa4fe",
+      "state": "a9596317",
       "events": "95fddaa3",
       "rng": {
         "draws": 0,
@@ -515,7 +519,7 @@
       "tick": 40,
       "time": 2,
       "nextId": 949,
-      "state": "2b8ed5de",
+      "state": "d1d8b54f",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -655,6 +659,7 @@
         {
           "aggroTargetId": 948,
           "aiState": "idle",
+          "attackPower": 26,
           "auras": [
             {
               "duration": 5,
@@ -675,18 +680,19 @@
           "dodgeChance": 0.05,
           "fallStartY": 1.5,
           "fiveSecondRule": 99,
-          "hp": 127,
+          "hp": 6627,
           "id": 947,
           "inCombat": true,
           "kind": "mob",
           "level": 12,
           "lootFfaTimer": "Infinity",
-          "maxHp": 194,
+          "maxHp": 12694,
           "moveSpeed": 8,
           "onGround": true,
           "overpowerUntil": -1,
           "ownerId": 941,
           "petMode": "defensive",
+          "petOwnerHpBonus": 12500,
           "petTauntTimer": 10,
           "pos": {
             "x": 4,
@@ -700,7 +706,7 @@
             "z": -1
           },
           "stats": {
-            "armor": 110
+            "armor": 202
           },
           "templateId": "forest_wolf",
           "weapon": {
@@ -974,7 +980,7 @@
       "tick": 40,
       "time": 2,
       "nextId": 951,
-      "state": "a78d878f",
+      "state": "cef690d5",
       "events": "f7115cd5",
       "rng": {
         "draws": 0,
@@ -1169,6 +1175,7 @@
         },
         {
           "aiState": "idle",
+          "attackPower": 26,
           "combatTimer": 99,
           "comboUntil": -1,
           "critChance": 0.05,
@@ -1181,12 +1188,13 @@
           "kind": "mob",
           "level": 12,
           "lootFfaTimer": "Infinity",
-          "maxHp": 194,
+          "maxHp": 12694,
           "moveSpeed": 8,
           "onGround": true,
           "overpowerUntil": -1,
           "ownerId": 941,
           "petMode": "defensive",
+          "petOwnerHpBonus": 12500,
           "pos": {
             "x": 4,
             "y": 1.5,
@@ -1199,7 +1207,7 @@
             "z": -1
           },
           "stats": {
-            "armor": 110
+            "armor": 202
           },
           "templateId": "forest_wolf",
           "weapon": {
@@ -1214,7 +1222,7 @@
       "tick": 40,
       "time": 2,
       "nextId": 951,
-      "state": "570af68b",
+      "state": "a8ecabfa",
       "events": "2e74fa1c",
       "rng": {
         "draws": 0,
@@ -1409,6 +1417,7 @@
         },
         {
           "aiState": "idle",
+          "attackPower": 26,
           "combatTimer": 99,
           "comboUntil": -1,
           "critChance": 0.05,
@@ -1416,17 +1425,18 @@
           "dodgeChance": 0.05,
           "fallStartY": 1.5,
           "fiveSecondRule": 99,
-          "hp": 68,
+          "hp": 4443,
           "id": 950,
           "kind": "mob",
           "level": 12,
           "lootFfaTimer": "Infinity",
-          "maxHp": 194,
+          "maxHp": 12694,
           "moveSpeed": 8,
           "onGround": true,
           "overpowerUntil": -1,
           "ownerId": 941,
           "petMode": "defensive",
+          "petOwnerHpBonus": 12500,
           "pos": {
             "x": 4,
             "y": 1.5,
@@ -1439,7 +1449,7 @@
             "z": -1
           },
           "stats": {
-            "armor": 110
+            "armor": 202
           },
           "templateId": "forest_wolf",
           "weapon": {

--- a/tests/pet_command.test.ts
+++ b/tests/pet_command.test.ts
@@ -114,11 +114,23 @@ describe('/pet command', () => {
     const sim = makeWorld();
     const a = sim.addPlayer('hunter', 'Aleph');
     const pet = givePet(sim, a);
-    pet.hp = Math.round(pet.maxHp * 0.5);
+    // givePet adopts a wild mob directly rather than going through completeTame, so
+    // the pet arrives without the owner's inherited share (pet/pet_scaling.ts). Tick
+    // once to let that settle before pinning a ratio: the first application grows the
+    // pool AND hands the pet the new headroom, which would otherwise move the
+    // percentage out from under this assertion. A real tame is already scaled.
+    sim.tick();
+    // Pin an exact pool so the ratio is unambiguous. The inherited share leaves an odd
+    // pool where no integer HP reads as exactly 50%, and the readout's rounding is
+    // what this test is actually about. Re-deriving is a no-op once the share has
+    // settled (the delta is zero), so maxHp stays put through the tick below.
+    pet.maxHp = 100;
+    pet.hp = 50;
     sim.tick();
 
     sim.chat('/pet', a);
     const text = errorText(sim.tick())!;
+    expect(text).toContain('HP 50/100');
     expect(text).toContain('(50%)');
   });
 

--- a/tests/pet_scaling.test.ts
+++ b/tests/pet_scaling.test.ts
@@ -2,7 +2,15 @@ import { describe, expect, it } from 'vitest';
 import { MOBS } from '../src/sim/data';
 import { createMob } from '../src/sim/entity';
 import { applyPetOwnerScaling } from '../src/sim/pet/pet_ai';
-import { completeTame, petOf, summonPet } from '../src/sim/pet/pet_commands';
+import {
+  abandonPet,
+  completeTame,
+  petOf,
+  restorePet,
+  serializePet,
+  summonPet,
+  tameError,
+} from '../src/sim/pet/pet_commands';
 import {
   isTameableFamily,
   PET_CATCHUP_SPEED_MULT,
@@ -202,12 +210,73 @@ describe('pet_scaling: re-deriving is safe', () => {
   });
 });
 
+describe('pet_scaling: lifecycle paths', () => {
+  it('survives a save/load round trip without inflating the pool', () => {
+    // PetState stores hp but never maxHp, so a reload rebuilds the pool from the
+    // template plus a FRESH share. If restorePet applied the share on top of an
+    // already-shared pool, every relog would grow the pet.
+    const { sim, hid, pet } = tamedWolf();
+    const pooled = pet.maxHp;
+    pet.hp = Math.round(pet.maxHp * 0.5);
+    const saved = serializePet(sim.ctx, hid);
+    expect(saved).not.toBeNull();
+    abandonPet(sim.ctx, hid);
+
+    const owner = sim.entities.get(hid) as AnyEntity;
+    restorePet(sim.ctx, owner, saved as NonNullable<typeof saved>);
+    const restored = petOf(sim.ctx, hid) as AnyEntity;
+    expect(restored.maxHp).toBe(pooled);
+    expect(restored.hp).toBe(Math.round(pooled * 0.5));
+    expect(restored.petOwnerHpBonus).toBe(petOwnerScaling(ownerStats(owner)).hp);
+
+    // And a second round trip is still stable.
+    const again = serializePet(sim.ctx, hid);
+    abandonPet(sim.ctx, hid);
+    restorePet(sim.ctx, owner, again as NonNullable<typeof again>);
+    expect((petOf(sim.ctx, hid) as AnyEntity).maxHp).toBe(pooled);
+  });
+
+  it('re-derives rather than compounds when the pet levels with its owner', () => {
+    // syncPetLevel rebuilds maxHp from the template, so it must zero the tracked
+    // share first or the pet keeps the old bonus AND gains a new one.
+    const { sim, hid, hunter, pet } = tamedWolf(10);
+    expect(pet.level).toBe(10);
+    sim.setPlayerLevel(20, hid);
+    for (let i = 0; i < 5; i++) sim.tick();
+    const grown = petOf(sim.ctx, hid) as AnyEntity;
+    expect(grown.level).toBe(20);
+    const base = templateHp('forest_wolf', 20);
+    const share = petOwnerScaling(ownerStats(hunter)).hp;
+    expect(grown.petOwnerHpBonus).toBe(share);
+    expect(grown.maxHp).toBe(base + share);
+  });
+});
+
 describe('pet_scaling: scope', () => {
   it('inherits only for the families a hunter can actually tame', () => {
     expect(isTameableFamily('beast')).toBe(true);
     expect(isTameableFamily('spider')).toBe(true);
     expect(isTameableFamily('demon')).toBe(false);
     expect(isTameableFamily('elemental')).toBe(false);
+  });
+
+  it('keeps the tame gate accepting and rejecting exactly what it did before', () => {
+    // tameError now routes its family check through isTameableFamily. Pin the real
+    // verdict per family so the shared predicate cannot quietly widen or narrow it.
+    const { sim, hunter } = hunterWorld();
+    const verdict = (templateId: string): string | null => {
+      const target = createMob(sim.nextId++, MOBS[templateId], 2, {
+        x: hunter.pos.x + 3,
+        y: hunter.pos.y,
+        z: hunter.pos.z,
+      }) as AnyEntity;
+      sim.addEntity(target);
+      return tameError(sim.ctx, hunter, target);
+    };
+    expect(verdict('forest_wolf')).toBeNull(); // beast
+    expect(verdict('webwood_spider')).toBeNull(); // spider
+    expect(verdict('gloomshade')).toBe('Only beasts can be tamed.'); // demon
+    expect(verdict('water_elemental')).toBe('Only beasts can be tamed.'); // elemental
   });
 
   it('leaves a demon parked on a hunter alone', () => {

--- a/tests/pet_scaling.test.ts
+++ b/tests/pet_scaling.test.ts
@@ -120,6 +120,23 @@ describe('pet_scaling: heel speed', () => {
     const fastest = RUN_SPEED * 1.8;
     expect(petHeelSpeed(8, fastest)).toBeGreaterThan(fastest);
   });
+
+  it('tracks a non-mount speed buff on the owner', () => {
+    // moveSpeedMult folds buffs and mounts alike, so a Courser's Guise owner pulls
+    // the pet along the same way a mount does.
+    const buffed = RUN_SPEED * 1.3;
+    expect(petHeelSpeed(5.2, buffed)).toBeCloseTo(buffed * PET_CATCHUP_SPEED_MULT, 5);
+  });
+
+  it('does not sprint a pet past a snared owner', () => {
+    // The deliberate other half of tracking the owner: behind a slowed owner the pet
+    // now falls back to its OWN speed instead of the old flat 7.7 floor. It still
+    // closes, because its own speed comfortably beats the snared owner's.
+    const snared = RUN_SPEED * 0.5;
+    expect(petHeelSpeed(5.2, snared)).toBe(5.2);
+    expect(petHeelSpeed(5.2, snared)).toBeLessThan(RUN_SPEED * 1.1);
+    expect(petHeelSpeed(5.2, snared)).toBeGreaterThan(snared);
+  });
 });
 
 describe('pet_scaling: a tamed beast inherits from its hunter', () => {
@@ -138,10 +155,28 @@ describe('pet_scaling: a tamed beast inherits from its hunter', () => {
     expect(pet.attackPower).toBeGreaterThan(0);
   });
 
+  it('inherits on a same-level tame, where syncPetLevel does nothing', () => {
+    // syncPetLevel early-returns when the pet is already the owner's level, so this
+    // is the ONLY case that exercises completeTame's own scaling call, and it is the
+    // common one in play (and what the balance sweep does).
+    const { sim, hid, hunter } = hunterWorld(20);
+    completeTame(sim.ctx, hunter, spawnWolf(sim, hunter, 20));
+    const pet = petOf(sim.ctx, hid) as AnyEntity;
+    expect(pet.level).toBe(hunter.level);
+    const share = petOwnerScaling(ownerStats(hunter));
+    expect(pet.maxHp).toBe(templateHp('forest_wolf', 20) + share.hp);
+    expect(pet.hp).toBe(pet.maxHp);
+    expect(pet.attackPower).toBe(share.attackPower);
+    expect(pet.attackPower).toBeGreaterThan(0);
+  });
+
   it('adds the owner armor share on top of the template armor', () => {
     const { hunter, pet } = tamedWolf();
-    const baseArmor = Math.round(MOBS.forest_wolf.armorPerLevel * (pet.level - 1));
-    expect(pet.stats.armor).toBe(baseArmor + petOwnerScaling(ownerStats(hunter)).armor);
+    // Derive the template half from the real producer, not from a copy of the
+    // formula the implementation uses, so the two cannot move together silently.
+    const fresh = createMob(-1, MOBS.forest_wolf, pet.level, pet.pos) as AnyEntity;
+    expect(pet.stats.armor).toBe(fresh.stats.armor + petOwnerScaling(ownerStats(hunter)).armor);
+    expect(pet.stats.armor).toBeGreaterThan(fresh.stats.armor);
   });
 
   it('compresses the tame lottery: a starter beast gains proportionally more', () => {
@@ -180,10 +215,15 @@ describe('pet_scaling: re-deriving is safe', () => {
 
   it('clamps a shrinking pet into the smaller pool instead of overflowing', () => {
     const { sim, hunter, pet } = tamedWolf();
+    const base = templateHp('forest_wolf', pet.level);
     hunter.maxHp = Math.round(hunter.maxHp / 2);
+    const smaller = petOwnerScaling(ownerStats(hunter)).hp;
     applyPetOwnerScaling(sim.ctx, pet);
-    expect(pet.hp).toBeLessThanOrEqual(pet.maxHp);
-    expect(pet.maxHp).toBeGreaterThan(0);
+    // Exact pool and exact health, not merely "hp <= maxHp", which almost any
+    // implementation satisfies (including one that zeroes the pool).
+    expect(pet.maxHp).toBe(base + smaller);
+    expect(pet.petOwnerHpBonus).toBe(smaller);
+    expect(pet.hp).toBe(pet.maxHp); // was at full, so it stays capped at full
   });
 
   it('never revives a dead pet by growing its pool', () => {

--- a/tests/pet_scaling.test.ts
+++ b/tests/pet_scaling.test.ts
@@ -1,0 +1,303 @@
+import { describe, expect, it } from 'vitest';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+import { applyPetOwnerScaling } from '../src/sim/pet/pet_ai';
+import { completeTame, petOf, summonPet } from '../src/sim/pet/pet_commands';
+import {
+  isTameableFamily,
+  PET_CATCHUP_SPEED_MULT,
+  petHeelSpeed,
+  petOwnerScaling,
+} from '../src/sim/pet/pet_scaling';
+import { Sim } from '../src/sim/sim';
+import { DT, type Entity, RUN_SPEED, type Vec3 } from '../src/sim/types';
+import { terrainHeight } from '../src/sim/world';
+
+// A hunter pet used to be frozen at tame time: its health and damage came only
+// from the wild-mob template it was tamed from, and Entity.attackPower stayed 0
+// for its whole life, so hunter gear did nothing for it. It also heeled at a fixed
+// 7.7 yd/s floor, which every mount outran. These pin the owner-share inheritance
+// and the owner-tracking heel speed that replaced both.
+
+const SEED = 42;
+
+type AnySim = Sim & Record<string, any>;
+type AnyEntity = Entity & Record<string, any>;
+
+function hunterWorld(level = 20, seed = 11): { sim: AnySim; hid: number; hunter: AnyEntity } {
+  const sim = new Sim({ seed, playerClass: 'hunter', noPlayer: true }) as AnySim;
+  const hid = sim.addPlayer('hunter', 'Owner') as number;
+  sim.setPlayerLevel(level, hid);
+  return { sim, hid, hunter: sim.entities.get(hid) as AnyEntity };
+}
+
+function spawnWolf(sim: AnySim, near: AnyEntity, level = 2): AnyEntity {
+  const wolf = createMob(sim.nextId++, MOBS.forest_wolf, level, {
+    x: near.pos.x + 3,
+    y: near.pos.y,
+    z: near.pos.z,
+  }) as AnyEntity;
+  wolf.hostile = true;
+  sim.addEntity(wolf);
+  return wolf;
+}
+
+/** The pet pool a template alone would give, i.e. the old behavior. */
+function templateHp(templateId: string, level: number): number {
+  const t = MOBS[templateId];
+  return Math.round(t.hpBase + t.hpPerLevel * (level - 1));
+}
+
+function tamedWolf(level = 20): {
+  sim: AnySim;
+  hid: number;
+  hunter: AnyEntity;
+  pet: AnyEntity;
+} {
+  const { sim, hid, hunter } = hunterWorld(level);
+  completeTame(sim.ctx, hunter, spawnWolf(sim, hunter));
+  return { sim, hid, hunter, pet: petOf(sim.ctx, hid) as AnyEntity };
+}
+
+describe('pet_scaling: owner share math', () => {
+  it('splits the owner into the documented shares', () => {
+    // Literal pin of the ratios themselves (0.25 hp, 0.35 armor, 0.22 ranged AP),
+    // so a retune has to come here and be deliberate.
+    expect(petOwnerScaling({ maxHp: 1000, armor: 400, rangedPower: 300 })).toEqual({
+      hp: 250,
+      armor: 140,
+      attackPower: 66,
+    });
+  });
+
+  it('rounds rather than truncates each share', () => {
+    expect(petOwnerScaling({ maxHp: 101, armor: 101, rangedPower: 101 })).toEqual({
+      hp: 25,
+      armor: 35,
+      attackPower: 22,
+    });
+  });
+
+  it('never returns a negative share for a drained owner', () => {
+    expect(petOwnerScaling({ maxHp: -50, armor: -10, rangedPower: -1 })).toEqual({
+      hp: 0,
+      armor: 0,
+      attackPower: 0,
+    });
+  });
+});
+
+describe('pet_scaling: heel speed', () => {
+  it('keeps a slow pet moving at the owner catch-up speed', () => {
+    // A 5.2 yd/s demon-speed pet behind a 7 yd/s owner runs at the owner's pace
+    // plus the catch-up margin, not its own crawl.
+    expect(petHeelSpeed(5.2, 7)).toBeCloseTo(7.7, 5);
+  });
+
+  it('lets a fast beast keep its own higher speed', () => {
+    expect(petHeelSpeed(9.5, 7)).toBeCloseTo(9.5, 5);
+  });
+
+  it('outruns a mounted owner, which the old fixed floor did not', () => {
+    // The bug: the floor was RUN_SPEED * 1.1 = 7.7 regardless of the owner, while
+    // the slowest mount puts a player at 7 * 1.6 = 11.2 yd/s.
+    const mounted = RUN_SPEED * 1.6;
+    const oldFixedFloor = RUN_SPEED * 1.1;
+    expect(oldFixedFloor).toBeLessThan(mounted);
+    expect(petHeelSpeed(8, mounted)).toBeGreaterThan(mounted);
+    expect(petHeelSpeed(8, mounted)).toBeCloseTo(mounted * PET_CATCHUP_SPEED_MULT, 5);
+  });
+
+  it('scales with the fastest mounts too', () => {
+    const fastest = RUN_SPEED * 1.8;
+    expect(petHeelSpeed(8, fastest)).toBeGreaterThan(fastest);
+  });
+});
+
+describe('pet_scaling: a tamed beast inherits from its hunter', () => {
+  it('adds the owner health share on top of the template pool', () => {
+    const { hunter, pet } = tamedWolf();
+    const base = templateHp('forest_wolf', pet.level);
+    expect(pet.maxHp).toBe(base + petOwnerScaling(ownerStats(hunter)).hp);
+    expect(pet.maxHp).toBeGreaterThan(base);
+    expect(pet.hp).toBe(pet.maxHp); // a fresh tame starts at the FULL inherited pool
+  });
+
+  it('gives the pet attack power, which was previously always zero', () => {
+    const { hunter, pet } = tamedWolf();
+    expect(hunter.rangedPower).toBeGreaterThan(0);
+    expect(pet.attackPower).toBe(petOwnerScaling(ownerStats(hunter)).attackPower);
+    expect(pet.attackPower).toBeGreaterThan(0);
+  });
+
+  it('adds the owner armor share on top of the template armor', () => {
+    const { hunter, pet } = tamedWolf();
+    const baseArmor = Math.round(MOBS.forest_wolf.armorPerLevel * (pet.level - 1));
+    expect(pet.stats.armor).toBe(baseArmor + petOwnerScaling(ownerStats(hunter)).armor);
+  });
+
+  it('compresses the tame lottery: a starter beast gains proportionally more', () => {
+    // The whole point of inheriting from the owner instead of the template. The
+    // weakest and strongest tameable beasts must end up closer than they started.
+    const { sim, hid, hunter } = hunterWorld();
+    completeTame(sim.ctx, hunter, spawnWolf(sim, hunter));
+    const weak = petOf(sim.ctx, hid) as AnyEntity;
+    const weakBase = templateHp('forest_wolf', weak.level);
+    const strongBase = templateHp('terrace_howler', weak.level);
+    const share = petOwnerScaling(ownerStats(hunter)).hp;
+    const before = strongBase / weakBase;
+    const after = (strongBase + share) / (weakBase + share);
+    expect(after).toBeLessThan(before);
+  });
+});
+
+describe('pet_scaling: re-deriving is safe', () => {
+  it('does not compound the pool when applied repeatedly', () => {
+    const { sim, pet } = tamedWolf();
+    const settled = pet.maxHp;
+    for (let i = 0; i < 40; i++) sim.tick();
+    expect(pet.maxHp).toBe(settled);
+  });
+
+  it('grows the pet and hands it the new headroom when the owner gets stronger', () => {
+    const { sim, hunter, pet } = tamedWolf();
+    const before = pet.maxHp;
+    const beforeHp = pet.hp;
+    hunter.maxHp += 400;
+    applyPetOwnerScaling(sim.ctx, pet);
+    const gained = Math.round(400 * 0.25);
+    expect(pet.maxHp).toBe(before + gained);
+    expect(pet.hp).toBe(beforeHp + gained);
+  });
+
+  it('clamps a shrinking pet into the smaller pool instead of overflowing', () => {
+    const { sim, hunter, pet } = tamedWolf();
+    hunter.maxHp = Math.round(hunter.maxHp / 2);
+    applyPetOwnerScaling(sim.ctx, pet);
+    expect(pet.hp).toBeLessThanOrEqual(pet.maxHp);
+    expect(pet.maxHp).toBeGreaterThan(0);
+  });
+
+  it('never revives a dead pet by growing its pool', () => {
+    const { sim, hunter, pet } = tamedWolf();
+    pet.dead = true;
+    pet.hp = 0;
+    hunter.maxHp += 400;
+    applyPetOwnerScaling(sim.ctx, pet);
+    expect(pet.dead).toBe(true);
+    expect(pet.hp).toBe(0);
+  });
+
+  it('preserves raid stat-aura health when the owner share is re-derived', () => {
+    // applyNonPlayerStatAura writes maxHp too, so the share has to move as a delta
+    // rather than rebuild the pool from the template and eat the buff.
+    const { sim, hunter, pet } = tamedWolf();
+    const auraHp = 120;
+    pet.maxHp += auraHp;
+    pet.hp += auraHp;
+    const withAura = pet.maxHp;
+    hunter.maxHp += 400;
+    applyPetOwnerScaling(sim.ctx, pet);
+    expect(pet.maxHp).toBe(withAura + Math.round(400 * 0.25));
+  });
+});
+
+describe('pet_scaling: scope', () => {
+  it('inherits only for the families a hunter can actually tame', () => {
+    expect(isTameableFamily('beast')).toBe(true);
+    expect(isTameableFamily('spider')).toBe(true);
+    expect(isTameableFamily('demon')).toBe(false);
+    expect(isTameableFamily('elemental')).toBe(false);
+  });
+
+  it('leaves a demon parked on a hunter alone', () => {
+    // The gate is the tameable FAMILY, not just the owner's class, so a pet a hunter
+    // could never have tamed keeps its authored pool.
+    const { sim, hid, hunter } = hunterWorld();
+    const demon = createMob(sim.nextId++, MOBS.gloomshade, 20, {
+      x: hunter.pos.x + 2,
+      y: hunter.pos.y,
+      z: hunter.pos.z,
+    }) as AnyEntity;
+    demon.ownerId = hid;
+    demon.hostile = false;
+    demon.hp = demon.maxHp;
+    sim.addEntity(demon);
+    applyPetOwnerScaling(sim.ctx, demon);
+    expect(demon.maxHp).toBe(templateHp('gloomshade', 20));
+    expect(demon.attackPower).toBe(0);
+    expect(demon.petOwnerHpBonus).toBe(0);
+  });
+
+  it('leaves a warlock demon on its authored pool', () => {
+    const sim = new Sim({ seed: 5, playerClass: 'warlock', noPlayer: true }) as AnySim;
+    const wid = sim.addPlayer('warlock', 'Caster') as number;
+    sim.setPlayerLevel(20, wid);
+    const warlock = sim.entities.get(wid) as AnyEntity;
+    summonPet(sim.ctx, warlock, 'gloomshade');
+    const demon = petOf(sim.ctx, wid) as AnyEntity;
+    expect(demon.maxHp).toBe(templateHp('gloomshade', demon.level));
+    expect(demon.attackPower).toBe(0);
+    expect(demon.petOwnerHpBonus).toBe(0);
+    for (let i = 0; i < 20; i++) sim.tick();
+    expect(demon.maxHp).toBe(templateHp('gloomshade', demon.level));
+    expect(demon.attackPower).toBe(0);
+  });
+});
+
+describe('pet_scaling: heeling a mounted owner', () => {
+  it('closes on a mounted owner instead of falling behind', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'hunter', noPlayer: true }) as AnySim;
+    const pid = sim.addPlayer('hunter', 'Rider') as number;
+    const owner = sim.entities.get(pid) as AnyEntity;
+    let pet: AnyEntity | null = null;
+    for (const e of sim.entities.values()) {
+      if (e.kind === 'mob' && !e.dead && e.ownerId === null) {
+        pet = e as AnyEntity;
+        break;
+      }
+    }
+    if (!pet) throw new Error('no wild mob to adopt');
+    pet.ownerId = pid;
+    pet.hostile = false;
+    pet.hp = pet.maxHp;
+    pet.petMode = 'passive'; // stay in the heel branch, never pick a target
+    // Pin the pet SLOWER than the old fixed floor, so the old code's step would be
+    // exactly RUN_SPEED * 1.1 * DT and only owner-tracking can beat it. A fast wild
+    // beast (forest_wolf runs 8) would otherwise clear the bar without the fix.
+    pet.moveSpeed = 5.2;
+    place(owner, 0, 0);
+    place(pet, 0, -30); // well past the heel distance, well inside the warp range
+    // The rider must actually own the reins, or updateMountTransition force-dismounts
+    // them mid-tick and the owner is never really mounted.
+    sim.addItem('reins_valorsteed', 1, pid);
+    owner.mountKey = 'valorsteed';
+
+    const startDist = dist(pet.pos, owner.pos);
+    const before = { ...pet.pos };
+    sim.tick();
+    const step = dist(before, pet.pos);
+
+    expect(sim.moveSpeedMult(owner)).toBeCloseTo(1.6, 5); // the mount really is up
+    // Old behavior stepped RUN_SPEED * 1.1 * DT = 0.385 yd per tick regardless of the
+    // mount. Tracking a 1.6x mount steps 7 * 1.6 * 1.1 * DT = 0.616 instead. Pinned
+    // to the real value, not merely "greater than 0.385", because the two are close
+    // enough that a float-noise comparison would pass on the old code.
+    expect(step).toBeCloseTo(RUN_SPEED * 1.6 * PET_CATCHUP_SPEED_MULT * DT, 3);
+    expect(step).toBeGreaterThan(RUN_SPEED * 1.1 * DT * 1.5);
+    expect(dist(pet.pos, owner.pos)).toBeLessThan(startDist);
+  });
+});
+
+function ownerStats(owner: AnyEntity): { maxHp: number; armor: number; rangedPower: number } {
+  return { maxHp: owner.maxHp, armor: owner.stats.armor, rangedPower: owner.rangedPower };
+}
+
+function place(e: AnyEntity, x: number, z: number): void {
+  e.pos = { x, y: terrainHeight(x, z, SEED), z };
+  e.prevPos = { ...e.pos };
+}
+
+function dist(a: Vec3, b: Vec3): number {
+  return Math.hypot(a.x - b.x, a.z - b.z);
+}

--- a/tests/sweep_engagement.test.ts
+++ b/tests/sweep_engagement.test.ts
@@ -1,35 +1,26 @@
 import { describe, expect, it } from 'vitest';
 import {
+  attributeSweepDamage,
+  DAMAGE_EFFECTS,
   DEAD_ZONE_MARGIN,
   engagementDistance,
   MELEE_REACH,
+  STATION_DEAD_BAND,
+  station,
 } from '../scripts/lib/sweep_engagement.mjs';
-import { abilitiesKnownAt } from '../src/sim/content/classes';
+import { CHOICE_ROWS } from '../src/sim/content/choice_rows';
+import { TALENTS } from '../src/sim/content/talents';
 import { CLASSES } from '../src/sim/data';
-import { MAX_LEVEL, type PlayerClass } from '../src/sim/types';
+import { Sim } from '../src/sim/sim';
+import { ALL_CLASSES, MAX_LEVEL, type PlayerClass } from '../src/sim/types';
 
 // The row sweep used to walk every class to melee reach, which put the hunter inside
 // the 8 yard dead zone its whole ranged kit refuses to fire from, so the sweep
 // measured a hunter as a bad melee class. These pin the standoff rule that replaced
 // it, including the deliberate no-op for every class that has no dead zone.
 
-const DAMAGE_EFFECTS = new Set([
-  'aoeDamage',
-  'aoeRoot',
-  'directDamage',
-  'dot',
-  'drainTick',
-  'finisherDamage',
-  'groundAoE',
-  'weaponDamage',
-  'weaponStrike',
-]);
-
-function damagingDefsAtCap(cls: PlayerClass): Array<{ minRange?: number; range?: number }> {
-  return abilitiesKnownAt(cls, MAX_LEVEL)
-    .filter((a) => a.def.effects.some((e) => DAMAGE_EFFECTS.has(e.type)))
-    .map((a) => a.def);
-}
+const TICKS_PER_SECOND = 20;
+const APPROACH_SPEED = 7;
 
 describe('engagementDistance', () => {
   it('holds melee reach when nothing in the kit has a minimum range', () => {
@@ -57,10 +48,20 @@ describe('engagementDistance', () => {
   });
 
   it('never steps past the shortest reachable ceiling', () => {
-    // A 25 yd ability with an 8 yd floor caps the standoff at 25, not 10 -> fine, but
-    // a class capped at 9 must not be stationed at 10.
     expect(engagementDistance([{ minRange: 8, range: 9 }], { maxRange: 35 })).toBe(9);
     expect(engagementDistance([{ minRange: 8, range: 35 }], { maxRange: 9 })).toBe(9);
+  });
+
+  it('ignores the range of abilities that declared no dead zone', () => {
+    // A short-range ability with no minRange must not drag the standoff back into
+    // the dead zone the ranged kit needs cleared.
+    expect(engagementDistance([{ minRange: 8, range: 35 }, { range: 3 }], null)).toBe(
+      8 + DEAD_ZONE_MARGIN,
+    );
+  });
+
+  it('tolerates a dead-zone ability that declares no range', () => {
+    expect(engagementDistance([{ minRange: 8 }], null)).toBe(8 + DEAD_ZONE_MARGIN);
   });
 
   it('falls back to the floor when the ceiling is inside the dead zone', () => {
@@ -70,19 +71,111 @@ describe('engagementDistance', () => {
   });
 });
 
-describe('engagementDistance against the real class kits', () => {
+describe('engagementDistance against the kits the sweep actually runs', () => {
+  // Built the way runBuild() builds them: real Sim, level cap, spec applied, and the
+  // talent rows allocated. abilitiesKnownAt() alone misses 13 damaging abilities the
+  // sweep sees (spec-gated and talent-granted ones), so evaluating the rule against
+  // it would verify a different kit than the one being measured.
+  function sweptKit(cls: PlayerClass, rows: Record<number, string> = {}) {
+    const sim = new Sim({ seed: 7300, playerClass: 'warrior', noPlayer: true, autoEquip: true });
+    const pid = sim.addPlayer(cls, 'Sweep') as number;
+    sim.setPlayerLevel(MAX_LEVEL, pid);
+    sim.applyTalents({ spec: TALENTS[cls].specs[0]?.id ?? null, rows }, pid);
+    const meta = sim.meta(pid);
+    if (!meta) throw new Error(`no meta for ${cls}`);
+    return meta.known
+      .filter((a) => a.def.effects.some((e) => DAMAGE_EFFECTS.has(e.type)))
+      .map((a) => a.def);
+  }
+
+  const standoff = (cls: PlayerClass, rows?: Record<number, string>) =>
+    engagementDistance(sweptKit(cls, rows), CLASSES[cls].ranged);
+
   it('stations the hunter outside its dead zone', () => {
-    const stand = engagementDistance(damagingDefsAtCap('hunter'), CLASSES.hunter.ranged);
+    const stand = standoff('hunter');
     expect(stand).toBeGreaterThan(8);
+    expect(stand).toBe(10);
     expect(stand).toBeLessThanOrEqual(CLASSES.hunter.ranged?.maxRange ?? 35);
   });
 
-  it('is the hunter alone: every other class keeps standing at melee reach', () => {
-    // The narrow scope is the point. Fixing the sweep must not silently move the
-    // eight classes whose numbers were already measured correctly.
-    const moved = (Object.keys(CLASSES) as PlayerClass[]).filter(
-      (cls) => engagementDistance(damagingDefsAtCap(cls), CLASSES[cls].ranged) !== MELEE_REACH,
-    );
-    expect(moved).toEqual(['hunter']);
+  it('is the hunter alone, across every talent row option', () => {
+    // The narrow scope is the point: fixing the sweep must not silently move the
+    // eight classes whose numbers were already measured correctly. Checked against
+    // every single-row build too, so a talent-granted minRange ability on another
+    // class fails here rather than quietly relocating it in the sweep.
+    const moved = new Set<string>();
+    for (const cls of ALL_CLASSES) {
+      if (standoff(cls) !== MELEE_REACH) moved.add(cls);
+      for (const row of CHOICE_ROWS[cls].rows) {
+        for (const option of row.options) {
+          if (standoff(cls, { [row.level]: option.id }) !== MELEE_REACH) moved.add(cls);
+        }
+      }
+    }
+    expect([...moved]).toEqual(['hunter']);
+  });
+});
+
+describe('station', () => {
+  const at = (x: number) => ({ pos: { x, z: 0 } }) as { pos: { x: number; z: number } };
+
+  it('closes toward the reach', () => {
+    const mover = at(0);
+    station(mover, at(30), 10, APPROACH_SPEED, TICKS_PER_SECOND);
+    expect(mover.pos.x).toBeCloseTo(APPROACH_SPEED / TICKS_PER_SECOND, 5);
+  });
+
+  it('backs off when it is too close, which the old mover never did', () => {
+    // The sign is load-bearing: inverted, the character walks to zero range and
+    // reproduces the exact dead-zone defect this rule exists to fix.
+    const mover = at(0);
+    station(mover, at(2.25), 10, APPROACH_SPEED, TICKS_PER_SECOND);
+    expect(mover.pos.x).toBeLessThan(0);
+  });
+
+  it('converges on the reach and then holds without oscillating', () => {
+    const mover = at(0);
+    const target = at(30);
+    for (let i = 0; i < 200; i++) station(mover, target, 10, APPROACH_SPEED, TICKS_PER_SECOND);
+    const settled = mover.pos.x;
+    // It comes to rest within the dead band of the reach, never exactly on it.
+    expect(Math.abs(Math.abs(30 - settled) - 10)).toBeLessThan(STATION_DEAD_BAND);
+    for (let i = 0; i < 20; i++) station(mover, target, 10, APPROACH_SPEED, TICKS_PER_SECOND);
+    expect(mover.pos.x).toBe(settled); // dead band: fully at rest, not jittering
+  });
+
+  it('never overshoots the reach in a single step', () => {
+    const mover = at(9.9);
+    station(mover, at(20), 10, APPROACH_SPEED, TICKS_PER_SECOND);
+    expect(20 - mover.pos.x).toBeGreaterThanOrEqual(10);
+  });
+
+  it('does not move a casting character, or one at zero separation', () => {
+    const casting = { pos: { x: 0, z: 0 }, castingAbility: 'aimed_shot' };
+    station(casting, at(30), 10, APPROACH_SPEED, TICKS_PER_SECOND);
+    expect(casting.pos.x).toBe(0);
+    const stacked = at(5);
+    station(stacked, at(5), 10, APPROACH_SPEED, TICKS_PER_SECOND);
+    expect(stacked.pos.x).toBe(5);
+  });
+});
+
+describe('attributeSweepDamage', () => {
+  it('credits the player their own damage', () => {
+    expect(attributeSweepDamage(7, 7, { kind: 'player' })).toBe('player');
+  });
+
+  it('credits the player their own pet', () => {
+    expect(attributeSweepDamage(42, 7, { kind: 'mob', ownerId: 7 })).toBe('pet');
+  });
+
+  it('ignores another player and their pet', () => {
+    expect(attributeSweepDamage(9, 7, { kind: 'player' })).toBeNull();
+    expect(attributeSweepDamage(42, 7, { kind: 'mob', ownerId: 9 })).toBeNull();
+  });
+
+  it('ignores an unowned mob and a missing source', () => {
+    expect(attributeSweepDamage(42, 7, { kind: 'mob', ownerId: null })).toBeNull();
+    expect(attributeSweepDamage(42, 7, undefined)).toBeNull();
   });
 });

--- a/tests/sweep_engagement.test.ts
+++ b/tests/sweep_engagement.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEAD_ZONE_MARGIN,
+  engagementDistance,
+  MELEE_REACH,
+} from '../scripts/lib/sweep_engagement.mjs';
+import { abilitiesKnownAt } from '../src/sim/content/classes';
+import { CLASSES } from '../src/sim/data';
+import { MAX_LEVEL, type PlayerClass } from '../src/sim/types';
+
+// The row sweep used to walk every class to melee reach, which put the hunter inside
+// the 8 yard dead zone its whole ranged kit refuses to fire from, so the sweep
+// measured a hunter as a bad melee class. These pin the standoff rule that replaced
+// it, including the deliberate no-op for every class that has no dead zone.
+
+const DAMAGE_EFFECTS = new Set([
+  'aoeDamage',
+  'aoeRoot',
+  'directDamage',
+  'dot',
+  'drainTick',
+  'finisherDamage',
+  'groundAoE',
+  'weaponDamage',
+  'weaponStrike',
+]);
+
+function damagingDefsAtCap(cls: PlayerClass): Array<{ minRange?: number; range?: number }> {
+  return abilitiesKnownAt(cls, MAX_LEVEL)
+    .filter((a) => a.def.effects.some((e) => DAMAGE_EFFECTS.has(e.type)))
+    .map((a) => a.def);
+}
+
+describe('engagementDistance', () => {
+  it('holds melee reach when nothing in the kit has a minimum range', () => {
+    expect(engagementDistance([{ range: 30 }, { range: 0 }], { maxRange: 30 })).toBe(MELEE_REACH);
+  });
+
+  it('handles an empty or missing kit', () => {
+    expect(engagementDistance([], null)).toBe(MELEE_REACH);
+    expect(engagementDistance(undefined, undefined)).toBe(MELEE_REACH);
+  });
+
+  it('clears the largest minimum range by the margin', () => {
+    expect(engagementDistance([{ minRange: 8, range: 35 }], { maxRange: 35 })).toBe(
+      8 + DEAD_ZONE_MARGIN,
+    );
+    expect(
+      engagementDistance(
+        [
+          { minRange: 8, range: 35 },
+          { minRange: 12, range: 35 },
+        ],
+        null,
+      ),
+    ).toBe(12 + DEAD_ZONE_MARGIN);
+  });
+
+  it('never steps past the shortest reachable ceiling', () => {
+    // A 25 yd ability with an 8 yd floor caps the standoff at 25, not 10 -> fine, but
+    // a class capped at 9 must not be stationed at 10.
+    expect(engagementDistance([{ minRange: 8, range: 9 }], { maxRange: 35 })).toBe(9);
+    expect(engagementDistance([{ minRange: 8, range: 35 }], { maxRange: 9 })).toBe(9);
+  });
+
+  it('falls back to the floor when the ceiling is inside the dead zone', () => {
+    expect(engagementDistance([{ minRange: 8, range: 6 }], { maxRange: 6 })).toBe(
+      8 + DEAD_ZONE_MARGIN,
+    );
+  });
+});
+
+describe('engagementDistance against the real class kits', () => {
+  it('stations the hunter outside its dead zone', () => {
+    const stand = engagementDistance(damagingDefsAtCap('hunter'), CLASSES.hunter.ranged);
+    expect(stand).toBeGreaterThan(8);
+    expect(stand).toBeLessThanOrEqual(CLASSES.hunter.ranged?.maxRange ?? 35);
+  });
+
+  it('is the hunter alone: every other class keeps standing at melee reach', () => {
+    // The narrow scope is the point. Fixing the sweep must not silently move the
+    // eight classes whose numbers were already measured correctly.
+    const moved = (Object.keys(CLASSES) as PlayerClass[]).filter(
+      (cls) => engagementDistance(damagingDefsAtCap(cls), CLASSES[cls].ranged) !== MELEE_REACH,
+    );
+    expect(moved).toEqual(['hunter']);
+  });
+});


### PR DESCRIPTION
## Summary

Hunters sit at the bottom of the DPS charts in dungeons and raids. This addresses the
pet half of that, and fixes the benchmark that was misreporting it.

**Pets now inherit from their hunter instead of being frozen at tame time.** A tamed pet
was a copy of the wild mob it came from: health and armor came only from that template's
ladder, and `Entity.attackPower` stayed `0` for the pet's entire life. Two things fell out
of that. Hunter gear did nothing whatsoever for the pet, and *which beast you happened to
tame* decided your damage, permanently, with nothing in the UI to tell you. The tameable
ladder spans 306 to 486 health and 17 to 32 dps at level 20, so a hunter still carrying a
starter wolf did about 40% less total damage than one who tamed a level-20 beast.

Pets now take a share of the owner's max health, armor, and ranged attack power, following
the classic-era hunter pet scaling model. Because the share is flat, it is worth
proportionally more to a weak beast, which also compresses that tame lottery.

**Pets keep up with mounts.** Heel speed was floored at a fixed `RUN_SPEED * 1.1` (7.7
yd/s) while mounts put a player at 11.2 to 12.6, so a pet fell behind every mounted owner
until the 60 yd teleport rescued it. It now tracks the owner's actual speed, mount and
buffs included.

**The balance sweep was measuring hunters wrong**, in three independent ways, so the
number everyone was reading was not a balance signal:

- `approach()` walked **every** class to 2.25 yd. Every hunter shot carries `minRange: 8`,
  so Auto Shot, Fell Shot, Venom Barb, Long Draw, Splitshot and Hushing Shot all failed
  with "Too close!" and the sweep measured a hunter as a bad melee class.
- `healerClasses` included `hunter`, pinning it to 60% health each tick and spending its
  global cooldowns self-casting the 3s pet heal.
- Damage was counted only from `sourceId === pid`, and no pet class was ever given a pet,
  discarding roughly half a hunter's real output. (The in-game meter has always folded pet
  damage into its owner, `src/ui/meters.ts`.)

## Type of change

- [x] Feature: new functionality
- [x] Bug fix
- [x] Build, CI, or tooling

## How was this tested?

Commands:

- `npx vitest run tests/pet_scaling.test.ts tests/sweep_engagement.test.ts` (44 tests)
- `npx vitest run tests/parity` (goldens re-minted, see below)
- `npx vitest run tests/architecture.test.ts tests/localization_fixes.test.ts`
- `npx tsc --noEmit`, and biome over every changed file

**The full `npm run gate` has NOT been run end to end on this branch yet.** The suites
above are green, along with the parity, architecture and i18n guards, but the complete
gate still needs a serialized run before merge.

### Why this holds regardless of the hunter rework

The case for this change is structural and does not depend on the rotation, which
matters because the focus-based hunter redesign (PR #2218) lands shortly and would
invalidate any rotation-dependent argument:

- A pet's `attackPower` was literally `0` for its entire life, so hunter gear did
  nothing for it. That is true on both branches.
- Beast pets sit at 407 median health at level 20 against warlock tank demons at 602
  to 928, with an `armorPerLevel` of 8 to 14 against their 38 to 55. Pets were dying
  to AoE that demons survive, and both pet rosters are unchanged by the rework.
- The tameable ladder spans a 92% pet-dps gap end to end, decided once at tame time,
  invisible in the UI, and permanent.
- Heel speed vs mount speed is pure kinematics: 7.7 yd/s against 11.2 to 12.6.

I verified the three owner fields the share reads (`maxHp` basis, `armor` basis, and
`rangedPower = agi * 2`) are byte-identical on the rework, so the code ports unchanged.

### What the pet actually gains

The share is a flat amount on top of whatever the tamed template gives, so it tracks
the owner's gear:

| hunter | maxHP | armor | ranged AP | pet gains |
|---|---:|---:|---:|---|
| starting gear | 725 | 375 | 164 | +181 HP, +131 armor, +36 AP |
| best-in-slot | 1515 | 1153 | 290 | +379 HP, +404 armor, +64 AP |

Starting-gear hunter, level 20:

| beast | HP | armor | swing DPS |
|---|---|---|---|
| forest_wolf (weakest tameable) | 306 to 487 (+59%) | 190 to 321 (+69%) | 17.3 to 19.8 (+15%) |
| mire_prowler (median) | 407 to 588 (+44%) | 228 to 359 (+57%) | 24.3 to 26.8 (+11%) |
| terrace_howler (strongest) | 486 to 667 (+37%) | 247 to 378 (+53%) | 32.1 to 34.7 (+8%) |

Best-in-slot hunter, level 20:

| beast | HP | armor | swing DPS |
|---|---|---|---|
| forest_wolf | 306 to 685 (+124%) | 190 to 594 (+213%) | 17.3 to 21.8 (+27%) |
| mire_prowler | 407 to 786 (+93%) | 228 to 632 (+177%) | 24.3 to 28.8 (+19%) |
| terrace_howler | 486 to 865 (+78%) | 247 to 651 (+164%) | 32.1 to 36.7 (+14%) |

Three things to read off these. It is overwhelmingly a SURVIVABILITY change: health and
armor move far more than damage, because attack power enters as
`+(AP / 14) * weaponSpeed` on top of a template weapon roll rather than as a multiplier.
The weakest beast gains the most everywhere, which is the tame lottery compressing (the
strongest-to-weakest dps ratio narrows from 1.85x to 1.75x, and to 1.68x at best-in-slot).
And every "after" column moves with gear at all, where before this PR it was identical to
"before" no matter what the hunter wore.

For durability context, effective health (health after armor mitigation, level-20
attacker): terrace_howler goes 543 to 787 at starting gear and to 1133 at best-in-slot,
against warlock tank demons at 847 (gloomshade), 873 (warfiend) and 1390 (pyre_colossus).
Warlock pets are deliberately NOT owner-scaled here, so a best-in-slot beast does pass the
two standard tank demons, and the share has no ceiling as future gear tiers raise owner
stats. Flagging that explicitly as a tuning decision rather than an oversight.

### Measured on the rework branch (what will matter shortly)

Cherry-picked onto `integration/v031-class-overhauls` and measured per spec, 180s
sustained, **focus never refilled** so the generator/spender loop is real. Mean of 5
seeds:

| spec | sustained before | after | under raid AoE before | after |
|---|---:|---:|---:|---:|
| beast_mastery | 23.0 | 28.1 (+22%) | 18.1 | 22.6 (+25%) |
| marksmanship | 16.7 | 20.1 (+20%) | 14.6 | 16.6 (+14%) |
| survival | 14.7 | 18.6 (+27%) | 13.7 | 14.6 (+7%) |

Pet health 486 to 667-682, pet uptime 18% to 27%. Notably **no overshoot on Beast
Mastery**, the pet spec, despite its multiplicative Ferocity and Frenzy stack: it gains
+22%, between marksmanship's +20% and survival's +27%, and the spread across specs
tightens slightly (1.56x to 1.51x) rather than skewing.

### Measured on this branch (what merges now)

Same probe shape against the current mana hunter: 29.6 to 35.4 clean, and 23.6 to 32.8
under raid AoE with pet uptime 24% to 33%. These numbers describe a rotation that is on
its way out, so they are recorded for completeness rather than as the argument.

**Determinism.** The parity goldens moved, by design, but only their `state` digests: every
`rng` digest and draw count is byte-identical, which is the correct signature for a
value-only change with no draw reordering. Only `pet_commands.json` changed; the demon-pet
scenarios are correctly untouched because the share is gated on tameable families.

Every new behavior was mutation-tested (revert the line, confirm the matching test turns
red): the follow speed, the AP share, the HP share, the `syncPetLevel` reset, the
`restorePet` application, and the `completeTame` application.

## Notes for the reviewer

**`docs/balance/row-sweep.md` is deliberately NOT regenerated here.** The harness fix
changes what the sweep measures, so the committed chart is now stale with respect to the
script, but regenerating it takes well over half an hour of wall clock (the fixed harness
simulates a pet for 1,458 of the 6,561 builds and the hunter now actually lands its kit),
and nothing gates its freshness. It should be regenerated in a follow-up with
`node scripts/row_build_sweep.mjs`. The before/after numbers quoted above come from a
purpose-built raid-shaped probe, not from that chart.

Two further things deliberately left alone, rather than dropped silently:

1. **A percent stamina aura leaves a small residue** (measured: 9 health on a 587 pool) when
   the pet's pool moves inside a buff window, because `applyNonPlayerStatAura` reverses
   itself off the *current* pool. This predates the change (`syncPetLevel` drops the whole
   aura contribution outright today) and a correct fix means changing the shared non-player
   aura bookkeeping, which warlock pets ride too. It is documented at the call site.
2. **No personal hunter damage buff.** The pet scaling alone moves the numbers above on
   both branches, and it specifically rescues the low-end population rather than lifting
   an already-fine hunter further.

Also worth knowing for whoever picks up the rework: the sweep refills
`player.resource = player.maxResource` every tick, which hands a 100-cap focus hunter
infinite focus and bypasses the generator/spender loop entirely. That is a fourth
harness defect, specific to the reworked hunter, and it is NOT fixed here.

Scoped to hunters on purpose: warlock demons and the mage Water Elemental are authored as
pets with their own tuned pools, while a tamed beast is a wild mob template that was never
balanced to be a companion. The gate shares one predicate with the tame gate so the two
cannot drift.

## Checklist

### Quality

- [ ] **The full gate passes.** Not yet run end to end (see "How was this tested?").
      Targeted suites, the parity/architecture/i18n guards, `tsc`, and changed-file
      biome are all green, and decisive tests were added for every changed behavior.

### Cross-platform

- [x] N/A. No UI, layout, or input surface changes; pet frames render existing values.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings. The one string touched
      (`Only beasts can be tamed.`) is unchanged at the same emit site.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files.
