### PR TITLE
perf(ci): classify PR changes via the GitHub API instead of a checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,77 +99,49 @@ jobs:
       - name: Verify release version surfaces
         run: npm run release:check
 
-  # Classify whether this run touches the code path set (D10). Prefer native
-  # git-diff + job if over third-party path-filter actions. Default code=true
-  # (fail closed toward the full suite); only a confirmed docs-only PR sets
-  # code=false. Release jobs never need this job and never read its output.
+  # Classify whether this run touches the code path set (D10). The classifier
+  # reads the PR's changed files from the GitHub API (the pull request files
+  # endpoint, paginated) instead of a checkout + git diff: the old full-history
+  # checkout of this binary-heavy repo cost about 10 serial minutes on every PR
+  # before any test could start, and twice wedged for 90+ minutes with no
+  # timeout to kill it. Default code=true (fail closed toward the full suite):
+  # any API error, pagination overflow, payload mismatch, or non-PR event
+  # yields code=true; only a provably docs-only PR sets code=false. The rules
+  # and the fail-closed decision live in scripts/lib/ci_change_classify.mjs
+  # (unit-tested by tests/ci_change_classify.test.ts). Release jobs never need
+  # this job and never read its output.
   changes:
     name: Detect code path changes
     runs-on: ubuntu-latest
+    # Every PR-tier job waits on this one, so a wedged runner must fail fast
+    # and be retried, never hang for an hour and a half.
+    timeout-minutes: 5
+    # Job-scoped read-only widen: once workflow-level permissions are declared,
+    # unlisted scopes are none, and the PR files endpoint needs
+    # pull-requests: read. Nothing here may ever be a write scope.
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       code: ${{ steps.filter.outputs.code }}
     steps:
-      - name: Check out repository
+      - name: Check out classifier script
         uses: actions/checkout@v6
         with:
-          # Full history so the PR base and head SHAs resolve for git diff.
-          # This job is cheap (no npm install); depth is not a wall concern.
-          fetch-depth: 0
+          # Blob-less shallow sparse checkout: this job needs only the
+          # classifier script, never the tree or the history.
+          filter: blob:none
+          sparse-checkout: |
+            scripts
 
       - name: Classify changed paths
         id: filter
         env:
-          EVENT_NAME: ${{ github.event_name }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
-          set -euo pipefail
-          # Single write at the end. Default true = full PR tier (fail closed).
-          code=true
-          if [ "$EVENT_NAME" != "pull_request" ]; then
-            echo "non-PR event: full PR tier (code=true)"
-            echo "code=$code" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          if [ -z "${BASE_SHA:-}" ] || [ -z "${HEAD_SHA:-}" ]; then
-            echo "missing PR base/head SHAs: full PR tier (code=true)"
-            echo "code=$code" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          # Ensure both ends exist (shallow edge cases / force-push races).
-          git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null || git fetch --no-tags --depth=1 origin "$BASE_SHA"
-          git cat-file -e "${HEAD_SHA}^{commit}" 2>/dev/null || git fetch --no-tags --depth=1 origin "$HEAD_SHA"
-          # Triple-dot: commits reachable from HEAD but not from the merge base
-          # with BASE (the PR's own changes). ACMRD covers add/copy/mod/rename/delete.
-          mapfile -t files < <(git diff --name-only --diff-filter=ACMRD "$BASE_SHA"..."$HEAD_SHA")
-          if [ "${#files[@]}" -eq 0 ]; then
-            echo "empty file list: full PR tier (code=true)"
-            echo "code=$code" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          code=false
-          for f in "${files[@]}"; do
-            case "$f" in
-              src/*|server/*|tests/*|headless/*|bot/*|scripts/*|\
-              package.json|pnpm-lock.yaml|\
-              tsconfig.json|tsconfig.admin.json|\
-              vite.config.ts|vitest.browser.config.ts|\
-              biome.json|\
-              .github/workflows/*|\
-              electron/*|android/*|ios/*|public/*|\
-              deploy/*|mediawiki/*|\
-              Dockerfile|Dockerfile.*|docker-compose.yml|docker-compose.yaml)
-                code=true
-                break
-                ;;
-            esac
-          done
-          if [ "$code" = "true" ]; then
-            echo "code path change detected: full PR tier"
-          else
-            echo "docs-only (or non-code) change: skip pr-gate, pr-checks, browser-gate"
-          fi
-          echo "code=$code" >> "$GITHUB_OUTPUT"
+          GITHUB_TOKEN: ${{ github.token }}
+        # The classifier is stdlib-only (global fetch), so it runs on the
+        # runner's preinstalled Node: no setup-node, no dependency install on
+        # this serial critical path.
+        run: node scripts/detect_code_changes.mjs
 
   # Biome formatter + linter, adopted as a forward ratchet: only files actually
   # changed by this push/PR are checked (`--changed`), so the large existing tree

--- a/scripts/detect_code_changes.mjs
+++ b/scripts/detect_code_changes.mjs
@@ -1,0 +1,44 @@
+// CI entry for the ci.yml `changes` job ("Detect code path changes"): decide
+// whether the run touches the code path set and write the `code` step output.
+// The changed-file list comes from the GitHub pull request files endpoint, so
+// the job needs no git history at all; the decision logic lives in
+// lib/ci_change_classify.mjs (unit-tested) and is fail closed end to end (any
+// error means code=true, the full PR tier). No npm deps: Node 18+ global
+// fetch only, since this job deliberately skips the dependency install.
+//
+// Reads the standard GitHub Actions environment: GITHUB_EVENT_NAME,
+// GITHUB_EVENT_PATH, GITHUB_REPOSITORY, GITHUB_API_URL, GITHUB_OUTPUT, plus
+// GITHUB_TOKEN passed in by the workflow step.
+import { appendFileSync, readFileSync } from 'node:fs';
+import { detectCode } from './lib/ci_change_classify.mjs';
+
+/** @returns {any} the parsed event payload, or null when unreadable (fail closed downstream) */
+function readEventPayload(path) {
+  if (!path) return null;
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+const payload = readEventPayload(process.env.GITHUB_EVENT_PATH);
+const pr = payload?.pull_request;
+
+const { code, reason } = await detectCode({
+  eventName: process.env.GITHUB_EVENT_NAME ?? '',
+  prNumber: typeof pr?.number === 'number' ? pr.number : Number.NaN,
+  reportedCount: typeof pr?.changed_files === 'number' ? pr.changed_files : undefined,
+  repo: process.env.GITHUB_REPOSITORY ?? '',
+  token: process.env.GITHUB_TOKEN ?? '',
+  apiUrl: process.env.GITHUB_API_URL || 'https://api.github.com',
+});
+
+console.log(`[detect_code_changes] ${reason}`);
+
+const outputLine = `code=${code}\n`;
+if (process.env.GITHUB_OUTPUT) {
+  appendFileSync(process.env.GITHUB_OUTPUT, outputLine);
+} else {
+  process.stdout.write(outputLine);
+}

--- a/scripts/lib/ci_change_classify.d.mts
+++ b/scripts/lib/ci_change_classify.d.mts
@@ -1,0 +1,36 @@
+export interface PrFileEntry {
+  filename?: string;
+  previous_filename?: string | null;
+}
+
+export interface CodeDecision {
+  code: boolean;
+  reason: string;
+}
+
+export const PR_FILES_CAP: number;
+
+export function isCodePath(path: string): boolean;
+
+export function classifyPrFiles(files: readonly PrFileEntry[]): CodeDecision;
+
+export function fetchPrFiles(opts: {
+  repo: string;
+  prNumber: number;
+  token: string;
+  apiUrl?: string;
+  fetchImpl?: typeof fetch;
+  perPage?: number;
+  cap?: number;
+  timeoutMs?: number;
+}): Promise<PrFileEntry[]>;
+
+export function detectCode(opts: {
+  eventName: string;
+  prNumber: number;
+  reportedCount?: number;
+  repo: string;
+  token: string;
+  apiUrl?: string;
+  fetchImpl?: typeof fetch;
+}): Promise<CodeDecision>;

--- a/scripts/lib/ci_change_classify.mjs
+++ b/scripts/lib/ci_change_classify.mjs
@@ -1,0 +1,213 @@
+// Pure classification + fail-closed decision logic for the ci.yml `changes`
+// job ("Detect code path changes"). The job used to answer "does this PR touch
+// the code path set" with a full-history checkout plus `git diff`, which cost
+// about 10 serial minutes on every PR (binary-heavy history) and twice wedged
+// for 90+ minutes on the checkout step. The answer now comes from the GitHub
+// pull request files endpoint (paginated), with the rules extracted here so
+// Vitest can pin every branch without a workflow run.
+//
+// SAFETY DIRECTION: code=true means "run the full PR tier"; code=false means
+// "docs-only, skip pr-gate/pr-checks/browser-gate". Every unprovable case
+// (non-PR event, missing context, API error, pagination overflow, payload
+// mismatch, unclassifiable entry) must resolve to code=true. A slow green is
+// acceptable; a fast false-green is not.
+
+// The code path set, matching the shell case patterns the changes job carried
+// inline before extraction (kept in the same order). A shell case `dir/*`
+// matches any path under the directory (case globs cross `/`), so directory
+// entries here are prefixes; bare filenames are exact top-level matches.
+const CODE_PATH_PREFIXES = Object.freeze([
+  'src/',
+  'server/',
+  'tests/',
+  'headless/',
+  'bot/',
+  'scripts/',
+  '.github/workflows/',
+  'electron/',
+  'android/',
+  'ios/',
+  'public/',
+  // Security-adjacent / deploy surfaces: must not skip malware+builds.
+  'deploy/',
+  'mediawiki/',
+  'Dockerfile.',
+]);
+
+const CODE_PATH_EXACT = Object.freeze([
+  'package.json',
+  'pnpm-lock.yaml',
+  'tsconfig.json',
+  'tsconfig.admin.json',
+  'vite.config.ts',
+  'vitest.browser.config.ts',
+  'biome.json',
+  'Dockerfile',
+  'docker-compose.yml',
+  'docker-compose.yaml',
+]);
+
+// The pull request files endpoint lists at most 3000 files; past that the
+// listing is silently incomplete, so classification cannot be proven.
+export const PR_FILES_CAP = 3000;
+
+/**
+ * True when the path belongs to the code path set. Anything that is not a
+ * classifiable repo-relative string also returns true: an input this predicate
+ * cannot read must fail toward the full suite, never toward a skip.
+ *
+ * @param {string} path
+ * @returns {boolean}
+ */
+export function isCodePath(path) {
+  if (typeof path !== 'string' || path === '') return true;
+  if (CODE_PATH_EXACT.includes(path)) return true;
+  return CODE_PATH_PREFIXES.some((prefix) => path.startsWith(prefix));
+}
+
+/**
+ * Classify a full PR file listing. A rename is classified by BOTH ends
+ * (`filename` and `previous_filename`): the API folds a rename into one entry,
+ * but a file renamed out of the code path set still changes the code path set,
+ * exactly as the old `git diff --diff-filter=ACMRD` (which listed the delete
+ * and the add separately) saw it.
+ *
+ * @param {ReadonlyArray<{ filename?: string, previous_filename?: string | null }>} files
+ * @returns {{ code: boolean, reason: string }}
+ */
+export function classifyPrFiles(files) {
+  for (const file of files) {
+    if (!file || typeof file.filename !== 'string' || file.filename === '') {
+      return { code: true, reason: 'unclassifiable file entry: full PR tier (code=true)' };
+    }
+    if (isCodePath(file.filename)) {
+      return { code: true, reason: `code path change detected (${file.filename}): full PR tier` };
+    }
+    if (file.previous_filename != null && isCodePath(file.previous_filename)) {
+      return {
+        code: true,
+        reason: `code path change detected (renamed from ${file.previous_filename}): full PR tier`,
+      };
+    }
+  }
+  return {
+    code: false,
+    reason: 'docs-only (or non-code) change: skip pr-gate, pr-checks, browser-gate',
+  };
+}
+
+/**
+ * Fetch the complete changed-file list for a pull request, paginated. Throws
+ * on any HTTP error, non-array payload, or a listing that exceeds `cap`
+ * (provably or by exhausting the page budget); callers translate a throw into
+ * code=true.
+ *
+ * @param {{
+ *   repo: string,
+ *   prNumber: number,
+ *   token: string,
+ *   apiUrl?: string,
+ *   fetchImpl?: typeof fetch,
+ *   perPage?: number,
+ *   cap?: number,
+ *   timeoutMs?: number,
+ * }} opts
+ * @returns {Promise<Array<{ filename?: string, previous_filename?: string | null }>>}
+ */
+export async function fetchPrFiles({
+  repo,
+  prNumber,
+  token,
+  apiUrl = 'https://api.github.com',
+  fetchImpl = fetch,
+  perPage = 100,
+  cap = PR_FILES_CAP,
+  timeoutMs = 30_000,
+}) {
+  /** @type {Array<{ filename?: string, previous_filename?: string | null }>} */
+  const files = [];
+  // One page past the cap: reaching it proves the listing overflowed rather
+  // than looping forever on a misbehaving endpoint.
+  const maxPages = Math.ceil(cap / perPage) + 1;
+  for (let page = 1; page <= maxPages; page++) {
+    const url = `${apiUrl}/repos/${repo}/pulls/${prNumber}/files?per_page=${perPage}&page=${page}`;
+    const res = await fetchImpl(url, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (!res.ok) {
+      throw new Error(`pull request files page ${page} failed: HTTP ${res.status}`);
+    }
+    const batch = await res.json();
+    if (!Array.isArray(batch)) {
+      throw new Error(`pull request files page ${page} returned a non-array payload`);
+    }
+    files.push(...batch);
+    if (files.length > cap) {
+      throw new Error(`pull request lists more than ${cap} files; listing is incomplete`);
+    }
+    if (batch.length < perPage) return files;
+  }
+  throw new Error(`pull request files pagination exceeded ${maxPages} pages`);
+}
+
+/**
+ * The whole decision, fail closed end to end: never throws, and every path
+ * that cannot PROVE a docs-only change returns code=true. `reportedCount` is
+ * the event payload's `changed_files`; a mismatch against the fetched listing
+ * (a push racing the pagination, or a truncated listing) discards the
+ * classification.
+ *
+ * @param {{
+ *   eventName: string,
+ *   prNumber: number,
+ *   reportedCount?: number,
+ *   repo: string,
+ *   token: string,
+ *   apiUrl?: string,
+ *   fetchImpl?: typeof fetch,
+ * }} opts
+ * @returns {Promise<{ code: boolean, reason: string }>}
+ */
+export async function detectCode({
+  eventName,
+  prNumber,
+  reportedCount,
+  repo,
+  token,
+  apiUrl,
+  fetchImpl,
+}) {
+  try {
+    if (eventName !== 'pull_request') {
+      return { code: true, reason: 'non-PR event: full PR tier (code=true)' };
+    }
+    if (!repo || !Number.isInteger(prNumber) || prNumber <= 0) {
+      return { code: true, reason: 'missing PR context: full PR tier (code=true)' };
+    }
+    if (!token) {
+      return { code: true, reason: 'missing API token: full PR tier (code=true)' };
+    }
+    const files = await fetchPrFiles({ repo, prNumber, token, apiUrl, fetchImpl });
+    if (files.length === 0) {
+      return { code: true, reason: 'empty file list: full PR tier (code=true)' };
+    }
+    if (Number.isInteger(reportedCount) && reportedCount !== files.length) {
+      return {
+        code: true,
+        reason: `listed ${files.length} files but the event reports ${reportedCount}: full PR tier (code=true)`,
+      };
+    }
+    return classifyPrFiles(files);
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    return {
+      code: true,
+      reason: `changed-file listing failed (${detail}): full PR tier (code=true)`,
+    };
+  }
+}

--- a/scripts/lib/ci_change_classify.mjs
+++ b/scripts/lib/ci_change_classify.mjs
@@ -8,14 +8,19 @@
 //
 // SAFETY DIRECTION: code=true means "run the full PR tier"; code=false means
 // "docs-only, skip pr-gate/pr-checks/browser-gate". Every unprovable case
-// (non-PR event, missing context, API error, pagination overflow, payload
+// (non-PR event, missing context, API error, truncated listing, payload
 // mismatch, unclassifiable entry) must resolve to code=true. A slow green is
 // acceptable; a fast false-green is not.
 
-// The code path set, matching the shell case patterns the changes job carried
-// inline before extraction (kept in the same order). A shell case `dir/*`
-// matches any path under the directory (case globs cross `/`), so directory
-// entries here are prefixes; bare filenames are exact top-level matches.
+// The code path set. The first block matches the shell case patterns the
+// changes job carried inline before extraction (kept in the same order); a
+// shell case `dir/*` matches any path under the directory (case globs cross
+// `/`), so directory entries here are prefixes and bare filenames are exact
+// top-level matches. The second block widens the set with root-level build
+// and supply-chain inputs the inline set missed (flagged in security review
+// when the rules became a tested module): every one of these feeds a shipped
+// bundle or the install itself, so a change to any of them must reach the
+// malware gate and the builds, never skip them as docs.
 const CODE_PATH_PREFIXES = Object.freeze([
   'src/',
   'server/',
@@ -32,6 +37,8 @@ const CODE_PATH_PREFIXES = Object.freeze([
   'deploy/',
   'mediawiki/',
   'Dockerfile.',
+  // Widened beyond the old inline set: bundled game data.
+  'data/',
 ]);
 
 const CODE_PATH_EXACT = Object.freeze([
@@ -45,10 +52,28 @@ const CODE_PATH_EXACT = Object.freeze([
   'Dockerfile',
   'docker-compose.yml',
   'docker-compose.yaml',
+  // Widened beyond the old inline set: the shipped entry documents (they
+  // carry inline scripts and third-party tags), the build/install configs,
+  // and the deploy-image filter.
+  'index.html',
+  'play.html',
+  'admin.html',
+  'guide.html',
+  'editor.html',
+  'wallet-handoff.html',
+  'music_editor.html',
+  'svelte.config.js',
+  'capacitor.config.ts',
+  'tsconfig.bot.json',
+  'turbo.json',
+  '.npmrc',
+  '.browserslistrc',
+  '.dockerignore',
 ]);
 
-// The pull request files endpoint lists at most 3000 files; past that the
-// listing is silently incomplete, so classification cannot be proven.
+// The pull request files endpoint lists at most 3000 files; a listing that
+// reaches that ceiling is indistinguishable from a truncated one, so reaching
+// it (not just exceeding it) is treated as unprovable.
 export const PR_FILES_CAP = 3000;
 
 /**
@@ -67,10 +92,17 @@ export function isCodePath(path) {
 
 /**
  * Classify a full PR file listing. A rename is classified by BOTH ends
- * (`filename` and `previous_filename`): the API folds a rename into one entry,
- * but a file renamed out of the code path set still changes the code path set,
- * exactly as the old `git diff --diff-filter=ACMRD` (which listed the delete
- * and the add separately) saw it.
+ * (`filename` and `previous_filename`). This is deliberately STRICTER than the
+ * old `git diff --name-only` classifier: under git's default rename detection
+ * that command printed only the destination path, so a file renamed out of the
+ * code path set (src/x.ts to docs/x.md) classified as docs-only. The API folds
+ * a rename into one entry but keeps the source in `previous_filename`, and a
+ * rename out of the code path set still changes the code path set, so both
+ * ends are checked. Do not "restore parity" by dropping the second arm.
+ *
+ * Filenames are attacker-controlled (git allows newlines in paths), and the
+ * reason string is echoed into the CI job log where line-leading `::` workflow
+ * commands are parsed, so embedded filenames are JSON-escaped.
  *
  * @param {ReadonlyArray<{ filename?: string, previous_filename?: string | null }>} files
  * @returns {{ code: boolean, reason: string }}
@@ -81,12 +113,15 @@ export function classifyPrFiles(files) {
       return { code: true, reason: 'unclassifiable file entry: full PR tier (code=true)' };
     }
     if (isCodePath(file.filename)) {
-      return { code: true, reason: `code path change detected (${file.filename}): full PR tier` };
+      return {
+        code: true,
+        reason: `code path change detected (${JSON.stringify(file.filename)}): full PR tier`,
+      };
     }
     if (file.previous_filename != null && isCodePath(file.previous_filename)) {
       return {
         code: true,
-        reason: `code path change detected (renamed from ${file.previous_filename}): full PR tier`,
+        reason: `code path change detected (renamed from ${JSON.stringify(file.previous_filename)}): full PR tier`,
       };
     }
   }
@@ -98,9 +133,16 @@ export function classifyPrFiles(files) {
 
 /**
  * Fetch the complete changed-file list for a pull request, paginated. Throws
- * on any HTTP error, non-array payload, or a listing that exceeds `cap`
- * (provably or by exhausting the page budget); callers translate a throw into
- * code=true.
+ * on any HTTP error, non-array payload, or a listing that reaches `cap`
+ * (the endpoint's ceiling, past which truncation is silent); callers translate
+ * a throw into code=true. The loop needs no page budget: a short page returns,
+ * a non-array throws, and a server that keeps sending full pages hits the cap
+ * throw, so every path terminates.
+ *
+ * One AbortSignal covers the WHOLE listing, not each page: the enclosing CI
+ * job has a 5 minute timeout, and a per-page budget could otherwise let a
+ * slow-but-not-erroring API run the job into the hard kill (where dependents
+ * skip) instead of the fail-closed code=true path.
  *
  * @param {{
  *   repo: string,
@@ -126,10 +168,8 @@ export async function fetchPrFiles({
 }) {
   /** @type {Array<{ filename?: string, previous_filename?: string | null }>} */
   const files = [];
-  // One page past the cap: reaching it proves the listing overflowed rather
-  // than looping forever on a misbehaving endpoint.
-  const maxPages = Math.ceil(cap / perPage) + 1;
-  for (let page = 1; page <= maxPages; page++) {
+  const signal = AbortSignal.timeout(timeoutMs);
+  for (let page = 1; ; page++) {
     const url = `${apiUrl}/repos/${repo}/pulls/${prNumber}/files?per_page=${perPage}&page=${page}`;
     const res = await fetchImpl(url, {
       headers: {
@@ -137,7 +177,7 @@ export async function fetchPrFiles({
         Accept: 'application/vnd.github+json',
         'X-GitHub-Api-Version': '2022-11-28',
       },
-      signal: AbortSignal.timeout(timeoutMs),
+      signal,
     });
     if (!res.ok) {
       throw new Error(`pull request files page ${page} failed: HTTP ${res.status}`);
@@ -147,20 +187,22 @@ export async function fetchPrFiles({
       throw new Error(`pull request files page ${page} returned a non-array payload`);
     }
     files.push(...batch);
-    if (files.length > cap) {
-      throw new Error(`pull request lists more than ${cap} files; listing is incomplete`);
+    if (files.length >= cap) {
+      throw new Error(
+        `pull request lists ${cap} or more files; the listing cannot be proven complete`,
+      );
     }
     if (batch.length < perPage) return files;
   }
-  throw new Error(`pull request files pagination exceeded ${maxPages} pages`);
 }
 
 /**
  * The whole decision, fail closed end to end: never throws, and every path
  * that cannot PROVE a docs-only change returns code=true. `reportedCount` is
  * the event payload's `changed_files`; a mismatch against the fetched listing
- * (a push racing the pagination, or a truncated listing) discards the
- * classification.
+ * (a push racing the pagination) discards the classification. The docs-only
+ * reason carries the listed and reported counts so a suspicious skip can be
+ * audited from the job log alone.
  *
  * @param {{
  *   eventName: string,
@@ -202,7 +244,15 @@ export async function detectCode({
         reason: `listed ${files.length} files but the event reports ${reportedCount}: full PR tier (code=true)`,
       };
     }
-    return classifyPrFiles(files);
+    const result = classifyPrFiles(files);
+    if (!result.code) {
+      const reported = Number.isInteger(reportedCount) ? reportedCount : 'n/a';
+      return {
+        code: false,
+        reason: `${result.reason} (${files.length} files listed; event reports ${reported})`,
+      };
+    }
+    return result;
   } catch (err) {
     const detail = err instanceof Error ? err.message : String(err);
     return {

--- a/scripts/lib/ci_change_classify.mjs
+++ b/scripts/lib/ci_change_classify.mjs
@@ -37,8 +37,10 @@ const CODE_PATH_PREFIXES = Object.freeze([
   'deploy/',
   'mediawiki/',
   'Dockerfile.',
-  // Widened beyond the old inline set: bundled game data.
+  // Widened beyond the old inline set: bundled game data, and the shipped
+  // Python RL bindings (scanner-relevant sources nothing else checks).
   'data/',
+  'python/',
 ]);
 
 const CODE_PATH_EXACT = Object.freeze([
@@ -254,7 +256,9 @@ export async function detectCode({
     }
     return result;
   } catch (err) {
-    const detail = err instanceof Error ? err.message : String(err);
+    // JSON-escaped like the filenames: V8 parse errors embed raw response
+    // snippets (newlines included), and this string reaches the CI log.
+    const detail = JSON.stringify(err instanceof Error ? err.message : String(err));
     return {
       code: true,
       reason: `changed-file listing failed (${detail}): full PR tier (code=true)`,

--- a/tests/ci_change_classify.test.ts
+++ b/tests/ci_change_classify.test.ts
@@ -1,0 +1,278 @@
+import { describe, expect, it } from 'vitest';
+import {
+  classifyPrFiles,
+  detectCode,
+  fetchPrFiles,
+  isCodePath,
+  PR_FILES_CAP,
+} from '../scripts/lib/ci_change_classify.mjs';
+
+type Entry = { filename?: string; previous_filename?: string | null };
+
+// Minimal fetch stub: serves `files` through the paginated PR files endpoint
+// shape (per_page/page query params), recording every call for order and
+// header assertions. Plain objects stand in for Response; the lib only reads
+// ok, status, and json().
+function pagedFetch(files: Entry[]) {
+  const calls: Array<{ url: string; init: RequestInit | undefined }> = [];
+  const impl = (async (url: string | URL, init?: RequestInit) => {
+    calls.push({ url: String(url), init });
+    const u = new URL(String(url));
+    const page = Number(u.searchParams.get('page'));
+    const perPage = Number(u.searchParams.get('per_page'));
+    return {
+      ok: true,
+      status: 200,
+      json: async () => files.slice((page - 1) * perPage, page * perPage),
+    };
+  }) as unknown as typeof fetch;
+  return { impl, calls };
+}
+
+const failingFetch = (status: number) =>
+  (async () => ({
+    ok: false,
+    status,
+    json: async () => ({}),
+  })) as unknown as typeof fetch;
+
+const BASE = {
+  eventName: 'pull_request',
+  prNumber: 123,
+  repo: 'levy-street/world-of-claudecraft',
+  token: 'ghs_test',
+} as const;
+
+describe('isCodePath', () => {
+  it('matches directory rules at any depth, exactly as the old shell case globs did', () => {
+    expect(isCodePath('src/sim/sim.ts')).toBe(true);
+    expect(isCodePath('src/ui/hud/town/index.ts')).toBe(true);
+    expect(isCodePath('scripts/lib/ci_change_classify.mjs')).toBe(true);
+    expect(isCodePath('.github/workflows/ci.yml')).toBe(true);
+    // Sibling-name near misses must not match: prefixes end at the slash.
+    expect(isCodePath('srcs/notes.md')).toBe(false);
+    expect(isCodePath('docs/src/diagram.md')).toBe(false);
+    // Non-workflow .github files are not code (the PR template, agent docs).
+    expect(isCodePath('.github/PULL_REQUEST_TEMPLATE.md')).toBe(false);
+  });
+
+  it('matches the top-level exact rules without widening them to nested paths', () => {
+    for (const exact of [
+      'package.json',
+      'pnpm-lock.yaml',
+      'tsconfig.json',
+      'tsconfig.admin.json',
+      'vite.config.ts',
+      'vitest.browser.config.ts',
+      'biome.json',
+      'Dockerfile',
+      'docker-compose.yml',
+      'docker-compose.yaml',
+    ]) {
+      expect(isCodePath(exact)).toBe(true);
+    }
+    expect(isCodePath('Dockerfile.bot')).toBe(true);
+    // The shell case matched the WHOLE path, so a nested copy of an exact name
+    // outside every code directory stayed non-code; preserve that.
+    expect(isCodePath('docs/package.json')).toBe(false);
+    expect(isCodePath('docs/examples/Dockerfile')).toBe(false);
+  });
+
+  it('leaves documentation surfaces classifiable as non-code', () => {
+    expect(isCodePath('README.md')).toBe(false);
+    expect(isCodePath('CLAUDE.md')).toBe(false);
+    expect(isCodePath('docs/prd/some-spec.md')).toBe(false);
+    expect(isCodePath('docs/screenshots/before.png')).toBe(false);
+    expect(isCodePath('CREDITS.md')).toBe(false);
+  });
+
+  it('fails closed on input it cannot read', () => {
+    expect(isCodePath('')).toBe(true);
+    expect(isCodePath(undefined as unknown as string)).toBe(true);
+    expect(isCodePath(7 as unknown as string)).toBe(true);
+  });
+});
+
+describe('classifyPrFiles', () => {
+  it('flags a code file anywhere in the listing and names it in the reason', () => {
+    const result = classifyPrFiles([
+      { filename: 'docs/prd/spec.md' },
+      { filename: 'server/game.ts' },
+      { filename: 'README.md' },
+    ]);
+    expect(result.code).toBe(true);
+    expect(result.reason).toBe('code path change detected (server/game.ts): full PR tier');
+  });
+
+  it('classifies a fully non-code listing as docs-only with the skip reason', () => {
+    const result = classifyPrFiles([
+      { filename: 'docs/prd/spec.md' },
+      { filename: 'docs/screenshots/after.png' },
+      { filename: 'README.md' },
+    ]);
+    expect(result).toEqual({
+      code: false,
+      reason: 'docs-only (or non-code) change: skip pr-gate, pr-checks, browser-gate',
+    });
+  });
+
+  it('classifies both ends of a rename, like the old add+delete diff pair', () => {
+    // Renamed OUT of the code path set: the API folds this into one entry
+    // whose filename is non-code; only previous_filename betrays it.
+    const out = classifyPrFiles([
+      { filename: 'docs/old_sim.md', previous_filename: 'src/sim/old.ts' },
+    ]);
+    expect(out.code).toBe(true);
+    expect(out.reason).toBe(
+      'code path change detected (renamed from src/sim/old.ts): full PR tier',
+    );
+    // A rename fully inside docs stays non-code.
+    const docs = classifyPrFiles([
+      { filename: 'docs/prd/new-name.md', previous_filename: 'docs/prd/old-name.md' },
+    ]);
+    expect(docs.code).toBe(false);
+  });
+
+  it('fails closed on an entry it cannot read', () => {
+    expect(classifyPrFiles([{ filename: 'docs/a.md' }, {}]).code).toBe(true);
+    expect(classifyPrFiles([{ filename: '' }]).code).toBe(true);
+    expect(
+      classifyPrFiles([{ filename: 'docs/a.md', previous_filename: 9 as unknown as string }]).code,
+    ).toBe(true);
+  });
+});
+
+describe('fetchPrFiles', () => {
+  it('paginates until a short page and returns the concatenated listing', async () => {
+    const files: Entry[] = Array.from({ length: 250 }, (_, i) => ({ filename: `docs/f${i}.md` }));
+    const { impl, calls } = pagedFetch(files);
+    const listed = await fetchPrFiles({ ...BASE, fetchImpl: impl });
+    expect(listed).toHaveLength(250);
+    expect(listed[249]).toEqual({ filename: 'docs/f249.md' });
+    expect(calls.map((c) => new URL(c.url).searchParams.get('page'))).toEqual(['1', '2', '3']);
+    expect(calls[0].url).toBe(
+      'https://api.github.com/repos/levy-street/world-of-claudecraft/pulls/123/files?per_page=100&page=1',
+    );
+  });
+
+  it('sends the token and API headers on every page request', async () => {
+    const { impl, calls } = pagedFetch([{ filename: 'docs/a.md' }]);
+    await fetchPrFiles({ ...BASE, fetchImpl: impl });
+    const headers = calls[0].init?.headers as Record<string, string>;
+    expect(headers.Authorization).toBe('Bearer ghs_test');
+    expect(headers.Accept).toBe('application/vnd.github+json');
+    expect(headers['X-GitHub-Api-Version']).toBe('2022-11-28');
+    expect(calls[0].init?.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('throws on an HTTP error status', async () => {
+    await expect(fetchPrFiles({ ...BASE, fetchImpl: failingFetch(403) })).rejects.toThrow(
+      /HTTP 403/,
+    );
+  });
+
+  it('throws on a non-array payload', async () => {
+    const impl = (async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ message: 'unexpected' }),
+    })) as unknown as typeof fetch;
+    await expect(fetchPrFiles({ ...BASE, fetchImpl: impl })).rejects.toThrow(/non-array/);
+  });
+
+  it('throws once the listing exceeds the completeness cap', async () => {
+    const files: Entry[] = Array.from({ length: 250 }, (_, i) => ({ filename: `docs/f${i}.md` }));
+    const { impl } = pagedFetch(files);
+    await expect(fetchPrFiles({ ...BASE, fetchImpl: impl, cap: 200 })).rejects.toThrow(
+      /more than 200 files/,
+    );
+    // The real cap matches the documented endpoint limit.
+    expect(PR_FILES_CAP).toBe(3000);
+  });
+});
+
+describe('detectCode (fail closed end to end)', () => {
+  const neverFetch = (async () => {
+    throw new Error('fetch must not be called for this case');
+  }) as unknown as typeof fetch;
+
+  it('returns code=true for non-PR events without touching the API', async () => {
+    for (const eventName of ['push', 'workflow_dispatch', 'schedule', '']) {
+      expect(await detectCode({ ...BASE, eventName, fetchImpl: neverFetch })).toEqual({
+        code: true,
+        reason: 'non-PR event: full PR tier (code=true)',
+      });
+    }
+  });
+
+  it('returns code=true when the PR context or token is missing', async () => {
+    expect((await detectCode({ ...BASE, prNumber: Number.NaN, fetchImpl: neverFetch })).code).toBe(
+      true,
+    );
+    expect((await detectCode({ ...BASE, prNumber: 0, fetchImpl: neverFetch })).code).toBe(true);
+    expect((await detectCode({ ...BASE, repo: '', fetchImpl: neverFetch })).code).toBe(true);
+    expect(await detectCode({ ...BASE, token: '', fetchImpl: neverFetch })).toEqual({
+      code: true,
+      reason: 'missing API token: full PR tier (code=true)',
+    });
+  });
+
+  it('returns code=true on a forced API failure, never code=false', async () => {
+    // The acceptance case for the API-driven classifier: an API that errors,
+    // times out, or rejects must run the full suite.
+    const rejecting = (async () => {
+      throw new Error('ECONNRESET');
+    }) as unknown as typeof fetch;
+    const rejected = await detectCode({ ...BASE, fetchImpl: rejecting });
+    expect(rejected.code).toBe(true);
+    expect(rejected.reason).toBe(
+      'changed-file listing failed (ECONNRESET): full PR tier (code=true)',
+    );
+    const denied = await detectCode({ ...BASE, fetchImpl: failingFetch(401) });
+    expect(denied.code).toBe(true);
+    expect(denied.reason).toMatch(/^changed-file listing failed .*HTTP 401/);
+    // A non-Error throw still resolves to code=true.
+    const weird = (async () => {
+      throw 'string failure';
+    }) as unknown as typeof fetch;
+    expect((await detectCode({ ...BASE, fetchImpl: weird })).code).toBe(true);
+  });
+
+  it('returns code=true on an empty listing or a changed_files mismatch', async () => {
+    const { impl: empty } = pagedFetch([]);
+    expect(await detectCode({ ...BASE, fetchImpl: empty })).toEqual({
+      code: true,
+      reason: 'empty file list: full PR tier (code=true)',
+    });
+    const { impl } = pagedFetch([{ filename: 'docs/a.md' }, { filename: 'docs/b.md' }]);
+    const mismatched = await detectCode({ ...BASE, reportedCount: 5, fetchImpl: impl });
+    expect(mismatched).toEqual({
+      code: true,
+      reason: 'listed 2 files but the event reports 5: full PR tier (code=true)',
+    });
+  });
+
+  it('classifies a docs-only PR as code=false when the listing is complete', async () => {
+    const docs: Entry[] = [
+      { filename: 'docs/prd/spec.md' },
+      { filename: 'README.md' },
+      { filename: 'docs/screenshots/after.png' },
+    ];
+    const { impl } = pagedFetch(docs);
+    const counted = await detectCode({ ...BASE, reportedCount: 3, fetchImpl: impl });
+    expect(counted.code).toBe(false);
+    // changed_files missing from the payload skips the count check but still
+    // classifies (the listing itself terminated normally).
+    const { impl: uncounted } = pagedFetch(docs);
+    expect((await detectCode({ ...BASE, fetchImpl: uncounted })).code).toBe(false);
+  });
+
+  it('classifies a code PR as code=true through the same path', async () => {
+    const { impl } = pagedFetch([{ filename: 'docs/a.md' }, { filename: 'src/sim/sim.ts' }]);
+    const result = await detectCode({ ...BASE, reportedCount: 2, fetchImpl: impl });
+    expect(result).toEqual({
+      code: true,
+      reason: 'code path change detected (src/sim/sim.ts): full PR tier',
+    });
+  });
+});

--- a/tests/ci_change_classify.test.ts
+++ b/tests/ci_change_classify.test.ts
@@ -1,4 +1,11 @@
-import { describe, expect, it } from 'vitest';
+import { spawn } from 'node:child_process';
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { createServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import {
   classifyPrFiles,
   detectCode,
@@ -10,9 +17,9 @@ import {
 type Entry = { filename?: string; previous_filename?: string | null };
 
 // Minimal fetch stub: serves `files` through the paginated PR files endpoint
-// shape (per_page/page query params), recording every call for order and
-// header assertions. Plain objects stand in for Response; the lib only reads
-// ok, status, and json().
+// shape (per_page/page query params), recording every call for order, header,
+// and signal assertions. Plain objects stand in for Response; the lib only
+// reads ok, status, and json().
 function pagedFetch(files: Entry[]) {
   const calls: Array<{ url: string; init: RequestInit | undefined }> = [];
   const impl = (async (url: string | URL, init?: RequestInit) => {
@@ -49,6 +56,7 @@ describe('isCodePath', () => {
     expect(isCodePath('src/ui/hud/town/index.ts')).toBe(true);
     expect(isCodePath('scripts/lib/ci_change_classify.mjs')).toBe(true);
     expect(isCodePath('.github/workflows/ci.yml')).toBe(true);
+    expect(isCodePath('data/battleground/thornhollow.map.json')).toBe(true);
     // Sibling-name near misses must not match: prefixes end at the slash.
     expect(isCodePath('srcs/notes.md')).toBe(false);
     expect(isCodePath('docs/src/diagram.md')).toBe(false);
@@ -78,6 +86,30 @@ describe('isCodePath', () => {
     expect(isCodePath('docs/examples/Dockerfile')).toBe(false);
   });
 
+  it('classifies the root build and supply-chain inputs as code (widened set)', () => {
+    // These were holes in the old inline set: each feeds a shipped bundle or
+    // the install itself, so skipping the malware gate and builds on them was
+    // a bypass (index.html alone carries inline scripts and third-party tags).
+    for (const widened of [
+      'index.html',
+      'play.html',
+      'admin.html',
+      'guide.html',
+      'editor.html',
+      'wallet-handoff.html',
+      'music_editor.html',
+      'svelte.config.js',
+      'capacitor.config.ts',
+      'tsconfig.bot.json',
+      'turbo.json',
+      '.npmrc',
+      '.browserslistrc',
+      '.dockerignore',
+    ]) {
+      expect(isCodePath(widened)).toBe(true);
+    }
+  });
+
   it('leaves documentation surfaces classifiable as non-code', () => {
     expect(isCodePath('README.md')).toBe(false);
     expect(isCodePath('CLAUDE.md')).toBe(false);
@@ -94,14 +126,20 @@ describe('isCodePath', () => {
 });
 
 describe('classifyPrFiles', () => {
-  it('flags a code file anywhere in the listing and names it in the reason', () => {
+  it('flags a code file anywhere in the listing and names it, JSON-escaped, in the reason', () => {
     const result = classifyPrFiles([
       { filename: 'docs/prd/spec.md' },
       { filename: 'server/game.ts' },
       { filename: 'README.md' },
     ]);
     expect(result.code).toBe(true);
-    expect(result.reason).toBe('code path change detected (server/game.ts): full PR tier');
+    expect(result.reason).toBe('code path change detected ("server/game.ts"): full PR tier');
+    // Filenames are attacker-controlled and the reason reaches the CI log,
+    // where a line-leading :: is a workflow command; a newline must arrive
+    // escaped, never literal.
+    const sneaky = classifyPrFiles([{ filename: 'src/a\n::error::forged' }]);
+    expect(sneaky.reason).not.toContain('\n');
+    expect(sneaky.reason).toContain('\\n::error::forged');
   });
 
   it('classifies a fully non-code listing as docs-only with the skip reason', () => {
@@ -116,15 +154,17 @@ describe('classifyPrFiles', () => {
     });
   });
 
-  it('classifies both ends of a rename, like the old add+delete diff pair', () => {
-    // Renamed OUT of the code path set: the API folds this into one entry
-    // whose filename is non-code; only previous_filename betrays it.
+  it('classifies both ends of a rename, stricter than the old diff on purpose', () => {
+    // The old git-diff classifier printed only the DESTINATION under default
+    // rename detection, so renaming src/sim/old.ts to docs/old_sim.md read as
+    // docs-only. previous_filename closes that hole; this pin keeps a future
+    // "restore parity" cleanup from reopening it.
     const out = classifyPrFiles([
       { filename: 'docs/old_sim.md', previous_filename: 'src/sim/old.ts' },
     ]);
     expect(out.code).toBe(true);
     expect(out.reason).toBe(
-      'code path change detected (renamed from src/sim/old.ts): full PR tier',
+      'code path change detected (renamed from "src/sim/old.ts"): full PR tier',
     );
     // A rename fully inside docs stays non-code.
     const docs = classifyPrFiles([
@@ -155,14 +195,20 @@ describe('fetchPrFiles', () => {
     );
   });
 
-  it('sends the token and API headers on every page request', async () => {
-    const { impl, calls } = pagedFetch([{ filename: 'docs/a.md' }]);
+  it('sends the token and API headers, and ONE shared deadline, on every page', async () => {
+    const files: Entry[] = Array.from({ length: 250 }, (_, i) => ({ filename: `docs/f${i}.md` }));
+    const { impl, calls } = pagedFetch(files);
     await fetchPrFiles({ ...BASE, fetchImpl: impl });
     const headers = calls[0].init?.headers as Record<string, string>;
     expect(headers.Authorization).toBe('Bearer ghs_test');
     expect(headers.Accept).toBe('application/vnd.github+json');
     expect(headers['X-GitHub-Api-Version']).toBe('2022-11-28');
+    // One AbortSignal instance across all pages: the timeout bounds the whole
+    // listing, so a slow API fails closed inside the job's 5 minute timeout
+    // instead of running it into the hard kill (where dependents skip).
+    expect(calls).toHaveLength(3);
     expect(calls[0].init?.signal).toBeInstanceOf(AbortSignal);
+    expect(new Set(calls.map((c) => c.init?.signal)).size).toBe(1);
   });
 
   it('throws on an HTTP error status', async () => {
@@ -180,12 +226,22 @@ describe('fetchPrFiles', () => {
     await expect(fetchPrFiles({ ...BASE, fetchImpl: impl })).rejects.toThrow(/non-array/);
   });
 
-  it('throws once the listing exceeds the completeness cap', async () => {
-    const files: Entry[] = Array.from({ length: 250 }, (_, i) => ({ filename: `docs/f${i}.md` }));
-    const { impl } = pagedFetch(files);
-    await expect(fetchPrFiles({ ...BASE, fetchImpl: impl, cap: 200 })).rejects.toThrow(
-      /more than 200 files/,
-    );
+  it('throws once the listing REACHES the completeness cap, not only past it', async () => {
+    // The endpoint truncates at the cap silently, so a listing of exactly cap
+    // entries is indistinguishable from a truncated one and must fail closed
+    // on its own, without depending on the optional changed_files field.
+    const files = (n: number): Entry[] =>
+      Array.from({ length: n }, (_, i) => ({ filename: `docs/f${i}.md` }));
+    await expect(
+      fetchPrFiles({ ...BASE, fetchImpl: pagedFetch(files(250)).impl, cap: 200 }),
+    ).rejects.toThrow(/200 or more files/);
+    await expect(
+      fetchPrFiles({ ...BASE, fetchImpl: pagedFetch(files(200)).impl, cap: 200 }),
+    ).rejects.toThrow(/200 or more files/);
+    // One under the cap is a complete, provable listing.
+    await expect(
+      fetchPrFiles({ ...BASE, fetchImpl: pagedFetch(files(199)).impl, cap: 200 }),
+    ).resolves.toHaveLength(199);
     // The real cap matches the documented endpoint limit.
     expect(PR_FILES_CAP).toBe(3000);
   });
@@ -252,19 +308,29 @@ describe('detectCode (fail closed end to end)', () => {
     });
   });
 
-  it('classifies a docs-only PR as code=false when the listing is complete', async () => {
+  it('classifies a docs-only PR as code=false with an auditable count in the reason', async () => {
     const docs: Entry[] = [
       { filename: 'docs/prd/spec.md' },
       { filename: 'README.md' },
       { filename: 'docs/screenshots/after.png' },
     ];
     const { impl } = pagedFetch(docs);
-    const counted = await detectCode({ ...BASE, reportedCount: 3, fetchImpl: impl });
-    expect(counted.code).toBe(false);
+    // The skip decision must be auditable from the job log alone: how many
+    // files were listed and what the event reported.
+    expect(await detectCode({ ...BASE, reportedCount: 3, fetchImpl: impl })).toEqual({
+      code: false,
+      reason:
+        'docs-only (or non-code) change: skip pr-gate, pr-checks, browser-gate (3 files listed; event reports 3)',
+    });
     // changed_files missing from the payload skips the count check but still
-    // classifies (the listing itself terminated normally).
+    // classifies (pagination terminated below the cap, so the listing is
+    // complete), and the log says the report was absent.
     const { impl: uncounted } = pagedFetch(docs);
-    expect((await detectCode({ ...BASE, fetchImpl: uncounted })).code).toBe(false);
+    expect(await detectCode({ ...BASE, fetchImpl: uncounted })).toEqual({
+      code: false,
+      reason:
+        'docs-only (or non-code) change: skip pr-gate, pr-checks, browser-gate (3 files listed; event reports n/a)',
+    });
   });
 
   it('classifies a code PR as code=true through the same path', async () => {
@@ -272,7 +338,95 @@ describe('detectCode (fail closed end to end)', () => {
     const result = await detectCode({ ...BASE, reportedCount: 2, fetchImpl: impl });
     expect(result).toEqual({
       code: true,
-      reason: 'code path change detected (src/sim/sim.ts): full PR tier',
+      reason: 'code path change detected ("src/sim/sim.ts"): full PR tier',
     });
+  });
+});
+
+// The entry script is the wiring between the Actions environment and the
+// tested lib, and its GITHUB_OUTPUT write is what the three dependent jobs
+// gate on: a silently missing write leaves the output empty and every
+// dependent SKIPS, which is a false green. So the entry runs for real here,
+// as a subprocess, against a local HTTP stub standing in for the API.
+describe('detect_code_changes.mjs entry (subprocess)', () => {
+  const repoRoot = fileURLToPath(new URL('..', import.meta.url));
+  const scratch = mkdtempSync(join(tmpdir(), 'wocc-detect-entry-'));
+  let apiUrl = '';
+  const server = createServer((_req, res) => {
+    res.setHeader('content-type', 'application/json');
+    res.end(JSON.stringify([{ filename: 'docs/prd/spec.md' }, { filename: 'README.md' }]));
+  });
+
+  beforeAll(async () => {
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    apiUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+  });
+  afterAll(async () => {
+    await new Promise<void>((resolve, reject) =>
+      server.close((err) => (err ? reject(err) : resolve())),
+    );
+  });
+
+  async function runEntry(name: string, env: Record<string, string>) {
+    const outFile = join(scratch, `${name}.out`);
+    writeFileSync(outFile, '');
+    const child = spawn(process.execPath, ['scripts/detect_code_changes.mjs'], {
+      cwd: repoRoot,
+      env: { PATH: process.env.PATH ?? '', GITHUB_OUTPUT: outFile, ...env },
+    });
+    let log = '';
+    child.stdout.on('data', (chunk) => {
+      log += String(chunk);
+    });
+    child.stderr.on('data', (chunk) => {
+      log += String(chunk);
+    });
+    const exitCode = await new Promise<number | null>((resolve) => child.on('close', resolve));
+    return { exitCode, log, output: readFileSync(outFile, 'utf8') };
+  }
+
+  function eventFixture(name: string, payload: unknown): string {
+    const file = join(scratch, `${name}.json`);
+    writeFileSync(file, JSON.stringify(payload));
+    return file;
+  }
+
+  it('writes code=true to GITHUB_OUTPUT for a push event', async () => {
+    const run = await runEntry('push', { GITHUB_EVENT_NAME: 'push' });
+    expect(run.exitCode).toBe(0);
+    expect(run.output).toBe('code=true\n');
+    expect(run.log).toContain('non-PR event');
+  });
+
+  it('writes code=false for a docs-only PR through the real fetch path', async () => {
+    const run = await runEntry('docs', {
+      GITHUB_EVENT_NAME: 'pull_request',
+      GITHUB_EVENT_PATH: eventFixture('docs-event', {
+        pull_request: { number: 12, changed_files: 2 },
+      }),
+      GITHUB_REPOSITORY: 'levy-street/world-of-claudecraft',
+      GITHUB_TOKEN: 'ghs_test',
+      GITHUB_API_URL: apiUrl,
+    });
+    expect(run.exitCode).toBe(0);
+    expect(run.output).toBe('code=false\n');
+    expect(run.log).toContain('2 files listed; event reports 2');
+  });
+
+  it('fails closed when the payload count disagrees with the listing', async () => {
+    // This also pins that changed_files is actually read and passed through:
+    // if that wiring broke, this case would classify docs-only.
+    const run = await runEntry('mismatch', {
+      GITHUB_EVENT_NAME: 'pull_request',
+      GITHUB_EVENT_PATH: eventFixture('mismatch-event', {
+        pull_request: { number: 12, changed_files: 5 },
+      }),
+      GITHUB_REPOSITORY: 'levy-street/world-of-claudecraft',
+      GITHUB_TOKEN: 'ghs_test',
+      GITHUB_API_URL: apiUrl,
+    });
+    expect(run.exitCode).toBe(0);
+    expect(run.output).toBe('code=true\n');
+    expect(run.log).toContain('listed 2 files but the event reports 5');
   });
 });

--- a/tests/ci_change_classify.test.ts
+++ b/tests/ci_change_classify.test.ts
@@ -1,5 +1,5 @@
 import { spawn } from 'node:child_process';
-import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { createServer } from 'node:http';
 import type { AddressInfo } from 'node:net';
 import { tmpdir } from 'node:os';
@@ -105,6 +105,8 @@ describe('isCodePath', () => {
       '.npmrc',
       '.browserslistrc',
       '.dockerignore',
+      'python/wow_env.py',
+      'python/example_random_agent.py',
     ]) {
       expect(isCodePath(widened)).toBe(true);
     }
@@ -281,8 +283,10 @@ describe('detectCode (fail closed end to end)', () => {
     }) as unknown as typeof fetch;
     const rejected = await detectCode({ ...BASE, fetchImpl: rejecting });
     expect(rejected.code).toBe(true);
+    // The detail is JSON-escaped like the filenames: V8 parse errors embed
+    // raw response snippets, newlines included, and this reaches the CI log.
     expect(rejected.reason).toBe(
-      'changed-file listing failed (ECONNRESET): full PR tier (code=true)',
+      'changed-file listing failed ("ECONNRESET"): full PR tier (code=true)',
     );
     const denied = await detectCode({ ...BASE, fetchImpl: failingFetch(401) });
     expect(denied.code).toBe(true);
@@ -350,7 +354,7 @@ describe('detectCode (fail closed end to end)', () => {
 // as a subprocess, against a local HTTP stub standing in for the API.
 describe('detect_code_changes.mjs entry (subprocess)', () => {
   const repoRoot = fileURLToPath(new URL('..', import.meta.url));
-  const scratch = mkdtempSync(join(tmpdir(), 'wocc-detect-entry-'));
+  let scratch = '';
   let apiUrl = '';
   const server = createServer((_req, res) => {
     res.setHeader('content-type', 'application/json');
@@ -358,6 +362,9 @@ describe('detect_code_changes.mjs entry (subprocess)', () => {
   });
 
   beforeAll(async () => {
+    // In beforeAll, not at collection time: a filtered run that skips this
+    // describe must not mint a scratch dir, and afterAll removes it.
+    scratch = mkdtempSync(join(tmpdir(), 'wocc-detect-entry-'));
     await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
     apiUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
   });
@@ -365,6 +372,7 @@ describe('detect_code_changes.mjs entry (subprocess)', () => {
     await new Promise<void>((resolve, reject) =>
       server.close((err) => (err ? reject(err) : resolve())),
     );
+    rmSync(scratch, { recursive: true, force: true });
   });
 
   async function runEntry(name: string, env: Record<string, string>) {
@@ -372,7 +380,15 @@ describe('detect_code_changes.mjs entry (subprocess)', () => {
     writeFileSync(outFile, '');
     const child = spawn(process.execPath, ['scripts/detect_code_changes.mjs'], {
       cwd: repoRoot,
-      env: { PATH: process.env.PATH ?? '', GITHUB_OUTPUT: outFile, ...env },
+      // Minimal on purpose: keeps the runner's real GITHUB_* vars and
+      // vitest's NODE_OPTIONS out of the child. Windows children still need
+      // SystemRoot for network/crypto init.
+      env: {
+        PATH: process.env.PATH ?? '',
+        ...(process.env.SystemRoot ? { SystemRoot: process.env.SystemRoot } : {}),
+        GITHUB_OUTPUT: outFile,
+        ...env,
+      },
     });
     let log = '';
     child.stdout.on('data', (chunk) => {
@@ -381,7 +397,23 @@ describe('detect_code_changes.mjs entry (subprocess)', () => {
     child.stderr.on('data', (chunk) => {
       log += String(chunk);
     });
-    const exitCode = await new Promise<number | null>((resolve) => child.on('close', resolve));
+    const exitCode = await new Promise<number | null>((resolve, reject) => {
+      // A hung or unspawnable entry must fail THIS test with its log, not
+      // stall the vitest worker or orphan the child.
+      const killer = setTimeout(() => {
+        child.kill('SIGKILL');
+        reject(new Error(`entry did not exit within 15s; log so far:\n${log}`));
+      }, 15_000);
+      killer.unref();
+      child.on('error', (err) => {
+        clearTimeout(killer);
+        reject(err);
+      });
+      child.on('close', (code) => {
+        clearTimeout(killer);
+        resolve(code);
+      });
+    });
     return { exitCode, log, output: readFileSync(outFile, 'utf8') };
   }
 

--- a/tests/ci_workflow.test.ts
+++ b/tests/ci_workflow.test.ts
@@ -109,6 +109,25 @@ const CODE_PATH_SAMPLES = [
   ['Dockerfile.*', 'Dockerfile.bot'],
   ['docker-compose.yml', 'docker-compose.yml'],
   ['docker-compose.yaml', 'docker-compose.yaml'],
+  // Widened when the rules became a tested module: root build and
+  // supply-chain inputs the old inline set skipped (the shipped entry
+  // documents carry inline scripts and third-party tags; the configs steer
+  // the install and every bundle).
+  ['index.html', 'index.html'],
+  ['play.html', 'play.html'],
+  ['admin.html', 'admin.html'],
+  ['guide.html', 'guide.html'],
+  ['editor.html', 'editor.html'],
+  ['wallet-handoff.html', 'wallet-handoff.html'],
+  ['music_editor.html', 'music_editor.html'],
+  ['svelte.config.js', 'svelte.config.js'],
+  ['capacitor.config.ts', 'capacitor.config.ts'],
+  ['tsconfig.bot.json', 'tsconfig.bot.json'],
+  ['turbo.json', 'turbo.json'],
+  ['.npmrc', '.npmrc'],
+  ['.browserslistrc', '.browserslistrc'],
+  ['.dockerignore', '.dockerignore'],
+  ['data/*', 'data/battleground/thornhollow.map.json'],
 ] as const;
 
 // Paths that must stay classifiable as docs-only, or every documentation PR
@@ -387,11 +406,18 @@ describe('CI workflow parity', () => {
     expect(changes).toContain('id: filter');
     expect(changes).toContain('outputs:');
     expect(changes).toContain('code: ${{ steps.filter.outputs.code }}');
-    expect(changes).toContain('run: node scripts/detect_code_changes.mjs');
-    // The only checkout is blob-less, shallow, and sparse: the ~10 minute
+    // Anchored, not toContain: a YAML-commented-out step keeps the substring
+    // but loses the indented shape, and this one line is the whole classifier.
+    expect(changes).toMatch(/\n {8}run: node scripts\/detect_code_changes\.mjs\n/);
+    // The script's appendFile is the ONLY writer of the code output: a shell
+    // step echoing into GITHUB_OUTPUT could override the classifier verdict.
+    expect(changes).not.toContain('GITHUB_OUTPUT');
+    // Exactly one checkout, blob-less, shallow, and sparse: the ~10 minute
     // full-history checkout (which also wedged for 90+ minutes twice) must not
     // return, and nothing in this job may need the tree beyond scripts/.
-    expect(changes).not.toContain('fetch-depth');
+    expect(changes.match(/uses: actions\/checkout/g)).toHaveLength(1);
+    expect(changes).not.toMatch(/^\s+fetch-depth:/m);
+    expect(changes).not.toContain('--unshallow');
     expect(changes).toContain('filter: blob:none');
     expect(changes).toMatch(/sparse-checkout: \|\n {12}scripts\n/);
     // No toolchain setup or dependency install on this serial critical path:
@@ -605,7 +631,9 @@ describe('CI workflow parity', () => {
     expect(jobSource('changes')).toMatch(
       /\n {4}permissions:\n {6}contents: read\n {6}pull-requests: read\n/,
     );
-    expect(workflow).not.toMatch(/^\s*[\w-]+: write\s*$/m);
+    // \b, not $: a trailing comment after a write scope must not hide it, and
+    // \b after "write" also matches the write-all shorthand.
+    expect(workflow).not.toMatch(/^\s*[\w-]+:\s*write\b/m);
     expect(workflow).not.toContain('secrets.');
     expect(workflow).not.toContain("secrets['");
     expect(workflow).not.toContain('secrets["');

--- a/tests/ci_workflow.test.ts
+++ b/tests/ci_workflow.test.ts
@@ -128,6 +128,7 @@ const CODE_PATH_SAMPLES = [
   ['.browserslistrc', '.browserslistrc'],
   ['.dockerignore', '.dockerignore'],
   ['data/*', 'data/battleground/thornhollow.map.json'],
+  ['python/*', 'python/wow_env.py'],
 ] as const;
 
 // Paths that must stay classifiable as docs-only, or every documentation PR
@@ -145,8 +146,11 @@ function jobSource(name: string): string {
   // uppercase initial: a future job id like `pr-gate2` or `Release` would
   // otherwise not terminate the previous slice, letting one job's text bleed
   // into another and quietly satisfying a by-name pin from the wrong job.
+  // It also stops at a top-level (two-space) comment line: those document the
+  // NEXT job, and letting them bleed into the previous slice makes negative
+  // pins (not.toContain) fail on a neighbour's comment text.
   const match = workflow.match(
-    new RegExp(`\\n  ${name}:[\\s\\S]*?(?=\\n  [A-Za-z][A-Za-z0-9_-]*:|$)`),
+    new RegExp(`\\n  ${name}:[\\s\\S]*?(?=\\n  [A-Za-z][A-Za-z0-9_-]*:|\\n  #|$)`),
   );
   if (!match) throw new Error(`missing CI job: ${name}`);
   return match[0];

--- a/tests/ci_workflow.test.ts
+++ b/tests/ci_workflow.test.ts
@@ -1,8 +1,13 @@
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
+import { isCodePath } from '../scripts/lib/ci_change_classify.mjs';
 import { buildFullGateSteps } from '../scripts/lib/gate_steps.mjs';
 
 const workflow = readFileSync(new URL('../.github/workflows/ci.yml', import.meta.url), 'utf8');
+const detectEntry = readFileSync(
+  new URL('../scripts/detect_code_changes.mjs', import.meta.url),
+  'utf8',
+);
 const packageJson = JSON.parse(
   readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
 ) as { packageManager?: string };
@@ -74,33 +79,46 @@ const PR_TIER_EVENT_FRAGMENT =
 // Extra parens around the event fragment keep || from binding past the && code arm.
 const PR_TIER_IF_LINE = `    if: (${PR_TIER_EVENT_FRAGMENT}) && needs.changes.outputs.code == 'true'`;
 
-// Minimum code path globs the changes job must classify as code=true (D10).
-const CODE_PATH_GLOBS = [
-  'src/*',
-  'server/*',
-  'tests/*',
-  'headless/*',
-  'bot/*',
-  'scripts/*',
-  'package.json',
-  'pnpm-lock.yaml',
-  'tsconfig.json',
-  'tsconfig.admin.json',
-  'vite.config.ts',
-  'vitest.browser.config.ts',
-  'biome.json',
-  '.github/workflows/*',
-  'electron/*',
-  'android/*',
-  'ios/*',
-  'public/*',
+// Minimum code path set the changes job must classify as code=true (D10).
+// Each row pairs the original inline-YAML glob with a representative path;
+// the pin is behavioral (through scripts/lib/ci_change_classify.mjs) because
+// the rules no longer live in the workflow text at all.
+const CODE_PATH_SAMPLES = [
+  ['src/*', 'src/sim/sim.ts'],
+  ['server/*', 'server/game.ts'],
+  ['tests/*', 'tests/sim.test.ts'],
+  ['headless/*', 'headless/env_server.ts'],
+  ['bot/*', 'bot/src/index.ts'],
+  ['scripts/*', 'scripts/gate.mjs'],
+  ['package.json', 'package.json'],
+  ['pnpm-lock.yaml', 'pnpm-lock.yaml'],
+  ['tsconfig.json', 'tsconfig.json'],
+  ['tsconfig.admin.json', 'tsconfig.admin.json'],
+  ['vite.config.ts', 'vite.config.ts'],
+  ['vitest.browser.config.ts', 'vitest.browser.config.ts'],
+  ['biome.json', 'biome.json'],
+  ['.github/workflows/*', '.github/workflows/ci.yml'],
+  ['electron/*', 'electron/main.ts'],
+  ['android/*', 'android/app/build.gradle'],
+  ['ios/*', 'ios/App/AppDelegate.swift'],
+  ['public/*', 'public/models/prop.glb'],
   // Security-adjacent / deploy surfaces: must not skip malware+builds (privacy review).
-  'deploy/*',
-  'mediawiki/*',
-  'Dockerfile',
-  'Dockerfile.*',
-  'docker-compose.yml',
-  'docker-compose.yaml',
+  ['deploy/*', 'deploy/mediawiki/first-boot.sh'],
+  ['mediawiki/*', 'mediawiki/Dockerfile'],
+  ['Dockerfile', 'Dockerfile'],
+  ['Dockerfile.*', 'Dockerfile.bot'],
+  ['docker-compose.yml', 'docker-compose.yml'],
+  ['docker-compose.yaml', 'docker-compose.yaml'],
+] as const;
+
+// Paths that must stay classifiable as docs-only, or every documentation PR
+// silently pays the full 8-shard tier again.
+const NON_CODE_SAMPLES = [
+  'README.md',
+  'CLAUDE.md',
+  'docs/prd/some-spec.md',
+  'docs/screenshots/before.png',
+  '.github/PULL_REQUEST_TEMPLATE.md',
 ] as const;
 
 function jobSource(name: string): string {
@@ -357,30 +375,50 @@ describe('CI workflow parity', () => {
     expect(releaseGate).not.toContain('Cache tsc incremental buildinfo');
   });
 
-  it('classifies docs-only PRs via a native changes job and keeps release unfiltered', () => {
-    // D10: native git-diff classifier (no dorny/paths-filter). Output code=true
-    // forces the full PR tier; code=false skips pr-gate/pr-checks/browser-gate.
-    // lint stays unfiltered. Release jobs never consult the output.
+  it('classifies docs-only PRs via the API-driven changes job and keeps release unfiltered', () => {
+    // D10 classifier: the changes job asks the GitHub API for the PR file list
+    // through scripts/detect_code_changes.mjs; rules and the fail-closed
+    // decision live in scripts/lib/ci_change_classify.mjs, whose behavior
+    // (every error path resolving to code=true) is pinned by
+    // tests/ci_change_classify.test.ts. Output code=true forces the full PR
+    // tier; code=false skips pr-gate/pr-checks/browser-gate. lint stays
+    // unfiltered. Release jobs never consult the output.
     const changes = jobSource('changes');
     expect(changes).toContain('id: filter');
     expect(changes).toContain('outputs:');
     expect(changes).toContain('code: ${{ steps.filter.outputs.code }}');
-    expect(changes).toContain('fetch-depth: 0');
-    expect(changes).toContain('EVENT_NAME');
-    expect(changes).toContain('BASE_SHA');
-    expect(changes).toContain('HEAD_SHA');
+    expect(changes).toContain('run: node scripts/detect_code_changes.mjs');
+    // The only checkout is blob-less, shallow, and sparse: the ~10 minute
+    // full-history checkout (which also wedged for 90+ minutes twice) must not
+    // return, and nothing in this job may need the tree beyond scripts/.
+    expect(changes).not.toContain('fetch-depth');
+    expect(changes).toContain('filter: blob:none');
+    expect(changes).toMatch(/sparse-checkout: \|\n {12}scripts\n/);
+    // No toolchain setup or dependency install on this serial critical path:
+    // the classifier is stdlib-only and runs on the runner's preinstalled Node.
+    expect(changes).not.toContain('pnpm install');
+    expect(changes).not.toContain('actions/setup-node');
+    // A wedged runner fails fast (single-digit timeout) and gets retried,
+    // instead of stalling every downstream shard for 90+ minutes.
+    expect(changes).toMatch(/\n {4}timeout-minutes: [1-9]\n/);
+    // The API call authenticates with the workflow token via env (never
+    // secrets.* and never string-interpolated into the run line).
+    expect(changes).toContain('GITHUB_TOKEN: ${{ github.token }}');
     // changes must always run (no job-level if). Gating it to pull_request only
     // would leave needs.changes dependents skipped on push to main/dev.
     expect(changes.match(/^\s{4}if: .+$/gm) ?? []).toEqual([]);
-    // Non-PR events and empty/missing diffs fail closed toward code=true.
-    expect(changes).toContain('non-PR event: full PR tier (code=true)');
-    expect(changes).toContain('missing PR base/head SHAs: full PR tier (code=true)');
-    expect(changes).toContain('empty file list: full PR tier (code=true)');
-    expect(changes).toContain('echo "code=$code" >> "$GITHUB_OUTPUT"');
-    expect(changes).toContain('code=false');
-    expect(changes).toContain('code=true');
-    for (const glob of CODE_PATH_GLOBS) {
-      expect(changes).toContain(glob);
+    // The entry stays wired to the tested lib and writes the step output; the
+    // fail-closed reason strings themselves are pinned behaviorally in
+    // tests/ci_change_classify.test.ts.
+    expect(detectEntry).toContain("from './lib/ci_change_classify.mjs'");
+    expect(detectEntry).toContain('detectCode');
+    expect(detectEntry).toContain('GITHUB_OUTPUT');
+    expect(detectEntry).toContain('code=${code}');
+    for (const [, sample] of CODE_PATH_SAMPLES) {
+      expect(isCodePath(sample)).toBe(true);
+    }
+    for (const sample of NON_CODE_SAMPLES) {
+      expect(isCodePath(sample)).toBe(false);
     }
     // No third-party path-filter action (D10: justify dorny in progress.md if added).
     expect(workflow).not.toContain('dorny/paths-filter');
@@ -558,9 +596,16 @@ describe('CI workflow parity', () => {
     // entry would let `packages: write` be appended underneath it.
     expect(workflow).toMatch(/\npermissions:\n {2}contents: read\n\n/);
     // Unanchored on purpose: the read-only grant is workflow-level, and a JOB
-    // may re-declare `permissions:` at its own indent to widen it. Matching
-    // only at column 0 would miss exactly that escalation.
-    expect(workflow.match(/^\s*permissions:/gm)).toHaveLength(1);
+    // may re-declare `permissions:` at its own indent to widen it. Exactly two
+    // blocks are sanctioned: the workflow-level read-only default and the
+    // changes job's read-only widen (pull-requests: read, which the PR files
+    // endpoint needs once workflow permissions are declared). Any third block
+    // is an escalation; so is any write scope anywhere in the file.
+    expect(workflow.match(/^\s*permissions:/gm)).toHaveLength(2);
+    expect(jobSource('changes')).toMatch(
+      /\n {4}permissions:\n {6}contents: read\n {6}pull-requests: read\n/,
+    );
+    expect(workflow).not.toMatch(/^\s*[\w-]+: write\s*$/m);
     expect(workflow).not.toContain('secrets.');
     expect(workflow).not.toContain("secrets['");
     expect(workflow).not.toContain('secrets["');


### PR DESCRIPTION
## Summary

"Detect code path changes" (the `changes` job in ci.yml) gates every PR-tier job, and it paid a full-history checkout of a binary-heavy repo (about 10 serial minutes on a healthy runner) just to run `git diff` for a docs-only classification. On 2026-08-05 it also wedged on that checkout twice for 90+ minutes, with no timeout to kill it.

The job now asks the GitHub API instead (the pull request files endpoint, paginated) and needs no git history at all: its only checkout is a blob-less sparse checkout of `scripts/`, and the classification runs as `node scripts/detect_code_changes.mjs` on the runner's preinstalled Node, with `timeout-minutes: 5` so a wedged runner fails fast and can be retried. The `code` output contract and its consumers (pr-gate, pr-checks, browser-gate) are unchanged.

The rules and the decision are a tested module now (`scripts/lib/ci_change_classify.mjs`), fail closed end to end: any API error, timeout, truncated or mismatched listing, or unclassifiable entry yields `code=true` (run the full tier). A slow green is acceptable; a fast false-green is not.

Deliberate behavior tightenings that came out of the security and coverage reviews, all in the fail-closed direction:

- The code path set gains root build and supply-chain inputs the old inline set skipped: the entry HTML documents (`index.html` alone carries inline scripts and third-party tags), `svelte.config.js`, `capacitor.config.ts`, `tsconfig.bot.json`, `turbo.json`, `.npmrc`, `.browserslistrc`, `.dockerignore`, `data/`, and `python/` (the RL bindings are malware-scanner-relevant and nothing else checks them). Previously a PR touching only these skipped the malware gate and every build.
- Renames are classified by both ends: the old diff printed only the destination under default rename detection, so a rename out of `src/` used to read as docs-only.
- A listing that reaches the endpoint's 3000-file ceiling is treated as unprovable on its own, and the whole listing shares one 30 second deadline so a slow API fails closed inside the job timeout.
- Filenames and error details are JSON-escaped before they reach the job log (git permits newlines in paths, and Actions parses line-leading `::` workflow commands), and a docs-only skip logs the listed and reported counts so it can be audited at a glance.

The job's token is widened job-scoped and read-only (`pull-requests: read`, which the files endpoint needs once workflow permissions are declared); `tests/ci_workflow.test.ts` pins exactly two permissions blocks in the file, both read-only, and bans any write scope including `write-all`.

## Type of change

- [x] Build, CI, or tooling
- [x] Tests
- [x] Refactor or performance (no behavior change)

## How was this tested?

- Commands:
  - `npx vitest run tests/ci_change_classify.test.ts tests/ci_workflow.test.ts` (39 tests: behavioral pins for every classification rule including the widened set, forced API failure, pagination, the cap boundary, changed_files mismatch, plus three subprocess end-to-end runs of the entry against a local HTTP stub asserting the actual `GITHUB_OUTPUT` writes)
  - `node scripts/gate_select.mjs` green (full selective gate: suites, browser regressions, typecheck, all builds)
  - `npx tsc --noEmit`, changed-files Biome clean
- Manual steps: smoke-ran `scripts/detect_code_changes.mjs` locally for the non-PR and missing-context paths (both write `code=true`).
- Reviewed by qa-checklist, privacy-security-review, and test-coverage-auditor agents (the coverage pass mutation-tested the pins); all findings applied, including two mutation-proven fail-open holes in the original test coverage.
- To verify on this PR's own run: the "Detect code path changes" wall clock (acceptance: under one minute; baseline was about 10 minutes).

---

## Checklist

### Quality

- [x] **The gate passes.** `node scripts/gate_select.mjs` is green. I added or updated decisive tests for changed behavior and recorded any manual checks above.

### Cross-platform

- ~Tested on desktop and mobile.~ N/A: CI-only change, no UI.
- ~Accessible.~ N/A.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings (CI job-log text is dev-channel English by rule).

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files.
