### PR TITLE
test(content): fill the forgotten deeds catalog hash pin

### DIFF
--- a/tests/deeds_content.test.ts
+++ b/tests/deeds_content.test.ts
@@ -508,7 +508,7 @@ describe('frozen trigger + renown catalog (design rule 9: never retro-edit a tri
   // amberfall, nightbloom, wraithwood, palmreach, and evergarden (drakelands
   // already covered by the brood rework above). No shipped trigger or renown
   // changed on either side.
-  const FROZEN_CATALOG_SHA256 = 'PLACEHOLDER';
+  const FROZEN_CATALOG_SHA256 = 'edaa9bd88929ab1cb7c586e162577c41f2f52240d615ecbd4d308e5daec95a25';
 
   it('every shipped deed keeps its trigger and renown unchanged', () => {
     const canonical = JSON.stringify(


### PR DESCRIPTION
<!--
Thanks for contributing to World of ClaudeCraft!
-->

## Summary

`tests/deeds_content.test.ts` fails on a clean checkout of `release/v0.35.0`: the
frozen-catalog hash guard (`FROZEN_CATALOG_SHA256`) was left as the literal string
`'PLACEHOLDER'` instead of the regenerated digest when the trailing re-baseline
comment (Rift coverage plus the remaining bottom-map chronicle deed pairs) was
written. This fills in the real hash so the pre-existing test failure is fixed,
with no change to deed content itself.

## Related issues

N/A

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx tsc --noEmit`
  - `npx vitest run tests/deeds_content.test.ts` (was failing on `release/v0.35.0`, now passes)
  - `npm run gate` (full CI-equivalent gate: i18n gen + freshness, malware scan, biome,
    full test suite, `tsc`, all builds) - green
- Manual steps: N/A (test-only change, no player- or operator-visible behavior)

### Why this test was flagged, not the five others that also failed under an unbounded run

An initial unbounded `npx vitest run` also showed transient failures in
`threat.test.ts`, `eastbrook_gameplay_integration.test.ts`, `escort_quest.test.ts`,
`frost_mage_procs.test.ts`, and `parity/coverage_c.test.ts`. Each of those passed
individually and passed again under `npm run gate`'s bounded-worker run, confirming
they were CPU-contention flakiness from running the whole suite unbounded, not a
real regression:

```mermaid
flowchart TD
    A["npx vitest run (unbounded)"] --> B{"8 files fail"}
    B --> C["2 files: i18n_status_registry,\nlocalization_fixes"]
    B --> D["1 file: deeds_content\n(fails in isolation too)"]
    B --> E["5 files: threat, eastbrook_gameplay_integration,\nescort_quest, frost_mage_procs, parity/coverage_c\n(pass in isolation)"]
    C --> F["Fixed by npm run i18n:gen\n(gitignored generated artifact, not a bug)"]
    D --> G["Real bug: FROZEN_CATALOG_SHA256\nwas the literal 'PLACEHOLDER'"]
    E --> H["Worker-contention flakiness under\nan unbounded parallel run"]
    G --> I["Fixed in this PR"]
    H --> J["npm run gate (bounded workers)\nall green, no fix needed"]
```

## Screenshots / recordings

N/A. Test-only change with no player- or operator-visible surface.

---

## Checklist

### Quality

- [x] **The gate passes.** `npm run gate` is green. I added the fix as a decisive,
      single-line change to an existing pinned-hash test rather than loosening the
      assertion.

### Cross-platform

- ~Tested on desktop and mobile.~ N/A, no UI surface touched.
- ~Accessible.~ N/A, no UI surface touched.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files.
