### PR TITLE
feat(ci): merge-queue readiness (merge_group routing plus the required-check contract)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,12 @@ name: CI
 
 on:
   pull_request:
+  # The merge queue on main and release/** tests each candidate merge result on
+  # a merge_group event. This trigger is load-bearing: without it the required
+  # checks never report on queue runs and every queued PR stalls until the
+  # queue's status-check timeout rejects it. Queue settings live in the repo's
+  # rulesets (not in git); docs/merge-queue.md is the operator note.
+  merge_group:
   push:
     branches:
       - main
@@ -66,8 +72,9 @@ concurrency:
 # Path filters (D10): a cheap `changes` job classifies pull_request diffs as
 # code vs docs-only. Docs/markdown/screenshot-only PRs keep lint (and any other
 # always-on cheap jobs) but skip pr-gate, pr-checks, and browser-gate. Any touch
-# of the code path set forces the full PR tier. push to main/dev-* and
-# workflow_dispatch always report code=true (full PR tier when unsure).
+# of the code path set forces the full PR tier. push to main/dev-*,
+# workflow_dispatch, and merge_group queue runs always report code=true (full
+# PR tier when unsure).
 # Release/** pushes and release-to-main PRs never consult the filter:
 # release-gate, release-checks, and release-version-gate stay always-full
 # (no path skip on those jobs).
@@ -80,6 +87,18 @@ concurrency:
 # reference semantics and the audit contract live in docs/qa-gate.md
 # ("Selective PR-tier CI"). Selection NEVER applies to release-gate or the
 # nightly workflow: those are the unconditional full-suite backstops.
+#
+# Merge queue runs: a merge_group event routes through the PR-tier jobs
+# (changes, lint, pr-gate, pr-checks, browser-gate). The changes job treats
+# every non-PR event as code=true and test_mode=full, so the queue always runs
+# the FULL suite on the exact merge result it is about to make the branch tip.
+# That is deliberate, not an optimization target: the queue is the last
+# pre-merge bar, and selection never applies to it. This also covers a queued
+# release-to-main PR (the pull_request-only exclusions below cannot match a
+# merge_group event, so the full PR tier runs on its merge group too). The
+# release lanes' if arms match pull_request and push only, so they stay off
+# queue runs; the release/** push that fires after the queue merges remains
+# the unconditional full-suite backstop on the real tip.
 
 jobs:
   release-version-gate:
@@ -196,12 +215,20 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           BASE_REF: ${{ github.base_ref }}
           BEFORE_SHA: ${{ github.event.before }}
+          MERGE_GROUP_BASE_SHA: ${{ github.event.merge_group.base_sha }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           zeros='0000000000000000000000000000000000000000'
           if [ "$EVENT_NAME" = "pull_request" ]; then
             git fetch --no-tags --depth=1 origin "$BASE_REF"
             echo "ref=origin/$BASE_REF" >> "$GITHUB_OUTPUT"
+          elif [ "$EVENT_NAME" = "merge_group" ] && [ -n "$MERGE_GROUP_BASE_SHA" ]; then
+            # A queue run diffs the merge group against the target-branch tip it
+            # was built on. Falling through to the default-branch arm would diff
+            # a release/** group against main and drag the whole release delta
+            # (including the intentionally-red whole-repo debt) into biome.
+            git fetch --no-tags --depth=1 origin "$MERGE_GROUP_BASE_SHA"
+            echo "ref=$MERGE_GROUP_BASE_SHA" >> "$GITHUB_OUTPUT"
           elif [ -n "$BEFORE_SHA" ] && [ "$BEFORE_SHA" != "$zeros" ]; then
             # Shallow checkout is tip-only; fetch the pre-push tip alone.
             if ! git cat-file -e "${BEFORE_SHA}^{commit}" 2>/dev/null; then
@@ -282,8 +309,10 @@ jobs:
     # Compose release-to-main exclusion with the code path filter (D10). Do not
     # drop either arm: release-to-main must still select release-*, and docs-only
     # PRs must skip this matrix. needs.changes only; no needs edge to pr-checks.
+    # merge_group always lands here (the queue bar is the full PR tier; the
+    # release-to-main exclusion is a pull_request-arm concern and cannot match).
     needs: changes
-    if: ((github.event_name == 'pull_request' && (github.base_ref != 'main' || !startsWith(github.head_ref, 'release/'))) || (github.event_name == 'push' && !startsWith(github.ref, 'refs/heads/release/')) || github.event_name == 'workflow_dispatch') && needs.changes.outputs.code == 'true'
+    if: ((github.event_name == 'pull_request' && (github.base_ref != 'main' || !startsWith(github.head_ref, 'release/'))) || (github.event_name == 'push' && !startsWith(github.ref, 'refs/heads/release/')) || github.event_name == 'workflow_dispatch' || github.event_name == 'merge_group') && needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
 
     # fail-fast stays off: shards pass or fail independently, so one red shard
@@ -341,8 +370,10 @@ jobs:
     name: PR checks (freshness, typecheck, builds)
     # Same composition as pr-gate: release exclusion + code path filter. Skipped
     # entirely on docs-only PRs (malware/typecheck/builds are code-path gates).
+    # merge_group lands here too: the queue re-proves freshness, typecheck, and
+    # every build on the merge result, not just the PR head.
     needs: changes
-    if: ((github.event_name == 'pull_request' && (github.base_ref != 'main' || !startsWith(github.head_ref, 'release/'))) || (github.event_name == 'push' && !startsWith(github.ref, 'refs/heads/release/')) || github.event_name == 'workflow_dispatch') && needs.changes.outputs.code == 'true'
+    if: ((github.event_name == 'pull_request' && (github.base_ref != 'main' || !startsWith(github.head_ref, 'release/'))) || (github.event_name == 'push' && !startsWith(github.ref, 'refs/heads/release/')) || github.event_name == 'workflow_dispatch' || github.event_name == 'merge_group') && needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,11 @@ permissions:
 # isolated from ordinary PR traffic and cannot cancel each other (D4).
 # cancel-in-progress is true for every event in this group; release isolation
 # comes from the event_name segment, not from disabling cancel on push.
+# merge_group runs key on github.ref, which is the queue's own
+# gh-readonly-queue/<branch>/pr-<n>-<sha> ref: unique per live merge group, so
+# cancel-in-progress cannot cross-cancel two live groups (the queue dissolves a
+# group before any ref could be reused), and the event_name segment keeps queue
+# runs from ever colliding with PR or push runs.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -216,19 +221,31 @@ jobs:
           BASE_REF: ${{ github.base_ref }}
           BEFORE_SHA: ${{ github.event.before }}
           MERGE_GROUP_BASE_SHA: ${{ github.event.merge_group.base_sha }}
+          MERGE_GROUP_BASE_REF: ${{ github.event.merge_group.base_ref }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           zeros='0000000000000000000000000000000000000000'
           if [ "$EVENT_NAME" = "pull_request" ]; then
             git fetch --no-tags --depth=1 origin "$BASE_REF"
             echo "ref=origin/$BASE_REF" >> "$GITHUB_OUTPUT"
-          elif [ "$EVENT_NAME" = "merge_group" ] && [ -n "$MERGE_GROUP_BASE_SHA" ]; then
+          elif [ "$EVENT_NAME" = "merge_group" ] && printf '%s' "$MERGE_GROUP_BASE_SHA" | grep -qE '^[0-9a-f]{40}$'; then
             # A queue run diffs the merge group against the target-branch tip it
             # was built on. Falling through to the default-branch arm would diff
             # a release/** group against main and drag the whole release delta
-            # (including the intentionally-red whole-repo debt) into biome.
-            git fetch --no-tags --depth=1 origin "$MERGE_GROUP_BASE_SHA"
-            echo "ref=$MERGE_GROUP_BASE_SHA" >> "$GITHUB_OUTPUT"
+            # (including the intentionally-red whole-repo debt) into biome. The
+            # shape guard keeps anything but a bare hex SHA out of GITHUB_OUTPUT
+            # (same belt-and-suspenders standard as detect_code_changes.mjs).
+            if git fetch --no-tags --depth=1 origin "$MERGE_GROUP_BASE_SHA"; then
+              echo "ref=$MERGE_GROUP_BASE_SHA" >> "$GITHUB_OUTPUT"
+            else
+              # Unreachable base SHA (a dissolved predecessor group, or a
+              # transient fetch failure): fall back to the live target-branch
+              # tip, still never the default branch, so one flaky fetch cannot
+              # eject a good PR from the queue with a red required check.
+              base_branch="${MERGE_GROUP_BASE_REF#refs/heads/}"
+              git fetch --no-tags --depth=1 origin "$base_branch"
+              echo "ref=origin/$base_branch" >> "$GITHUB_OUTPUT"
+            fi
           elif [ -n "$BEFORE_SHA" ] && [ "$BEFORE_SHA" != "$zeros" ]; then
             # Shallow checkout is tip-only; fetch the pre-push tip alone.
             if ! git cat-file -e "${BEFORE_SHA}^{commit}" 2>/dev/null; then
@@ -252,8 +269,12 @@ jobs:
     name: Browser regressions (Chromium)
     # Skip on confirmed docs-only PRs (no browser tests/code touched). Non-PR
     # and code PRs keep the job (changes.code defaults true off PR events).
+    # != 'false', not == 'true': only an explicit docs-only verdict may skip.
+    # A missing or empty output must run the job, matching the classifier's own
+    # fail-closed doctrine; == 'true' is the one place doubt would fail toward
+    # SKIP, and under the merge queue a skipped required check reads satisfied.
     needs: changes
-    if: needs.changes.outputs.code == 'true'
+    if: needs.changes.outputs.code != 'false'
     runs-on: ubuntu-latest
 
     steps:
@@ -312,7 +333,7 @@ jobs:
     # merge_group always lands here (the queue bar is the full PR tier; the
     # release-to-main exclusion is a pull_request-arm concern and cannot match).
     needs: changes
-    if: ((github.event_name == 'pull_request' && (github.base_ref != 'main' || !startsWith(github.head_ref, 'release/'))) || (github.event_name == 'push' && !startsWith(github.ref, 'refs/heads/release/')) || github.event_name == 'workflow_dispatch' || github.event_name == 'merge_group') && needs.changes.outputs.code == 'true'
+    if: ((github.event_name == 'pull_request' && (github.base_ref != 'main' || !startsWith(github.head_ref, 'release/'))) || (github.event_name == 'push' && !startsWith(github.ref, 'refs/heads/release/')) || github.event_name == 'workflow_dispatch' || github.event_name == 'merge_group') && needs.changes.outputs.code != 'false'
     runs-on: ubuntu-latest
 
     # fail-fast stays off: shards pass or fail independently, so one red shard
@@ -373,7 +394,7 @@ jobs:
     # merge_group lands here too: the queue re-proves freshness, typecheck, and
     # every build on the merge result, not just the PR head.
     needs: changes
-    if: ((github.event_name == 'pull_request' && (github.base_ref != 'main' || !startsWith(github.head_ref, 'release/'))) || (github.event_name == 'push' && !startsWith(github.ref, 'refs/heads/release/')) || github.event_name == 'workflow_dispatch' || github.event_name == 'merge_group') && needs.changes.outputs.code == 'true'
+    if: ((github.event_name == 'pull_request' && (github.base_ref != 'main' || !startsWith(github.head_ref, 'release/'))) || (github.event_name == 'push' && !startsWith(github.ref, 'refs/heads/release/')) || github.event_name == 'workflow_dispatch' || github.event_name == 'merge_group') && needs.changes.outputs.code != 'false'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,10 @@ permissions:
 # gh-readonly-queue/<branch>/pr-<n>-<sha> ref: unique per live merge group, so
 # cancel-in-progress cannot cross-cancel two live groups (the queue dissolves a
 # group before any ref could be reused), and the event_name segment keeps queue
-# runs from ever colliding with PR or push runs.
+# runs from ever colliding with PR or push runs. The flip side of unique refs:
+# a dissolved group's superseded run is never cancelled by this group either;
+# that cleanup is GitHub's, so the trade costs at most idle runner minutes,
+# never a live group's required checks.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -228,21 +231,30 @@ jobs:
           if [ "$EVENT_NAME" = "pull_request" ]; then
             git fetch --no-tags --depth=1 origin "$BASE_REF"
             echo "ref=origin/$BASE_REF" >> "$GITHUB_OUTPUT"
-          elif [ "$EVENT_NAME" = "merge_group" ] && printf '%s' "$MERGE_GROUP_BASE_SHA" | grep -qE '^[0-9a-f]{40}$'; then
+          elif [ "$EVENT_NAME" = "merge_group" ]; then
             # A queue run diffs the merge group against the target-branch tip it
-            # was built on. Falling through to the default-branch arm would diff
-            # a release/** group against main and drag the whole release delta
-            # (including the intentionally-red whole-repo debt) into biome. The
-            # shape guard keeps anything but a bare hex SHA out of GITHUB_OUTPUT
-            # (same belt-and-suspenders standard as detect_code_changes.mjs).
-            if git fetch --no-tags --depth=1 origin "$MERGE_GROUP_BASE_SHA"; then
+            # was built on, and a merge_group event must NEVER fall through to
+            # the default-branch arm: that would diff a release/** group against
+            # main and drag the whole release delta (including the
+            # intentionally-red whole-repo debt) into biome. So this arm keys on
+            # the event alone, and anything unusable about the SHA lands in the
+            # fallback below, never outside the arm. The shape guard only
+            # selects the SHA path (grep matches per line; the backstop for a
+            # malformed value is the fetch itself, since nothing is written to
+            # GITHUB_OUTPUT unless its fetch succeeded).
+            if printf '%s' "$MERGE_GROUP_BASE_SHA" | grep -qE '^[0-9a-f]{40}$' \
+              && git fetch --no-tags --depth=1 origin "$MERGE_GROUP_BASE_SHA"; then
               echo "ref=$MERGE_GROUP_BASE_SHA" >> "$GITHUB_OUTPUT"
             else
-              # Unreachable base SHA (a dissolved predecessor group, or a
-              # transient fetch failure): fall back to the live target-branch
-              # tip, still never the default branch, so one flaky fetch cannot
-              # eject a good PR from the queue with a red required check.
+              # Malformed or unreachable base SHA (a dissolved predecessor
+              # group, a transient fetch failure): fall back to the live
+              # target-branch tip, still never the default branch, so one flaky
+              # fetch cannot eject a good PR from the queue. An empty base ref
+              # has no safe fallback at all: the bare [ -n ] test fails the
+              # step loudly (fetching "" would quietly succeed and write a
+              # broken ref=origin/ output instead).
               base_branch="${MERGE_GROUP_BASE_REF#refs/heads/}"
+              [ -n "$base_branch" ]
               git fetch --no-tags --depth=1 origin "$base_branch"
               echo "ref=origin/$base_branch" >> "$GITHUB_OUTPUT"
             fi
@@ -273,6 +285,9 @@ jobs:
     # A missing or empty output must run the job, matching the classifier's own
     # fail-closed doctrine; == 'true' is the one place doubt would fail toward
     # SKIP, and under the merge queue a skipped required check reads satisfied.
+    # This covers a green-but-empty output only: a FAILED changes job still
+    # skips dependents through needs regardless of this expression, which is
+    # why "Detect code path changes" must itself be a required check.
     needs: changes
     if: needs.changes.outputs.code != 'false'
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -332,4 +332,5 @@ correct.
 `README.md` (host/develop/play + fidelity checklist) · `DESIGN.md` (the adopted interface
 design-language standard; interface changes land through its rollout phases) ·
 `DEPLOY.md` (production) · `CREDITS.md` (asset licenses) · `docs/design/` (design docs) ·
-`docs/prd/` (feature specs) · `docs/qa-gate.md` (the layered QA gate).
+`docs/prd/` (feature specs) · `docs/qa-gate.md` (the layered QA gate) ·
+`docs/merge-queue.md` (the merge queue + required-check contract on protected branches).

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -20,6 +20,7 @@ feature spec), or its program's dir; the top level is only for a living runbook.
 | `design/` | How systems are/should be built (notes below). |
 | `prd/` | Feature specs: requirements + `file:line` hook points + acceptance criteria. |
 | `qa-gate.md` | The QA-gate reference (Stop hook, pre-push floor, `npm run gate`, `/qa`); root CLAUDE.md points here. Living. |
+| `merge-queue.md` | The merge queue + required-check contract on `main` and `release/**` (the ruleset settings are not in git; this is their written contract, and the operator note for queue rejections). Living. |
 | `image-to-glb-asset-workflow.md` | Living runbook for reference-image intake, procedural Three.js authoring, optimized GLB export, renderer integration, performance gates, and in-game visual proof. |
 | `ai-pr-bot.md` | The non-blocking PR CI review helper (`prepare_ai_review.mjs`/`post_ai_review.mjs`), plus the local diff-scoped screenshot capture (`scripts/pr_shot_targets.mjs`). Living. |
 | `desktop-release.md`, `desktop-ship-notes.md`, `mobile-store-release.md` | Release runbooks (Electron/Steam; iOS/Android). Living. |

--- a/docs/merge-queue.md
+++ b/docs/merge-queue.md
@@ -6,6 +6,12 @@ merge queue. Settings do not live in git; this note is the contract those
 settings implement, and the one place it is written down. If the ruleset and
 this note disagree, fix whichever one drifted.
 
+Rollout status: a repo admin applies the ruleset to `release/**` first, after
+the ci.yml merge_group trigger lands there; `main` joins at the next
+release-to-main merge, which is what carries that trigger onto main (enabling
+the queue on a branch whose ci.yml lacks the trigger stalls every queued PR).
+Until a branch is covered by the ruleset, its merge button is unchanged.
+
 Why: on 2026-08-05 two merges landed on an already-red release tip, every open
 PR inherited 67 broken tests, and repair took a day of close/reopen churn. The
 queue makes a green tip structural: nothing merges without the full suite
@@ -53,12 +59,20 @@ Required on both `main` and `release/**`, all sourced from GitHub Actions:
 
 - `Detect code path changes`. Required itself, and load-bearing: when it fails,
   its dependents report skipped, and branch protection treats skipped as
-  satisfied. Requiring the job that decides is what closes that hole.
+  satisfied. Requiring the job that decides closes that hole for a classifier
+  FAILURE. The residual is inherent to CI-config-in-repo: a queue run executes
+  the queued tree's own copy of ci.yml and the classifier, so an honest
+  mistake there is caught only because `.github/` and `scripts/` are
+  themselves code paths (always `code=true`, always full suite); a hostile
+  edit is a review problem, not something protection can solve.
 - `PR gate (English-only legal) (1)` through `(8)`: the sharded test suite.
 - `PR checks (freshness, typecheck, builds)`.
 - `Format + lint (Biome, changed files)`: deterministic, diff-scoped, minutes
   long, and a red here is always a real defect in the changed files. On queue
-  runs it diffs against the merge group's own base tip, never against main.
+  runs it diffs against the merge group's base SHA, falling back to the live
+  target-branch tip if that SHA is unreachable, so a `release/**` queue run
+  never sweeps the release-vs-main delta (and its intentionally-red whole-repo
+  debt) into biome.
 - `Browser regressions (Chromium)`: the real-browser net for a browser game.
   It reports (or is skipped, which satisfies) on every PR and queue run.
 
@@ -78,11 +92,22 @@ The same rule generalizes: a check may only join the required list if ci.yml
 produces (or explicitly skips) it on every `pull_request` AND every
 `merge_group` run. Anything else deadlocks the queue. And required-check names
 are string-matched: renaming a CI job silently un-requires it, so treat the job
-names above as pinned (they are also pinned by `tests/ci_workflow.test.ts`).
+names above as pinned (`tests/ci_workflow.test.ts` holds each name to ci.yml
+and to this doc, including the shard-count suffix range).
+
+## Queueing a fork PR is the privileged step
+
+A merge group runs the QUEUED tree (base plus the PR's diff) in this
+repository's own context: repository secrets are resolvable there and no
+fork-approval prompt guards it, unlike the PR's own workflow runs. Queueing
+requires write access, so this is always a maintainer action: read the diff
+before queueing a fork PR, and treat any fork change under `.github/**` or
+`scripts/**` as needing a real review first.
 
 ## What did not change
 
-- Fork PRs still need maintainer approval before workflows run.
+- Fork PRs still need maintainer approval before their `pull_request` workflows
+  run; the new privileged step is queueing (see above).
 - The release-tier lanes still run on release refs and release-to-main PRs,
   visible but not required.
 - The `release/**` push run after each queue merge and the nightly gate

--- a/docs/merge-queue.md
+++ b/docs/merge-queue.md
@@ -1,0 +1,89 @@
+# Merge queue and required checks on main and release/**
+
+`main` and `release/**` are protected by a repository ruleset (Settings, Rules,
+Rulesets) that requires the PR-tier checks and routes every merge through a
+merge queue. Settings do not live in git; this note is the contract those
+settings implement, and the one place it is written down. If the ruleset and
+this note disagree, fix whichever one drifted.
+
+Why: on 2026-08-05 two merges landed on an already-red release tip, every open
+PR inherited 67 broken tests, and repair took a day of close/reopen churn. The
+queue makes a green tip structural: nothing merges without the full suite
+passing on the exact merge result, and a queued PR whose base moves is retested
+automatically instead of by hand.
+
+## What changes at the merge button
+
+- The merge button becomes **Merge when ready**. It queues the PR instead of
+  merging it. `gh pr merge` queues the same way.
+- A PR can be queued once its own required checks are green. The queue then
+  builds the candidate merge result (your PR merged onto the current tip, plus
+  any PRs queued ahead of you) and runs CI on it as a `merge_group` event.
+  ci.yml routes that run through the full PR tier: `changes` reports
+  `test_mode=full`, so the queue always runs the complete 8-shard suite plus
+  checks, browser, and lint on the tree it is about to make the branch tip.
+- If the queue run is green, GitHub merges automatically. No close/reopen, no
+  re-merge of the base: base movement is the queue's job now.
+- The queue merges with one repo-wide method (merge commit). The per-PR
+  squash/merge choice does not apply on the protected branches.
+- Direct pushes to the protected branches are blocked by the
+  require-a-pull-request rule. Repository admins keep an always-on bypass for
+  emergency repair; a bypassed push skips the queue's proof, so treat it as
+  emergency-only and expect the next nightly or push run to be the real verdict.
+
+## When the queue rejects a PR
+
+A rejection removes the PR from the queue and leaves a red `merge_group` run on
+the Checks tab (filter by event: merge_group).
+
+1. Open the failed run and find the red job. The shard logs carry the same
+   `[ci-shard]` audit lines as PR runs.
+2. If the same failure is red on your PR's own run too, it is your change: fix
+   and re-queue.
+3. If your PR run was green, the failure is usually the interaction between
+   your diff and commits that landed ahead of you (another queued PR, or a base
+   move). Reproduce locally by merging the current base branch into your
+   branch, fix, push, re-queue.
+4. A flake verdict needs a clean rerun, not a shrug: re-run the failed job; if
+   it greens, re-queue. Judge red CI by clean-runner reruns.
+
+## The required-check contract
+
+Required on both `main` and `release/**`, all sourced from GitHub Actions:
+
+- `Detect code path changes`. Required itself, and load-bearing: when it fails,
+  its dependents report skipped, and branch protection treats skipped as
+  satisfied. Requiring the job that decides is what closes that hole.
+- `PR gate (English-only legal) (1)` through `(8)`: the sharded test suite.
+- `PR checks (freshness, typecheck, builds)`.
+- `Format + lint (Biome, changed files)`: deterministic, diff-scoped, minutes
+  long, and a red here is always a real defect in the changed files. On queue
+  runs it diffs against the merge group's own base tip, never against main.
+- `Browser regressions (Chromium)`: the real-browser net for a browser game.
+  It reports (or is skipped, which satisfies) on every PR and queue run.
+
+Never require these, deliberately:
+
+- The release lanes (`Release gate (tests)`, `Release i18n (21-locale fill)`,
+  `Release checks (freshness, typecheck, builds)`, `Release version gate`):
+  release-process lanes, legitimately red or skipped mid-cycle. Release i18n in
+  particular is red by design until the release-time locale fill.
+- The AI-assist checks (`PR AI assist` jobs): standing policy, they never gate.
+- `Dependency audit`: its workflow is path-filtered to dependency changes, so
+  on most PRs (and on every queue run) the check never reports at all, and a
+  required check that never reports blocks the merge forever. Skipped jobs
+  satisfy protection; absent workflows do not.
+
+The same rule generalizes: a check may only join the required list if ci.yml
+produces (or explicitly skips) it on every `pull_request` AND every
+`merge_group` run. Anything else deadlocks the queue. And required-check names
+are string-matched: renaming a CI job silently un-requires it, so treat the job
+names above as pinned (they are also pinned by `tests/ci_workflow.test.ts`).
+
+## What did not change
+
+- Fork PRs still need maintainer approval before workflows run.
+- The release-tier lanes still run on release refs and release-to-main PRs,
+  visible but not required.
+- The `release/**` push run after each queue merge and the nightly gate
+  (`docs/qa-gate.md`) remain the unconditional full-suite backstops.

--- a/docs/merge-queue.md
+++ b/docs/merge-queue.md
@@ -62,9 +62,10 @@ Required on both `main` and `release/**`, all sourced from GitHub Actions:
   satisfied. Requiring the job that decides closes that hole for a classifier
   FAILURE. The residual is inherent to CI-config-in-repo: a queue run executes
   the queued tree's own copy of ci.yml and the classifier, so an honest
-  mistake there is caught only because `.github/` and `scripts/` are
-  themselves code paths (always `code=true`, always full suite); a hostile
-  edit is a review problem, not something protection can solve.
+  mistake there is caught only because the workflow files
+  (`.github/workflows/`) and the selection pipeline's own scripts are
+  themselves fail-closed triggers (always `code=true`, always full mode); a
+  hostile edit is a review problem, not something protection can solve.
 - `PR gate (English-only legal) (1)` through `(8)`: the sharded test suite.
 - `PR checks (freshness, typecheck, builds)`.
 - `Format + lint (Biome, changed files)`: deterministic, diff-scoped, minutes

--- a/docs/qa-gate.md
+++ b/docs/qa-gate.md
@@ -14,7 +14,7 @@ Codex have different entry points and share the same deterministic scripts and c
 | **Selective gate** | `node scripts/gate_select.mjs` | **Before implementation is called ready / pre-merge** | **Yes (the merge bar)** |
 | Full local gate | `npm run gate` through `scripts/gate.mjs` | When you want the whole suite locally, or the planner falls back | Yes (deeper check) |
 | Selective PR-tier CI | ci.yml `pr-gate` shards through `scripts/ci_shard_test.mjs` (same selection semantics, sharded; full suite on any unprovable diff) | Every pull request | Yes (PR checks) |
-| Merge queue | ci.yml on the `merge_group` event: the full PR tier over the exact merge result about to become the branch tip (see `docs/merge-queue.md`) | Every queued merge into `main` / `release/**` | Yes (required checks on the merge group) |
+| Merge queue | ci.yml on the `merge_group` event: the full PR tier over the exact merge result about to become the branch tip (see `docs/merge-queue.md`, including rollout status: `release/**` first, `main` at the next release-to-main merge) | Every queued merge into a queue-protected branch | Yes (required checks on the merge group) |
 | Nightly full gate | `.github/workflows/nightly.yml`: full suite + checks + browser over the tips of main and the active `release/**` branch | Scheduled nightly (04:47 UTC) | No (alerting: files and closes one tracking issue) |
 | Judgment review | Claude `/qa` or Codex `$woc-qa`, plus scoped reviewers | End of a contribution | Advisory locally |
 

--- a/docs/qa-gate.md
+++ b/docs/qa-gate.md
@@ -14,6 +14,7 @@ Codex have different entry points and share the same deterministic scripts and c
 | **Selective gate** | `node scripts/gate_select.mjs` | **Before implementation is called ready / pre-merge** | **Yes (the merge bar)** |
 | Full local gate | `npm run gate` through `scripts/gate.mjs` | When you want the whole suite locally, or the planner falls back | Yes (deeper check) |
 | Selective PR-tier CI | ci.yml `pr-gate` shards through `scripts/ci_shard_test.mjs` (same selection semantics, sharded; full suite on any unprovable diff) | Every pull request | Yes (PR checks) |
+| Merge queue | ci.yml on the `merge_group` event: the full PR tier over the exact merge result about to become the branch tip (see `docs/merge-queue.md`) | Every queued merge into `main` / `release/**` | Yes (required checks on the merge group) |
 | Nightly full gate | `.github/workflows/nightly.yml`: full suite + checks + browser over the tips of main and the active `release/**` branch | Scheduled nightly (04:47 UTC) | No (alerting: files and closes one tracking issue) |
 | Judgment review | Claude `/qa` or Codex `$woc-qa`, plus scoped reviewers | End of a contribution | Advisory locally |
 
@@ -190,8 +191,10 @@ and everything under `tests/parity/`), PLUS every test file the PR changed. CI a
 on triggers the local gate does not need: any `.github/` path, the selection pipeline's own
 scripts (a PR runs its own copy of them), any removed or renamed source/test path (a
 deleted module's importers are invisible to `related`), and any listing it cannot relay or
-read safely. Selection never applies off `pull_request` events: `release-gate` keeps the
-unconditional full 8-shard run line, and the nightly gate re-proves the tips daily.
+read safely. Selection never applies off `pull_request` events: a merge-queue run
+(`merge_group`) always takes `test_mode=full` (the queue is the last pre-merge bar),
+`release-gate` keeps the unconditional full 8-shard run line, and the nightly gate
+re-proves the tips daily.
 
 Every decision prints in the job log (`[detect_code_changes]` in the changes job,
 `[ci-shard]` in each shard: mode, reason, floor size, related sources, and the
@@ -207,10 +210,12 @@ What the selective PR tier still cannot prove: the merge-result INTERACTION betw
 the PR's diff and base commits that landed after the PR's merge base. The shards check
 out the merge ref (the PR merged onto the current base tip), but selection derives
 from the PR's own changed files, so a test that only fails in the combination of a PR
-change and a newer base change is outside both the floor and the related set. The
-full-suite run on every `release/**` push re-proves each merged result at merge time,
-and the nightly re-proves the tip daily; a PR wanting the combination proven pre-merge
-can re-merge its base (the moving-base workflow this repo already uses).
+change and a newer base change is outside both the floor and the related set. On the
+queue-protected branches (`main` and `release/**`, see `docs/merge-queue.md`) the merge
+queue closes this pre-merge: every queued PR is retested with the FULL suite on the
+exact merge result against the current tip before it may land. The full-suite run on
+every `release/**` push still re-proves the landed tip, and the nightly re-proves it
+daily.
 
 **Evidence it works.** Fault injection, 5/5 caught: a `Math.random()` in `src/sim`, a combat
 constant, a content record, a sim-emitted player string, and a deleted weapon `.glb`. In two

--- a/tests/ci_change_classify.test.ts
+++ b/tests/ci_change_classify.test.ts
@@ -477,6 +477,22 @@ describe('detect_code_changes.mjs entry (subprocess)', () => {
     expect(run.log).toContain('non-PR event');
   });
 
+  it('writes code=true and test_mode=full to GITHUB_OUTPUT for a merge queue run', async () => {
+    // The merge_group event is the queue's own run over the candidate merge
+    // result; the queue is the last pre-merge bar, so the handover the shard
+    // jobs read must be the full-suite contract, end to end through the real
+    // entry, exactly as for push.
+    const run = await runEntry('merge-group', { GITHUB_EVENT_NAME: 'merge_group' });
+    expect(run.exitCode).toBe(0);
+    expect(run.output).toBe(
+      'code=true\n' +
+        'test_mode=full\n' +
+        'test_mode_reason=selection applies to pull requests only: full suite\n' +
+        'changed_files=[]\n',
+    );
+    expect(run.log).toContain('non-PR event');
+  });
+
   it('writes code=false and the selective handover for a docs-only PR through the real fetch path', async () => {
     const run = await runEntry('docs', {
       GITHUB_EVENT_NAME: 'pull_request',

--- a/tests/ci_change_classify.test.ts
+++ b/tests/ci_change_classify.test.ts
@@ -255,7 +255,9 @@ describe('detectCode (fail closed end to end)', () => {
   }) as unknown as typeof fetch;
 
   it('returns code=true for non-PR events without touching the API', async () => {
-    for (const eventName of ['push', 'workflow_dispatch', 'schedule', '']) {
+    // merge_group is the queue's event: a queue run must always take the full
+    // PR tier (there is no PR files listing to classify on a merge group).
+    for (const eventName of ['push', 'workflow_dispatch', 'schedule', 'merge_group', '']) {
       expect(await detectCode({ ...BASE, eventName, fetchImpl: neverFetch })).toEqual({
         code: true,
         reason: 'non-PR event: full PR tier (code=true)',

--- a/tests/ci_test_select.test.ts
+++ b/tests/ci_test_select.test.ts
@@ -31,7 +31,9 @@ describe('decideTestMode: when selection is allowed at all', () => {
   });
 
   it('never selects off a non-PR event', () => {
-    for (const eventName of ['push', 'workflow_dispatch', 'schedule', '']) {
+    // merge_group included: the merge queue is the last pre-merge bar, so a
+    // queue run must never narrow the suite.
+    for (const eventName of ['push', 'workflow_dispatch', 'schedule', 'merge_group', '']) {
       const d = decideTestMode({ eventName, code: true, files: [mod('src/ui/hud.ts')] });
       expect(d.mode).toBe('full');
       expect(d.changedPaths).toEqual([]);

--- a/tests/ci_workflow.test.ts
+++ b/tests/ci_workflow.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 import { isCodePath } from '../scripts/lib/ci_change_classify.mjs';
+import { decideTestMode } from '../scripts/lib/ci_test_select.mjs';
 import { buildFullGateSteps } from '../scripts/lib/gate_steps.mjs';
 
 const workflow = readFileSync(new URL('../.github/workflows/ci.yml', import.meta.url), 'utf8');
@@ -71,10 +72,13 @@ const CHECK_RUN_STEPS = [
 const RELEASE_IF_LINE =
   "    if: (github.event_name == 'pull_request' && github.base_ref == 'main' && startsWith(github.head_ref, 'release/')) || (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release/'))";
 
-// PR-tier event routing (release-to-main exclusion + non-release push + dispatch).
+// PR-tier event routing (release-to-main exclusion + non-release push + dispatch
+// + merge queue). merge_group is unconditional: the queue bar is the full PR
+// tier, including a queued release-to-main merge (the release exclusion lives on
+// the pull_request arm and cannot match a merge_group event).
 // Path-filter arm is AND-composed separately so either arm can be pinned alone.
 const PR_TIER_EVENT_FRAGMENT =
-  "(github.event_name == 'pull_request' && (github.base_ref != 'main' || !startsWith(github.head_ref, 'release/'))) || (github.event_name == 'push' && !startsWith(github.ref, 'refs/heads/release/')) || github.event_name == 'workflow_dispatch'";
+  "(github.event_name == 'pull_request' && (github.base_ref != 'main' || !startsWith(github.head_ref, 'release/'))) || (github.event_name == 'push' && !startsWith(github.ref, 'refs/heads/release/')) || github.event_name == 'workflow_dispatch' || github.event_name == 'merge_group'";
 
 // Exact composed if for pr-gate and pr-checks after Phase 5 path filters (D10).
 // Extra parens around the event fragment keep || from binding past the && code arm.
@@ -506,6 +510,52 @@ describe('CI workflow parity', () => {
       expect(job).not.toContain('paths-ignore');
       expect(job).not.toContain('needs.changes');
       expect(job).not.toMatch(/^\s{4}needs:/m);
+    }
+  });
+
+  it('routes merge queue runs through the full PR tier and keeps release lanes off them', () => {
+    // The merge queue on main and release/** tests each candidate merge result
+    // on a merge_group event. The trigger is load-bearing: required checks that
+    // never report stall every queued PR until the queue's status-check timeout
+    // rejects it. Anchored to the on: block shape (comments allowed between
+    // keys) so a commented-out trigger cannot satisfy the pin.
+    expect(workflow).toMatch(/\non:\n {2}pull_request:\n(?: {2}#[^\n]*\n)* {2}merge_group:\n/);
+
+    // The queue always runs the FULL suite on the merge result: the changes job
+    // has no job-level if (pinned elsewhere), and the selector treats every
+    // non-PR event as mode=full. Behavioral pin through the real module so a
+    // future merge_group special case in the selector fails here, next to the
+    // workflow trigger it would undermine.
+    expect(decideTestMode({ eventName: 'merge_group', code: true, files: [] }).mode).toBe('full');
+
+    // pr-gate and pr-checks carry the merge_group arm (the exact composed if:
+    // line is pinned in the release-to-main test via PR_TIER_IF_LINE; this is
+    // the readable statement of intent).
+    expect(PR_TIER_EVENT_FRAGMENT).toContain("github.event_name == 'merge_group'");
+
+    // lint diffs a queue run against the target-branch tip the merge group was
+    // built on (event.merge_group.base_sha, passed via env, never interpolated
+    // into the run line). Without this arm the step falls through to the
+    // default-branch fallback and diffs a release/** group against main,
+    // dragging the whole release delta (intentionally-red whole-repo debt)
+    // into biome and rejecting every queued release PR.
+    const lint = jobSource('lint');
+    expect(lint).toContain('MERGE_GROUP_BASE_SHA: ${{ github.event.merge_group.base_sha }}');
+    expect(lint).toMatch(
+      /elif \[ "\$EVENT_NAME" = "merge_group" \] && \[ -n "\$MERGE_GROUP_BASE_SHA" \]; then\n(?: {12}#[^\n]*\n)* {12}git fetch --no-tags --depth=1 origin "\$MERGE_GROUP_BASE_SHA"\n {12}echo "ref=\$MERGE_GROUP_BASE_SHA" >> "\$GITHUB_OUTPUT"\n/,
+    );
+
+    // Release lanes stay off queue runs: their if arms match pull_request and
+    // push only, and the RELEASE_IF_LINE equality pins hold the exact lines.
+    // This negative keeps a future widen from quietly running a release lane
+    // (release-i18n is legitimately red mid-cycle) on every queued PR.
+    for (const name of [
+      'release-gate',
+      'release-i18n',
+      'release-checks',
+      'release-version-gate',
+    ] as const) {
+      expect(jobSource(name)).not.toContain('merge_group');
     }
   });
 

--- a/tests/ci_workflow.test.ts
+++ b/tests/ci_workflow.test.ts
@@ -82,7 +82,11 @@ const PR_TIER_EVENT_FRAGMENT =
 
 // Exact composed if for pr-gate and pr-checks after Phase 5 path filters (D10).
 // Extra parens around the event fragment keep || from binding past the && code arm.
-const PR_TIER_IF_LINE = `    if: (${PR_TIER_EVENT_FRAGMENT}) && needs.changes.outputs.code == 'true'`;
+// The code arm is != 'false' (not == 'true'): only an explicit docs-only verdict
+// may skip the tier. A missing or empty output runs it, matching the
+// classifier's fail-closed doctrine; under the merge queue a skipped required
+// check reads satisfied, so failing toward SKIP would be the wrong direction.
+const PR_TIER_IF_LINE = `    if: (${PR_TIER_EVENT_FRAGMENT}) && needs.changes.outputs.code != 'false'`;
 
 // Minimum code path set the changes job must classify as code=true (D10).
 // Each row pairs the original inline-YAML glob with a representative path;
@@ -306,7 +310,7 @@ describe('CI workflow parity', () => {
       const ifLines = job.match(/^\s{4}if: .+$/gm) ?? [];
       expect(ifLines).toEqual([PR_TIER_IF_LINE]);
       expect(job).toContain(PR_TIER_EVENT_FRAGMENT);
-      expect(job).toContain("needs.changes.outputs.code == 'true'");
+      expect(job).toContain("needs.changes.outputs.code != 'false'");
       expect(job).not.toContain('I18N_RELEASE_TIER');
     }
     // Both release jobs share the exact same job-level if line so they skip or
@@ -490,7 +494,7 @@ describe('CI workflow parity', () => {
     const browserGate = jobSource('browser-gate');
     expect(browserGate).toMatch(/^\s{4}needs: changes\s*$/m);
     const browserIf = browserGate.match(/^\s{4}if: .+$/gm) ?? [];
-    expect(browserIf).toEqual(["    if: needs.changes.outputs.code == 'true'"]);
+    expect(browserIf).toEqual(["    if: needs.changes.outputs.code != 'false'"]);
 
     // Aggregator only if branch protection cannot accept skipped checks. This
     // packet does not invent one without evidence (OPEN item 5: skipped release
@@ -517,20 +521,33 @@ describe('CI workflow parity', () => {
     // The merge queue on main and release/** tests each candidate merge result
     // on a merge_group event. The trigger is load-bearing: required checks that
     // never report stall every queued PR until the queue's status-check timeout
-    // rejects it. Anchored to the on: block shape (comments allowed between
-    // keys) so a commented-out trigger cannot satisfy the pin.
-    expect(workflow).toMatch(/\non:\n {2}pull_request:\n(?: {2}#[^\n]*\n)* {2}merge_group:\n/);
+    // rejects it. Anchored to a top-level on: key (comments and other trigger
+    // lines allowed before it) so a commented-out trigger or one nested under
+    // another event cannot satisfy the pin; key order is deliberately not
+    // pinned.
+    expect(workflow).toMatch(/\non:\n(?:[ \t]+[^\n]*\n)*? {2}merge_group:\n/);
 
     // The queue always runs the FULL suite on the merge result: the changes job
-    // has no job-level if (pinned elsewhere), and the selector treats every
-    // non-PR event as mode=full. Behavioral pin through the real module so a
-    // future merge_group special case in the selector fails here, next to the
-    // workflow trigger it would undermine.
-    expect(decideTestMode({ eventName: 'merge_group', code: true, files: [] }).mode).toBe('full');
+    // has no job-level if (pinned elsewhere), and the selector refuses every
+    // non-PR event. The file entry is what makes this decisive: with a real
+    // modified source in hand, only the event guard can force full (the same
+    // input under pull_request goes selective), so a future merge_group special
+    // case in the selector fails here, next to the workflow trigger it would
+    // undermine. The reason pin proves WHICH guard fired.
+    const queueDecision = decideTestMode({
+      eventName: 'merge_group',
+      code: true,
+      files: [{ filename: 'src/ui/hud.ts', status: 'modified' }],
+    });
+    expect(queueDecision.mode).toBe('full');
+    expect(queueDecision.reason).toBe('selection applies to pull requests only: full suite');
 
-    // pr-gate and pr-checks carry the merge_group arm (the exact composed if:
-    // line is pinned in the release-to-main test via PR_TIER_IF_LINE; this is
-    // the readable statement of intent).
+    // Deliberate tripwire on the constant, not a workflow pin: the workflow
+    // text itself is held to PR_TIER_IF_LINE by exact single-if-line equality
+    // in 'runs the release tier against a release-to-main pull request merge
+    // result' above. Editing the workflow AND the constant together to drop
+    // the queue arm still goes red here, forcing a conscious edit of this
+    // literal too.
     expect(PR_TIER_EVENT_FRAGMENT).toContain("github.event_name == 'merge_group'");
 
     // lint diffs a queue run against the target-branch tip the merge group was
@@ -538,11 +555,30 @@ describe('CI workflow parity', () => {
     // into the run line). Without this arm the step falls through to the
     // default-branch fallback and diffs a release/** group against main,
     // dragging the whole release delta (intentionally-red whole-repo debt)
-    // into biome and rejecting every queued release PR.
+    // into biome and rejecting every queued release PR. Both env lines are
+    // pinned INSIDE the Determine-base-ref step's env block (a raw substring
+    // would stay green commented-out or moved to the wrong step), and the
+    // shell arm's shape is pinned elif-to-fetch-to-echo with only comment
+    // lines allowed between.
     const lint = jobSource('lint');
-    expect(lint).toContain('MERGE_GROUP_BASE_SHA: ${{ github.event.merge_group.base_sha }}');
+    const baseRefEnvBlock = String.raw`\n {6}- name: Determine base ref\n {8}id: base\n {8}env:\n(?: {10}[A-Z_]+: [^\n]*\n)*?`;
     expect(lint).toMatch(
-      /elif \[ "\$EVENT_NAME" = "merge_group" \] && \[ -n "\$MERGE_GROUP_BASE_SHA" \]; then\n(?: {12}#[^\n]*\n)* {12}git fetch --no-tags --depth=1 origin "\$MERGE_GROUP_BASE_SHA"\n {12}echo "ref=\$MERGE_GROUP_BASE_SHA" >> "\$GITHUB_OUTPUT"\n/,
+      new RegExp(
+        `${baseRefEnvBlock} {10}MERGE_GROUP_BASE_SHA: \\$\\{\\{ github\\.event\\.merge_group\\.base_sha \\}\\}\n`,
+      ),
+    );
+    expect(lint).toMatch(
+      new RegExp(
+        `${baseRefEnvBlock} {10}MERGE_GROUP_BASE_REF: \\$\\{\\{ github\\.event\\.merge_group\\.base_ref \\}\\}\n`,
+      ),
+    );
+    expect(lint).toMatch(
+      /elif \[ "\$EVENT_NAME" = "merge_group" \] && printf '%s' "\$MERGE_GROUP_BASE_SHA" \| grep -qE '\^\[0-9a-f\]\{40\}\$'; then\n(?: {12}#[^\n]*\n)* {12}if git fetch --no-tags --depth=1 origin "\$MERGE_GROUP_BASE_SHA"; then\n {14}echo "ref=\$MERGE_GROUP_BASE_SHA" >> "\$GITHUB_OUTPUT"\n/,
+    );
+    // The unreachable-SHA fallback diffs against the live target-branch tip
+    // (never the default branch), so one flaky fetch cannot eject a good PR.
+    expect(lint).toMatch(
+      /base_branch="\$\{MERGE_GROUP_BASE_REF#refs\/heads\/\}"\n {14}git fetch --no-tags --depth=1 origin "\$base_branch"\n {14}echo "ref=origin\/\$base_branch" >> "\$GITHUB_OUTPUT"\n/,
     );
 
     // Release lanes stay off queue runs: their if arms match pull_request and
@@ -557,6 +593,47 @@ describe('CI workflow parity', () => {
     ] as const) {
       expect(jobSource(name)).not.toContain('merge_group');
     }
+  });
+
+  it('pins the merge queue required-check names to ci.yml and docs/merge-queue.md', () => {
+    // Branch protection string-matches check DISPLAY names, and the ruleset
+    // lives outside git: renaming any of these jobs silently un-requires the
+    // check, or worse leaves a required name that never reports, which blocks
+    // every queued merge until the queue timeout. docs/merge-queue.md is the
+    // written contract, so the workflow name line and the doc must both carry
+    // each name exactly.
+    const mergeQueueDoc = readFileSync(new URL('../docs/merge-queue.md', import.meta.url), 'utf8');
+    const requiredCheckNames = [
+      'Detect code path changes',
+      'PR gate (English-only legal)',
+      'PR checks (freshness, typecheck, builds)',
+      'Format + lint (Biome, changed files)',
+      'Browser regressions (Chromium)',
+    ] as const;
+    for (const name of requiredCheckNames) {
+      // Anchored to the job-level name: line (4-space indent), so a
+      // commented-out or step-level `- name:` cannot satisfy it.
+      expect(workflow).toContain(`\n    name: ${name}\n`);
+    }
+    // The doc names each required check in the exact form protection sees it:
+    // bare names for the unsharded jobs, and the matrix-suffixed range for the
+    // sharded gate. The range must track SHARD_N, or a future shard-count
+    // change silently leaves the extra shards un-required in a ruleset nobody
+    // can diff in git.
+    const docRequiredNameForms = [
+      '`Detect code path changes`',
+      `\`PR gate (English-only legal) (1)\` through \`(${SHARD_N})\``,
+      '`PR checks (freshness, typecheck, builds)`',
+      '`Format + lint (Biome, changed files)`',
+      '`Browser regressions (Chromium)`',
+    ] as const;
+    for (const form of docRequiredNameForms) {
+      expect(mergeQueueDoc).toContain(form);
+    }
+    // The doc must never list a release lane or the path-filtered audit as
+    // required: the release lanes are legitimately red mid-cycle, and a
+    // required check whose workflow never reports deadlocks the queue.
+    expect(mergeQueueDoc).toContain('Never require these');
   });
 
   it(`shards the PR and release test steps ${SHARD_N} ways and keeps the checks single-shard`, () => {

--- a/tests/ci_workflow.test.ts
+++ b/tests/ci_workflow.test.ts
@@ -86,6 +86,8 @@ const PR_TIER_EVENT_FRAGMENT =
 // may skip the tier. A missing or empty output runs it, matching the
 // classifier's fail-closed doctrine; under the merge queue a skipped required
 // check reads satisfied, so failing toward SKIP would be the wrong direction.
+// (Covers green-but-empty output only: a FAILED changes job skips dependents
+// via needs regardless, which requiring "Detect code path changes" closes.)
 const PR_TIER_IF_LINE = `    if: (${PR_TIER_EVENT_FRAGMENT}) && needs.changes.outputs.code != 'false'`;
 
 // Minimum code path set the changes job must classify as code=true (D10).
@@ -521,11 +523,11 @@ describe('CI workflow parity', () => {
     // The merge queue on main and release/** tests each candidate merge result
     // on a merge_group event. The trigger is load-bearing: required checks that
     // never report stall every queued PR until the queue's status-check timeout
-    // rejects it. Anchored to a top-level on: key (comments and other trigger
-    // lines allowed before it) so a commented-out trigger or one nested under
-    // another event cannot satisfy the pin; key order is deliberately not
-    // pinned.
-    expect(workflow).toMatch(/\non:\n(?:[ \t]+[^\n]*\n)*? {2}merge_group:\n/);
+    // rejects it. Anchored to a top-level on: key (comments, blank lines, and
+    // other trigger lines allowed before it) so a commented-out trigger or one
+    // nested under another event cannot satisfy the pin; key order is
+    // deliberately not pinned.
+    expect(workflow).toMatch(/\non:\n(?:(?:[ \t]+[^\n]*)?\n)*? {2}merge_group:\n/);
 
     // The queue always runs the FULL suite on the merge result: the changes job
     // has no job-level if (pinned elsewhere), and the selector refuses every
@@ -558,10 +560,11 @@ describe('CI workflow parity', () => {
     // into biome and rejecting every queued release PR. Both env lines are
     // pinned INSIDE the Determine-base-ref step's env block (a raw substring
     // would stay green commented-out or moved to the wrong step), and the
-    // shell arm's shape is pinned elif-to-fetch-to-echo with only comment
-    // lines allowed between.
+    // whole shell arm is ONE regex, elif through fi, so no line of it can be
+    // deleted, reordered, or parked as dead code elsewhere in the step; only
+    // comment and blank lines are allowed at the two comment sites.
     const lint = jobSource('lint');
-    const baseRefEnvBlock = String.raw`\n {6}- name: Determine base ref\n {8}id: base\n {8}env:\n(?: {10}[A-Z_]+: [^\n]*\n)*?`;
+    const baseRefEnvBlock = String.raw`\n {6}- name: Determine base ref\n {8}id: base\n {8}env:\n(?:(?: {10}[A-Z_]+: [^\n]*| {10}#[^\n]*)?\n)*?`;
     expect(lint).toMatch(
       new RegExp(
         `${baseRefEnvBlock} {10}MERGE_GROUP_BASE_SHA: \\$\\{\\{ github\\.event\\.merge_group\\.base_sha \\}\\}\n`,
@@ -572,13 +575,28 @@ describe('CI workflow parity', () => {
         `${baseRefEnvBlock} {10}MERGE_GROUP_BASE_REF: \\$\\{\\{ github\\.event\\.merge_group\\.base_ref \\}\\}\n`,
       ),
     );
+    // The arm enters on the EVENT alone: a malformed base SHA must land in the
+    // in-arm fallback, never fall through to the default-branch arm (the
+    // pre-fix disaster path). The [ -n ] line is the loud guard for an empty
+    // base ref (fetching "" quietly succeeds and would write a broken
+    // ref=origin/ output).
+    const comment12 = String.raw`(?:(?: {12}#[^\n]*)?\n)*?`;
+    const comment14 = String.raw`(?:(?: {14}#[^\n]*)?\n)*?`;
     expect(lint).toMatch(
-      /elif \[ "\$EVENT_NAME" = "merge_group" \] && printf '%s' "\$MERGE_GROUP_BASE_SHA" \| grep -qE '\^\[0-9a-f\]\{40\}\$'; then\n(?: {12}#[^\n]*\n)* {12}if git fetch --no-tags --depth=1 origin "\$MERGE_GROUP_BASE_SHA"; then\n {14}echo "ref=\$MERGE_GROUP_BASE_SHA" >> "\$GITHUB_OUTPUT"\n/,
-    );
-    // The unreachable-SHA fallback diffs against the live target-branch tip
-    // (never the default branch), so one flaky fetch cannot eject a good PR.
-    expect(lint).toMatch(
-      /base_branch="\$\{MERGE_GROUP_BASE_REF#refs\/heads\/\}"\n {14}git fetch --no-tags --depth=1 origin "\$base_branch"\n {14}echo "ref=origin\/\$base_branch" >> "\$GITHUB_OUTPUT"\n/,
+      new RegExp(
+        String.raw`elif \[ "\$EVENT_NAME" = "merge_group" \]; then\n` +
+          comment12 +
+          String.raw` {12}if printf '%s' "\$MERGE_GROUP_BASE_SHA" \| grep -qE '\^\[0-9a-f\]\{40\}\$' \\\n` +
+          String.raw` {14}&& git fetch --no-tags --depth=1 origin "\$MERGE_GROUP_BASE_SHA"; then\n` +
+          String.raw` {14}echo "ref=\$MERGE_GROUP_BASE_SHA" >> "\$GITHUB_OUTPUT"\n` +
+          String.raw` {12}else\n` +
+          comment14 +
+          String.raw` {14}base_branch="\$\{MERGE_GROUP_BASE_REF#refs/heads/\}"\n` +
+          String.raw` {14}\[ -n "\$base_branch" \]\n` +
+          String.raw` {14}git fetch --no-tags --depth=1 origin "\$base_branch"\n` +
+          String.raw` {14}echo "ref=origin/\$base_branch" >> "\$GITHUB_OUTPUT"\n` +
+          String.raw` {12}fi\n`,
+      ),
     );
 
     // Release lanes stay off queue runs: their if arms match pull_request and
@@ -619,7 +637,16 @@ describe('CI workflow parity', () => {
     // bare names for the unsharded jobs, and the matrix-suffixed range for the
     // sharded gate. The range must track SHARD_N, or a future shard-count
     // change silently leaves the extra shards un-required in a ruleset nobody
-    // can diff in git.
+    // can diff in git. The doc is sliced at its "Never require these" heading:
+    // each required name must sit in the REQUIRED half, and none may appear in
+    // the never-require list, so quietly moving a check between the two lists
+    // fails here rather than reading as a contract change nobody pinned.
+    const neverIdx = mergeQueueDoc.indexOf('Never require these');
+    expect(neverIdx).toBeGreaterThan(0);
+    const requiredHalf = mergeQueueDoc.slice(0, neverIdx);
+    const neverSectionEnd = mergeQueueDoc.indexOf('\n## ', neverIdx);
+    expect(neverSectionEnd).toBeGreaterThan(neverIdx);
+    const neverSection = mergeQueueDoc.slice(neverIdx, neverSectionEnd);
     const docRequiredNameForms = [
       '`Detect code path changes`',
       `\`PR gate (English-only legal) (1)\` through \`(${SHARD_N})\``,
@@ -628,12 +655,11 @@ describe('CI workflow parity', () => {
       '`Browser regressions (Chromium)`',
     ] as const;
     for (const form of docRequiredNameForms) {
-      expect(mergeQueueDoc).toContain(form);
+      expect(requiredHalf).toContain(form);
     }
-    // The doc must never list a release lane or the path-filtered audit as
-    // required: the release lanes are legitimately red mid-cycle, and a
-    // required check whose workflow never reports deadlocks the queue.
-    expect(mergeQueueDoc).toContain('Never require these');
+    for (const name of requiredCheckNames) {
+      expect(neverSection).not.toContain(`\`${name}\``);
+    }
   });
 
   it(`shards the PR and release test steps ${SHARD_N} ways and keeps the checks single-shard`, () => {


### PR DESCRIPTION
## Summary

Make CI merge-queue ready so branch protection plus a merge queue can keep the
`release/**` and `main` tips green by construction (the 2026-08-05 red-tip
incident class; both of today's red merges into release/v0.35.0 are the same
class).

- Add the `merge_group` trigger to ci.yml and route queue runs through the PR
  tier (`changes`, lint, pr-gate, pr-checks, browser-gate). The trigger is
  load-bearing: without it, required checks never report on queue runs and
  every queued PR stalls until the queue timeout rejects it.
- A queue run always tests the FULL suite on the exact merge result: the
  `changes` job already fails closed to `code=true` and `test_mode=full` on
  any non-PR event, and the selector refuses non-PR events (no script changes;
  now pinned explicitly for `merge_group`). Selection never applies to the
  queue; the queue is the last pre-merge bar.
- lint gains a `merge_group` arm that diffs against the merge group's base SHA
  (hex-shape guarded, with an unreachable-SHA fallback to the live
  target-branch tip). Without it the step would fall through to the
  default-branch arm and drag the whole release-vs-main delta (intentionally
  red whole-repo biome debt) into every queued release PR.
- The PR-tier/browser-gate code arm becomes `!= 'false'` (was `== 'true'`):
  only an explicit docs-only verdict may skip the tier. Under a queue, a
  skipped required check reads satisfied, so doubt must fail toward RUN.
- Release lanes stay off queue runs by construction (their `if` arms match
  `pull_request` and `push` only, pinned negatively).
- `docs/merge-queue.md` is the new team-facing contract: what the merge button
  becomes, what to do on a queue rejection, the exact required-check list and
  the checks that must never be required (release lanes, AI assist, the
  path-filtered dependency audit), rollout status, and the fork-queueing
  caution. `tests/ci_workflow.test.ts` holds the required-check display names
  to ci.yml AND the doc, including the shard-suffix range.
- The ruleset itself (required checks + queue) is applied by a repo admin
  outside git, sequenced AFTER this PR lands; enabling the queue before the
  trigger exists on the target branch is exactly the stall this PR prevents.

No check names changed; they are now load-bearing for protection.

## Type of change

- [x] Build, CI, or tooling
- [x] Documentation
- [x] Tests

## How was this tested?

- Commands:
  - `npx vitest run tests/ci_workflow.test.ts tests/ci_change_classify.test.ts
    tests/ci_test_select.test.ts` (84 tests green, including the new
    merge_group pins and the required-check-name cross-pin)
  - `npx tsc --noEmit` clean; changed-files biome clean
  - `node scripts/gate_select.mjs`: PASS, all 11 steps green (596-file
    always-run floor across 4 legs, browser suite, typecheck, all builds), run
    on this branch with the current release tip merged in
  - YAML parse check: `on` resolves to pull_request, merge_group, push,
    workflow_dispatch; all nine jobs parse; job display names unchanged
- Manual steps: reviewed with a three-agent fan-out (QA checklist, privacy and
  security, test-coverage audit) plus a fresh fix-round review; all findings
  applied.

## Screenshots / recordings

N/A (no player-visible or operator-visible UI change).

---

## Checklist

### Quality

- [x] **The gate passes.** See commands above.

### Cross-platform

- ~Tested on desktop and mobile.~ N/A (CI configuration and docs).
- ~Accessible.~ N/A.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS`
      is not enabled in any production path.
- [x] I didn't hand-edit generated files.
