### PR TITLE
fix(ci): bound the test and browser jobs against the checkout-stall class

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,6 +302,12 @@ jobs:
     # why "Detect code path changes" must itself be a required check.
     needs: changes
     if: needs.changes.outputs.code != 'false'
+    # Fail fast on the checkout-stall class (rationale and evidence on the
+    # pr-gate bound): this job's healthy worst case is 2.4 minutes plus a
+    # cold Playwright Chromium download on a cache miss, and its one stalled
+    # run sat 17.5 minutes in checkout inside an 18.4 minute wall
+    # (run 31107474546).
+    timeout-minutes: 10
     runs-on: ubuntu-latest
 
     steps:
@@ -361,6 +367,17 @@ jobs:
     # release-to-main exclusion is a pull_request-arm concern and cannot match).
     needs: changes
     if: ((github.event_name == 'pull_request' && (github.base_ref != 'main' || !startsWith(github.head_ref, 'release/'))) || (github.event_name == 'push' && !startsWith(github.ref, 'refs/heads/release/')) || github.event_name == 'workflow_dispatch' || github.event_name == 'merge_group') && needs.changes.outputs.code != 'false'
+    # Fail fast on the runner-side checkout-stall class instead of burning
+    # tail: on 2026-08-06 thirteen shard, lane, and browser jobs across seven
+    # runs sat 9.6 to 24.4 minutes inside actions/checkout before completing
+    # (healthy checkout is under 3 minutes; the worst stalled job wall was
+    # 32.8 minutes), and the stall, not any test, set every one of those
+    # runs' tails. Sized from the measured healthy worst case plus margin:
+    # the slowest healthy shard observed is 13.6 minutes (the Phase 2
+    # content-only selective drill, PR #2991), so 20 kills only stalled
+    # jobs, which get rerun on a fresh runner instead of holding the tail.
+    # The evidence table lives in the packet's detect-wedge postmortem note.
+    timeout-minutes: 20
     runs-on: ubuntu-latest
 
     # fail-fast stays off: shards pass or fail independently, so one red shard
@@ -486,9 +503,12 @@ jobs:
     if: ((github.event_name == 'pull_request' && (github.base_ref != 'main' || !startsWith(github.head_ref, 'release/'))) || (github.event_name == 'push' && !startsWith(github.ref, 'refs/heads/release/')) || github.event_name == 'workflow_dispatch' || github.event_name == 'merge_group') && needs.changes.outputs.code != 'false'
     # The lane concentrates the four slowest suites in one required job with
     # no sibling shard to report around it, so a hang would otherwise hold a
-    # required check for GitHub's 6 hour default. Generous against the
-    # measured ~10 minute worst case.
-    timeout-minutes: 30
+    # required check for GitHub's 6 hour default. Sized from the measured
+    # healthy worst case plus margin, like the shard matrices (rationale and
+    # the checkout-stall evidence on the pr-gate bound): the lane's healthy
+    # worst case is 8.1 minutes, and its one stalled run sat 15.6 minutes in
+    # checkout inside a 23.3 minute wall (run 31105262161).
+    timeout-minutes: 15
     runs-on: ubuntu-latest
 
     steps:
@@ -621,6 +641,12 @@ jobs:
     # the label is what an operator reads in the checks list to tell the two reds apart.
     name: Release gate (tests)
     if: (github.event_name == 'pull_request' && github.base_ref == 'main' && startsWith(github.head_ref, 'release/')) || (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release/'))
+    # Same checkout-stall bound as pr-gate (rationale and evidence there).
+    # This matrix keeps the long sims in-shard by design, and its healthy
+    # worst case is the 11.9 minute pre-lane baseline tail; 20 preserves the
+    # same margin. The nightly workflow deliberately keeps its own generous
+    # bounds and is untouched.
+    timeout-minutes: 20
     runs-on: ubuntu-latest
 
     # No I18N_RELEASE_TIER here BY DESIGN (D8 revised, issue #2820). This job runs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,8 +162,13 @@ jobs:
     name: Detect code path changes
     runs-on: ubuntu-latest
     # Every PR-tier job waits on this one, so a wedged runner must fail fast
-    # and be retried, never hang for an hour and a half.
-    timeout-minutes: 5
+    # and be retried, never hang for an hour and a half. 8, not 5: the
+    # Phase 6 replay found a healthy 4.42 minute run on this serial critical
+    # path (run 31117143257 attempt 1, carrying a 4.00 minute runner setup
+    # spike, which counts inside the bound), an 88 percent fill of the old
+    # bound where a false kill costs a whole re-run; still single-digit per
+    # the Phase 1 acceptance.
+    timeout-minutes: 8
     # Job-scoped read-only widen: once workflow-level permissions are declared,
     # unlisted scopes are none, and the PR files endpoint needs
     # pull-requests: read. Nothing here may ever be a write scope.
@@ -378,13 +383,15 @@ jobs:
     # the slowest healthy GREEN shard observed is 13.6 minutes (the Phase 2
     # content-only selective drill, PR #2991) and the slowest healthy RED
     # one 18.6 minutes (run 31067745370, a 17.8 minute failing test step),
-    # so 20 kills only stalled jobs. A 24 hour replay of 2549 jobs found
-    # zero healthy jobs over their bound, and 21 stalled-but-green jobs
-    # these bounds convert into reds needing a manual failed-jobs rerun:
-    # the buy is bounding the unbounded worst case (the pre-Phase-1 90
-    # minute wedges) and making stalls visible as failures for the runner
-    # escalation, not the average tail. Full evidence: the packet's internal
-    # detect-wedge postmortem note (docs/prd/ci-cd-performance/).
+    # so 20 kills only stalled jobs. Two independent 24 hour replays (the
+    # review's and its verifier's, different windows and counting bases)
+    # both found ZERO healthy jobs over their bound, and 21 to 31
+    # stalled-but-green jobs per day these bounds convert into reds needing
+    # a manual failed-jobs rerun: the buy is bounding the unbounded worst
+    # case (the pre-Phase-1 90 minute wedges) and making stalls visible as
+    # failures for the runner escalation, not the average tail. Full
+    # evidence: the packet's internal detect-wedge postmortem note
+    # (docs/prd/ci-cd-performance/).
     timeout-minutes: 20
     runs-on: ubuntu-latest
 
@@ -513,12 +520,13 @@ jobs:
     # no sibling shard to report around it, so a hang would otherwise hold a
     # required check for GitHub's 6 hour default. 20 matches the shard
     # matrices (rationale and the checkout-stall evidence on the pr-gate
-    # bound): the lane's own healthy worst case is 8.1 minutes, but the
-    # sample is thin (the job is days old), the chronomancy sweep inside it
-    # is the suite whose budget was raised for loaded runners, and a bound
-    # below 20 cannot lower the run tail anyway while pr-gate holds 20 in
-    # the same run. Its one stalled run sat 15.6 minutes in checkout inside
-    # a 23.3 minute wall (run 31105262161).
+    # bound): the lane's healthy worst cases are 8.1 minutes GREEN and 10.7
+    # minutes RED (run 31118669058), the sample is thin (the job is days
+    # old), the chronomancy sweep inside it is the suite whose budget was
+    # raised for loaded runners, and a bound below 20 cannot lower the run
+    # tail anyway while pr-gate holds 20 in the same run. Its one stalled
+    # run sat 15.6 minutes in checkout inside a 23.3 minute wall
+    # (run 31105262161).
     timeout-minutes: 20
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -390,8 +390,9 @@ jobs:
     # a manual failed-jobs rerun: the buy is bounding the unbounded worst
     # case (the pre-Phase-1 90 minute wedges) and making stalls visible as
     # failures for the runner escalation, not the average tail. Full
-    # evidence: the packet's internal detect-wedge postmortem note
-    # (docs/prd/ci-cd-performance/).
+    # evidence: the CI/CD performance packet's detect-wedge postmortem note
+    # (an internal, untracked packet record; the run ids above are the
+    # in-repo anchors).
     timeout-minutes: 20
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -303,9 +303,11 @@ jobs:
     needs: changes
     if: needs.changes.outputs.code != 'false'
     # Fail fast on the checkout-stall class (rationale and evidence on the
-    # pr-gate bound): this job's healthy worst case is 2.4 minutes plus a
-    # cold Playwright Chromium download on a cache miss, and its one stalled
-    # run sat 17.5 minutes in checkout inside an 18.4 minute wall
+    # pr-gate bound): the slowest healthy wall observed in the 24 hour
+    # replay is 3.73 minutes (run 31053693012), and that sample already
+    # contains the slowest observed cold Playwright Chromium install (2.33
+    # minutes), so 10 keeps a 2.7x margin over a cold-cache day. Its one
+    # stalled run sat 17.5 minutes in checkout inside an 18.4 minute wall
     # (run 31107474546).
     timeout-minutes: 10
     runs-on: ubuntu-latest
@@ -370,13 +372,19 @@ jobs:
     # Fail fast on the runner-side checkout-stall class instead of burning
     # tail: on 2026-08-06 thirteen shard, lane, and browser jobs across seven
     # runs sat 9.6 to 24.4 minutes inside actions/checkout before completing
-    # (healthy checkout is under 3 minutes; the worst stalled job wall was
-    # 32.8 minutes), and the stall, not any test, set every one of those
+    # (healthy checkout is under 3 minutes; worst stalled wall 32.8 minutes,
+    # run 31111919431 attempt 1), and the stall, not any test, set those
     # runs' tails. Sized from the measured healthy worst case plus margin:
-    # the slowest healthy shard observed is 13.6 minutes (the Phase 2
-    # content-only selective drill, PR #2991), so 20 kills only stalled
-    # jobs, which get rerun on a fresh runner instead of holding the tail.
-    # The evidence table lives in the packet's detect-wedge postmortem note.
+    # the slowest healthy GREEN shard observed is 13.6 minutes (the Phase 2
+    # content-only selective drill, PR #2991) and the slowest healthy RED
+    # one 18.6 minutes (run 31067745370, a 17.8 minute failing test step),
+    # so 20 kills only stalled jobs. A 24 hour replay of 2549 jobs found
+    # zero healthy jobs over their bound, and 21 stalled-but-green jobs
+    # these bounds convert into reds needing a manual failed-jobs rerun:
+    # the buy is bounding the unbounded worst case (the pre-Phase-1 90
+    # minute wedges) and making stalls visible as failures for the runner
+    # escalation, not the average tail. Full evidence: the packet's internal
+    # detect-wedge postmortem note (docs/prd/ci-cd-performance/).
     timeout-minutes: 20
     runs-on: ubuntu-latest
 
@@ -503,12 +511,15 @@ jobs:
     if: ((github.event_name == 'pull_request' && (github.base_ref != 'main' || !startsWith(github.head_ref, 'release/'))) || (github.event_name == 'push' && !startsWith(github.ref, 'refs/heads/release/')) || github.event_name == 'workflow_dispatch' || github.event_name == 'merge_group') && needs.changes.outputs.code != 'false'
     # The lane concentrates the four slowest suites in one required job with
     # no sibling shard to report around it, so a hang would otherwise hold a
-    # required check for GitHub's 6 hour default. Sized from the measured
-    # healthy worst case plus margin, like the shard matrices (rationale and
-    # the checkout-stall evidence on the pr-gate bound): the lane's healthy
-    # worst case is 8.1 minutes, and its one stalled run sat 15.6 minutes in
-    # checkout inside a 23.3 minute wall (run 31105262161).
-    timeout-minutes: 15
+    # required check for GitHub's 6 hour default. 20 matches the shard
+    # matrices (rationale and the checkout-stall evidence on the pr-gate
+    # bound): the lane's own healthy worst case is 8.1 minutes, but the
+    # sample is thin (the job is days old), the chronomancy sweep inside it
+    # is the suite whose budget was raised for loaded runners, and a bound
+    # below 20 cannot lower the run tail anyway while pr-gate holds 20 in
+    # the same run. Its one stalled run sat 15.6 minutes in checkout inside
+    # a 23.3 minute wall (run 31105262161).
+    timeout-minutes: 20
     runs-on: ubuntu-latest
 
     steps:
@@ -642,9 +653,11 @@ jobs:
     name: Release gate (tests)
     if: (github.event_name == 'pull_request' && github.base_ref == 'main' && startsWith(github.head_ref, 'release/')) || (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release/'))
     # Same checkout-stall bound as pr-gate (rationale and evidence there).
-    # This matrix keeps the long sims in-shard by design, and its healthy
-    # worst case is the 11.9 minute pre-lane baseline tail; 20 preserves the
-    # same margin. The nightly workflow deliberately keeps its own generous
+    # This matrix keeps the long sims in-shard by design; its slowest
+    # healthy shard observed is 14.63 minutes (run 31117143257, a sample
+    # that also carried a 4.68 minute runner "Set up job" spike, a
+    # component that counts inside the bound), so 20 keeps a 5 minute
+    # margin. The nightly workflow deliberately keeps its own generous
     # bounds and is untouched.
     timeout-minutes: 20
     runs-on: ubuntu-latest

--- a/docs/merge-queue.md
+++ b/docs/merge-queue.md
@@ -62,9 +62,13 @@ the Checks tab (filter by event: merge_group).
 5. A job that failed with "exceeded the maximum execution time of N minutes"
    hit its checkout-stall bound (the test and browser jobs carry job-level
    timeout-minutes sized from measured healthy worst cases; the stall class
-   is runner-side, 10 to 25 minutes inside actions/checkout). That is a
-   rerun, not a code investigation: re-run the failed jobs and re-queue. If
-   the SAME job times out twice on healthy-looking logs, treat it as a real
+   is runner-side, 9.6 to 24.4 minutes inside actions/checkout in the
+   measured window). First open the killed job's log: if a test step was
+   already failing or still running near the bound, treat it as a real
+   failure or a real slowdown, not a stall (a genuinely red shard on a
+   runner with a setup spike can die AS a timeout). Otherwise it is a rerun,
+   not a code investigation: re-run the failed jobs and re-queue. If the
+   SAME job times out twice on healthy-looking logs, treat it as a real
    slowdown and investigate before resizing any bound.
 
 ## The required-check contract

--- a/docs/merge-queue.md
+++ b/docs/merge-queue.md
@@ -59,6 +59,13 @@ the Checks tab (filter by event: merge_group).
    branch, fix, push, re-queue.
 4. A flake verdict needs a clean rerun, not a shrug: re-run the failed job; if
    it greens, re-queue. Judge red CI by clean-runner reruns.
+5. A job that failed with "exceeded the maximum execution time of N minutes"
+   hit its checkout-stall bound (the test and browser jobs carry job-level
+   timeout-minutes sized from measured healthy worst cases; the stall class
+   is runner-side, 10 to 25 minutes inside actions/checkout). That is a
+   rerun, not a code investigation: re-run the failed jobs and re-queue. If
+   the SAME job times out twice on healthy-looking logs, treat it as a real
+   slowdown and investigate before resizing any bound.
 
 ## The required-check contract
 

--- a/docs/merge-queue.md
+++ b/docs/merge-queue.md
@@ -62,8 +62,8 @@ the Checks tab (filter by event: merge_group).
 5. A job that failed with "exceeded the maximum execution time of N minutes"
    hit its checkout-stall bound (the test and browser jobs carry job-level
    timeout-minutes sized from measured healthy worst cases; the stall class
-   is runner-side, 9.6 to 24.4 minutes inside actions/checkout in the
-   measured window). First open the killed job's log: if a test step was
+   is runner-side and runs tens of minutes inside actions/checkout, 9.6 to
+   24.4 in the incident sample and up to 68 in the 24 hour replay). First open the killed job's log: if a test step was
    already failing or still running near the bound, treat it as a real
    failure or a real slowdown, not a stall (a genuinely red shard on a
    runner with a setup spike can die AS a timeout). Otherwise it is a rerun,

--- a/tests/ci_workflow.test.ts
+++ b/tests/ci_workflow.test.ts
@@ -697,12 +697,19 @@ describe('CI workflow parity', () => {
       ['release-gate', 20],
       ['pr-long-sims', 20],
       ['browser-gate', 10],
+      // 8 is a measured decision like the rest (healthy worst 4.42 min, all
+      // observed stalls over 8), so it is pinned exactly here beside the
+      // single-digit shape check the classifier test keeps.
+      ['changes', 8],
     ] as const;
     // Both the positive and the negatives run over the full index-based job
     // span (this job key to the next), never the comment-terminated
     // jobSource slice, so a stray top-level comment inside a job body can
     // hide neither a duplicate job-level bound nor a step bound (the fix
     // round's verifier proved the jobSource form evadable both ways).
+    // Deliberate consequence: a span INCLUDES the 2-space comment block that
+    // documents the NEXT job, so only indentation-anchored patterns belong
+    // on spans; a bare not.toContain would trip on a neighbour's comment.
     const jobSpan = (name: string) => {
       const start = workflow.indexOf(`\n  ${name}:`);
       expect(start).toBeGreaterThanOrEqual(0);
@@ -718,10 +725,8 @@ describe('CI workflow parity', () => {
       // A step bound can also legally sit as the FIRST key of a step item.
       expect(span).not.toMatch(/\n {6}- timeout-minutes:/);
     }
-    // Completeness: every ci.yml job is either in the bounds table above,
-    // the separately-bounded changes job (its single-digit bound has its own
-    // pin beside the classifier assertions), or the named
-    // unbounded-by-design list: the checks and release lanes sit outside
+    // Completeness: every ci.yml job is either in the bounds table above or
+    // the named unbounded-by-design list: the checks and release lanes sit outside
     // Phase 6's measured pass, and bounding them is a recorded follow-up in
     // the packet's postmortem note, not an accident. A new job therefore
     // cannot arrive silently unbounded, and moving a job between the lists
@@ -742,7 +747,7 @@ describe('CI workflow parity', () => {
       ...jobsSection.matchAll(/\n {2}([A-Za-z][A-Za-z0-9_-]*):[ \t]*(?:#[^\n]*)?\n/g),
     ].map((m) => m[1]);
     expect([...jobKeys].sort()).toEqual(
-      [...bounds.map(([name]) => name), 'changes', ...UNBOUNDED_BY_DESIGN].sort(),
+      [...bounds.map(([name]) => name), ...UNBOUNDED_BY_DESIGN].sort(),
     );
     // Two-way: a job on the unbounded list must actually BE unbounded, so
     // the list is an assertion, not documentation that can rot.
@@ -760,6 +765,9 @@ describe('CI workflow parity', () => {
     expect(mergeQueueTriage).toContain('exceeded the maximum execution time');
     expect(mergeQueueTriage).toContain('checkout-stall bound');
     expect(mergeQueueTriage).toContain('failing or still running');
+    // The routing is the entry's operational point: a timeout kill goes to
+    // a rerun, never straight to a code investigation.
+    expect(mergeQueueTriage).toContain('re-run the failed jobs and re-queue');
   });
 
   it(`shards the PR and release test steps ${SHARD_N} ways and keeps the checks single-shard`, () => {

--- a/tests/ci_workflow.test.ts
+++ b/tests/ci_workflow.test.ts
@@ -676,6 +676,39 @@ describe('CI workflow parity', () => {
     }
   });
 
+  it('bounds the test and browser jobs against the runner-side checkout-stall class', () => {
+    // Phase 6 of the CI/CD performance packet: on 2026-08-06 thirteen shard,
+    // lane, and browser jobs across seven runs sat 9.6 to 24.4 minutes inside
+    // actions/checkout before completing (runner-pool-side; healthy checkout
+    // is under 3 minutes; the worst stalled job wall was 32.8 minutes), and
+    // the stall, not any test, set those runs' tails. Each bound is sized
+    // from that job's measured healthy worst case plus margin (the sizing
+    // rationale sits on each ci.yml bound; the evidence table lives in the
+    // packet's detect-wedge postmortem note), so a stalled job dies and gets
+    // rerun on a fresh runner instead of holding a required check. Exact
+    // values, not a floor: resizing a bound is a conscious, measured decision
+    // (the full-core lane revert is the packet's precedent for what happens
+    // to unmeasured resizes). Exactly one job-level line per job, so a
+    // duplicate cannot shadow the pinned one; and job-level, never
+    // step-level, because a step bound leaves the rest of the job free to
+    // hang toward GitHub's 6 hour default.
+    const bounds = [
+      ['pr-gate', 20],
+      ['release-gate', 20],
+      ['pr-long-sims', 15],
+      ['browser-gate', 10],
+    ] as const;
+    for (const [name, minutes] of bounds) {
+      const job = jobSource(name);
+      const jobLevel = job.match(/^ {4}timeout-minutes: \d+$/gm) ?? [];
+      expect(jobLevel).toEqual([`    timeout-minutes: ${minutes}`]);
+      expect(job).not.toMatch(/\n {8}timeout-minutes:/);
+    }
+    // The changes job keeps its own single-digit bound (pinned with the
+    // classifier assertions); the nightly workflow's deliberately generous
+    // bounds are pinned in tests/nightly_workflow.test.ts and stay untouched.
+  });
+
   it(`shards the PR and release test steps ${SHARD_N} ways and keeps the checks single-shard`, () => {
     const prGate = jobSource('pr-gate');
     const prChecks = jobSource('pr-checks');

--- a/tests/ci_workflow.test.ts
+++ b/tests/ci_workflow.test.ts
@@ -695,18 +695,48 @@ describe('CI workflow parity', () => {
     const bounds = [
       ['pr-gate', 20],
       ['release-gate', 20],
-      ['pr-long-sims', 15],
+      ['pr-long-sims', 20],
       ['browser-gate', 10],
     ] as const;
     for (const [name, minutes] of bounds) {
       const job = jobSource(name);
       const jobLevel = job.match(/^ {4}timeout-minutes: \d+$/gm) ?? [];
       expect(jobLevel).toEqual([`    timeout-minutes: ${minutes}`]);
-      expect(job).not.toMatch(/\n {8}timeout-minutes:/);
+      // The step-level negative runs over the full index-based job span
+      // (this job key to the next), not the comment-terminated jobSource
+      // slice, so a stray top-level comment inside a job body cannot hide a
+      // step bound from it.
+      const start = workflow.indexOf(`\n  ${name}:\n`);
+      expect(start).toBeGreaterThanOrEqual(0);
+      const rest = workflow.slice(start + 1);
+      const nextJob = rest.search(/\n {2}[A-Za-z][A-Za-z0-9_-]*:\n/);
+      const span = nextJob === -1 ? rest : rest.slice(0, nextJob);
+      expect(span).not.toMatch(/\n {8}timeout-minutes:/);
     }
-    // The changes job keeps its own single-digit bound (pinned with the
-    // classifier assertions); the nightly workflow's deliberately generous
-    // bounds are pinned in tests/nightly_workflow.test.ts and stay untouched.
+    // Completeness: every ci.yml job is either in the bounds table above,
+    // the separately-bounded changes job (its single-digit bound has its own
+    // pin beside the classifier assertions), or the named
+    // unbounded-by-design list: the checks and release lanes sit outside
+    // Phase 6's measured pass, and bounding them is a recorded follow-up in
+    // the packet's postmortem note, not an accident. A new job therefore
+    // cannot arrive silently unbounded, and moving a job between the lists
+    // is a conscious edit here. The nightly workflow's deliberately
+    // generous bounds have their own presence pins in
+    // tests/nightly_workflow.test.ts and stay untouched.
+    const UNBOUNDED_BY_DESIGN = [
+      'release-version-gate',
+      'lint',
+      'pr-checks',
+      'release-i18n',
+      'release-checks',
+    ] as const;
+    const jobsSection = workflow.slice(workflow.indexOf('\njobs:'));
+    const jobKeys = [...jobsSection.matchAll(/\n {2}([A-Za-z][A-Za-z0-9_-]*):\n/g)].map(
+      (m) => m[1],
+    );
+    expect([...jobKeys].sort()).toEqual(
+      [...bounds.map(([name]) => name), 'changes', ...UNBOUNDED_BY_DESIGN].sort(),
+    );
   });
 
   it(`shards the PR and release test steps ${SHARD_N} ways and keeps the checks single-shard`, () => {

--- a/tests/ci_workflow.test.ts
+++ b/tests/ci_workflow.test.ts
@@ -698,20 +698,25 @@ describe('CI workflow parity', () => {
       ['pr-long-sims', 20],
       ['browser-gate', 10],
     ] as const;
-    for (const [name, minutes] of bounds) {
-      const job = jobSource(name);
-      const jobLevel = job.match(/^ {4}timeout-minutes: \d+$/gm) ?? [];
-      expect(jobLevel).toEqual([`    timeout-minutes: ${minutes}`]);
-      // The step-level negative runs over the full index-based job span
-      // (this job key to the next), not the comment-terminated jobSource
-      // slice, so a stray top-level comment inside a job body cannot hide a
-      // step bound from it.
-      const start = workflow.indexOf(`\n  ${name}:\n`);
+    // Both the positive and the negatives run over the full index-based job
+    // span (this job key to the next), never the comment-terminated
+    // jobSource slice, so a stray top-level comment inside a job body can
+    // hide neither a duplicate job-level bound nor a step bound (the fix
+    // round's verifier proved the jobSource form evadable both ways).
+    const jobSpan = (name: string) => {
+      const start = workflow.indexOf(`\n  ${name}:`);
       expect(start).toBeGreaterThanOrEqual(0);
       const rest = workflow.slice(start + 1);
-      const nextJob = rest.search(/\n {2}[A-Za-z][A-Za-z0-9_-]*:\n/);
-      const span = nextJob === -1 ? rest : rest.slice(0, nextJob);
+      const next = rest.search(/\n {2}[A-Za-z][A-Za-z0-9_-]*:[ \t]*(?:#[^\n]*)?\n/);
+      return next === -1 ? rest : rest.slice(0, next);
+    };
+    for (const [name, minutes] of bounds) {
+      const span = jobSpan(name);
+      const jobLevel = span.match(/^ {4}timeout-minutes: \d+$/gm) ?? [];
+      expect(jobLevel).toEqual([`    timeout-minutes: ${minutes}`]);
       expect(span).not.toMatch(/\n {8}timeout-minutes:/);
+      // A step bound can also legally sit as the FIRST key of a step item.
+      expect(span).not.toMatch(/\n {6}- timeout-minutes:/);
     }
     // Completeness: every ci.yml job is either in the bounds table above,
     // the separately-bounded changes job (its single-digit bound has its own
@@ -720,9 +725,11 @@ describe('CI workflow parity', () => {
     // Phase 6's measured pass, and bounding them is a recorded follow-up in
     // the packet's postmortem note, not an accident. A new job therefore
     // cannot arrive silently unbounded, and moving a job between the lists
-    // is a conscious edit here. The nightly workflow's deliberately
-    // generous bounds have their own presence pins in
-    // tests/nightly_workflow.test.ts and stay untouched.
+    // is a conscious edit here. The key regex tolerates a trailing comment
+    // or space after the colon, both valid YAML that would otherwise make an
+    // eleventh job invisible. The nightly workflow's deliberately generous
+    // bounds have their own presence pins in tests/nightly_workflow.test.ts
+    // and stay untouched.
     const UNBOUNDED_BY_DESIGN = [
       'release-version-gate',
       'lint',
@@ -731,12 +738,28 @@ describe('CI workflow parity', () => {
       'release-checks',
     ] as const;
     const jobsSection = workflow.slice(workflow.indexOf('\njobs:'));
-    const jobKeys = [...jobsSection.matchAll(/\n {2}([A-Za-z][A-Za-z0-9_-]*):\n/g)].map(
-      (m) => m[1],
-    );
+    const jobKeys = [
+      ...jobsSection.matchAll(/\n {2}([A-Za-z][A-Za-z0-9_-]*):[ \t]*(?:#[^\n]*)?\n/g),
+    ].map((m) => m[1]);
     expect([...jobKeys].sort()).toEqual(
       [...bounds.map(([name]) => name), 'changes', ...UNBOUNDED_BY_DESIGN].sort(),
     );
+    // Two-way: a job on the unbounded list must actually BE unbounded, so
+    // the list is an assertion, not documentation that can rot.
+    for (const name of UNBOUNDED_BY_DESIGN) {
+      expect(jobSpan(name).match(/^ {4}timeout-minutes: \d+$/gm) ?? []).toEqual([]);
+    }
+    // The operator triage for a timeout kill is part of the contract: the
+    // doc must keep the rejection signature, route it to a rerun, and tell
+    // the operator to check for a failing test step first (a genuinely red
+    // shard on a runner with a setup spike can die AS a timeout).
+    const mergeQueueTriage = readFileSync(
+      new URL('../docs/merge-queue.md', import.meta.url),
+      'utf8',
+    );
+    expect(mergeQueueTriage).toContain('exceeded the maximum execution time');
+    expect(mergeQueueTriage).toContain('checkout-stall bound');
+    expect(mergeQueueTriage).toContain('failing or still running');
   });
 
   it(`shards the PR and release test steps ${SHARD_N} ways and keeps the checks single-shard`, () => {


### PR DESCRIPTION
## Summary

Phase 6 of the CI/CD performance packet: fail fast on the runner-side checkout-stall class. Thirteen shard, lane, and browser jobs across seven runs on 2026-08-06 sat 9.6 to 24.4 minutes inside actions/checkout (healthy checkout is under 3 minutes; worst stalled wall 32.8 minutes, run 31111919431 attempt 1), making the stall the dominant PR-tier tail cost, an order above anything the Phase 4 caching saves.

Every test and browser job now carries a job-level timeout-minutes sized from its measured healthy worst case plus margin: pr-gate 20, release-gate 20, the long-sims lane 20 (down from 30), browser-gate 10, and the detect job rises 5 to 8 on the same evidence (healthy worst 4.42 min including a 4.00 min runner setup spike; every observed stall exceeds 8, none live between 5 and 8). Two independent 24 hour replays (2549 and 1454 job executions) both found ZERO healthy jobs over their bound; the honest cost is 21 to 31 stalled-but-eventually-green jobs per day becoming reds that need a manual failed-jobs rerun. The buy is bounding the previously unbounded worst case and making stalls visible as failures for the GitHub support escalation.

tests/ci_workflow.test.ts pins the exact values, a job-inventory completeness check with a named unbounded-by-design list (the checks jobs are a recorded follow-up, not an accident), and the docs/merge-queue.md timeout-kill triage entry, which routes a kill to a rerun with a failing-test check first.

No job renamed; the nightly workflow untouched; merge_group routing untouched.

## Type of change

- [x] Build, CI, or tooling

## How was this tested?

- Commands: `node scripts/gate_select.mjs` green at 84e5f0e129 (all 11 steps); the re-gate at the review tip went red ONLY on the known teardown-rpc flake signature (all 3583 tests passed, exit 1 in teardown, tests/professions_window_layout green solo, the class the sibling flake-retry PR addresses). `npx vitest run tests/ci_workflow.test.ts tests/ci_shard_plan.test.ts tests/nightly_workflow.test.ts` green (76 tests). `npx tsc --noEmit` clean; YAML parse clean.
- Reviews: four rounds (QA checklist with its own 24 h API replay, pin audit 20/20 mutations, security review, then two delta verifications that mutation-confirmed every closure and re-measured every cited number against the GitHub API).

## Checklist

### Quality

- [x] **The gate passes** (per above; the one red was the documented flake signature with a green solo rerun).

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files.
