### PR TITLE
docs(ci): dispatch also waits for the nightly workflow to reach main

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -23,15 +23,18 @@ name: Nightly gate
 # permanently open and train everyone to ignore it. The release push run in
 # ci.yml still carries that lane.
 #
-# The schedule fires on the default branch, so the cron arms only once this
-# file reaches main. workflow_dispatch has two modes: with the ref input
-# EMPTY it is a manual production pass (gates main plus the release tip and
-# reports under the production issue identity); with a ref it gates exactly
-# that one ref and reports under the separate nightly-gate-drill identity, so
-# an acceptance drill against a scratch branch with a deliberately broken
-# test never touches the production tracking issue. A red drill's issue has
-# nothing scheduled to drain it: close it by hand, or finish the drill with a
-# green dispatch at the same ref.
+# GitHub registers a workflow (its cron AND its workflow_dispatch surface)
+# from the DEFAULT branch, so nothing here can fire until this file reaches
+# main with a release merge: before that, dispatching by name or file 404s
+# (verified 2026-08-05). Once registered, workflow_dispatch has two modes:
+# with the ref input EMPTY it is a manual production pass (gates main plus
+# the release tip and reports under the production issue identity); with a
+# ref it gates exactly that one ref and reports under the separate
+# nightly-gate-drill identity, so an acceptance drill against a scratch
+# branch with a deliberately broken test never touches the production
+# tracking issue. A red drill's issue has nothing scheduled to drain it:
+# close it by hand, or finish the drill with a green dispatch at the same
+# ref.
 on:
   schedule:
     # Daily, 04:47 UTC. Off the hour so this does not pile into the

--- a/docs/qa-gate.md
+++ b/docs/qa-gate.md
@@ -207,8 +207,9 @@ by hand or finish the drill with a green dispatch at the same ref.
 
 Deliberate exclusions: the release-i18n 21-locale lane (expected red mid-cycle, issue
 #2820) and the release version gate (cannot rot without a push, which ci.yml covers).
-The cron arms only once the workflow file reaches `main` (GitHub reads schedules from
-the default branch); until then, dispatch it manually on the branch that carries it.
+GitHub registers a workflow's cron AND its `workflow_dispatch` surface from the default
+branch, so neither can fire until the file reaches `main` with a release merge; the
+first drill and the first manual pass both come after that.
 Planning logic: `scripts/lib/nightly_plan.mjs`, pinned by `tests/nightly_plan.test.ts`;
 the workflow shape is pinned by `tests/nightly_workflow.test.ts`.
 


### PR DESCRIPTION
## Summary

Follow-up to #2987. The workflow header and the docs/qa-gate.md nightly section claimed the workflow could be dispatched manually on the branch that carries it before the cron arms. That is wrong, verified against the live API right after the merge: GitHub registers a workflow_dispatch surface from the default branch only, so dispatching the nightly by name or file path 404s until a release merge lands the file on main. Both the acceptance drill and the manual production pass wait for that; this corrects the two comments so nobody burns time on a 404 later.

Comment and docs text only; no behavior change. The workflow-shape tests still pass (the trigger pins live inside the on: block, untouched).

## Type of change

- [x] Documentation

## How was this tested?

- Commands: npx vitest run tests/nightly_workflow.test.ts tests/nightly_plan.test.ts tests/ci_workflow.test.ts (49 tests green)
- Manual steps: gh api repos/levy-street/world-of-claudecraft/actions/workflows/nightly.yml returns 404 while the file exists only on release/v0.35.0, confirming the corrected claim.

## Checklist

- [x] N/A. Comment and docs text only; no player-visible strings, no behavior change.