### PR TITLE
fix(content): give the #2905 claw/tusk harvest materials their craft consumers

### DIFF
--- a/scripts/shot_2513_unmapped_corpse.mjs
+++ b/scripts/shot_2513_unmapped_corpse.mjs
@@ -1,17 +1,23 @@
 // Visual capture for #2513: the corpse loot popup on a template whose every
-// component family is unmapped (fen_troll: claw, tusk). Before the fix the popup
-// carried a full Harvest picker whose every submit the sim refused after
-// spending the corpse's single-use claim; after it, the popup is loot only.
+// component family is unmapped. Before the fix the popup carried a full
+// Harvest picker whose every submit the sim refused after spending the
+// corpse's single-use claim; after it, the popup is loot only.
 //
-// Staging note: fen_troll lives in mirefen_marsh, not the starting zone, so this
-// forces `templateId` on a corpse in the loaded zone rather than teleporting.
-// That is the honest minimum, because `templateId` is exactly the input under
-// test: everything downstream (corpseLootAvailability, corpseHarvestView, the
-// loot window controller) is the real shipped code reading the real content
+// Staging note: no SHIPPED template is all-unmapped any more (#2905 wired claw
+// and tusk, retiring fen_troll, the original fixture here), so this forces
+// `templateId` on a corpse in the loaded zone AND retags that template with
+// the two still-unmapped families via the __game.MOBS debug surface: the same
+// withUnmappedTemplate idiom the test suites use
+// (tests/corpse_harvest_sim.test.ts, tests/loot_window_controller.test.ts).
+// Everything downstream (corpseLootAvailability, corpseHarvestView, the loot
+// window controller) is still the real shipped code reading the real content
 // table. Pass SHOT_OUT to name the file.
 //
 // Usage (with `npm run dev` on GAME_URL):
 //   GAME_URL=http://localhost:5199 SHOT_OUT=after node scripts/shot_2513_unmapped_corpse.mjs
+// Mixed control case (picker must stay):
+//   SHOT_TEMPLATE=sethrael_palecoil SHOT_TEMPLATE_NAME='Sethrael Palecoil' \
+//   SHOT_TAGS= SHOT_EXPECT_PICKER=1 SHOT_OUT=control node scripts/shot_2513_unmapped_corpse.mjs
 
 import fs from 'node:fs';
 import puppeteer from 'puppeteer-core';
@@ -21,9 +27,15 @@ const URL = (process.env.GAME_URL ?? 'http://localhost:5173') + '/?gfx=ultra';
 const OUT = process.env.SHOT_OUT ?? 'after';
 const MOBILE = process.env.SHOT_MOBILE === '1';
 // SHOT_TEMPLATE lets the same rig capture the control case (a MIXED template,
-// whose picker this change must not move).
-const TEMPLATE = process.env.SHOT_TEMPLATE ?? 'fen_troll';
-const TEMPLATE_NAME = process.env.SHOT_TEMPLATE_NAME ?? 'Mirefen Troll';
+// whose picker this change must not move). SHOT_TAGS retags the template for
+// the run (comma-separated; empty keeps its real tags), and SHOT_EXPECT_PICKER
+// declares the staged truth so a premise drift fails loudly instead of
+// shipping a shot of the wrong state (what happened when #2905 mapped
+// fen_troll's families out from under the old default here).
+const TEMPLATE = process.env.SHOT_TEMPLATE ?? 'warlock_imp';
+const TEMPLATE_NAME = process.env.SHOT_TEMPLATE_NAME ?? 'Fen Horror';
+const TAGS = (process.env.SHOT_TAGS ?? 'gills,horn').split(',').filter(Boolean);
+const EXPECT_PICKER = process.env.SHOT_EXPECT_PICKER === '1';
 const BOOT_VIEW = { width: 1600, height: 900, deviceScaleFactor: 2 };
 const SHOT_VIEW = MOBILE ? { width: 844, height: 390, deviceScaleFactor: 2 } : BOOT_VIEW;
 fs.mkdirSync('tmp', { recursive: true });
@@ -111,12 +123,13 @@ await page.keyboard.press('Escape');
 await sleep(500);
 
 await page.evaluate(
-  ([tpl, name, mobile]) => {
+  ([tpl, name, mobile, tags]) => {
     window.__shotTemplate = tpl;
     window.__shotTemplateName = name;
     window.__shotMobile = mobile;
+    window.__shotTags = tags;
   },
-  [TEMPLATE, TEMPLATE_NAME, MOBILE],
+  [TEMPLATE, TEMPLATE_NAME, MOBILE, TAGS],
 );
 const staged = await page.evaluate(() => {
   const g = window.__game;
@@ -124,8 +137,16 @@ const staged = await page.evaluate(() => {
   const p = sim.player;
   const mob = [...sim.entities.values()].find((e) => e.kind === 'mob' && !e.dead);
   if (!mob) return { error: 'no live mob found in loaded zone' };
-  // The one forced input: the template whose componentTags all miss the yield
-  // table. Everything the popup reads flows from here.
+  if (!g.MOBS?.[window.__shotTemplate]) {
+    return { error: `template ${window.__shotTemplate} not in __game.MOBS` };
+  }
+  // The two forced inputs: the template id, and (when SHOT_TAGS is set) that
+  // template's componentTags, retagged the way the test suites do it, since no
+  // shipped template is all-unmapped since #2905. Everything the popup reads
+  // flows from here through the real content table.
+  if (window.__shotTags.length) {
+    g.MOBS[window.__shotTemplate].componentTags = [...window.__shotTags];
+  }
   mob.templateId = window.__shotTemplate;
   mob.name = window.__shotTemplateName;
   mob.tappedById = p.id;
@@ -158,6 +179,16 @@ const staged = await page.evaluate(() => {
 });
 console.log('staged:', JSON.stringify(staged));
 if (staged.error) {
+  await browser.close();
+  process.exit(1);
+}
+// Fail loudly rather than shipping a shot of the wrong predicate state: the
+// staged harvest section must match what this run declares it evidences.
+if (staged.harvestSection !== EXPECT_PICKER) {
+  console.log(
+    `ABORT: staged harvestSection=${staged.harvestSection} but SHOT_EXPECT_PICKER=${EXPECT_PICKER};` +
+      ' the staged premise has drifted (did a harvest family get mapped or unmapped?)',
+  );
   await browser.close();
   process.exit(1);
 }

--- a/src/game/corpse_loot_availability.ts
+++ b/src/game/corpse_loot_availability.ts
@@ -46,7 +46,8 @@ export function corpseLootAvailability(
 ) {
   const componentTags = MOBS[mob.templateId]?.componentTags;
   // isHarvestableCorpse, the sim's own predicate, not a tag count of our own
-  // (#2513): a corpse whose every family is unmapped (fen_troll: claw, tusk)
+  // (#2513): a corpse whose every family is unmapped (no shipped template
+  // since #2905 mapped fen_troll's claw and tusk; the fixtures retag one)
   // cannot yield anything and the command boundary refuses it, so offering the
   // picker here would advertise a dead end. This arm was the one place in this
   // function that restated a sim rule instead of importing it, which is exactly

--- a/src/guide/content.generated.ts
+++ b/src/guide/content.generated.ts
@@ -6695,6 +6695,14 @@ export const GUIDE_PROF_CRAFTS: GuideProfCraft[] = [
         "feeCopper": 10000,
         "materials": [
           {
+            "name": "Pristine Claw",
+            "count": 1
+          },
+          {
+            "name": "Sharp Claw",
+            "count": 2
+          },
+          {
             "name": "Rough Hide",
             "count": 4
           },
@@ -7412,6 +7420,10 @@ export const GUIDE_PROF_CRAFTS: GuideProfCraft[] = [
         "acquisition": "trainer",
         "feeCopper": 0,
         "materials": [
+          {
+            "name": "Curved Tusk",
+            "count": 2
+          },
           {
             "name": "Ironbark Log",
             "count": 3

--- a/src/main.ts
+++ b/src/main.ts
@@ -251,6 +251,7 @@ import {
   ITEMS,
   isDelvePos,
   isRiftPos,
+  MOBS,
   QUESTS,
   questRewardItem,
   setActiveWorldContent,
@@ -4680,6 +4681,11 @@ async function startGame(
           perf,
           gamepad,
           music,
+          // The live content table, for E2E rigs that stage a template state
+          // shipped content cannot reach (scripts/shot_2513_unmapped_corpse.mjs
+          // retags a template all-unmapped, the tests' withUnmappedTemplate
+          // idiom). Debug surface only; never written by game code.
+          MOBS,
           /** Opens the board and drains queued sim events. Do not call sim.lockpickEngage directly offline. */
           lockpickEngage: (objectId: number, ante: number) =>
             hud.submitLockpickEngage(objectId, ante as 1 | 2 | 3),

--- a/src/sim/content/recipes.ts
+++ b/src/sim/content/recipes.ts
@@ -680,7 +680,12 @@ export const LADDER_RECIPES: ProfessionRecipeRecord[] = [
     professionId: 'weaponcrafting',
     resultItemId: 'ironbark_boar_spear',
     resultCount: 1,
+    // Tusk-crested boar spear: the first curved_tusk consumer, closing the
+    // zero-consumer harvest family #2905 shipped the same way Phase 15 closed
+    // wolf_fang (the fang-hilted arming sword above). wild_boar itself drops
+    // the tusks, so the rung-0 recipe stays zone-1 legal. Input 50 vs output 36.
     reagents: [
+      { itemId: 'curved_tusk', count: 2 },
       { itemId: 'ironbark_log', count: 3 },
       { itemId: 'copper_ore', count: 2 },
       { itemId: 'smithing_flux', count: 1 },
@@ -1217,7 +1222,15 @@ export const LADDER_RECIPES: ProfessionRecipeRecord[] = [
     professionId: 'leatherworking',
     resultItemId: 'mirewarden_treads',
     resultCount: 1,
+    // Claw-spiked treads: the first sharp_claw and pristine_claw consumers,
+    // closing the two remaining zero-consumer harvest families #2905 shipped
+    // (the wolf_fang precedent), with the specimen riding count-1 beside its
+    // base material like the serpent elixir's pristine_venom_gland. The mire
+    // prowlers this line is named for are claw carriers themselves. Input 125
+    // vs output 78.
     reagents: [
+      { itemId: 'pristine_claw', count: 1 },
+      { itemId: 'sharp_claw', count: 2 },
       { itemId: 'rough_hide', count: 4 },
       { itemId: 'spider_silk', count: 2 },
       { itemId: 'thorium_ore', count: 1 },

--- a/src/sim/interaction.ts
+++ b/src/sim/interaction.ts
@@ -357,12 +357,14 @@ export function harvestCorpse(
   //
   // Scope, the other half of the #2504 comment: that one covers a tag the
   // corpse does not CARRY, which sanitizes away and spreads. This covers a tag
-  // it carries that HARVEST_COMPONENT_ITEMS does not map (claw, tusk, gills,
-  // horn) on a corpse that ALSO carries a mapped one. A corpse whose tags ALL
-  // map to nothing never reaches this gate at all any more (#2513): the
-  // isHarvestableCorpse check above answers on mapped families, so fen_troll
-  // (claw, tusk) is refused there with error.corpseNothingToHarvest, exactly
-  // like the 101 shipped templates that carry no component tags. That closed
+  // it carries that HARVEST_COMPONENT_ITEMS does not map (gills, horn) on a
+  // corpse that ALSO carries a mapped one. A corpse whose tags ALL map to
+  // nothing never reaches this gate at all any more (#2513): the
+  // isHarvestableCorpse check above answers on mapped families, so such a
+  // corpse is refused there with error.corpseNothingToHarvest, exactly like
+  // the 101 shipped templates that carry no component tags. (fen_troll (claw,
+  // tusk) was the shipped example until #2905 mapped both; the all-unmapped
+  // state now lives only in retagged test fixtures.) That closed
   // the last path to a claim spent in silence, and it is why this predicate's
   // second half (`taggedComponents.some(yields)`) is now belt and braces here
   // rather than the term that kept an all-unmapped corpse claimable.

--- a/src/sim/loot/loot_roll.ts
+++ b/src/sim/loot/loot_roll.ts
@@ -925,8 +925,9 @@ export function pruneCorpseLoot(ctx: SimContext, mob: Entity): void {
     // the fast arm.
     //
     // "A harvest half" is isHarvestableCorpse, not a tag COUNT (#2513): a corpse
-    // whose every family is unmapped (fen_troll: claw, tusk) owes nobody a
-    // harvest, because the command boundary now refuses one. Counting its tags
+    // whose every family is unmapped (none shipped since #2905 mapped claw and
+    // tusk; the fixtures retag one) owes nobody a harvest, because the command
+    // boundary now refuses one. Counting its tags
     // here would hold the grace window open for 30 seconds waiting on a claim
     // that can never be spent, which is strictly worse than the pre-#2513
     // world, where a player could at least burn the claim and collapse it.

--- a/src/sim/professions/gathering.ts
+++ b/src/sim/professions/gathering.ts
@@ -1218,9 +1218,11 @@ export function harvestFamilyYieldsItem(component: string): boolean {
  * Does this mob's corpse support profession harvest at all? Answers on the
  * MAPPED families the corpse carries, not on its tag COUNT (#2513).
  *
- * The count answer was a lie on exactly one shipped template: fen_troll carries
- * `claw` and `tusk` and HARVEST_COMPONENT_ITEMS maps neither, so its corpse
- * advertised a harvest it could never pay, accepted the command, spent the
+ * The count answer was a lie on exactly one shipped template: fen_troll
+ * carried `claw` and `tusk` and HARVEST_COMPONENT_ITEMS mapped neither at the
+ * time (#2905 has since wired both, so no shipped template is all-unmapped
+ * today), so its corpse advertised a harvest it could never pay, accepted the
+ * command, spent the
  * single-use claim, drew one tier roll per effective family, granted nothing,
  * and emitted NOTHING AT ALL (the harvestResult ledger is gated on
  * `granted.length > 0`). Measured pre-fix: an omitted pick, `[]` and
@@ -1404,9 +1406,11 @@ export function effectiveFocusComponents(
  * function starts answering a question nobody asked it, and the two gates would
  * be one narrowing away from disagreeing. Its second half is now belt and
  * braces rather than the load-bearing term it was for #2509, and both states
- * are pinned separately (tests/corpse_harvest_view.test.ts holds
- * forfeitsEveryYield FALSE on fen_troll while harvestDisabled is TRUE, so the
- * two terms can never quietly coincide).
+ * are pinned separately (tests/corpse_harvest_view.test.ts drives both terms
+ * on sethrael_palecoil's real mixed tags, and the all-unmapped arm rides the
+ * retagged fixtures in tests/corpse_harvest_window.test.ts and
+ * tests/loot_window_controller.test.ts, so the two terms can never quietly
+ * coincide).
  *
  * Pure and rng-free, so the refusal it drives draws nothing.
  */

--- a/src/ui/hud/loot/corpse_harvest_view.ts
+++ b/src/ui/hud/loot/corpse_harvest_view.ts
@@ -82,7 +82,8 @@ export interface CorpseHarvestViewModel {
  * same predicate, so the dead-end submit is not offered in the first place.
  *
  * Mirrored EXACTLY, including where it does not fire: on a corpse whose tags all
- * map to nothing (fen_troll: claw, tusk) NO pick forfeits anything, because no
+ * map to nothing (gills, horn on a retagged fixture; fen_troll was the shipped
+ * case until #2905 mapped claw and tusk) NO pick forfeits anything, because no
  * pick could have paid out, so `forfeitsEveryYield` stays false there. What
  * disables that corpse is the OTHER term, isHarvestableCorpse (#2513): the sim
  * refuses the command outright, so the button must not submit. The two terms are

--- a/tests/ladder_crafting.test.ts
+++ b/tests/ladder_crafting.test.ts
@@ -72,11 +72,13 @@ describe('ladder recipe execution sweep (all 54)', () => {
     }
   });
 
-  it('the four specimen consumers consume the signed instance slot itself', () => {
+  it('the five specimen consumers consume the signed instance slot itself', () => {
     // One recipe per specimen family (pinned literally in
-    // tests/recipe_economy.test.ts's demand block); the assert above already
-    // proves count 0, this pins that no UNSIGNED grant would have satisfied
-    // the sweep: the granted reagent was a signed instance slot.
+    // tests/recipe_economy.test.ts's demand block; pristine_claw joined via
+    // mirewarden_treads when #2905's claw family got its consumers); the
+    // assert above already proves count 0, this pins that no UNSIGNED grant
+    // would have satisfied the sweep: the granted reagent was a signed
+    // instance slot.
     const consumers = LADDER_RECIPES.filter((r) =>
       r.reagents.some((reagent) => SPECIMEN_IDS.has(reagent.itemId)),
     );
@@ -84,6 +86,7 @@ describe('ladder recipe execution sweep (all 54)', () => {
       'recipe_elixir_of_the_serpent',
       'recipe_marlows_grand_roast',
       'recipe_mirewarden_jerkin',
+      'recipe_mirewarden_treads',
       'recipe_silkbinders_raiment',
     ]);
     for (const recipe of consumers) {

--- a/tests/loot_window_controller.test.ts
+++ b/tests/loot_window_controller.test.ts
@@ -21,14 +21,34 @@ import type { IWorld } from '../src/world_api';
 
 const itemIds = Object.keys(ITEMS);
 // isHarvestableCorpse, not a tag COUNT (#2513): a template can carry tags whose
-// every family is unmapped (fen_troll: claw, tusk), and the sim refuses a
-// harvest there. A count-based selector could pick such a template under a
-// future content reorder and silently invert every harvest case in this file.
+// every family is unmapped (the retagged fixture below: gills, horn), and the
+// sim refuses a harvest there. A count-based selector could pick such a template
+// under a future content reorder and silently invert every harvest case in this file.
 const harvestMob = Object.values(MOBS).find((mob) => isHarvestableCorpse(mob.componentTags));
 if (itemIds.length < 2) throw new Error('loot item fixtures not found');
 if (!harvestMob?.componentTags?.length) throw new Error('harvestable mob fixture not found');
 const harvestMobId = harvestMob.id;
 const harvestMobTags = harvestMob.componentTags;
+
+// No shipped template is all-unmapped since #2905 wired claw and tusk (that
+// retired fen_troll, the old all-unmapped fixture here), so the #2513 cases
+// below drive a real template retagged for the duration of a callback: the
+// shared UNMAPPED fixture idiom of the sim suites
+// (tests/corpse_harvest_sim.test.ts). warlock_imp carries no tags of its own
+// (this file's untagged fixture elsewhere), so retagging it borrows no other
+// case's premise, and the mutation is always restored in a `finally`.
+const UNMAPPED_TEMPLATE_ID = 'warlock_imp';
+const UNMAPPED_TEMPLATE_TAGS = ['gills', 'horn'];
+function withUnmappedTemplate<T>(body: () => T): T {
+  const template = MOBS[UNMAPPED_TEMPLATE_ID];
+  const prior = template.componentTags;
+  template.componentTags = [...UNMAPPED_TEMPLATE_TAGS];
+  try {
+    return body();
+  } finally {
+    template.componentTags = prior;
+  }
+}
 
 function entity(
   id: number,
@@ -267,50 +287,58 @@ describe('LootWindowController', () => {
 
   it('opens for the coin but draws NO harvest picker on an all-unmapped corpse (#2513)', () => {
     // The gate the whole "no reason line is owed" argument rests on, pinned
-    // instead of asserted in prose. fen_troll carries claw and tusk, neither
-    // mapped, so `harvestable` is false and openCorpse must skip the picker; it
-    // must still open, because the corpse holds copper the player can take.
-    // Driven through the REAL corpseLootAvailability against a real template, so
-    // loosening `if (harvestable && componentTags)` back to `if (componentTags)`
-    // reds here rather than passing with every other gate green.
-    expect(MOBS.fen_troll.componentTags).toEqual(['claw', 'tusk']);
-    const troll = entity(20, {
-      kind: 'mob',
-      templateId: 'fen_troll',
-      loot: { copper: 50, items: [] },
+    // instead of asserted in prose. The retagged fixture carries gills and
+    // horn, neither mapped, so `harvestable` is false and openCorpse must skip
+    // the picker; it must still open, because the corpse holds copper the
+    // player can take. Driven through the REAL corpseLootAvailability against
+    // a real (retagged) template, so loosening `if (harvestable &&
+    // componentTags)` back to `if (componentTags)` reds here rather than
+    // passing with every other gate green. The premise pin goes red the day
+    // gills or horn gets its harvest item, which is the cue to move this
+    // fixture again (as #2905 mapping claw and tusk retired fen_troll here).
+    expect(isHarvestableCorpse(UNMAPPED_TEMPLATE_TAGS)).toBe(false);
+    withUnmappedTemplate(() => {
+      const imp = entity(20, {
+        kind: 'mob',
+        templateId: UNMAPPED_TEMPLATE_ID,
+        loot: { copper: 50, items: [] },
+      });
+      const test = harness([imp], (entry) => corpseLootAvailability(entry, 7));
+
+      test.controller.openCorpse(20, 0, 0);
+
+      expect(test.element.style.display).toBe('block');
+      expect(test.element.innerHTML).toContain('money:50');
+      expect(test.element.querySelector('.corpse-harvest')).toBeNull();
+      expect(test.element.querySelector('.corpse-harvest-btn')).toBeNull();
+      expect(test.element.querySelectorAll('.corpse-harvest-check')).toHaveLength(0);
+      // No dead control anywhere: nothing disabled, and nothing to click.
+      expect(test.element.querySelectorAll('button[disabled]')).toHaveLength(0);
+      // ...and no sentence promising a harvest half this corpse does not have. The
+      // unified-press hint says the interact key "loots and harvests"; on a
+      // loot-only corpse that is simply false, so it is not rendered.
+      expect(test.element.querySelector('.town-focus-hint')).toBeNull();
     });
-    const test = harness([troll], (entry) => corpseLootAvailability(entry, 7));
-
-    test.controller.openCorpse(20, 0, 0);
-
-    expect(test.element.style.display).toBe('block');
-    expect(test.element.innerHTML).toContain('money:50');
-    expect(test.element.querySelector('.corpse-harvest')).toBeNull();
-    expect(test.element.querySelector('.corpse-harvest-btn')).toBeNull();
-    expect(test.element.querySelectorAll('.corpse-harvest-check')).toHaveLength(0);
-    // No dead control anywhere: nothing disabled, and nothing to click.
-    expect(test.element.querySelectorAll('button[disabled]')).toHaveLength(0);
-    // ...and no sentence promising a harvest half this corpse does not have. The
-    // unified-press hint says the interact key "loots and harvests"; on a
-    // loot-only corpse that is simply false, so it is not rendered.
-    expect(test.element.querySelector('.town-focus-hint')).toBeNull();
     // The discriminator on the identical rig: a MIXED template carrying the same
-    // unmapped `tusk` beside two mapped families still draws its picker, so this
-    // is the predicate and not the controller refusing every corpse.
-    expect(MOBS.wild_boar.componentTags).toEqual(['hide', 'tusk', 'meat']);
-    const boar = entity(21, {
+    // unmapped `horn` beside two mapped families still draws its picker, so this
+    // is the predicate and not the controller refusing every corpse. Both
+    // halves of "mixed" are pinned: horn alone is unharvestable (so it is
+    // genuinely unmapped), and the tag list is palecoil's real shipped one.
+    expect(isHarvestableCorpse(['horn'])).toBe(false);
+    expect(MOBS.sethrael_palecoil.componentTags).toEqual(['hide', 'claw', 'horn']);
+    const palecoil = entity(21, {
       kind: 'mob',
-      templateId: 'wild_boar',
+      templateId: 'sethrael_palecoil',
       loot: { copper: 50, items: [] },
     });
-    const boarTest = harness([boar], (entry) => corpseLootAvailability(entry, 7));
-    boarTest.controller.openCorpse(21, 0, 0);
-    expect(boarTest.element.querySelector('.corpse-harvest')).not.toBeNull();
-    expect(boarTest.element.querySelectorAll('.corpse-harvest-check')).toHaveLength(3);
+    const mixedTest = harness([palecoil], (entry) => corpseLootAvailability(entry, 7));
+    mixedTest.controller.openCorpse(21, 0, 0);
+    expect(mixedTest.element.querySelector('.corpse-harvest')).not.toBeNull();
+    expect(mixedTest.element.querySelectorAll('.corpse-harvest-check')).toHaveLength(3);
     // The hint's other arm, on the same rig: where a harvest really is on offer
     // the sentence is true and still rendered, so the gate is not a blanket
     // removal.
-    expect(boarTest.element.querySelector('.town-focus-hint')?.textContent).toBe(
+    expect(mixedTest.element.querySelector('.town-focus-hint')?.textContent).toBe(
       'The interact key loots and harvests in one press, using your town focus.',
     );
   });
@@ -339,13 +367,15 @@ describe('LootWindowController', () => {
     // Once the coin is gone there is no reason to open: `canOpen` is
     // `hasLoot || harvestable` and both are now false, so the popup stays shut
     // instead of presenting an empty body with a dead Harvest button.
-    const troll = entity(22, { kind: 'mob', templateId: 'fen_troll', loot: null });
-    const test = harness([troll], (entry) => corpseLootAvailability(entry, 7));
+    withUnmappedTemplate(() => {
+      const imp = entity(22, { kind: 'mob', templateId: UNMAPPED_TEMPLATE_ID, loot: null });
+      const test = harness([imp], (entry) => corpseLootAvailability(entry, 7));
 
-    test.controller.openCorpse(22, 0, 0);
+      test.controller.openCorpse(22, 0, 0);
 
-    expect(test.element.style.display).not.toBe('block');
-    expect(test.closeTransient).not.toHaveBeenCalled();
+      expect(test.element.style.display).not.toBe('block');
+      expect(test.closeTransient).not.toHaveBeenCalled();
+    });
     // The discriminator: a depleted corpse WITH a mapped family still opens for
     // its harvest half, which is the behavior this must not have broken.
     const wolf = entity(23, { kind: 'mob', templateId: harvestMobId, loot: null });

--- a/tests/recipe_economy.test.ts
+++ b/tests/recipe_economy.test.ts
@@ -9,7 +9,11 @@
 // leggings) closed through the maintainer-approved paired arm (input rework
 // plus an output sellValue re-price), so the frozen list below is EMPTY.
 import { describe, expect, it } from 'vitest';
-import { STATION_TYPE_BY_CRAFT } from '../src/sim/content/professions';
+import {
+  HARVEST_COMPONENT_ITEMS,
+  HARVEST_COMPONENT_SPECIMENS,
+  STATION_TYPE_BY_CRAFT,
+} from '../src/sim/content/professions';
 import {
   ALL_RECIPES,
   COMBO_RECIPES,
@@ -308,6 +312,9 @@ describe('REFERENTIAL INTEGRITY', () => {
 describe('MATERIAL DEMAND COVERAGE', () => {
   // Every gathered/harvested/vendor material Phases 4 and 10 introduced must be
   // consumed by at least one recipe, so no supply node produces a dead good.
+  // The corpse-harvest families closed later ride the same pin: wolf_fang
+  // (Phase 15) and the #2905 claw/tusk trio, so HARVEST_MATERIALS and SPECIMENS
+  // now list every HARVEST_COMPONENT_ITEMS / HARVEST_COMPONENT_SPECIMENS value.
   const NODE_YIELDS = [
     'copper_ore',
     'iron_ore',
@@ -321,12 +328,21 @@ describe('MATERIAL DEMAND COVERAGE', () => {
   ];
   const HARVEST_MATERIALS = [
     'rough_hide',
+    'wolf_fang',
     'spider_silk',
     'venom_gland',
     'game_meat',
     'homespun_cloth',
+    'sharp_claw',
+    'curved_tusk',
   ];
-  const SPECIMENS = ['pristine_hide', 'pristine_silk', 'pristine_venom_gland', 'prime_cut'];
+  const SPECIMENS = [
+    'pristine_hide',
+    'pristine_silk',
+    'pristine_venom_gland',
+    'prime_cut',
+    'pristine_claw',
+  ];
   const VENDOR_REAGENTS = [
     'smithing_flux',
     'spool_of_thread',
@@ -354,6 +370,14 @@ describe('MATERIAL DEMAND COVERAGE', () => {
       for (const row of Object.values(byZone)) liveYields.add(row.itemId);
     }
     expect([...liveYields].sort()).toEqual([...NODE_YIELDS].sort());
+  });
+
+  it('pins the harvest material and specimen literals to the live component tables', () => {
+    // Same anti-rot arm as the node yields above: the next harvest family
+    // must join these lists (and so the consumed-by-a-recipe sweep below), not
+    // drift past them the way #2905's claw/tusk trio originally shipped.
+    expect([...HARVEST_MATERIALS].sort()).toEqual(Object.values(HARVEST_COMPONENT_ITEMS).sort());
+    expect([...SPECIMENS].sort()).toEqual(Object.values(HARVEST_COMPONENT_SPECIMENS).sort());
   });
 
   it('every material, specimen, and vendor reagent is consumed by at least one recipe', () => {
@@ -400,10 +424,13 @@ describe('LADDER SHAPE PINS', () => {
     'ironbark_log',
     'silverleaf_herb',
     'rough_hide',
+    'wolf_fang',
     'spider_silk',
     'venom_gland',
     'game_meat',
     'homespun_cloth',
+    'sharp_claw',
+    'curved_tusk',
     'linen_scrap',
     'bone_fragments',
     'spider_leg',
@@ -418,6 +445,7 @@ describe('LADDER SHAPE PINS', () => {
     'pristine_silk',
     'pristine_venom_gland',
     'prime_cut',
+    'pristine_claw',
   ]);
 
   function isConsumable(itemId: string): boolean {


### PR DESCRIPTION
## Summary

#2905 wired the claw and tusk corpse-harvest families but shipped all three new materials (sharp_claw, curved_tusk, pristine_claw) with zero craft consumers, and it retired the last shipped all-unmapped mob template. That reds two PR-tier shards on this base branch for every open PR (shard 3: tests/material_profession_affinity.test.ts no-orphan-reagents pin; shard 7: the two #2513 cases in tests/loot_window_controller.test.ts), and blocks the release gate for #3014.

This closes the families the way Phase 15 closed wolf_fang (the exact precedent named in the recipes file):

- curved_tusk (x2) joins recipe_ironbark_boar_spear: wild_boar drops the tusks, so the rung-0 recipe stays zone-1 legal. Input 50 vs output 36.
- sharp_claw (x2) plus a count-1 pristine_claw join recipe_mirewarden_treads, mirroring the serpent elixir's specimen-beside-base pairing. Input 125 vs output 78.
- Both stay strictly gold-negative and neither enters the pinned counterfactually-vendor-fed set (no buyValue on either material).
- The two #2513 loot-window cases now drive a retagged warlock_imp (the shared withUnmappedTemplate idiom from tests/corpse_harvest_sim.test.ts, restored in a finally), with sethrael_palecoil as the mixed discriminator and premise pins that go red the day gills or horn get their harvest items.

Follow-through from the QA pass over the diff:

- tests/recipe_economy.test.ts: HARVEST_MATERIALS / SPECIMENS / LOW_BAND / RARE_BAND literals completed (wolf_fang was missing too) plus a new anti-rot pin holding the harvest lists equal to the live HARVEST_COMPONENT_ITEMS / HARVEST_COMPONENT_SPECIMENS tables, so the next family cannot ship past them the way this trio did.
- tests/ladder_crafting.test.ts: the specimen-consumer membership pin goes four to five.
- scripts/shot_2513_unmapped_corpse.mjs still staged fen_troll as all-unmapped and silently captured the opposite of its premise; it now retags via a new __game.MOBS debug field (one-line addition to the existing E2E debug surface in src/main.ts) and aborts loudly when the staged state contradicts what the run declares.
- Five source comments that still presented fen_troll as the live all-unmapped example (interaction.ts, corpse_loot_availability.ts, loot_roll.ts, corpse_harvest_view.ts, gathering.ts, including one dead test pointer) now record the real state.
- src/guide/content.generated.ts regenerated for the two reagent lists.

## Design note for the maintainer

The free rung-0 boar spear now needs a corpse-harvest material (2 tusks). This matches the existing rung-0 precedent (recipe_eastbrook_arming_sword consumes wolf_fang, tier-1 bare-hands harvestable), but it does change the earliest weaponcrafting rung's supply story; happy to move the tusks to a higher rung if you prefer.

## Test plan

- [x] tests/material_profession_affinity.test.ts, tests/loot_window_controller.test.ts, tests/recipe_economy.test.ts, tests/corpse_harvest_window.test.ts, tests/corpse_harvest_sim.test.ts, tests/ladder_crafting.test.ts green locally
- [x] Blast radius green: progression, material_taxonomy (+bootstrap), affinity bootstrap, hint view, professions_crafting, masterwork, typed_reagents, crafting_materials_quality, master_craft_core, harvest_component_materials, economy_yield, woc_balance, guide, harvest_yields, gathering, crafting_view, crafting_reagent_refresh, perks, craft_xp, hobby_craft, mob_component_tags, shipped_item_ids, duplicate_test_blocks, professions_grandfather, ip_scrub, localization_fixes, architecture
- [x] tsc, biome on changed files, pre-push floor
- [x] No rng or parity impact (crafting's masterwork draw is reagent-independent; the parity professions scenario drives other recipes)
- [x] No i18n impact (all three item names shipped with full locale rows in #2905)