### PR TITLE
fix(sim): let a pet heel while its owner is mounted

### DIFF
--- a/src/sim/pet/pet_ai.ts
+++ b/src/sim/pet/pet_ai.ts
@@ -103,10 +103,9 @@ export function updatePet(ctx: SimContext, pet: Entity): void {
   let target = pet.aggroTargetId !== null ? (ctx.entities.get(pet.aggroTargetId) ?? null) : null;
   if (target && (target.dead || !ctx.isHostileTo(pet, target) || !petCanSeeTarget(pet, target)))
     target = null;
-  if (target && dist2d(owner.pos, pet.pos) > PET_LEASH) target = null;
-  // Drop a target the pet already had, so mounting up disengages it rather than
-  // leaving it locked on while you ride away.
-  if (travelling) target = null;
+  // Both arms are the same rule: stop fighting something the owner has left behind.
+  // Out of leash range they walked away from it; mounted they rode away from it.
+  if (target && (travelling || dist2d(owner.pos, pet.pos) > PET_LEASH)) target = null;
   if (!target && !owner.dead) target = petPickTarget(ctx, pet, owner);
   pet.aggroTargetId = target?.id ?? null;
   pet.inCombat = target !== null;

--- a/src/sim/pet/pet_ai.ts
+++ b/src/sim/pet/pet_ai.ts
@@ -86,12 +86,27 @@ export function updatePet(ctx: SimContext, pet: Entity): void {
     pet.hp = Math.min(pet.maxHp, pet.hp + Math.max(1, Math.round(pet.maxHp * 0.02)));
   }
 
-  pullNearbyMobs(ctx, pet);
+  // A mounted owner is travelling, so the pet only heels: it neither body-pulls the
+  // camps you ride past nor answers the mobs YOU pulled running through them. Riding
+  // across a zone used to drag the pet into every fight along the way, and no stance
+  // avoided it: defensive correctly answers anything attacking its owner, and even
+  // passive still body-pulled because that scan never consulted the stance.
+  //
+  // This needs no toggling and cannot strand you, because it self-restores: nothing
+  // dismounts you for taking damage, but casting or swinging does (casting_lifecycle,
+  // auto_attack), so the moment you choose to fight the pet is back to normal on the
+  // next tick. Mounting mid-fight is not a way in either, since the summon channel
+  // cancels on entering combat (mounts.ts).
+  const travelling = ownerIsMounted(owner);
+  if (!travelling) pullNearbyMobs(ctx, pet);
 
   let target = pet.aggroTargetId !== null ? (ctx.entities.get(pet.aggroTargetId) ?? null) : null;
   if (target && (target.dead || !ctx.isHostileTo(pet, target) || !petCanSeeTarget(pet, target)))
     target = null;
   if (target && dist2d(owner.pos, pet.pos) > PET_LEASH) target = null;
+  // Drop a target the pet already had, so mounting up disengages it rather than
+  // leaving it locked on while you ride away.
+  if (travelling) target = null;
   if (!target && !owner.dead) target = petPickTarget(ctx, pet, owner);
   pet.aggroTargetId = target?.id ?? null;
   pet.inCombat = target !== null;
@@ -396,8 +411,22 @@ export function startWaterJet(
   pet.petTauntTimer = jet.cooldown;
 }
 
+/**
+ * Whether the owner is riding, and so travelling rather than fighting.
+ *
+ * `Entity.mountKey` is '' when dismounted (types.ts) and only players ever carry one,
+ * so this is false for every other owner.
+ */
+export function ownerIsMounted(owner: Entity): boolean {
+  return (owner.mountKey ?? '') !== '';
+}
+
 export function petPickTarget(ctx: SimContext, pet: Entity, owner: Entity): Entity | null {
   if (pet.petMode === 'passive') return null;
+  // While the owner rides, the pet heels in every stance (see updatePet). Guarding
+  // acquisition here as well as clearing the target there means a pet cannot pick a
+  // new one up mid-ride, in aggressive stance or by assisting.
+  if (ownerIsMounted(owner)) return null;
   // Anti-AFK: an aggressive pet only proactively pulls fresh targets while its
   // owner is actually playing. An idle owner's pet still defends (engagingUs /
   // ownerOffense below) but cannot farm the area alone (hunter/warlock).

--- a/tests/pet_mounted_heel.test.ts
+++ b/tests/pet_mounted_heel.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from 'vitest';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+import { ownerIsMounted, petPickTarget } from '../src/sim/pet/pet_ai';
+import { completeTame, petOf } from '../src/sim/pet/pet_commands';
+import { Sim } from '../src/sim/sim';
+import type { Entity, PetMode } from '../src/sim/types';
+import { terrainHeight } from '../src/sim/world';
+
+// Riding across a zone used to drag the pet into every fight on the way, and no
+// stance avoided it: defensive correctly answers whatever is attacking its owner
+// (which is exactly what you pull running through a camp), and even passive still
+// body-pulled, because that scan never consulted the stance at all. A mounted owner
+// is travelling, so the pet now just heels.
+
+const SEED = 21;
+type AnySim = Sim & Record<string, any>;
+type AnyEntity = Entity & Record<string, any>;
+
+function place(e: AnyEntity, x: number, z: number): void {
+  e.pos = { x, y: terrainHeight(x, z, SEED), z };
+  e.prevPos = { ...e.pos };
+}
+
+function world(mode: PetMode = 'defensive'): {
+  sim: AnySim;
+  hid: number;
+  hunter: AnyEntity;
+  pet: AnyEntity;
+} {
+  const sim = new Sim({ seed: SEED, playerClass: 'hunter', noPlayer: true }) as AnySim;
+  const hid = sim.addPlayer('hunter', 'Rider') as number;
+  sim.setPlayerLevel(20, hid);
+  const hunter = sim.entities.get(hid) as AnyEntity;
+  place(hunter, 300, 300); // open ground, away from the starting camps
+  const beast = createMob(sim.nextId++, MOBS.forest_wolf, 2, {
+    x: hunter.pos.x + 3,
+    y: hunter.pos.y,
+    z: hunter.pos.z,
+  }) as AnyEntity;
+  beast.hostile = true;
+  sim.addEntity(beast);
+  completeTame(sim.ctx, hunter, beast);
+  const pet = petOf(sim.ctx, hid) as AnyEntity;
+  pet.petMode = mode;
+  place(pet, hunter.pos.x + 1, hunter.pos.z);
+  return { sim, hid, hunter, pet };
+}
+
+/** A hostile mob already locked onto the hunter, i.e. what you pull running through. */
+function chaser(sim: AnySim, hunter: AnyEntity): AnyEntity {
+  const m = createMob(sim.nextId++, MOBS.forest_wolf, 20, {
+    x: hunter.pos.x + 4,
+    y: hunter.pos.y,
+    z: hunter.pos.z + 1,
+  }) as AnyEntity;
+  m.hostile = true;
+  m.aiState = 'chase';
+  m.aggroTargetId = hunter.id;
+  sim.addEntity(m);
+  return m;
+}
+
+/** Give the rider a mount they actually own, or updateMountTransition dismounts them. */
+function mount(sim: AnySim, hid: number, hunter: AnyEntity): void {
+  sim.addItem('reins_valorsteed', 1, hid);
+  hunter.mountKey = 'valorsteed';
+}
+
+/**
+ * An idle mob parked beside a LAGGING pet and well outside MAX_AGGRO_RADIUS (20) of
+ * the hunter, so the only thing that can aggro it is the pet's own body-pull. Placing
+ * it near a heeling pet instead would sit inside the hunter's radius and the player
+ * would pull it, which proves nothing about the pet.
+ */
+function strayNearPet(sim: AnySim, hunter: AnyEntity, pet: AnyEntity): AnyEntity {
+  place(pet, hunter.pos.x, hunter.pos.z + 38);
+  const m = createMob(sim.nextId++, MOBS.forest_wolf, 20, {
+    x: pet.pos.x + 2,
+    y: pet.pos.y,
+    z: pet.pos.z,
+  }) as AnyEntity;
+  m.hostile = true;
+  m.aiState = 'idle';
+  m.aggroTargetId = null;
+  m.spawnPos = { ...m.pos };
+  sim.addEntity(m);
+  return m;
+}
+
+describe('ownerIsMounted', () => {
+  it('reads the mount slot, treating the empty string as dismounted', () => {
+    expect(ownerIsMounted({ mountKey: 'valorsteed' } as Entity)).toBe(true);
+    expect(ownerIsMounted({ mountKey: '' } as Entity)).toBe(false);
+    expect(ownerIsMounted({} as Entity)).toBe(false);
+  });
+});
+
+describe('a mounted owner leaves the pet heeling', () => {
+  it('ignores a mob chasing the hunter, which defensive would otherwise answer', () => {
+    const { sim, hid, hunter, pet } = world('defensive');
+    const mob = chaser(sim, hunter);
+    // Control: on foot, this is exactly the case a defensive pet engages.
+    expect(petPickTarget(sim.ctx, pet, hunter)?.id).toBe(mob.id);
+    mount(sim, hid, hunter);
+    expect(petPickTarget(sim.ctx, pet, hunter)).toBeNull();
+  });
+
+  it('holds in aggressive stance too', () => {
+    const { sim, hid, hunter, pet } = world('aggressive');
+    const mob = chaser(sim, hunter);
+    expect(petPickTarget(sim.ctx, pet, hunter)?.id).toBe(mob.id);
+    mount(sim, hid, hunter);
+    expect(petPickTarget(sim.ctx, pet, hunter)).toBeNull();
+  });
+
+  it('drops a target the pet already had when the owner mounts up', () => {
+    const { sim, hid, hunter, pet } = world('defensive');
+    const mob = chaser(sim, hunter);
+    sim.tick();
+    expect(pet.aggroTargetId).toBe(mob.id);
+    mount(sim, hid, hunter);
+    sim.tick();
+    expect(pet.aggroTargetId).toBeNull();
+    expect(pet.inCombat).toBe(false);
+  });
+
+  it('does not body-pull an idle mob the pet rides past', () => {
+    // pullNearbyMobs never consulted the stance, so this is the half that passive
+    // did NOT fix: a trailing pet aggroed camps onto itself regardless.
+    const { sim, hid, hunter, pet } = world('passive');
+    mount(sim, hid, hunter);
+    const idle = strayNearPet(sim, hunter, pet);
+    for (let i = 0; i < 4; i++) sim.tick();
+    expect(idle.aggroTargetId).toBeNull();
+    expect(idle.aiState).toBe('idle');
+  });
+
+  it('still body-pulls that same mob on foot, so the pull itself is intact', () => {
+    const { sim, hunter, pet } = world('passive');
+    const idle = strayNearPet(sim, hunter, pet);
+    for (let i = 0; i < 4; i++) sim.tick();
+    expect(idle.aggroTargetId).toBe(pet.id);
+  });
+
+  it('self-restores the moment the rider dismounts, with no toggling', () => {
+    const { sim, hid, hunter, pet } = world('defensive');
+    const mob = chaser(sim, hunter);
+    mount(sim, hid, hunter);
+    sim.tick();
+    expect(pet.aggroTargetId).toBeNull();
+    hunter.mountKey = ''; // what casting or swinging does via forceDismount
+    sim.tick();
+    expect(pet.aggroTargetId).toBe(mob.id);
+  });
+});


### PR DESCRIPTION
## Summary

Riding across a zone dragged the pet into every fight on the way, and **no pet stance
avoided it**.

Defensive was working exactly as designed: the mobs you pull running through a camp are
attacking *you*, so `petPickTarget`'s `engagingUs` arm fires and the pet turns to fight
them. Switching to passive only half helped, because `pullNearbyMobs` runs before the
stance is ever consulted, so a passive pet still body-pulled the camps it trailed past,
onto itself, and then refused to defend itself from what it had just pulled.

A mounted owner is travelling, so the pet now simply heels: no body-pull, no assist, no
acquisition, in any stance, and it drops a target it already had.

Worth noting, since it was the first thing I assumed and it is wrong: the pet's pull
radius is **not** larger than the player's. Both use
`clamp(4, 20, template.aggroRadius + (mob.level - target.level) * 1.5)`, and `syncPetLevel`
keeps the pet at the owner's level, so the level term matches too. The pet is a second
body on a slightly different line, not a bigger magnet. What differs is the *direction*:
your pull points the mob at you, the pet's points it at the pet, which is what then trips
the defensive assist.

## Why this needs no toggling, and cannot strand you

It self-restores. Nothing dismounts a rider for taking damage, but casting an ability
(`casting_lifecycle.ts`) or auto-attacking (`auto_attack.ts`) does. So the instant you
choose to fight, you are dismounted and the pet is back to normal behavior on the next
tick. There is no state to remember and nothing to toggle back.

Mounting mid-fight is not a way into a bad state either: the mount summon channel cancels
on entering combat (`mounts.ts`), so a pet is never abandoned mid-target by its owner
mounting up.

The one real cost, called out so it is a decision rather than an oversight: if you are
attacked while riding, your pet will not defend you until you act. Acting is instant and
re-arms it, so I think that is the right trade, but it is a behavior change.

## Type of change

- [x] Bug fix

## How was this tested?

- `npx vitest run tests/pet_mounted_heel.test.ts` (7 tests, new)
- `npx vitest run tests/parity tests/architecture.test.ts tests/localization_fixes.test.ts` plus the
  five existing pet suites: 280 passed, and the parity goldens are **unchanged**, since no
  scenario rides with a pet out
- `npx tsc --noEmit`, biome over both changed files

The new suite pins both arms rather than only the fix, because the pull itself must
survive: mounted, an idle mob beside the pet stays idle; on foot, that same mob aggros
onto the pet. It also covers defensive and aggressive stances, dropping an existing
target on mounting, and the dismount self-restore.

Note the geometry in `strayNearPet`: the stray sits beside a deliberately lagging pet and
outside `MAX_AGGRO_RADIUS` of the hunter. My first attempt parked it next to a heeling
pet, which put it inside the *player's* own aggro radius, so the player pulled it and the
test proved nothing about the pet.

**The full `npm run gate` has NOT been run end to end on this branch.** The suites above,
the guards, `tsc` and changed-file biome are green.

## Notes for the reviewer

This deliberately does NOT extend to "a heeling pet never body-pulls". That would let you
walk a pet through a camp unnoticed, which is a real behavioral change and plausibly
exploitable for positioning. Gating on mounted keeps the pet a physical presence in
normal play.

Touches `src/sim/pet/pet_ai.ts`, which PR #2938 (hunter pet scaling) also edits. The two
are independent and the overlap is different functions in the same file, so expect a
trivial conflict at most depending on merge order.

## Checklist

- [ ] **The full gate passes.** Not yet run end to end (see above). Targeted suites, the
      parity/architecture/i18n guards, `tsc` and changed-file biome are green, and decisive
      tests were added for every changed behavior.
- [x] N/A cross-platform. No UI, layout, or input surface changes.
- [x] N/A localization. This PR adds no player-visible strings.
- [x] No secrets committed, `ALLOW_DEV_COMMANDS` untouched, no generated files hand-edited.
