### PR TITLE
perf(ci): carry the vitest transform cache on the long-sims lane job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -509,6 +509,26 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # Same vitest transform cache as the shard matrices (the Phase 4 rider:
+      # whichever of the cache step and the lane landed second gains the
+      # other). The full rationale (staleness vs tamper safety, layout-pinned
+      # key, no restore-keys, save-on-miss-only, measured sizes) sits on the
+      # pr-gate copy of this step. This job has no shard matrix, so the key
+      # carries a lane segment where the matrices carry shard${{ matrix.shard }}:
+      # a bare matrix.shard would render empty here, and the lane's store (the
+      # four CI_LONG_SUITES import closures) only partially resembles any one
+      # shard's, so it earns its own entry instead of borrowing shard keys.
+      # Producer reality for this key: release-gate is deliberately not
+      # lane-split, so release/** push runs never save a lane entry into the
+      # base-branch scope; warm hits come from this job's own main and dev-*
+      # push runs and from later runs of the same PR restoring the first run's
+      # save into the PR's own scope.
+      - name: Cache vitest transform cache
+        uses: actions/cache@v4
+        with:
+          path: node_modules/.experimental-vitest-cache
+          key: vitest-fsmodule-${{ runner.os }}-lane-long-sims-${{ hashFiles('pnpm-lock.yaml', 'vite.config.ts', '.npmrc', 'package.json') }}
+
       # Same selection relay as the shard step (env, never run-line
       # interpolation); the lane entry spawns `npm test` itself, so pretest
       # regenerates the i18n artifacts here exactly as in every shard.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -423,7 +423,12 @@ jobs:
       # ref), roughly 1 GB across the two long-lived producer scopes (main
       # plus the release branch) beside the pnpm store, Playwright, and tsc
       # caches. If hot-entry eviction is ever observed, the lever is
-      # restricting this step's save to push events, never restore-keys.
+      # restricting this step's save to push events, never restore-keys
+      # (though note the long-sims lane leans on PR-scope saves, so that
+      # lever costs the lane most of its benefit). Scope arithmetic after
+      # the lane copy landed: a pr-gate-tier producer scope (main, dev-*)
+      # holds 9 entries (8 shard + 1 lane); the release scope stays at 8
+      # (release-gate is deliberately not lane-split).
       # Producers beyond release-gate: pr-gate's own main and dev-* push runs
       # seed those branches' scopes the same way.
       # Per-shard keys: in full mode each shard transforms
@@ -515,14 +520,19 @@ jobs:
       # key, no restore-keys, save-on-miss-only, measured sizes) sits on the
       # pr-gate copy of this step. This job has no shard matrix, so the key
       # carries a lane segment where the matrices carry shard${{ matrix.shard }}:
-      # a bare matrix.shard would render empty here, and the lane's store (the
-      # four CI_LONG_SUITES import closures) only partially resembles any one
-      # shard's, so it earns its own entry instead of borrowing shard keys.
-      # Producer reality for this key: release-gate is deliberately not
-      # lane-split, so release/** push runs never save a lane entry into the
-      # base-branch scope; warm hits come from this job's own main and dev-*
-      # push runs and from later runs of the same PR restoring the first run's
-      # save into the PR's own scope.
+      # a bare matrix.shard would render empty here, and the lane's store (in
+      # full mode, the four CI_LONG_SUITES import closures; in selective mode
+      # only the floor/changed members, so a PR-scope save can be a thin
+      # store that save-on-miss never refreshes within that key) only
+      # partially resembles any one shard's, so it earns its own entry
+      # instead of borrowing shard keys. Producer reality for this key:
+      # release-gate is deliberately not lane-split, so release/** push runs
+      # never save a lane entry into the base-branch scope; main's entry
+      # (seeded by this job's own main and dev-* push runs) only hits while
+      # the release branch's four key inputs still hash like main's, which
+      # they do not whenever main trails the release lockfile (true today),
+      # so for release-based PRs most warm hits come from later runs of the
+      # SAME PR restoring the first run's save into the PR's own scope.
       - name: Cache vitest transform cache
         uses: actions/cache@v4
         with:

--- a/docs/qa-gate.md
+++ b/docs/qa-gate.md
@@ -82,10 +82,11 @@ is dirty (same reason `gate:fast` skips those paths for related expansion). Pref
 transforms under `node_modules/.experimental-vitest-cache` (clear with
 `npx vitest --clearCache` if a warm run looks wrong). The same store is persisted
 across CI runs since Phase 4 of the CI/CD performance packet: the pr-gate and
-release-gate shard jobs carry an `actions/cache` step for it, keyed per shard on the
-node_modules-layout inputs (lockfile, vite config, `.npmrc`, `package.json`), with the
-design constraints written on the step in `.github/workflows/ci.yml` and pinned by
-`tests/ci_workflow.test.ts`. The nightly gate deliberately stays cold: it is the
+release-gate shard jobs carry an `actions/cache` step for it, keyed per shard, and the
+long-sims lane job carries the same step keyed per lane (Phase 6, the recorded Phase 4
+rider), all over the node_modules-layout inputs (lockfile, vite config, `.npmrc`,
+`package.json`), with the design constraints written on the pr-gate copy of the step in
+`.github/workflows/ci.yml` and pinned by `tests/ci_workflow.test.ts`. The nightly gate deliberately stays cold: it is the
 uncached full replay. Most DOM-environment unit
 tests use `// @vitest-environment happy-dom`; a short exception list still pins
 `jsdom` where happy-dom API gaps bite (see `docs/local-gate-perf/baselines.md`

--- a/tests/ci_workflow.test.ts
+++ b/tests/ci_workflow.test.ts
@@ -741,8 +741,9 @@ describe('CI workflow parity', () => {
     expect(prLongSims).not.toContain('strategy:');
     expect(prLongSims).not.toContain('matrix:');
     expect(prLongSims).not.toContain('--shard=');
-    // Checkout, setup-pnpm, setup-node, pnpm install, and the lane run.
-    expect(prLongSims.match(/\n {6}- name: /g)).toHaveLength(5);
+    // Checkout, setup-pnpm, setup-node, pnpm install, the vitest transform
+    // cache (the Phase 4 rider), and the lane run.
+    expect(prLongSims.match(/\n {6}- name: /g)).toHaveLength(6);
     for (const job of [releaseGate, releaseChecks, jobSource('release-i18n')]) {
       expect(job).not.toContain('ci_shard_test.mjs');
       expect(job).not.toContain('TEST_MODE');
@@ -821,7 +822,7 @@ describe('CI workflow parity', () => {
     expect(releaseGate.match(/\n {6}- name: /g)).toHaveLength(6);
   });
 
-  it('persists the vitest transform cache on both shard matrices with a bounded key', () => {
+  it('persists the vitest transform cache on the shard matrices and the long-sims lane', () => {
     // Phase 4 of the CI/CD performance packet: vitest's fsModuleCache store
     // (enabled in vite.config.ts) keys entries by content, so the
     // actions/cache key manages rotation and size; the tamper boundary is
@@ -832,9 +833,19 @@ describe('CI workflow parity', () => {
     // trailing key (the mutation that beat the pin's first draft).
     const cacheStepRe =
       /- name: Cache vitest transform cache\n(?: {8}#[^\n]*\n)* {8}uses: actions\/cache@v(?:[4-9]|\d{2,})[^\n]*\n {8}with:\n {10}path: node_modules\/\.experimental-vitest-cache\n {10}key: vitest-fsmodule-\$\{\{ runner\.os \}\}-shard\$\{\{ matrix\.shard \}\}-\$\{\{ hashFiles\('pnpm-lock\.yaml', 'vite\.config\.ts', '\.npmrc', 'package\.json'\) \}\}\n\n/;
-    for (const name of ['pr-gate', 'release-gate'] as const) {
+    // The lane job (Phase 4 rider) carries the same step with a lane key
+    // segment where the matrices carry shard${{ matrix.shard }}: the lane has
+    // no matrix, so the shard expression would render empty there, and the
+    // lane's store earns its own entry rather than borrowing a shard's.
+    const laneCacheStepRe =
+      /- name: Cache vitest transform cache\n(?: {8}#[^\n]*\n)* {8}uses: actions\/cache@v(?:[4-9]|\d{2,})[^\n]*\n {8}with:\n {10}path: node_modules\/\.experimental-vitest-cache\n {10}key: vitest-fsmodule-\$\{\{ runner\.os \}\}-lane-long-sims-\$\{\{ hashFiles\('pnpm-lock\.yaml', 'vite\.config\.ts', '\.npmrc', 'package\.json'\) \}\}\n\n/;
+    for (const [name, stepRe] of [
+      ['pr-gate', cacheStepRe],
+      ['release-gate', cacheStepRe],
+      ['pr-long-sims', laneCacheStepRe],
+    ] as const) {
       const job = jobSource(name);
-      expect(job).toMatch(cacheStepRe);
+      expect(job).toMatch(stepRe);
       // Restore strictly between the install and the test run: earlier and
       // pnpm install may prune or re-layout what was just restored, later and
       // the run never sees the store. Step-name literals, not bare phrases,
@@ -865,14 +876,16 @@ describe('CI workflow parity', () => {
     const viteConfigCode = viteConfig.replace(/(^|[^:])\/\/.*$/gm, '$1');
     expect(viteConfigCode).toMatch(/\n\s+fsModuleCache: true,/);
     expect(viteConfigCode).not.toContain('fsModuleCachePath');
-    // Exactly the two shard matrices carry the step, counted workflow-wide so
-    // a copy added to ANY other job fails (browser-gate has no matrix, so
-    // ${{ matrix.shard }} would render empty there and every run would
-    // collide on one key). The path line is counted rather than the bare
-    // string because the pr-gate rationale comment mentions the directory.
-    expect(workflow.match(/- name: Cache vitest transform cache\n/g)).toHaveLength(2);
+    // Exactly the two shard matrices plus the long-sims lane carry the step,
+    // counted workflow-wide so a copy added to ANY other job fails
+    // (browser-gate has no matrix, so ${{ matrix.shard }} would render empty
+    // there and every run would collide on one key; the lane carries its own
+    // lane-long-sims key segment for the same reason). The path line is
+    // counted rather than the bare string because the pr-gate rationale
+    // comment mentions the directory.
+    expect(workflow.match(/- name: Cache vitest transform cache\n/g)).toHaveLength(3);
     expect(workflow.match(/ {10}path: node_modules\/\.experimental-vitest-cache\n/g)).toHaveLength(
-      2,
+      3,
     );
     for (const name of [
       'pr-checks',

--- a/tests/ci_workflow.test.ts
+++ b/tests/ci_workflow.test.ts
@@ -831,14 +831,19 @@ describe('CI workflow parity', () => {
     // BLANK LINE THAT ENDS THE STEP: a YAML-commented-out copy cannot satisfy
     // it, and neither can a step neutered by an appended `if:` or any other
     // trailing key (the mutation that beat the pin's first draft).
-    const cacheStepRe =
-      /- name: Cache vitest transform cache\n(?: {8}#[^\n]*\n)* {8}uses: actions\/cache@v(?:[4-9]|\d{2,})[^\n]*\n {8}with:\n {10}path: node_modules\/\.experimental-vitest-cache\n {10}key: vitest-fsmodule-\$\{\{ runner\.os \}\}-shard\$\{\{ matrix\.shard \}\}-\$\{\{ hashFiles\('pnpm-lock\.yaml', 'vite\.config\.ts', '\.npmrc', 'package\.json'\) \}\}\n\n/;
+    // One shared prefix and hashFiles tail for every copy of the step, so
+    // the shard and lane regexes cannot drift apart: an edit to the key's
+    // input list either moves all three ci.yml key lines or goes red here.
+    const cacheStepPrefix = String.raw`- name: Cache vitest transform cache\n(?: {8}#[^\n]*\n)* {8}uses: actions\/cache@v(?:[4-9]|\d{2,})[^\n]*\n {8}with:\n {10}path: node_modules\/\.experimental-vitest-cache\n {10}key: vitest-fsmodule-\$\{\{ runner\.os \}\}-`;
+    const cacheKeyTail = String.raw`-\$\{\{ hashFiles\('pnpm-lock\.yaml', 'vite\.config\.ts', '\.npmrc', 'package\.json'\) \}\}\n\n`;
+    const cacheStepRe = new RegExp(
+      `${cacheStepPrefix}${String.raw`shard\$\{\{ matrix\.shard \}\}`}${cacheKeyTail}`,
+    );
     // The lane job (Phase 4 rider) carries the same step with a lane key
     // segment where the matrices carry shard${{ matrix.shard }}: the lane has
     // no matrix, so the shard expression would render empty there, and the
     // lane's store earns its own entry rather than borrowing a shard's.
-    const laneCacheStepRe =
-      /- name: Cache vitest transform cache\n(?: {8}#[^\n]*\n)* {8}uses: actions\/cache@v(?:[4-9]|\d{2,})[^\n]*\n {8}with:\n {10}path: node_modules\/\.experimental-vitest-cache\n {10}key: vitest-fsmodule-\$\{\{ runner\.os \}\}-lane-long-sims-\$\{\{ hashFiles\('pnpm-lock\.yaml', 'vite\.config\.ts', '\.npmrc', 'package\.json'\) \}\}\n\n/;
+    const laneCacheStepRe = new RegExp(`${cacheStepPrefix}lane-long-sims${cacheKeyTail}`);
     for (const [name, stepRe] of [
       ['pr-gate', cacheStepRe],
       ['release-gate', cacheStepRe],

--- a/tests/nightly_workflow.test.ts
+++ b/tests/nightly_workflow.test.ts
@@ -137,8 +137,9 @@ describe('nightly gate workflow', () => {
     expect(workflow).not.toContain('I18N_RELEASE_TIER');
     // Uncached by design, and pinned because docs/qa-gate.md says so out
     // loud: the nightly is the one full replay that never restores the
-    // vitest transform cache the PR-tier shard jobs persist (Phase 4), so a
-    // cache-layer bug can never hide from it.
+    // vitest transform cache the PR-tier test jobs persist (Phase 4, plus
+    // the long-sims lane since Phase 6), so a cache-layer bug can never
+    // hide from it.
     expect(workflow).not.toContain('.experimental-vitest-cache');
   });
 


### PR DESCRIPTION
## Summary

Phase 6 of the CI/CD performance packet, the recorded Phase 4 rider: whichever of the vitest transform cache (#3017) and the long-sims lane (#3018) landed second gains the other. Both merged, so the "PR gate (long sims)" job now carries the same actions/cache step for `node_modules/.experimental-vitest-cache` the two shard matrices carry, with a `lane-long-sims` key segment (the job has no matrix, so the shard expression would render empty there, and the lane's store only partially resembles any one shard's).

Producer reality, stated honestly on the step: release-gate is deliberately not lane-split, so release pushes never seed a lane entry; main's entry only hits while the release branch's four key inputs hash like main's (untrue today), so for release-based PRs most warm hits come from later runs of the same PR.

No job renamed, no key input changed, merge_group routing untouched, the nightly stays uncached (pinned).

## Type of change

- [x] Build, CI, or tooling

## How was this tested?

- Commands: `node scripts/gate_select.mjs` PASS, all 11 steps green (at b47c46c7af; the final commit is a test-only regex refactor re-verified with `npx vitest run tests/ci_workflow.test.ts`). `npx vitest run tests/ci_workflow.test.ts tests/ci_shard_plan.test.ts tests/nightly_workflow.test.ts` green (75 tests). `npx tsc --noEmit` clean. YAML parse clean.
- Reviews: three reviewers (QA checklist READY, security no-critical, pin audit 30/30 mutations caught, zero survivors), all findings applied; the fix round was tip-verified by the pin auditor.
- Measurement: the cold/warm delta for the lane copy will be recorded from this PR's own CI runs (first run seeds the PR scope, second run hits it), same protocol as #3017's shard measurement.

## Checklist

### Quality

- [x] **The gate passes.** `node scripts/gate_select.mjs` is green, and tests/ci_workflow.test.ts consciously moves the cache-step copy counts from two to three with the lane's ordering and no-restore-keys pins.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files.
