### PR TITLE
test(drill): selective-tier measurement, content-only (do not merge)

### DIFF
--- a/src/sim/content/amberfall.ts
+++ b/src/sim/content/amberfall.ts
@@ -573,3 +573,5 @@ export const AMBERFALL_PROPS: ZonePropsDef = {
     [-364, 1838],
   ],
 };
+
+// Phase 2 selective-CI measurement drill: content-only comment-level change.


### PR DESCRIPTION
Measurement drill for the Phase 2 packet notes: a comment-level content-only diff, expected to run mode=selective with a large related set (the honest content-PR number). Will be closed once the wall clock is recorded. Do not merge.