### PR TITLE
fix(ci): repair four inherited failures on the release branch tip

### DIFF
--- a/src/ui/i18n.locales/fr_CA.ts
+++ b/src/ui/i18n.locales/fr_CA.ts
@@ -300,5 +300,4 @@ export const fr_CA: Partial<Record<TranslationKey, string>> = {
   'hud.prompts.guildInviteCancelled':
     'Une invitation de guilde en attente a été annulée parce que la guilde a été renommée.',
   'hud.prompts.guildRenamed': "Votre guilde a été renommée en {name} par l'équipe de modération.",
-  'hudChrome.options.hideUnusedActionSlots': "Masquer les emplacements d'action inutilisés",
 };

--- a/src/ui/i18n.locales/ja_JP.ts
+++ b/src/ui/i18n.locales/ja_JP.ts
@@ -7787,6 +7787,8 @@ export const ja_JP: Partial<Record<TranslationKey, string>> = {
   'editor.layers.blocker': 'ブロッカー壁',
   'editor.status.blockerCapReached':
     'ブロッカー壁の上限（{max}）に達しました。新しい壁は追加されませんでした。',
+  'editor.status.campCapReached':
+    'キャンプの上限（{max}）に達しました。新しいキャンプは追加されませんでした。',
   'editor.help.tool.blocker': 'プレイテストで移動を妨げる見えない壁をドラッグで描きます。',
   'editor.inspector.label': 'ツールオプション',
   'editor.brush.title': 'ブラシ',

--- a/src/ui/i18n.locales/ko_KR.ts
+++ b/src/ui/i18n.locales/ko_KR.ts
@@ -7777,6 +7777,8 @@ export const ko_KR: Partial<Record<TranslationKey, string>> = {
   'editor.layers.blocker': '차단벽',
   'editor.status.blockerCapReached':
     '차단벽 한도({max})에 도달했습니다. 새 벽이 추가되지 않았습니다.',
+  'editor.status.campCapReached':
+    '야영지 한도({max})에 도달했습니다. 새 야영지가 추가되지 않았습니다.',
   'editor.help.tool.blocker': '플레이테스트에서 이동을 막는 보이지 않는 벽을 드래그로 그립니다.',
   'editor.inspector.label': '도구 옵션',
   'editor.brush.title': '브러시',

--- a/src/ui/i18n.locales/ru_RU.ts
+++ b/src/ui/i18n.locales/ru_RU.ts
@@ -7902,6 +7902,7 @@ export const ru_RU: Partial<Record<TranslationKey, string>> = {
   'editor.layers.blocker': 'Невидимые стены',
   'editor.status.blockerCapReached':
     'Достигнут предел невидимых стен ({max}). Новая стена не добавлена.',
+  'editor.status.campCapReached': 'Достигнут предел лагерей ({max}). Новый лагерь не добавлен.',
   'editor.help.tool.blocker': 'Рисует невидимые стены, которые блокируют движение в тестовой игре.',
   'editor.inspector.label': 'Параметры инструмента',
   'editor.brush.title': 'Кисть',

--- a/src/ui/i18n.locales/zh_CN.ts
+++ b/src/ui/i18n.locales/zh_CN.ts
@@ -7462,6 +7462,7 @@ export const zh_CN: Partial<Record<TranslationKey, string>> = {
   'editor.selection.radiusHint': '“自动”根据资源缩放推导碰撞半径；拖动滑块可覆盖它。',
   'editor.layers.blocker': '空气墙',
   'editor.status.blockerCapReached': '已达到空气墙上限（{max}）。新墙未被添加。',
+  'editor.status.campCapReached': '已达到营地上限（{max}）。新营地未被添加。',
   'editor.help.tool.blocker': '拖动绘制在试玩中阻挡移动的隐形墙。',
   'editor.inspector.label': '工具选项',
   'editor.brush.title': '笔刷',

--- a/src/ui/i18n.locales/zh_TW.ts
+++ b/src/ui/i18n.locales/zh_TW.ts
@@ -7461,6 +7461,7 @@ export const zh_TW: Partial<Record<TranslationKey, string>> = {
   'editor.selection.radiusHint': '「自動」依資源縮放推導碰撞半徑；拖曳滑桿可覆寫它。',
   'editor.layers.blocker': '空氣牆',
   'editor.status.blockerCapReached': '已達到空氣牆上限（{max}）。新牆未被加入。',
+  'editor.status.campCapReached': '已達到營地上限（{max}）。新營地未被加入。',
   'editor.help.tool.blocker': '拖曳繪製在試玩中阻擋移動的隱形牆。',
   'editor.inspector.label': '工具選項',
   'editor.brush.title': '筆刷',

--- a/src/ui/i18n.resolved.generated/ja_JP.ts
+++ b/src/ui/i18n.resolved.generated/ja_JP.ts
@@ -5062,7 +5062,7 @@ export const ja_JP: EnTranslations = {
       "terrainCapReached": "地形編集の上限に達しました（{max}）。超過分のスカルプトは追加されませんでした。",
       "placementCapReached": "配置数の上限に達しました（{max}）。超過分のアセットは追加されませんでした。",
       "blockerCapReached": "ブロッカー壁の上限（{max}）に達しました。新しい壁は追加されませんでした。",
-      "campCapReached": "Camp limit reached ({max}). The new camp was not added.",
+      "campCapReached": "キャンプの上限（{max}）に達しました。新しいキャンプは追加されませんでした。",
       "autosaveOff": "自動保存をオフにしました：{reason} 手動で保存してから、再度オンにしてください。"
     },
     "confirm": {

--- a/src/ui/i18n.resolved.generated/ko_KR.ts
+++ b/src/ui/i18n.resolved.generated/ko_KR.ts
@@ -5062,7 +5062,7 @@ export const ko_KR: EnTranslations = {
       "terrainCapReached": "지형 편집 한도에 도달했습니다({max}). 초과된 스컬프트 스탬프는 추가되지 않았습니다.",
       "placementCapReached": "배치 한도에 도달했습니다({max}). 초과된 에셋은 추가되지 않았습니다.",
       "blockerCapReached": "차단벽 한도({max})에 도달했습니다. 새 벽이 추가되지 않았습니다.",
-      "campCapReached": "Camp limit reached ({max}). The new camp was not added.",
+      "campCapReached": "야영지 한도({max})에 도달했습니다. 새 야영지가 추가되지 않았습니다.",
       "autosaveOff": "자동 저장이 꺼졌습니다: {reason} 수동으로 저장한 뒤 다시 켜세요."
     },
     "confirm": {

--- a/src/ui/i18n.resolved.generated/pending.ts
+++ b/src/ui/i18n.resolved.generated/pending.ts
@@ -1079,7 +1079,6 @@ export const pending: Record<string, readonly string[]> = {
     "hudChrome.warfare.reasons.battlegroundWin"
   ],
   "zh_CN": [
-    "editor.status.campCapReached",
     "hudChrome.bg.clock",
     "hudChrome.materialHint.usedBy",
     "hudChrome.mobTooltip.boss",
@@ -1088,7 +1087,6 @@ export const pending: Record<string, readonly string[]> = {
     "hudChrome.pvp.launcherTitle"
   ],
   "zh_TW": [
-    "editor.status.campCapReached",
     "hudChrome.bg.clock",
     "hudChrome.materialHint.usedBy",
     "hudChrome.mobTooltip.boss",
@@ -1097,7 +1095,6 @@ export const pending: Record<string, readonly string[]> = {
     "hudChrome.pvp.launcherTitle"
   ],
   "ko_KR": [
-    "editor.status.campCapReached",
     "hudChrome.bg.clock",
     "hudChrome.materialHint.usedBy",
     "hudChrome.mobTooltip.boss",
@@ -1106,7 +1103,6 @@ export const pending: Record<string, readonly string[]> = {
     "hudChrome.pvp.launcherTitle"
   ],
   "ja_JP": [
-    "editor.status.campCapReached",
     "hudChrome.bg.clock",
     "hudChrome.materialHint.usedBy",
     "hudChrome.mobTooltip.boss",
@@ -1293,7 +1289,6 @@ export const pending: Record<string, readonly string[]> = {
     "hudChrome.warfare.reasons.battlegroundWin"
   ],
   "ru_RU": [
-    "editor.status.campCapReached",
     "hudChrome.bg.clock",
     "hudChrome.materialHint.usedBy",
     "hudChrome.mobTooltip.boss",

--- a/src/ui/i18n.resolved.generated/ru_RU.ts
+++ b/src/ui/i18n.resolved.generated/ru_RU.ts
@@ -5062,7 +5062,7 @@ export const ru_RU: EnTranslations = {
       "terrainCapReached": "Достигнут лимит правок рельефа ({max}). Лишние штампы не были добавлены.",
       "placementCapReached": "Достигнут лимит размещений ({max}). Лишние объекты не были добавлены.",
       "blockerCapReached": "Достигнут предел невидимых стен ({max}). Новая стена не добавлена.",
-      "campCapReached": "Camp limit reached ({max}). The new camp was not added.",
+      "campCapReached": "Достигнут предел лагерей ({max}). Новый лагерь не добавлен.",
       "autosaveOff": "Автосохранение отключено: {reason} Сохраните вручную, затем включите снова."
     },
     "confirm": {

--- a/src/ui/i18n.resolved.generated/zh_CN.ts
+++ b/src/ui/i18n.resolved.generated/zh_CN.ts
@@ -5062,7 +5062,7 @@ export const zh_CN: EnTranslations = {
       "terrainCapReached": "已达到地形编辑上限（{max}）。多余的雕刻印记未被添加。",
       "placementCapReached": "已达到放置上限（{max}）。多余的资源未被添加。",
       "blockerCapReached": "已达到空气墙上限（{max}）。新墙未被添加。",
-      "campCapReached": "Camp limit reached ({max}). The new camp was not added.",
+      "campCapReached": "已达到营地上限（{max}）。新营地未被添加。",
       "autosaveOff": "自动保存已关闭：{reason} 请手动保存后再重新开启。"
     },
     "confirm": {

--- a/src/ui/i18n.resolved.generated/zh_TW.ts
+++ b/src/ui/i18n.resolved.generated/zh_TW.ts
@@ -5062,7 +5062,7 @@ export const zh_TW: EnTranslations = {
       "terrainCapReached": "已達到地形編輯上限（{max}）。多餘的雕刻印記未被加入。",
       "placementCapReached": "已達到放置上限（{max}）。多餘的資源未被加入。",
       "blockerCapReached": "已達到空氣牆上限（{max}）。新牆未被加入。",
-      "campCapReached": "Camp limit reached ({max}). The new camp was not added.",
+      "campCapReached": "已達到營地上限（{max}）。新營地未被加入。",
       "autosaveOff": "自動儲存已關閉：{reason} 請手動儲存後再重新開啟。"
     },
     "confirm": {

--- a/tests/crafting_window_focus.test.ts
+++ b/tests/crafting_window_focus.test.ts
@@ -61,6 +61,7 @@ function craftingDeps(): CraftingWindowDeps {
     onToggleCommission: () => {},
     selectedCraft: () => null,
     onSelectCraft: () => {},
+    onOpenOrders: () => {},
   };
 }
 
@@ -122,27 +123,33 @@ describe('crafting window: Tab focus trap and restore-on-close', () => {
     const capturedOpener = bridge.captureFocus();
     expect(capturedOpener).toBe(opener);
 
-    // Document order: Close (panel-title), the craft's tab-strip button
-    // (.crafting-tabs), then the Craft row button (.crafting-body).
+    // Document order: the commission-board button then Close (both panel-title),
+    // the craft's tab-strip button (.crafting-tabs), then the Craft row button
+    // (.crafting-body).
+    const ordersBtn = el.querySelector<HTMLButtonElement>('[data-open-orders]');
     const closeBtn = el.querySelector<HTMLButtonElement>('[data-close]');
     const tabBtn = el.querySelector<HTMLButtonElement>('.crafting-tab');
     const craftBtn = el.querySelector<HTMLButtonElement>('.crafting-recipe-btn');
+    expect(ordersBtn).not.toBeNull();
     expect(closeBtn).not.toBeNull();
     expect(tabBtn).not.toBeNull();
     expect(craftBtn).not.toBeNull();
     expect(craftBtn?.disabled).toBe(false); // the craftable fixture precondition
 
-    // Walk the full three-control cycle: every Tab is intercepted (the trap
+    // Walk the full four-control cycle: every Tab is intercepted (the trap
     // is really installed, not a no-op that happens to leave focus alone),
-    // and it wraps back to Close rather than ever reaching the opener or body.
-    closeBtn?.focus();
+    // and it wraps back to the first control rather than ever reaching the
+    // opener or body.
+    ordersBtn?.focus();
+    expect(document.activeElement).toBe(ordersBtn);
+    expect(pressTab()).toBe(true);
     expect(document.activeElement).toBe(closeBtn);
     expect(pressTab()).toBe(true);
     expect(document.activeElement).toBe(tabBtn);
     expect(pressTab()).toBe(true);
     expect(document.activeElement).toBe(craftBtn);
     expect(pressTab()).toBe(true);
-    expect(document.activeElement).toBe(closeBtn); // wraps
+    expect(document.activeElement).toBe(ordersBtn); // wraps
     expect(document.activeElement).not.toBe(opener);
     expect(document.activeElement).not.toBe(document.body);
   });


### PR DESCRIPTION
## Summary

`release/v0.35.0` is currently red at its tip, and every PR based on it inherits the failure.
Four PRs merged without a textual conflict but with a semantic one. None of them is wrong on its
own; each pair only breaks once both are in the tree, which is exactly the class of failure a
merge queue does not catch.

Reproduced on a clean checkout of the untouched branch tip (`9a4fce93e`), no local changes:

```
$ npx tsc --noEmit
tests/crafting_window_focus.test.ts(52,3): error TS2741: Property 'onOpenOrders' is missing
  in type '{ ... }' but required in type 'CraftingWindowDeps'.

$ npm run i18n:gen && npx vitest run tests/i18n_dialect_resolution.test.ts tests/i18n_completeness.test.ts
AssertionError: fr_CA overlay key hudChrome.options.hideUnusedActionSlots must diverge
  from its fr_FR base value
AssertionError: untranslated English leaked into non-Latin player surfaces:
  zh_CN editor.status.campCapReached ... (5 locales)
```

**The crafting focus test, two ways.** The commission order board (#2776) added `onOpenOrders`
to `CraftingWindowDeps` and a board button to the crafting panel title. `crafting_window_focus`
builds its own `CraftingWindowDeps` literal, so the new member failed `tsc`, and its Tab cycle
still expected Close as the first focusable when the board button now precedes it in document
order. The stub gains the member and the cycle walks all four controls (board, Close, tab strip,
Craft) rather than three, so it still proves the trap is installed and still proves it wraps
without ever reaching the opener or `body`.

**A dialect overlay row identical to its base.** `fr_CA` is a divergence-only overlay, so a row
byte-identical to `fr_FR` is a defect by construction: `tests/i18n_dialect_resolution.test.ts`
asserts every overlay key overrides its base, and an identical value cannot. Deleting the row is
the fix, not editing it: the omitted key falls through to `fr_FR` and renders the same string, so
this is a no-op for players. That is what #2955 already did for the `fr_CA direfang_quiver` row,
which is the same defect one PR earlier.

**A wordy English key with no non-Latin fills.** `editor.status.campCapReached` (#2894) is prose,
so the M16 rule applies and `tests/i18n_completeness.test.ts` reds at PR tier when the build
English-fills it into the five non-Latin locales. Filled from its `blockerCapReached` sibling,
which is the same sentence shape and already translated in all five, so the camp string reuses
each locale's established term (`营地` / `營地` / `キャンプ` / `야영지` / `Лагерь`) from the
existing `editor.tool.camp` and `editor.camp.title` rows.

I am a contributor rather than the maintainer, so per `src/ui/CLAUDE.md` I would normally add
English only and leave the overlays alone. Flagging that I edited them deliberately: these are a
row DELETION and one M16 fill that the rule says must land with the key, both of them repairs to
already-merged work rather than new strings of mine, and the branch stays red for everyone until
someone does it. Happy to drop the i18n half if you would rather fill it at release.

## Related issues

N/A. Found while diagnosing an inherited CI failure on #2953.

## Type of change

- [ ] Bug fix
- [ ] Feature: new functionality
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [ ] Tests
- [x] Build, CI, or tooling
- [ ] Breaking change

## How was this tested?

- Commands:
  - `npx tsc --noEmit` (clean; fails on the untouched branch tip)
  - `npx vitest run tests/crafting_window_focus.test.ts tests/i18n_dialect_resolution.test.ts tests/i18n_completeness.test.ts` (22 passed; 2 files fail on the untouched tip)
  - `npm run i18n:gen` (deterministic: a second run leaves the tree clean)
  - `npx @biomejs/biome check` on every changed file
  - the pre-push QA floor (green)
- Each of the four failures was reproduced FIRST on a clean worktree of `origin/release/v0.35.0`
  with no changes applied, which is what rules out this being anything about my branch.
- The Tab-cycle case is the one behavioral change rather than a mechanical fix: it now asserts
  the board button is present, is the first control, and is what the wrap lands on. It fails
  against the pre-fix expectation.

## Screenshots / recordings

N/A. No visual change: a test stub, a deleted overlay row that resolves to the identical string,
and five translations of an existing editor status message.

---

## Checklist

### Quality

- [x] `tsc`, the three previously failing suites, changed-files biome, and the pre-push floor are
      all green. The full gate is not the check that matters here: what matters is that the four
      failures reproduce on the untouched tip and do not reproduce with this branch applied.

### Cross-platform

- [x] N/A. No sim, server, or renderer surface; nothing platform-specific.

### Localization (i18n)

- [x] No new English keys. `editor.status.campCapReached` already exists; this supplies the five
      non-Latin fills M16 requires, mirroring its `blockerCapReached` sibling and reusing the
      camp term each locale already uses.
- [x] The deleted `fr_CA` row changes no rendered string: a dialect overlay omission resolves to
      the `fr_FR` base, which held the identical value.
- [x] Generated files under `i18n.resolved.generated/` are `npm run i18n:gen` output, not
      hand-edited.

### Hygiene

- [x] No secrets or `.env`; `ALLOW_DEV_COMMANDS` untouched.
- [x] No generated files hand-edited.

### Notes for the reviewer

- Worth landing before the other open PRs on this base: they are all inheriting at least the
  `tsc` failure, and their red CI is currently indistinguishable from a real regression.
- The `fr_CA` and `es_ES` duplicate-value defect has now appeared twice in consecutive PRs
  (`direfang_quiver` in #2955, `hideUnusedActionSlots` here). If the release fill is generating
  dialect rows by copying the base, that is worth fixing at the tool rather than one row at a
  time.
