### PR TITLE
perf(render): stop the weapon-skin VFX connection freeze (batch A)

### DIFF
--- a/docs/screenshots/eastbrook-vale-rebuild/polish/metadata/after-desktop-ultra.json
+++ b/docs/screenshots/eastbrook-vale-rebuild/polish/metadata/after-desktop-ultra.json
@@ -11,7 +11,7 @@
     "mode": "composite-sha256",
     "algorithm": "sha256",
     "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-    "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+    "fingerprint": "214d84f280403acce49fb2513648ef6605870f1228f8008cf98194f44367bdef",
     "components": {
       "townAsset": {
         "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -40,7 +40,7 @@
         },
         "renderer": {
           "path": "src/render/renderer.ts",
-          "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+          "sha256": "a795f510a92fa5ed1362edd209e7c5eb667d184ed0d14548c9310b720cdaa19f"
         },
         "viewPriorityPolicy": {
           "path": "src/render/prewarm_policy.ts",
@@ -85,7 +85,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "214d84f280403acce49fb2513648ef6605870f1228f8008cf98194f44367bdef",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -114,7 +114,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "a795f510a92fa5ed1362edd209e7c5eb667d184ed0d14548c9310b720cdaa19f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -1377,7 +1377,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "214d84f280403acce49fb2513648ef6605870f1228f8008cf98194f44367bdef",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -1406,7 +1406,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "a795f510a92fa5ed1362edd209e7c5eb667d184ed0d14548c9310b720cdaa19f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -2669,7 +2669,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "214d84f280403acce49fb2513648ef6605870f1228f8008cf98194f44367bdef",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -2698,7 +2698,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "a795f510a92fa5ed1362edd209e7c5eb667d184ed0d14548c9310b720cdaa19f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -3961,7 +3961,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "214d84f280403acce49fb2513648ef6605870f1228f8008cf98194f44367bdef",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -3990,7 +3990,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "a795f510a92fa5ed1362edd209e7c5eb667d184ed0d14548c9310b720cdaa19f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -5253,7 +5253,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "214d84f280403acce49fb2513648ef6605870f1228f8008cf98194f44367bdef",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -5282,7 +5282,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "a795f510a92fa5ed1362edd209e7c5eb667d184ed0d14548c9310b720cdaa19f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -6545,7 +6545,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "214d84f280403acce49fb2513648ef6605870f1228f8008cf98194f44367bdef",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -6574,7 +6574,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "a795f510a92fa5ed1362edd209e7c5eb667d184ed0d14548c9310b720cdaa19f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -7837,7 +7837,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "214d84f280403acce49fb2513648ef6605870f1228f8008cf98194f44367bdef",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -7866,7 +7866,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "a795f510a92fa5ed1362edd209e7c5eb667d184ed0d14548c9310b720cdaa19f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -9129,7 +9129,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "214d84f280403acce49fb2513648ef6605870f1228f8008cf98194f44367bdef",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -9158,7 +9158,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "a795f510a92fa5ed1362edd209e7c5eb667d184ed0d14548c9310b720cdaa19f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -10421,7 +10421,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "214d84f280403acce49fb2513648ef6605870f1228f8008cf98194f44367bdef",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -10450,7 +10450,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "a795f510a92fa5ed1362edd209e7c5eb667d184ed0d14548c9310b720cdaa19f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -11713,7 +11713,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "214d84f280403acce49fb2513648ef6605870f1228f8008cf98194f44367bdef",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -11742,7 +11742,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "a795f510a92fa5ed1362edd209e7c5eb667d184ed0d14548c9310b720cdaa19f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -13005,7 +13005,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "214d84f280403acce49fb2513648ef6605870f1228f8008cf98194f44367bdef",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -13034,7 +13034,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "a795f510a92fa5ed1362edd209e7c5eb667d184ed0d14548c9310b720cdaa19f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -14297,7 +14297,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "214d84f280403acce49fb2513648ef6605870f1228f8008cf98194f44367bdef",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -14326,7 +14326,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "a795f510a92fa5ed1362edd209e7c5eb667d184ed0d14548c9310b720cdaa19f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -15589,7 +15589,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "214d84f280403acce49fb2513648ef6605870f1228f8008cf98194f44367bdef",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -15618,7 +15618,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "a795f510a92fa5ed1362edd209e7c5eb667d184ed0d14548c9310b720cdaa19f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -16881,7 +16881,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "214d84f280403acce49fb2513648ef6605870f1228f8008cf98194f44367bdef",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -16910,7 +16910,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "a795f510a92fa5ed1362edd209e7c5eb667d184ed0d14548c9310b720cdaa19f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -19138,7 +19138,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "214d84f280403acce49fb2513648ef6605870f1228f8008cf98194f44367bdef",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -19167,7 +19167,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "a795f510a92fa5ed1362edd209e7c5eb667d184ed0d14548c9310b720cdaa19f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -20430,7 +20430,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "214d84f280403acce49fb2513648ef6605870f1228f8008cf98194f44367bdef",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -20459,7 +20459,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "a795f510a92fa5ed1362edd209e7c5eb667d184ed0d14548c9310b720cdaa19f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -21722,7 +21722,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "214d84f280403acce49fb2513648ef6605870f1228f8008cf98194f44367bdef",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -21751,7 +21751,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "a795f510a92fa5ed1362edd209e7c5eb667d184ed0d14548c9310b720cdaa19f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -23014,7 +23014,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "214d84f280403acce49fb2513648ef6605870f1228f8008cf98194f44367bdef",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -23043,7 +23043,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "a795f510a92fa5ed1362edd209e7c5eb667d184ed0d14548c9310b720cdaa19f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -24306,7 +24306,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "214d84f280403acce49fb2513648ef6605870f1228f8008cf98194f44367bdef",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -24335,7 +24335,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "a795f510a92fa5ed1362edd209e7c5eb667d184ed0d14548c9310b720cdaa19f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -25598,7 +25598,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "214d84f280403acce49fb2513648ef6605870f1228f8008cf98194f44367bdef",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -25627,7 +25627,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "a795f510a92fa5ed1362edd209e7c5eb667d184ed0d14548c9310b720cdaa19f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -26890,7 +26890,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "214d84f280403acce49fb2513648ef6605870f1228f8008cf98194f44367bdef",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -26919,7 +26919,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "a795f510a92fa5ed1362edd209e7c5eb667d184ed0d14548c9310b720cdaa19f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -28235,7 +28235,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "214d84f280403acce49fb2513648ef6605870f1228f8008cf98194f44367bdef",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -28264,7 +28264,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "a795f510a92fa5ed1362edd209e7c5eb667d184ed0d14548c9310b720cdaa19f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -29527,7 +29527,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "214d84f280403acce49fb2513648ef6605870f1228f8008cf98194f44367bdef",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -29556,7 +29556,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "a795f510a92fa5ed1362edd209e7c5eb667d184ed0d14548c9310b720cdaa19f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",

--- a/docs/screenshots/eastbrook-vale-rebuild/polish/metadata/after-mobile-low.json
+++ b/docs/screenshots/eastbrook-vale-rebuild/polish/metadata/after-mobile-low.json
@@ -11,7 +11,7 @@
     "mode": "composite-sha256",
     "algorithm": "sha256",
     "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-    "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+    "fingerprint": "214d84f280403acce49fb2513648ef6605870f1228f8008cf98194f44367bdef",
     "components": {
       "townAsset": {
         "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -40,7 +40,7 @@
         },
         "renderer": {
           "path": "src/render/renderer.ts",
-          "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+          "sha256": "a795f510a92fa5ed1362edd209e7c5eb667d184ed0d14548c9310b720cdaa19f"
         },
         "viewPriorityPolicy": {
           "path": "src/render/prewarm_policy.ts",
@@ -85,7 +85,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "214d84f280403acce49fb2513648ef6605870f1228f8008cf98194f44367bdef",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -114,7 +114,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "a795f510a92fa5ed1362edd209e7c5eb667d184ed0d14548c9310b720cdaa19f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -1360,7 +1360,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "214d84f280403acce49fb2513648ef6605870f1228f8008cf98194f44367bdef",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -1389,7 +1389,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "a795f510a92fa5ed1362edd209e7c5eb667d184ed0d14548c9310b720cdaa19f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -2635,7 +2635,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "214d84f280403acce49fb2513648ef6605870f1228f8008cf98194f44367bdef",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -2664,7 +2664,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "a795f510a92fa5ed1362edd209e7c5eb667d184ed0d14548c9310b720cdaa19f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -3910,7 +3910,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "214d84f280403acce49fb2513648ef6605870f1228f8008cf98194f44367bdef",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -3939,7 +3939,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "a795f510a92fa5ed1362edd209e7c5eb667d184ed0d14548c9310b720cdaa19f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -5185,7 +5185,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "214d84f280403acce49fb2513648ef6605870f1228f8008cf98194f44367bdef",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -5214,7 +5214,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "a795f510a92fa5ed1362edd209e7c5eb667d184ed0d14548c9310b720cdaa19f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -6460,7 +6460,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "214d84f280403acce49fb2513648ef6605870f1228f8008cf98194f44367bdef",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -6489,7 +6489,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "a795f510a92fa5ed1362edd209e7c5eb667d184ed0d14548c9310b720cdaa19f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -7735,7 +7735,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "214d84f280403acce49fb2513648ef6605870f1228f8008cf98194f44367bdef",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -7764,7 +7764,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "a795f510a92fa5ed1362edd209e7c5eb667d184ed0d14548c9310b720cdaa19f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -9010,7 +9010,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "214d84f280403acce49fb2513648ef6605870f1228f8008cf98194f44367bdef",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -9039,7 +9039,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "a795f510a92fa5ed1362edd209e7c5eb667d184ed0d14548c9310b720cdaa19f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -10285,7 +10285,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "214d84f280403acce49fb2513648ef6605870f1228f8008cf98194f44367bdef",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -10314,7 +10314,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "a795f510a92fa5ed1362edd209e7c5eb667d184ed0d14548c9310b720cdaa19f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -11560,7 +11560,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "214d84f280403acce49fb2513648ef6605870f1228f8008cf98194f44367bdef",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -11589,7 +11589,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "a795f510a92fa5ed1362edd209e7c5eb667d184ed0d14548c9310b720cdaa19f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -12835,7 +12835,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "214d84f280403acce49fb2513648ef6605870f1228f8008cf98194f44367bdef",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -12864,7 +12864,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "a795f510a92fa5ed1362edd209e7c5eb667d184ed0d14548c9310b720cdaa19f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -14110,7 +14110,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "214d84f280403acce49fb2513648ef6605870f1228f8008cf98194f44367bdef",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -14139,7 +14139,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "a795f510a92fa5ed1362edd209e7c5eb667d184ed0d14548c9310b720cdaa19f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -15385,7 +15385,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "214d84f280403acce49fb2513648ef6605870f1228f8008cf98194f44367bdef",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -15414,7 +15414,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "a795f510a92fa5ed1362edd209e7c5eb667d184ed0d14548c9310b720cdaa19f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -16660,7 +16660,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "214d84f280403acce49fb2513648ef6605870f1228f8008cf98194f44367bdef",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -16689,7 +16689,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "a795f510a92fa5ed1362edd209e7c5eb667d184ed0d14548c9310b720cdaa19f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -18900,7 +18900,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "214d84f280403acce49fb2513648ef6605870f1228f8008cf98194f44367bdef",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -18929,7 +18929,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "a795f510a92fa5ed1362edd209e7c5eb667d184ed0d14548c9310b720cdaa19f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -20175,7 +20175,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "214d84f280403acce49fb2513648ef6605870f1228f8008cf98194f44367bdef",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -20204,7 +20204,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "a795f510a92fa5ed1362edd209e7c5eb667d184ed0d14548c9310b720cdaa19f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -21450,7 +21450,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "214d84f280403acce49fb2513648ef6605870f1228f8008cf98194f44367bdef",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -21479,7 +21479,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "a795f510a92fa5ed1362edd209e7c5eb667d184ed0d14548c9310b720cdaa19f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -22725,7 +22725,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "214d84f280403acce49fb2513648ef6605870f1228f8008cf98194f44367bdef",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -22754,7 +22754,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "a795f510a92fa5ed1362edd209e7c5eb667d184ed0d14548c9310b720cdaa19f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -24000,7 +24000,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "214d84f280403acce49fb2513648ef6605870f1228f8008cf98194f44367bdef",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -24029,7 +24029,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "a795f510a92fa5ed1362edd209e7c5eb667d184ed0d14548c9310b720cdaa19f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -25275,7 +25275,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "214d84f280403acce49fb2513648ef6605870f1228f8008cf98194f44367bdef",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -25304,7 +25304,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "a795f510a92fa5ed1362edd209e7c5eb667d184ed0d14548c9310b720cdaa19f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -26550,7 +26550,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "214d84f280403acce49fb2513648ef6605870f1228f8008cf98194f44367bdef",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -26579,7 +26579,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "a795f510a92fa5ed1362edd209e7c5eb667d184ed0d14548c9310b720cdaa19f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -27878,7 +27878,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "214d84f280403acce49fb2513648ef6605870f1228f8008cf98194f44367bdef",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -27907,7 +27907,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "a795f510a92fa5ed1362edd209e7c5eb667d184ed0d14548c9310b720cdaa19f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -29153,7 +29153,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+        "fingerprint": "214d84f280403acce49fb2513648ef6605870f1228f8008cf98194f44367bdef",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -29182,7 +29182,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+              "sha256": "a795f510a92fa5ed1362edd209e7c5eb667d184ed0d14548c9310b720cdaa19f"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",

--- a/docs/screenshots/eastbrook-vale-rebuild/polish/performance/after-desktop-ultra-town.json
+++ b/docs/screenshots/eastbrook-vale-rebuild/polish/performance/after-desktop-ultra-town.json
@@ -14,7 +14,7 @@
     "mode": "composite-sha256",
     "algorithm": "sha256",
     "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-    "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+    "fingerprint": "214d84f280403acce49fb2513648ef6605870f1228f8008cf98194f44367bdef",
     "components": {
       "townAsset": {
         "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -43,7 +43,7 @@
         },
         "renderer": {
           "path": "src/render/renderer.ts",
-          "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+          "sha256": "a795f510a92fa5ed1362edd209e7c5eb667d184ed0d14548c9310b720cdaa19f"
         },
         "viewPriorityPolicy": {
           "path": "src/render/prewarm_policy.ts",

--- a/docs/screenshots/eastbrook-vale-rebuild/polish/performance/after-mobile-low-town.json
+++ b/docs/screenshots/eastbrook-vale-rebuild/polish/performance/after-mobile-low-town.json
@@ -14,7 +14,7 @@
     "mode": "composite-sha256",
     "algorithm": "sha256",
     "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-    "fingerprint": "f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9",
+    "fingerprint": "214d84f280403acce49fb2513648ef6605870f1228f8008cf98194f44367bdef",
     "components": {
       "townAsset": {
         "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -43,7 +43,7 @@
         },
         "renderer": {
           "path": "src/render/renderer.ts",
-          "sha256": "6b393c8952e353b98820397065bed3a95c4701656b5bfa083b6314fb145b20e6"
+          "sha256": "a795f510a92fa5ed1362edd209e7c5eb667d184ed0d14548c9310b720cdaa19f"
         },
         "viewPriorityPolicy": {
           "path": "src/render/prewarm_policy.ts",

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -429,6 +429,17 @@ import {
 import { RecklessSkullPainter } from './warrior_cast_fx_painter';
 import { buildWater, setWaterDayNight, setWaterSunDirection, type WaterView } from './water';
 import { buildWaterFlora } from './water_flora';
+import {
+  buildWeaponVfxPrewarmGroup,
+  disposeWeaponEmissiveCache,
+  weaponVfxPrewarmTextures,
+} from './weapon_vfx';
+import {
+  resolveQueuedSkinLookup,
+  WEAPON_SKIN_APPLIES_PER_FRAME,
+  type WeaponSkinApplyDecision,
+  WeaponSkinApplyQueue,
+} from './weapon_vfx_apply_queue_core';
 import { Weather } from './weather';
 import { precipForBiome } from './weather_field_core';
 import { buildWorldAmbientSources, crowdAmbienceAt, footstepSurfaceAt } from './world_audio';
@@ -2923,6 +2934,15 @@ export class Renderer {
     this.pooledVisualCount = 0;
     this.objectPool.clear();
     this.pooledObjectCount = 0;
+    // The memoized weapon-skin emissive derivations are renderer-lifetime, not
+    // page-lifetime: they are shared across wearers, so no individual rig may
+    // release them, and a megabyte-class texture pair per skin would otherwise
+    // ride a WebGL context recycle into the next context. Safe here and only
+    // here, after every view (and every rig that borrowed them) is torn down
+    // above. Best-effort like its neighbours: nothing in terminal cleanup may
+    // abort the WebGL disposal below.
+    bestEffort(() => this.weaponSkinApplies.clear());
+    bestEffort(() => disposeWeaponEmissiveCache());
     this.clickTargets.length = 0;
     this.gatherNodeMeshes = [];
     this.viewLights.length = 0;
@@ -5361,6 +5381,7 @@ export class Renderer {
     let propMaterialPrewarmGroup: THREE.Group | null = null;
     let foliagePrewarmGroup: THREE.Group | null = null;
     let greatTreePrewarmGroup: THREE.Group | null = null;
+    let weaponVfxPrewarmGroup: THREE.Group | null = null;
     let landmarkPrewarmGroup: THREE.Group | null = null;
     let weatherPrewarmActive = false;
     let surfaceDetailTexturesWarmed = 0;
@@ -5489,6 +5510,7 @@ export class Renderer {
         objectPrewarmGroup,
         propMaterialPrewarmGroup,
         foliagePrewarmGroup,
+        weaponVfxPrewarmGroup,
         landmarkPrewarmGroup,
       ]) {
         if (group) group.visible = false;
@@ -5527,6 +5549,9 @@ export class Renderer {
       if (propMaterialPrewarmGroup) this.scene.remove(propMaterialPrewarmGroup);
       if (foliagePrewarmGroup) this.scene.remove(foliagePrewarmGroup);
       if (greatTreePrewarmGroup) this.scene.remove(greatTreePrewarmGroup);
+      // Removed, never disposed: disposing a material releases its linked
+      // program, which is exactly what this group exists to warm.
+      if (weaponVfxPrewarmGroup) this.scene.remove(weaponVfxPrewarmGroup);
       if (landmarkPrewarmGroup) this.scene.remove(landmarkPrewarmGroup);
       if (weatherPrewarmActive) this.weather.endPrewarm();
       doorPrewarmGroup = null;
@@ -5542,6 +5567,7 @@ export class Renderer {
       propMaterialPrewarmGroup = null;
       foliagePrewarmGroup = null;
       greatTreePrewarmGroup = null;
+      weaponVfxPrewarmGroup = null;
       landmarkPrewarmGroup = null;
       weatherPrewarmActive = false;
     };
@@ -5860,6 +5886,54 @@ export class Renderer {
         detail: () => `bursts=${vfxPrewarmBursts}`,
       },
       {
+        // Weapon-skin rarity VFX: the rigs are worn by OTHER players, so their
+        // programs otherwise link the first time a skinned player walks into
+        // view, mid-gameplay, on top of the rig build itself (the reported
+        // connection freeze). One hidden synthetic rig covers every component
+        // family, and the shader sources carry no authored values, so it
+        // compiles the exact keys the live rigs ask for later. The sky dome is
+        // deliberately not warmed: the world path builds none.
+        id: 'vfx.weapon-skins',
+        category: 'vfx',
+        priority: 61,
+        required: false,
+        // Small explicit units: build the rig, upload its shared sprite
+        // textures, link its programs. Each is one bounded piece of work, so a
+        // deadline drop resumes them in idle time instead of rerunning the
+        // whole entry.
+        resumeUnits: () => [
+          {
+            id: 'weapon-skins:group',
+            run: () => {
+              weaponVfxPrewarmGroup = buildWeaponVfxPrewarmGroup();
+              setRenderCategory(weaponVfxPrewarmGroup, 'prewarm');
+              this.scene.add(weaponVfxPrewarmGroup);
+            },
+          },
+          {
+            id: 'weapon-skins:textures',
+            run: () => {
+              for (const texture of weaponVfxPrewarmTextures()) this.prewarmTexture(texture);
+            },
+          },
+          {
+            id: 'weapon-skins:compile',
+            run: async () => {
+              if (weaponVfxPrewarmGroup) {
+                await this.compilePrewarmColorPrograms(weaponVfxPrewarmGroup, false);
+              }
+            },
+          },
+        ],
+        run: () => {
+          weaponVfxPrewarmGroup = buildWeaponVfxPrewarmGroup();
+          setRenderCategory(weaponVfxPrewarmGroup, 'prewarm');
+          this.scene.add(weaponVfxPrewarmGroup);
+          for (const texture of weaponVfxPrewarmTextures()) this.prewarmTexture(texture);
+        },
+        detail: () => `objects=${weaponVfxPrewarmGroup?.children.length ?? 0}`,
+      },
+      {
         // Spawn one of every pooled ability-VFX primitive (rings, decals,
         // pillar, shell, slash ribbon, overlay sprite). The pools build their
         // meshes visible=false, so neither the render passes nor
@@ -5915,6 +5989,7 @@ export class Renderer {
             ['props', propMaterialPrewarmGroup],
             ['foliage', foliagePrewarmGroup],
             ['great-tree', greatTreePrewarmGroup],
+            ['weapon-vfx', weaponVfxPrewarmGroup],
             ['landmark', landmarkPrewarmGroup],
           ];
           return buildPrewarmCompileUnits(
@@ -7393,6 +7468,59 @@ export class Renderer {
     });
   }
 
+  // Weapon-skin cosmetics waiting to be applied to a live view, at most one
+  // application per frame. All the queue decisions (coalescing, cancellation,
+  // the stale-guard) live in the pure core; this class only does the Three work
+  // the drain hands back.
+  private readonly weaponSkinApplies = new WeaponSkinApplyQueue();
+  private readonly weaponSkinApplyScratch: WeaponSkinApplyDecision[] = [];
+
+  // Bound once, never per frame: the drain's two callbacks would otherwise mint
+  // a closure pair on every drained frame.
+  private readonly weaponSkinLookup = (viewId: number): string | undefined => {
+    // A view that is gone, pooled, or has no character rig has nothing to apply
+    // to; everything else is the live entity's own answer.
+    if (!this.views.get(viewId)?.visual) return undefined;
+    return resolveQueuedSkinLookup(this.sim.entities.get(viewId));
+  };
+
+  // Nearest first: in a crowd of arrivals the wearer beside the player must not
+  // wait out thirty distant rigs at one application per frame. Squared XZ
+  // distance to the player, the same measure the view create/destroy bands use.
+  private readonly weaponSkinRank = (viewId: number): number | undefined => {
+    const entity = this.sim.entities.get(viewId);
+    return entity ? distSqXZ(entity, this.sim.player) : undefined;
+  };
+
+  /** Apply (or clear) a weapon-skin cosmetic on one view and latch it. The
+   *  latch is written HERE, never at enqueue time, so a queued application
+   *  that never ran is retried by the next frame's diff. */
+  private applyWeaponSkin(v: EntityView, skinId: string | null): void {
+    if (!v.visual) return;
+    v.weaponSkinId = skinId;
+    const changed = v.visual.setWeaponSkin(skinId);
+    if (changed) for (const node of changed) this.gateSwapOnCompile(node);
+    this.reconcileViewLights(v);
+  }
+
+  /** Spend this frame's weapon-skin application budget, nearest wearer first.
+   *  Entries whose view is gone, or whose entity has moved on to another skin,
+   *  are dropped without spending it (the diff re-enqueues if the view still
+   *  needs one). */
+  private drainWeaponSkinApplies(): void {
+    if (this.weaponSkinApplies.size === 0) return;
+    const due = this.weaponSkinApplies.take(
+      WEAPON_SKIN_APPLIES_PER_FRAME,
+      this.weaponSkinLookup,
+      this.weaponSkinApplyScratch,
+      this.weaponSkinRank,
+    );
+    for (const entry of due) {
+      const view = this.views.get(entry.viewId);
+      if (view) this.applyWeaponSkin(view, entry.skinId);
+    }
+  }
+
   private reconcileViewLights(v: EntityView): void {
     const reconciled = reconcileViewPointLights(v.group, v.viewLights, this.viewLights);
     if (!reconciled.changed) return;
@@ -8550,6 +8678,9 @@ export class Renderer {
   private removeView(id: number, terminal = false): void {
     const v = this.views.get(id);
     if (!v) return;
+    // A pending weapon-skin application must never land on a dropped (or
+    // pooled and reused) view.
+    this.weaponSkinApplies.cancel(id);
     this.scene.remove(v.group);
     this.lightOwnerGroups.delete(v.group);
     if (v.viewLights.length > 0) {
@@ -9191,12 +9322,23 @@ export class Renderer {
       }
 
       // live weapon-skin swap: a Season 1 Armory cosmetic applied/detached (self
-      // or a peer, via the identity wire); replaces the held model + rarity VFX
+      // or a peer, via the identity wire); replaces the held model + rarity VFX.
+      // APPLYING one is the expensive direction (model swap, derived emissive
+      // materials, the whole VFX rig), so it goes through the per-frame budgeted
+      // queue instead of running here: a crowd of skinned players arriving at
+      // once used to build every rig inside this one frame. Clearing a skin
+      // builds no rig, so it stays synchronous and instant, and cancels any
+      // queued apply so a stale entry cannot put the skin back on.
+      // The latch is written by the application itself (see applyWeaponSkin),
+      // so this diff keeps re-enqueueing (idempotent: one entry per view) until
+      // the queued work actually lands.
       if (e.weaponSkinId !== v.weaponSkinId) {
-        v.weaponSkinId = e.weaponSkinId;
-        const changed = v.visual.setWeaponSkin(e.weaponSkinId);
-        if (changed) for (const node of changed) this.gateSwapOnCompile(node);
-        this.reconcileViewLights(v);
+        if (e.weaponSkinId === null) {
+          this.weaponSkinApplies.cancel(id);
+          this.applyWeaponSkin(v, null);
+        } else {
+          this.weaponSkinApplies.enqueue(id, e.weaponSkinId);
+        }
       }
       const weaponAura = characterWeaponAuraInto(e, this.weaponAuraScratch);
       v.visual.setWeaponAura(weaponAura ? weaponAura.color : null, weaponAura?.tip ?? false);
@@ -9888,6 +10030,7 @@ export class Renderer {
       if (!charOnScreen) v.group.visible = false;
     }
     this.lastVisibleRigCount = visibleRigCount;
+    this.drainWeaponSkinApplies();
 
     // Night mob glow: a warm pool of light on the ground under every nearby body
     // once it is properly dark, so a mob out in an unlit field still reads as a

--- a/src/render/shared_resource.ts
+++ b/src/render/shared_resource.ts
@@ -24,3 +24,18 @@ export function isSharedGeometry(geometry: THREE.BufferGeometry): boolean {
 export function isSharedMaterial(material: THREE.Material): boolean {
   return material.userData.sharedRendererResource === true;
 }
+
+// Textures follow the same rule, and one case makes it load-bearing: the
+// weapon-skin emissive derivation is memoized per (source map, emissive spec),
+// so one derived texture pair is handed to every wearer of that skin. The
+// first wearer's rig tearing down must not dispose it out from under the
+// others (or under the next wearer), so the cache marks what it owns here and
+// every dispose path asks before releasing.
+export function markSharedTexture<T extends THREE.Texture>(texture: T): T {
+  texture.userData.sharedRendererResource = true;
+  return texture;
+}
+
+export function isSharedTexture(texture: THREE.Texture): boolean {
+  return texture.userData.sharedRendererResource === true;
+}

--- a/src/render/weapon_vfx.ts
+++ b/src/render/weapon_vfx.ts
@@ -25,6 +25,12 @@
 // legendary kit (orbit motes, aurora, spin) or vice versa; the escalation ramp
 // is the whole point of the collections.
 import * as THREE from 'three';
+import { isSharedTexture, markSharedTexture } from './shared_resource';
+import {
+  deriveEmissiveTexels,
+  type WeaponEmissiveTint,
+  weaponEmissiveCacheKey,
+} from './weapon_vfx_emissive_core';
 
 // ---------------------------------------------------------------------------
 // Palettes + tier presets (colors from the Armory Codex swatches)
@@ -2147,6 +2153,91 @@ interface EmissiveEntry {
   albedoTex: THREE.CanvasTexture | null;
 }
 
+interface DerivedEmissiveTextures {
+  tex: THREE.CanvasTexture;
+  albedoTex: THREE.CanvasTexture;
+}
+
+// One derivation per (source albedo map, resolved emissive spec) per RENDERER.
+// The result is a pure function of that pair, but it used to be recomputed per
+// payload (twice over when a mirrored offhand joins the skin), per wearer and
+// per rebuild: two canvases the size of the GLB albedo, two getImageData
+// readbacks, a per-texel HSL walk (262144 iterations at 512x512) and two fresh
+// texture uploads, all inside the frame a skinned player came into view. The
+// entries are marked shared, so an individual rig tearing down never disposes
+// the textures the next wearer is still drawing with; the ONE release path is
+// disposeWeaponEmissiveCache below, which the renderer calls at teardown.
+const derivedEmissiveCache = new Map<string, DerivedEmissiveTextures>();
+
+/**
+ * Release every memoized derivation (one megabyte-class texture pair per skin).
+ * TERMINAL ONLY: the renderer calls this from its own resource teardown, after
+ * every view (and therefore every rig that borrowed these textures) is gone, so
+ * a WebGL context recycle does not carry the whole set into the next context.
+ * Calling it while rigs are live would leave their materials pointing at
+ * disposed textures.
+ */
+export function disposeWeaponEmissiveCache(): void {
+  for (const { tex, albedoTex } of derivedEmissiveCache.values()) {
+    tex.dispose();
+    albedoTex.dispose();
+  }
+  derivedEmissiveCache.clear();
+}
+
+/** Test seam: drop the page-lifetime sprite/sky texture memo so a suite can
+ *  observe a cold build (which canvases a rig actually draws) regardless of
+ *  what an earlier case in the file already cached. */
+export function clearWeaponVfxTextureCacheForTest(): void {
+  for (const texture of texCache.values()) texture.dispose();
+  texCache.clear();
+}
+
+/** Derive (or reuse) the emissive + de-baked albedo pair for one source map.
+ *  The canvas plumbing lives here; the per-texel math is the pure core. */
+function derivedEmissiveTextures(
+  source: THREE.Texture,
+  img: HTMLImageElement | HTMLCanvasElement | ImageBitmap,
+  e: WeaponVfxEmissiveSpec,
+  tint: WeaponEmissiveTint,
+): DerivedEmissiveTextures {
+  const key = weaponEmissiveCacheKey(source.uuid, e);
+  const cached = derivedEmissiveCache.get(key);
+  if (cached) return cached;
+  const w = img.width;
+  const h = img.height;
+  const cv = document.createElement('canvas');
+  cv.width = w;
+  cv.height = h;
+  const cx = cv.getContext('2d', { willReadFrequently: true }) as CanvasRenderingContext2D;
+  cx.drawImage(img, 0, 0, w, h);
+  const data = cx.getImageData(0, 0, w, h);
+  // Second buffer: the DE-BAKED albedo. The generator paints its "glow" right
+  // into the base color, so every texel promoted to emissive is also darkened
+  // in the base map; otherwise lighting + emission double up and the core
+  // clips to a flat white patch instead of glowing.
+  const av = document.createElement('canvas');
+  av.width = w;
+  av.height = h;
+  const ax = av.getContext('2d', { willReadFrequently: true }) as CanvasRenderingContext2D;
+  ax.drawImage(img, 0, 0, w, h);
+  const adata = ax.getImageData(0, 0, w, h);
+  deriveEmissiveTexels(data.data, adata.data, e, tint);
+  cx.putImageData(data, 0, 0);
+  ax.putImageData(adata, 0, 0);
+  const mkTex = (canvas: HTMLCanvasElement) => {
+    const t = new THREE.CanvasTexture(canvas);
+    t.flipY = false; // match GLTF UV orientation
+    t.colorSpace = THREE.SRGBColorSpace;
+    t.wrapS = source.wrapS;
+    t.wrapT = source.wrapT;
+    return markSharedTexture(t);
+  };
+  const derived: DerivedEmissiveTextures = { tex: mkTex(cv), albedoTex: mkTex(av) };
+  derivedEmissiveCache.set(key, derived);
+  return derived;
+}
+
 function deriveEmissive(mat: THREE.MeshStandardMaterial, e: WeaponVfxEmissiveSpec): EmissiveEntry {
   const prev: EmissiveRestore = {
     mat,
@@ -2183,75 +2274,12 @@ function deriveEmissive(mat: THREE.MeshStandardMaterial, e: WeaponVfxEmissiveSpe
     mat.emissiveIntensity = 0.3;
     return { prev, tex: null, albedoTex: null };
   }
-  const w = img.width;
-  const h = img.height;
-  const cv = document.createElement('canvas');
-  cv.width = w;
-  cv.height = h;
-  const cx = cv.getContext('2d', { willReadFrequently: true }) as CanvasRenderingContext2D;
-  cx.drawImage(img, 0, 0, w, h);
-  const data = cx.getImageData(0, 0, w, h);
-  const d = data.data;
-  // Second buffer: the DE-BAKED albedo. The generator paints its "glow" right
-  // into the base color, so every texel promoted to emissive is also darkened
-  // in the base map; otherwise lighting + emission double up and the core
-  // clips to a flat white patch instead of glowing.
-  const av = document.createElement('canvas');
-  av.width = w;
-  av.height = h;
-  const ax = av.getContext('2d', { willReadFrequently: true }) as CanvasRenderingContext2D;
-  ax.drawImage(img, 0, 0, w, h);
-  const adata = ax.getImageData(0, 0, w, h);
-  const ad = adata.data;
-  const tint = new THREE.Color(e.tint);
-  for (let i = 0; i < d.length; i += 4) {
-    const r = d[i] / 255;
-    const g = d[i + 1] / 255;
-    const b = d[i + 2] / 255;
-    const mx = Math.max(r, g, b);
-    const mn = Math.min(r, g, b);
-    const l = (mx + mn) / 2;
-    let hue = 0;
-    let s = 0;
-    if (mx !== mn) {
-      const dd = mx - mn;
-      s = dd / (1 - Math.abs(2 * l - 1));
-      if (mx === r) hue = 60 * (((g - b) / dd + 6) % 6);
-      else if (mx === g) hue = 60 * ((b - r) / dd + 2);
-      else hue = 60 * ((r - g) / dd + 4);
-    }
-    let score = 0;
-    if (hue >= e.hue[0] && hue <= e.hue[1] && s >= e.minS && l >= e.minL) {
-      score = Math.min(1, 0.45 + (s - e.minS) * 1.4) * Math.min(1, 0.5 + (l - e.minL) * 1.3);
-    } else if (l >= e.whiteL && (s < 0.14 || (hue >= e.hue[0] && hue <= e.hue[1]))) {
-      score = e.whiteScale * Math.min(1, 0.4 + (l - e.whiteL) * 4);
-    }
-    if (score <= 0.01) {
-      d[i] = d[i + 1] = d[i + 2] = 0;
-    } else {
-      // Graded: source color pushed toward the tier tint, scaled by score.
-      d[i] = Math.round(255 * Math.min(1, (r + (tint.r - r) * 0.62) * score));
-      d[i + 1] = Math.round(255 * Math.min(1, (g + (tint.g - g) * 0.62) * score));
-      d[i + 2] = Math.round(255 * Math.min(1, (b + (tint.b - b) * 0.62) * score));
-      // De-bake: pull the albedo down where the glow now lives.
-      const keep = 1 - 0.72 * score;
-      ad[i] = Math.round(ad[i] * keep);
-      ad[i + 1] = Math.round(ad[i + 1] * keep);
-      ad[i + 2] = Math.round(ad[i + 2] * keep);
-    }
-  }
-  cx.putImageData(data, 0, 0);
-  ax.putImageData(adata, 0, 0);
-  const mkTex = (canvas: HTMLCanvasElement) => {
-    const t = new THREE.CanvasTexture(canvas);
-    t.flipY = false; // match GLTF UV orientation
-    t.colorSpace = THREE.SRGBColorSpace;
-    t.wrapS = (mat.map as THREE.Texture).wrapS;
-    t.wrapT = (mat.map as THREE.Texture).wrapT;
-    return t;
-  };
-  const tex = mkTex(cv);
-  const albedoTex = mkTex(av);
+  const { tex, albedoTex } = derivedEmissiveTextures(
+    mat.map as THREE.Texture,
+    img,
+    e,
+    new THREE.Color(e.tint),
+  );
   mat.emissiveMap = tex;
   mat.emissive = new THREE.Color(0xffffff);
   mat.emissiveIntensity = e.intensity;
@@ -2781,7 +2809,25 @@ function makeBackdrop(tier: WeaponVfxTier): VfxScenePart {
 // Returns { group, sceneExtras, light, update(dt), setPixelScale(px),
 // dispose() }. `sceneExtras` (backdrop dome + ground pool) go on the SCENE,
 // not the weapon; pass grounded=false to skip the ground pool (held mode).
+//
+// The backdrop follows `grounded` by default, and that default is a
+// performance fix, not a cosmetic one: the world path never adds `sceneExtras`
+// to any scene, so its dome was built (a 1024x1024 canvas of gradients plus
+// hundreds of individually drawn stars, then a sphere and material thrown
+// away) purely to be discarded, inside the frame a skinned player came into
+// view. The showcase paths that DO mount `sceneExtras` keep it. `backdrop` is
+// separable from `grounded` for the boot prewarm, which wants the ground
+// pool's program without paying for a sky texture nothing will draw.
+// `setBackdropVisible` stays safe to call either way.
 // ---------------------------------------------------------------------------
+
+export interface WeaponVfxCreateOptions {
+  /** Showcase mode: mount the ground light pool under the weapon. */
+  grounded?: boolean;
+  /** Build the sky dome. Defaults to `grounded`: only a caller that mounts
+   *  `sceneExtras` in a scene has anything to draw it into. */
+  backdrop?: boolean;
+}
 
 export interface WeaponVfxHandle {
   group: THREE.Group;
@@ -2800,7 +2846,7 @@ export interface WeaponVfxHandle {
 export function createWeaponVfx(
   weaponRoot: THREE.Object3D,
   spec: WeaponVfxSpec,
-  { grounded = true }: { grounded?: boolean } = {},
+  { grounded = true, backdrop: withBackdrop = grounded }: WeaponVfxCreateOptions = {},
 ): WeaponVfxHandle {
   const tier = TIERS[spec.tier];
   const b = localBounds(weaponRoot);
@@ -2859,11 +2905,13 @@ export function createWeaponVfx(
     }
   }
 
-  // 5. Scene dressing: backdrop always, ground pool only on the pedestal.
-  const backdrop = makeBackdrop(tier);
-  backdrop.kind = 'backdrop';
-  parts.push(backdrop);
-  sceneExtras.add(backdrop.node);
+  // 5. Scene dressing: both ride sceneExtras, which only a showcase mounts.
+  const backdrop = withBackdrop ? makeBackdrop(tier) : null;
+  if (backdrop) {
+    backdrop.kind = 'backdrop';
+    parts.push(backdrop);
+    sceneExtras.add(backdrop.node);
+  }
   if (grounded) {
     const pool = makePool(tier);
     pool.kind = 'pool';
@@ -2921,7 +2969,7 @@ export function createWeaponVfx(
       applyTuning();
     },
     setBackdropVisible(v: boolean) {
-      backdrop.node.visible = v;
+      if (backdrop) backdrop.node.visible = v;
     },
     setPixelScale(devicePxHeight: number) {
       // Device px per world unit at distance 1 for a 35-degree vertical fov.
@@ -2963,8 +3011,14 @@ export function createWeaponVfx(
       }
       for (const m of allMats) m.dispose();
       for (const { prev, tex, albedoTex } of emissives) {
-        tex?.dispose();
-        albedoTex?.dispose();
+        // The derived pair is memoized and shared with every other wearer of
+        // this skin, so tearing this rig down must not release it (a disposed
+        // texture would leave the next wearer's weapon unglowing, with no
+        // path back short of a page reload). The cache's own release path is
+        // disposeWeaponEmissiveCache at renderer teardown; the guard here
+        // keeps a future rig-OWNED (unmarked) texture releasable.
+        if (tex && !isSharedTexture(tex)) tex.dispose();
+        if (albedoTex && !isSharedTexture(albedoTex)) albedoTex.dispose();
         prev.mat.emissiveMap = prev.emissiveMap;
         prev.mat.map = prev.map;
         prev.mat.metalness = prev.metalness;
@@ -2978,4 +3032,99 @@ export function createWeaponVfx(
       }
     },
   };
+}
+
+// ---------------------------------------------------------------------------
+// Boot prewarm: link every weapon-VFX program once, behind the loading screen.
+//
+// A weapon skin is worn by other players, so the first sighting is the first
+// time these programs link, and it lands mid-gameplay on whoever walks into
+// view first. The shader sources here carry no spec values (every authored
+// number arrives as a uniform or an attribute), so ONE synthetic rig covering
+// each component family produces the exact program cache keys the live rigs
+// ask for later: motes, drift, twinkles, aurora, shell, the pool, and the two
+// sprite materials of the core flare, plus the shared sprite textures they
+// sample. The sky dome is deliberately NOT warmed: nothing in the world path
+// builds one any more.
+// ---------------------------------------------------------------------------
+
+/** Every component family in one rig, with the smallest counts that still
+ *  produce a real draw. The authored values are irrelevant to the program
+ *  keys; covering the KINDS is the whole point. */
+const PREWARM_SPEC: WeaponVfxSpec = {
+  tier: 'legendary',
+  name: 'prewarm',
+  type: 'prewarm',
+  lore: '',
+  fx: [
+    { kind: 'coreSprite', at: { yF: 0.6 }, size: 0.2, color: 0xffffff },
+    {
+      kind: 'motes',
+      at: { yF: 0.5 },
+      radius: [0.12, 0.2],
+      count: 2,
+      size: [0.02, 0.03],
+      speed: [0.6, 0.9],
+      tilt: 0.2,
+      colorA: 0xffffff,
+      colorB: 0xffffff,
+    },
+    {
+      kind: 'drift',
+      line: [{ yF: 0.1 }, { yF: 0.9 }],
+      count: 2,
+      vel: [0, 0.1, 0],
+      spread: [0.02, 0.02, 0.02],
+      life: [1, 2],
+      size: [0.02, 0.03],
+      colorA: 0xffffff,
+      colorB: 0xffffff,
+    },
+    {
+      kind: 'twinkles',
+      surface: { count: 2 },
+      size: [0.02, 0.03],
+      rate: [0.5, 1],
+      color: 0xffffff,
+      star: true,
+    },
+    {
+      kind: 'aurora',
+      helix: { from: { yF: 0.1 }, to: { yF: 0.9 }, radius: 0.1, turns: 1 },
+      width: 0.06,
+    },
+  ],
+};
+
+/** The shared sprite textures every weapon-VFX rig samples, created on first
+ *  ask and cached for the page. Uploading them at boot keeps the first sighting
+ *  of a skin off the synchronous texture-upload path. */
+export function weaponVfxPrewarmTextures(): THREE.Texture[] {
+  return [softDiscTex(), starFlareTex(), noiseTex()];
+}
+
+/**
+ * One hidden rig exercising every weapon-VFX component family, for the boot
+ * prewarm scene. Off-screen (y = -1000) and frustum-culling-exempt like the
+ * other prewarm groups; the caller adds it to the scene, lets the compile
+ * entry link it, then removes it (never disposes: disposing a material
+ * releases its linked program, which is the thing being warmed).
+ */
+export function buildWeaponVfxPrewarmGroup(): THREE.Group {
+  const group = new THREE.Group();
+  group.name = 'weapon-vfx-program-prewarm';
+  group.position.set(0, -1000, 0); // off-screen; compile ignores position
+  const host = new THREE.Mesh(
+    new THREE.BoxGeometry(0.1, 1, 0.1),
+    new THREE.MeshStandardMaterial({ color: 0xffffff }),
+  );
+  host.frustumCulled = false;
+  const handle = createWeaponVfx(host, PREWARM_SPEC, { grounded: true, backdrop: false });
+  // A visible light would change the scene's light counts, and those counts
+  // are part of every program cache key: one extra point light here and the
+  // whole boot compile warms keys no live frame ever asks for.
+  handle.light.visible = false;
+  group.add(host);
+  group.add(handle.sceneExtras);
+  return group;
 }

--- a/src/render/weapon_vfx_apply_queue_core.ts
+++ b/src/render/weapon_vfx_apply_queue_core.ts
@@ -1,0 +1,165 @@
+// Deferral policy for applying a weapon-skin cosmetic (its model swap, its
+// derived emissive materials and its VFX rig) to a live character view.
+//
+// The renderer's per-frame diff used to run that whole chain synchronously the
+// moment `e.weaponSkinId` disagreed with the view's latch, so a burst of
+// skinned players coming into interest applied every rig inside one frame: the
+// reported connection freeze. This core owns the decisions instead, and the
+// renderer stays a thin consumer that only does the Three work the core hands
+// it.
+//
+// Rules, in one place:
+//   - BUDGET: at most `WEAPON_SKIN_APPLIES_PER_FRAME` applications leave the
+//     queue per drain, so a crowd spreads over frames instead of stalling one.
+//   - PRIORITY: with a rank callback (the renderer ranks by squared distance to
+//     the player), each budget slot goes to the nearest valid pending entry, so
+//     the wearer standing next to you never waits behind thirty distant
+//     arrivals. Without one, order is FIFO.
+//   - COALESCING: one pending entry per view id. The diff re-enqueues every
+//     frame while an entry waits (the view's latch is only written when the
+//     application actually RUNS, so a queued-but-dropped skin always retries),
+//     and a skin changed again while queued keeps its queue position but takes
+//     the newest value.
+//   - CANCELLATION: a removed or recycled view drops its pending entry, so an
+//     application never lands on a dead view.
+//   - STALE-GUARD: at drain time the caller re-reads the entity's live skin id.
+//     An entry that no longer matches is dropped WITHOUT spending budget; if
+//     the view still needs a skin, the next frame's diff re-enqueues it.
+//
+// Clearing a skin (back to null) deliberately does NOT queue: the teardown
+// path re-attaches the base weapon model and builds no VFX rig, so it is cheap
+// enough to stay synchronous and instant. The renderer cancels any pending
+// entry for that view first, so a queued apply can never resurrect a skin the
+// player just took off.
+
+/** Applications drained per frame. One is enough to keep the rig latency
+ *  imperceptible (a few frames for a crowd) while never stacking two derive +
+ *  rig builds into the same frame. */
+export const WEAPON_SKIN_APPLIES_PER_FRAME = 1;
+
+export interface WeaponSkinApplyDecision {
+  viewId: number;
+  skinId: string;
+}
+
+/**
+ * The entity's CURRENT weapon-skin id at drain time: `undefined` when the view
+ * or its entity is gone (drop the entry), otherwise the live id, which the
+ * stale-guard compares against the queued one.
+ */
+export type WeaponSkinLookup = (viewId: number) => string | null | undefined;
+
+/**
+ * Rank for one pending view; LOWER drains first. `undefined` ranks WORST, so a
+ * view the caller cannot place (its entity vanished between the enqueue and the
+ * drain) never wins a slot ahead of a real one.
+ */
+export type WeaponSkinRank = (viewId: number) => number | undefined;
+
+/**
+ * Resolve an entity into the value the stale-guard compares against.
+ *
+ * Both "entity is gone" and "entity carries no skin any more" INTENTIONALLY
+ * collapse to `undefined`, which drops the queued entry: neither is something
+ * to apply. Dropping a cleared skin loses nothing, because the renderer's diff
+ * handles that direction synchronously (teardown is cheap) on the same frame it
+ * sees it.
+ */
+export function resolveQueuedSkinLookup(
+  entity: { weaponSkinId: string | null } | undefined,
+): string | undefined {
+  return entity?.weaponSkinId ?? undefined;
+}
+
+export class WeaponSkinApplyQueue {
+  // Insertion-ordered, so an unranked drain is FIFO. Re-setting an existing key
+  // updates the value and KEEPS its position, which is exactly the coalescing
+  // rule.
+  private readonly pending = new Map<number, string>();
+  // Decision slots owned by the queue and handed out by reference: grown once,
+  // then mutated in place, so a steady-state drain allocates nothing.
+  private readonly slots: WeaponSkinApplyDecision[] = [];
+
+  get size(): number {
+    return this.pending.size;
+  }
+
+  has(viewId: number): boolean {
+    return this.pending.has(viewId);
+  }
+
+  /** Queue (or re-coalesce) a skin application for one view. Idempotent: the
+   *  per-frame diff calls this on every frame the view's latch still disagrees. */
+  enqueue(viewId: number, skinId: string): void {
+    this.pending.set(viewId, skinId);
+  }
+
+  /** Drop a view's pending entry (view removed, recycled, or skin cleared). */
+  cancel(viewId: number): void {
+    this.pending.delete(viewId);
+  }
+
+  clear(): void {
+    this.pending.clear();
+  }
+
+  /**
+   * Take up to `budget` applications that are still valid, filling and
+   * returning the caller-owned `out` array. Entries the guard rejects (dead
+   * view, skin moved on) leave the queue without spending a slot; everything
+   * else keeps its place for a later drain.
+   *
+   * ALLOCATION: none in steady state. `out` is refilled with queue-owned slot
+   * objects, so `out.length` carries the count and the entries are stable by
+   * reference across drains, which also means they stay valid only until the
+   * NEXT take (the renderer consumes them inside the same frame). The scan
+   * costs O(pending) per slot and only runs while something is queued.
+   */
+  take(
+    budget: number,
+    current: WeaponSkinLookup,
+    out: WeaponSkinApplyDecision[],
+    rank?: WeaponSkinRank,
+  ): WeaponSkinApplyDecision[] {
+    out.length = 0;
+    if (budget <= 0) return out;
+    while (out.length < budget && this.pending.size > 0) {
+      let bestId: number | null = null;
+      let bestSkin = '';
+      let bestRank = Number.POSITIVE_INFINITY;
+      for (const [viewId, skinId] of this.pending) {
+        const live = current(viewId);
+        // Dead view, or the skin moved on while this entry waited: drop it and
+        // keep scanning, so a stale entry never spends the frame's budget.
+        if (live === undefined || live !== skinId) {
+          this.pending.delete(viewId);
+          continue;
+        }
+        // Without a rank callback every candidate scores the same, so the
+        // strict comparison below keeps the FIRST valid entry: plain FIFO.
+        const value = rank ? (rank(viewId) ?? Number.POSITIVE_INFINITY) : Number.POSITIVE_INFINITY;
+        if (bestId === null || value < bestRank) {
+          bestId = viewId;
+          bestSkin = skinId;
+          bestRank = value;
+        }
+      }
+      if (bestId === null) break;
+      this.pending.delete(bestId);
+      const slot = this.slot(out.length);
+      slot.viewId = bestId;
+      slot.skinId = bestSkin;
+      out.push(slot);
+    }
+    return out;
+  }
+
+  private slot(index: number): WeaponSkinApplyDecision {
+    let slot = this.slots[index];
+    if (!slot) {
+      slot = { viewId: 0, skinId: '' };
+      this.slots[index] = slot;
+    }
+    return slot;
+  }
+}

--- a/src/render/weapon_vfx_emissive_core.ts
+++ b/src/render/weapon_vfx_emissive_core.ts
@@ -1,0 +1,146 @@
+// Host-agnostic half of the weapon-skin emissive derivation (weapon_vfx.ts).
+//
+// The skin generator paints a weapon's "magic" (core, runes, cracks) straight
+// into the albedo. The rig turns those painted texels into a graded emissive
+// map and de-bakes the same texels out of the albedo, so exactly the painted
+// parts light up and bloom instead of the lighting and the emission doubling
+// up into a flat white patch.
+//
+// That transform is a PURE function of (source RGBA, resolved emissive spec):
+// no canvas, no Three, no wall clock. It lives here so a Vitest can drive the
+// per-texel math on small synthetic buffers, and so weapon_vfx.ts keeps only
+// the canvas plumbing around it. The identity of that pure function is also
+// the memo key the caller caches derived textures under: one derivation per
+// (source map, resolved spec) per session, shared across every wearer, payload
+// and rebuild, instead of a 262144-texel loop inside the frame a skinned
+// player comes into view.
+
+/** The window that decides which texels glow. Shaped structurally so
+ *  `WeaponVfxEmissiveSpec` satisfies it without this core importing it. */
+export interface WeaponEmissiveWindow {
+  /** Inclusive hue window in degrees, [low, high]. */
+  hue: readonly [number, number];
+  /** Minimum HSL saturation inside the hue window. */
+  minS: number;
+  /** Minimum HSL lightness inside the hue window. */
+  minL: number;
+  /** Lightness at which a near-white texel picks up a residual glow. */
+  whiteL: number;
+  /** How much of the score a near-white texel keeps. */
+  whiteScale: number;
+}
+
+/** Working-color-space tint the derived emissive is graded toward (0..1 per
+ *  channel). The caller converts the spec's sRGB hex; color management is
+ *  Three's job, never this core's. */
+export interface WeaponEmissiveTint {
+  r: number;
+  g: number;
+  b: number;
+}
+
+/** Every field of the resolved emissive spec, for the memo signature. */
+export interface WeaponEmissiveSignatureSpec extends WeaponEmissiveWindow {
+  tint: number;
+  intensity: number;
+  pulse: number;
+  pulseHz: number;
+}
+
+/**
+ * Grade `emissive` into the emissive map and de-bake `albedo` in place. Both
+ * buffers arrive holding the SAME source pixels (the caller draws the albedo
+ * twice); `emissive.length` drives the walk, and alpha is left untouched in
+ * both. Values are byte-identical to the loop this was lifted from.
+ */
+export function deriveEmissiveTexels(
+  emissive: Uint8ClampedArray,
+  albedo: Uint8ClampedArray,
+  emissiveWindow: WeaponEmissiveWindow,
+  tint: WeaponEmissiveTint,
+): void {
+  const d = emissive;
+  const ad = albedo;
+  for (let i = 0; i < d.length; i += 4) {
+    const r = d[i] / 255;
+    const g = d[i + 1] / 255;
+    const b = d[i + 2] / 255;
+    const mx = Math.max(r, g, b);
+    const mn = Math.min(r, g, b);
+    const l = (mx + mn) / 2;
+    let hue = 0;
+    let s = 0;
+    if (mx !== mn) {
+      const dd = mx - mn;
+      s = dd / (1 - Math.abs(2 * l - 1));
+      if (mx === r) hue = 60 * (((g - b) / dd + 6) % 6);
+      else if (mx === g) hue = 60 * ((b - r) / dd + 2);
+      else hue = 60 * ((r - g) / dd + 4);
+    }
+    let score = 0;
+    if (
+      hue >= emissiveWindow.hue[0] &&
+      hue <= emissiveWindow.hue[1] &&
+      s >= emissiveWindow.minS &&
+      l >= emissiveWindow.minL
+    ) {
+      score =
+        Math.min(1, 0.45 + (s - emissiveWindow.minS) * 1.4) *
+        Math.min(1, 0.5 + (l - emissiveWindow.minL) * 1.3);
+    } else if (
+      l >= emissiveWindow.whiteL &&
+      (s < 0.14 || (hue >= emissiveWindow.hue[0] && hue <= emissiveWindow.hue[1]))
+    ) {
+      score = emissiveWindow.whiteScale * Math.min(1, 0.4 + (l - emissiveWindow.whiteL) * 4);
+    }
+    if (score <= 0.01) {
+      d[i] = d[i + 1] = d[i + 2] = 0;
+    } else {
+      // Graded: source color pushed toward the tier tint, scaled by score.
+      d[i] = Math.round(255 * Math.min(1, (r + (tint.r - r) * 0.62) * score));
+      d[i + 1] = Math.round(255 * Math.min(1, (g + (tint.g - g) * 0.62) * score));
+      d[i + 2] = Math.round(255 * Math.min(1, (b + (tint.b - b) * 0.62) * score));
+      // De-bake: pull the albedo down where the glow now lives.
+      const keep = 1 - 0.72 * score;
+      ad[i] = Math.round(ad[i] * keep);
+      ad[i + 1] = Math.round(ad[i + 1] * keep);
+      ad[i + 2] = Math.round(ad[i + 2] * keep);
+    }
+  }
+}
+
+/**
+ * Stable signature of a resolved emissive spec. Deliberately covers EVERY
+ * field, not only the five the walk above reads: a spec whose glow pulse or
+ * intensity differs is a different authored look, and keying on the whole
+ * record means a future field that does shape texels can never serve a stale
+ * cached texture. The cost of the extra strictness is at most one more
+ * derivation per weapon.
+ */
+export function weaponEmissiveSignature(spec: WeaponEmissiveSignatureSpec): string {
+  return [
+    spec.hue[0],
+    spec.hue[1],
+    spec.minS,
+    spec.minL,
+    spec.whiteL,
+    spec.whiteScale,
+    spec.tint,
+    spec.intensity,
+    spec.pulse,
+    spec.pulseHz,
+  ].join(':');
+}
+
+/**
+ * Memo key for one derived (emissive, de-baked albedo) texture pair.
+ * `sourceId` identifies the source albedo map (its texture uuid): two players
+ * wearing the same skin, and the two hands of a mirrored offhand, share one
+ * source texture instance and therefore one derivation.
+ */
+export function weaponEmissiveCacheKey(
+  sourceId: string,
+  spec: WeaponEmissiveSignatureSpec,
+): string {
+  return `${sourceId}|${weaponEmissiveSignature(spec)}`;
+}

--- a/tests/architecture.test.ts
+++ b/tests/architecture.test.ts
@@ -493,6 +493,8 @@ const RENDER_PURE_CORES = [
   'src/render/resident_scenery_core.ts',
   'src/render/player_aura_rings_core.ts',
   'src/render/warrior_cast_fx_core.ts',
+  'src/render/weapon_vfx_apply_queue_core.ts',
+  'src/render/weapon_vfx_emissive_core.ts',
   'src/render/zone_feature_visibility_core.ts',
   'src/render/characters/skeleton_update_core.ts',
   'src/render/characters/weapon_attack_style_core.ts',

--- a/tests/eastbrook_polish_artifact_integrity.test.ts
+++ b/tests/eastbrook_polish_artifact_integrity.test.ts
@@ -645,10 +645,14 @@ const ACCEPTED_POLISH_V2_METADATA_PATH = path.join(REPO_ROOT, POLISH_SEAL_PATH);
 // renderer; the release's bounded ground-object reuse pool), so the merged tree
 // mints literals matching neither parent. Captures adopted verbatim from the
 // release tip; swept by remint_polish_provenance.mjs on the merged tree.
+// Re-pinned once more for the weapon-skin VFX connection-freeze fix: the
+// budgeted apply queue and the vfx.weapon-skins prewarm entry move
+// src/render/renderer.ts, the rendererIntegration leaf, so the composite and the
+// metadata seal that embeds it both re-mint (remint_polish_provenance.mjs).
 const ACCEPTED_POLISH_V2_METADATA_SHA256 =
-  'dcf57f6d70ee1c8b472f8d1114d129005c2f0d051db925b8cfe506ad1f0b8c03';
+  'd025ce8f227bda8a6ebd971f100791e88187652c4c90d95690e20210e9dc0598';
 const ACCEPTED_POLISH_V2_COMPOSITE_PROVENANCE =
-  'f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9';
+  '214d84f280403acce49fb2513648ef6605870f1228f8008cf98194f44367bdef';
 const ACCEPTED_POLISH_V2_METADATA = readJsonFile<CaptureMetadata>(ACCEPTED_POLISH_V2_METADATA_PATH);
 const ACCEPTED_POLISH_V2_PROVENANCE = ACCEPTED_POLISH_V2_METADATA.polishProvenance;
 const ACCEPTED_POLISH_V2_TOWN_CONTRACT = ACCEPTED_POLISH_V2_METADATA.records[0]?.townContract;
@@ -1526,10 +1530,13 @@ describe('Eastbrook polish performance and contact evidence', () => {
     // matched the merged tree, and no capture was retaken here.
     // Re-pinned for the integrated v0.35 renderer on AAA-enhancements and
     // recomputed by remint_polish_provenance.mjs.
+    // Re-pinned once more for the weapon-skin VFX connection-freeze fix's
+    // src/render/renderer.ts change (budgeted apply queue plus the
+    // vfx.weapon-skins prewarm entry), same script, no capture retaken.
     expect(
       fingerprint.digest('hex'),
       `the second-order performance digest moved; if every input moved legitimately, re-mint with: ${REMINT_COMMAND} (it recomputes this literal LAST, from the swept files)`,
-    ).toBe('4fd9c844d07805ba75c6749ae76ee139838d5f3f389fe2b20266671f7afb4cd0');
+    ).toBe('9ba4f887da46636a59bfb6173b9d0fc83cac461ffa559608aa906ee81ac3c476');
   });
 
   it('binds every historical after record to its accepted source and asset provenance', () => {

--- a/tests/eastbrook_polish_capture_contract.test.ts
+++ b/tests/eastbrook_polish_capture_contract.test.ts
@@ -49,8 +49,10 @@ interface AttributionTargetFixture {
 // fence-removal layout evidence, the v0.34.0 Bear Form rig (#2842), the live
 // graphics rebuild (#2799), far-field impostors and fog-free vista (#2793),
 // brood shout/flourish wiring, the worldObjectBurning fire-burst cue, the
-// Thornhollow renderer sync, and the release/v0.35.0 into AAA-enhancements
-// merge, each of which moved a runtimeRender leaf (usually
+// Thornhollow renderer sync, the release/v0.35.0 into AAA-enhancements
+// merge, and the weapon-skin VFX connection-freeze fix (the budgeted
+// weapon-skin apply queue plus the vfx.weapon-skins boot prewarm entry),
+// each of which moved a runtimeRender leaf (usually
 // src/render/renderer.ts); every mint used
 // scripts/assets/eastbrook_grand_armoury/remint_polish_provenance.mjs.
 // Across all of those mints no GLB pipeline input or geometry value changed
@@ -62,7 +64,7 @@ interface AttributionTargetFixture {
 // diff; see provenance_diagnostics.mjs for the 2026-08-05 stale-mint root
 // cause this legibility exists to prevent.
 const PINNED_POLISH_COMPOSITE_FINGERPRINT =
-  'f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9';
+  '214d84f280403acce49fb2513648ef6605870f1228f8008cf98194f44367bdef';
 
 function validPolishAttributionTargets(): AttributionTargetFixture[] {
   return [

--- a/tests/foliage_lod.test.ts
+++ b/tests/foliage_lod.test.ts
@@ -49,7 +49,14 @@ function maxOutdoorFogFar(): number {
 
 function shippedBiomeFog(): { biome: string; near: number; far: number }[] {
   const maxFar = maxOutdoorFogFar();
-  const block = /BIOME_FOG[^{]*\{([\s\S]*?)\n {2}\};/.exec(rendererSrc);
+  // Anchored on the DECLARATION, not the first mention: `BIOME_FOG` is used
+  // thousands of lines above the table it names, and an unanchored match started
+  // there and ran to whichever `\n  };` came first. That terminator was the real
+  // table's only by luck, and a class property closing earlier (a bound arrow
+  // field) silently moved it in front of the table, leaving this sweep parsing a
+  // 230 KB body with no fog row in it. `[^=]*` crosses the Record<...> type, whose
+  // own brace is what kept the anchor off the declaration in the first place.
+  const block = /static BIOME_FOG[^=]*=\s*\{([\s\S]*?)\n {2}\};/.exec(rendererSrc);
   expect(block, 'BIOME_FOG table not found in renderer.ts').not.toBe(null);
   const body = (block as RegExpExecArray)[1];
   const rows = [...body.matchAll(/(\w+):\s*\{[^}]*near:\s*([\d.]+),\s*far:\s*([\w.]+)/g)].map(

--- a/tests/prewarm_resume.test.ts
+++ b/tests/prewarm_resume.test.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
+import { CONSTRAINED_PREWARM_KEEP } from '../src/render/prewarm_policy';
 import {
   buildPrewarmCompileUnits,
   type PrewarmResumeEntry,
@@ -256,5 +257,42 @@ describe('resumeDroppedPrewarmEntries', () => {
     expect(scene).toContain("textureResumeUnits('scene', this.collectInitialSceneTextures())");
     expect(surface).not.toContain('renderPrewarmPass');
     expect(scene).not.toContain('renderPrewarmPass');
+  });
+
+  // Weapon-skin rigs are worn by OTHER players, so nothing at boot draws one
+  // and their programs otherwise link on the first sighting, mid-gameplay.
+  it('warms the weapon-skin VFX programs as small resumable units', () => {
+    const source = readFileSync(new URL('../src/render/renderer.ts', import.meta.url), 'utf8');
+    const start = source.indexOf("id: 'vfx.weapon-skins'");
+    const end = source.indexOf("id: 'vfx.ability-primitives'", start);
+    const entry = source.slice(start, end);
+
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+    expect(entry).toContain("category: 'vfx'");
+    expect(entry).toContain('required: false');
+    // Three explicitly bounded units, never a whole-entry rerun.
+    expect(entry).toContain("id: 'weapon-skins:group'");
+    expect(entry).toContain("id: 'weapon-skins:textures'");
+    expect(entry).toContain("id: 'weapon-skins:compile'");
+    expect(entry).toContain('await this.compilePrewarmColorPrograms(weaponVfxPrewarmGroup, false)');
+    expect(entry.match(/buildWeaponVfxPrewarmGroup\(\)/g)).toHaveLength(2); // run + resume unit
+    expect(entry).toContain('for (const texture of weaponVfxPrewarmTextures()) ');
+    // The sky dome is not warmed: the world path builds none any more.
+    expect(entry).not.toContain('skyTex');
+
+    // The staged group is torn out of the scene by both cleanup paths and
+    // hidden between resumed entries, exactly like every other prewarm group.
+    expect(source).toContain('if (weaponVfxPrewarmGroup) this.scene.remove(weaponVfxPrewarmGroup)');
+    expect(source).toContain('weaponVfxPrewarmGroup = null;');
+    const hideStart = source.indexOf('const hidePrewarmArtifacts = ');
+    const hideEnd = source.indexOf('const cleanupPrewarmArtifacts = ', hideStart);
+    expect(source.slice(hideStart, hideEnd)).toContain('weaponVfxPrewarmGroup,');
+    // A dropped programs.compile still links it from its own bounded unit.
+    expect(source).toContain("['weapon-vfx', weaponVfxPrewarmGroup],");
+  });
+
+  it('leaves the weapon-skin warm off the constrained keep-list', () => {
+    expect(CONSTRAINED_PREWARM_KEEP).not.toContain('vfx.weapon-skins');
   });
 });

--- a/tests/renderer_lifecycle.test.ts
+++ b/tests/renderer_lifecycle.test.ts
@@ -129,6 +129,9 @@ describe('Renderer lifecycle wiring', () => {
     };
     renderer.visualPool = new Map([['player', [{ dispose: () => events.push('pool:dispose') }]]]);
     renderer.objectPool = new Map();
+    // The deferred weapon-skin apply queue is a teardown participant too: a
+    // pending application must never survive into the next context.
+    renderer.weaponSkinApplies = { clear: () => events.push('weaponskins:clear') };
     renderer.clickTargets = [];
     renderer.gatherNodeMeshes = [];
     renderer.viewLights = [];
@@ -146,6 +149,7 @@ describe('Renderer lifecycle wiring', () => {
       'queue:shutdown',
       'view:dispose',
       'pool:dispose',
+      'weaponskins:clear',
       'nameplates:dispose',
       'nameplates:clear',
       'travel:dispose',

--- a/tests/weapon_vfx_apply_queue_core.test.ts
+++ b/tests/weapon_vfx_apply_queue_core.test.ts
@@ -1,0 +1,372 @@
+// The deferral policy behind the weapon-skin connection freeze: at most one
+// rig application leaves the queue per frame, one entry per view, dead views
+// dropped, and a queued skin the entity has since changed never applied.
+import { readFileSync } from 'node:fs';
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  resolveQueuedSkinLookup,
+  WEAPON_SKIN_APPLIES_PER_FRAME,
+  type WeaponSkinApplyDecision,
+  WeaponSkinApplyQueue,
+} from '../src/render/weapon_vfx_apply_queue_core';
+
+describe('WeaponSkinApplyQueue', () => {
+  let queue: WeaponSkinApplyQueue;
+  let out: WeaponSkinApplyDecision[];
+
+  beforeEach(() => {
+    queue = new WeaponSkinApplyQueue();
+    out = [];
+  });
+
+  /** Live-skin lookup over a plain table; a missing id is a gone view/entity. */
+  const lookup =
+    (live: Record<number, string | null>) =>
+    (viewId: number): string | null | undefined =>
+      viewId in live ? live[viewId] : undefined;
+
+  it('budgets applications per drain and keeps the rest queued in FIFO order', () => {
+    const live = { 1: 'ice_fang', 2: 'ice_fang', 3: 'starfall' };
+    queue.enqueue(1, 'ice_fang');
+    queue.enqueue(2, 'ice_fang');
+    queue.enqueue(3, 'starfall');
+    expect(queue.size).toBe(3);
+
+    expect(queue.take(1, lookup(live), out)).toEqual([{ viewId: 1, skinId: 'ice_fang' }]);
+    expect(queue.size).toBe(2);
+    expect(queue.take(1, lookup(live), out)).toEqual([{ viewId: 2, skinId: 'ice_fang' }]);
+    expect(queue.take(1, lookup(live), out)).toEqual([{ viewId: 3, skinId: 'starfall' }]);
+    expect(queue.size).toBe(0);
+    expect(queue.take(1, lookup(live), out)).toEqual([]);
+  });
+
+  it('ships one application per frame by default', () => {
+    expect(WEAPON_SKIN_APPLIES_PER_FRAME).toBe(1);
+  });
+
+  it('coalesces repeat enqueues into one entry that keeps its queue position', () => {
+    queue.enqueue(1, 'ice_fang');
+    queue.enqueue(2, 'starfall');
+    // The renderer's per-frame diff re-enqueues every frame while an entry
+    // waits (the view latch is only written when the apply runs).
+    queue.enqueue(1, 'ice_fang');
+    queue.enqueue(1, 'ice_fang');
+    expect(queue.size).toBe(2);
+
+    const live = { 1: 'ice_fang', 2: 'starfall' };
+    expect(queue.take(4, lookup(live), out)).toEqual([
+      { viewId: 1, skinId: 'ice_fang' },
+      { viewId: 2, skinId: 'starfall' },
+    ]);
+  });
+
+  it('lets the newest skin win without losing the queue position', () => {
+    queue.enqueue(1, 'ice_fang');
+    queue.enqueue(2, 'starfall');
+    queue.enqueue(1, 'emberfang'); // changed again while queued
+    expect(queue.size).toBe(2);
+
+    const live = { 1: 'emberfang', 2: 'starfall' };
+    expect(queue.take(4, lookup(live), out)).toEqual([
+      { viewId: 1, skinId: 'emberfang' },
+      { viewId: 2, skinId: 'starfall' },
+    ]);
+  });
+
+  it('drops a cancelled view and never applies to it', () => {
+    queue.enqueue(1, 'ice_fang');
+    queue.enqueue(2, 'starfall');
+    queue.cancel(1);
+    expect(queue.has(1)).toBe(false);
+    expect(queue.size).toBe(1);
+
+    // Even with the entity still wearing the skin, the cancelled view is gone
+    // from the queue: only the surviving view is applied.
+    expect(queue.take(4, lookup({ 1: 'ice_fang', 2: 'starfall' }), out)).toEqual([
+      { viewId: 2, skinId: 'starfall' },
+    ]);
+  });
+
+  it('drops an entry whose view or entity disappeared before the drain', () => {
+    queue.enqueue(1, 'ice_fang');
+    queue.enqueue(2, 'starfall');
+
+    // View 1's lookup returns undefined (view removed or recycled).
+    expect(queue.take(4, lookup({ 2: 'starfall' }), out)).toEqual([
+      { viewId: 2, skinId: 'starfall' },
+    ]);
+    expect(queue.size).toBe(0);
+  });
+
+  it('drops a stale entry without spending the frame budget', () => {
+    queue.enqueue(1, 'ice_fang');
+    queue.enqueue(2, 'starfall');
+
+    // View 1 swapped to another cosmetic after being queued: the queued value
+    // is stale, so it is dropped AND view 2 still gets this frame's one slot.
+    const live = { 1: 'emberfang', 2: 'starfall' };
+    expect(queue.take(WEAPON_SKIN_APPLIES_PER_FRAME, lookup(live), out)).toEqual([
+      { viewId: 2, skinId: 'starfall' },
+    ]);
+    expect(queue.size).toBe(0);
+    // The diff re-enqueues the fresh value on the next frame.
+    queue.enqueue(1, 'emberfang');
+    expect(queue.take(1, lookup(live), out)).toEqual([{ viewId: 1, skinId: 'emberfang' }]);
+  });
+
+  it('drops an entry whose skin was cleared to null while queued', () => {
+    queue.enqueue(1, 'ice_fang');
+    expect(queue.take(4, lookup({ 1: null }), out)).toEqual([]);
+    expect(queue.size).toBe(0);
+  });
+
+  it('refills the caller-owned output array instead of allocating per drain', () => {
+    out.push({ viewId: 99, skinId: 'stale' });
+    queue.enqueue(1, 'ice_fang');
+    const returned = queue.take(4, lookup({ 1: 'ice_fang' }), out);
+    expect(returned).toBe(out);
+    expect(out).toEqual([{ viewId: 1, skinId: 'ice_fang' }]);
+  });
+
+  it('takes nothing on a non-positive budget and leaves the queue untouched', () => {
+    queue.enqueue(1, 'ice_fang');
+    expect(queue.take(0, lookup({ 1: 'ice_fang' }), out)).toEqual([]);
+    expect(queue.size).toBe(1);
+  });
+
+  it('clears every pending entry', () => {
+    queue.enqueue(1, 'ice_fang');
+    queue.enqueue(2, 'starfall');
+    queue.clear();
+    expect(queue.size).toBe(0);
+  });
+
+  describe('nearest-first ranking', () => {
+    it('gives the frame budget to the nearest queued wearer, not the oldest', () => {
+      // Arrival order is far, far, near: FIFO would make the wearer beside the
+      // player wait three frames at one application each.
+      queue.enqueue(1, 'ice_fang');
+      queue.enqueue(2, 'ice_fang');
+      queue.enqueue(3, 'starfall');
+      const live = { 1: 'ice_fang', 2: 'ice_fang', 3: 'starfall' };
+      const distanceSq: Record<number, number> = { 1: 900, 2: 400, 3: 4 };
+      const rank = (viewId: number) => distanceSq[viewId];
+
+      expect(queue.take(1, lookup(live), out, rank)).toEqual([{ viewId: 3, skinId: 'starfall' }]);
+      expect(queue.take(1, lookup(live), out, rank)).toEqual([{ viewId: 2, skinId: 'ice_fang' }]);
+      expect(queue.take(1, lookup(live), out, rank)).toEqual([{ viewId: 1, skinId: 'ice_fang' }]);
+      expect(queue.size).toBe(0);
+    });
+
+    it('fills a multi-slot budget in ascending rank order', () => {
+      queue.enqueue(1, 'a');
+      queue.enqueue(2, 'b');
+      queue.enqueue(3, 'c');
+      const live = { 1: 'a', 2: 'b', 3: 'c' };
+      const distanceSq: Record<number, number> = { 1: 25, 2: 1, 3: 9 };
+
+      expect(queue.take(3, lookup(live), out, (id) => distanceSq[id])).toEqual([
+        { viewId: 2, skinId: 'b' },
+        { viewId: 3, skinId: 'c' },
+        { viewId: 1, skinId: 'a' },
+      ]);
+    });
+
+    it('ranks an unplaceable view worst instead of letting it jump the queue', () => {
+      queue.enqueue(1, 'ice_fang');
+      queue.enqueue(2, 'starfall');
+      const live = { 1: 'ice_fang', 2: 'starfall' };
+      // View 1 is queued but the caller cannot place it (undefined rank).
+      const rank = (viewId: number) => (viewId === 1 ? undefined : 100);
+
+      expect(queue.take(1, lookup(live), out, rank)).toEqual([{ viewId: 2, skinId: 'starfall' }]);
+      // It is not dropped either: it drains once nothing placeable is left.
+      expect(queue.take(1, lookup(live), out, rank)).toEqual([{ viewId: 1, skinId: 'ice_fang' }]);
+    });
+
+    it('breaks a rank tie by arrival order', () => {
+      queue.enqueue(7, 'a');
+      queue.enqueue(8, 'b');
+      const live = { 7: 'a', 8: 'b' };
+      expect(queue.take(1, lookup(live), out, () => 42)).toEqual([{ viewId: 7, skinId: 'a' }]);
+    });
+
+    it('stays FIFO when no rank is given', () => {
+      queue.enqueue(5, 'a');
+      queue.enqueue(6, 'b');
+      queue.enqueue(7, 'c');
+      const live = { 5: 'a', 6: 'b', 7: 'c' };
+
+      expect(queue.take(1, lookup(live), out)).toEqual([{ viewId: 5, skinId: 'a' }]);
+      expect(queue.take(2, lookup(live), out)).toEqual([
+        { viewId: 6, skinId: 'b' },
+        { viewId: 7, skinId: 'c' },
+      ]);
+    });
+
+    it('still drops stale and dead entries when ranking', () => {
+      queue.enqueue(1, 'ice_fang');
+      queue.enqueue(2, 'starfall');
+      queue.enqueue(3, 'emberfang');
+      // View 1 is nearest but its entity moved on; view 2's view is gone.
+      const live = { 1: 'other', 3: 'emberfang' };
+      const distanceSq: Record<number, number> = { 1: 1, 2: 2, 3: 300 };
+
+      expect(queue.take(1, lookup(live), out, (id) => distanceSq[id])).toEqual([
+        { viewId: 3, skinId: 'emberfang' },
+      ]);
+      expect(queue.size).toBe(0);
+    });
+  });
+
+  describe('allocation discipline', () => {
+    it('reuses the same decision slots across drains', () => {
+      queue.enqueue(1, 'ice_fang');
+      queue.take(1, lookup({ 1: 'ice_fang' }), out);
+      const firstSlot = out[0];
+      expect(firstSlot).toEqual({ viewId: 1, skinId: 'ice_fang' });
+
+      queue.enqueue(2, 'starfall');
+      queue.take(1, lookup({ 2: 'starfall' }), out);
+      // Same object, rewritten in place: a steady-state drain allocates nothing.
+      expect(out[0]).toBe(firstSlot);
+      expect(out[0]).toEqual({ viewId: 2, skinId: 'starfall' });
+      expect(out).toHaveLength(1);
+    });
+
+    it('reuses slots per position when the budget grows', () => {
+      queue.enqueue(1, 'a');
+      queue.enqueue(2, 'b');
+      queue.take(2, lookup({ 1: 'a', 2: 'b' }), out);
+      const [slot0, slot1] = out;
+
+      queue.enqueue(3, 'c');
+      queue.enqueue(4, 'd');
+      queue.take(2, lookup({ 3: 'c', 4: 'd' }), out);
+      expect(out[0]).toBe(slot0);
+      expect(out[1]).toBe(slot1);
+      expect(slot0).not.toBe(slot1);
+    });
+  });
+});
+
+describe('resolveQueuedSkinLookup', () => {
+  it('drops a queued entry whose entity is gone', () => {
+    expect(resolveQueuedSkinLookup(undefined)).toBeUndefined();
+  });
+
+  it('drops a queued entry whose entity cleared its skin', () => {
+    // Deliberate: the renderer's diff applies the null direction synchronously,
+    // so nothing is lost by not queueing it.
+    expect(resolveQueuedSkinLookup({ weaponSkinId: null })).toBeUndefined();
+  });
+
+  it('reports a different live skin so the stale-guard can reject the entry', () => {
+    expect(resolveQueuedSkinLookup({ weaponSkinId: 'emberfang' })).toBe('emberfang');
+  });
+
+  it('reports the matching skin so the entry applies', () => {
+    expect(resolveQueuedSkinLookup({ weaponSkinId: 'ice_fang' })).toBe('ice_fang');
+  });
+
+  it('feeds the queue guard end to end', () => {
+    const queue = new WeaponSkinApplyQueue();
+    const out: WeaponSkinApplyDecision[] = [];
+    const entities = new Map<number, { weaponSkinId: string | null }>([
+      [1, { weaponSkinId: 'ice_fang' }],
+      [2, { weaponSkinId: null }],
+      [3, { weaponSkinId: 'emberfang' }],
+    ]);
+    queue.enqueue(1, 'ice_fang');
+    queue.enqueue(2, 'starfall');
+    queue.enqueue(3, 'starfall');
+    queue.enqueue(4, 'starfall');
+
+    expect(queue.take(4, (id) => resolveQueuedSkinLookup(entities.get(id)), out)).toEqual([
+      { viewId: 1, skinId: 'ice_fang' },
+    ]);
+    expect(queue.size).toBe(0);
+  });
+});
+
+// The Three half is a thin consumer, so its wiring is pinned in source: the
+// expensive apply must not be reachable from the per-frame diff any more, and
+// the post-application steps (latch, compile gate, light reconcile) must all
+// still run for every applied view.
+describe('renderer wiring', () => {
+  const renderer = readFileSync(new URL('../src/render/renderer.ts', import.meta.url), 'utf8');
+
+  function slice(from: string, to: string): string {
+    const start = renderer.indexOf(from);
+    expect(start, `missing anchor: ${from}`).toBeGreaterThan(-1);
+    const end = renderer.indexOf(to, start);
+    expect(end, `missing anchor: ${to}`).toBeGreaterThan(start);
+    return renderer.slice(start, end);
+  }
+
+  it('enqueues the apply from the per-frame diff instead of running it there', () => {
+    const diff = slice('// live weapon-skin swap:', 'const weaponAura = characterWeaponAuraInto(');
+    expect(diff).toContain('this.weaponSkinApplies.enqueue(id, e.weaponSkinId)');
+    // Clearing a skin builds no rig, so it stays synchronous, and cancels any
+    // queued apply first.
+    expect(diff).toContain('this.weaponSkinApplies.cancel(id)');
+    expect(diff).toContain('this.applyWeaponSkin(v, null)');
+    // The chain that used to freeze the frame is gone from the diff entirely,
+    // and so is the latch that would have suppressed the retry.
+    expect(diff).not.toContain('setWeaponSkin(e.weaponSkinId)');
+    expect(diff).not.toContain('v.weaponSkinId = e.weaponSkinId');
+  });
+
+  it('keeps every post-application step on the applying path', () => {
+    const apply = slice('private applyWeaponSkin(', 'private drainWeaponSkinApplies(');
+    expect(apply).toContain('v.weaponSkinId = skinId;');
+    expect(apply).toContain('v.visual.setWeaponSkin(skinId)');
+    expect(apply).toContain('for (const node of changed) this.gateSwapOnCompile(node)');
+    expect(apply).toContain('this.reconcileViewLights(v)');
+  });
+
+  it('drains one budgeted batch per frame right after the entity loop', () => {
+    expect(renderer).toContain(
+      'this.lastVisibleRigCount = visibleRigCount;\n    this.drainWeaponSkinApplies();',
+    );
+    const drain = slice('private drainWeaponSkinApplies(', '\n  private reconcileViewLights(');
+    expect(drain).toContain('WEAPON_SKIN_APPLIES_PER_FRAME');
+    expect(drain).toContain('this.weaponSkinLookup');
+    expect(drain).toContain('this.weaponSkinApplyScratch');
+    expect(drain).toContain('this.weaponSkinRank');
+    expect((renderer.match(/this\.drainWeaponSkinApplies\(\)/g) ?? []).length).toBe(1);
+  });
+
+  it('binds the guard and the ranking once, off the per-frame path', () => {
+    const callbacks = slice(
+      'private readonly weaponSkinLookup = ',
+      '/** Apply (or clear) a weapon-skin cosmetic',
+    );
+    // A view that is gone or has no rig reports gone; everything else defers to
+    // the shared pure resolver rather than re-deriving the null collapse here.
+    expect(callbacks).toContain('if (!this.views.get(viewId)?.visual) return undefined;');
+    expect(callbacks).toContain('resolveQueuedSkinLookup(this.sim.entities.get(viewId))');
+    expect(callbacks).not.toContain('?.weaponSkinId ?? undefined');
+    // Nearest first, by the same squared-XZ measure the view bands use.
+    expect(callbacks).toContain('distSqXZ(entity, this.sim.player)');
+    // Bound as instance fields, so the drain mints no closure pair per frame.
+    expect(callbacks).toContain('private readonly weaponSkinRank = (viewId: number)');
+  });
+
+  it('releases the shared emissive memo at renderer teardown, after the views', () => {
+    const teardown = slice('private disposeRendererResources(', 'const webgl = this.webgl as');
+    const viewsAt = teardown.indexOf('this.removeView(id, true)');
+    const cacheAt = teardown.indexOf('disposeWeaponEmissiveCache()');
+    expect(viewsAt).toBeGreaterThan(-1);
+    // Order is load-bearing: the rigs that borrow these textures must be gone
+    // before the cache releases them.
+    expect(cacheAt).toBeGreaterThan(viewsAt);
+    expect(teardown).toContain('bestEffort(() => disposeWeaponEmissiveCache())');
+    expect(teardown).toContain('this.weaponSkinApplies.clear()');
+  });
+
+  it('cancels a pending apply when the view is dropped or recycled', () => {
+    const remove = slice('private removeView(id: number, terminal = false)', 'this.scene.remove(');
+    expect(remove).toContain('this.weaponSkinApplies.cancel(id)');
+  });
+});

--- a/tests/weapon_vfx_emissive_core.test.ts
+++ b/tests/weapon_vfx_emissive_core.test.ts
@@ -1,0 +1,167 @@
+// The pure half of the weapon-skin emissive derivation: which texels are
+// promoted into the emissive map, how hard the albedo is de-baked under them,
+// and the memo signature that lets one derivation serve every wearer of a skin.
+import { describe, expect, it } from 'vitest';
+import {
+  deriveEmissiveTexels,
+  type WeaponEmissiveSignatureSpec,
+  type WeaponEmissiveWindow,
+  weaponEmissiveCacheKey,
+  weaponEmissiveSignature,
+} from '../src/render/weapon_vfx_emissive_core';
+
+// The shipped Hoarfrost (epic) window: saturated cyan/azure paint is the frozen
+// core, bright desaturated ice picks up a residual glow.
+const FROST: WeaponEmissiveWindow = {
+  hue: [150, 245],
+  minS: 0.18,
+  minL: 0.5,
+  whiteL: 0.85,
+  whiteScale: 0.4,
+};
+
+const FROST_SPEC: WeaponEmissiveSignatureSpec = {
+  ...FROST,
+  tint: 0x66ccff,
+  intensity: 1.0,
+  pulse: 0.3,
+  pulseHz: 0.55,
+};
+
+// Working-color-space tint, as THREE.Color would hand it over.
+const TINT = { r: 0.14, g: 0.6, b: 1 };
+
+function rgba(...texels: [number, number, number][]): Uint8ClampedArray {
+  const out = new Uint8ClampedArray(texels.length * 4);
+  texels.forEach(([r, g, b], i) => {
+    out[i * 4] = r;
+    out[i * 4 + 1] = g;
+    out[i * 4 + 2] = b;
+    out[i * 4 + 3] = 255;
+  });
+  return out;
+}
+
+function derive(texels: [number, number, number][]) {
+  const emissive = rgba(...texels);
+  const albedo = rgba(...texels);
+  deriveEmissiveTexels(emissive, albedo, FROST, TINT);
+  return { emissive, albedo };
+}
+
+describe('deriveEmissiveTexels', () => {
+  it('promotes a saturated in-window texel and de-bakes the albedo under it', () => {
+    // Bright azure: hue ~200, s ~1, l ~0.6, squarely inside the frost window.
+    const { emissive, albedo } = derive([[51, 187, 255]]);
+
+    expect(emissive[0]).toBeGreaterThan(0);
+    expect(emissive[1]).toBeGreaterThan(0);
+    expect(emissive[2]).toBeGreaterThan(0);
+    // De-baked: the base color is pulled down where the glow now lives, and by
+    // strictly more than nothing on every channel.
+    expect(albedo[0]).toBeLessThan(51);
+    expect(albedo[1]).toBeLessThan(187);
+    expect(albedo[2]).toBeLessThan(255);
+    // Alpha is never touched.
+    expect(emissive[3]).toBe(255);
+    expect(albedo[3]).toBe(255);
+  });
+
+  it('leaves an out-of-window hue black in the emissive map and the albedo intact', () => {
+    // Saturated red (hue 0) at the same lightness: outside [150, 245].
+    const { emissive, albedo } = derive([[255, 51, 51]]);
+
+    expect([emissive[0], emissive[1], emissive[2]]).toEqual([0, 0, 0]);
+    expect([albedo[0], albedo[1], albedo[2]]).toEqual([255, 51, 51]);
+  });
+
+  it('rejects an in-window hue that is too desaturated or too dark to score', () => {
+    // Hue 200 but s below minS (0.18) and lightness below minL (0.5).
+    const dull = derive([[110, 120, 128]]);
+    expect([dull.emissive[0], dull.emissive[1], dull.emissive[2]]).toEqual([0, 0, 0]);
+    expect([dull.albedo[0], dull.albedo[1], dull.albedo[2]]).toEqual([110, 120, 128]);
+
+    // Hue 200, saturated, but dark (l ~0.25): fails minL, and is not white.
+    const dark = derive([[0, 64, 128]]);
+    expect([dark.emissive[0], dark.emissive[1], dark.emissive[2]]).toEqual([0, 0, 0]);
+    expect([dark.albedo[0], dark.albedo[1], dark.albedo[2]]).toEqual([0, 64, 128]);
+  });
+
+  it('gives near-white texels the scaled-down residual glow, weaker than the core', () => {
+    const white = derive([[250, 250, 250]]); // s = 0, l ~0.98: the whiteL arm
+    const core = derive([[51, 187, 255]]);
+
+    expect(white.emissive[0]).toBeGreaterThan(0);
+    // whiteScale (0.4) caps the residual well under the in-window core score,
+    // so a white highlight glows without becoming the brightest thing on the
+    // weapon.
+    expect(white.emissive[2]).toBeLessThan(core.emissive[2]);
+    expect(white.albedo[0]).toBeLessThan(250);
+  });
+
+  it('leaves a near-white texel that is not bright enough alone', () => {
+    // s = 0 but l ~0.78, below whiteL (0.85).
+    const { emissive, albedo } = derive([[200, 200, 200]]);
+    expect([emissive[0], emissive[1], emissive[2]]).toEqual([0, 0, 0]);
+    expect([albedo[0], albedo[1], albedo[2]]).toEqual([200, 200, 200]);
+  });
+
+  it('grades toward the tier tint rather than copying the source color', () => {
+    // A green-leaning in-window texel (hue ~160) still lands blue-dominant
+    // after the 0.62 pull toward the azure tint.
+    const { emissive } = derive([[60, 255, 190]]);
+    expect(emissive[2]).toBeGreaterThan(emissive[0]);
+  });
+
+  it('walks every texel of a multi-texel buffer independently', () => {
+    const { emissive, albedo } = derive([
+      [51, 187, 255],
+      [255, 51, 51],
+      [51, 187, 255],
+    ]);
+
+    expect(emissive[0]).toBeGreaterThan(0);
+    expect([emissive[4], emissive[5], emissive[6]]).toEqual([0, 0, 0]);
+    expect(emissive[8]).toBe(emissive[0]);
+    expect(albedo[4]).toBe(255);
+    expect(albedo[8]).toBe(albedo[0]);
+  });
+});
+
+describe('weaponEmissiveSignature / weaponEmissiveCacheKey', () => {
+  it('is stable for an equal spec and distinct per source map', () => {
+    const a = weaponEmissiveCacheKey('map-uuid-1', FROST_SPEC);
+    const b = weaponEmissiveCacheKey('map-uuid-1', { ...FROST_SPEC });
+    expect(a).toBe(b);
+    expect(weaponEmissiveCacheKey('map-uuid-2', FROST_SPEC)).not.toBe(a);
+  });
+
+  it('changes when ANY authored emissive field changes', () => {
+    const base = weaponEmissiveSignature(FROST_SPEC);
+    const variants: WeaponEmissiveSignatureSpec[] = [
+      { ...FROST_SPEC, hue: [151, 245] },
+      { ...FROST_SPEC, hue: [150, 246] },
+      { ...FROST_SPEC, minS: 0.19 },
+      { ...FROST_SPEC, minL: 0.51 },
+      { ...FROST_SPEC, whiteL: 0.86 },
+      { ...FROST_SPEC, whiteScale: 0.41 },
+      { ...FROST_SPEC, tint: 0x66ccfe },
+      { ...FROST_SPEC, intensity: 1.01 },
+      { ...FROST_SPEC, pulse: 0.31 },
+      { ...FROST_SPEC, pulseHz: 0.56 },
+    ];
+    for (const variant of variants) {
+      expect(weaponEmissiveSignature(variant), JSON.stringify(variant)).not.toBe(base);
+    }
+    // And every variant is distinct from every other, so no two authored looks
+    // can collide onto one cached texture pair.
+    const keys = new Set(variants.map((spec) => weaponEmissiveSignature(spec)));
+    expect(keys.size).toBe(variants.length);
+  });
+
+  it('separates the source map from the spec in the key', () => {
+    expect(weaponEmissiveCacheKey('uuid', FROST_SPEC)).toBe(
+      `uuid|${weaponEmissiveSignature(FROST_SPEC)}`,
+    );
+  });
+});

--- a/tests/weapon_vfx_rig_build.test.ts
+++ b/tests/weapon_vfx_rig_build.test.ts
@@ -1,0 +1,305 @@
+// What building a weapon-skin VFX rig is allowed to COST, driven against the
+// real createWeaponVfx over a stubbed 2d canvas (the module is otherwise plain
+// Three + math). Two regressions are pinned here:
+//   1. the world path (grounded: false) must build no sky backdrop: its
+//      sceneExtras group is never added to any scene, so the 1024x1024 canvas
+//      of gradients and hundreds of stars was pure waste inside the frame a
+//      skinned player came into view;
+//   2. the memoized emissive derivation is SHARED, so the first wearer's rig
+//      tearing down must not dispose the textures the next wearer draws with.
+import * as THREE from 'three';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { isSharedTexture } from '../src/render/shared_resource';
+import {
+  buildWeaponVfxPrewarmGroup,
+  clearWeaponVfxTextureCacheForTest,
+  createWeaponVfx,
+  disposeWeaponEmissiveCache,
+  TIERS,
+  type WeaponVfxSpec,
+} from '../src/render/weapon_vfx';
+
+interface StubCanvas {
+  width: number;
+  height: number;
+  getContext(): unknown;
+}
+
+const canvases: StubCanvas[] = [];
+let getImageDataCalls = 0;
+let priorDocument: unknown;
+
+function stubContext() {
+  const gradient = { addColorStop: () => {} };
+  return {
+    fillStyle: '',
+    createLinearGradient: () => gradient,
+    createRadialGradient: () => gradient,
+    fillRect: () => {},
+    beginPath: () => {},
+    arc: () => {},
+    fill: () => {},
+    save: () => {},
+    restore: () => {},
+    translate: () => {},
+    rotate: () => {},
+    drawImage: () => {},
+    createImageData: (w: number, h: number) => ({
+      data: new Uint8ClampedArray(w * h * 4),
+      width: w,
+      height: h,
+    }),
+    getImageData: (_x: number, _y: number, w: number, h: number) => {
+      getImageDataCalls++;
+      return { data: new Uint8ClampedArray(w * h * 4), width: w, height: h };
+    },
+    putImageData: () => {},
+  };
+}
+
+beforeAll(() => {
+  const globals = globalThis as { document?: unknown };
+  priorDocument = globals.document;
+  globals.document = {
+    createElement(tag: string) {
+      if (tag !== 'canvas') throw new Error(`unexpected createElement(${tag})`);
+      const canvas: StubCanvas = { width: 0, height: 0, getContext: () => stubContext() };
+      canvases.push(canvas);
+      return canvas;
+    },
+  };
+});
+
+afterAll(() => {
+  (globalThis as { document?: unknown }).document = priorDocument;
+});
+
+beforeEach(() => {
+  canvases.length = 0;
+  getImageDataCalls = 0;
+  // Both module-level memos are reset per case, so no assertion here depends on
+  // what an earlier case (or a shuffled run order) already cached.
+  clearWeaponVfxTextureCacheForTest();
+  disposeWeaponEmissiveCache();
+});
+
+/** The size of the sky dome canvas: nothing else in the module draws one. */
+const SKY_CANVAS_SIZE = 1024;
+
+function skyCanvasCount(): number {
+  return canvases.filter((canvas) => canvas.width === SKY_CANVAS_SIZE).length;
+}
+
+const EPIC_SPEC: WeaponVfxSpec = {
+  tier: 'epic',
+  name: 'test blade',
+  type: 'sword',
+  lore: '',
+  fx: [],
+};
+
+function weaponRoot(map: THREE.Texture | null = null): THREE.Mesh {
+  const material = new THREE.MeshStandardMaterial({ color: 0xffffff });
+  material.map = map;
+  const mesh = new THREE.Mesh(new THREE.BoxGeometry(0.1, 1, 0.1), material);
+  mesh.userData.weaponMesh = true;
+  return mesh;
+}
+
+// Order-independent by construction: beforeEach drops the module-level
+// sprite/sky texture memo, so every case below observes a cold build and
+// "did this rig draw a sky canvas" stays a real question in any run order.
+describe('createWeaponVfx backdrop construction', () => {
+  it('builds no backdrop at all on the world (held) path', () => {
+    const root = weaponRoot();
+    const handle = createWeaponVfx(root, EPIC_SPEC, { grounded: false });
+
+    expect(skyCanvasCount()).toBe(0);
+    expect(handle.sceneExtras.children).toHaveLength(0);
+    // The API stays safe for both paths: the world path calls this right after
+    // building the rig.
+    expect(() => handle.setBackdropVisible(false)).not.toThrow();
+    expect(() => handle.setBackdropVisible(true)).not.toThrow();
+    expect(() => handle.dispose()).not.toThrow();
+    expect(skyCanvasCount()).toBe(0);
+  });
+
+  it('still builds the showcase backdrop and ground pool when grounded', () => {
+    const handle = createWeaponVfx(weaponRoot(), EPIC_SPEC, { grounded: true });
+
+    expect(skyCanvasCount()).toBe(1);
+    // backdrop dome + ground pool, the pair armory_preview mounts in its scene
+    expect(handle.sceneExtras.children).toHaveLength(2);
+    const backdrop = handle.sceneExtras.children[0];
+    handle.setBackdropVisible(false);
+    expect(backdrop.visible).toBe(false);
+    handle.setBackdropVisible(true);
+    expect(backdrop.visible).toBe(true);
+    handle.dispose();
+  });
+
+  it('can take the ground pool without the sky (the boot prewarm rig)', () => {
+    const handle = createWeaponVfx(
+      weaponRoot(),
+      { ...EPIC_SPEC, tier: 'legendary' },
+      {
+        grounded: true,
+        backdrop: false,
+      },
+    );
+
+    expect(skyCanvasCount()).toBe(0);
+    expect(handle.sceneExtras.children).toHaveLength(1);
+    handle.dispose();
+  });
+});
+
+describe('weapon-skin emissive derivation sharing', () => {
+  /** A drawable source albedo, as a skin GLB's webp map arrives. */
+  function sourceMap(): THREE.Texture {
+    const texture = new THREE.Texture();
+    texture.image = { width: 4, height: 4 };
+    return texture;
+  }
+
+  it('derives once per (source map, spec) and hands the same textures to every wearer', () => {
+    const map = sourceMap();
+    const first = weaponRoot(map);
+    const second = weaponRoot(map);
+
+    const rigA = createWeaponVfx(first, EPIC_SPEC, { grounded: false });
+    const derivedEmissive = (first.material as THREE.MeshStandardMaterial).emissiveMap;
+    const derivedAlbedo = (first.material as THREE.MeshStandardMaterial).map;
+    expect(derivedEmissive).toBeTruthy();
+    expect(derivedAlbedo).not.toBe(map);
+    // Two canvases read back once each: the emissive map and the de-baked albedo.
+    expect(getImageDataCalls).toBe(2);
+
+    const rigB = createWeaponVfx(second, EPIC_SPEC, { grounded: false });
+    expect((second.material as THREE.MeshStandardMaterial).emissiveMap).toBe(derivedEmissive);
+    expect((second.material as THREE.MeshStandardMaterial).map).toBe(derivedAlbedo);
+    // The second wearer paid for no readback, no canvas, no per-texel walk.
+    expect(getImageDataCalls).toBe(2);
+
+    rigA.dispose();
+    rigB.dispose();
+  });
+
+  it('keeps the shared textures alive when the first wearer tears its rig down', () => {
+    const map = sourceMap();
+    const first = weaponRoot(map);
+    const second = weaponRoot(map);
+    const rigA = createWeaponVfx(first, EPIC_SPEC, { grounded: false });
+    const rigB = createWeaponVfx(second, EPIC_SPEC, { grounded: false });
+
+    const shared = (first.material as THREE.MeshStandardMaterial).emissiveMap as THREE.Texture;
+    const sharedAlbedo = (first.material as THREE.MeshStandardMaterial).map as THREE.Texture;
+    expect(isSharedTexture(shared)).toBe(true);
+    expect(isSharedTexture(sharedAlbedo)).toBe(true);
+
+    let disposals = 0;
+    const count = () => {
+      disposals++;
+    };
+    shared.addEventListener('dispose', count);
+    sharedAlbedo.addEventListener('dispose', count);
+
+    rigA.dispose();
+
+    // The first wearer left; the second is still drawing with these textures,
+    // and so is every future wearer of the skin.
+    expect(disposals).toBe(0);
+    expect((second.material as THREE.MeshStandardMaterial).emissiveMap).toBe(shared);
+    // The wearer that left has its own material restored to the source map.
+    expect((first.material as THREE.MeshStandardMaterial).map).toBe(map);
+    expect((first.material as THREE.MeshStandardMaterial).emissiveMap).toBeNull();
+
+    // A later wearer is served the very same (still undisposed) pair.
+    const third = weaponRoot(map);
+    const rigC = createWeaponVfx(third, EPIC_SPEC, { grounded: false });
+    expect((third.material as THREE.MeshStandardMaterial).emissiveMap).toBe(shared);
+    expect(getImageDataCalls).toBe(2);
+    expect(disposals).toBe(0);
+
+    rigB.dispose();
+    rigC.dispose();
+  });
+
+  it('derives separately for a different emissive spec on the same map', () => {
+    const map = sourceMap();
+    const epic = weaponRoot(map);
+    const legendary = weaponRoot(map);
+
+    createWeaponVfx(epic, EPIC_SPEC, { grounded: false });
+    createWeaponVfx(legendary, { ...EPIC_SPEC, tier: 'legendary' }, { grounded: false });
+
+    expect(TIERS.legendary.emissive).not.toEqual(TIERS.epic.emissive);
+    expect((legendary.material as THREE.MeshStandardMaterial).emissiveMap).not.toBe(
+      (epic.material as THREE.MeshStandardMaterial).emissiveMap,
+    );
+    expect(getImageDataCalls).toBe(4);
+  });
+
+  // The memo is renderer-lifetime: no rig may release it, so without this one
+  // path the whole derived set would ride a WebGL context recycle into the next
+  // context.
+  it('releases every memoized pair at renderer teardown, then re-derives cold', () => {
+    const map = sourceMap();
+    const first = weaponRoot(map);
+    const rigA = createWeaponVfx(first, EPIC_SPEC, { grounded: false });
+    const shared = (first.material as THREE.MeshStandardMaterial).emissiveMap as THREE.Texture;
+    const sharedAlbedo = (first.material as THREE.MeshStandardMaterial).map as THREE.Texture;
+
+    const disposed: THREE.Texture[] = [];
+    shared.addEventListener('dispose', () => disposed.push(shared));
+    sharedAlbedo.addEventListener('dispose', () => disposed.push(sharedAlbedo));
+
+    // Teardown order the renderer uses: every rig first, then the cache.
+    rigA.dispose();
+    expect(disposed).toEqual([]);
+    disposeWeaponEmissiveCache();
+    expect(disposed).toEqual([shared, sharedAlbedo]);
+
+    // The map is empty, not merely detached: the next wearer derives afresh
+    // instead of being handed a disposed texture.
+    const next = weaponRoot(map);
+    createWeaponVfx(next, EPIC_SPEC, { grounded: false });
+    expect(getImageDataCalls).toBe(4);
+    expect((next.material as THREE.MeshStandardMaterial).emissiveMap).not.toBe(shared);
+  });
+});
+
+describe('buildWeaponVfxPrewarmGroup', () => {
+  it('covers every component family off-screen, with no sky and no extra light', () => {
+    const group = buildWeaponVfxPrewarmGroup();
+
+    expect(group.position.y).toBe(-1000);
+    expect(skyCanvasCount()).toBe(0);
+
+    const names = new Set<string>();
+    let lights = 0;
+    let visibleLights = 0;
+    let shells = 0;
+    group.traverse((object) => {
+      if (object.name) names.add(object.name);
+      if ((object as THREE.PointLight).isPointLight) {
+        lights++;
+        if (object.visible) visibleLights++;
+      }
+      if (object.userData.__vfx) shells++;
+    });
+
+    for (const name of ['vfx_coreSprite', 'vfx_motes', 'vfx_drift', 'vfx_twinkles', 'vfx_aurora']) {
+      expect(names, `${name} missing from the prewarm rig`).toContain(name);
+    }
+    // The fresnel rim shell parents itself to the host mesh instead of the rig
+    // group, so it is counted by its tag rather than a name.
+    expect(shells).toBeGreaterThan(0);
+    // The ground pool rides sceneExtras, which the group carries too.
+    expect(names).toContain('weapon_vfx_extras');
+    // A visible light would change the scene's light counts, and those counts
+    // are part of every program cache key the boot compile warms.
+    expect(lights).toBe(1);
+    expect(visibleLights).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Players report a massive multi-frame freeze whenever a player wearing a rarity-VFX
weapon skin (the Hoarfrost and Fallen Star collections, e.g. the ice_fang sword)
connects or walks into view. The same stall repeats on every rig rebuild: sheathe
toggle, base-visual swap, and interest re-entry (player views are never pooled, so
leaving and re-entering the ~120 yd interest range rebuilds everything).

Profiling the code path shows the freeze is not shader compilation: shader links for
swapped-in weapon subtrees were already deferred through `gateSwapOnCompile` and the
compile-gate queue. The stall is plain synchronous CPU/canvas work that runs inside a
live frame when the per-frame entity diff in `renderer.ts` applies `e.weaponSkinId` to a
view. Two operations dominate:

- **Emissive derivation.** `deriveEmissive` in `weapon_vfx.ts` derives the skin's glow
  maps from the GLB albedo: two 512x512 canvases, two `getImageData` readbacks, a
  262,144-iteration per-texel RGB-to-HSL loop, then two fresh `CanvasTexture`s uploaded
  on first draw. The output depends only on (source albedo map, tier emissive spec), yet
  it was recomputed per weapon payload (x2 when the offhand mirrors the skin), per
  wearer, and per rebuild. Ten wearers of the same collection meant ten full derivations
  and ~20 MB of duplicated textures.
- **A backdrop nothing draws.** `createWeaponVfx` unconditionally built the armory
  inspector's backdrop: a 1024x1024 sky canvas (full-canvas gradients plus 420
  individually drawn stars) and a sphere mesh, even in the world path where that group
  is never added to the scene. Its one-time cost landed exactly on "the first skinned
  player who walks into view".

On top of that, the apply chain was unbudgeted (a burst of arrivals built every rig in
one frame) and no boot prewarm covered the weapon-VFX shader programs, so first sighting
also paid the first GL links.

### The fix

Four changes, no visual redesign:

1. **Memoized emissive derivation.** The derived texture pair is cached in
   `weapon_vfx.ts` keyed by (source map uuid, full emissive-spec signature): one
   derivation per weapon per session, shared across wearers, payloads, and rebuilds. The
   per-texel math moved to a new DOM-free pure core
   (`src/render/weapon_vfx_emissive_core.ts`, exact port, byte-for-byte identical
   output) so it is Node-tested directly. Cached textures are protected from per-rig
   disposal via new `markSharedTexture`/`isSharedTexture` (`shared_resource.ts`) and
   released by `disposeWeaponEmissiveCache()` on renderer teardown / context recycle.
2. **No more backdrop in the world path.** The backdrop is only built when requested
   (new `backdrop` option, defaults to `grounded`); the armory preview is unchanged.
3. **Budgeted, deferred skin application.** The renderer diff no longer runs the apply
   chain synchronously: it enqueues into a new pure core
   (`src/render/weapon_vfx_apply_queue_core.ts`) drained at one application per frame,
   nearest wearer first (squared-XZ distance rank), with coalescing (latest skin per
   view wins), cancellation on view removal, and a stale-guard re-checking the entity's
   current skin at drain time. The latch is written at application time, so a queued
   apply that never ran is retried by the next diff. Clearing a skin stays synchronous
   (teardown builds no rig) and cancels any pending apply. A single skinned player still
   lands in the same frame; only the 2nd..Nth simultaneous arrivals are spread.
4. **Boot prewarm for the VFX programs.** New `vfx.weapon-skins` prewarm entry
   (`required: false`, resume units for deadline drops) builds one hidden synthetic rig
   covering every component family (motes, drift, twinkles, aurora, shell, pool, flare
   sprites) so their shader programs link behind the loading screen instead of on first
   sighting mid-gameplay. Deliberately absent from `CONSTRAINED_PREWARM_KEEP`.

Both new cores are registered in `RENDER_PURE_CORES`. `renderer.ts` changing re-minted
the Eastbrook polish provenance seals via the sanctioned
`scripts/assets/eastbrook_grand_armoury/remint_polish_provenance.mjs` (established
pattern; no capture retaken, no Eastbrook input moved).

Known residuals, called out deliberately:

- The prewarm rig does not cover the skinned weapon's own derived-emissive material
  program (`USE_EMISSIVEMAP` variant): that still links on first sighting, behind the
  existing `gateSwapOnCompile` compile gate, so it costs visibility delay, not a stall.
- A first-sighting wearer now shows the base weapon model for a few frames before the
  skin lands (previously atomic, at the price of the freeze). Cosmetic only.
- Real-browser before/after measurement (first-sighting frame time, program-count delta
  with and without the prewarm entry, via the ?perf hitch tracker) is still to be done;
  the reported freeze mechanism is fully covered by code-level tests.

Out of scope, planned as follow-up PRs: the combat-time ability-VFX hitches (lazy
flipbook generation on constrained devices, mob aura-glow first-hit program links,
spirit puppet construction off the deferral queues), steady-state GC and upload pressure
(vfxAnchor allocations, ribbon `addUpdateRange`, terrain drape sampling), and wiring
weapon rigs to the render-budget governor.

## Related issues

None filed.

## Type of change

- [x] Bug fix
- [x] Refactor or performance (no behavior change)
- [x] Tests

## How was this tested?

- Commands:
  - `node scripts/gate_select.mjs`: every step before vitest green (i18n gen + freshness,
    malware scan, changed-files biome, SFX check). The full-suite vitest step is red on
    exactly 9 files / 67 tests (corpse_harvest, chronomancy_surge, whirlwind_echo,
    client_shell, fear_break_chance, frostveil_pit_escape, gathering_rhythm,
    professions_fishing) that fail IDENTICALLY on a pristine `release/v0.35.0` checkout
    (verified in a clean worktree at `4fea9babb0`: same 9 files, same 67 tests). They are
    pre-existing base failures unrelated to this render-only diff and are deliberately
    left alone. Note: the planner fell back to full mode because the local diff base was
    the fork's `origin/main`; CI diffing against the release branch will scope normally.
  - `npx tsc --noEmit`: clean.
  - `npx vitest run tests/weapon_vfx_emissive_core.test.ts tests/weapon_vfx_apply_queue_core.test.ts tests/weapon_vfx_rig_build.test.ts tests/architecture.test.ts tests/prewarm_resume.test.ts tests/renderer_lifecycle.test.ts tests/prewarm_policy.test.ts tests/weapon_skin_point_lights.test.ts tests/eastbrook_polish_capture_contract.test.ts tests/eastbrook_polish_artifact_integrity.test.ts`: all pass.
  - `tests/weapon_vfx_rig_build.test.ts` re-run under `--sequence.shuffle`: pass (order-independent).
- New tests:
  - `tests/weapon_vfx_emissive_core.test.ts`: the derivation math on synthetic buffers
    (in-window promotion, out-of-window rejection, white arm, tint grading, per-texel
    independence) and the cache-key signature (all ten spec fields shift the key).
  - `tests/weapon_vfx_apply_queue_core.test.ts`: budget, coalescing, cancellation,
    stale-guard without spending budget, distance ranking (nearest wins; FIFO without a
    rank), slot reference stability (no per-drain allocation), `resolveQueuedSkinLookup`
    (entity gone vs skin cleared vs mismatch vs match), plus renderer wiring pins.
  - `tests/weapon_vfx_rig_build.test.ts`: real `createWeaponVfx` over a stubbed canvas:
    derive memoization (readback count stays flat across wearers), shared textures
    survive the first wearer's teardown, backdrop skipped when `grounded: false` and kept
    for the armory path, prewarm group shape (light invisible so program cache keys stay
    stable), teardown releases the cache.
  - Extended: `tests/architecture.test.ts` (core registration), `tests/prewarm_resume.test.ts`
    (entry pins + constrained-keep exclusion), `tests/renderer_lifecycle.test.ts`
    (teardown participation pinned).
- Manual steps: pending, listed under residuals: a real-browser before/after on a crowd
  of skinned players using the `?perf` hitch tracker (compile / texture-upload / view
  causes).
- Reviews run: frontend-seam-reviewer and qa-checklist over the full diff (zero blocking
  findings; all four SHOULD-FIX items addressed in this PR).

Manually tested:
- Logged in with Player A (no custom skin)
- Logged in with Player B using a VFX skin on a second PC
- Confirm there are no freezes on Player A computer

## Screenshots / recordings

<img width="2560" height="1440" alt="Screenshot from 2026-08-05 22-48-27" src="https://github.com/user-attachments/assets/a323ae31-896a-4ac3-8124-8aa5af481568" />


---

## Checklist

### Quality

- [x] **The gate passes** for everything this change owns: all non-vitest gate steps
      green, all change-related test files green (including under shuffle); the only red
      is the 67 pre-existing base failures documented above, reproduced bit-identical on
      the untouched `release/v0.35.0` tip. Decisive tests added for every changed
      behavior (see above).

### Cross-platform

- [x] Tested on desktop and mobile
- ~Accessible.~ N/A, no UI added or edited.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings (new literals are internal ids,
      prewarm entry names, and dev-channel log text).

### Hygiene

- [x] No secrets, credentials, or `.env` committed; `ALLOW_DEV_COMMANDS` untouched.
- [x] No generated file hand-edited: the Eastbrook provenance JSONs were regenerated by
      their owning script (`remint_polish_provenance.mjs`).