### PR TITLE
perf(ci): persist the vitest transform cache across shard runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -405,9 +405,12 @@ jobs:
       # the key is new and never refreshed within that state, so the hit rate
       # decays as sources drift until the next rotation (start there if the
       # speedup fades). The binding budget is GitHub's 10 GB per-repo cache
-      # quota with LRU eviction: both matrices together hold roughly 1 GB per
-      # toolchain state per scope beside the pnpm store, Playwright, and tsc
-      # caches, so if hot-entry eviction is ever observed, the lever is
+      # quota with LRU eviction: about 0.5 GB per toolchain state per scope
+      # (8 entries at 57-73 MB; no single scope holds both matrices, since
+      # their if arms are exact complements on the events that could share a
+      # ref), roughly 1 GB across the two long-lived producer scopes (main
+      # plus the release branch) beside the pnpm store, Playwright, and tsc
+      # caches. If hot-entry eviction is ever observed, the lever is
       # restricting this step's save to push events, never restore-keys.
       # Producers beyond release-gate: pr-gate's own main and dev-* push runs
       # seed those branches' scopes the same way.
@@ -585,10 +588,11 @@ jobs:
 
       # Same vitest transform cache as pr-gate, same key on purpose: this
       # job's release/** PUSH runs are the producer that saves the store into
-      # the base-branch cache scope, the only scope PR runs can restore from
-      # (this job's other arm, the release-to-main pull_request, saves into
-      # that PR's own scope like any PR run). The full rationale (staleness
-      # vs tamper safety, layout-pinned key, no restore-keys,
+      # the release branch's scope, the base-branch scope PR runs restore
+      # from (this job's other arm, the release-to-main pull_request, saves
+      # into that PR's own scope like any PR run; pr-gate's main and dev-*
+      # push runs seed those branches' scopes likewise). The full rationale
+      # (staleness vs tamper safety, layout-pinned key, no restore-keys,
       # save-on-miss-only, measured sizes) sits on the pr-gate copy of this
       # step.
       - name: Cache vitest transform cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -377,6 +377,30 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # Persist the vitest transform cache across runs (vite.config.ts enables
+      # experimental.fsModuleCache; the store is
+      # node_modules/.experimental-vitest-cache). Correctness lives inside
+      # vitest, not in this key: every entry is content-addressed (sha1 over the
+      # module source, the config file contents, NODE_ENV, and the vitest
+      # version), and vitest discards the whole store when pnpm-lock.yaml
+      # changes, so a stale restore can only miss, never serve a wrong
+      # transform. The key still pins lockfile + vite config so a rotated
+      # toolchain starts clean instead of restoring a store vitest would
+      # immediately discard; no restore-keys for the same reason. actions/cache
+      # saves only when the primary key missed, so entries stay bounded (one per
+      # shard per toolchain state) instead of accumulating per commit. Per-shard
+      # keys because each shard transforms its own pack's import closure.
+      # release-gate carries the same step with the same key: its release/**
+      # push runs are what save the cache into the base-branch scope PR runs can
+      # restore from (pr-gate never runs on release pushes, and a PR-scoped save
+      # is invisible to every other PR). Both selective legs and the full replay
+      # read the same store: every leg is vitest under the same config.
+      - name: Cache vitest transform cache
+        uses: actions/cache@v4
+        with:
+          path: node_modules/.experimental-vitest-cache
+          key: vitest-fsmodule-${{ runner.os }}-shard${{ matrix.shard }}-${{ hashFiles('pnpm-lock.yaml', 'vite.config.ts') }}
+
       # The shard runner spawns `npm test` itself, so pretest still regenerates
       # the i18n artifacts in EVERY shard BY DESIGN (the S3 guard, guide
       # freshness, and the git-subprocess suites need the generated artifacts no
@@ -532,6 +556,17 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      # Same vitest transform cache as pr-gate, same key on purpose: these push
+      # runs are the producer that saves the store into the base-branch cache
+      # scope, which is the only scope PR runs can restore from. The full
+      # rationale (content-addressed entries, lockfile integrity discard, no
+      # restore-keys, save-on-miss-only) sits on the pr-gate copy of this step.
+      - name: Cache vitest transform cache
+        uses: actions/cache@v4
+        with:
+          path: node_modules/.experimental-vitest-cache
+          key: vitest-fsmodule-${{ runner.os }}-shard${{ matrix.shard }}-${{ hashFiles('pnpm-lock.yaml', 'vite.config.ts') }}
 
       # `npm test` regenerates the i18n artifacts itself (pretest) in EVERY
       # shard BY DESIGN (the S3 guard, guide freshness, and the git-subprocess

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -384,9 +384,9 @@ jobs:
       # source, the config file contents, NODE_ENV, and the fsModuleCache
       # format version, so a changed input can only miss (a vitest upgrade
       # rotates via the lockfile, in this key and in vitest's own integrity
-      # discard, which hashes the derived node_modules/.pnpm/lock.yaml,
-      # byte-identical to pnpm-lock.yaml under the hoisted layout and present
-      # only after install, one reason this step sits after the install step).
+      # discard, which hashes the derived node_modules/.pnpm/lock.yaml, the
+      # byte-identical copy pnpm writes during install and therefore present
+      # only after it, one reason this step sits after the install step).
       # TAMPER safety is GitHub's per-ref cache scoping, not vitest: entries
       # are keyed by content, never verified against it, and the store is
       # executed as module code, so this step must never gain restore-keys or
@@ -404,7 +404,14 @@ jobs:
       # toolchain state per scope (measured 2026-08-06), written once when
       # the key is new and never refreshed within that state, so the hit rate
       # decays as sources drift until the next rotation (start there if the
-      # speedup fades). Per-shard keys: in full mode each shard transforms
+      # speedup fades). The binding budget is GitHub's 10 GB per-repo cache
+      # quota with LRU eviction: both matrices together hold roughly 1 GB per
+      # toolchain state per scope beside the pnpm store, Playwright, and tsc
+      # caches, so if hot-entry eviction is ever observed, the lever is
+      # restricting this step's save to push events, never restore-keys.
+      # Producers beyond release-gate: pr-gate's own main and dev-* push runs
+      # seed those branches' scopes the same way.
+      # Per-shard keys: in full mode each shard transforms
       # its own pack's import closure; in selective mode the collected set is
       # smaller and only partially resembles the full-mode store it restores,
       # which still hits on the shared source closure that dominates the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -379,27 +379,46 @@ jobs:
 
       # Persist the vitest transform cache across runs (vite.config.ts enables
       # experimental.fsModuleCache; the store is
-      # node_modules/.experimental-vitest-cache). Correctness lives inside
-      # vitest, not in this key: every entry is content-addressed (sha1 over the
-      # module source, the config file contents, NODE_ENV, and the vitest
-      # version), and vitest discards the whole store when pnpm-lock.yaml
-      # changes, so a stale restore can only miss, never serve a wrong
-      # transform. The key still pins lockfile + vite config so a rotated
-      # toolchain starts clean instead of restoring a store vitest would
-      # immediately discard; no restore-keys for the same reason. actions/cache
-      # saves only when the primary key missed, so entries stay bounded (one per
-      # shard per toolchain state) instead of accumulating per commit. Per-shard
-      # keys because each shard transforms its own pack's import closure.
-      # release-gate carries the same step with the same key: its release/**
-      # push runs are what save the cache into the base-branch scope PR runs can
-      # restore from (pr-gate never runs on release pushes, and a PR-scoped save
-      # is invisible to every other PR). Both selective legs and the full replay
-      # read the same store: every leg is vitest under the same config.
+      # node_modules/.experimental-vitest-cache). STALENESS safety lives inside
+      # vitest, not in this key: every entry is keyed by sha1 over the module
+      # source, the config file contents, NODE_ENV, and the fsModuleCache
+      # format version, so a changed input can only miss (a vitest upgrade
+      # rotates via the lockfile, in this key and in vitest's own integrity
+      # discard, which hashes the derived node_modules/.pnpm/lock.yaml,
+      # byte-identical to pnpm-lock.yaml under the hoisted layout and present
+      # only after install, one reason this step sits after the install step).
+      # TAMPER safety is GitHub's per-ref cache scoping, not vitest: entries
+      # are keyed by content, never verified against it, and the store is
+      # executed as module code, so this step must never gain restore-keys or
+      # a shared scope without redoing that analysis. Accepted residual: a
+      # fork PR's first run (which already executes the PR's own code by
+      # design) can seed its own refs/pull/N/merge scope for later runs of
+      # the SAME PR; that scope cannot reach other PRs, merge_group runs,
+      # release-gate, or the nightly, and the PR tier holds no secrets and a
+      # read-only token. The key pins every node_modules-layout input
+      # (lockfile, vite config, .npmrc for node-linker, package.json for the
+      # packageManager pin) so a re-layout starts clean instead of restoring
+      # a store vitest would discard or mis-resolve; no restore-keys for the
+      # same reason. actions/cache saves only when the primary key missed, so
+      # entries stay bounded: one 57-73 MB compressed entry per shard per
+      # toolchain state per scope (measured 2026-08-06), written once when
+      # the key is new and never refreshed within that state, so the hit rate
+      # decays as sources drift until the next rotation (start there if the
+      # speedup fades). Per-shard keys: in full mode each shard transforms
+      # its own pack's import closure; in selective mode the collected set is
+      # smaller and only partially resembles the full-mode store it restores,
+      # which still hits on the shared source closure that dominates the
+      # store. release-gate carries the same step with the same key: its
+      # release/** push runs are what save the store into the base-branch
+      # scope PR runs can restore from (pr-gate never runs on release pushes,
+      # and a PR-scoped save is invisible to every other PR). Both selective
+      # legs and the full replay read the same store: every leg is vitest
+      # under the same config.
       - name: Cache vitest transform cache
         uses: actions/cache@v4
         with:
           path: node_modules/.experimental-vitest-cache
-          key: vitest-fsmodule-${{ runner.os }}-shard${{ matrix.shard }}-${{ hashFiles('pnpm-lock.yaml', 'vite.config.ts') }}
+          key: vitest-fsmodule-${{ runner.os }}-shard${{ matrix.shard }}-${{ hashFiles('pnpm-lock.yaml', 'vite.config.ts', '.npmrc', 'package.json') }}
 
       # The shard runner spawns `npm test` itself, so pretest still regenerates
       # the i18n artifacts in EVERY shard BY DESIGN (the S3 guard, guide
@@ -557,16 +576,19 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      # Same vitest transform cache as pr-gate, same key on purpose: these push
-      # runs are the producer that saves the store into the base-branch cache
-      # scope, which is the only scope PR runs can restore from. The full
-      # rationale (content-addressed entries, lockfile integrity discard, no
-      # restore-keys, save-on-miss-only) sits on the pr-gate copy of this step.
+      # Same vitest transform cache as pr-gate, same key on purpose: this
+      # job's release/** PUSH runs are the producer that saves the store into
+      # the base-branch cache scope, the only scope PR runs can restore from
+      # (this job's other arm, the release-to-main pull_request, saves into
+      # that PR's own scope like any PR run). The full rationale (staleness
+      # vs tamper safety, layout-pinned key, no restore-keys,
+      # save-on-miss-only, measured sizes) sits on the pr-gate copy of this
+      # step.
       - name: Cache vitest transform cache
         uses: actions/cache@v4
         with:
           path: node_modules/.experimental-vitest-cache
-          key: vitest-fsmodule-${{ runner.os }}-shard${{ matrix.shard }}-${{ hashFiles('pnpm-lock.yaml', 'vite.config.ts') }}
+          key: vitest-fsmodule-${{ runner.os }}-shard${{ matrix.shard }}-${{ hashFiles('pnpm-lock.yaml', 'vite.config.ts', '.npmrc', 'package.json') }}
 
       # `npm test` regenerates the i18n artifacts itself (pretest) in EVERY
       # shard BY DESIGN (the S3 guard, guide freshness, and the git-subprocess

--- a/docs/local-gate-perf/baselines.md
+++ b/docs/local-gate-perf/baselines.md
@@ -293,7 +293,7 @@ Vitest guidance: fs cache helps most on small re-runs with large module graphs).
 | Item | Value |
 |---|---|
 | Config | `test.experimental.fsModuleCache: true` |
-| Cache dir | `node_modules/.experimental-vitest-cache` (~3.8 MiB after full suite) |
+| Cache dir | `node_modules/.experimental-vitest-cache` (measured 2026-08-06: ~102 MB, ~1078 entries after a partial run; a CI shard's store compresses to 57-73 MB per `actions/cache` entry; the ~3.8 MiB figure recorded here earlier was wrong) |
 | Clear | `npx vitest --clearCache` |
 | `test:related` | `vitest related --run --passWithNoTests` |
 | `test:changed` | `vitest run --passWithNoTests --changed` |

--- a/docs/qa-gate.md
+++ b/docs/qa-gate.md
@@ -80,7 +80,13 @@ is dirty (same reason `gate:fast` skips those paths for related expansion). Pref
 `test:related` with explicit sources, or `gate:fast`, for day-to-day work. Vitest
 `experimental.fsModuleCache` is on in `vite.config.ts` so warm re-runs reuse module
 transforms under `node_modules/.experimental-vitest-cache` (clear with
-`npx vitest --clearCache` if a warm run looks wrong). Most DOM-environment unit
+`npx vitest --clearCache` if a warm run looks wrong). The same store is persisted
+across CI runs since Phase 4 of the CI/CD performance packet: the pr-gate and
+release-gate shard jobs carry an `actions/cache` step for it, keyed per shard on the
+node_modules-layout inputs (lockfile, vite config, `.npmrc`, `package.json`), with the
+design constraints written on the step in `.github/workflows/ci.yml` and pinned by
+`tests/ci_workflow.test.ts`. The nightly gate deliberately stays cold: it is the
+uncached full replay. Most DOM-environment unit
 tests use `// @vitest-environment happy-dom`; a short exception list still pins
 `jsdom` where happy-dom API gaps bite (see `docs/local-gate-perf/baselines.md`
 Phase 5). Default environment remains `node`.

--- a/tests/ci_workflow.test.ts
+++ b/tests/ci_workflow.test.ts
@@ -775,10 +775,42 @@ describe('CI workflow parity', () => {
     expect(releaseI18n).not.toContain('--shard=');
     expect(releaseI18n.match(/\n {6}- name: /g)).toHaveLength(5);
     // Structural step counts: each test job is exactly checkout, setup-pnpm,
-    // setup-node, pnpm install, and the sharded test run. An unconditioned
-    // addition would run N times per push; a dropped step shrinks the job silently.
-    expect(prGate.match(/\n {6}- name: /g)).toHaveLength(5);
-    expect(releaseGate.match(/\n {6}- name: /g)).toHaveLength(5);
+    // setup-node, pnpm install, the vitest transform cache, and the sharded
+    // test run. An unconditioned addition would run N times per push; a
+    // dropped step shrinks the job silently.
+    expect(prGate.match(/\n {6}- name: /g)).toHaveLength(6);
+    expect(releaseGate.match(/\n {6}- name: /g)).toHaveLength(6);
+  });
+
+  it('persists the vitest transform cache on both shard matrices with a bounded key', () => {
+    // Phase 4 of the CI/CD performance packet: the fsModuleCache store
+    // (enabled in vite.config.ts) is content-addressed inside vitest, so the
+    // actions/cache key only manages rotation and size, never correctness.
+    // Name-to-uses adjacency plus the path line so a YAML-commented-out step
+    // cannot satisfy the pin, mirroring the Playwright cache pin above.
+    const cacheStepRe =
+      /- name: Cache vitest transform cache\n(?: {8}#[^\n]*\n)* {8}uses: actions\/cache@[^\n]+\n {8}with:\n {10}path: node_modules\/\.experimental-vitest-cache\n {10}key: vitest-fsmodule-\$\{\{ runner\.os \}\}-shard\$\{\{ matrix\.shard \}\}-\$\{\{ hashFiles\('pnpm-lock\.yaml', 'vite\.config\.ts'\) \}\}\n/;
+    for (const name of ['pr-gate', 'release-gate'] as const) {
+      const job = jobSource(name);
+      expect(job).toMatch(cacheStepRe);
+      // Restore before the test step, or the run never sees the store.
+      expect(job.indexOf('Cache vitest transform cache')).toBeLessThan(
+        job.indexOf('- name: Run tests'),
+      );
+      // No restore-keys: a cross-lockfile restore is discarded by vitest's own
+      // integrity check and a cross-config restore misses every entry, so a
+      // prefix fallback can only ever download dead weight. Anchored to the
+      // YAML key shape because the step's own comment says the word.
+      expect(job).not.toMatch(/\n\s+restore-keys:/);
+    }
+    // The store is enabled in the config this cache serves; if fsModuleCache is
+    // ever turned off there, this step becomes dead weight and must go too.
+    expect(viteConfig).toContain('fsModuleCache: true');
+    // Only the two shard matrices carry the step: the check jobs never run
+    // vitest, and release-i18n's five-file run is seconds long.
+    for (const name of ['pr-checks', 'release-checks', 'release-i18n', 'changes'] as const) {
+      expect(jobSource(name)).not.toContain('.experimental-vitest-cache');
+    }
   });
 
   it('builds every bundle in the local gate too, including the Discord bot', () => {

--- a/tests/ci_workflow.test.ts
+++ b/tests/ci_workflow.test.ts
@@ -783,33 +783,63 @@ describe('CI workflow parity', () => {
   });
 
   it('persists the vitest transform cache on both shard matrices with a bounded key', () => {
-    // Phase 4 of the CI/CD performance packet: the fsModuleCache store
-    // (enabled in vite.config.ts) is content-addressed inside vitest, so the
-    // actions/cache key only manages rotation and size, never correctness.
-    // Name-to-uses adjacency plus the path line so a YAML-commented-out step
-    // cannot satisfy the pin, mirroring the Playwright cache pin above.
+    // Phase 4 of the CI/CD performance packet: vitest's fsModuleCache store
+    // (enabled in vite.config.ts) keys entries by content, so the
+    // actions/cache key manages rotation and size; the tamper boundary is
+    // GitHub's per-ref cache scoping (see the step comment in ci.yml).
+    // Name-to-uses adjacency plus the path and key lines, TERMINATED BY THE
+    // BLANK LINE THAT ENDS THE STEP: a YAML-commented-out copy cannot satisfy
+    // it, and neither can a step neutered by an appended `if:` or any other
+    // trailing key (the mutation that beat the pin's first draft).
     const cacheStepRe =
-      /- name: Cache vitest transform cache\n(?: {8}#[^\n]*\n)* {8}uses: actions\/cache@[^\n]+\n {8}with:\n {10}path: node_modules\/\.experimental-vitest-cache\n {10}key: vitest-fsmodule-\$\{\{ runner\.os \}\}-shard\$\{\{ matrix\.shard \}\}-\$\{\{ hashFiles\('pnpm-lock\.yaml', 'vite\.config\.ts'\) \}\}\n/;
+      /- name: Cache vitest transform cache\n(?: {8}#[^\n]*\n)* {8}uses: actions\/cache@[^\n]+\n {8}with:\n {10}path: node_modules\/\.experimental-vitest-cache\n {10}key: vitest-fsmodule-\$\{\{ runner\.os \}\}-shard\$\{\{ matrix\.shard \}\}-\$\{\{ hashFiles\('pnpm-lock\.yaml', 'vite\.config\.ts', '\.npmrc', 'package\.json'\) \}\}\n\n/;
     for (const name of ['pr-gate', 'release-gate'] as const) {
       const job = jobSource(name);
       expect(job).toMatch(cacheStepRe);
-      // Restore before the test step, or the run never sees the store.
-      expect(job.indexOf('Cache vitest transform cache')).toBeLessThan(
+      // Restore strictly between the install and the test run: earlier and
+      // pnpm install may prune or re-layout what was just restored, later and
+      // the run never sees the store. Step-name literals, not bare phrases,
+      // so a comment mentioning the name cannot shift the comparison.
+      expect(job.indexOf('- name: Install dependencies')).toBeLessThan(
+        job.indexOf('- name: Cache vitest transform cache'),
+      );
+      expect(job.indexOf('- name: Cache vitest transform cache')).toBeLessThan(
         job.indexOf('- name: Run tests'),
       );
       // No restore-keys: a cross-lockfile restore is discarded by vitest's own
       // integrity check and a cross-config restore misses every entry, so a
       // prefix fallback can only ever download dead weight. Anchored to the
-      // YAML key shape because the step's own comment says the word.
-      expect(job).not.toMatch(/\n\s+restore-keys:/);
+      // YAML key shape (quoted or bare) because the step's own comment says
+      // the word.
+      expect(job).not.toMatch(/\n\s+"?restore-keys"?:/);
     }
-    // The store is enabled in the config this cache serves; if fsModuleCache is
-    // ever turned off there, this step becomes dead weight and must go too.
-    expect(viteConfig).toContain('fsModuleCache: true');
-    // Only the two shard matrices carry the step: the check jobs never run
-    // vitest, and release-i18n's five-file run is seconds long.
-    for (const name of ['pr-checks', 'release-checks', 'release-i18n', 'changes'] as const) {
-      expect(jobSource(name)).not.toContain('.experimental-vitest-cache');
+    // The store is enabled in the config this cache serves, at the DEFAULT
+    // path the workflow hardcodes. Comment-stripped first (a `//` prefix
+    // must fail the pin, not satisfy it), then anchored to the real config
+    // line shape; and fsModuleCachePath must stay unset or the two would
+    // silently point at different directories.
+    const viteConfigCode = viteConfig.replace(/(^|[^:])\/\/.*$/gm, '$1');
+    expect(viteConfigCode).toMatch(/\n\s+fsModuleCache: true,/);
+    expect(viteConfigCode).not.toContain('fsModuleCachePath');
+    // Exactly the two shard matrices carry the step, counted workflow-wide so
+    // a copy added to ANY other job fails (browser-gate has no matrix, so
+    // ${{ matrix.shard }} would render empty there and every run would
+    // collide on one key). The path line is counted rather than the bare
+    // string because the pr-gate rationale comment mentions the directory.
+    expect(workflow.match(/- name: Cache vitest transform cache\n/g)).toHaveLength(2);
+    expect(workflow.match(/ {10}path: node_modules\/\.experimental-vitest-cache\n/g)).toHaveLength(
+      2,
+    );
+    for (const name of [
+      'pr-checks',
+      'release-checks',
+      'release-i18n',
+      'changes',
+      'browser-gate',
+      'lint',
+      'release-version-gate',
+    ] as const) {
+      expect(jobSource(name)).not.toContain('path: node_modules/.experimental-vitest-cache');
     }
   });
 

--- a/tests/ci_workflow.test.ts
+++ b/tests/ci_workflow.test.ts
@@ -792,26 +792,31 @@ describe('CI workflow parity', () => {
     // it, and neither can a step neutered by an appended `if:` or any other
     // trailing key (the mutation that beat the pin's first draft).
     const cacheStepRe =
-      /- name: Cache vitest transform cache\n(?: {8}#[^\n]*\n)* {8}uses: actions\/cache@[^\n]+\n {8}with:\n {10}path: node_modules\/\.experimental-vitest-cache\n {10}key: vitest-fsmodule-\$\{\{ runner\.os \}\}-shard\$\{\{ matrix\.shard \}\}-\$\{\{ hashFiles\('pnpm-lock\.yaml', 'vite\.config\.ts', '\.npmrc', 'package\.json'\) \}\}\n\n/;
+      /- name: Cache vitest transform cache\n(?: {8}#[^\n]*\n)* {8}uses: actions\/cache@v(?:[4-9]|\d{2,})[^\n]*\n {8}with:\n {10}path: node_modules\/\.experimental-vitest-cache\n {10}key: vitest-fsmodule-\$\{\{ runner\.os \}\}-shard\$\{\{ matrix\.shard \}\}-\$\{\{ hashFiles\('pnpm-lock\.yaml', 'vite\.config\.ts', '\.npmrc', 'package\.json'\) \}\}\n\n/;
     for (const name of ['pr-gate', 'release-gate'] as const) {
       const job = jobSource(name);
       expect(job).toMatch(cacheStepRe);
       // Restore strictly between the install and the test run: earlier and
       // pnpm install may prune or re-layout what was just restored, later and
       // the run never sees the store. Step-name literals, not bare phrases,
-      // so a comment mentioning the name cannot shift the comparison.
-      expect(job.indexOf('- name: Install dependencies')).toBeLessThan(
-        job.indexOf('- name: Cache vitest transform cache'),
-      );
-      expect(job.indexOf('- name: Cache vitest transform cache')).toBeLessThan(
-        job.indexOf('- name: Run tests'),
-      );
+      // so a comment mentioning the name cannot shift the comparison; and
+      // every anchor must EXIST first, because indexOf returns -1 for a
+      // missing step and -1 compares less-than everything, making the
+      // ordering vacuously green if a step were deleted.
+      const install = job.indexOf('- name: Install dependencies');
+      const cache = job.indexOf('- name: Cache vitest transform cache');
+      const runTests = job.indexOf('- name: Run tests');
+      expect(install).toBeGreaterThanOrEqual(0);
+      expect(cache).toBeGreaterThanOrEqual(0);
+      expect(runTests).toBeGreaterThanOrEqual(0);
+      expect(install).toBeLessThan(cache);
+      expect(cache).toBeLessThan(runTests);
       // No restore-keys: a cross-lockfile restore is discarded by vitest's own
       // integrity check and a cross-config restore misses every entry, so a
       // prefix fallback can only ever download dead weight. Anchored to the
-      // YAML key shape (quoted or bare) because the step's own comment says
-      // the word.
-      expect(job).not.toMatch(/\n\s+"?restore-keys"?:/);
+      // YAML key shape (bare, double- or single-quoted) because the step's
+      // own comment says the word.
+      expect(job).not.toMatch(/\n\s+["']?restore-keys["']?:/);
     }
     // The store is enabled in the config this cache serves, at the DEFAULT
     // path the workflow hardcodes. Comment-stripped first (a `//` prefix

--- a/tests/nightly_workflow.test.ts
+++ b/tests/nightly_workflow.test.ts
@@ -135,6 +135,11 @@ describe('nightly gate workflow', () => {
     // The expected-red release-i18n locale tier stays out of the whole file
     // (issue #2820), not just out of the tests job.
     expect(workflow).not.toContain('I18N_RELEASE_TIER');
+    // Uncached by design, and pinned because docs/qa-gate.md says so out
+    // loud: the nightly is the one full replay that never restores the
+    // vitest transform cache the PR-tier shard jobs persist (Phase 4), so a
+    // cache-layer bug can never hide from it.
+    expect(workflow).not.toContain('.experimental-vitest-cache');
   });
 
   it('mirrors the serialized release checks from ci.yml and the browser lane', () => {


### PR DESCRIPTION
## Summary

Phase 4 (shard fixed-cost reduction) of the CI/CD performance packet, sub-item 2: persist the vitest fs module cache across CI runs so shard jobs stop re-transforming an unchanged module graph from scratch.

vite.config.ts already enables `experimental.fsModuleCache` (Vitest 4.1), so every local run keeps a content-addressed transform store under `node_modules/.experimental-vitest-cache`; CI threw it away every run. Both shard matrices (pr-gate and release-gate) now carry an `actions/cache` step for that directory, keyed per shard on `hashFiles('pnpm-lock.yaml', 'vite.config.ts')`.

Design points, spelled out in the step comment and pinned by tests/ci_workflow.test.ts:

- **Correctness lives inside vitest, not in the cache key.** Every entry is content-addressed (sha1 over the module source, the config file contents, NODE_ENV, and the vitest version), and vitest discards the whole store when `pnpm-lock.yaml` changes (its `ensureCacheIntegrity` check). A stale restore can only miss, never serve a wrong transform.
- **release-gate carries the same step with the same key on purpose.** pr-gate never runs on `release/**` pushes, and a cache saved in a PR's merge-ref scope is invisible to every other PR, so the release push runs are the producer that saves the store into the base-branch scope PR runs restore from.
- **No restore-keys, save only on primary-key miss.** A cross-lockfile restore would be immediately discarded by vitest and a cross-config restore misses every entry, so a prefix fallback can only download dead weight; save-on-miss-only keeps the entries bounded (one per shard per toolchain state, roughly 8 x compressed store size) instead of accumulating per commit like a sha-suffixed key would, which matters against the repo's 10 GB Actions cache budget.
- **Both selective legs and the full replay benefit**: the floor leg, the `vitest related` leg, and full mode all run vitest under the same config and read the same store.

Baseline this targets (run 31096632273, all 8 pr-gate shards, warm pnpm store): vitest reports per shard aggregate transform 31-49 s and import 116-217 s. Before/after wall clocks from this PR's own runs will be recorded in the packet's phase-04-qa.md: this PR's first run is the cold+save measurement, and the next push to this branch restores from the merge-ref scope and is the warm measurement.

Measurement protocol note: this PR's own CI runs in mode=full (a `.github/` diff is a fail-closed selection trigger), which is exactly the right mode to compare against the run 31096632273 baseline.

## Type of change

- [x] Build, CI, or tooling
- [x] Refactor or performance (no behavior change)

## How was this tested?

- Commands: `npx vitest run tests/ci_workflow.test.ts` (19 passed, including the new bounded-key pin), `npx tsc --noEmit`, `npx @biomejs/biome check tests/ci_workflow.test.ts`, js-yaml parse of ci.yml. Local selective gate run recorded in the packet QA file before this is called done.
- Manual steps: verified from real run logs (run 31096632273 and the 2026-08-05 cold run 31050808406) that the pnpm store cache already hits 8/8 in shard jobs, that the fsModuleCache store is ~384 MB / ~5.7 k content-addressed files for a full local suite, and that vitest 4.1.10's cache reads validate per-entry so a stale restore is inert.

## Checklist

### Quality

- [x] **The gate passes.** Targeted suites green (`tests/ci_workflow.test.ts`, `tests/localization_fixes.test.ts`, `tests/architecture.test.ts`); `node scripts/gate_select.mjs` run recorded in the packet QA record.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files.