### PR TITLE
feat(ci): nightly full gate with same-day issue alerting

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,250 @@
+name: Nightly gate
+
+# Scheduled full run over the tips of the default branch and the active
+# release/** branch, with same-day alerting. Motivated by the 2026-08-05
+# incident: a release tip carried 67 broken tests for days because the push
+# runs that showed it were red with nobody watching, so every open PR
+# inherited failures its author could not explain. This workflow re-proves the
+# tips nightly and routes a red verdict to a single tracking issue (created on
+# first failure, updated on repeat failures, closed with a comment on
+# recovery) via scripts/nightly_report.mjs.
+#
+# Kept OUT of ci.yml for the same reason audit.yml is: adding `schedule` there
+# would newly fire its PR-shaped jobs on every cron tick. This file is also
+# deliberately NOT triggered by pull_request or push: it must never add a
+# second of latency to PR feedback.
+#
+# What runs per ref: the full unsharded test suite (the same one the local
+# gate runs, at PR tier), the serialized checks (i18n artifacts + freshness,
+# malware gate, typecheck, all four builds), and the Chromium browser
+# regressions. The release-i18n 21-locale lane is deliberately absent: it is
+# legitimately red for most of a cycle until the release-time locale fill
+# (issue #2820), so alerting on it nightly would keep the tracking issue
+# permanently open and train everyone to ignore it. The release push run in
+# ci.yml still carries that lane.
+#
+# The schedule fires on the default branch, so the cron arms only once this
+# file reaches main; until then (and for the acceptance drill against a
+# scratch branch with a deliberately broken test) use workflow_dispatch with
+# the ref input, which gates exactly that one ref.
+on:
+  schedule:
+    # Daily, 04:47 UTC. Off the hour so this does not pile into the
+    # top-of-hour spike in GitHub's shared cron scheduler.
+    - cron: '47 4 * * *'
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Gate exactly this ref instead of main plus the active release branch'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+# A dispatch must never cancel a running scheduled pass (or vice versa): the
+# event name and ref keep the groups apart, and nothing here cancels.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ inputs.ref || github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  # Resolve which refs to gate: the default branch plus the highest
+  # release/vX.Y.Z, or the dispatch ref alone. On an API failure the script
+  # falls back to the default branch loudly rather than silencing the night's
+  # run; the failure still surfaces through the report job if the job itself
+  # dies.
+  targets:
+    name: Resolve nightly refs
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      refs: ${{ steps.resolve.outputs.refs }}
+    steps:
+      - name: Check out resolver script
+        uses: actions/checkout@v6
+        with:
+          # Blob-less shallow sparse checkout: this job needs only the
+          # scripts, never the tree or the history.
+          filter: blob:none
+          sparse-checkout: |
+            scripts
+
+      - name: Resolve refs
+        id: resolve
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          NIGHTLY_REF: ${{ inputs.ref }}
+        # Stdlib-only script on the runner's preinstalled Node: no toolchain
+        # setup for a single API call.
+        run: node scripts/nightly_targets.mjs
+
+  # The full test suite, unsharded, exactly like the local `npm run gate`
+  # vitest step (bounded workers, PR tier): wall clock does not matter at
+  # 04:47, and one job per ref keeps the tracking issue's failed-job list
+  # legible. `npm test` regenerates the i18n artifacts itself (pretest), which
+  # the S3 guard and guide freshness suites need.
+  tests:
+    name: Nightly tests (${{ matrix.ref }})
+    needs: targets
+    runs-on: ubuntu-latest
+    timeout-minutes: 300
+    strategy:
+      fail-fast: false
+      matrix:
+        ref: ${{ fromJSON(needs.targets.outputs.refs) }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ matrix.ref }}
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.34.5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 26
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run tests (full suite, PR tier)
+        run: npm test -- --maxWorkers="$(node -p 'Math.max(1, Math.floor(require("node:os").availableParallelism() / 2))')"
+
+  # The serialized checks, mirroring the release-checks job in ci.yml (same
+  # step list, no tsc incremental cache: nightly wall clock is not worth a
+  # cache keyed to a moving tip).
+  checks:
+    name: Nightly checks (${{ matrix.ref }})
+    needs: targets
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        ref: ${{ fromJSON(needs.targets.outputs.refs) }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ matrix.ref }}
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.34.5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 26
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate i18n artifacts
+        run: npm run i18n:gen
+
+      - name: Verify committed i18n artifacts are fresh
+        run: git diff --exit-code -- src/ui/i18n.resolved.generated src/admin/i18n.resolved.generated src/ui/i18n.catalog/translation_keys.generated.ts
+
+      - name: Malicious-code gate
+        run: npm run security:gate
+
+      - name: Typecheck
+        run: npm run check:types
+
+      - name: Build headless environment
+        run: npm run build:env
+
+      - name: Build server
+        run: npm run build:server
+
+      - name: Build Discord bot
+        run: npm run build:bot
+
+      - name: Build client
+        run: npm run build
+
+  # The Chromium browser regressions, mirroring the browser-gate job in ci.yml.
+  browser:
+    name: Nightly browser (${{ matrix.ref }})
+    needs: targets
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        ref: ${{ fromJSON(needs.targets.outputs.refs) }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ matrix.ref }}
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.34.5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 26
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Resolve Playwright version for cache key
+        id: playwright-version
+        run: echo "version=$(node -p "require('playwright/package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright Chromium browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-chromium-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+          restore-keys: |
+            playwright-chromium-${{ runner.os }}-
+
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Run browser regressions
+        run: npm run test:browser
+
+  # The alerting deliverable: runs on every outcome (if: always()), judges the
+  # completed jobs above through scripts/lib/nightly_plan.mjs, and upserts the
+  # single nightly-gate tracking issue. A targets failure counts as red here
+  # too, so a night whose refs could not even be resolved still pages.
+  report:
+    name: Report nightly verdict
+    needs: [targets, tests, checks, browser]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # The one write scope in this workflow, job-scoped: the report job files,
+    # updates, and closes the tracking issue. Never widen the workflow level.
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Check out report script
+        uses: actions/checkout@v6
+        with:
+          filter: blob:none
+          sparse-checkout: |
+            scripts
+
+      - name: File, update, or close the tracking issue
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          NIGHTLY_TARGETS: ${{ needs.targets.outputs.refs }}
+        run: node scripts/nightly_report.mjs

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -26,7 +26,9 @@ name: Nightly gate
 # The schedule fires on the default branch, so the cron arms only once this
 # file reaches main; until then (and for the acceptance drill against a
 # scratch branch with a deliberately broken test) use workflow_dispatch with
-# the ref input, which gates exactly that one ref.
+# the ref input, which gates exactly that one ref. A dispatch run reports
+# under the separate nightly-gate-drill issue identity, so drills never touch
+# the production tracking issue.
 on:
   schedule:
     # Daily, 04:47 UTC. Off the hour so this does not pile into the
@@ -43,7 +45,12 @@ permissions:
   contents: read
 
 # A dispatch must never cancel a running scheduled pass (or vice versa): the
-# event name and ref keep the groups apart, and nothing here cancels.
+# event name and ref keep the groups apart, and nothing here cancels. The
+# flip side (a dispatch report racing the scheduled report on the SAME issue
+# identity) is accepted rather than serialized with a job-level concurrency
+# group, because a queued-then-superseded report job would be cancelled
+# outright, losing that run's alert; the planner's oldest-wins update rule
+# bounds the damage to a duplicate issue that drains on green runs.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ inputs.ref || github.ref }}
   cancel-in-progress: false
@@ -69,12 +76,14 @@ jobs:
           filter: blob:none
           sparse-checkout: |
             scripts
+          persist-credentials: false
 
       - name: Resolve refs
         id: resolve
         env:
           GITHUB_TOKEN: ${{ github.token }}
           NIGHTLY_REF: ${{ inputs.ref }}
+          NIGHTLY_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         # Stdlib-only script on the runner's preinstalled Node: no toolchain
         # setup for a single API call.
         run: node scripts/nightly_targets.mjs
@@ -98,6 +107,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ matrix.ref }}
+          persist-credentials: false
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
@@ -117,8 +127,9 @@ jobs:
         run: npm test -- --maxWorkers="$(node -p 'Math.max(1, Math.floor(require("node:os").availableParallelism() / 2))')"
 
   # The serialized checks, mirroring the release-checks job in ci.yml (same
-  # step list, no tsc incremental cache: nightly wall clock is not worth a
-  # cache keyed to a moving tip).
+  # run-step list, pinned to it by tests/nightly_workflow.test.ts; the one
+  # omission is the tsc incremental cache step, which is a uses: cache keyed
+  # to a moving tip and not worth carrying here).
   checks:
     name: Nightly checks (${{ matrix.ref }})
     needs: targets
@@ -133,6 +144,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ matrix.ref }}
+          persist-credentials: false
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
@@ -150,6 +162,9 @@ jobs:
 
       - name: Generate i18n artifacts
         run: npm run i18n:gen
+
+      - name: Post i18n coverage summary
+        run: node scripts/i18n_coverage_summary.mjs
 
       - name: Verify committed i18n artifacts are fresh
         run: git diff --exit-code -- src/ui/i18n.resolved.generated src/admin/i18n.resolved.generated src/ui/i18n.catalog/translation_keys.generated.ts
@@ -187,6 +202,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ matrix.ref }}
+          persist-credentials: false
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
@@ -239,12 +255,16 @@ jobs:
       - name: Check out report script
         uses: actions/checkout@v6
         with:
+          # No ref input here EVER: the write-scoped job runs only the
+          # workflow's own script, never code from a resolved ref.
           filter: blob:none
           sparse-checkout: |
             scripts
+          persist-credentials: false
 
       - name: File, update, or close the tracking issue
         env:
           GITHUB_TOKEN: ${{ github.token }}
           NIGHTLY_TARGETS: ${{ needs.targets.outputs.refs }}
+          NIGHTLY_REF: ${{ inputs.ref }}
         run: node scripts/nightly_report.mjs

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,11 +24,14 @@ name: Nightly gate
 # ci.yml still carries that lane.
 #
 # The schedule fires on the default branch, so the cron arms only once this
-# file reaches main; until then (and for the acceptance drill against a
-# scratch branch with a deliberately broken test) use workflow_dispatch with
-# the ref input, which gates exactly that one ref. A dispatch run reports
-# under the separate nightly-gate-drill issue identity, so drills never touch
-# the production tracking issue.
+# file reaches main. workflow_dispatch has two modes: with the ref input
+# EMPTY it is a manual production pass (gates main plus the release tip and
+# reports under the production issue identity); with a ref it gates exactly
+# that one ref and reports under the separate nightly-gate-drill identity, so
+# an acceptance drill against a scratch branch with a deliberately broken
+# test never touches the production tracking issue. A red drill's issue has
+# nothing scheduled to drain it: close it by hand, or finish the drill with a
+# green dispatch at the same ref.
 on:
   schedule:
     # Daily, 04:47 UTC. Off the hour so this does not pile into the

--- a/docs/qa-gate.md
+++ b/docs/qa-gate.md
@@ -13,6 +13,7 @@ Codex have different entry points and share the same deterministic scripts and c
 | Day-loop fast path | `npm run gate:fast` through `scripts/gate_fast.mjs` | While iterating (agents and mid/low-tier machines) | No (local only; not merge) |
 | **Selective gate** | `node scripts/gate_select.mjs` | **Before implementation is called ready / pre-merge** | **Yes (the merge bar)** |
 | Full local gate | `npm run gate` through `scripts/gate.mjs` | When you want the whole suite locally, or the planner falls back | Yes (deeper check) |
+| Nightly full gate | `.github/workflows/nightly.yml`: full suite + checks + browser over the tips of main and the active `release/**` branch | Scheduled nightly (04:47 UTC) | No (alerting: files and closes one tracking issue) |
 | Judgment review | Claude `/qa` or Codex `$woc-qa`, plus scoped reviewers | End of a contribution | Advisory locally |
 
 ### Instant copy gate
@@ -165,9 +166,10 @@ surface where an escape could hide, and it is what to actually study.
 **What it still cannot prove, and why that is acceptable.** The out-of-graph pattern list is
 a floor, not a proof, so this path is empirically complete rather than provably complete.
 The backstop is CI: `.github/workflows/ci.yml` runs the FULL suite (8-shard matrix) on every
-`pull_request` AND on every push to `main` / `release/**`. A local selection miss therefore
-costs feedback latency, not correctness, because the full suite still runs on the PR before
-it merges. That is what makes this safe as the local bar.
+`pull_request` AND on every push to `main` / `release/**`, and the scheduled nightly full
+gate (next section) re-proves the tips daily with same-day alerting. A local selection miss
+therefore costs feedback latency, not correctness, because the full suite still runs on the
+PR before it merges. That is what makes this safe as the local bar.
 
 **Evidence it works.** Fault injection, 5/5 caught: a `Math.random()` in `src/sim`, a combat
 constant, a content record, a sim-emitted player string, and a deleted weapon `.glb`. In two
@@ -185,6 +187,29 @@ the toolchain-relevant part its own comment cites as the reason for the pin.
 
 Pure planning logic: `scripts/lib/gate_discovery.mjs`, `scripts/lib/gate_select_plan.mjs`
 and `scripts/lib/test_visibility.mjs`, all pinned by `tests/gate_select_plan.test.ts`.
+
+### Nightly full gate (scheduled backstop)
+
+`.github/workflows/nightly.yml` re-proves the tips of `main` and the highest
+`release/vX.Y.Z` branch every night: the full unsharded test suite, the serialized
+checks lane (mirroring ci.yml's release-checks run steps), and the Chromium browser
+lane, per ref. It exists because a red release tip once sat unwatched for days while
+every open PR inherited its failures; push runs show rot, but only to someone looking.
+
+The verdict lands in exactly one tracking issue (label `nightly-gate`, title "Nightly
+full gate is red"): created on the first red run, updated with the failed-job list on
+repeat failures, closed with a recovery comment on the first green run. A run that
+reports no failures but did not actually complete its lanes counts as red ("unproven"),
+never as recovery. A `workflow_dispatch` with the `ref` input gates exactly that ref and
+reports under the separate `nightly-gate-drill` identity, so acceptance drills never
+touch the production issue.
+
+Deliberate exclusions: the release-i18n 21-locale lane (expected red mid-cycle, issue
+#2820) and the release version gate (cannot rot without a push, which ci.yml covers).
+The cron arms only once the workflow file reaches `main` (GitHub reads schedules from
+the default branch); until then, dispatch it manually on the branch that carries it.
+Planning logic: `scripts/lib/nightly_plan.mjs`, pinned by `tests/nightly_plan.test.ts`;
+the workflow shape is pinned by `tests/nightly_workflow.test.ts`.
 
 ### Judgment review
 

--- a/docs/qa-gate.md
+++ b/docs/qa-gate.md
@@ -191,7 +191,7 @@ and `scripts/lib/test_visibility.mjs`, all pinned by `tests/gate_select_plan.tes
 ### Nightly full gate (scheduled backstop)
 
 `.github/workflows/nightly.yml` re-proves the tips of `main` and the highest
-`release/vX.Y.Z` branch every night: the full unsharded test suite, the serialized
+`release/vX.Y.Z` branch (the `v` is optional) every night: the full unsharded test suite, the serialized
 checks lane (mirroring ci.yml's release-checks run steps), and the Chromium browser
 lane, per ref. It exists because a red release tip once sat unwatched for days while
 every open PR inherited its failures; push runs show rot, but only to someone looking.
@@ -202,7 +202,8 @@ repeat failures, closed with a recovery comment on the first green run. A run th
 reports no failures but did not actually complete its lanes counts as red ("unproven"),
 never as recovery. A `workflow_dispatch` with the `ref` input gates exactly that ref and
 reports under the separate `nightly-gate-drill` identity, so acceptance drills never
-touch the production issue.
+touch the production issue; nothing scheduled drains a red drill's issue, so close it
+by hand or finish the drill with a green dispatch at the same ref.
 
 Deliberate exclusions: the release-i18n 21-locale lane (expected red mid-cycle, issue
 #2820) and the release version gate (cannot rot without a push, which ci.yml covers).

--- a/scripts/lib/nightly_plan.d.mts
+++ b/scripts/lib/nightly_plan.d.mts
@@ -1,0 +1,54 @@
+export const NIGHTLY_ISSUE_LABEL: string;
+export const NIGHTLY_ISSUE_TITLE: string;
+
+export interface NightlyJobResult {
+  name: string;
+  conclusion: string;
+  html_url: string;
+}
+
+export function pickActiveReleaseBranch(names: readonly string[]): string | null;
+
+export function buildTargets(opts: {
+  inputRef?: string | null;
+  releaseBranch?: string | null;
+  defaultBranch?: string;
+}): string[];
+
+export function summarizeRunJobs(
+  jobs: ReadonlyArray<{
+    name?: string;
+    status?: string;
+    conclusion?: string | null;
+    html_url?: string;
+  }>,
+): { completed: NightlyJobResult[]; failed: NightlyJobResult[] };
+
+export function renderIssueBody(opts: {
+  runUrl: string;
+  targets: readonly string[];
+  timestamp: string;
+  failed: readonly NightlyJobResult[];
+}): string;
+
+export function renderFailureComment(opts: {
+  runUrl: string;
+  timestamp: string;
+  failed: readonly NightlyJobResult[];
+}): string;
+
+export function renderRecoveryComment(opts: { runUrl: string; timestamp: string }): string;
+
+export type NightlyReportPlan =
+  | { action: 'create'; title: string; body: string; labels: string[] }
+  | { action: 'update'; issueNumber: number; body: string; comment: string }
+  | { action: 'close'; issueNumber: number; comment: string }
+  | { action: 'none'; reason: string };
+
+export function planNightlyReport(opts: {
+  failed: readonly NightlyJobResult[];
+  openIssues: ReadonlyArray<{ number?: number; state?: string; pull_request?: unknown }>;
+  runUrl: string;
+  targets: readonly string[];
+  timestamp: string;
+}): NightlyReportPlan;

--- a/scripts/lib/nightly_plan.d.mts
+++ b/scripts/lib/nightly_plan.d.mts
@@ -1,11 +1,22 @@
 export const NIGHTLY_ISSUE_LABEL: string;
 export const NIGHTLY_ISSUE_TITLE: string;
+export const NIGHTLY_DRILL_ISSUE_LABEL: string;
+export const NIGHTLY_DRILL_ISSUE_TITLE: string;
+export const NIGHTLY_LANES_PER_REF: number;
 
 export interface NightlyJobResult {
   name: string;
   conclusion: string;
   html_url: string;
 }
+
+export function trackingIssueIdentity(drill: boolean): { label: string; title: string };
+
+export function refNamesFromMatchingRefs(entries: ReadonlyArray<{ ref?: unknown }>): string[];
+
+export function parseTargetsEnv(raw: string | undefined): string[];
+
+export function labelEnsureFailed(ok: boolean, status: number): boolean;
 
 export function pickActiveReleaseBranch(names: readonly string[]): string | null;
 
@@ -47,8 +58,15 @@ export type NightlyReportPlan =
 
 export function planNightlyReport(opts: {
   failed: readonly NightlyJobResult[];
-  openIssues: ReadonlyArray<{ number?: number; state?: string; pull_request?: unknown }>;
+  completed: readonly NightlyJobResult[];
+  openIssues: ReadonlyArray<{
+    number?: number;
+    state?: string;
+    title?: string;
+    pull_request?: unknown;
+  }>;
   runUrl: string;
   targets: readonly string[];
   timestamp: string;
+  drill?: boolean;
 }): NightlyReportPlan;

--- a/scripts/lib/nightly_plan.mjs
+++ b/scripts/lib/nightly_plan.mjs
@@ -1,0 +1,196 @@
+// Pure planning logic for the nightly full-gate workflow
+// (.github/workflows/nightly.yml): which refs to gate, which run jobs count as
+// failures, and what to do to the single tracking issue. Kept free of fetch/fs
+// so Vitest can pin every branch; the two thin entries
+// (scripts/nightly_targets.mjs and scripts/nightly_report.mjs) do the HTTP.
+//
+// The alerting contract, from the incident that motivated the workflow (a
+// release tip carried 67 broken tests for days because push runs were red with
+// nobody watching): a red nightly run must land in exactly ONE open tracking
+// issue (create it if absent, update it if present, never stack a second), and
+// a green run must close that issue with a recovery comment. The label below
+// is the finder, so renaming it strands any issue created under the old name.
+
+export const NIGHTLY_ISSUE_LABEL = 'nightly-gate';
+export const NIGHTLY_ISSUE_TITLE = 'Nightly full gate is red';
+
+/**
+ * Pick the active release branch from a list of branch names: the highest
+ * `release/vX.Y.Z` (or `release/X.Y.Z`) by semver. Names that do not parse are
+ * ignored rather than string-compared, so a stray `release/next` can never
+ * outrank a real version. Returns null when nothing parses.
+ *
+ * @param {readonly string[]} names
+ * @returns {string | null}
+ */
+export function pickActiveReleaseBranch(names) {
+  let best = null;
+  let bestKey = null;
+  for (const name of names) {
+    const match = /^release\/v?(\d+)\.(\d+)\.(\d+)$/.exec(name);
+    if (!match) continue;
+    const key = [Number(match[1]), Number(match[2]), Number(match[3])];
+    if (
+      bestKey === null ||
+      key[0] > bestKey[0] ||
+      (key[0] === bestKey[0] && key[1] > bestKey[1]) ||
+      (key[0] === bestKey[0] && key[1] === bestKey[1] && key[2] > bestKey[2])
+    ) {
+      best = name;
+      bestKey = key;
+    }
+  }
+  return best;
+}
+
+/**
+ * The refs the nightly run gates. A manual dispatch ref replaces the whole
+ * list (that is the acceptance path: point the workflow at a scratch branch);
+ * otherwise the default branch plus the active release branch, deduplicated.
+ *
+ * @param {{ inputRef?: string | null, releaseBranch?: string | null, defaultBranch?: string }} opts
+ * @returns {string[]}
+ */
+export function buildTargets({ inputRef, releaseBranch, defaultBranch = 'main' }) {
+  const dispatch = typeof inputRef === 'string' ? inputRef.trim() : '';
+  if (dispatch !== '') return [dispatch];
+  const targets = [defaultBranch];
+  if (releaseBranch && releaseBranch !== defaultBranch) targets.push(releaseBranch);
+  return targets;
+}
+
+/**
+ * Split a workflow run's job listing into completed jobs and failures. Only
+ * completed jobs are judged (the report job itself is still in progress when
+ * it asks); among those, anything that is not success, skipped, or neutral
+ * counts as a failure: cancelled, timed_out, action_required, and stale all
+ * mean "the nightly did not prove the tip green", which is the fail-closed
+ * direction for an alerting job.
+ *
+ * @param {ReadonlyArray<{ name?: string, status?: string, conclusion?: string | null, html_url?: string }>} jobs
+ * @returns {{
+ *   completed: Array<{ name: string, conclusion: string, html_url: string }>,
+ *   failed: Array<{ name: string, conclusion: string, html_url: string }>,
+ * }}
+ */
+export function summarizeRunJobs(jobs) {
+  const completed = [];
+  const failed = [];
+  for (const job of jobs) {
+    if (job?.status !== 'completed') continue;
+    const entry = {
+      name: typeof job.name === 'string' ? job.name : '(unnamed job)',
+      conclusion: typeof job.conclusion === 'string' ? job.conclusion : 'unknown',
+      html_url: typeof job.html_url === 'string' ? job.html_url : '',
+    };
+    completed.push(entry);
+    if (
+      entry.conclusion !== 'success' &&
+      entry.conclusion !== 'skipped' &&
+      entry.conclusion !== 'neutral'
+    ) {
+      failed.push(entry);
+    }
+  }
+  return { completed, failed };
+}
+
+/**
+ * @param {{ runUrl: string, targets: readonly string[], timestamp: string,
+ *   failed: ReadonlyArray<{ name: string, conclusion: string, html_url: string }> }} opts
+ * @returns {string}
+ */
+export function renderIssueBody({ runUrl, targets, timestamp, failed }) {
+  const lines = [
+    'The scheduled full gate found the tip red. This issue is managed by the',
+    'nightly workflow: it is updated on repeat failures and closed automatically',
+    'on the first green run, so keep it open until the tip is actually repaired.',
+    '',
+    `Latest red run: ${runUrl} (${timestamp})`,
+    `Refs gated: ${targets.length > 0 ? targets.join(', ') : 'unknown (ref resolution failed)'}`,
+    '',
+    'Failed jobs:',
+    ...failed.map(
+      (job) => `- ${job.name}: ${job.conclusion}${job.html_url ? ` (${job.html_url})` : ''}`,
+    ),
+  ];
+  return lines.join('\n');
+}
+
+/**
+ * @param {{ runUrl: string, timestamp: string,
+ *   failed: ReadonlyArray<{ name: string, conclusion: string, html_url: string }> }} opts
+ * @returns {string}
+ */
+export function renderFailureComment({ runUrl, timestamp, failed }) {
+  const lines = [
+    `Still red: ${runUrl} (${timestamp})`,
+    '',
+    ...failed.map(
+      (job) => `- ${job.name}: ${job.conclusion}${job.html_url ? ` (${job.html_url})` : ''}`,
+    ),
+  ];
+  return lines.join('\n');
+}
+
+/**
+ * @param {{ runUrl: string, timestamp: string }} opts
+ * @returns {string}
+ */
+export function renderRecoveryComment({ runUrl, timestamp }) {
+  return `Recovered: the nightly full gate is green again. ${runUrl} (${timestamp})`;
+}
+
+/**
+ * Decide what to do to the tracking issue. `openIssues` may be the raw issues
+ * listing: pull requests (which the issues API also returns) and anything not
+ * open are filtered here, and when several tracking issues exist (which the
+ * create rule makes impossible short of a manual duplicate) the OLDEST is
+ * updated and none are created, preserving the exactly-one contract.
+ *
+ * @param {{
+ *   failed: ReadonlyArray<{ name: string, conclusion: string, html_url: string }>,
+ *   openIssues: ReadonlyArray<{ number?: number, state?: string, pull_request?: unknown }>,
+ *   runUrl: string,
+ *   targets: readonly string[],
+ *   timestamp: string,
+ * }} opts
+ * @returns {{ action: 'create', title: string, body: string, labels: string[] }
+ *   | { action: 'update', issueNumber: number, body: string, comment: string }
+ *   | { action: 'close', issueNumber: number, comment: string }
+ *   | { action: 'none', reason: string }}
+ */
+export function planNightlyReport({ failed, openIssues, runUrl, targets, timestamp }) {
+  const tracking = openIssues
+    .filter((issue) => issue && issue.state === 'open' && issue.pull_request === undefined)
+    .filter((issue) => Number.isInteger(issue.number))
+    .sort((a, b) => a.number - b.number);
+  const existing = tracking[0];
+
+  if (failed.length > 0) {
+    const body = renderIssueBody({ runUrl, targets, timestamp, failed });
+    if (existing === undefined) {
+      return {
+        action: 'create',
+        title: NIGHTLY_ISSUE_TITLE,
+        body,
+        labels: [NIGHTLY_ISSUE_LABEL],
+      };
+    }
+    return {
+      action: 'update',
+      issueNumber: existing.number,
+      body,
+      comment: renderFailureComment({ runUrl, timestamp, failed }),
+    };
+  }
+
+  if (existing !== undefined) {
+    return {
+      action: 'close',
+      issueNumber: existing.number,
+      comment: renderRecoveryComment({ runUrl, timestamp }),
+    };
+  }
+  return { action: 'none', reason: 'green run and no open tracking issue' };
+}

--- a/scripts/lib/nightly_plan.mjs
+++ b/scripts/lib/nightly_plan.mjs
@@ -8,11 +8,89 @@
 // release tip carried 67 broken tests for days because push runs were red with
 // nobody watching): a red nightly run must land in exactly ONE open tracking
 // issue (create it if absent, update it if present, never stack a second), and
-// a green run must close that issue with a recovery comment. The label below
-// is the finder, so renaming it strands any issue created under the old name.
+// a green run must close that issue with a recovery comment. The finder is the
+// label AND the exact title together, so a human applying the label to an
+// unrelated issue can never get that issue's body overwritten or auto-closed.
+// Renaming either constant strands any issue created under the old identity.
+//
+// A dispatch drill (the ref input) files under a SEPARATE identity, so the
+// acceptance drill against a scratch branch never touches the production
+// tracking issue.
 
 export const NIGHTLY_ISSUE_LABEL = 'nightly-gate';
 export const NIGHTLY_ISSUE_TITLE = 'Nightly full gate is red';
+export const NIGHTLY_DRILL_ISSUE_LABEL = 'nightly-gate-drill';
+export const NIGHTLY_DRILL_ISSUE_TITLE = 'Nightly full gate drill is red';
+
+// The per-ref lanes the workflow fans out (tests, checks, browser). The
+// proven-green guard below counts successes against this, so removing a lane
+// from the workflow without updating this constant turns the nightly
+// permanently "unproven" (loudly red), never silently green.
+export const NIGHTLY_LANES_PER_REF = 3;
+
+/**
+ * The issue identity a run reports under: the production pair, or the drill
+ * pair when the run was dispatched at an explicit ref.
+ *
+ * @param {boolean} drill
+ * @returns {{ label: string, title: string }}
+ */
+export function trackingIssueIdentity(drill) {
+  return drill
+    ? { label: NIGHTLY_DRILL_ISSUE_LABEL, title: NIGHTLY_DRILL_ISSUE_TITLE }
+    : { label: NIGHTLY_ISSUE_LABEL, title: NIGHTLY_ISSUE_TITLE };
+}
+
+/**
+ * Branch names from a git matching-refs API batch. Entries that are not
+ * `refs/heads/...` strings are dropped. If this strip ever broke, every name
+ * would fail pickActiveReleaseBranch's anchor and the nightly would quietly
+ * gate main alone, which is why it lives here under test instead of inline in
+ * the entry.
+ *
+ * @param {ReadonlyArray<{ ref?: unknown }>} entries
+ * @returns {string[]}
+ */
+export function refNamesFromMatchingRefs(entries) {
+  /** @type {string[]} */
+  const names = [];
+  for (const entry of entries) {
+    if (typeof entry?.ref === 'string' && entry.ref.startsWith('refs/heads/')) {
+      names.push(entry.ref.slice('refs/heads/'.length));
+    }
+  }
+  return names;
+}
+
+/**
+ * Parse the NIGHTLY_TARGETS env value (the targets job's `refs` output).
+ * Anything that is not a JSON array collapses to [], which the report plan
+ * treats as "targets unknown" (fail closed toward an unproven verdict).
+ *
+ * @param {string | undefined} raw
+ * @returns {string[]}
+ */
+export function parseTargetsEnv(raw) {
+  try {
+    const parsed = JSON.parse(raw ?? '');
+    if (Array.isArray(parsed)) return parsed.filter((ref) => typeof ref === 'string');
+  } catch {
+    // Fall through to the unknown-targets shape.
+  }
+  return [];
+}
+
+/**
+ * Whether an ensure-label response is a real failure. 422 means the label
+ * already exists, which is the expected steady state.
+ *
+ * @param {boolean} ok
+ * @param {number} status
+ * @returns {boolean}
+ */
+export function labelEnsureFailed(ok, status) {
+  return !ok && status !== 422;
+}
 
 /**
  * Pick the active release branch from a list of branch names: the highest
@@ -63,9 +141,9 @@ export function buildTargets({ inputRef, releaseBranch, defaultBranch = 'main' }
  * Split a workflow run's job listing into completed jobs and failures. Only
  * completed jobs are judged (the report job itself is still in progress when
  * it asks); among those, anything that is not success, skipped, or neutral
- * counts as a failure: cancelled, timed_out, action_required, and stale all
- * mean "the nightly did not prove the tip green", which is the fail-closed
- * direction for an alerting job.
+ * counts as a failure: cancelled, timed_out, action_required, stale, and an
+ * unreadable conclusion all mean "the nightly did not prove the tip green",
+ * which is the fail-closed direction for an alerting job.
  *
  * @param {ReadonlyArray<{ name?: string, status?: string, conclusion?: string | null, html_url?: string }>} jobs
  * @returns {{
@@ -142,46 +220,91 @@ export function renderRecoveryComment({ runUrl, timestamp }) {
 }
 
 /**
- * Decide what to do to the tracking issue. `openIssues` may be the raw issues
- * listing: pull requests (which the issues API also returns) and anything not
- * open are filtered here, and when several tracking issues exist (which the
- * create rule makes impossible short of a manual duplicate) the OLDEST is
- * updated and none are created, preserving the exactly-one contract.
+ * Decide what to do to the tracking issue.
+ *
+ * The verdict is not "no failures": a run whose lanes never materialized (an
+ * empty matrix, a skipped chain, unknown targets) proves nothing, so a green
+ * verdict additionally requires one success for the targets job plus
+ * NIGHTLY_LANES_PER_REF successes per gated ref among the completed jobs.
+ * Anything short of that synthesizes an "unproven" failure, because closing
+ * the tracking issue on a run that ran nothing is exactly the silent-green
+ * failure mode this workflow exists to abolish.
+ *
+ * `openIssues` may be the raw issues listing: pull requests (which the issues
+ * API also returns) and anything not open are filtered here, and only issues
+ * whose title matches the run's identity are considered, so a human applying
+ * the label to an unrelated issue never gets it rewritten or closed. When
+ * several tracking issues exist, the OLDEST is updated and none are created;
+ * duplicates are possible only when a dispatch run races the scheduled run
+ * (they sit in different concurrency groups), and they drain one per green
+ * run through the close branch.
  *
  * @param {{
  *   failed: ReadonlyArray<{ name: string, conclusion: string, html_url: string }>,
- *   openIssues: ReadonlyArray<{ number?: number, state?: string, pull_request?: unknown }>,
+ *   completed: ReadonlyArray<{ name: string, conclusion: string, html_url: string }>,
+ *   openIssues: ReadonlyArray<{ number?: number, state?: string, title?: string, pull_request?: unknown }>,
  *   runUrl: string,
  *   targets: readonly string[],
  *   timestamp: string,
+ *   drill?: boolean,
  * }} opts
  * @returns {{ action: 'create', title: string, body: string, labels: string[] }
  *   | { action: 'update', issueNumber: number, body: string, comment: string }
  *   | { action: 'close', issueNumber: number, comment: string }
  *   | { action: 'none', reason: string }}
  */
-export function planNightlyReport({ failed, openIssues, runUrl, targets, timestamp }) {
+export function planNightlyReport({
+  failed,
+  completed,
+  openIssues,
+  runUrl,
+  targets,
+  timestamp,
+  drill = false,
+}) {
+  const identity = trackingIssueIdentity(drill);
   const tracking = openIssues
-    .filter((issue) => issue && issue.state === 'open' && issue.pull_request === undefined)
-    .filter((issue) => Number.isInteger(issue.number))
+    // pull_request == null tolerates both the omitted key (GitHub) and an
+    // explicit null (normalizing proxies); either way it is not a PR.
+    .filter((issue) => issue && issue.state === 'open' && issue.pull_request == null)
+    .filter((issue) => Number.isInteger(issue.number) && issue.title === identity.title)
     .sort((a, b) => a.number - b.number);
   const existing = tracking[0];
 
-  if (failed.length > 0) {
-    const body = renderIssueBody({ runUrl, targets, timestamp, failed });
+  const successCount = completed.filter((job) => job.conclusion === 'success').length;
+  const requiredSuccesses = targets.length > 0 ? 1 + NIGHTLY_LANES_PER_REF * targets.length : null;
+  const proven = requiredSuccesses !== null && successCount >= requiredSuccesses;
+  const effectiveFailed =
+    failed.length > 0
+      ? failed
+      : proven
+        ? []
+        : [
+            {
+              name:
+                requiredSuccesses === null
+                  ? 'nightly run reported no failures but its targets are unknown (unproven)'
+                  : `nightly run reported no failures but only ${successCount} of the ${requiredSuccesses} expected jobs succeeded (unproven)`,
+              conclusion: 'unproven',
+              html_url: '',
+            },
+          ];
+
+  if (effectiveFailed.length > 0) {
+    const body = renderIssueBody({ runUrl, targets, timestamp, failed: effectiveFailed });
     if (existing === undefined) {
       return {
         action: 'create',
-        title: NIGHTLY_ISSUE_TITLE,
+        title: identity.title,
         body,
-        labels: [NIGHTLY_ISSUE_LABEL],
+        labels: [identity.label],
       };
     }
     return {
       action: 'update',
       issueNumber: existing.number,
       body,
-      comment: renderFailureComment({ runUrl, timestamp, failed }),
+      comment: renderFailureComment({ runUrl, timestamp, failed: effectiveFailed }),
     };
   }
 

--- a/scripts/nightly_report.mjs
+++ b/scripts/nightly_report.mjs
@@ -1,0 +1,125 @@
+// Entry for the nightly workflow's report job: read the current run's job
+// results and upsert the single tracking issue (create on first red, update on
+// repeat red, close on recovery). The decision logic lives in
+// lib/nightly_plan.mjs (unit-tested); this file is the HTTP plumbing. No npm
+// deps: Node 18+ global fetch only.
+//
+// Unlike the targets entry, an API failure HERE throws and fails the job: the
+// report is the alerting deliverable, so degrading it silently would recreate
+// the watched-by-nobody red tip this workflow exists to prevent. A red report
+// job is itself visible in the Actions list.
+import { NIGHTLY_ISSUE_LABEL, planNightlyReport, summarizeRunJobs } from './lib/nightly_plan.mjs';
+
+const API = process.env.GITHUB_API_URL || 'https://api.github.com';
+const repo = process.env.GITHUB_REPOSITORY ?? '';
+const token = process.env.GITHUB_TOKEN ?? '';
+const runId = process.env.GITHUB_RUN_ID ?? '';
+const serverUrl = process.env.GITHUB_SERVER_URL || 'https://github.com';
+if (!repo || !token || !runId) {
+  throw new Error('missing GITHUB_REPOSITORY, GITHUB_TOKEN, or GITHUB_RUN_ID');
+}
+
+const headers = {
+  Authorization: `Bearer ${token}`,
+  Accept: 'application/vnd.github+json',
+  'X-GitHub-Api-Version': '2022-11-28',
+  'Content-Type': 'application/json',
+};
+
+/** @param {string} url @param {RequestInit} [init] @returns {Promise<any>} */
+async function api(url, init) {
+  const res = await fetch(`${API}${url}`, {
+    headers,
+    signal: AbortSignal.timeout(30_000),
+    ...init,
+  });
+  if (!res.ok) {
+    throw new Error(
+      `${init?.method ?? 'GET'} ${url} failed: HTTP ${res.status} ${await res.text()}`,
+    );
+  }
+  return res.json();
+}
+
+// The current run's jobs, paginated. Only completed jobs are judged, which
+// also excludes this report job itself (still in progress while asking).
+/** @type {any[]} */
+const jobs = [];
+for (let page = 1; page <= 10; page++) {
+  const payload = await api(`/repos/${repo}/actions/runs/${runId}/jobs?per_page=100&page=${page}`);
+  const batch = Array.isArray(payload?.jobs) ? payload.jobs : [];
+  jobs.push(...batch);
+  if (batch.length < 100) break;
+}
+
+const { completed, failed } = summarizeRunJobs(jobs);
+console.log(
+  `[nightly_report] ${completed.length} completed jobs, ${failed.length} failed` +
+    failed.map((job) => `\n  - ${job.name}: ${job.conclusion}`).join(''),
+);
+
+const openIssues = await api(
+  `/repos/${repo}/issues?state=open&labels=${encodeURIComponent(NIGHTLY_ISSUE_LABEL)}&per_page=100`,
+);
+
+/** @type {string[]} */
+let targets = [];
+try {
+  const parsed = JSON.parse(process.env.NIGHTLY_TARGETS ?? '');
+  if (Array.isArray(parsed)) targets = parsed.filter((ref) => typeof ref === 'string');
+} catch {
+  // Ref resolution failed upstream; the body says so instead of guessing.
+}
+
+const plan = planNightlyReport({
+  failed,
+  openIssues: Array.isArray(openIssues) ? openIssues : [],
+  runUrl: `${serverUrl}/${repo}/actions/runs/${runId}`,
+  targets,
+  timestamp: new Date().toISOString(),
+});
+
+if (plan.action === 'create') {
+  // The label is the finder for every later run, so it must exist before the
+  // issue carries it. 422 means it already does.
+  const labelRes = await fetch(`${API}/repos/${repo}/labels`, {
+    method: 'POST',
+    headers,
+    signal: AbortSignal.timeout(30_000),
+    body: JSON.stringify({
+      name: NIGHTLY_ISSUE_LABEL,
+      color: 'b60205',
+      description: 'Tracking issue managed by the nightly full gate',
+    }),
+  });
+  if (!labelRes.ok && labelRes.status !== 422) {
+    throw new Error(`ensuring the ${NIGHTLY_ISSUE_LABEL} label failed: HTTP ${labelRes.status}`);
+  }
+  const issue = await api(`/repos/${repo}/issues`, {
+    method: 'POST',
+    body: JSON.stringify({ title: plan.title, body: plan.body, labels: plan.labels }),
+  });
+  console.log(`[nightly_report] created tracking issue #${issue.number}`);
+} else if (plan.action === 'update') {
+  await api(`/repos/${repo}/issues/${plan.issueNumber}`, {
+    method: 'PATCH',
+    body: JSON.stringify({ body: plan.body }),
+  });
+  await api(`/repos/${repo}/issues/${plan.issueNumber}/comments`, {
+    method: 'POST',
+    body: JSON.stringify({ body: plan.comment }),
+  });
+  console.log(`[nightly_report] updated tracking issue #${plan.issueNumber}`);
+} else if (plan.action === 'close') {
+  await api(`/repos/${repo}/issues/${plan.issueNumber}/comments`, {
+    method: 'POST',
+    body: JSON.stringify({ body: plan.comment }),
+  });
+  await api(`/repos/${repo}/issues/${plan.issueNumber}`, {
+    method: 'PATCH',
+    body: JSON.stringify({ state: 'closed', state_reason: 'completed' }),
+  });
+  console.log(`[nightly_report] closed tracking issue #${plan.issueNumber} (recovered)`);
+} else {
+  console.log(`[nightly_report] nothing to do: ${plan.reason}`);
+}

--- a/scripts/nightly_report.mjs
+++ b/scripts/nightly_report.mjs
@@ -4,11 +4,21 @@
 // lib/nightly_plan.mjs (unit-tested); this file is the HTTP plumbing. No npm
 // deps: Node 18+ global fetch only.
 //
+// A dispatch drill (NIGHTLY_REF set) reports under the separate drill
+// label/title, so acceptance runs against a scratch branch never touch the
+// production tracking issue.
+//
 // Unlike the targets entry, an API failure HERE throws and fails the job: the
 // report is the alerting deliverable, so degrading it silently would recreate
 // the watched-by-nobody red tip this workflow exists to prevent. A red report
 // job is itself visible in the Actions list.
-import { NIGHTLY_ISSUE_LABEL, planNightlyReport, summarizeRunJobs } from './lib/nightly_plan.mjs';
+import {
+  labelEnsureFailed,
+  parseTargetsEnv,
+  planNightlyReport,
+  summarizeRunJobs,
+  trackingIssueIdentity,
+} from './lib/nightly_plan.mjs';
 
 const API = process.env.GITHUB_API_URL || 'https://api.github.com';
 const repo = process.env.GITHUB_REPOSITORY ?? '';
@@ -17,6 +27,12 @@ const runId = process.env.GITHUB_RUN_ID ?? '';
 const serverUrl = process.env.GITHUB_SERVER_URL || 'https://github.com';
 if (!repo || !token || !runId) {
   throw new Error('missing GITHUB_REPOSITORY, GITHUB_TOKEN, or GITHUB_RUN_ID');
+}
+
+const drill = (process.env.NIGHTLY_REF ?? '').trim() !== '';
+const identity = trackingIssueIdentity(drill);
+if (drill) {
+  console.log(`[nightly_report] dispatch drill: reporting under the ${identity.label} identity`);
 }
 
 const headers = {
@@ -59,24 +75,17 @@ console.log(
 );
 
 const openIssues = await api(
-  `/repos/${repo}/issues?state=open&labels=${encodeURIComponent(NIGHTLY_ISSUE_LABEL)}&per_page=100`,
+  `/repos/${repo}/issues?state=open&labels=${encodeURIComponent(identity.label)}&per_page=100`,
 );
-
-/** @type {string[]} */
-let targets = [];
-try {
-  const parsed = JSON.parse(process.env.NIGHTLY_TARGETS ?? '');
-  if (Array.isArray(parsed)) targets = parsed.filter((ref) => typeof ref === 'string');
-} catch {
-  // Ref resolution failed upstream; the body says so instead of guessing.
-}
 
 const plan = planNightlyReport({
   failed,
+  completed,
   openIssues: Array.isArray(openIssues) ? openIssues : [],
   runUrl: `${serverUrl}/${repo}/actions/runs/${runId}`,
-  targets,
+  targets: parseTargetsEnv(process.env.NIGHTLY_TARGETS),
   timestamp: new Date().toISOString(),
+  drill,
 });
 
 if (plan.action === 'create') {
@@ -87,13 +96,15 @@ if (plan.action === 'create') {
     headers,
     signal: AbortSignal.timeout(30_000),
     body: JSON.stringify({
-      name: NIGHTLY_ISSUE_LABEL,
+      name: identity.label,
       color: 'b60205',
-      description: 'Tracking issue managed by the nightly full gate',
+      description: drill
+        ? 'Drill issue managed by the nightly full gate (dispatch runs)'
+        : 'Tracking issue managed by the nightly full gate',
     }),
   });
-  if (!labelRes.ok && labelRes.status !== 422) {
-    throw new Error(`ensuring the ${NIGHTLY_ISSUE_LABEL} label failed: HTTP ${labelRes.status}`);
+  if (labelEnsureFailed(labelRes.ok, labelRes.status)) {
+    throw new Error(`ensuring the ${identity.label} label failed: HTTP ${labelRes.status}`);
   }
   const issue = await api(`/repos/${repo}/issues`, {
     method: 'POST',

--- a/scripts/nightly_targets.mjs
+++ b/scripts/nightly_targets.mjs
@@ -1,0 +1,73 @@
+// Entry for the nightly workflow's ref-resolution job: decide which refs the
+// scheduled full gate runs against and write them as a JSON array to the
+// `refs` step output (consumed via fromJSON into the job matrix). Planning
+// logic lives in lib/nightly_plan.mjs (unit-tested); this file only does the
+// environment and HTTP plumbing. No npm deps: Node 18+ global fetch only.
+//
+// Fail direction: ref resolution exists to WIDEN the nightly, so an API error
+// here must not silence the whole run. On any failure the targets collapse to
+// the default branch alone, loudly, and the run still happens.
+import { appendFileSync } from 'node:fs';
+import { buildTargets, pickActiveReleaseBranch } from './lib/nightly_plan.mjs';
+
+const API = process.env.GITHUB_API_URL || 'https://api.github.com';
+const repo = process.env.GITHUB_REPOSITORY ?? '';
+const token = process.env.GITHUB_TOKEN ?? '';
+
+/** @returns {Promise<string[]>} branch names under release/ */
+async function listReleaseBranches() {
+  if (!repo || !token) throw new Error('missing GITHUB_REPOSITORY or GITHUB_TOKEN');
+  /** @type {string[]} */
+  const names = [];
+  // matching-refs paginates like every list endpoint; release branches are few,
+  // but a short-page loop costs nothing and cannot truncate silently.
+  for (let page = 1; page <= 10; page++) {
+    const url = `${API}/repos/${repo}/git/matching-refs/heads/release/?per_page=100&page=${page}`;
+    const res = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+      signal: AbortSignal.timeout(30_000),
+    });
+    if (!res.ok) throw new Error(`matching-refs page ${page} failed: HTTP ${res.status}`);
+    const batch = await res.json();
+    if (!Array.isArray(batch)) throw new Error(`matching-refs page ${page}: non-array payload`);
+    for (const entry of batch) {
+      if (typeof entry?.ref === 'string' && entry.ref.startsWith('refs/heads/')) {
+        names.push(entry.ref.slice('refs/heads/'.length));
+      }
+    }
+    if (batch.length < 100) return names;
+  }
+  return names;
+}
+
+const inputRef = process.env.NIGHTLY_REF ?? '';
+let targets;
+if (inputRef.trim() !== '') {
+  targets = buildTargets({ inputRef });
+  console.log(`[nightly_targets] dispatch ref override: gating ${targets.join(', ')}`);
+} else {
+  try {
+    const releaseBranch = pickActiveReleaseBranch(await listReleaseBranches());
+    targets = buildTargets({ inputRef: null, releaseBranch });
+    console.log(
+      `[nightly_targets] gating ${targets.join(', ')}${releaseBranch ? '' : ' (no release/vX.Y.Z branch found)'}`,
+    );
+  } catch (err) {
+    targets = buildTargets({ inputRef: null, releaseBranch: null });
+    const detail = err instanceof Error ? err.message : String(err);
+    console.log(
+      `[nightly_targets] release branch resolution failed (${detail}); gating ${targets.join(', ')} only`,
+    );
+  }
+}
+
+const outputLine = `refs=${JSON.stringify(targets)}\n`;
+if (process.env.GITHUB_OUTPUT) {
+  appendFileSync(process.env.GITHUB_OUTPUT, outputLine);
+} else {
+  process.stdout.write(outputLine);
+}

--- a/scripts/nightly_targets.mjs
+++ b/scripts/nightly_targets.mjs
@@ -8,11 +8,19 @@
 // here must not silence the whole run. On any failure the targets collapse to
 // the default branch alone, loudly, and the run still happens.
 import { appendFileSync } from 'node:fs';
-import { buildTargets, pickActiveReleaseBranch } from './lib/nightly_plan.mjs';
+import {
+  buildTargets,
+  pickActiveReleaseBranch,
+  refNamesFromMatchingRefs,
+} from './lib/nightly_plan.mjs';
 
 const API = process.env.GITHUB_API_URL || 'https://api.github.com';
 const repo = process.env.GITHUB_REPOSITORY ?? '';
 const token = process.env.GITHUB_TOKEN ?? '';
+// The workflow passes the real default branch; the 'main' fallback only
+// covers a missing env var, so a renamed default branch cannot strand the
+// nightly on a nonexistent ref.
+const defaultBranch = (process.env.NIGHTLY_DEFAULT_BRANCH ?? '').trim() || 'main';
 
 /** @returns {Promise<string[]>} branch names under release/ */
 async function listReleaseBranches() {
@@ -34,11 +42,7 @@ async function listReleaseBranches() {
     if (!res.ok) throw new Error(`matching-refs page ${page} failed: HTTP ${res.status}`);
     const batch = await res.json();
     if (!Array.isArray(batch)) throw new Error(`matching-refs page ${page}: non-array payload`);
-    for (const entry of batch) {
-      if (typeof entry?.ref === 'string' && entry.ref.startsWith('refs/heads/')) {
-        names.push(entry.ref.slice('refs/heads/'.length));
-      }
-    }
+    names.push(...refNamesFromMatchingRefs(batch));
     if (batch.length < 100) return names;
   }
   return names;
@@ -47,17 +51,17 @@ async function listReleaseBranches() {
 const inputRef = process.env.NIGHTLY_REF ?? '';
 let targets;
 if (inputRef.trim() !== '') {
-  targets = buildTargets({ inputRef });
+  targets = buildTargets({ inputRef, defaultBranch });
   console.log(`[nightly_targets] dispatch ref override: gating ${targets.join(', ')}`);
 } else {
   try {
     const releaseBranch = pickActiveReleaseBranch(await listReleaseBranches());
-    targets = buildTargets({ inputRef: null, releaseBranch });
+    targets = buildTargets({ inputRef: null, releaseBranch, defaultBranch });
     console.log(
       `[nightly_targets] gating ${targets.join(', ')}${releaseBranch ? '' : ' (no release/vX.Y.Z branch found)'}`,
     );
   } catch (err) {
-    targets = buildTargets({ inputRef: null, releaseBranch: null });
+    targets = buildTargets({ inputRef: null, releaseBranch: null, defaultBranch });
     const detail = err instanceof Error ? err.message : String(err);
     console.log(
       `[nightly_targets] release branch resolution failed (${detail}); gating ${targets.join(', ')} only`,

--- a/tests/deploy_node_version.test.ts
+++ b/tests/deploy_node_version.test.ts
@@ -17,6 +17,7 @@ const ciWorkflow = readFileSync('.github/workflows/ci.yml', 'utf8');
 const auditWorkflow = readFileSync('.github/workflows/audit.yml', 'utf8');
 const prAiWorkflow = readFileSync('.github/workflows/pr-ai.yml', 'utf8');
 const desktopWorkflow = readFileSync('.github/workflows/desktop-publish.yml', 'utf8');
+const nightlyWorkflow = readFileSync('.github/workflows/nightly.yml', 'utf8');
 const deployDoc = readFileSync('DEPLOY.md', 'utf8');
 const compose = readFileSync('docker-compose.yml', 'utf8');
 
@@ -102,6 +103,16 @@ describe('deploy and CI Node version pin', () => {
     expect(values.length).toBeGreaterThan(0);
     for (const value of values) expect(value).toBe(TARGET_MAJOR);
     expect(auditWorkflow).toContain(`node-version: ${TARGET_MAJOR}`);
+  });
+
+  // nightly.yml re-proves the tips on a schedule with its own setup-node steps, so it
+  // is a bump carrier like audit.yml: fold it into the coordinated move or the nightly
+  // would silently prove the tree against a Node nothing else ships on.
+  it('pins every nightly.yml node-version to the target Node major', () => {
+    const values = nodeVersionValues(nightlyWorkflow);
+    expect(values.length).toBeGreaterThan(0);
+    for (const value of values) expect(value).toBe(TARGET_MAJOR);
+    expect(nightlyWorkflow).toContain(`node-version: ${TARGET_MAJOR}`);
   });
 
   // pr-ai.yml runs only the codex-action review jobs and deliberately sets up no Node

--- a/tests/nightly_plan.test.ts
+++ b/tests/nightly_plan.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildTargets,
+  NIGHTLY_ISSUE_LABEL,
+  NIGHTLY_ISSUE_TITLE,
+  pickActiveReleaseBranch,
+  planNightlyReport,
+  renderIssueBody,
+  renderRecoveryComment,
+  summarizeRunJobs,
+} from '../scripts/lib/nightly_plan.mjs';
+
+const RUN = {
+  runUrl: 'https://github.com/levy-street/world-of-claudecraft/actions/runs/123',
+  targets: ['main', 'release/v0.35.0'],
+  timestamp: '2026-08-05T04:47:00.000Z',
+} as const;
+
+const FAILED = [
+  {
+    name: 'Nightly tests (release/v0.35.0)',
+    conclusion: 'failure',
+    html_url: 'https://github.com/levy-street/world-of-claudecraft/runs/1',
+  },
+] as const;
+
+const openIssue = (number: number, extra: Record<string, unknown> = {}) => ({
+  number,
+  state: 'open',
+  ...extra,
+});
+
+describe('pickActiveReleaseBranch', () => {
+  it('picks the highest release/vX.Y.Z by semver, not by string order', () => {
+    expect(
+      pickActiveReleaseBranch([
+        'release/v0.9.0',
+        'release/v0.35.0',
+        'release/v0.27.0',
+        'release/v0.10.1',
+      ]),
+    ).toBe('release/v0.35.0');
+    // String comparison would call v0.9.0 the highest here; semver must win.
+    expect(pickActiveReleaseBranch(['release/v0.9.0', 'release/v0.10.0'])).toBe('release/v0.10.0');
+  });
+
+  it('accepts the unprefixed form and ignores names that do not parse', () => {
+    expect(pickActiveReleaseBranch(['release/0.36.0', 'release/v0.35.0'])).toBe('release/0.36.0');
+    expect(
+      pickActiveReleaseBranch(['release/next', 'release/v1.2', 'main', 'feature/release/v9.9.9']),
+    ).toBeNull();
+    expect(pickActiveReleaseBranch([])).toBeNull();
+  });
+});
+
+describe('buildTargets', () => {
+  it('gates main plus the active release branch on a scheduled run', () => {
+    expect(buildTargets({ inputRef: null, releaseBranch: 'release/v0.35.0' })).toEqual([
+      'main',
+      'release/v0.35.0',
+    ]);
+  });
+
+  it('collapses to the default branch when no release branch resolves', () => {
+    expect(buildTargets({ inputRef: null, releaseBranch: null })).toEqual(['main']);
+    expect(buildTargets({ inputRef: '   ', releaseBranch: null })).toEqual(['main']);
+  });
+
+  it('lets a dispatch ref replace the whole list (the acceptance drill path)', () => {
+    expect(
+      buildTargets({ inputRef: 'scratch/broken-test', releaseBranch: 'release/v0.35.0' }),
+    ).toEqual(['scratch/broken-test']);
+  });
+
+  it('never lists the default branch twice', () => {
+    expect(buildTargets({ inputRef: null, releaseBranch: 'main' })).toEqual(['main']);
+  });
+});
+
+describe('summarizeRunJobs', () => {
+  it('judges only completed jobs, so the in-progress report job never counts', () => {
+    const { completed, failed } = summarizeRunJobs([
+      { name: 'Nightly tests (main)', status: 'completed', conclusion: 'success', html_url: 'u1' },
+      { name: 'Report nightly verdict', status: 'in_progress', conclusion: null, html_url: 'u2' },
+    ]);
+    expect(completed.map((job) => job.name)).toEqual(['Nightly tests (main)']);
+    expect(failed).toEqual([]);
+  });
+
+  it('counts every non-success, non-skipped, non-neutral conclusion as a failure', () => {
+    const { failed } = summarizeRunJobs([
+      { name: 'a', status: 'completed', conclusion: 'failure', html_url: '' },
+      { name: 'b', status: 'completed', conclusion: 'cancelled', html_url: '' },
+      { name: 'c', status: 'completed', conclusion: 'timed_out', html_url: '' },
+      { name: 'd', status: 'completed', conclusion: 'action_required', html_url: '' },
+      { name: 'e', status: 'completed', conclusion: 'success', html_url: '' },
+      { name: 'f', status: 'completed', conclusion: 'skipped', html_url: '' },
+      { name: 'g', status: 'completed', conclusion: 'neutral', html_url: '' },
+    ]);
+    expect(failed.map((job) => job.name)).toEqual(['a', 'b', 'c', 'd']);
+  });
+
+  it('fails closed on a completed job with an unreadable conclusion', () => {
+    const { failed } = summarizeRunJobs([
+      { name: 'weird', status: 'completed', conclusion: null, html_url: '' },
+    ]);
+    expect(failed.map((job) => job.name)).toEqual(['weird']);
+    expect(failed[0].conclusion).toBe('unknown');
+  });
+});
+
+describe('planNightlyReport', () => {
+  it('creates the labeled tracking issue on the first red run', () => {
+    const plan = planNightlyReport({ ...RUN, failed: [...FAILED], openIssues: [] });
+    expect(plan).toEqual({
+      action: 'create',
+      title: NIGHTLY_ISSUE_TITLE,
+      body: renderIssueBody({ ...RUN, failed: [...FAILED] }),
+      labels: [NIGHTLY_ISSUE_LABEL],
+    });
+    if (plan.action !== 'create') throw new Error('unreachable');
+    expect(plan.body).toContain(RUN.runUrl);
+    expect(plan.body).toContain('Nightly tests (release/v0.35.0): failure');
+    expect(plan.body).toContain('Refs gated: main, release/v0.35.0');
+  });
+
+  it('updates the existing open issue on a repeat failure, never a second issue', () => {
+    const plan = planNightlyReport({ ...RUN, failed: [...FAILED], openIssues: [openIssue(42)] });
+    expect(plan.action).toBe('update');
+    if (plan.action !== 'update') throw new Error('unreachable');
+    expect(plan.issueNumber).toBe(42);
+    expect(plan.comment).toContain('Still red');
+    expect(plan.comment).toContain(RUN.runUrl);
+  });
+
+  it('keeps exactly one tracking issue even if duplicates exist: oldest wins, none created', () => {
+    const plan = planNightlyReport({
+      ...RUN,
+      failed: [...FAILED],
+      openIssues: [openIssue(50), openIssue(42)],
+    });
+    expect(plan.action).toBe('update');
+    if (plan.action !== 'update') throw new Error('unreachable');
+    expect(plan.issueNumber).toBe(42);
+  });
+
+  it('ignores pull requests and non-open entries from the issues listing', () => {
+    const plan = planNightlyReport({
+      ...RUN,
+      failed: [...FAILED],
+      openIssues: [
+        openIssue(7, { pull_request: { url: 'x' } }),
+        { number: 8, state: 'closed' },
+        { state: 'open' },
+      ],
+    });
+    expect(plan.action).toBe('create');
+  });
+
+  it('closes the issue with a recovery comment on the first green run', () => {
+    const plan = planNightlyReport({ ...RUN, failed: [], openIssues: [openIssue(42)] });
+    expect(plan).toEqual({
+      action: 'close',
+      issueNumber: 42,
+      comment: renderRecoveryComment(RUN),
+    });
+    if (plan.action !== 'close') throw new Error('unreachable');
+    expect(plan.comment).toContain('green again');
+  });
+
+  it('does nothing on a green run with no open tracking issue', () => {
+    expect(planNightlyReport({ ...RUN, failed: [], openIssues: [] })).toEqual({
+      action: 'none',
+      reason: 'green run and no open tracking issue',
+    });
+  });
+
+  it('says so in the body when ref resolution failed instead of guessing', () => {
+    const plan = planNightlyReport({ ...RUN, targets: [], failed: [...FAILED], openIssues: [] });
+    if (plan.action !== 'create') throw new Error('expected create');
+    expect(plan.body).toContain('unknown (ref resolution failed)');
+  });
+});

--- a/tests/nightly_plan.test.ts
+++ b/tests/nightly_plan.test.ts
@@ -1,13 +1,20 @@
 import { describe, expect, it } from 'vitest';
 import {
   buildTargets,
+  labelEnsureFailed,
+  NIGHTLY_DRILL_ISSUE_LABEL,
+  NIGHTLY_DRILL_ISSUE_TITLE,
   NIGHTLY_ISSUE_LABEL,
   NIGHTLY_ISSUE_TITLE,
+  NIGHTLY_LANES_PER_REF,
+  parseTargetsEnv,
   pickActiveReleaseBranch,
   planNightlyReport,
+  refNamesFromMatchingRefs,
   renderIssueBody,
   renderRecoveryComment,
   summarizeRunJobs,
+  trackingIssueIdentity,
 } from '../scripts/lib/nightly_plan.mjs';
 
 const RUN = {
@@ -24,10 +31,46 @@ const FAILED = [
   },
 ] as const;
 
+const success = (name: string) => ({ name, conclusion: 'success', html_url: '' });
+
+// A fully proven green run for RUN's two targets: the targets job plus
+// NIGHTLY_LANES_PER_REF lanes per ref, all successful.
+const FULL_GREEN = [
+  success('Resolve nightly refs'),
+  success('Nightly tests (main)'),
+  success('Nightly checks (main)'),
+  success('Nightly browser (main)'),
+  success('Nightly tests (release/v0.35.0)'),
+  success('Nightly checks (release/v0.35.0)'),
+  success('Nightly browser (release/v0.35.0)'),
+];
+
 const openIssue = (number: number, extra: Record<string, unknown> = {}) => ({
   number,
   state: 'open',
+  title: NIGHTLY_ISSUE_TITLE,
   ...extra,
+});
+
+describe('issue identity constants', () => {
+  it('pins the literal label and title the cross-run finder depends on', () => {
+    // The label is the issues-API finder and the title is the in-plan finder;
+    // renaming either strands every issue created under the old identity, so
+    // the literals are pinned here, not just compared to themselves.
+    expect(NIGHTLY_ISSUE_LABEL).toBe('nightly-gate');
+    expect(NIGHTLY_ISSUE_TITLE).toBe('Nightly full gate is red');
+    expect(NIGHTLY_DRILL_ISSUE_LABEL).toBe('nightly-gate-drill');
+    expect(NIGHTLY_DRILL_ISSUE_TITLE).toBe('Nightly full gate drill is red');
+    expect(NIGHTLY_LANES_PER_REF).toBe(3);
+    expect(trackingIssueIdentity(false)).toEqual({
+      label: 'nightly-gate',
+      title: 'Nightly full gate is red',
+    });
+    expect(trackingIssueIdentity(true)).toEqual({
+      label: 'nightly-gate-drill',
+      title: 'Nightly full gate drill is red',
+    });
+  });
 });
 
 describe('pickActiveReleaseBranch', () => {
@@ -44,6 +87,16 @@ describe('pickActiveReleaseBranch', () => {
     expect(pickActiveReleaseBranch(['release/v0.9.0', 'release/v0.10.0'])).toBe('release/v0.10.0');
   });
 
+  it('decides on every dimension, not just the minor version', () => {
+    // Patch decides: losing this clause would gate a stale release tip.
+    expect(pickActiveReleaseBranch(['release/v0.35.0', 'release/v0.35.1'])).toBe('release/v0.35.1');
+    expect(pickActiveReleaseBranch(['release/v0.35.10', 'release/v0.35.9'])).toBe(
+      'release/v0.35.10',
+    );
+    // Major decides.
+    expect(pickActiveReleaseBranch(['release/v0.36.0', 'release/v1.0.0'])).toBe('release/v1.0.0');
+  });
+
   it('accepts the unprefixed form and ignores names that do not parse', () => {
     expect(pickActiveReleaseBranch(['release/0.36.0', 'release/v0.35.0'])).toBe('release/0.36.0');
     expect(
@@ -54,11 +107,14 @@ describe('pickActiveReleaseBranch', () => {
 });
 
 describe('buildTargets', () => {
-  it('gates main plus the active release branch on a scheduled run', () => {
+  it('gates the default branch plus the active release branch on a scheduled run', () => {
     expect(buildTargets({ inputRef: null, releaseBranch: 'release/v0.35.0' })).toEqual([
       'main',
       'release/v0.35.0',
     ]);
+    expect(
+      buildTargets({ inputRef: null, releaseBranch: 'release/v0.35.0', defaultBranch: 'trunk' }),
+    ).toEqual(['trunk', 'release/v0.35.0']);
   });
 
   it('collapses to the default branch when no release branch resolves', () => {
@@ -74,6 +130,46 @@ describe('buildTargets', () => {
 
   it('never lists the default branch twice', () => {
     expect(buildTargets({ inputRef: null, releaseBranch: 'main' })).toEqual(['main']);
+  });
+});
+
+describe('refNamesFromMatchingRefs', () => {
+  it('strips the refs/heads/ prefix and drops everything else', () => {
+    // If this strip broke, every name would fail pickActiveReleaseBranch's
+    // anchor and the nightly would quietly gate main alone forever.
+    expect(
+      refNamesFromMatchingRefs([
+        { ref: 'refs/heads/release/v0.35.0' },
+        { ref: 'refs/heads/main' },
+        { ref: 'refs/tags/v0.35.0' },
+        { ref: 42 as unknown as string },
+        {},
+        { ref: 'release/v0.34.0' },
+      ]),
+    ).toEqual(['release/v0.35.0', 'main']);
+    expect(refNamesFromMatchingRefs([])).toEqual([]);
+  });
+});
+
+describe('parseTargetsEnv', () => {
+  it('parses a JSON string array and collapses everything else to unknown', () => {
+    expect(parseTargetsEnv('["main","release/v0.35.0"]')).toEqual(['main', 'release/v0.35.0']);
+    expect(parseTargetsEnv('["main",5,null]')).toEqual(['main']);
+    expect(parseTargetsEnv('')).toEqual([]);
+    expect(parseTargetsEnv(undefined)).toEqual([]);
+    expect(parseTargetsEnv('null')).toEqual([]);
+    expect(parseTargetsEnv('{"ref":"main"}')).toEqual([]);
+    expect(parseTargetsEnv('not json')).toEqual([]);
+  });
+});
+
+describe('labelEnsureFailed', () => {
+  it('tolerates only success and already-exists', () => {
+    expect(labelEnsureFailed(true, 201)).toBe(false);
+    expect(labelEnsureFailed(false, 422)).toBe(false);
+    // Inverting this makes the very first red night throw instead of filing.
+    expect(labelEnsureFailed(false, 403)).toBe(true);
+    expect(labelEnsureFailed(false, 500)).toBe(true);
   });
 });
 
@@ -93,25 +189,40 @@ describe('summarizeRunJobs', () => {
       { name: 'b', status: 'completed', conclusion: 'cancelled', html_url: '' },
       { name: 'c', status: 'completed', conclusion: 'timed_out', html_url: '' },
       { name: 'd', status: 'completed', conclusion: 'action_required', html_url: '' },
-      { name: 'e', status: 'completed', conclusion: 'success', html_url: '' },
-      { name: 'f', status: 'completed', conclusion: 'skipped', html_url: '' },
-      { name: 'g', status: 'completed', conclusion: 'neutral', html_url: '' },
+      { name: 'e', status: 'completed', conclusion: 'stale', html_url: '' },
+      { name: 'f', status: 'completed', conclusion: 'success', html_url: '' },
+      { name: 'g', status: 'completed', conclusion: 'skipped', html_url: '' },
+      { name: 'h', status: 'completed', conclusion: 'neutral', html_url: '' },
     ]);
-    expect(failed.map((job) => job.name)).toEqual(['a', 'b', 'c', 'd']);
+    expect(failed.map((job) => job.name)).toEqual(['a', 'b', 'c', 'd', 'e']);
   });
 
-  it('fails closed on a completed job with an unreadable conclusion', () => {
+  it('fails closed on a completed job with unreadable fields', () => {
     const { failed } = summarizeRunJobs([
-      { name: 'weird', status: 'completed', conclusion: null, html_url: '' },
+      { status: 'completed', conclusion: null, html_url: 7 as unknown as string },
     ]);
-    expect(failed.map((job) => job.name)).toEqual(['weird']);
-    expect(failed[0].conclusion).toBe('unknown');
+    expect(failed).toEqual([{ name: '(unnamed job)', conclusion: 'unknown', html_url: '' }]);
+  });
+});
+
+describe('renderIssueBody', () => {
+  it('omits the parenthesised link when a job has no URL', () => {
+    const body = renderIssueBody({
+      ...RUN,
+      failed: [
+        { name: 'with-url', conclusion: 'failure', html_url: 'https://example.com/1' },
+        { name: 'without-url', conclusion: 'unproven', html_url: '' },
+      ],
+    });
+    expect(body).toContain('- with-url: failure (https://example.com/1)');
+    expect(body.endsWith('- without-url: unproven')).toBe(true);
+    expect(body).not.toContain('unproven (');
   });
 });
 
 describe('planNightlyReport', () => {
   it('creates the labeled tracking issue on the first red run', () => {
-    const plan = planNightlyReport({ ...RUN, failed: [...FAILED], openIssues: [] });
+    const plan = planNightlyReport({ ...RUN, failed: [...FAILED], completed: [], openIssues: [] });
     expect(plan).toEqual({
       action: 'create',
       title: NIGHTLY_ISSUE_TITLE,
@@ -120,23 +231,32 @@ describe('planNightlyReport', () => {
     });
     if (plan.action !== 'create') throw new Error('unreachable');
     expect(plan.body).toContain(RUN.runUrl);
+    expect(plan.body).toContain(RUN.timestamp);
     expect(plan.body).toContain('Nightly tests (release/v0.35.0): failure');
     expect(plan.body).toContain('Refs gated: main, release/v0.35.0');
   });
 
   it('updates the existing open issue on a repeat failure, never a second issue', () => {
-    const plan = planNightlyReport({ ...RUN, failed: [...FAILED], openIssues: [openIssue(42)] });
+    const plan = planNightlyReport({
+      ...RUN,
+      failed: [...FAILED],
+      completed: [],
+      openIssues: [openIssue(42)],
+    });
     expect(plan.action).toBe('update');
     if (plan.action !== 'update') throw new Error('unreachable');
     expect(plan.issueNumber).toBe(42);
     expect(plan.comment).toContain('Still red');
     expect(plan.comment).toContain(RUN.runUrl);
+    // The comment must say WHICH job is still red, not just that something is.
+    expect(plan.comment).toContain('Nightly tests (release/v0.35.0): failure');
   });
 
   it('keeps exactly one tracking issue even if duplicates exist: oldest wins, none created', () => {
     const plan = planNightlyReport({
       ...RUN,
       failed: [...FAILED],
+      completed: [],
       openIssues: [openIssue(50), openIssue(42)],
     });
     expect(plan.action).toBe('update');
@@ -144,21 +264,58 @@ describe('planNightlyReport', () => {
     expect(plan.issueNumber).toBe(42);
   });
 
-  it('ignores pull requests and non-open entries from the issues listing', () => {
+  it('ignores pull requests and non-open entries, but keeps a null pull_request field', () => {
     const plan = planNightlyReport({
       ...RUN,
       failed: [...FAILED],
+      completed: [],
       openIssues: [
         openIssue(7, { pull_request: { url: 'x' } }),
-        { number: 8, state: 'closed' },
-        { state: 'open' },
+        { number: 8, state: 'closed', title: NIGHTLY_ISSUE_TITLE },
+        { state: 'open', title: NIGHTLY_ISSUE_TITLE },
       ],
     });
     expect(plan.action).toBe('create');
+    // pull_request: null (a normalizing proxy) is still an issue, not a PR.
+    const tolerant = planNightlyReport({
+      ...RUN,
+      failed: [...FAILED],
+      completed: [],
+      openIssues: [openIssue(9, { pull_request: null })],
+    });
+    expect(tolerant.action).toBe('update');
+    if (tolerant.action !== 'update') throw new Error('unreachable');
+    expect(tolerant.issueNumber).toBe(9);
   });
 
-  it('closes the issue with a recovery comment on the first green run', () => {
-    const plan = planNightlyReport({ ...RUN, failed: [], openIssues: [openIssue(42)] });
+  it('never touches a mislabeled foreign issue: the title is part of the finder', () => {
+    const foreign = openIssue(3, { title: 'Server login is broken' });
+    // Red run: the foreign issue must not be updated (its body would be
+    // overwritten wholesale); a fresh tracking issue is created instead.
+    const red = planNightlyReport({
+      ...RUN,
+      failed: [...FAILED],
+      completed: [],
+      openIssues: [foreign],
+    });
+    expect(red.action).toBe('create');
+    // Green run: the foreign issue must not be closed as "recovered".
+    const green = planNightlyReport({
+      ...RUN,
+      failed: [],
+      completed: FULL_GREEN,
+      openIssues: [foreign],
+    });
+    expect(green.action).toBe('none');
+  });
+
+  it('closes the issue with a recovery comment on the first proven green run', () => {
+    const plan = planNightlyReport({
+      ...RUN,
+      failed: [],
+      completed: FULL_GREEN,
+      openIssues: [openIssue(42)],
+    });
     expect(plan).toEqual({
       action: 'close',
       issueNumber: 42,
@@ -166,17 +323,119 @@ describe('planNightlyReport', () => {
     });
     if (plan.action !== 'close') throw new Error('unreachable');
     expect(plan.comment).toContain('green again');
+    expect(plan.comment).toContain(RUN.runUrl);
   });
 
-  it('does nothing on a green run with no open tracking issue', () => {
-    expect(planNightlyReport({ ...RUN, failed: [], openIssues: [] })).toEqual({
+  it('closes the oldest duplicate on green, draining extras one per green run', () => {
+    const plan = planNightlyReport({
+      ...RUN,
+      failed: [],
+      completed: FULL_GREEN,
+      openIssues: [openIssue(50), openIssue(42)],
+    });
+    expect(plan.action).toBe('close');
+    if (plan.action !== 'close') throw new Error('unreachable');
+    expect(plan.issueNumber).toBe(42);
+  });
+
+  it('does nothing on a proven green run with no open tracking issue', () => {
+    expect(
+      planNightlyReport({ ...RUN, failed: [], completed: FULL_GREEN, openIssues: [] }),
+    ).toEqual({
       action: 'none',
       reason: 'green run and no open tracking issue',
     });
   });
 
+  it('treats a no-failure run that proved nothing as red, never as recovery', () => {
+    // Zero failures but only the targets job and one lane completed: closing
+    // the tracking issue here would be the silent-green failure mode itself.
+    const partial = [success('Resolve nightly refs'), success('Nightly tests (main)')];
+    const plan = planNightlyReport({
+      ...RUN,
+      failed: [],
+      completed: partial,
+      openIssues: [openIssue(42)],
+    });
+    expect(plan.action).toBe('update');
+    if (plan.action !== 'update') throw new Error('unreachable');
+    expect(plan.body).toContain('only 2 of the 7 expected jobs succeeded (unproven)');
+    // And with no open issue, it files one rather than staying silent.
+    const fresh = planNightlyReport({ ...RUN, failed: [], completed: partial, openIssues: [] });
+    expect(fresh.action).toBe('create');
+  });
+
+  it('treats unknown targets as unproven even with zero failures', () => {
+    const plan = planNightlyReport({
+      ...RUN,
+      targets: [],
+      failed: [],
+      completed: FULL_GREEN,
+      openIssues: [],
+    });
+    expect(plan.action).toBe('create');
+    if (plan.action !== 'create') throw new Error('unreachable');
+    expect(plan.body).toContain('targets are unknown (unproven)');
+    expect(plan.body).toContain('unknown (ref resolution failed)');
+  });
+
+  it('reports a drill under the drill identity and never sees the production issue', () => {
+    const prod = openIssue(42);
+    const drillRun = { ...RUN, targets: ['scratch/broken-test'] };
+    const red = planNightlyReport({
+      ...drillRun,
+      failed: [...FAILED],
+      completed: [],
+      openIssues: [prod],
+      drill: true,
+    });
+    expect(red).toMatchObject({
+      action: 'create',
+      title: NIGHTLY_DRILL_ISSUE_TITLE,
+      labels: [NIGHTLY_DRILL_ISSUE_LABEL],
+    });
+    // A proven green drill (targets job + 3 lanes for its one ref) must not
+    // close the production issue either.
+    const green = planNightlyReport({
+      ...drillRun,
+      failed: [],
+      completed: [
+        success('Resolve nightly refs'),
+        success('Nightly tests (scratch/broken-test)'),
+        success('Nightly checks (scratch/broken-test)'),
+        success('Nightly browser (scratch/broken-test)'),
+      ],
+      openIssues: [prod],
+      drill: true,
+    });
+    expect(green.action).toBe('none');
+    // And it does close its own drill issue.
+    const drillIssue = openIssue(60, { title: NIGHTLY_DRILL_ISSUE_TITLE });
+    const recovery = planNightlyReport({
+      ...drillRun,
+      failed: [],
+      completed: [
+        success('Resolve nightly refs'),
+        success('Nightly tests (scratch/broken-test)'),
+        success('Nightly checks (scratch/broken-test)'),
+        success('Nightly browser (scratch/broken-test)'),
+      ],
+      openIssues: [drillIssue],
+      drill: true,
+    });
+    expect(recovery.action).toBe('close');
+    if (recovery.action !== 'close') throw new Error('unreachable');
+    expect(recovery.issueNumber).toBe(60);
+  });
+
   it('says so in the body when ref resolution failed instead of guessing', () => {
-    const plan = planNightlyReport({ ...RUN, targets: [], failed: [...FAILED], openIssues: [] });
+    const plan = planNightlyReport({
+      ...RUN,
+      targets: [],
+      failed: [...FAILED],
+      completed: [],
+      openIssues: [],
+    });
     if (plan.action !== 'create') throw new Error('expected create');
     expect(plan.body).toContain('unknown (ref resolution failed)');
   });

--- a/tests/nightly_workflow.test.ts
+++ b/tests/nightly_workflow.test.ts
@@ -1,0 +1,133 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const workflow = readFileSync(new URL('../.github/workflows/nightly.yml', import.meta.url), 'utf8');
+const packageJson = JSON.parse(
+  readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
+) as { packageManager?: string };
+const targetsEntry = readFileSync(
+  new URL('../scripts/nightly_targets.mjs', import.meta.url),
+  'utf8',
+);
+const reportEntry = readFileSync(new URL('../scripts/nightly_report.mjs', import.meta.url), 'utf8');
+
+const PNPM_VERSION = (() => {
+  const field = packageJson.packageManager ?? '';
+  const match = field.match(/^pnpm@(\d+\.\d+\.\d+)$/);
+  if (!match) {
+    throw new Error(`package.json packageManager must be pnpm@X.Y.Z, got ${JSON.stringify(field)}`);
+  }
+  return match[1];
+})();
+
+// Same job-boundary slicing as tests/ci_workflow.test.ts: the lookahead stops
+// at the next two-space job key so one job's text cannot satisfy a pin meant
+// for another.
+function jobSource(name: string): string {
+  const match = workflow.match(
+    new RegExp(`\\n  ${name}:[\\s\\S]*?(?=\\n  [A-Za-z][A-Za-z0-9_-]*:|$)`),
+  );
+  if (!match) throw new Error(`missing nightly job: ${name}`);
+  return match[0];
+}
+
+// The serialized check steps the nightly mirrors from ci.yml's release-checks
+// job (minus the tsc incremental cache, which is keyed to a moving tip here).
+const NIGHTLY_CHECK_STEPS = [
+  'run: npm run i18n:gen',
+  'run: git diff --exit-code -- src/ui/i18n.resolved.generated',
+  'run: npm run security:gate',
+  'run: npm run check:types',
+  'run: npm run build:env',
+  'run: npm run build:server',
+  'run: npm run build:bot',
+  'run: npm run build\n',
+] as const;
+
+describe('nightly gate workflow', () => {
+  it('runs on a schedule and manual dispatch only, never on PR or push traffic', () => {
+    const triggers = workflow.slice(workflow.indexOf('\non:'), workflow.indexOf('\npermissions:'));
+    expect(triggers).toMatch(
+      /\n {2}schedule:\n {4}# [^\n]+\n[^\n]*\n {4}- cron: '47 4 \* \* \*'\n/,
+    );
+    expect(triggers).toContain('workflow_dispatch:');
+    expect(triggers).toMatch(/\n {6}ref:\n/);
+    // The whole point of a separate file: zero added PR latency, and no cron
+    // fan-out into ci.yml's PR-shaped jobs (same reasoning as audit.yml).
+    expect(triggers).not.toContain('pull_request');
+    expect(triggers).not.toMatch(/\n {2}push:/);
+  });
+
+  it('resolves refs through the tested script and fans every lane over them', () => {
+    const targets = jobSource('targets');
+    expect(targets).toContain('run: node scripts/nightly_targets.mjs');
+    expect(targets).toContain('refs: ${{ steps.resolve.outputs.refs }}');
+    expect(targets).toContain('NIGHTLY_REF: ${{ inputs.ref }}');
+    expect(targets).toContain('filter: blob:none');
+    for (const name of ['tests', 'checks', 'browser'] as const) {
+      const job = jobSource(name);
+      expect(job).toMatch(/^\s{4}needs: targets$/m);
+      expect(job).toContain('ref: ${{ fromJSON(needs.targets.outputs.refs) }}');
+      expect(job).toContain('fail-fast: false');
+      expect(job).toContain('ref: ${{ matrix.ref }}');
+      expect(job).toContain('run: pnpm install --frozen-lockfile');
+      expect(job).toContain(`version: ${PNPM_VERSION}`);
+    }
+    // The entry scripts stay wired to the unit-tested planning lib.
+    expect(targetsEntry).toContain("from './lib/nightly_plan.mjs'");
+    expect(targetsEntry).toContain('refs=');
+    expect(reportEntry).toContain("from './lib/nightly_plan.mjs'");
+    expect(reportEntry).toContain('planNightlyReport');
+  });
+
+  it('runs the full unsharded suite per ref, with the bounded worker cap', () => {
+    const tests = jobSource('tests');
+    expect(tests).toContain(
+      'run: npm test -- --maxWorkers="$(node -p \'Math.max(1, Math.floor(require("node:os").availableParallelism() / 2))\')"',
+    );
+    // Unsharded by design: a --shard flag here would quietly turn the nightly
+    // proof into a partial run.
+    expect(tests).not.toContain('--shard');
+    expect(tests).not.toContain('I18N_RELEASE_TIER');
+  });
+
+  it('mirrors the serialized release checks and the browser lane', () => {
+    const checks = jobSource('checks');
+    for (const step of NIGHTLY_CHECK_STEPS) {
+      expect(checks).toMatch(new RegExp(`\\n {8}${step.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`));
+    }
+    expect(checks).not.toContain('run: npm test');
+    const browser = jobSource('browser');
+    expect(browser).toContain('run: npx playwright install --with-deps chromium');
+    expect(browser).toContain('run: npm run test:browser');
+    expect(browser).toContain('path: ~/.cache/ms-playwright');
+  });
+
+  it('always reports, and only the report job may write issues', () => {
+    const report = jobSource('report');
+    expect(report).toMatch(/^\s{4}needs: \[targets, tests, checks, browser\]$/m);
+    expect(report).toMatch(/^\s{4}if: \$\{\{ always\(\) \}\}$/m);
+    expect(report).toContain('run: node scripts/nightly_report.mjs');
+    expect(report).toContain('GITHUB_TOKEN: ${{ github.token }}');
+    expect(report).toContain('NIGHTLY_TARGETS: ${{ needs.targets.outputs.refs }}');
+    // The report job must judge the workflow's own ref, never the matrix ref:
+    // it is the one job holding a write scope.
+    expect(report).not.toContain('matrix.ref');
+    // Workflow-level permissions stay read-only; the report job's block is the
+    // only widen and issues: write is the only write scope in the file.
+    expect(workflow).toMatch(/\npermissions:\n {2}contents: read\n\n/);
+    expect(workflow.match(/^\s*permissions:/gm)).toHaveLength(2);
+    expect(report).toMatch(/\n {4}permissions:\n {6}contents: read\n {6}issues: write\n/);
+    expect(workflow.match(/^\s*[\w-]+: write\s*$/gm)).toEqual(['      issues: write']);
+    expect(workflow).not.toContain('secrets.');
+    expect(workflow).not.toContain('pull_request_target');
+  });
+
+  it('bounds every job so a wedged runner cannot eat the night', () => {
+    // One timeout per job: five jobs, five timeouts.
+    expect(workflow.match(/^\s{4}timeout-minutes: \d+$/gm)).toHaveLength(5);
+    // Nothing cancels a nightly pass; dispatch and schedule stay in separate
+    // concurrency groups.
+    expect(workflow).toContain('cancel-in-progress: false');
+  });
+});

--- a/tests/nightly_workflow.test.ts
+++ b/tests/nightly_workflow.test.ts
@@ -1,7 +1,9 @@
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
+import { NIGHTLY_LANES_PER_REF } from '../scripts/lib/nightly_plan.mjs';
 
 const workflow = readFileSync(new URL('../.github/workflows/nightly.yml', import.meta.url), 'utf8');
+const ciWorkflow = readFileSync(new URL('../.github/workflows/ci.yml', import.meta.url), 'utf8');
 const packageJson = JSON.parse(
   readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
 ) as { packageManager?: string };
@@ -23,26 +25,28 @@ const PNPM_VERSION = (() => {
 // Same job-boundary slicing as tests/ci_workflow.test.ts: the lookahead stops
 // at the next two-space job key so one job's text cannot satisfy a pin meant
 // for another.
-function jobSource(name: string): string {
-  const match = workflow.match(
-    new RegExp(`\\n  ${name}:[\\s\\S]*?(?=\\n  [A-Za-z][A-Za-z0-9_-]*:|$)`),
-  );
-  if (!match) throw new Error(`missing nightly job: ${name}`);
+function jobSourceIn(text: string, name: string, file: string): string {
+  const match = text.match(new RegExp(`\\n  ${name}:[\\s\\S]*?(?=\\n  [A-Za-z][A-Za-z0-9_-]*:|$)`));
+  if (!match) throw new Error(`missing ${file} job: ${name}`);
   return match[0];
 }
+const jobSource = (name: string) => jobSourceIn(workflow, name, 'nightly.yml');
 
-// The serialized check steps the nightly mirrors from ci.yml's release-checks
-// job (minus the tsc incremental cache, which is keyed to a moving tip here).
-const NIGHTLY_CHECK_STEPS = [
-  'run: npm run i18n:gen',
-  'run: git diff --exit-code -- src/ui/i18n.resolved.generated',
-  'run: npm run security:gate',
-  'run: npm run check:types',
-  'run: npm run build:env',
-  'run: npm run build:server',
-  'run: npm run build:bot',
-  'run: npm run build\n',
-] as const;
+// Anchored step-line form (\n + exact indent), the repo's comment-proof pin:
+// a YAML-commented-out step keeps the substring but loses the anchored shape.
+const stepLine = (line: string) =>
+  new RegExp(`\\n {8}${line.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`);
+
+/** Every run: line of a job, in order, trimmed. */
+function runLines(job: string): string[] {
+  return (job.match(/\n {8}run: [^\n]+/g) ?? []).map((line) => line.trim());
+}
+
+// The five jobs, in file order. The inventory is pinned so a new lane cannot
+// arrive without joining every per-job assertion below (timeout, checkout
+// hygiene), and so the lanes-per-ref constant stays wired to reality.
+const JOB_NAMES = ['targets', 'tests', 'checks', 'browser', 'report'] as const;
+const LANE_JOBS = ['tests', 'checks', 'browser'] as const;
 
 describe('nightly gate workflow', () => {
   it('runs on a schedule and manual dispatch only, never on PR or push traffic', () => {
@@ -58,76 +62,116 @@ describe('nightly gate workflow', () => {
     expect(triggers).not.toMatch(/\n {2}push:/);
   });
 
+  it('keeps the job inventory pinned, each job bounded, and every checkout credential-free', () => {
+    const jobsSection = workflow.slice(workflow.indexOf('\njobs:'));
+    const jobKeys = (jobsSection.match(/^ {2}[a-z][\w-]*:$/gm) ?? []).map((key) =>
+      key.trim().replace(/:$/, ''),
+    );
+    expect(jobKeys).toEqual([...JOB_NAMES]);
+    for (const name of JOB_NAMES) {
+      const job = jobSource(name);
+      // A wedged runner must fail the job, not eat the night.
+      expect(job).toMatch(/\n {4}timeout-minutes: \d+\n/);
+      // No checkout leaves a token in .git/config (pr-ai.yml precedent): the
+      // write-scoped report job must not persist one, and the lanes are where
+      // arbitrary-ref code runs.
+      expect(job).toContain('persist-credentials: false');
+    }
+    expect(workflow.match(/persist-credentials: false/g)).toHaveLength(JOB_NAMES.length);
+    // Nothing cancels a nightly pass; dispatch and schedule stay in separate
+    // concurrency groups.
+    expect(workflow).toContain('cancel-in-progress: false');
+  });
+
   it('resolves refs through the tested script and fans every lane over them', () => {
     const targets = jobSource('targets');
-    expect(targets).toContain('run: node scripts/nightly_targets.mjs');
+    expect(targets).toMatch(stepLine('run: node scripts/nightly_targets.mjs'));
     expect(targets).toContain('refs: ${{ steps.resolve.outputs.refs }}');
     expect(targets).toContain('NIGHTLY_REF: ${{ inputs.ref }}');
+    // The real default branch rides in from the event, so a renamed default
+    // branch cannot strand the nightly on a hardcoded 'main'.
+    expect(targets).toContain(
+      'NIGHTLY_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}',
+    );
     expect(targets).toContain('filter: blob:none');
-    for (const name of ['tests', 'checks', 'browser'] as const) {
+    for (const name of LANE_JOBS) {
       const job = jobSource(name);
       expect(job).toMatch(/^\s{4}needs: targets$/m);
       expect(job).toContain('ref: ${{ fromJSON(needs.targets.outputs.refs) }}');
       expect(job).toContain('fail-fast: false');
       expect(job).toContain('ref: ${{ matrix.ref }}');
-      expect(job).toContain('run: pnpm install --frozen-lockfile');
+      expect(job).toMatch(stepLine('run: pnpm install --frozen-lockfile'));
       expect(job).toContain(`version: ${PNPM_VERSION}`);
     }
-    // The entry scripts stay wired to the unit-tested planning lib.
+    // The proven-green guard counts this many lanes per ref; the workflow and
+    // the planning lib must agree or every night reads as unproven.
+    expect(LANE_JOBS).toHaveLength(NIGHTLY_LANES_PER_REF);
+    // The entry scripts stay wired to the unit-tested planning lib: the
+    // targets entry emits the JSON-escaped refs output the matrix consumes,
+    // and the report entry calls the planner and the drill identity switch.
     expect(targetsEntry).toContain("from './lib/nightly_plan.mjs'");
-    expect(targetsEntry).toContain('refs=');
+    expect(targetsEntry).toContain('refs=${JSON.stringify(targets)}');
+    expect(targetsEntry).toContain('refNamesFromMatchingRefs(');
     expect(reportEntry).toContain("from './lib/nightly_plan.mjs'");
-    expect(reportEntry).toContain('planNightlyReport');
+    expect(reportEntry).toMatch(/planNightlyReport\(\{/);
+    expect(reportEntry).toContain('summarizeRunJobs(');
+    expect(reportEntry).toContain('trackingIssueIdentity(');
+    expect(reportEntry).toContain('parseTargetsEnv(');
+    expect(reportEntry).toContain('labelEnsureFailed(');
   });
 
   it('runs the full unsharded suite per ref, with the bounded worker cap', () => {
     const tests = jobSource('tests');
+    expect(tests).toMatch(stepLine('run: npm test -- --maxWorkers='));
     expect(tests).toContain(
       'run: npm test -- --maxWorkers="$(node -p \'Math.max(1, Math.floor(require("node:os").availableParallelism() / 2))\')"',
     );
     // Unsharded by design: a --shard flag here would quietly turn the nightly
     // proof into a partial run.
     expect(tests).not.toContain('--shard');
-    expect(tests).not.toContain('I18N_RELEASE_TIER');
+    // The expected-red release-i18n locale tier stays out of the whole file
+    // (issue #2820), not just out of the tests job.
+    expect(workflow).not.toContain('I18N_RELEASE_TIER');
   });
 
-  it('mirrors the serialized release checks and the browser lane', () => {
+  it('mirrors the serialized release checks from ci.yml and the browser lane', () => {
+    // Derived from ci.yml rather than a hand-copied list, so a check step
+    // added to the release lane cannot leave the nightly silently thinner.
+    // The tsc incremental cache is a uses: step, not a run: step, so the two
+    // run-line sequences must match exactly, in order.
+    const releaseChecks = jobSourceIn(ciWorkflow, 'release-checks', 'ci.yml');
     const checks = jobSource('checks');
-    for (const step of NIGHTLY_CHECK_STEPS) {
-      expect(checks).toMatch(new RegExp(`\\n {8}${step.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`));
-    }
+    expect(runLines(checks)).toEqual(runLines(releaseChecks));
     expect(checks).not.toContain('run: npm test');
     const browser = jobSource('browser');
-    expect(browser).toContain('run: npx playwright install --with-deps chromium');
-    expect(browser).toContain('run: npm run test:browser');
+    expect(browser).toMatch(stepLine('run: npx playwright install --with-deps chromium'));
+    expect(browser).toMatch(stepLine('run: npm run test:browser'));
     expect(browser).toContain('path: ~/.cache/ms-playwright');
   });
 
   it('always reports, and only the report job may write issues', () => {
     const report = jobSource('report');
     expect(report).toMatch(/^\s{4}needs: \[targets, tests, checks, browser\]$/m);
-    expect(report).toMatch(/^\s{4}if: \$\{\{ always\(\) \}\}$/m);
-    expect(report).toContain('run: node scripts/nightly_report.mjs');
+    expect(report).toMatch(/^ {4}if: .*always\(\)/m);
+    expect(report).toMatch(stepLine('run: node scripts/nightly_report.mjs'));
     expect(report).toContain('GITHUB_TOKEN: ${{ github.token }}');
     expect(report).toContain('NIGHTLY_TARGETS: ${{ needs.targets.outputs.refs }}');
-    // The report job must judge the workflow's own ref, never the matrix ref:
-    // it is the one job holding a write scope.
+    // The drill switch: a dispatch ref makes the report use the drill issue
+    // identity instead of the production one.
+    expect(report).toContain('NIGHTLY_REF: ${{ inputs.ref }}');
+    // The report job must judge the workflow's own ref, never a resolved one:
+    // it is the one job holding a write scope, so its checkout carries no
+    // ref: input at all (not merely not matrix.ref).
     expect(report).not.toContain('matrix.ref');
+    expect(report).not.toMatch(/^ {10}ref:/m);
     // Workflow-level permissions stay read-only; the report job's block is the
     // only widen and issues: write is the only write scope in the file.
     expect(workflow).toMatch(/\npermissions:\n {2}contents: read\n\n/);
     expect(workflow.match(/^\s*permissions:/gm)).toHaveLength(2);
     expect(report).toMatch(/\n {4}permissions:\n {6}contents: read\n {6}issues: write\n/);
     expect(workflow.match(/^\s*[\w-]+: write\s*$/gm)).toEqual(['      issues: write']);
+    expect(workflow).not.toContain('write-all');
     expect(workflow).not.toContain('secrets.');
     expect(workflow).not.toContain('pull_request_target');
-  });
-
-  it('bounds every job so a wedged runner cannot eat the night', () => {
-    // One timeout per job: five jobs, five timeouts.
-    expect(workflow.match(/^\s{4}timeout-minutes: \d+$/gm)).toHaveLength(5);
-    // Nothing cancels a nightly pass; dispatch and schedule stay in separate
-    // concurrency groups.
-    expect(workflow).toContain('cancel-in-progress: false');
   });
 });

--- a/tests/nightly_workflow.test.ts
+++ b/tests/nightly_workflow.test.ts
@@ -23,10 +23,13 @@ const PNPM_VERSION = (() => {
 })();
 
 // Same job-boundary slicing as tests/ci_workflow.test.ts: the lookahead stops
-// at the next two-space job key so one job's text cannot satisfy a pin meant
-// for another.
+// at the next two-space job key OR a top-level comment line (which documents
+// the next job), so one job's text or a neighbour's comment cannot satisfy a
+// pin meant for another.
 function jobSourceIn(text: string, name: string, file: string): string {
-  const match = text.match(new RegExp(`\\n  ${name}:[\\s\\S]*?(?=\\n  [A-Za-z][A-Za-z0-9_-]*:|$)`));
+  const match = text.match(
+    new RegExp(`\\n  ${name}:[\\s\\S]*?(?=\\n  [A-Za-z][A-Za-z0-9_-]*:|\\n  #|$)`),
+  );
   if (!match) throw new Error(`missing ${file} job: ${name}`);
   return match[0];
 }

--- a/tests/nightly_workflow.test.ts
+++ b/tests/nightly_workflow.test.ts
@@ -141,6 +141,11 @@ describe('nightly gate workflow', () => {
     // run-line sequences must match exactly, in order.
     const releaseChecks = jobSourceIn(ciWorkflow, 'release-checks', 'ci.yml');
     const checks = jobSource('checks');
+    // runLines reads single-line run: steps only, so a block scalar would be
+    // compared by its first line alone; refuse loudly instead of comparing a
+    // truncated view.
+    expect(checks).not.toContain('run: |');
+    expect(releaseChecks).not.toContain('run: |');
     expect(runLines(checks)).toEqual(runLines(releaseChecks));
     expect(checks).not.toContain('run: npm test');
     const browser = jobSource('browser');
@@ -152,7 +157,9 @@ describe('nightly gate workflow', () => {
   it('always reports, and only the report job may write issues', () => {
     const report = jobSource('report');
     expect(report).toMatch(/^\s{4}needs: \[targets, tests, checks, browser\]$/m);
-    expect(report).toMatch(/^ {4}if: .*always\(\)/m);
+    // Anchored to the full line (both legal spellings): `always() && false`
+    // would silently disable the workflow's only alerting deliverable.
+    expect(report).toMatch(/^ {4}if: (\$\{\{ always\(\) \}\}|always\(\))$/m);
     expect(report).toMatch(stepLine('run: node scripts/nightly_report.mjs'));
     expect(report).toContain('GITHUB_TOKEN: ${{ github.token }}');
     expect(report).toContain('NIGHTLY_TARGETS: ${{ needs.targets.outputs.refs }}');


### PR DESCRIPTION
## Summary

On 2026-08-05 the release tip carried 67 broken tests for days: the push runs that showed it were red with nobody watching, so every open PR inherited failures its author could not explain. Tip rot needs to page someone the same day.

This adds `.github/workflows/nightly.yml`: a scheduled run (04:47 UTC daily) that re-proves the tips of `main` and the highest `release/vX.Y.Z` branch. Per ref it runs the full unsharded test suite (the same one the local gate runs, bounded workers, PR tier), the serialized checks lane (asserted step-for-step equal to ci.yml's release-checks run list by `tests/nightly_workflow.test.ts`, so mirror drift fails a test), and the Chromium browser lane.

The verdict lands in exactly one tracking issue (label `nightly-gate`, matched by label AND exact title so a mislabeled unrelated issue can never be overwritten or auto-closed): created on the first red run, updated with the failed-job list on repeat failures, closed with a recovery comment on the first green run. Two hardening rules from review: a run that reports no failures but did not actually complete its lanes counts as "unproven" and stays red (a nightly that ran nothing must never read as recovery), and a `workflow_dispatch` with the `ref` input reports under a separate `nightly-gate-drill` identity so acceptance drills against scratch branches never touch the production issue. Dispatching with the ref input left empty is a manual production pass.

Decision logic is pure and tested (`scripts/lib/nightly_plan.mjs`); the two entries (`scripts/nightly_targets.mjs`, `scripts/nightly_report.mjs`) are stdlib-only HTTP plumbing. Ref resolution fails toward still gating the default branch, loudly; the report job fails loudly (a dead report job is itself a red run). Security posture: workflow-level `contents: read`; the report job alone holds `issues: write`, checks out only the workflow's own ref (pinned to carry no `ref:` key at all), and every checkout sets `persist-credentials: false`.

Deliberate exclusions, documented in the workflow header: the release-i18n 21-locale lane (legitimately red mid-cycle until the release locale fill, issue #2820, and alerting on it nightly would keep the tracking issue permanently open) and the release version gate (cannot rot without a push, which ci.yml covers). The workflow has no `pull_request` or `push` trigger and adds zero PR latency; it lives outside ci.yml for the same reason audit.yml does.

Notes for after the merge: GitHub reads schedules from the default branch, so the cron arms once this reaches `main`; until then it can be dispatched manually on the release branch. The acceptance drill (scratch branch with a deliberately broken test, dispatch with the ref input, expect one drill issue, an update on a second red, a close on recovery) should be run once after landing. `docs/qa-gate.md` gains the nightly layer row and section, which also resolves the existing dangling "scheduled full run" references in `scripts/gate_select.mjs` and `scripts/CLAUDE.md`.

## Type of change

- [x] Build, CI, or tooling
- [x] Tests
- [x] Documentation

## How was this tested?

- Commands:
  - `npx vitest run tests/nightly_plan.test.ts tests/nightly_workflow.test.ts tests/deploy_node_version.test.ts tests/ci_workflow.test.ts` (the alerting contract per-branch: exactly-one issue, oldest-wins on duplicates, close-on-recovery, unproven-is-never-recovery, drill isolation, semver picker on all three dimensions; the workflow shape: job inventory, per-job timeouts, credential-free checkouts, single write scope, anchored comment-proof step pins, the ci.yml checks mirror)
  - `node scripts/gate_select.mjs` (suites, browser, typecheck, builds)
  - `npx tsc --noEmit`, changed-files Biome clean
- Manual steps: smoke-ran `scripts/nightly_targets.mjs` for the API-failure fallback (gates `main` alone, loudly) and the dispatch override; confirmed `scripts/nightly_report.mjs` fails loudly without its environment.
- Reviewed by qa-checklist, privacy-security-review, and test-coverage-auditor agents (the coverage pass mutation-tested the pins; the QA pass verified the proven-green arithmetic by simulation and the checks mirror against canonical main's ci.yml); all findings applied across two review rounds.

---

## Checklist

### Quality

- [x] **The gate passes.** `node scripts/gate_select.mjs` is green. I added or updated decisive tests for changed behavior and recorded any manual checks above.

### Cross-platform

- ~Tested on desktop and mobile.~ N/A: CI-only change, no UI.
- ~Accessible.~ N/A.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings (issue text and job logs are the operator/dev channel).

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files.
