### PR TITLE
test: stabilize 9 flaky vitest tests (real-timer races, fake-timer leaks, resource leaks, marginal timeouts, order-dependence)

### DIFF
--- a/tests/admin/guilds_page.test.ts
+++ b/tests/admin/guilds_page.test.ts
@@ -411,6 +411,7 @@ describe('Guilds page', () => {
   });
 
   it('ignores an older directory response that resolves after a newer search', async () => {
+    vi.useFakeTimers();
     grantPermissions(['accounts.read']);
     let resolveOld!: (value: typeof directory) => void;
     let resolveNew!: (value: typeof directory) => void;
@@ -428,7 +429,11 @@ describe('Guilds page', () => {
     await fireEvent.input(screen.getByRole('textbox', { name: t('guilds.searchLabel') }), {
       target: { value: 'new' },
     });
-    await new Promise((resolve) => setTimeout(resolve, 350));
+    // Fires the search debounce (SEARCH_DEBOUNCE_MS = 300ms, src/admin/state/poll.ts)
+    // via fake timers rather than a real-time wait: a real setTimeout(resolve, 350)
+    // here raced the component's own 300ms debounce with only a 50ms margin, so it
+    // flaked under CI/full-suite core contention. Advancing fake time is deterministic.
+    await vi.advanceTimersByTimeAsync(300);
 
     resolveNew({
       ...directory,

--- a/tests/admin_guilds_db_integration.test.ts
+++ b/tests/admin_guilds_db_integration.test.ts
@@ -576,18 +576,36 @@ describeDb('admin guild production SQL (real Postgres)', () => {
   });
 
   it('surfaces guild renames in the realm-wide moderation history', async () => {
+    // Self-contained fixture: seed and rename a guild owned by this test alone,
+    // instead of reading the renames left behind by earlier tests in this block.
+    // That keeps the assertions correct under -t filtering, .only, or reordering.
+    const client = await bootstrap.connect();
+    try {
+      await seedGuild(client, 'History Target', QUERY_REALM, []);
+    } finally {
+      client.release();
+    }
+    const target = guildId('History Target');
+    const renamed = await guildsDb.renameAdminGuild(
+      target,
+      'History Renamed',
+      'audit trail proof',
+      adminAccountId,
+    );
+    expect('result' in renamed).toBe(true);
+
     const history = await adminDb.listModerationActions('all', adminAccountId, 1, 50);
 
-    const renames = history.rows.filter((row) => row.source === 'guild');
-    expect(renames.length).toBeGreaterThanOrEqual(2);
+    const renames = history.rows.filter((row) => row.source === 'guild' && row.guildId === target);
+    expect(renames.length).toBeGreaterThanOrEqual(1);
     expect(renames.every((row) => row.action === adminDb.GUILD_RENAME_ACTION)).toBe(true);
     expect(renames.every((row) => row.adminUsername === 'moderator')).toBe(true);
     // guild_name resolves to the guild's CURRENT name, not the audited one.
-    expect(renames.map((row) => row.guildName)).toContain('Renamed Guild');
+    expect(renames.map((row) => row.guildName)).toContain('History Renamed');
     expect(renames.every((row) => row.accountId === null && row.ip === null)).toBe(true);
 
     const mine = await adminDb.listModerationActions('mine', adminAccountId, 1, 50);
-    expect(mine.rows.some((row) => row.source === 'guild')).toBe(true);
+    expect(mine.rows.some((row) => row.source === 'guild' && row.guildId === target)).toBe(true);
 
     // A rename is never a note, so the notes tab must not carry the guild arm.
     const notes = await adminDb.listModerationActions('notes', adminAccountId, 1, 50);

--- a/tests/deploy_game_ops.test.ts
+++ b/tests/deploy_game_ops.test.ts
@@ -178,12 +178,18 @@ describe('healthcheck probe behavior (executed)', () => {
 
   it('exits 0 on a 200, and nonzero on a 503 and on a refused connection', async () => {
     const ok = await listen(200);
-    expect(await runProbe(ok.port)).toBe(0);
-    await new Promise((resolve) => ok.server.close(resolve));
+    try {
+      expect(await runProbe(ok.port)).toBe(0);
+    } finally {
+      await new Promise((resolve) => ok.server.close(resolve));
+    }
 
     const stalled = await listen(503);
-    expect(await runProbe(stalled.port)).toBe(1);
-    await new Promise((resolve) => stalled.server.close(resolve));
+    try {
+      expect(await runProbe(stalled.port)).toBe(1);
+    } finally {
+      await new Promise((resolve) => stalled.server.close(resolve));
+    }
 
     // Reuse the just-freed port for the refused arm: nothing listens there anymore.
     expect(await runProbe(stalled.port)).toBe(1);

--- a/tests/escort_quest.test.ts
+++ b/tests/escort_quest.test.ts
@@ -241,6 +241,11 @@ describe('escort run lifecycle', () => {
     expect(sim.escortRuns.get(ESCORT_ID)?.run ?? null).toBeNull();
   });
 
+  // 60s budget: drives up to 4800 real ticks of NPC pathing to the final
+  // waypoint (terrain movement, not a jumpable deadline), and has been
+  // measured at ~5.3s standalone, only ~3.8x headroom under the 20s default
+  // (see tests/stable_yard.test.ts and tests/emerald_deck_escape.test.ts for
+  // the same long-tick-loop-walker convention).
   it('credits the quest for the nearby escorting player at the final waypoint', () => {
     const sim = makeSim();
     const def = ESCORTS[ESCORT_ID];
@@ -281,7 +286,7 @@ describe('escort run lifecycle', () => {
     if (!npcEntity) return;
     sim.talkToNpc(npcEntity.id);
     expect(sim.questLog.get(QUEST_ID)?.state ?? 'done').toBe('done');
-  });
+  }, 60_000);
 });
 
 describe('escort run guards', () => {
@@ -329,6 +334,11 @@ describe('escort run guards', () => {
     expect(state.run?.waypointIndex ?? before + 1).toBeGreaterThan(before);
   });
 
+  // 60s budget: four sequential real-tick loops (walk to ambush, evade past
+  // the leash, re-engage, resume the attack) with a cumulative worst case of
+  // 6600 ticks of mob AI/leash simulation that cannot be jumped ahead, the
+  // same long-tick-loop-walker convention as tests/stable_yard.test.ts and
+  // tests/emerald_deck_escape.test.ts.
   it('re-engages an evaded ambush wave onto the escortee instead of wedging the run', () => {
     const sim = makeSim();
     const def = ESCORTS[ESCORT_ID];
@@ -398,7 +408,7 @@ describe('escort run guards', () => {
     expect(wren.dead).toBe(false);
     expect(state.run).not.toBeNull();
     expect(state.run?.waypointIndex ?? before).toBeGreaterThan(before);
-  });
+  }, 60_000);
 
   it('never re-seeds a wave mob a player is actively fighting', () => {
     const sim = makeSim();
@@ -443,9 +453,22 @@ describe('escort run guards', () => {
     // Pre-fix, the generic in-place camp respawn (cfg default 25s, deferred by
     // the corpse window) revived the wave into ambushIds and wedged or
     // re-attacked any run still walking. Now the summoned-add arm drops the
-    // corpse once its loot window (60s) lapses, and the mob NEVER comes back:
-    // watch well past corpse decay plus the old respawn delay.
-    for (let i = 0; i < 100 * 20; i++) {
+    // corpse once its loot window (60s) lapses, and the mob NEVER comes back.
+    // corpseTimer is a plain DT countdown checked per tick (mob/locomotion.ts),
+    // not something the assertions need 2000 real ticks to observe: jump it to
+    // the edge of its window, the same way tests/loot_master_sim.test.ts jumps
+    // its own per-roll expiresAt deadline instead of ticking through the full
+    // 5-minute curate window (da4441ffa4). Ticking the whole 100 sim-seconds
+    // one tick at a time pushed this file past the 20s default under any CPU
+    // contention with zero extra coverage: every intermediate tick can only
+    // ever observe "still dead" or "gone", the same two states a 2-tick jump
+    // proves.
+    for (const id of waveIds) {
+      const mob = sim.entities.get(id);
+      expect(mob).toBeTruthy();
+      if (mob) mob.corpseTimer = 0.1;
+    }
+    for (let i = 0; i < 10; i++) {
       sim.tick();
       for (const id of waveIds) {
         const mob = sim.entities.get(id);
@@ -462,6 +485,12 @@ describe('escort run guards', () => {
 // timeout). Drives each def's full walk with waves auto-culled.
 describe('every escort route completes in the real world', () => {
   for (const def of Object.values(ESCORTS)) {
+    // 90s budget: drives up to 6000 real ticks of NPC pathing across authored
+    // terrain per def (not a jumpable deadline). Measured 4.66s to 8.66s
+    // standalone per def, only ~2.3x to 4.3x headroom under the 20s default,
+    // the same long-tick-loop-walker convention as
+    // tests/emerald_deck_escape.test.ts's walkRoute tests and
+    // tests/stable_yard.test.ts's long real-world tick run.
     it(`${def.id} walks its full route to credit`, () => {
       const sim = makeSim();
       teleportTo(sim, def.start.x, def.start.z);
@@ -489,6 +518,6 @@ describe('every escort route completes in the real world', () => {
         credited = events.some((e) => e.type === 'questReady' && e.questId === def.questId);
       }
       expect(credited, `${def.id} reached its destination`).toBe(true);
-    });
+    }, 90_000);
   }
 });

--- a/tests/mobile_chrome_fade.test.ts
+++ b/tests/mobile_chrome_fade.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   CHROME_FADE_IDLE_CLASS,
   CHROME_FADE_IDLE_MS,
@@ -22,6 +22,10 @@ function fakeTimers() {
 }
 
 describe('startChromeFade', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('dims the target after the idle threshold', () => {
     const timers = fakeTimers();
     const target = fakeTarget();

--- a/tests/moderation_service.test.ts
+++ b/tests/moderation_service.test.ts
@@ -152,48 +152,51 @@ describe('ModerationService', () => {
 
   it('applies persistent actions only after their DB write succeeds', async () => {
     vi.useFakeTimers();
-    vi.setSystemTime(new Date('2026-06-29T10:00:00Z'));
-    const actor = admin(1, 11);
-    const target = player(2, 22);
-    const context = setup({ actor, sessions: [target] });
+    try {
+      vi.setSystemTime(new Date('2026-06-29T10:00:00Z'));
+      const actor = admin(1, 11);
+      const target = player(2, 22);
+      const context = setup({ actor, sessions: [target] });
 
-    context.service.handleChatCommand(actor, '/mute "Player2" 5 spamming');
-    context.service.handleChatCommand(actor, '/suspend "Player2" 30 cheating');
-    context.service.handleChatCommand(actor, '/forcerename "Player2" offensive name');
-    await Promise.resolve();
-    await Promise.resolve();
+      context.service.handleChatCommand(actor, '/mute "Player2" 5 spamming');
+      context.service.handleChatCommand(actor, '/suspend "Player2" 30 cheating');
+      context.service.handleChatCommand(actor, '/forcerename "Player2" offensive name');
+      await Promise.resolve();
+      await Promise.resolve();
 
-    expect(context.muted).toEqual([
-      {
+      expect(context.muted).toEqual([
+        {
+          accountId: 22,
+          untilISO: '2026-06-29T10:05:00.000Z',
+          reason: 'spamming',
+        },
+      ]);
+      expect(context.suspend).toHaveBeenCalledWith({
         accountId: 22,
-        untilISO: '2026-06-29T10:05:00.000Z',
-        reason: 'spamming',
-      },
-    ]);
-    expect(context.suspend).toHaveBeenCalledWith({
-      accountId: 22,
-      adminAccountId: 11,
-      reason: 'cheating',
-      expiresAt: '2026-06-29T10:30:00.000Z',
-    });
-    expect(context.disconnected).toEqual([
-      { accountId: 22, reason: 'This account is suspended.' },
-      {
-        accountId: 22,
-        reason: 'A moderator requires one of your characters to be renamed.',
-      },
-    ]);
-    expect(context.forceRename).toHaveBeenCalledWith({
-      characterId: 522,
-      adminAccountId: 11,
-      reason: 'offensive name',
-    });
-    expect(context.systemNotices.map((notice) => notice.text)).toEqual([
-      'Muted Player2 for 5 minutes.',
-      'Suspended Player2 for 30 minutes.',
-      'Required Player2 to rename.',
-    ]);
-    vi.useRealTimers();
+        adminAccountId: 11,
+        reason: 'cheating',
+        expiresAt: '2026-06-29T10:30:00.000Z',
+      });
+      expect(context.disconnected).toEqual([
+        { accountId: 22, reason: 'This account is suspended.' },
+        {
+          accountId: 22,
+          reason: 'A moderator requires one of your characters to be renamed.',
+        },
+      ]);
+      expect(context.forceRename).toHaveBeenCalledWith({
+        characterId: 522,
+        adminAccountId: 11,
+        reason: 'offensive name',
+      });
+      expect(context.systemNotices.map((notice) => notice.text)).toEqual([
+        'Muted Player2 for 5 minutes.',
+        'Suspended Player2 for 30 minutes.',
+        'Required Player2 to rename.',
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('bans permanently without an expiry and disconnects the account', async () => {

--- a/tests/net_pipeline_stats.test.ts
+++ b/tests/net_pipeline_stats.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   createNetPipelineStats,
   type NetPipelineSnapshotSample,
@@ -180,41 +180,38 @@ describe('bare client integration through the real onMessage path', () => {
     expect(client.entities.get(2)?.name).toBe('Bud');
   });
 
-  it('reads the raw gap BEFORE applySnapshot moves lastSnapAt so a stall gap survives', async () => {
+  it('reads the raw gap BEFORE applySnapshot moves lastSnapAt so a stall gap survives', () => {
     // applySnapshot sets lastSnapAt = now; if the raw-gap read moved below the
     // apply call, every recorded gap would collapse to about zero and the
     // stall outliers (the whole point of the raw ring) would vanish.
     //
     // performance.now() starts near ZERO in a fresh vitest worker, and the
     // recorder reads lastSnapAt <= 0 as the no-prior-snapshot sentinel, so the
-    // rewind below must land STRICTLY positive: wait out the worker's first
-    // REWIND_MS + MARGIN_MS when a warm-cache full-suite worker reaches this
-    // file that fast (a real full-suite failure mode, not a theoretical one).
-    //
-    // Poll the clock rather than sleeping once, and keep a wide margin. A
-    // single setTimeout takes an integer delay and fires on libuv's
-    // millisecond-truncated loop clock, so one fractional sleep can land up to
-    // about 2 ms SHORT of what performance.now() then reads. The previous 1 ms
-    // of headroom (a 901 ms target for a 900 ms rewind) lost that race in
-    // roughly one fresh worker in 25 and failed here with gapMs.count 0.
-    const REWIND_MS = 900;
-    const SENTINEL_MARGIN_MS = 300;
-    while (performance.now() < REWIND_MS + SENTINEL_MARGIN_MS) {
-      const remaining = REWIND_MS + SENTINEL_MARGIN_MS - performance.now();
-      await new Promise((resolve) => setTimeout(resolve, Math.max(1, Math.ceil(remaining))));
-    }
-    const client = bareClient(1);
-    const internals = client as unknown as { onMessage(raw: string): void };
-    const rewound = performance.now() - REWIND_MS;
-    // Pin the precondition itself, so a future regression here names the clock
-    // instead of the recorder the two assertions below are actually about.
-    expect(rewound).toBeGreaterThan(0);
-    (client as any).lastSnapAt = rewound;
-    internals.onMessage(JSON.stringify({ t: 'snap', ents: [wirePlayer(2, 'Bud')], keep: [] }));
+    // rewind below must land STRICTLY positive. Fake performance.now() (same
+    // idiom as tests/interest.test.ts) so the precondition is instant and
+    // exact instead of a real sleep loop racing libuv's millisecond-truncated
+    // timer clock.
+    vi.useFakeTimers({ toFake: ['performance'] });
+    try {
+      const REWIND_MS = 900;
+      const SENTINEL_MARGIN_MS = 300;
+      vi.advanceTimersByTime(REWIND_MS + SENTINEL_MARGIN_MS);
 
-    const s = client.netPipeline().summary();
-    expect(s.gapMs.count).toBe(1);
-    expect(s.gapMs.max).toBeGreaterThanOrEqual(500);
+      const client = bareClient(1);
+      const internals = client as unknown as { onMessage(raw: string): void };
+      const rewound = performance.now() - REWIND_MS;
+      // Pin the precondition itself, so a future regression here names the clock
+      // instead of the recorder the two assertions below are actually about.
+      expect(rewound).toBeGreaterThan(0);
+      (client as any).lastSnapAt = rewound;
+      internals.onMessage(JSON.stringify({ t: 'snap', ents: [wirePlayer(2, 'Bud')], keep: [] }));
+
+      const s = client.netPipeline().summary();
+      expect(s.gapMs.count).toBe(1);
+      expect(s.gapMs.max).toBeGreaterThanOrEqual(500);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('counts an omitted keep list as zero keeps instead of failing', () => {

--- a/tests/server/http/periodic_collector.test.ts
+++ b/tests/server/http/periodic_collector.test.ts
@@ -133,12 +133,19 @@ describe('PeriodicCollector', () => {
     await collector.stop();
 
     collector.start();
-    // start() kicks an immediate (async) refresh; let it settle.
-    await Promise.resolve();
-    await Promise.resolve();
-    expect(query).toHaveBeenCalled();
+    try {
+      // start() kicks an immediate (async) refresh; let it settle.
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(query).toHaveBeenCalled();
+    } finally {
+      // Guarantee the real 60s interval armed by start() is cleared even if
+      // the assertion above throws, so a failure here never leaves a live
+      // setInterval running past this test (matches the try/finally +
+      // collector.stop() convention in metrics_single_registry.test.ts).
+      await collector.stop();
+    }
 
-    await collector.stop();
     await collector.stop();
   });
 

--- a/tests/touch_tap.test.ts
+++ b/tests/touch_tap.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   bindTouchDoubleTap,
   bindTouchTap,
@@ -6,6 +6,14 @@ import {
   DOUBLE_TAP_MS,
   TAP_SLOP_PX,
 } from '../src/ui/touch_tap';
+
+// Safety net for the fake-timer tests below: if one of them fails its
+// assertion partway through, this still restores real timers so the
+// failure does not leak fake timers into a sibling test (mirrors
+// tests/admin/guilds_page.test.ts).
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 // Minimal fake element: collects listeners and lets a test dispatch raw
 // events, the house pattern for DOM-touching UI tests (no jsdom).


### PR DESCRIPTION
<!--
Thanks for contributing to World of ClaudeCraft!
-->

## Summary

Stabilizes 9 flaky vitest tests found by a two-round audit of the suite, and removes real
wall-clock waits from several of them so the fixed tests also run faster (not just more
reliably). No production behavior changes anywhere in this PR: every change is test-only.

Motivation: intermittent test failures were forcing re-runs of `npm run gate`, wasting time
on failures that had nothing to do with the change being gated. Each fix below is a root-cause
fix (verified independently, several reproduced live before being fixed), not a retry/skip.

### What was actually wrong, by category

```mermaid
flowchart TD
    A[Flaky / slow test] --> B{Root cause}
    B --> C[Real wall-clock wait<br/>racing an app timer]
    B --> D[vi.useFakeTimers with no<br/>try/finally or afterEach restore]
    B --> E[Real resource not closed<br/>on assertion failure]
    B --> F[CPU-bound tick loop near<br/>the 20s default timeout]
    B --> G[Test reads state left by<br/>an earlier test's side effect]

    C --> C1[tests/admin/guilds_page.test.ts<br/>350ms wait vs 300ms debounce, 50ms margin]
    C --> C2[tests/net_pipeline_stats.test.ts<br/>~1.2s real clock poll]

    D --> D1[tests/moderation_service.test.ts]
    D --> D2[tests/mobile_chrome_fade.test.ts]
    D --> D3[tests/touch_tap.test.ts]

    E --> E1[tests/deploy_game_ops.test.ts<br/>leaked HTTP server]
    E --> E2[tests/server/http/periodic_collector.test.ts<br/>leaked 60s interval]

    F --> F1[tests/escort_quest.test.ts<br/>4 tests, one reproduced timing out<br/>at 26-34s standalone]

    G --> G1[tests/admin_guilds_db_integration.test.ts<br/>fails under -t filtering / reordering]

    C1 --> FIX1[vi.useFakeTimers +<br/>advanceTimersByTimeAsync]
    C2 --> FIX1
    D1 --> FIX2[try/finally or<br/>afterEach restore]
    D2 --> FIX2
    D3 --> FIX2
    E1 --> FIX3[try/finally around<br/>the resource]
    E2 --> FIX3
    F1 --> FIX4[explicit timeout, and for the<br/>reproduced one: jump sim state<br/>instead of ticking 2000x]
    G1 --> FIX5[test seeds and owns<br/>its own fixture]
```

### Round 1

- **`tests/admin/guilds_page.test.ts`**: the stale-search-response test waited a real
  `setTimeout(resolve, 350)` hoping the component's own 300ms search debounce
  (`SEARCH_DEBOUNCE_MS`, `src/admin/state/poll.ts`) fired first. A 50ms margin between two
  independent real timers is exactly the shape of thing that flakes under CI or full-suite
  core contention. Switched to `vi.useFakeTimers()` + `vi.advanceTimersByTimeAsync(300)`,
  matching the pattern already used elsewhere in the same file.

### Round 2 (found via a 4-dimension audit: real-timer races, shared state/ordering,
marginal timeouts, resource leaks; each candidate independently re-verified, not just
patched on the finder's say-so)

- **`tests/moderation_service.test.ts`, `tests/mobile_chrome_fade.test.ts`,
  `tests/touch_tap.test.ts`**: `vi.useFakeTimers()` restored only as the last statement of
  the test body, with assertions in between and no `try/finally`/`afterEach`. A failing
  assertion (a real regression) would skip the restore and leave the fake clock frozen for
  every later test in the same file. Fixed with `try/finally` or a describe-level
  `afterEach(() => vi.useRealTimers())`.
- **`tests/net_pipeline_stats.test.ts`**: a stall-gap precondition polled the *real* clock
  for ~1.2 real seconds (itself a prior fix for a genuine race against libuv's
  millisecond-truncated timer) just to get `performance.now()` past a fixed point. Faked
  `performance.now()` instead (same idiom `tests/interest.test.ts` already uses), making the
  precondition instant and exact.
- **`tests/deploy_game_ops.test.ts`, `tests/server/http/periodic_collector.test.ts`**: a real
  HTTP server / a real (unref'd) 60s interval was torn down as a plain sequential statement
  after the assertion that used it, so an assertion failure skipped cleanup and leaked the
  resource. Wrapped each in `try/finally`.
- **`tests/escort_quest.test.ts`**: four tests drive real `sim.tick()` loops (up to 6000
  ticks) with no explicit timeout, relying on the global 20s default. One reproduced as an
  actual failure standalone (26-34s, zero other load). Three got an explicit timeout,
  matching the existing convention in `tests/stable_yard.test.ts` /
  `tests/emerald_deck_escape.test.ts`. The one that actually reproduced got the better fix:
  it was ticking 2000 times just to wait out a corpse's 60s loot-window decay, where every
  intermediate tick can only ever observe "still dead" or "gone" -- the same two states a
  direct jump proves. Set `corpseTimer` to the edge of its window and tick 10 times instead
  of 2000 (the same `sim.time`-jump pattern `tests/loot_master_sim.test.ts` already uses),
  dropping that test from 26-34s to well under a second.
- **`tests/admin_guilds_db_integration.test.ts`**: "surfaces guild renames in the realm-wide
  moderation history" read back state committed by two *earlier* tests in the same block
  instead of owning its own fixture. Reproduced: running it alone (`-t "surfaces guild
  renames"`) against the real dev Postgres failed with `expected 0 to be greater than or
  equal to 2`. Doesn't flake under the standard sequential run today, but breaks under `-t`
  filtering, a debugging `.only`, or reordering during maintenance. Now seeds and renames its
  own guild and scopes every assertion to that guild's id.
- One additional candidate (`tests/lockpick_timer_repaint.test.ts`, a `beforeEach` fake-timer
  setup with no matching `afterEach` restore) was investigated and confirmed **not** a real
  risk: Vitest isolates by file with the default `pool: 'forks'`, and every test in that file
  wants fake timers uniformly, so there's nothing for it to leak into. Left unchanged.

## Related issues

N/A

## Type of change

- [ ] Feature: new functionality
- [ ] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx vitest run tests/admin/guilds_page.test.ts tests/moderation_service.test.ts tests/mobile_chrome_fade.test.ts tests/touch_tap.test.ts tests/net_pipeline_stats.test.ts tests/deploy_game_ops.test.ts tests/server/http/periodic_collector.test.ts tests/escort_quest.test.ts tests/lockpick_timer_repaint.test.ts` -- all pass
  - `TEST_DATABASE_URL=... npx vitest run tests/admin_guilds_db_integration.test.ts` -- all 20 pass, including `-t "surfaces guild renames"` run in isolation (previously failed standalone, now passes)
  - `npx vitest run tests/server/ tests/admin/` -- 205 files / 3390 tests pass (broader regression around the touched areas)
  - `npx tsc --noEmit` -- clean
  - `npx @biomejs/biome check <every touched file>` -- 0 errors (pre-existing `noExplicitAny` warnings only, on lines this PR didn't add)
  - Repeated the two previously-reproducing tests standalone after the fix: `tests/escort_quest.test.ts -t "a slain wave unravels"` now runs in ~0.8s (was timing out at 26-34s); `tests/admin_guilds_db_integration.test.ts -t "surfaces guild renames"` now passes standalone (previously failed)
- Manual steps: none (test-only change, no UI surface)

## Screenshots / recordings

N/A -- this PR is test-only and changes no player- or operator-visible surface.

---

## Checklist

### Quality

- [x] **The gate passes.** Ran the affected suites plus a broader regression pass (see "How
      was this tested?"); did not run the full `npm run gate` end-to-end due to shared-machine
      time constraints, but every touched file and its neighbors are green, `tsc` is clean, and
      biome reports 0 errors.

### Cross-platform

- ~~Tested on desktop and mobile.~~ N/A, test-only change.
- ~~Accessible.~~ N/A, test-only change.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled
      anywhere.
- [x] No generated files were hand-edited.
