### PR TITLE
fix(render): vfx performance improvements batch B

### DIFF
--- a/docs/screenshots/eastbrook-vale-rebuild/polish/metadata/after-desktop-ultra.json
+++ b/docs/screenshots/eastbrook-vale-rebuild/polish/metadata/after-desktop-ultra.json
@@ -11,7 +11,7 @@
     "mode": "composite-sha256",
     "algorithm": "sha256",
     "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-    "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+    "fingerprint": "6f8df557520fb299864269a31435143500b315523f8301c183faf227d4491559",
     "components": {
       "townAsset": {
         "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -40,11 +40,11 @@
         },
         "renderer": {
           "path": "src/render/renderer.ts",
-          "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+          "sha256": "8b6065763e606077324d2226adad8a4812b525c6f2fa4b5a5e309a6c773da10f"
         },
         "viewPriorityPolicy": {
           "path": "src/render/prewarm_policy.ts",
-          "sha256": "7a6b8bf7e88cb6a190efd672ed0987387633d6d08935344b61550825bcb3892b"
+          "sha256": "b3665ec4aed3caf4b6798a0b7d851fd71bdc6c61f819f89f3ed2d99c12ec8890"
         }
       },
       "mailbox": {
@@ -85,7 +85,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "6f8df557520fb299864269a31435143500b315523f8301c183faf227d4491559",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -114,11 +114,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "8b6065763e606077324d2226adad8a4812b525c6f2fa4b5a5e309a6c773da10f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "7a6b8bf7e88cb6a190efd672ed0987387633d6d08935344b61550825bcb3892b"
+              "sha256": "b3665ec4aed3caf4b6798a0b7d851fd71bdc6c61f819f89f3ed2d99c12ec8890"
             }
           },
           "mailbox": {
@@ -1377,7 +1377,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "6f8df557520fb299864269a31435143500b315523f8301c183faf227d4491559",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -1406,11 +1406,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "8b6065763e606077324d2226adad8a4812b525c6f2fa4b5a5e309a6c773da10f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "7a6b8bf7e88cb6a190efd672ed0987387633d6d08935344b61550825bcb3892b"
+              "sha256": "b3665ec4aed3caf4b6798a0b7d851fd71bdc6c61f819f89f3ed2d99c12ec8890"
             }
           },
           "mailbox": {
@@ -2669,7 +2669,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "6f8df557520fb299864269a31435143500b315523f8301c183faf227d4491559",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -2698,11 +2698,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "8b6065763e606077324d2226adad8a4812b525c6f2fa4b5a5e309a6c773da10f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "7a6b8bf7e88cb6a190efd672ed0987387633d6d08935344b61550825bcb3892b"
+              "sha256": "b3665ec4aed3caf4b6798a0b7d851fd71bdc6c61f819f89f3ed2d99c12ec8890"
             }
           },
           "mailbox": {
@@ -3961,7 +3961,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "6f8df557520fb299864269a31435143500b315523f8301c183faf227d4491559",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -3990,11 +3990,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "8b6065763e606077324d2226adad8a4812b525c6f2fa4b5a5e309a6c773da10f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "7a6b8bf7e88cb6a190efd672ed0987387633d6d08935344b61550825bcb3892b"
+              "sha256": "b3665ec4aed3caf4b6798a0b7d851fd71bdc6c61f819f89f3ed2d99c12ec8890"
             }
           },
           "mailbox": {
@@ -5253,7 +5253,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "6f8df557520fb299864269a31435143500b315523f8301c183faf227d4491559",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -5282,11 +5282,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "8b6065763e606077324d2226adad8a4812b525c6f2fa4b5a5e309a6c773da10f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "7a6b8bf7e88cb6a190efd672ed0987387633d6d08935344b61550825bcb3892b"
+              "sha256": "b3665ec4aed3caf4b6798a0b7d851fd71bdc6c61f819f89f3ed2d99c12ec8890"
             }
           },
           "mailbox": {
@@ -6545,7 +6545,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "6f8df557520fb299864269a31435143500b315523f8301c183faf227d4491559",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -6574,11 +6574,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "8b6065763e606077324d2226adad8a4812b525c6f2fa4b5a5e309a6c773da10f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "7a6b8bf7e88cb6a190efd672ed0987387633d6d08935344b61550825bcb3892b"
+              "sha256": "b3665ec4aed3caf4b6798a0b7d851fd71bdc6c61f819f89f3ed2d99c12ec8890"
             }
           },
           "mailbox": {
@@ -7837,7 +7837,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "6f8df557520fb299864269a31435143500b315523f8301c183faf227d4491559",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -7866,11 +7866,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "8b6065763e606077324d2226adad8a4812b525c6f2fa4b5a5e309a6c773da10f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "7a6b8bf7e88cb6a190efd672ed0987387633d6d08935344b61550825bcb3892b"
+              "sha256": "b3665ec4aed3caf4b6798a0b7d851fd71bdc6c61f819f89f3ed2d99c12ec8890"
             }
           },
           "mailbox": {
@@ -9129,7 +9129,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "6f8df557520fb299864269a31435143500b315523f8301c183faf227d4491559",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -9158,11 +9158,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "8b6065763e606077324d2226adad8a4812b525c6f2fa4b5a5e309a6c773da10f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "7a6b8bf7e88cb6a190efd672ed0987387633d6d08935344b61550825bcb3892b"
+              "sha256": "b3665ec4aed3caf4b6798a0b7d851fd71bdc6c61f819f89f3ed2d99c12ec8890"
             }
           },
           "mailbox": {
@@ -10421,7 +10421,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "6f8df557520fb299864269a31435143500b315523f8301c183faf227d4491559",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -10450,11 +10450,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "8b6065763e606077324d2226adad8a4812b525c6f2fa4b5a5e309a6c773da10f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "7a6b8bf7e88cb6a190efd672ed0987387633d6d08935344b61550825bcb3892b"
+              "sha256": "b3665ec4aed3caf4b6798a0b7d851fd71bdc6c61f819f89f3ed2d99c12ec8890"
             }
           },
           "mailbox": {
@@ -11713,7 +11713,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "6f8df557520fb299864269a31435143500b315523f8301c183faf227d4491559",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -11742,11 +11742,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "8b6065763e606077324d2226adad8a4812b525c6f2fa4b5a5e309a6c773da10f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "7a6b8bf7e88cb6a190efd672ed0987387633d6d08935344b61550825bcb3892b"
+              "sha256": "b3665ec4aed3caf4b6798a0b7d851fd71bdc6c61f819f89f3ed2d99c12ec8890"
             }
           },
           "mailbox": {
@@ -13005,7 +13005,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "6f8df557520fb299864269a31435143500b315523f8301c183faf227d4491559",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -13034,11 +13034,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "8b6065763e606077324d2226adad8a4812b525c6f2fa4b5a5e309a6c773da10f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "7a6b8bf7e88cb6a190efd672ed0987387633d6d08935344b61550825bcb3892b"
+              "sha256": "b3665ec4aed3caf4b6798a0b7d851fd71bdc6c61f819f89f3ed2d99c12ec8890"
             }
           },
           "mailbox": {
@@ -14297,7 +14297,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "6f8df557520fb299864269a31435143500b315523f8301c183faf227d4491559",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -14326,11 +14326,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "8b6065763e606077324d2226adad8a4812b525c6f2fa4b5a5e309a6c773da10f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "7a6b8bf7e88cb6a190efd672ed0987387633d6d08935344b61550825bcb3892b"
+              "sha256": "b3665ec4aed3caf4b6798a0b7d851fd71bdc6c61f819f89f3ed2d99c12ec8890"
             }
           },
           "mailbox": {
@@ -15589,7 +15589,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "6f8df557520fb299864269a31435143500b315523f8301c183faf227d4491559",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -15618,11 +15618,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "8b6065763e606077324d2226adad8a4812b525c6f2fa4b5a5e309a6c773da10f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "7a6b8bf7e88cb6a190efd672ed0987387633d6d08935344b61550825bcb3892b"
+              "sha256": "b3665ec4aed3caf4b6798a0b7d851fd71bdc6c61f819f89f3ed2d99c12ec8890"
             }
           },
           "mailbox": {
@@ -16881,7 +16881,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "6f8df557520fb299864269a31435143500b315523f8301c183faf227d4491559",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -16910,11 +16910,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "8b6065763e606077324d2226adad8a4812b525c6f2fa4b5a5e309a6c773da10f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "7a6b8bf7e88cb6a190efd672ed0987387633d6d08935344b61550825bcb3892b"
+              "sha256": "b3665ec4aed3caf4b6798a0b7d851fd71bdc6c61f819f89f3ed2d99c12ec8890"
             }
           },
           "mailbox": {
@@ -19138,7 +19138,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "6f8df557520fb299864269a31435143500b315523f8301c183faf227d4491559",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -19167,11 +19167,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "8b6065763e606077324d2226adad8a4812b525c6f2fa4b5a5e309a6c773da10f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "7a6b8bf7e88cb6a190efd672ed0987387633d6d08935344b61550825bcb3892b"
+              "sha256": "b3665ec4aed3caf4b6798a0b7d851fd71bdc6c61f819f89f3ed2d99c12ec8890"
             }
           },
           "mailbox": {
@@ -20430,7 +20430,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "6f8df557520fb299864269a31435143500b315523f8301c183faf227d4491559",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -20459,11 +20459,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "8b6065763e606077324d2226adad8a4812b525c6f2fa4b5a5e309a6c773da10f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "7a6b8bf7e88cb6a190efd672ed0987387633d6d08935344b61550825bcb3892b"
+              "sha256": "b3665ec4aed3caf4b6798a0b7d851fd71bdc6c61f819f89f3ed2d99c12ec8890"
             }
           },
           "mailbox": {
@@ -21722,7 +21722,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "6f8df557520fb299864269a31435143500b315523f8301c183faf227d4491559",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -21751,11 +21751,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "8b6065763e606077324d2226adad8a4812b525c6f2fa4b5a5e309a6c773da10f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "7a6b8bf7e88cb6a190efd672ed0987387633d6d08935344b61550825bcb3892b"
+              "sha256": "b3665ec4aed3caf4b6798a0b7d851fd71bdc6c61f819f89f3ed2d99c12ec8890"
             }
           },
           "mailbox": {
@@ -23014,7 +23014,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "6f8df557520fb299864269a31435143500b315523f8301c183faf227d4491559",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -23043,11 +23043,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "8b6065763e606077324d2226adad8a4812b525c6f2fa4b5a5e309a6c773da10f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "7a6b8bf7e88cb6a190efd672ed0987387633d6d08935344b61550825bcb3892b"
+              "sha256": "b3665ec4aed3caf4b6798a0b7d851fd71bdc6c61f819f89f3ed2d99c12ec8890"
             }
           },
           "mailbox": {
@@ -24306,7 +24306,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "6f8df557520fb299864269a31435143500b315523f8301c183faf227d4491559",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -24335,11 +24335,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "8b6065763e606077324d2226adad8a4812b525c6f2fa4b5a5e309a6c773da10f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "7a6b8bf7e88cb6a190efd672ed0987387633d6d08935344b61550825bcb3892b"
+              "sha256": "b3665ec4aed3caf4b6798a0b7d851fd71bdc6c61f819f89f3ed2d99c12ec8890"
             }
           },
           "mailbox": {
@@ -25598,7 +25598,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "6f8df557520fb299864269a31435143500b315523f8301c183faf227d4491559",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -25627,11 +25627,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "8b6065763e606077324d2226adad8a4812b525c6f2fa4b5a5e309a6c773da10f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "7a6b8bf7e88cb6a190efd672ed0987387633d6d08935344b61550825bcb3892b"
+              "sha256": "b3665ec4aed3caf4b6798a0b7d851fd71bdc6c61f819f89f3ed2d99c12ec8890"
             }
           },
           "mailbox": {
@@ -26890,7 +26890,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "6f8df557520fb299864269a31435143500b315523f8301c183faf227d4491559",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -26919,11 +26919,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "8b6065763e606077324d2226adad8a4812b525c6f2fa4b5a5e309a6c773da10f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "7a6b8bf7e88cb6a190efd672ed0987387633d6d08935344b61550825bcb3892b"
+              "sha256": "b3665ec4aed3caf4b6798a0b7d851fd71bdc6c61f819f89f3ed2d99c12ec8890"
             }
           },
           "mailbox": {
@@ -28235,7 +28235,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "6f8df557520fb299864269a31435143500b315523f8301c183faf227d4491559",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -28264,11 +28264,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "8b6065763e606077324d2226adad8a4812b525c6f2fa4b5a5e309a6c773da10f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "7a6b8bf7e88cb6a190efd672ed0987387633d6d08935344b61550825bcb3892b"
+              "sha256": "b3665ec4aed3caf4b6798a0b7d851fd71bdc6c61f819f89f3ed2d99c12ec8890"
             }
           },
           "mailbox": {
@@ -29527,7 +29527,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "6f8df557520fb299864269a31435143500b315523f8301c183faf227d4491559",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -29556,11 +29556,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "8b6065763e606077324d2226adad8a4812b525c6f2fa4b5a5e309a6c773da10f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "7a6b8bf7e88cb6a190efd672ed0987387633d6d08935344b61550825bcb3892b"
+              "sha256": "b3665ec4aed3caf4b6798a0b7d851fd71bdc6c61f819f89f3ed2d99c12ec8890"
             }
           },
           "mailbox": {

--- a/docs/screenshots/eastbrook-vale-rebuild/polish/metadata/after-mobile-low.json
+++ b/docs/screenshots/eastbrook-vale-rebuild/polish/metadata/after-mobile-low.json
@@ -11,7 +11,7 @@
     "mode": "composite-sha256",
     "algorithm": "sha256",
     "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-    "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+    "fingerprint": "6f8df557520fb299864269a31435143500b315523f8301c183faf227d4491559",
     "components": {
       "townAsset": {
         "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -40,11 +40,11 @@
         },
         "renderer": {
           "path": "src/render/renderer.ts",
-          "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+          "sha256": "8b6065763e606077324d2226adad8a4812b525c6f2fa4b5a5e309a6c773da10f"
         },
         "viewPriorityPolicy": {
           "path": "src/render/prewarm_policy.ts",
-          "sha256": "7a6b8bf7e88cb6a190efd672ed0987387633d6d08935344b61550825bcb3892b"
+          "sha256": "b3665ec4aed3caf4b6798a0b7d851fd71bdc6c61f819f89f3ed2d99c12ec8890"
         }
       },
       "mailbox": {
@@ -85,7 +85,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "6f8df557520fb299864269a31435143500b315523f8301c183faf227d4491559",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -114,11 +114,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "8b6065763e606077324d2226adad8a4812b525c6f2fa4b5a5e309a6c773da10f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "7a6b8bf7e88cb6a190efd672ed0987387633d6d08935344b61550825bcb3892b"
+              "sha256": "b3665ec4aed3caf4b6798a0b7d851fd71bdc6c61f819f89f3ed2d99c12ec8890"
             }
           },
           "mailbox": {
@@ -1360,7 +1360,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "6f8df557520fb299864269a31435143500b315523f8301c183faf227d4491559",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -1389,11 +1389,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "8b6065763e606077324d2226adad8a4812b525c6f2fa4b5a5e309a6c773da10f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "7a6b8bf7e88cb6a190efd672ed0987387633d6d08935344b61550825bcb3892b"
+              "sha256": "b3665ec4aed3caf4b6798a0b7d851fd71bdc6c61f819f89f3ed2d99c12ec8890"
             }
           },
           "mailbox": {
@@ -2635,7 +2635,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "6f8df557520fb299864269a31435143500b315523f8301c183faf227d4491559",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -2664,11 +2664,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "8b6065763e606077324d2226adad8a4812b525c6f2fa4b5a5e309a6c773da10f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "7a6b8bf7e88cb6a190efd672ed0987387633d6d08935344b61550825bcb3892b"
+              "sha256": "b3665ec4aed3caf4b6798a0b7d851fd71bdc6c61f819f89f3ed2d99c12ec8890"
             }
           },
           "mailbox": {
@@ -3910,7 +3910,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "6f8df557520fb299864269a31435143500b315523f8301c183faf227d4491559",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -3939,11 +3939,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "8b6065763e606077324d2226adad8a4812b525c6f2fa4b5a5e309a6c773da10f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "7a6b8bf7e88cb6a190efd672ed0987387633d6d08935344b61550825bcb3892b"
+              "sha256": "b3665ec4aed3caf4b6798a0b7d851fd71bdc6c61f819f89f3ed2d99c12ec8890"
             }
           },
           "mailbox": {
@@ -5185,7 +5185,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "6f8df557520fb299864269a31435143500b315523f8301c183faf227d4491559",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -5214,11 +5214,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "8b6065763e606077324d2226adad8a4812b525c6f2fa4b5a5e309a6c773da10f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "7a6b8bf7e88cb6a190efd672ed0987387633d6d08935344b61550825bcb3892b"
+              "sha256": "b3665ec4aed3caf4b6798a0b7d851fd71bdc6c61f819f89f3ed2d99c12ec8890"
             }
           },
           "mailbox": {
@@ -6460,7 +6460,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "6f8df557520fb299864269a31435143500b315523f8301c183faf227d4491559",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -6489,11 +6489,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "8b6065763e606077324d2226adad8a4812b525c6f2fa4b5a5e309a6c773da10f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "7a6b8bf7e88cb6a190efd672ed0987387633d6d08935344b61550825bcb3892b"
+              "sha256": "b3665ec4aed3caf4b6798a0b7d851fd71bdc6c61f819f89f3ed2d99c12ec8890"
             }
           },
           "mailbox": {
@@ -7735,7 +7735,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "6f8df557520fb299864269a31435143500b315523f8301c183faf227d4491559",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -7764,11 +7764,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "8b6065763e606077324d2226adad8a4812b525c6f2fa4b5a5e309a6c773da10f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "7a6b8bf7e88cb6a190efd672ed0987387633d6d08935344b61550825bcb3892b"
+              "sha256": "b3665ec4aed3caf4b6798a0b7d851fd71bdc6c61f819f89f3ed2d99c12ec8890"
             }
           },
           "mailbox": {
@@ -9010,7 +9010,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "6f8df557520fb299864269a31435143500b315523f8301c183faf227d4491559",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -9039,11 +9039,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "8b6065763e606077324d2226adad8a4812b525c6f2fa4b5a5e309a6c773da10f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "7a6b8bf7e88cb6a190efd672ed0987387633d6d08935344b61550825bcb3892b"
+              "sha256": "b3665ec4aed3caf4b6798a0b7d851fd71bdc6c61f819f89f3ed2d99c12ec8890"
             }
           },
           "mailbox": {
@@ -10285,7 +10285,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "6f8df557520fb299864269a31435143500b315523f8301c183faf227d4491559",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -10314,11 +10314,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "8b6065763e606077324d2226adad8a4812b525c6f2fa4b5a5e309a6c773da10f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "7a6b8bf7e88cb6a190efd672ed0987387633d6d08935344b61550825bcb3892b"
+              "sha256": "b3665ec4aed3caf4b6798a0b7d851fd71bdc6c61f819f89f3ed2d99c12ec8890"
             }
           },
           "mailbox": {
@@ -11560,7 +11560,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "6f8df557520fb299864269a31435143500b315523f8301c183faf227d4491559",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -11589,11 +11589,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "8b6065763e606077324d2226adad8a4812b525c6f2fa4b5a5e309a6c773da10f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "7a6b8bf7e88cb6a190efd672ed0987387633d6d08935344b61550825bcb3892b"
+              "sha256": "b3665ec4aed3caf4b6798a0b7d851fd71bdc6c61f819f89f3ed2d99c12ec8890"
             }
           },
           "mailbox": {
@@ -12835,7 +12835,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "6f8df557520fb299864269a31435143500b315523f8301c183faf227d4491559",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -12864,11 +12864,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "8b6065763e606077324d2226adad8a4812b525c6f2fa4b5a5e309a6c773da10f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "7a6b8bf7e88cb6a190efd672ed0987387633d6d08935344b61550825bcb3892b"
+              "sha256": "b3665ec4aed3caf4b6798a0b7d851fd71bdc6c61f819f89f3ed2d99c12ec8890"
             }
           },
           "mailbox": {
@@ -14110,7 +14110,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "6f8df557520fb299864269a31435143500b315523f8301c183faf227d4491559",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -14139,11 +14139,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "8b6065763e606077324d2226adad8a4812b525c6f2fa4b5a5e309a6c773da10f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "7a6b8bf7e88cb6a190efd672ed0987387633d6d08935344b61550825bcb3892b"
+              "sha256": "b3665ec4aed3caf4b6798a0b7d851fd71bdc6c61f819f89f3ed2d99c12ec8890"
             }
           },
           "mailbox": {
@@ -15385,7 +15385,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "6f8df557520fb299864269a31435143500b315523f8301c183faf227d4491559",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -15414,11 +15414,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "8b6065763e606077324d2226adad8a4812b525c6f2fa4b5a5e309a6c773da10f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "7a6b8bf7e88cb6a190efd672ed0987387633d6d08935344b61550825bcb3892b"
+              "sha256": "b3665ec4aed3caf4b6798a0b7d851fd71bdc6c61f819f89f3ed2d99c12ec8890"
             }
           },
           "mailbox": {
@@ -16660,7 +16660,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "6f8df557520fb299864269a31435143500b315523f8301c183faf227d4491559",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -16689,11 +16689,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "8b6065763e606077324d2226adad8a4812b525c6f2fa4b5a5e309a6c773da10f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "7a6b8bf7e88cb6a190efd672ed0987387633d6d08935344b61550825bcb3892b"
+              "sha256": "b3665ec4aed3caf4b6798a0b7d851fd71bdc6c61f819f89f3ed2d99c12ec8890"
             }
           },
           "mailbox": {
@@ -18900,7 +18900,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "6f8df557520fb299864269a31435143500b315523f8301c183faf227d4491559",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -18929,11 +18929,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "8b6065763e606077324d2226adad8a4812b525c6f2fa4b5a5e309a6c773da10f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "7a6b8bf7e88cb6a190efd672ed0987387633d6d08935344b61550825bcb3892b"
+              "sha256": "b3665ec4aed3caf4b6798a0b7d851fd71bdc6c61f819f89f3ed2d99c12ec8890"
             }
           },
           "mailbox": {
@@ -20175,7 +20175,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "6f8df557520fb299864269a31435143500b315523f8301c183faf227d4491559",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -20204,11 +20204,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "8b6065763e606077324d2226adad8a4812b525c6f2fa4b5a5e309a6c773da10f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "7a6b8bf7e88cb6a190efd672ed0987387633d6d08935344b61550825bcb3892b"
+              "sha256": "b3665ec4aed3caf4b6798a0b7d851fd71bdc6c61f819f89f3ed2d99c12ec8890"
             }
           },
           "mailbox": {
@@ -21450,7 +21450,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "6f8df557520fb299864269a31435143500b315523f8301c183faf227d4491559",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -21479,11 +21479,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "8b6065763e606077324d2226adad8a4812b525c6f2fa4b5a5e309a6c773da10f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "7a6b8bf7e88cb6a190efd672ed0987387633d6d08935344b61550825bcb3892b"
+              "sha256": "b3665ec4aed3caf4b6798a0b7d851fd71bdc6c61f819f89f3ed2d99c12ec8890"
             }
           },
           "mailbox": {
@@ -22725,7 +22725,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "6f8df557520fb299864269a31435143500b315523f8301c183faf227d4491559",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -22754,11 +22754,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "8b6065763e606077324d2226adad8a4812b525c6f2fa4b5a5e309a6c773da10f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "7a6b8bf7e88cb6a190efd672ed0987387633d6d08935344b61550825bcb3892b"
+              "sha256": "b3665ec4aed3caf4b6798a0b7d851fd71bdc6c61f819f89f3ed2d99c12ec8890"
             }
           },
           "mailbox": {
@@ -24000,7 +24000,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "6f8df557520fb299864269a31435143500b315523f8301c183faf227d4491559",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -24029,11 +24029,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "8b6065763e606077324d2226adad8a4812b525c6f2fa4b5a5e309a6c773da10f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "7a6b8bf7e88cb6a190efd672ed0987387633d6d08935344b61550825bcb3892b"
+              "sha256": "b3665ec4aed3caf4b6798a0b7d851fd71bdc6c61f819f89f3ed2d99c12ec8890"
             }
           },
           "mailbox": {
@@ -25275,7 +25275,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "6f8df557520fb299864269a31435143500b315523f8301c183faf227d4491559",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -25304,11 +25304,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "8b6065763e606077324d2226adad8a4812b525c6f2fa4b5a5e309a6c773da10f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "7a6b8bf7e88cb6a190efd672ed0987387633d6d08935344b61550825bcb3892b"
+              "sha256": "b3665ec4aed3caf4b6798a0b7d851fd71bdc6c61f819f89f3ed2d99c12ec8890"
             }
           },
           "mailbox": {
@@ -26550,7 +26550,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "6f8df557520fb299864269a31435143500b315523f8301c183faf227d4491559",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -26579,11 +26579,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "8b6065763e606077324d2226adad8a4812b525c6f2fa4b5a5e309a6c773da10f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "7a6b8bf7e88cb6a190efd672ed0987387633d6d08935344b61550825bcb3892b"
+              "sha256": "b3665ec4aed3caf4b6798a0b7d851fd71bdc6c61f819f89f3ed2d99c12ec8890"
             }
           },
           "mailbox": {
@@ -27878,7 +27878,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "6f8df557520fb299864269a31435143500b315523f8301c183faf227d4491559",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -27907,11 +27907,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "8b6065763e606077324d2226adad8a4812b525c6f2fa4b5a5e309a6c773da10f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "7a6b8bf7e88cb6a190efd672ed0987387633d6d08935344b61550825bcb3892b"
+              "sha256": "b3665ec4aed3caf4b6798a0b7d851fd71bdc6c61f819f89f3ed2d99c12ec8890"
             }
           },
           "mailbox": {
@@ -29153,7 +29153,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "6f8df557520fb299864269a31435143500b315523f8301c183faf227d4491559",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -29182,11 +29182,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "8b6065763e606077324d2226adad8a4812b525c6f2fa4b5a5e309a6c773da10f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "7a6b8bf7e88cb6a190efd672ed0987387633d6d08935344b61550825bcb3892b"
+              "sha256": "b3665ec4aed3caf4b6798a0b7d851fd71bdc6c61f819f89f3ed2d99c12ec8890"
             }
           },
           "mailbox": {

--- a/docs/screenshots/eastbrook-vale-rebuild/polish/performance/after-desktop-ultra-town.json
+++ b/docs/screenshots/eastbrook-vale-rebuild/polish/performance/after-desktop-ultra-town.json
@@ -14,7 +14,7 @@
     "mode": "composite-sha256",
     "algorithm": "sha256",
     "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-    "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+    "fingerprint": "6f8df557520fb299864269a31435143500b315523f8301c183faf227d4491559",
     "components": {
       "townAsset": {
         "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -43,11 +43,11 @@
         },
         "renderer": {
           "path": "src/render/renderer.ts",
-          "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+          "sha256": "8b6065763e606077324d2226adad8a4812b525c6f2fa4b5a5e309a6c773da10f"
         },
         "viewPriorityPolicy": {
           "path": "src/render/prewarm_policy.ts",
-          "sha256": "7a6b8bf7e88cb6a190efd672ed0987387633d6d08935344b61550825bcb3892b"
+          "sha256": "b3665ec4aed3caf4b6798a0b7d851fd71bdc6c61f819f89f3ed2d99c12ec8890"
         }
       },
       "mailbox": {

--- a/docs/screenshots/eastbrook-vale-rebuild/polish/performance/after-mobile-low-town.json
+++ b/docs/screenshots/eastbrook-vale-rebuild/polish/performance/after-mobile-low-town.json
@@ -14,7 +14,7 @@
     "mode": "composite-sha256",
     "algorithm": "sha256",
     "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-    "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+    "fingerprint": "6f8df557520fb299864269a31435143500b315523f8301c183faf227d4491559",
     "components": {
       "townAsset": {
         "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -43,11 +43,11 @@
         },
         "renderer": {
           "path": "src/render/renderer.ts",
-          "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+          "sha256": "8b6065763e606077324d2226adad8a4812b525c6f2fa4b5a5e309a6c773da10f"
         },
         "viewPriorityPolicy": {
           "path": "src/render/prewarm_policy.ts",
-          "sha256": "7a6b8bf7e88cb6a190efd672ed0987387633d6d08935344b61550825bcb3892b"
+          "sha256": "b3665ec4aed3caf4b6798a0b7d851fd71bdc6c61f819f89f3ed2d99c12ec8890"
         }
       },
       "mailbox": {

--- a/src/render/CLAUDE.md
+++ b/src/render/CLAUDE.md
@@ -212,6 +212,14 @@ collision/movement.
   (material, z-band), share materials via `surfaceMat`, distance-cull/LOD in
   `sync` (see the `*_RANGE_SQ` constants). No per-frame `new THREE.*` in hot paths;
   reuse the `tmpV` scratch vectors / scratch arrays already in `renderer.ts`.
+- **Cloning a material? Use `material_clone_hooks.ts`.** `Material.clone()` copies
+  userData but silently DROPS `onBeforeCompile`, and three keys its program cache
+  on `customProgramCacheKey()`, whose default return value IS
+  `onBeforeCompile.toString()`. So a bare clone of a patched material (rim glow,
+  the worn surface-detail layer) both renders un-patched AND links a whole new
+  program on its first draw, wherever that draw lands. `cloneMaterialWithHooks`
+  re-attaches exactly the layers the source carried, in the source's order, so
+  the composed key comes out identical and the clone reuses the linked program.
 - **`render_budget.ts` is the renderer's adaptive-budget core** (tier-driven frame
   budget + telemetry, keyed off `gfx.ts` quality bands). `renderer.ts` owns it,
   degrades against it, and pushes the resulting grass/foliage/vfx quality levels into

--- a/src/render/ability_vfx/CLAUDE.md
+++ b/src/render/ability_vfx/CLAUDE.md
@@ -29,6 +29,15 @@ layers behind the `index.ts` barrel:
   spec impact flag, staggered rings, lingers, and the 14 signature motifs;
   instants run it compressed (0.15s release to impact). `fx_textures.ts`
   builds the shared canvas textures once, deterministically.
+- `prewarm.ts`: the warm-up work that is SAFE to run in a live frame, as
+  explicit units (`abilityVfxTexturePrewarmSteps`, one per impact sheet plus the
+  shared canvases; `collectAbilityVfxCompileTargets`, one program link per
+  distinct pooled material). `AbilityVfxFx.prewarmSpawn` stays boot-window only,
+  because it spawns VISIBLE primitives; these units are what the renderer's
+  `vfx.ability-primitives` manifest entry retains when the entry deadline drops
+  it, and what constrained (phone-class) devices run in the background instead
+  of the entry. Anything new added to `prewarmSpawn` that a live frame would
+  SEE must not be added here.
 
 Renderer contract: construct `AbilityVfxFx` with (scene, camera, anchor,
 groundY), hand it to `AbilityVfx` via deps (which also wires the Vfx particle

--- a/src/render/ability_vfx/fx.ts
+++ b/src/render/ability_vfx/fx.ts
@@ -16,7 +16,12 @@ import { ShockRings } from './rings';
 import { ArchetypeSequencer, type SequencerHost } from './sequencer';
 import { BuffShells } from './shells';
 import { isCrescendoArchetype, SPECTACLE } from './spectacle';
-import { asSpiritPath, SpiritApparitions, type SpiritAtKind } from './spirits';
+import {
+  asSpiritPath,
+  SpiritApparitions,
+  type SpiritAtKind,
+  type SpiritBuildScheduler,
+} from './spirits';
 
 export type { DecalStyle } from './decals';
 
@@ -405,6 +410,12 @@ export class AbilityVfxFx implements SequencerHost {
   // model is warm before its first cast - an unwarmed cast skips its spirit.
   warmSpiritsForClass(cls: string): void {
     this.spirits.warmForClass(cls);
+  }
+
+  // Hand the spirit puppets a host scheduler so their construction rides idle
+  // slots instead of the GLB resolve's own (live, in-combat) frame.
+  setSpiritBuildScheduler(schedule: SpiritBuildScheduler | null): void {
+    this.spirits.setBuildScheduler(schedule);
   }
 
   // Wired once by the painter: particle bursts ride the pooled Vfx cloud,

--- a/src/render/ability_vfx/index.ts
+++ b/src/render/ability_vfx/index.ts
@@ -14,3 +14,9 @@ export {
   type AbilityVfxSpellfxEvent,
   type AbilityVfxStat,
 } from './painter';
+export {
+  type AbilityVfxCompileTarget,
+  type AbilityVfxPrewarmTextureStep,
+  abilityVfxTexturePrewarmSteps,
+  collectAbilityVfxCompileTargets,
+} from './prewarm';

--- a/src/render/ability_vfx/prewarm.ts
+++ b/src/render/ability_vfx/prewarm.ts
@@ -1,0 +1,97 @@
+// The SAFE half of the ability-VFX boot warm-up, expressed as explicit small
+// units the renderer can run outside its world-entry window.
+//
+// AbilityVfxFx.prewarmSpawn is the boot-window warm-up: it spawns one of every
+// pooled primitive so the loading-screen frames draw them. That spawn can only
+// ever run BEHIND the loading screen, because a resumed one would pop a white
+// ring/decal/flipbook burst at the player's feet in a live frame. What CAN run
+// live is everything the spawn was really paying for:
+//
+//   - the six 8x8 impact sheets, each a procedurally drawn 512px canvas that is
+//     otherwise generated on the first impact of that school (the measured
+//     mid-combat stall on phone-class profiles, where the whole
+//     vfx.ability-primitives entry is skipped by the constrained manifest), and
+//     the shared canvas set every pool binds;
+//   - the pooled primitives' program links, one small ShaderMaterial at a time.
+//
+// Both are idempotent and invisible: building a sheet paints nothing, and a
+// compile only links a program for a mesh that stays visible=false until its
+// first real spawn. Renderer.prewarmInitialScene turns these steps into
+// PrewarmResumeUnits (see prewarm_resume.ts).
+
+import type * as THREE from 'three';
+import { abilityVfxTextures, FLIPBOOK_STYLES, flipbookSheet } from './fx_textures';
+
+export interface AbilityVfxPrewarmTextureStep {
+  id: string;
+  /** Builds (memoized in fx_textures) and returns the textures this step warms. */
+  build: () => THREE.Texture[];
+}
+
+export interface AbilityVfxCompileTarget {
+  id: string;
+  object: THREE.Object3D;
+}
+
+/**
+ * One unit per procedurally drawn impact sheet, plus one for the shared canvas
+ * set. The sheets are deliberately separate: each is an independent 64-frame
+ * canvas draw, and the whole point of the resume lane is that no single unit
+ * blocks a live frame for long.
+ */
+export function abilityVfxTexturePrewarmSteps(): AbilityVfxPrewarmTextureStep[] {
+  const steps: AbilityVfxPrewarmTextureStep[] = FLIPBOOK_STYLES.map((style) => ({
+    id: `flipbook:${style}`,
+    build: () => [flipbookSheet(style)],
+  }));
+  steps.push({
+    id: 'shared-canvases',
+    // ~140 KB of small canvases built in one memoized call, so they stay one
+    // unit rather than eight that would each re-enter the same builder.
+    build: () => Object.values(abilityVfxTextures()),
+  });
+  return steps;
+}
+
+/**
+ * Program identity for dedupe purposes. A pool that clones one prototype
+ * material per slot (the six flipbook slots) links ONE program for the set,
+ * because three derives a ShaderMaterial's program key from its shader source
+ * plus defines. Everything else falls back to material identity, which is the
+ * conservative answer: an extra unit only costs an idle slot and a cache hit,
+ * while a missed one is a link left for combat.
+ */
+function programIdentity(material: THREE.Material): string {
+  const shader = material as THREE.ShaderMaterial;
+  if (!shader.isShaderMaterial) return `material:${material.uuid}`;
+  // material.type separates the raw and non-raw variants, which compile
+  // differently from the same source.
+  return `shader:${material.type}|${shader.vertexShader}|${shader.fragmentShader}|${JSON.stringify(shader.defines ?? null)}`;
+}
+
+/**
+ * Pooled VFX meshes reachable from `root`, one per distinct program: the
+ * compile unit only needs SOME mesh carrying that program, and the pools stamp
+ * the renderCategory tag the scene-census diagnostics also key off. Objects
+ * without a material (a spirit holder group) carry no program of their own.
+ */
+export function collectAbilityVfxCompileTargets(root: THREE.Object3D): AbilityVfxCompileTarget[] {
+  const seen = new Set<string>();
+  const targets: AbilityVfxCompileTarget[] = [];
+  root.traverse((child) => {
+    if (child.userData?.renderCategory !== 'vfx') return;
+    const material = (child as THREE.Mesh).material;
+    if (!material) return;
+    const mats = Array.isArray(material) ? material : [material];
+    let fresh = false;
+    for (const mat of mats) {
+      const identity = programIdentity(mat);
+      if (seen.has(identity)) continue;
+      seen.add(identity);
+      fresh = true;
+    }
+    if (!fresh) return;
+    targets.push({ id: `${child.name || child.type}:${targets.length}`, object: child });
+  });
+  return targets;
+}

--- a/src/render/ability_vfx/spirits.ts
+++ b/src/render/ability_vfx/spirits.ts
@@ -204,6 +204,13 @@ function spiritModelsByClass(): Map<string, string[]> {
 const scratch = new THREE.Vector3();
 const bbScratch = new THREE.Box3();
 
+/**
+ * Runs one puppet build. The host supplies a scheduler that spends a browser
+ * idle slot and the shared GPU arbiter on it; hosts without one (tests, the
+ * editor viewport) keep the historical inline build.
+ */
+export type SpiritBuildScheduler = (build: () => void) => void;
+
 export class SpiritApparitions {
   private slots: SpiritSlot[] = [];
   private puppets = new Map<string, SpiritPuppet>();
@@ -213,6 +220,7 @@ export class SpiritApparitions {
   private compileGroup: THREE.Group;
   private compileQueue: SpiritPuppet[] = [];
   private compiling: SpiritPuppet | null = null;
+  private buildScheduler: SpiritBuildScheduler | null = null;
   private time = 0;
 
   constructor(
@@ -254,6 +262,18 @@ export class SpiritApparitions {
     scene.add(this.compileGroup);
   }
 
+  /**
+   * Route puppet construction (a SkeletonUtils rig clone, a material rebind
+   * traverse, and a per-vertex skinned-bounds measure) off the GLB resolve's
+   * synchronous continuation. Without this the whole build lands in whatever
+   * frame the loader happens to resolve in, which is a live combat frame:
+   * warmForClass fires on first SIGHTING of a class, so a player walking into
+   * a fight resolves several models at once.
+   */
+  setBuildScheduler(schedule: SpiritBuildScheduler | null): void {
+    this.buildScheduler = schedule;
+  }
+
   // Kick the async loads for every spirit model this class's kit authors.
   // Called on first sighting of a player of that class; misses are harmless
   // (an unwarmed model's first cast just skips its spirit).
@@ -270,8 +290,15 @@ export class SpiritApparitions {
     this.loading.add(model);
     loadGltf(url).then(
       (g) => {
-        this.loading.delete(model);
-        this.buildPuppet(model, g.scene, g.animations);
+        // The model stays marked loading until the build actually runs, so a
+        // deferred build cannot be queued twice by a second ensureLoaded.
+        const build = (): void => {
+          this.loading.delete(model);
+          if (this.puppets.has(model)) return;
+          this.buildPuppet(model, g.scene, g.animations);
+        };
+        if (this.buildScheduler) this.buildScheduler(build);
+        else build();
       },
       (err: unknown) => {
         // stays in `loading` forever on failure: never retried at frame rate

--- a/src/render/characters/visual.ts
+++ b/src/render/characters/visual.ts
@@ -8,6 +8,7 @@ import { offhandMirrorsWeaponSkin } from '../../sim/content/weapon_skin_rules';
 import { WEAPON_SKINS } from '../../sim/content/weapon_skins';
 import type { OverheadEmoteId } from '../../world_api';
 import { GFX } from '../gfx';
+import { cloneMaterialWithHooks } from '../material_clone_hooks';
 import { createWeaponVfx, WEAPON_VFX, type WeaponVfxHandle } from '../weapon_vfx';
 import { weaponVfxTuningFor } from '../weapon_vfx_tuning';
 import {
@@ -1218,7 +1219,11 @@ export class CharacterVisual {
       this.writeAuraGlow(cached);
       return cached;
     }
-    const glow = material.clone();
+    // Program-preserving clone: a bare clone() drops the source's
+    // onBeforeCompile layers, so it both renders un-patched and links a fresh
+    // program on its first draw (material_clone_hooks.ts). That first draw is
+    // the first spec'd hit on this rig, i.e. mid-combat for every mob.
+    const glow = cloneMaterialWithHooks(material);
     this.writeAuraGlow(glow);
     this.auraGlowMaterials.set(material, glow);
     return glow;

--- a/src/render/gfx.ts
+++ b/src/render/gfx.ts
@@ -1886,6 +1886,14 @@ export function addRimGlow(mat: THREE.Material): void {
     `pbr-rim-reuse|${previousCompileSource}|${previousProgramKey()}`;
 }
 
+/** True when addRimGlow already patched this exact material instance. A
+ *  Material.clone() is NOT the same instance and never carries the hook (clone
+ *  copies userData but drops onBeforeCompile), which is what
+ *  material_clone_hooks.ts re-attaches. */
+export function hasRimGlow(mat: THREE.Material): boolean {
+  return rimGlowMaterials.has(mat);
+}
+
 // Material factory: dedupes by (color|maps|flags) so hundreds of small box
 // meshes share a few dozen programs/uniform sets. Standard on high/ultra,
 // Lambert on low.

--- a/src/render/material_clone_hooks.ts
+++ b/src/render/material_clone_hooks.ts
@@ -1,0 +1,44 @@
+// Material.clone() copies every declarative property AND userData, but it
+// silently DROPS onBeforeCompile (Material.copy simply does not list it). Both
+// halves of that matter, because three keys its program cache on
+// Material.customProgramCacheKey(), whose default return value IS
+// `this.onBeforeCompile.toString()`:
+//
+//   1. a bare clone renders WITHOUT the patches its source shipped with (the
+//      character rim glow, the worn surface-detail layer), and
+//   2. its cache key no longer matches the source's, so its first draw LINKS A
+//      NEW PROGRAM instead of reusing the one the source already linked.
+//
+// (2) is the expensive half: cloning a rig's materials to tint them is a
+// per-visual operation, so the link lands on the first frame that shows the
+// effect. For the ability-VFX body glow that is the first hit on a mob rig, in
+// the middle of a fight.
+//
+// Re-attaching the source's hooks in the source's ORDER restores both: the
+// composed cache key comes out byte-identical, so three's acquireProgram
+// returns the already-linked program.
+
+import type * as THREE from 'three';
+import { addRimGlow, hasRimGlow } from './gfx';
+import { reapplySurfaceDetailToClone } from './worn_stone';
+
+/**
+ * Re-attach to `clone` the onBeforeCompile layers `source` carried, in the
+ * order tintedMaterial applies them (rim glow first, then surface detail: the
+ * detail layer chains the previous hook into its own cache key). Only layers
+ * the source actually had are re-attached, so a clone never gains a patch its
+ * source never carried, which would break program identity just as badly.
+ */
+export function reattachClonedMaterialHooks(source: THREE.Material, clone: THREE.Material): void {
+  if (hasRimGlow(source)) addRimGlow(clone);
+  // Reads the JSON spec applySurfaceDetail records in userData, which clone()
+  // did copy; a no-op for clones of undetailed materials.
+  reapplySurfaceDetailToClone(clone);
+}
+
+/** clone() plus reattachClonedMaterialHooks: the program-preserving clone. */
+export function cloneMaterialWithHooks<T extends THREE.Material>(source: T): T {
+  const clone = source.clone() as T;
+  reattachClonedMaterialHooks(source, clone);
+  return clone;
+}

--- a/src/render/prewarm_policy.ts
+++ b/src/render/prewarm_policy.ts
@@ -29,6 +29,21 @@ export const CONSTRAINED_PREWARM_KEEP: readonly string[] = [
   'render.settle-passes',
 ];
 
+/**
+ * Entries the minimal manifest still SKIPS at entry but whose explicit resume
+ * units run afterwards, in the same bounded background lane a deadline-dropped
+ * entry uses. This is the constrained-device answer to warm-up work that is too
+ * expensive for the entry window yet guaranteed to be needed seconds later: the
+ * ability-VFX impact sheets are procedurally drawn canvases whose first use is
+ * the first spell impact of that school, i.e. mid-combat.
+ *
+ * Membership is an opt-in per entry, never a blanket rule: everything else the
+ * minimal manifest skips is skipped for GPU-footprint reasons (the phone-class
+ * per-process memory ceiling) and must stay skipped. An id here is by
+ * construction NOT in CONSTRAINED_PREWARM_KEEP.
+ */
+export const CONSTRAINED_PREWARM_RESUME: readonly string[] = ['vfx.ability-primitives'];
+
 export const CONSTRAINED_TEXTURE_BATCH_SIZE = 4;
 export const CONSTRAINED_TEXTURE_MAX_MS = 1200;
 export const CONSTRAINED_ENTRY_VIEW_RAMP_MS = 300;
@@ -244,6 +259,16 @@ export function remainingPrewarmViewBudget(maxViews: number, createdViews: numbe
 export function prewarmEntryRuns(id: string, policy: PrewarmPolicy): boolean {
   if (!policy.minimalManifest) return true;
   return CONSTRAINED_PREWARM_KEEP.includes(id);
+}
+
+/**
+ * True when a minimal-manifest skip should still hand this entry's explicit
+ * units to the background resume lane. Only meaningful for an entry
+ * prewarmEntryRuns already rejected, so the unconstrained arm is always false.
+ */
+export function prewarmEntryResumesAfterSkip(id: string, policy: PrewarmPolicy): boolean {
+  if (!policy.minimalManifest) return false;
+  return CONSTRAINED_PREWARM_RESUME.includes(id);
 }
 
 /**

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -1641,6 +1641,10 @@ export class Renderer {
   // One shared lane for background work that touches WebGL. Idle callbacks from
   // independent zone/sky/archetype tasks can otherwise all start in one frame.
   private backgroundGpuWork = createBackgroundGpuQueue();
+  // Serial tail for spirit-puppet construction: several models resolve at once
+  // when a class is first sighted, so the builds queue behind one another and
+  // each spends its own idle slot instead of stacking into one combat frame.
+  private spiritBuildLane: Promise<unknown> = Promise.resolve();
   // Static terrain/water/features just beyond the current zone are built in a
   // single background lane when their rectangles enter the relaxed fog
   // horizon, so a walked boundary crossing lands on already-resident ground.
@@ -2714,6 +2718,7 @@ export class Renderer {
       this.webgl.domElement.clientHeight * this.webgl.getPixelRatio(),
       60,
     );
+    this.abilityVfxFx.setSpiritBuildScheduler((build) => this.queueSpiritPuppetBuild(build));
     this.abilityVfx = new AbilityVfx({
       vfx: this.vfx,
       fx: this.abilityVfxFx,
@@ -4917,6 +4922,19 @@ export class Renderer {
     if (!texture) return;
     this.webgl.initTexture(texture);
     this.gpuReadyTextures.add(texture);
+  }
+
+  /** One spirit-puppet build per idle slot, arbitrated with every other lane
+   *  that reaches WebGL. A rejected unit (renderer shut down mid-build) is a
+   *  dev-channel warning: an unbuilt puppet only means its next cast skips its
+   *  spirit, exactly like a model still in flight. */
+  private queueSpiritPuppetBuild(build: () => void): void {
+    this.spiritBuildLane = this.spiritBuildLane
+      .then(() => idleSlot(IDLE_PREWARM_TIMEOUT_MS))
+      .then(() => this.backgroundGpuWork.run(build, GPU_WORK_PRIORITY.BACKGROUND))
+      .catch((err: unknown) => {
+        console.warn('[spirits] deferred puppet build failed', err);
+      });
   }
 
   private readonly gpuReadyTextures = new WeakSet<THREE.Texture>();

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -4846,15 +4846,16 @@ export class Renderer {
       }
     }
     // One EXTRA rig per class wearing the ability-VFX aura glow: setAuraGlow's
-    // on-edge swaps the rig materials for private clones, and on the tinted
-    // player rigs that clone links a NEW program. Without this seed the FIRST
-    // spec'd cast of a session compiles it synchronously mid-frame - the
+    // on-edge swaps the rig materials for private clones, and the FIRST spec'd
+    // cast of a session used to compile them synchronously mid-frame (the
     // measured 'mage' program link landing inside the player's own cast
-    // moment (e.g. mid Solemn Prayer cast bar). Seeding glow-lit copies here
-    // puts the clone materials in front of programs.compile while the base
-    // rigs above still carry the un-glowed originals; the group is removed in
-    // the prewarm finally, but the linked programs stay cached for the
-    // session.
+    // moment, e.g. mid Solemn Prayer cast bar). The clones now keep the
+    // source's shader hooks and therefore its program cache key
+    // (material_clone_hooks.ts), which is what closes that hole for mob rigs
+    // and non-default skins too; this seed stays as the boot-side belt for the
+    // player classes, and for any rig material with no hook to preserve. The
+    // group is removed in the prewarm finally, but linked programs stay cached
+    // for the session.
     for (const cls of ALL_CLASSES) {
       if (performance.now() >= deadline) return { group, visualCount: idx };
       const color = CLASSES[cls]?.color ?? 0xffffff;

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -43,7 +43,12 @@ import { groundHeight, waterLevelAt, zoneBiomeAt } from '../sim/world';
 import type { ChatBubbleStyle } from '../ui/chat_bubble_style';
 import { tEntity } from '../ui/entity_i18n';
 import type { IWorld } from '../world_api';
-import { AbilityVfx, AbilityVfxFx } from './ability_vfx';
+import {
+  AbilityVfx,
+  AbilityVfxFx,
+  abilityVfxTexturePrewarmSteps,
+  collectAbilityVfxCompileTargets,
+} from './ability_vfx';
 import { ABILITY_VFX_FULL_SPECS } from './ability_vfx_full_specs';
 import { ABILITY_VFX_SPECS } from './ability_vfx_specs';
 import { type AmberFeaturesView, buildAmberFeatures } from './amber_features';
@@ -335,6 +340,7 @@ import {
   type PrewarmPolicy,
   partitionMandatoryLandmarkCandidates,
   prewarmBuildDeadline,
+  prewarmEntryResumesAfterSkip,
   prewarmEntryRuns,
   prewarmEntryShouldDefer,
   remainingPrewarmViewBudget,
@@ -5863,16 +5869,38 @@ export class Renderer {
       {
         // Spawn one of every pooled ability-VFX primitive (rings, decals,
         // pillar, shell, slash ribbon, overlay sprite). The pools build their
-        // meshes visible=false, so neither the render passes nor
-        // programs.compile ever see their ShaderMaterials, the first spec'd
-        // cast in the open world used to link them synchronously. The spawns
-        // also bind the per-style decal textures, so the texture re-walk below
-        // uploads the whole canvas set now. abilityVfxFx.clear() in the
-        // finally block hides everything again.
+        // meshes visible=false, so no render pass ever draws them: their
+        // textures and geometry stay un-uploaded, and the first spec'd cast in
+        // the open world used to pay for both synchronously. The spawns bind
+        // the per-style decal textures and the six impact sheets, so the
+        // texture re-walk below uploads the whole canvas set now.
+        // abilityVfxFx.clear() in the finally block hides everything again.
+        //
+        // resumeUnits deliberately does NOT replay the spawn: run live it
+        // would pop a white ring/decal/flipbook burst at the player's feet
+        // (the same reason vfx.atlas retains nothing). It carries the
+        // invisible half instead, one impact sheet per unit plus one program
+        // link per distinct pooled material. That is also the MINIMAL variant
+        // constrained devices get in place of this entry
+        // (CONSTRAINED_PREWARM_RESUME): there the whole entry is skipped, so
+        // each 512px sheet is otherwise drawn on the first impact of its
+        // school, i.e. mid-combat.
         id: 'vfx.ability-primitives',
         category: 'vfx',
         priority: 62,
         required: false,
+        resumeUnits: () => [
+          ...abilityVfxTexturePrewarmSteps().map((step) => ({
+            id: `texture:${step.id}`,
+            run: () => {
+              for (const texture of step.build()) this.prewarmTexture(texture);
+            },
+          })),
+          ...collectAbilityVfxCompileTargets(this.scene).map((target) => ({
+            id: `program:${target.id}`,
+            run: () => this.compilePrewarmColorPrograms(target.object, false),
+          })),
+        ],
         run: () => {
           this.abilityVfxFx.prewarmSpawn(p.pos.x, p.pos.y, p.pos.z - 5, p.id);
           this.scene.traverse((child) => {
@@ -6014,9 +6042,16 @@ export class Renderer {
       for (const entry of orderedManifest) {
         // Skip everything outside the minimal keep-list (prewarm_policy.ts),
         // recording the skip so the prewarm summary stays honest about what was
-        // deliberately not warmed. The skipped warms happen lazily in-world.
+        // deliberately not warmed. The skipped warms happen lazily in-world,
+        // except for the few entries that opt into the background resume lane
+        // (CONSTRAINED_PREWARM_RESUME): those hand over their explicit small
+        // units, which run after entry instead of never.
         if (!prewarmEntryRuns(entry.id, policy)) {
           const counts = this.prewarmCounts();
+          const skipUnits = prewarmEntryResumesAfterSkip(entry.id, policy)
+            ? (entry.resumeUnits?.() ?? [])
+            : [];
+          if (skipUnits.length > 0) droppedEntries.push({ id: entry.id, units: skipUnits });
           manifestEntries.push({
             id: entry.id,
             category: entry.category,
@@ -6032,7 +6067,10 @@ export class Renderer {
             texturesBefore: counts.textures,
             texturesAfter: counts.textures,
             textureDelta: 0,
-            detail: 'constrained-minimal',
+            detail:
+              skipUnits.length > 0
+                ? `constrained-minimal;resume=${skipUnits.length}`
+                : 'constrained-minimal',
           });
           continue;
         }

--- a/tests/ability_vfx_prewarm.test.ts
+++ b/tests/ability_vfx_prewarm.test.ts
@@ -1,0 +1,180 @@
+// The resumable half of the ability-VFX warm-up. AbilityVfxFx.prewarmSpawn can
+// only run behind the loading screen (it spawns visible primitives), so the
+// work that has to survive a missed boot deadline, and that constrained
+// devices get INSTEAD of the entry, is expressed as explicit small units here:
+// the six procedurally drawn impact sheets, the shared canvas set, and one
+// program link per distinct pooled material.
+
+import { readFileSync } from 'node:fs';
+import * as THREE from 'three';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { FLIPBOOK_STYLES } from '../src/render/ability_vfx/fx_textures';
+import {
+  abilityVfxTexturePrewarmSteps,
+  collectAbilityVfxCompileTargets,
+} from '../src/render/ability_vfx/prewarm';
+
+// The canvas textures are procedurally drawn, so a plain Node run needs a 2D
+// context stub (same shape as the ability-VFX and vfx suites use).
+function installCanvasStub(): void {
+  const noop = () => {};
+  const gradient = { addColorStop: noop };
+  const context = {
+    arc: noop,
+    beginPath: noop,
+    clip: noop,
+    closePath: noop,
+    createImageData: (width: number, height: number) => ({
+      data: new Uint8ClampedArray(width * height * 4),
+    }),
+    createLinearGradient: () => gradient,
+    createRadialGradient: () => gradient,
+    ellipse: noop,
+    fill: noop,
+    fillRect: noop,
+    lineTo: noop,
+    moveTo: noop,
+    putImageData: noop,
+    rect: noop,
+    restore: noop,
+    rotate: noop,
+    save: noop,
+    scale: noop,
+    stroke: noop,
+    translate: noop,
+  };
+  vi.stubGlobal('document', {
+    createElement: () => ({ width: 0, height: 0, getContext: () => context }),
+  });
+}
+
+function vfxMesh(name: string, material: THREE.Material | THREE.Material[]): THREE.Mesh {
+  const mesh = new THREE.Mesh(new THREE.PlaneGeometry(1, 1), material);
+  mesh.name = name;
+  mesh.visible = false;
+  mesh.userData.renderCategory = 'vfx';
+  return mesh;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('abilityVfxTexturePrewarmSteps', () => {
+  it('gives every impact sheet its own unit, plus one for the shared canvases', () => {
+    const steps = abilityVfxTexturePrewarmSteps();
+    const ids = steps.map((step) => step.id);
+    for (const style of FLIPBOOK_STYLES) expect(ids).toContain(`flipbook:${style}`);
+    expect(ids).toContain('shared-canvases');
+    expect(ids).toHaveLength(FLIPBOOK_STYLES.length + 1);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('builds real textures and returns the memoized instances on a second pass', () => {
+    installCanvasStub();
+    const first = abilityVfxTexturePrewarmSteps().map((step) => step.build());
+    for (const textures of first) {
+      expect(textures.length).toBeGreaterThan(0);
+      for (const texture of textures) expect(texture.isTexture).toBe(true);
+    }
+    // A resumed unit that ran twice (a skip and a later drop) must not rebuild
+    // the canvases: the pools bind these exact instances.
+    const second = abilityVfxTexturePrewarmSteps().map((step) => step.build());
+    expect(second).toEqual(first);
+  });
+
+  it('does not build anything until a unit actually runs', () => {
+    // No canvas stub installed: constructing the steps must stay inert, since
+    // the renderer builds the unit list inside the entry-time manifest loop.
+    expect(() => abilityVfxTexturePrewarmSteps()).not.toThrow();
+  });
+});
+
+describe('collectAbilityVfxCompileTargets', () => {
+  it('returns one target per distinct pooled material', () => {
+    const scene = new THREE.Scene();
+    const shared = new THREE.MeshBasicMaterial();
+    scene.add(vfxMesh('ring', shared));
+    scene.add(vfxMesh('ring-slot-2', shared)); // same material: already covered
+    scene.add(vfxMesh('decal', new THREE.MeshBasicMaterial()));
+    const targets = collectAbilityVfxCompileTargets(scene);
+    expect(targets).toHaveLength(2);
+    expect(targets.map((target) => target.object.name)).toEqual(['ring', 'decal']);
+    expect(new Set(targets.map((target) => target.id)).size).toBe(2);
+  });
+
+  it('ignores everything that is not a tagged VFX mesh', () => {
+    const scene = new THREE.Scene();
+    const holder = new THREE.Group();
+    holder.userData.renderCategory = 'vfx'; // a spirit holder: no material of its own
+    scene.add(holder);
+    scene.add(new THREE.Mesh(new THREE.PlaneGeometry(1, 1), new THREE.MeshBasicMaterial()));
+    const terrain = new THREE.Mesh(new THREE.PlaneGeometry(1, 1), new THREE.MeshBasicMaterial());
+    terrain.userData.renderCategory = 'terrain';
+    scene.add(terrain);
+    expect(collectAbilityVfxCompileTargets(scene)).toEqual([]);
+  });
+
+  it('folds a pool that clones one prototype per slot into a single unit', () => {
+    // ImpactFlipbooks clones its prototype material per slot: six distinct
+    // material instances, one program, so one compile unit.
+    const scene = new THREE.Scene();
+    const proto = new THREE.ShaderMaterial({
+      vertexShader: 'void main() { gl_Position = vec4(position, 1.0); }',
+      fragmentShader: 'void main() { gl_FragColor = vec4(1.0); }',
+    });
+    for (let slot = 0; slot < 6; slot++) scene.add(vfxMesh(`flip-${slot}`, proto.clone()));
+    // A different shader in the same pool family still earns its own unit.
+    scene.add(
+      vfxMesh(
+        'ribbon',
+        new THREE.ShaderMaterial({
+          vertexShader: 'void main() { gl_Position = vec4(position, 2.0); }',
+          fragmentShader: 'void main() { gl_FragColor = vec4(0.5); }',
+        }),
+      ),
+    );
+    const targets = collectAbilityVfxCompileTargets(scene);
+    expect(targets.map((target) => target.object.name)).toEqual(['flip-0', 'ribbon']);
+  });
+
+  it('covers a multi-material mesh once, on its first unseen material', () => {
+    const scene = new THREE.Scene();
+    const a = new THREE.MeshBasicMaterial();
+    const b = new THREE.MeshBasicMaterial();
+    scene.add(vfxMesh('pillar', [a, b]));
+    scene.add(vfxMesh('pillar-cap', [a, b]));
+    const targets = collectAbilityVfxCompileTargets(scene);
+    expect(targets.map((target) => target.object.name)).toEqual(['pillar']);
+  });
+});
+
+describe('the renderer wires the units into the prewarm resume lane', () => {
+  const renderer = readFileSync(new URL('../src/render/renderer.ts', import.meta.url), 'utf8');
+  const entryStart = renderer.indexOf("id: 'vfx.ability-primitives'");
+  const entry = renderer.slice(renderer.lastIndexOf('{', entryStart), entryStart + 2000);
+
+  it('retains texture and program units, never the visible spawn', () => {
+    expect(entryStart).toBeGreaterThan(-1);
+    const unitsStart = entry.indexOf('resumeUnits: () => [');
+    expect(unitsStart).toBeGreaterThan(-1);
+    const units = entry.slice(unitsStart, entry.indexOf('\n        ],', unitsStart));
+    expect(units).toContain('abilityVfxTexturePrewarmSteps()');
+    expect(units).toContain('this.prewarmTexture(texture)');
+    expect(units).toContain('collectAbilityVfxCompileTargets(this.scene)');
+    expect(units).toContain('this.compilePrewarmColorPrograms(target.object, false)');
+    // Replaying prewarmSpawn live would pop a white primitive burst.
+    expect(units).not.toContain('prewarmSpawn');
+  });
+
+  it('hands a policy-skipped entry its units instead of dropping them', () => {
+    expect(renderer).toContain('const skipUnits = prewarmEntryResumesAfterSkip(entry.id, policy)');
+    expect(renderer).toContain(
+      'if (skipUnits.length > 0) droppedEntries.push({ id: entry.id, units: skipUnits });',
+    );
+    // The summary stays honest about what a skip deferred rather than dropped.
+    const detailAt = renderer.indexOf('constrained-minimal;resume=');
+    expect(detailAt).toBeGreaterThan(-1);
+    expect(renderer.slice(detailAt, detailAt + 60)).toContain('skipUnits.length');
+  });
+});

--- a/tests/eastbrook_polish_artifact_integrity.test.ts
+++ b/tests/eastbrook_polish_artifact_integrity.test.ts
@@ -645,10 +645,15 @@ const ACCEPTED_POLISH_V2_METADATA_PATH = path.join(REPO_ROOT, POLISH_SEAL_PATH);
 // renderer; the release's bounded ground-object reuse pool), so the merged tree
 // mints literals matching neither parent. Captures adopted verbatim from the
 // release tip; swept by remint_polish_provenance.mjs on the merged tree.
+// Re-pinned for the ability VFX first-use fix rebased onto release/v0.35.0: it
+// moves the rendererIntegration leaf (idle-slot spirit puppet builds, resumable
+// ability warm-up) and the viewPriorityPolicy leaf (src/render/prewarm_policy.ts),
+// so the composite re-mints and the metadata file's swept provenance bytes follow.
+// The accepted captures are unchanged; only these swept bytes moved.
 const ACCEPTED_POLISH_V2_METADATA_SHA256 =
-  'dcf57f6d70ee1c8b472f8d1114d129005c2f0d051db925b8cfe506ad1f0b8c03';
+  '8b5ea2f776f2bf9a9c7b7553097b5c197354106e3727bd186198e01a4c46b4de';
 const ACCEPTED_POLISH_V2_COMPOSITE_PROVENANCE =
-  'f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9';
+  '6f8df557520fb299864269a31435143500b315523f8301c183faf227d4491559';
 const ACCEPTED_POLISH_V2_METADATA = readJsonFile<CaptureMetadata>(ACCEPTED_POLISH_V2_METADATA_PATH);
 const ACCEPTED_POLISH_V2_PROVENANCE = ACCEPTED_POLISH_V2_METADATA.polishProvenance;
 const ACCEPTED_POLISH_V2_TOWN_CONTRACT = ACCEPTED_POLISH_V2_METADATA.records[0]?.townContract;
@@ -1526,10 +1531,14 @@ describe('Eastbrook polish performance and contact evidence', () => {
     // matched the merged tree, and no capture was retaken here.
     // Re-pinned for the integrated v0.35 renderer on AAA-enhancements and
     // recomputed by remint_polish_provenance.mjs.
+    // Re-pinned again for the ability VFX first-use fix rebased onto
+    // release/v0.35.0: it moves the renderer-integration and view-priority-policy
+    // leaves of the first-order composite these files carry, so this second-order
+    // seal follows. Every measured value is unchanged; no capture was retaken.
     expect(
       fingerprint.digest('hex'),
       `the second-order performance digest moved; if every input moved legitimately, re-mint with: ${REMINT_COMMAND} (it recomputes this literal LAST, from the swept files)`,
-    ).toBe('4fd9c844d07805ba75c6749ae76ee139838d5f3f389fe2b20266671f7afb4cd0');
+    ).toBe('c04c7bf4513e92e910781f1e122fd6d9d1ca41ee49299986421791da54933380');
   });
 
   it('binds every historical after record to its accepted source and asset provenance', () => {

--- a/tests/eastbrook_polish_capture_contract.test.ts
+++ b/tests/eastbrook_polish_capture_contract.test.ts
@@ -49,9 +49,12 @@ interface AttributionTargetFixture {
 // fence-removal layout evidence, the v0.34.0 Bear Form rig (#2842), the live
 // graphics rebuild (#2799), far-field impostors and fog-free vista (#2793),
 // brood shout/flourish wiring, the worldObjectBurning fire-burst cue, the
-// Thornhollow renderer sync, and the release/v0.35.0 into AAA-enhancements
-// merge, each of which moved a runtimeRender leaf (usually
-// src/render/renderer.ts); every mint used
+// Thornhollow renderer sync, the release/v0.35.0 into AAA-enhancements
+// merge, and the ability VFX first-use fix rebased onto release/v0.35.0
+// (which moves two runtimeRender leaves at once, src/render/renderer.ts for
+// the idle-slot spirit puppet builds and resumable ability warm-up, plus
+// src/render/prewarm_policy.ts), each of which moved a runtimeRender leaf
+// (usually src/render/renderer.ts); every mint used
 // scripts/assets/eastbrook_grand_armoury/remint_polish_provenance.mjs.
 // Across all of those mints no GLB pipeline input or geometry value changed
 // and no capture was retaken here: Eastbrook itself is untouched, and the
@@ -62,7 +65,7 @@ interface AttributionTargetFixture {
 // diff; see provenance_diagnostics.mjs for the 2026-08-05 stale-mint root
 // cause this legibility exists to prevent.
 const PINNED_POLISH_COMPOSITE_FINGERPRINT =
-  'f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9';
+  '6f8df557520fb299864269a31435143500b315523f8301c183faf227d4491559';
 
 function validPolishAttributionTargets(): AttributionTargetFixture[] {
   return [

--- a/tests/material_clone_hooks.test.ts
+++ b/tests/material_clone_hooks.test.ts
@@ -1,0 +1,118 @@
+// Material.clone() drops onBeforeCompile while three keys its program cache on
+// Material.customProgramCacheKey(), whose default IS onBeforeCompile.toString().
+// A bare clone of a patched rig material therefore renders un-patched AND links
+// a fresh program on its first draw. The ability-VFX body glow clones exactly
+// such materials, per CharacterVisual, so that link landed on the first spec'd
+// hit on every new mob rig, mid-combat.
+
+import { readFileSync } from 'node:fs';
+import * as THREE from 'three';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { addRimGlow, gfxInternalsForTest, hasRimGlow } from '../src/render/gfx';
+import {
+  cloneMaterialWithHooks,
+  reattachClonedMaterialHooks,
+} from '../src/render/material_clone_hooks';
+import { applySurfaceDetail } from '../src/render/worn_stone';
+
+// A rig material as characters/assets.ts tintedMaterial builds it on the
+// standard tier: rim glow first, then the low-strength object-space worn layer.
+function riggedBodyMaterial(): THREE.MeshStandardMaterial {
+  const mat = new THREE.MeshStandardMaterial({ color: 0x808080 });
+  mat.name = 'knight_cloth';
+  addRimGlow(mat);
+  applySurfaceDetail(mat, 'fabric', { strength: 0.2, objectSpace: true });
+  return mat;
+}
+
+// Enough of three's PBR fragment shader for the rim patch to find its anchors.
+function fragmentShaderStub(): { uniforms: Record<string, unknown>; fragmentShader: string } {
+  return {
+    uniforms: {},
+    fragmentShader: [
+      '#include <common>',
+      'void main() {',
+      '#include <lights_fragment_begin>',
+      '}',
+    ].join('\n'),
+  };
+}
+
+// The rim + surface-detail layers only exist on the standard/detail tiers,
+// which is exactly where the glow clone used to split the program cache.
+let restoreGfx: () => void = () => {};
+
+beforeEach(() => {
+  restoreGfx = gfxInternalsForTest.overrideSettings({
+    standardMaterials: true,
+    surfaceDetail: true,
+  });
+});
+
+afterEach(() => {
+  restoreGfx();
+});
+
+describe('reattachClonedMaterialHooks', () => {
+  it('reproduces the bare-clone program split it exists to fix', () => {
+    const source = riggedBodyMaterial();
+    const bare = source.clone();
+    expect(bare.customProgramCacheKey()).not.toBe(source.customProgramCacheKey());
+    // The dropped hook is the same reason the bare clone renders un-patched.
+    expect(bare.onBeforeCompile).toBe(THREE.Material.prototype.onBeforeCompile);
+  });
+
+  it('restores the source program cache key exactly, so the clone reuses its program', () => {
+    const source = riggedBodyMaterial();
+    const clone = cloneMaterialWithHooks(source);
+    expect(clone).not.toBe(source);
+    expect(clone.customProgramCacheKey()).toBe(source.customProgramCacheKey());
+    // Both layers are represented: the detail layer's own prefix, and the rim
+    // hook it chains (surface-detail folds the previous hook's source into its
+    // key, which is why the two must be re-attached in the source's order).
+    expect(clone.customProgramCacheKey()).toContain('surface-detail|fabric');
+    expect(clone.customProgramCacheKey()).toContain('patchPbrRimGlowFragmentShader');
+  });
+
+  it('restores the shader patch itself, not just the key', () => {
+    const clone = cloneMaterialWithHooks(riggedBodyMaterial());
+    const shader = fragmentShaderStub();
+    clone.onBeforeCompile(shader as never, null as never);
+    expect(shader.fragmentShader).toContain('uniform float uRimBoost;');
+    expect(shader.uniforms.uRimBoost).toBeDefined();
+  });
+
+  it('never grants a clone a layer its source never carried', () => {
+    // A plain material (no rim, no detail): the clone must stay on the stock
+    // program key, or it would split the cache in the other direction.
+    const plain = new THREE.MeshStandardMaterial({ color: 0x223344 });
+    const clone = plain.clone();
+    reattachClonedMaterialHooks(plain, clone);
+    expect(hasRimGlow(clone)).toBe(false);
+    expect(clone.customProgramCacheKey()).toBe(plain.customProgramCacheKey());
+    expect(clone.onBeforeCompile).toBe(THREE.Material.prototype.onBeforeCompile);
+  });
+
+  it('re-attaches only the surface layer for a detail-only source', () => {
+    const source = new THREE.MeshStandardMaterial({ color: 0x445566 });
+    applySurfaceDetail(source, 'stone');
+    const clone = cloneMaterialWithHooks(source);
+    expect(hasRimGlow(clone)).toBe(false);
+    expect(clone.customProgramCacheKey()).toBe(source.customProgramCacheKey());
+    expect(clone.customProgramCacheKey()).toContain('surface-detail|stone');
+  });
+});
+
+describe('the ability-VFX body glow uses the program-preserving clone', () => {
+  it('clones the rig material through material_clone_hooks', () => {
+    const visual = readFileSync(
+      new URL('../src/render/characters/visual.ts', import.meta.url),
+      'utf8',
+    );
+    const start = visual.indexOf('private auraGlowMaterial(');
+    expect(start).toBeGreaterThan(-1);
+    const method = visual.slice(start, visual.indexOf('\n  setSoulRend(', start));
+    expect(method).toContain('cloneMaterialWithHooks(material)');
+    expect(method).not.toContain('material.clone()');
+  });
+});

--- a/tests/prewarm_policy.test.ts
+++ b/tests/prewarm_policy.test.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 import {
   CONSTRAINED_PREWARM_KEEP,
+  CONSTRAINED_PREWARM_RESUME,
   constrainedEntryViewCreateBudget,
   interactionLandmarkViewPriority,
   mandatoryLandmarkViewsReady,
@@ -10,6 +11,7 @@ import {
   type PrewarmPolicyInput,
   partitionMandatoryLandmarkCandidates,
   prewarmBuildDeadline,
+  prewarmEntryResumesAfterSkip,
   prewarmEntryRuns,
   prewarmEntryShouldDefer,
   remainingPrewarmViewBudget,
@@ -228,6 +230,44 @@ describe('the keep-list is the minimal entry set', () => {
         'world.initial-frame',
       ].sort(),
     );
+  });
+});
+
+describe('constrained skips that still resume in the background', () => {
+  const constrained = resolvePrewarmPolicy({ ...BASE, constrainedMemory: true });
+  const desktop = resolvePrewarmPolicy(BASE);
+
+  it('skips the ability-VFX warm-up at entry but keeps its units', () => {
+    // Both halves matter: skipping keeps the entry window short, resuming is
+    // what stops the six impact sheets from being drawn on the first spell
+    // impact of each school, i.e. mid-combat.
+    expect(prewarmEntryRuns('vfx.ability-primitives', constrained)).toBe(false);
+    expect(prewarmEntryResumesAfterSkip('vfx.ability-primitives', constrained)).toBe(true);
+  });
+
+  it('never resumes an entry skipped for its GPU footprint', () => {
+    for (const id of [
+      'entities.mob-archetypes',
+      'entities.npc-archetypes',
+      'sky.biome-variants',
+      'surface-detail.textures',
+      'vfx.atlas',
+    ]) {
+      expect(prewarmEntryRuns(id, constrained)).toBe(false);
+      expect(prewarmEntryResumesAfterSkip(id, constrained)).toBe(false);
+    }
+  });
+
+  it('is inert on the desktop manifest, which runs the entry outright', () => {
+    expect(prewarmEntryRuns('vfx.ability-primitives', desktop)).toBe(true);
+    expect(prewarmEntryResumesAfterSkip('vfx.ability-primitives', desktop)).toBe(false);
+  });
+
+  it('keeps the resume list disjoint from the keep-list', () => {
+    expect(CONSTRAINED_PREWARM_RESUME.length).toBeGreaterThan(0);
+    for (const id of CONSTRAINED_PREWARM_RESUME) {
+      expect(CONSTRAINED_PREWARM_KEEP).not.toContain(id);
+    }
   });
 });
 

--- a/tests/spirit_puppet_build.test.ts
+++ b/tests/spirit_puppet_build.test.ts
@@ -1,0 +1,128 @@
+// Spirit puppet construction (a SkeletonUtils rig clone, a material rebind
+// traverse, and a per-vertex skinned-bounds measure) used to run inside the GLB
+// resolve's own synchronous continuation. warmForClass fires on FIRST SIGHTING
+// of a class, so that continuation is a live combat frame, and several models
+// of one class resolve within a few frames of each other. The host now hands
+// the pool a scheduler that spends an idle slot per build.
+
+import { readFileSync } from 'node:fs';
+import * as THREE from 'three';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { SPIRIT_URLS, SpiritApparitions } from '../src/render/ability_vfx/spirits';
+
+const loadGltf = vi.fn();
+
+vi.mock('../src/render/assets/loader', () => ({
+  loadGltf: (url: string) => loadGltf(url),
+}));
+
+// A minimal resolved GLB: buildPuppet's skinned-bounds pass falls back to
+// Box3.setFromObject for static-mesh creatures, so no skeleton is needed.
+function fakeGltf(): { scene: THREE.Object3D; animations: THREE.AnimationClip[] } {
+  const root = new THREE.Group();
+  root.add(new THREE.Mesh(new THREE.BoxGeometry(1, 1, 1), new THREE.MeshBasicMaterial()));
+  return { scene: root, animations: [] };
+}
+
+interface PuppetProbe {
+  puppets: Map<string, unknown>;
+  loading: Set<string>;
+}
+
+function makePool(): { pool: SpiritApparitions; probe: PuppetProbe } {
+  const pool = new SpiritApparitions(new THREE.Scene(), () => 0);
+  return { pool, probe: pool as unknown as PuppetProbe };
+}
+
+// warmForClass resolves its models from the authored spec table; the shaman's
+// Ghost Wolf is the stable single-model case.
+const WOLF = 'wolf';
+
+beforeEach(() => {
+  loadGltf.mockReset();
+  loadGltf.mockResolvedValue(fakeGltf());
+});
+
+describe('SpiritApparitions puppet builds', () => {
+  it('builds inline when the host supplies no scheduler', async () => {
+    const { pool, probe } = makePool();
+    pool.warmForClass('shaman');
+    await vi.waitFor(() => expect(probe.puppets.has(WOLF)).toBe(true));
+    expect(probe.loading.has(WOLF)).toBe(false);
+  });
+
+  it('hands the build to the host scheduler instead of the resolve frame', async () => {
+    const { pool, probe } = makePool();
+    const queued: Array<() => void> = [];
+    pool.setBuildScheduler((build) => queued.push(build));
+    pool.warmForClass('shaman');
+    await vi.waitFor(() => expect(queued.length).toBe(1));
+    // Nothing was constructed in the loader's continuation.
+    expect(probe.puppets.has(WOLF)).toBe(false);
+    queued[0]();
+    expect(probe.puppets.has(WOLF)).toBe(true);
+  });
+
+  it('does not queue the same model twice while its build is still pending', async () => {
+    const { pool, probe } = makePool();
+    const queued: Array<() => void> = [];
+    pool.setBuildScheduler((build) => queued.push(build));
+    pool.warmForClass('shaman');
+    await vi.waitFor(() => expect(queued.length).toBe(1));
+    // A second sighting before the deferred build ran must see the model as
+    // still loading, or it would load and build a duplicate puppet, stranding
+    // the first one's mixer and materials.
+    expect(probe.loading.has(WOLF)).toBe(true);
+    pool.warmForClass('shaman');
+    await vi.waitFor(() => expect(loadGltf).toHaveBeenCalledTimes(1));
+    expect(queued).toHaveLength(1);
+  });
+
+  it('skips a cast whose puppet has not been built yet, without popping in late', async () => {
+    const { pool } = makePool();
+    pool.setBuildScheduler(() => {});
+    pool.warmForClass('shaman');
+    await vi.waitFor(() => expect(loadGltf).toHaveBeenCalled());
+    expect(
+      pool.spawn({
+        model: WOLF,
+        path: 'circle',
+        atKind: 'caster',
+        x: 0,
+        y: 0,
+        z: 0,
+        dirX: 1,
+        dirZ: 0,
+        scale: 1,
+        dur: 1.5,
+        colorHex: 0xffffff,
+        dim: 1,
+      }),
+    ).toBe(false);
+  });
+
+  it('warms only models the class can actually conjure', () => {
+    const { pool } = makePool();
+    pool.warmForClass('shaman');
+    for (const call of loadGltf.mock.calls) {
+      expect(Object.values(SPIRIT_URLS)).toContain(call[0]);
+    }
+    expect(loadGltf.mock.calls.length).toBeGreaterThan(0);
+  });
+});
+
+describe('the renderer runs each build on an idle slot behind the GPU arbiter', () => {
+  const renderer = readFileSync(new URL('../src/render/renderer.ts', import.meta.url), 'utf8');
+
+  it('wires the scheduler into the serial spirit build lane', () => {
+    expect(renderer).toContain(
+      'this.abilityVfxFx.setSpiritBuildScheduler((build) => this.queueSpiritPuppetBuild(build));',
+    );
+    const start = renderer.indexOf('private queueSpiritPuppetBuild(');
+    expect(start).toBeGreaterThan(-1);
+    const method = renderer.slice(start, renderer.indexOf('\n  }', start));
+    expect(method).toContain('this.spiritBuildLane = this.spiritBuildLane');
+    expect(method).toContain('idleSlot(IDLE_PREWARM_TIMEOUT_MS)');
+    expect(method).toContain('this.backgroundGpuWork.run(build, GPU_WORK_PRIORITY.BACKGROUND)');
+  });
+});


### PR DESCRIPTION
# fix(render): remove the first-use freezes in the ability VFX subsystem

## Summary

Players report frame freezes during combat since the per-ability VFX subsystem
landed. The subsystem itself is well pooled: every primitive family builds its
materials and geometry once at construction and only rebinds uniforms per spawn,
so steady state is cheap. What is not cheap is the FIRST time each thing
happens, and this PR closes the three first-use costs, each of which is a chunk
of synchronous main-thread work landing in a live frame.

### 1. The impact flipbook sheets are drawn on the first impact of each school

Each elemental school's impact flipbook is a procedurally drawn 8x8 sheet, 64
frames of canvas painting at 512px, built lazily on first use and then cached
(`fx_textures.ts` `flipbookSheet`). The boot prewarm has an entry that builds
all six up front (`vfx.ability-primitives`), but it was reachable in only one
way:

- it carried no `resumeUnits`, so when the world-entry deadline dropped it, the
  work was dropped for the whole session rather than deferred, and
- the constrained (phone-class) manifest skips it outright, since that profile
  deliberately runs a minimal entry list.

So on exactly the devices least able to absorb it, sheet generation plus the
first GL program links were guaranteed to happen mid-fight: the first fire
impact pays for the flame sheet, the first frost impact pays for shatter, and so
on through six schools.

### 2. The first hit on each new rig links a GL program

The ability VFX body glow tints a rig's emissive toward the spec color
(`CharacterVisual.setAuraGlow`, fired by the sequencer on every non-gentle
impact). On the off/on edge it swaps the rig's materials for private clones, so
the tint cannot leak into the shared originals.

The problem is what `Material.clone()` does NOT copy. It copies every
declarative property and deep-copies userData, but it silently drops
`onBeforeCompile`. And three keys its program cache on
`Material.customProgramCacheKey()`, whose default return value IS
`this.onBeforeCompile.toString()`. Rig materials are built with two chained
hooks (the fresnel rim glow from `gfx.ts`, and the worn surface-detail layer for
cloth and armor-metal names), so a bare clone comes out with a DIFFERENT cache
key from its source, and its first draw links a brand new program instead of
reusing the one the rig already linked. Two consequences, both real:

- a multi-millisecond program link on the first spec'd hit on every rig, and
- the glowing rig renders un-patched for as long as the glow is on (no rim, no
  worn surface layer), which is a visible pop on a sustained cast windup.

An earlier fix seeded glow-lit copies of the nine player-class rigs into the
boot prewarm, which put those program links in front of the world-entry compile.
Mobs, NPCs, non-default skins, and forms were left open, and those are exactly
the rigs a fight introduces one at a time.

### 3. Spirit puppets are built inside the GLB resolve's own continuation

A spirit apparition's puppet is built once per creature model: a
`SkeletonUtils` clone of the whole rig, a full material rebind traverse, and a
per-vertex skinned-bounds measure (`spirits.ts` `buildPuppet`). It runs in the
`.then` of the model's `loadGltf`, on the main thread, outside the idle and
background-GPU queues every other deferred build in the renderer goes through.

Puppets are warmed on first SIGHTING of a class, not on first cast, so that
continuation is a live combat frame by construction, and a class's several
models resolve within a few frames of each other.

## What changed

**1. The ability-VFX warm-up is resumable, and constrained devices get a
minimal variant** (`src/render/ability_vfx/prewarm.ts`, new).

`AbilityVfxFx.prewarmSpawn` can only ever run behind the loading screen: it
spawns VISIBLE primitives, so replaying it live would pop a white
ring/decal/flipbook burst at the player's feet (the same reason the `vfx.atlas`
entry retains nothing). The new module expresses the invisible half as explicit
small units instead: one per impact sheet, one for the shared canvas set, and
one program link per distinct pooled PROGRAM (a pool that clones one prototype
material per slot, as the six flipbook slots do, folds into a single unit). The
manifest entry retains those as `resumeUnits`, so a missed deadline defers them
to the existing idle plus background-GPU resume lane rather than dropping them.

On the constrained profile the entry stays skipped, because the entry window
must stay short, but it is now listed in `CONSTRAINED_PREWARM_RESUME`: a
minimal-manifest skip hands its explicit units to that same background lane
instead of never running them. The opt-in is per entry on purpose. Everything
else the minimal manifest skips is skipped for GPU-footprint reasons (the
phone-class per-process memory ceiling) and must stay skipped; the ability
sheets are the case where the work is guaranteed to be needed seconds later, in
combat.

On the memory question that profile exists to answer: the sheets are 1 MB each
on the GPU and were already going to be built and uploaded, one per school, the
moment combat produced that school's first impact. This moves the same 6 MB out
of the fight and into background idle after entry. It does not raise the
steady-state footprint, and it never touches the entry-window peak that gets the
WebContent process killed. The only new cost is for a session that would have
seen fewer than six schools land.

**2. Material clones keep their shader hooks, and therefore their program**
(`src/render/material_clone_hooks.ts`, new).

`cloneMaterialWithHooks` re-attaches exactly the layers the source carried, in
the source's order (rim first, then surface detail, because the detail layer
folds the previous hook's source into its own cache key). The composed key comes
out byte-identical, so three's `acquireProgram` returns the already-linked
program and the clone also renders with its patches again. `hasRimGlow` is
exported from `gfx.ts` so a clone can never GAIN a layer its source never had,
which would split the cache in the other direction.

The aura-glow clone in `characters/visual.ts` is the one call site. This closes
the hole for every rig at once, mobs and non-default skins included, which is
why the PR does not instead extend the boot seed to mob archetypes: the seed
would have to enumerate every rig a fight can introduce, and the root cause
would still be there for the next clone site. The existing player-class seed
stays as the boot-side belt for rig materials that carry no hook to preserve.

**3. Spirit puppet construction rides the queues** (`spirits.ts`, `fx.ts`,
`renderer.ts`).

`SpiritApparitions.setBuildScheduler` lets the host take the build out of the
resolve frame; the renderer runs one build per idle slot behind the shared GPU
arbiter, serialized so a class whose models all resolve at once cannot stack
them into a single frame. A model stays marked loading until its deferred build
runs, so a second sighting cannot queue a duplicate puppet and strand the first
one's mixer and materials. Hosts that pass no scheduler (tests, the editor
viewport) keep the historical inline build.

## Deliberately not in this PR

- **Program links on the constrained arm without
  `KHR_parallel_shader_compile` keep their existing policy.** That arm skips the
  monolithic compile because it is one multi-second synchronous block, and the
  ability-VFX program units added here are per-program and idle-paced precisely
  so they cannot reintroduce it.
- **The sibling clone sites in `characters/visual.ts` are untouched.** The
  ghost/stealth, soul-rend, rune-tint, and shapeshift treatments clone rig
  materials the same way and carry the same program split. Switching them over
  is a one-line change each, but each also decides whether that treatment should
  KEEP the rim and worn-surface layers it currently drops, which is a visual
  judgement per treatment rather than a mechanical fix.
- **The steady-state costs are a separate change**: the per-frame `new
  THREE.Vector3` in the VFX anchor helper, the full-buffer ribbon and overlay
  uploads that ignore `addUpdateRange`, and the terrain drape sampling that
  re-samples ground height per spawn and per moving aura band. Those are
  diffuse GC and upload pressure rather than a first-use stall, and they want
  their own before/after measurement.

## Behavior note

One visible delta, and it is a fix: a rig wearing the ability-VFX body glow used
to lose its rim glow and worn surface-detail shading for the duration of the
glow, because the bare clone rendered un-patched. It now keeps them. Most
visible on a sustained cast windup or a morph/ultimate rim rather than on the
short application pulse. No layout, HUD, or actionable-information change, so
the graphics-settings fairness contract is untouched.

## Type of change

- [x] Bug fix
- [x] Refactor or performance (no behavior change)
- [ ] Feature: new functionality
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change

## How was this tested?

- Commands:
  - `node scripts/gate_select.mjs`: every step green except the full vitest
    step, which reports 68 failures across 10 files (`corpse_harvest_sim`,
    `professions_fishing`, `corpse_harvest_result_event`, `chronomancy_surge`,
    `client_shell`, `whirlwind_echo`, `fear_break_chance`, `gathering_rhythm`,
    `frostveil_pit_escape`, `eastbrook_polish_capture_contract`). **All 68 are
    pre-existing on the base commit in this environment, not regressions from
    this PR:** re-running those exact 10 files in a detached worktree at the
    base commit with no changes reproduces the same 68 failures (4 + 52 + 12).
    They are seeded sim, professions, and capture-contract pins with no path to
    a `src/render` change.
  - `npx vitest run tests/ability_vfx_prewarm.test.ts tests/material_clone_hooks.test.ts tests/spirit_puppet_build.test.ts tests/prewarm_policy.test.ts`
  - `npx vitest run tests/architecture.test.ts tests/ability_vfx_fx_sleep.test.ts tests/ability_vfx_core.test.ts tests/ability_vfx_offscreen.test.ts tests/spirit_models.test.ts tests/prewarm_pass.test.ts tests/prewarm_resume.test.ts`
  - `npx tsc --noEmit`
  - `npx @biomejs/biome check` on every changed file
- Manual steps:
  - `npm run dev`, offline world entry in a real browser, driving casts through
    the ability-VFX probe hook (`scripts/ability_vfx_probe.mjs`): the world
    enters and spec'd casts draw their primitives as before, so the deferred
    sheets, the re-hooked glow clone, and the queued spirit builds do not change
    what a cast looks like.

New tests, each decisive on the behavior it covers:

- `tests/material_clone_hooks.test.ts` reproduces the bare-clone program split
  first (the bare clone's key differs from its source's and its hook is back to
  `Material.prototype.onBeforeCompile`), then pins that the re-hooked clone
  restores the key exactly AND the patch itself, with negative cases for a
  hookless source and a detail-only source.
- `tests/ability_vfx_prewarm.test.ts` pins the unit list (one per sheet plus the
  shared set, ids unique, builders lazy and memoized), the per-program dedupe of
  compile targets, and that the retained units never contain `prewarmSpawn`.
- `tests/spirit_puppet_build.test.ts` pins that a scheduled build leaves the
  resolve frame empty, that the model stays loading until the deferred build
  runs so a second sighting cannot duplicate it, and that the inline path is
  unchanged without a scheduler.
- `tests/prewarm_policy.test.ts` gains the skip-but-resume decision: the ability
  entry resumes after a constrained skip, nothing skipped for GPU footprint
  does, the desktop policy is inert, and the resume list stays disjoint from the
  keep-list.



## Screenshots / recordings

<img width="2560" height="1440" alt="Screenshot from 2026-08-05 22-31-04" src="https://github.com/user-attachments/assets/4c7ee6fe-a62d-41b9-aae1-4549eb7b88ea" />



## Checklist

### Quality

- [x] The gate was run (`node scripts/gate_select.mjs`). Every step is green
      except a set of vitest failures reproduced identically on the untouched
      base commit (detail above), with decisive tests added for the changed
      behavior and the manual run recorded above.

### Cross-platform

- [x] The change is renderer-internal (no HUD, no layout). The constrained
      (phone-class) profile is the one whose behavior changes most, and it is
      covered by the policy tests rather than by a viewport check.
- [x] Accessible: no UI surface added or edited.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings. The one new log line is
      dev-channel `console.warn`.

### Hygiene

- [x] No secrets, credentials, or `.env`; `ALLOW_DEV_COMMANDS` untouched.
- [x] No generated files hand-edited.