### PR TITLE
fix(assets): make an eastbrook provenance mismatch name its cause and fix

### DIFF
--- a/scripts/assets/eastbrook_grand_armoury/provenance_diagnostics.d.mts
+++ b/scripts/assets/eastbrook_grand_armoury/provenance_diagnostics.d.mts
@@ -1,5 +1,7 @@
 export const REMINT_COMMAND: string;
 
+export const POLISH_SEAL_PATH: string;
+
 export function diffProvenanceComponents(
   sealed: Record<string, unknown>,
   computed: Record<string, unknown>,
@@ -16,9 +18,27 @@ export function gitDirtyStatusLines(opts: {
   runGit?: (args: string[], cwd: string) => string;
 }): string[] | null;
 
+export function defaultRunGit(
+  args: string[],
+  cwd: string,
+  execImpl?: (file: string, args: string[], options: object) => string,
+): string;
+
+export function formatMintInputStatus(dirtyStatusLines: string[] | null): string[];
+
 export function formatPolishProvenanceMismatch(opts: {
   pinnedFingerprint: string;
   computed: { fingerprint: string; components: Record<string, unknown> };
   sealedComponents?: Record<string, unknown> | null;
   dirtyStatusLines?: string[] | null;
+}): string;
+
+export function buildPolishProvenanceMismatchReport(opts: {
+  pinnedFingerprint: string;
+  computed: { fingerprint: string; components: Record<string, unknown> };
+  repoRoot: string;
+  inputs: Record<string, string>;
+  sourceFileLists?: ReadonlyArray<readonly string[]>;
+  readSeal?: (absolutePath: string) => unknown;
+  runGit?: (args: string[], cwd: string) => string;
 }): string;

--- a/scripts/assets/eastbrook_grand_armoury/provenance_diagnostics.d.mts
+++ b/scripts/assets/eastbrook_grand_armoury/provenance_diagnostics.d.mts
@@ -1,0 +1,24 @@
+export const REMINT_COMMAND: string;
+
+export function diffProvenanceComponents(
+  sealed: Record<string, unknown>,
+  computed: Record<string, unknown>,
+): Array<{ key: string; sealed: unknown; computed: unknown }>;
+
+export function collectPolishProvenanceInputPaths(opts: {
+  inputs: Record<string, string>;
+  sourceFileLists?: ReadonlyArray<readonly string[]>;
+}): string[];
+
+export function gitDirtyStatusLines(opts: {
+  repoRoot: string;
+  paths: readonly string[];
+  runGit?: (args: string[], cwd: string) => string;
+}): string[] | null;
+
+export function formatPolishProvenanceMismatch(opts: {
+  pinnedFingerprint: string;
+  computed: { fingerprint: string; components: Record<string, unknown> };
+  sealedComponents?: Record<string, unknown> | null;
+  dirtyStatusLines?: string[] | null;
+}): string;

--- a/scripts/assets/eastbrook_grand_armoury/provenance_diagnostics.mjs
+++ b/scripts/assets/eastbrook_grand_armoury/provenance_diagnostics.mjs
@@ -18,10 +18,20 @@
 // now (the stale-mint hazard), and the exact one-step remint command.
 
 import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
 
 /** The one-step re-mint the failure messages point at. */
 export const REMINT_COMMAND =
   'node scripts/assets/eastbrook_grand_armoury/remint_polish_provenance.mjs';
+
+/**
+ * The committed evidence seal the diagnostics diff against, one constant so
+ * the failing test, the remint tool, and the unit suite cannot drift onto
+ * three different paths.
+ */
+export const POLISH_SEAL_PATH =
+  'docs/screenshots/eastbrook-vale-rebuild/polish/metadata/after-desktop-ultra.json';
 
 /**
  * Leaf-by-leaf diff of two provenance component trees (the sealed one from
@@ -50,6 +60,19 @@ export function diffProvenanceComponents(sealed, computed) {
         });
       }
     }
+    // Symmetric arm: a leaf that exists only on the COMPUTED side (the
+    // composite gained an input, or a schema bump added a branch) must be
+    // named too; a one-directional walk would report zero diffs and the
+    // formatter would then wrongly blame a hand-edited pin.
+    for (const key of Object.keys(b ?? {})) {
+      if (a !== null && a !== undefined && Object.hasOwn(a, key)) continue;
+      const computedValue = b[key];
+      if (computedValue !== null && typeof computedValue === 'object') {
+        walk({}, computedValue, `${prefix}${key}.`);
+      } else {
+        diffs.push({ key: `${prefix}${key}`, sealed: null, computed: computedValue ?? null });
+      }
+    }
   };
   walk(sealed, computed, '');
   return diffs;
@@ -70,7 +93,10 @@ export function diffProvenanceComponents(sealed, computed) {
 export function collectPolishProvenanceInputPaths({ inputs, sourceFileLists = [] }) {
   const paths = new Set();
   for (const [key, value] of Object.entries(inputs)) {
-    if (key === 'captureContract') continue;
+    // captureContract is a contract id, not a path; the shape guard backs
+    // the name up so a future non-path entry cannot slip into the git
+    // pathspecs (every real input carries a slash or an extension dot).
+    if (key === 'captureContract' || !/[/.]/.test(value)) continue;
     paths.add(value);
   }
   for (const list of sourceFileLists) {
@@ -93,15 +119,42 @@ export function collectPolishProvenanceInputPaths({ inputs, sourceFileLists = []
  */
 export function gitDirtyStatusLines({ repoRoot, paths, runGit = defaultRunGit }) {
   try {
-    const output = runGit(['status', '--porcelain', '--', ...paths], repoRoot);
+    // --no-optional-locks (a global option, so it precedes the subcommand)
+    // keeps the status read strictly a read: without it git refreshes
+    // .git/index stat data, which both mutates repo state from a test
+    // process and contends with any concurrent git in a sibling worktree.
+    const output = runGit(
+      ['--no-optional-locks', 'status', '--porcelain', '--', ...paths],
+      repoRoot,
+    );
     return output.split('\n').filter((line) => line.length > 0);
   } catch {
     return null;
   }
 }
 
-function defaultRunGit(args, cwd) {
-  return execFileSync('git', args, { cwd, encoding: 'utf8' });
+/**
+ * The real git runner, exported (with an injectable exec) so its hardening
+ * options are pinnable: bounded and quiet, because this runs on the
+ * synchronous path of a vitest worker, where a blocked git (index.lock
+ * contention, a stalled filesystem) would freeze the event loop past every
+ * test timeout and lose the diagnostic entirely; the deadline lands it in
+ * the null arm instead. stderr is dropped so a fatal from an unusual
+ * checkout cannot muddy the failure log the caller is about to print.
+ *
+ * @param {string[]} args
+ * @param {string} cwd
+ * @param {typeof execFileSync} execImpl
+ * @returns {string}
+ */
+export function defaultRunGit(args, cwd, execImpl = execFileSync) {
+  return execImpl('git', args, {
+    cwd,
+    encoding: 'utf8',
+    timeout: 10_000,
+    killSignal: 'SIGKILL',
+    stdio: ['ignore', 'pipe', 'ignore'],
+  });
 }
 
 /**
@@ -138,12 +191,14 @@ export function formatPolishProvenanceMismatch({
         '  (the seals and the pin move together in a re-mint, so suspect a hand edit).',
       );
     } else {
+      const show = (value) =>
+        value !== null && typeof value === 'object' ? JSON.stringify(value) : String(value);
       lines.push('  inputs that moved (leaves differing from the committed evidence seals):');
       for (const diff of diffs) {
         lines.push(
           `    ${diff.key}`,
-          `      sealed:   ${diff.sealed}`,
-          `      computed: ${diff.computed}`,
+          `      sealed:   ${show(diff.sealed)}`,
+          `      computed: ${show(diff.computed)}`,
         );
       }
     }
@@ -170,4 +225,91 @@ export function formatPolishProvenanceMismatch({
     `    ${REMINT_COMMAND}`,
   );
   return lines.join('\n');
+}
+
+/**
+ * The mint-time input-status verdict the remint tool prints, extracted here
+ * so its three arms (dirty, clean, git-unavailable) are unit-tested instead
+ * of living as inline console logic only a source-text pin could see.
+ *
+ * @param {string[] | null} dirtyStatusLines
+ * @returns {string[]}
+ */
+export function formatMintInputStatus(dirtyStatusLines) {
+  if (dirtyStatusLines === null) {
+    return [
+      'git status unavailable: could not check the fingerprinted inputs for',
+      'uncommitted edits; verify by hand before committing the new pins.',
+    ];
+  }
+  if (dirtyStatusLines.length > 0) {
+    return [
+      'WARNING: fingerprinted inputs differ from HEAD in this working tree:',
+      ...dirtyStatusLines.map((line) => `  ${line}`),
+      'This mint seals THESE bytes. Commit exactly these bytes with the new pins,',
+      'and RE-RUN this tool if any of them moves again before the commit (the',
+      '2026-08-05 craft-cast pin went stale exactly that way: renderer.ts moved',
+      'after the mint).',
+    ];
+  }
+  return [
+    'every fingerprinted input matches HEAD: this mint reproduces on any checkout',
+    'of the committed tree.',
+  ];
+}
+
+function defaultReadSeal(absolutePath) {
+  return JSON.parse(readFileSync(absolutePath, 'utf8'));
+}
+
+/**
+ * The whole failure-branch composition in one tested place: read the
+ * committed seal (fail-soft to the no-seal arm), collect the fingerprinted
+ * input paths, take the git dirty verdict, and format the report. The
+ * capture-contract suite calls exactly this on a pin mismatch, so the glue
+ * that only ever executes when a pin is already stale is unit-testable with
+ * injected seal-reader and git.
+ *
+ * @param {{
+ *   pinnedFingerprint: string,
+ *   computed: { fingerprint: string, components: Record<string, unknown> },
+ *   repoRoot: string,
+ *   inputs: Record<string, string>,
+ *   sourceFileLists?: ReadonlyArray<readonly string[]>,
+ *   readSeal?: (absolutePath: string) => unknown,
+ *   runGit?: (args: string[], cwd: string) => string,
+ * }} opts
+ * @returns {string}
+ */
+export function buildPolishProvenanceMismatchReport({
+  pinnedFingerprint,
+  computed,
+  repoRoot,
+  inputs,
+  sourceFileLists = [],
+  readSeal = defaultReadSeal,
+  runGit,
+}) {
+  // A missing or malformed seal must degrade to the no-seal arm, never
+  // replace the diagnostic with a bare filesystem error on the one path
+  // where the message matters.
+  let sealedComponents = null;
+  try {
+    const seal = readSeal(path.join(repoRoot, POLISH_SEAL_PATH));
+    sealedComponents = seal?.polishProvenance?.components ?? null;
+  } catch {
+    sealedComponents = null;
+  }
+  const inputPaths = collectPolishProvenanceInputPaths({ inputs, sourceFileLists });
+  const dirtyStatusLines = gitDirtyStatusLines({
+    repoRoot,
+    paths: inputPaths,
+    ...(runGit ? { runGit } : {}),
+  });
+  return formatPolishProvenanceMismatch({
+    pinnedFingerprint,
+    computed,
+    sealedComponents,
+    dirtyStatusLines,
+  });
 }

--- a/scripts/assets/eastbrook_grand_armoury/provenance_diagnostics.mjs
+++ b/scripts/assets/eastbrook_grand_armoury/provenance_diagnostics.mjs
@@ -1,0 +1,173 @@
+// Failure diagnostics for the Eastbrook composite polish provenance: the
+// Phase 6 (CI/CD performance packet) answer to the 2026-08-05 divergence
+// incident. Root cause, proven by recomputing the craft-cast merge's (#2965,
+// 4fea9babb0) composite from its own committed tree: the merge ran
+// remint_polish_provenance.mjs and src/render/renderer.ts then moved AGAIN
+// before the merge was committed, so the committed pin (628f66e2...) matched
+// a tree that never existed. Every pristine checkout computed 09f6f78b...,
+// exactly one leaf apart (runtimeRender.renderer.sha256). Local full gates
+// always run the polish suites while selective CI runs skip them unless the
+// diff reaches them, which is what dressed a stale pin up as a "local vs CI
+// divergence".
+//
+// The composite is computed from WORKING-TREE bytes by design: a mint must
+// be able to seal uncommitted edits that will be committed with it. What was
+// missing is legibility, and this module carries it for both the failing
+// tests and the remint tool: WHICH leaf moved (against the committed
+// evidence seals), whether any fingerprinted input differs from HEAD right
+// now (the stale-mint hazard), and the exact one-step remint command.
+
+import { execFileSync } from 'node:child_process';
+
+/** The one-step re-mint the failure messages point at. */
+export const REMINT_COMMAND =
+  'node scripts/assets/eastbrook_grand_armoury/remint_polish_provenance.mjs';
+
+/**
+ * Leaf-by-leaf diff of two provenance component trees (the sealed one from
+ * the committed evidence, the computed one from this tree). Returns dotted
+ * key paths so the diverged input is named directly, the exact analysis that
+ * localized the craft-cast incident to renderer.ts.
+ *
+ * @param {Record<string, unknown>} sealed
+ * @param {Record<string, unknown>} computed
+ * @returns {Array<{ key: string, sealed: unknown, computed: unknown }>}
+ */
+export function diffProvenanceComponents(sealed, computed) {
+  /** @type {Array<{ key: string, sealed: unknown, computed: unknown }>} */
+  const diffs = [];
+  const walk = (a, b, prefix) => {
+    for (const key of Object.keys(a ?? {})) {
+      const sealedValue = a?.[key];
+      const computedValue = b?.[key];
+      if (sealedValue !== null && typeof sealedValue === 'object') {
+        walk(sealedValue, computedValue ?? {}, `${prefix}${key}.`);
+      } else if (sealedValue !== computedValue) {
+        diffs.push({
+          key: `${prefix}${key}`,
+          sealed: sealedValue ?? null,
+          computed: computedValue ?? null,
+        });
+      }
+    }
+  };
+  walk(sealed, computed, '');
+  return diffs;
+}
+
+/**
+ * Every repo-relative file whose bytes feed the composite: the direct
+ * provenance inputs (minus the captureContract entry, which is a contract id,
+ * not a path) plus the GLB source-fingerprint file lists (which carry
+ * pnpm-lock.yaml and the exporter sources).
+ *
+ * @param {{
+ *   inputs: Record<string, string>,
+ *   sourceFileLists?: ReadonlyArray<readonly string[]>,
+ * }} opts
+ * @returns {string[]}
+ */
+export function collectPolishProvenanceInputPaths({ inputs, sourceFileLists = [] }) {
+  const paths = new Set();
+  for (const [key, value] of Object.entries(inputs)) {
+    if (key === 'captureContract') continue;
+    paths.add(value);
+  }
+  for (const list of sourceFileLists) {
+    for (const p of list) paths.add(p);
+  }
+  return [...paths].sort();
+}
+
+/**
+ * Raw `git status --porcelain` lines for the given paths (worktree or index
+ * differing from HEAD), or null when git is unavailable so the caller can
+ * say so instead of silently claiming a clean tree.
+ *
+ * @param {{
+ *   repoRoot: string,
+ *   paths: readonly string[],
+ *   runGit?: (args: string[], cwd: string) => string,
+ * }} opts
+ * @returns {string[] | null}
+ */
+export function gitDirtyStatusLines({ repoRoot, paths, runGit = defaultRunGit }) {
+  try {
+    const output = runGit(['status', '--porcelain', '--', ...paths], repoRoot);
+    return output.split('\n').filter((line) => line.length > 0);
+  } catch {
+    return null;
+  }
+}
+
+function defaultRunGit(args, cwd) {
+  return execFileSync('git', args, { cwd, encoding: 'utf8' });
+}
+
+/**
+ * The full mismatch explanation: computed vs pinned fingerprint, the moved
+ * leaves against the committed evidence seals, the dirty-input verdict that
+ * separates "your tree differs from HEAD" (fix the tree or commit the exact
+ * bytes; a mint now can go stale) from "the committed tree computes a new
+ * value everywhere" (a re-mint is legitimate), and the one-step command.
+ *
+ * @param {{
+ *   pinnedFingerprint: string,
+ *   computed: { fingerprint: string, components: Record<string, unknown> },
+ *   sealedComponents?: Record<string, unknown> | null,
+ *   dirtyStatusLines?: string[] | null,
+ * }} opts
+ * @returns {string}
+ */
+export function formatPolishProvenanceMismatch({
+  pinnedFingerprint,
+  computed,
+  sealedComponents = null,
+  dirtyStatusLines = null,
+}) {
+  const lines = [
+    'Eastbrook polish composite fingerprint mismatch.',
+    `  computed from this tree: ${computed.fingerprint}`,
+    `  pinned in the test:      ${pinnedFingerprint}`,
+  ];
+  if (sealedComponents) {
+    const diffs = diffProvenanceComponents(sealedComponents, computed.components);
+    if (diffs.length === 0) {
+      lines.push(
+        '  every leaf matches the committed evidence seals: the pin literal alone is stale',
+        '  (the seals and the pin move together in a re-mint, so suspect a hand edit).',
+      );
+    } else {
+      lines.push('  inputs that moved (leaves differing from the committed evidence seals):');
+      for (const diff of diffs) {
+        lines.push(
+          `    ${diff.key}`,
+          `      sealed:   ${diff.sealed}`,
+          `      computed: ${diff.computed}`,
+        );
+      }
+    }
+  }
+  if (dirtyStatusLines === null) {
+    lines.push('  git status unavailable: could not check the inputs for uncommitted edits.');
+  } else if (dirtyStatusLines.length > 0) {
+    lines.push(
+      '  WARNING: fingerprinted inputs differ from HEAD in this working tree:',
+      ...dirtyStatusLines.map((line) => `    ${line}`),
+      '  A re-mint now seals THESE bytes and matches the committed tree only if exactly',
+      '  these bytes land in the same commit. If an input moves again after minting, the',
+      '  pin goes stale for every checkout (the 2026-08-05 craft-cast pin failed exactly',
+      '  this way: renderer.ts moved after the mint).',
+    );
+  } else {
+    lines.push(
+      '  every fingerprinted input matches HEAD: this committed tree computes the value',
+      '  above everywhere (local and CI), the pin is stale, and a re-mint is legitimate.',
+    );
+  }
+  lines.push(
+    '  One-step re-mint (recomputes all three pinned literals and sweeps the evidence seals):',
+    `    ${REMINT_COMMAND}`,
+  );
+  return lines.join('\n');
+}

--- a/scripts/assets/eastbrook_grand_armoury/remint_polish_provenance.mjs
+++ b/scripts/assets/eastbrook_grand_armoury/remint_polish_provenance.mjs
@@ -4,16 +4,27 @@
 // committed evidence seals and two pinned test literals go stale. This
 // recomputes the provenance from the current tree with the capture contract's
 // own derivation, sweeps it through the four committed after seals (top-level
-// and per-record blocks), and prints the two literals to pin:
+// and per-record blocks), and prints the three literals to pin:
 //
 //   node scripts/assets/eastbrook_grand_armoury/remint_polish_provenance.mjs
 //
 // Then update, if they moved:
 //   - tests/eastbrook_polish_capture_contract.test.ts: the pinned composite
-//     fingerprint literal
-//   - tests/eastbrook_polish_artifact_integrity.test.ts: the second-order
-//     performance evidence digest literal (recomputed LAST, from the swept
-//     files, matching the test's own name\0bytes\0 stream)
+//     fingerprint literal (PINNED_POLISH_COMPOSITE_FINGERPRINT)
+//   - tests/eastbrook_polish_artifact_integrity.test.ts: the metadata
+//     authority sha256 (ACCEPTED_POLISH_V2_METADATA_SHA256, the swept
+//     after-desktop-ultra.json) and the second-order performance evidence
+//     digest literal (recomputed LAST, from the swept files, matching the
+//     test's own name\0bytes\0 stream)
+//
+// A mint reads WORKING-TREE bytes by design (it must be able to seal
+// uncommitted edits that land in the same commit), which is exactly how the
+// 2026-08-05 craft-cast pin went stale: the mint ran, then renderer.ts moved
+// again before the merge committed, so the pin matched no tree that ever
+// existed (see provenance_diagnostics.mjs for the proven root cause). This
+// tool therefore prints the git status of every fingerprinted input at mint
+// time: commit exactly those bytes with the new pin, and RE-RUN the mint if
+// any input moves again before the commit.
 //
 // GLB pipeline inputs (scripts/assets sources, pnpm-lock.yaml) are NOT
 // covered here: those need the full deterministic export re-run described in
@@ -104,9 +115,47 @@ for (const fileName of accepted) {
   secondOrder.update('\0');
 }
 
-console.log('composite fingerprint (pin in eastbrook_polish_capture_contract.test.ts):');
+const metadataAuthoritySha = createHash('sha256')
+  .update(await readFile(new URL(`${POLISH_ROOT}/metadata/after-desktop-ultra.json`, rootUrl)))
+  .digest('hex');
+
+console.log('composite fingerprint (pin in eastbrook_polish_capture_contract.test.ts,');
+console.log('PINNED_POLISH_COMPOSITE_FINGERPRINT):');
 console.log(`  ${current.fingerprint}`);
+console.log('metadata authority sha256 (pin in eastbrook_polish_artifact_integrity.test.ts,');
+console.log('ACCEPTED_POLISH_V2_METADATA_SHA256, recomputed from the swept file):');
+console.log(`  ${metadataAuthoritySha}`);
 console.log(
   'second-order performance digest (pin in eastbrook_polish_artifact_integrity.test.ts):',
 );
 console.log(`  ${secondOrder.digest('hex')}`);
+
+// The stale-mint tripwire: name every fingerprinted input that differs from
+// HEAD right now. Minting over dirty inputs is legitimate ONLY when exactly
+// these bytes ship in the same commit as the new pins.
+const diagnostics = await import(
+  new URL('scripts/assets/eastbrook_grand_armoury/provenance_diagnostics.mjs', rootUrl)
+);
+const inputPaths = diagnostics.collectPolishProvenanceInputPaths({
+  inputs: INPUTS,
+  sourceFileLists: [
+    town.EASTBROOK_TOWN_SOURCE_FILES,
+    mailbox.EASTBROOK_MAILBOX_SOURCE_FILES,
+    notice.EASTBROOK_NOTICEBOARD_SOURCE_FILES,
+  ],
+});
+const dirty = diagnostics.gitDirtyStatusLines({ repoRoot, paths: inputPaths });
+if (dirty === null) {
+  console.log('git status unavailable: could not check the fingerprinted inputs for');
+  console.log('uncommitted edits; verify by hand before committing the new pins.');
+} else if (dirty.length > 0) {
+  console.log('WARNING: fingerprinted inputs differ from HEAD in this working tree:');
+  for (const line of dirty) console.log(`  ${line}`);
+  console.log('This mint seals THESE bytes. Commit exactly these bytes with the new pins,');
+  console.log('and RE-RUN this tool if any of them moves again before the commit (the');
+  console.log('2026-08-05 craft-cast pin went stale exactly that way: renderer.ts moved');
+  console.log('after the mint).');
+} else {
+  console.log('every fingerprinted input matches HEAD: this mint reproduces on any checkout');
+  console.log('of the committed tree.');
+}

--- a/scripts/assets/eastbrook_grand_armoury/remint_polish_provenance.mjs
+++ b/scripts/assets/eastbrook_grand_armoury/remint_polish_provenance.mjs
@@ -48,6 +48,9 @@ const mailbox = await import(
 const notice = await import(
   new URL('scripts/assets/eastbrook_noticeboard/source_fingerprint.mjs', rootUrl)
 );
+const diagnostics = await import(
+  new URL('scripts/assets/eastbrook_grand_armoury/provenance_diagnostics.mjs', rootUrl)
+);
 
 const { deriveEastbrookPolishCompositeProvenance, EASTBROOK_POLISH_PROVENANCE_INPUTS: INPUTS } =
   contract;
@@ -116,7 +119,7 @@ for (const fileName of accepted) {
 }
 
 const metadataAuthoritySha = createHash('sha256')
-  .update(await readFile(new URL(`${POLISH_ROOT}/metadata/after-desktop-ultra.json`, rootUrl)))
+  .update(await readFile(new URL(diagnostics.POLISH_SEAL_PATH, rootUrl)))
   .digest('hex');
 
 console.log('composite fingerprint (pin in eastbrook_polish_capture_contract.test.ts,');
@@ -129,13 +132,13 @@ console.log(
   'second-order performance digest (pin in eastbrook_polish_artifact_integrity.test.ts):',
 );
 console.log(`  ${secondOrder.digest('hex')}`);
+console.log('do NOT touch ACCEPTED_POLISH_V2_TOWN_SOURCE_FINGERPRINT in that same test:');
+console.log('it is the FROZEN identity of the tree the captures were taken against, and');
+console.log('it moves only if the captures themselves are retaken.');
 
 // The stale-mint tripwire: name every fingerprinted input that differs from
 // HEAD right now. Minting over dirty inputs is legitimate ONLY when exactly
 // these bytes ship in the same commit as the new pins.
-const diagnostics = await import(
-  new URL('scripts/assets/eastbrook_grand_armoury/provenance_diagnostics.mjs', rootUrl)
-);
 const inputPaths = diagnostics.collectPolishProvenanceInputPaths({
   inputs: INPUTS,
   sourceFileLists: [
@@ -145,17 +148,6 @@ const inputPaths = diagnostics.collectPolishProvenanceInputPaths({
   ],
 });
 const dirty = diagnostics.gitDirtyStatusLines({ repoRoot, paths: inputPaths });
-if (dirty === null) {
-  console.log('git status unavailable: could not check the fingerprinted inputs for');
-  console.log('uncommitted edits; verify by hand before committing the new pins.');
-} else if (dirty.length > 0) {
-  console.log('WARNING: fingerprinted inputs differ from HEAD in this working tree:');
-  for (const line of dirty) console.log(`  ${line}`);
-  console.log('This mint seals THESE bytes. Commit exactly these bytes with the new pins,');
-  console.log('and RE-RUN this tool if any of them moves again before the commit (the');
-  console.log('2026-08-05 craft-cast pin went stale exactly that way: renderer.ts moved');
-  console.log('after the mint).');
-} else {
-  console.log('every fingerprinted input matches HEAD: this mint reproduces on any checkout');
-  console.log('of the committed tree.');
+for (const line of diagnostics.formatMintInputStatus(dirty)) {
+  console.log(line);
 }

--- a/tests/eastbrook_polish_artifact_integrity.test.ts
+++ b/tests/eastbrook_polish_artifact_integrity.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, it } from 'vitest';
 const captureContract =
   // @ts-expect-error The executable capture contract intentionally ships as plain Node ESM.
   await import('../scripts/assets/eastbrook_grand_armoury/capture_contract.mjs');
-const { REMINT_COMMAND } = await import(
+const { POLISH_SEAL_PATH, REMINT_COMMAND } = await import(
   '../scripts/assets/eastbrook_grand_armoury/provenance_diagnostics.mjs'
 );
 const {
@@ -619,10 +619,10 @@ function readJsonFile<T>(filePath: string): T {
 // literals; it only moves if the captures themselves are retaken.
 const ACCEPTED_POLISH_V2_TOWN_SOURCE_FINGERPRINT =
   'e15d65fda69efd04395e93dd28af8a56f2fb9bc1ff1125e3b605b07720891367';
-const ACCEPTED_POLISH_V2_METADATA_PATH = path.join(
-  POLISH_ROOT,
-  'metadata/after-desktop-ultra.json',
-);
+// Derived from the diagnostics module's one seal-path constant, so this
+// pin, the failure diagnostics, and the remint tool's printed metadata
+// authority sha can never silently point at three different files.
+const ACCEPTED_POLISH_V2_METADATA_PATH = path.join(REPO_ROOT, POLISH_SEAL_PATH);
 // Re-pinned for the merge of release/v0.34.0 into this branch. Every
 // rendererIntegration move on both sides now stacks on src/render/renderer.ts:
 // from the release, PR #2720's Eastbrook fence-removal layout evidence, the live

--- a/tests/eastbrook_polish_artifact_integrity.test.ts
+++ b/tests/eastbrook_polish_artifact_integrity.test.ts
@@ -6,6 +6,9 @@ import { describe, expect, it } from 'vitest';
 const captureContract =
   // @ts-expect-error The executable capture contract intentionally ships as plain Node ESM.
   await import('../scripts/assets/eastbrook_grand_armoury/capture_contract.mjs');
+const { REMINT_COMMAND } = await import(
+  '../scripts/assets/eastbrook_grand_armoury/provenance_diagnostics.mjs'
+);
 const {
   assertTownArmouryIdentity,
   assertTownAttributionTargetState,
@@ -936,8 +939,16 @@ describe('Eastbrook polish committed capture artifacts', () => {
   });
 
   it('pins the historical metadata authority independently', () => {
-    expect(sha256File(ACCEPTED_POLISH_V2_METADATA_PATH)).toBe(ACCEPTED_POLISH_V2_METADATA_SHA256);
-    expect(ACCEPTED_POLISH_V2_PROVENANCE.fingerprint).toBe(ACCEPTED_POLISH_V2_COMPOSITE_PROVENANCE);
+    // On a legitimate re-mint both literals move together with the capture
+    // contract's composite pin; the remint tool prints all three.
+    expect(
+      sha256File(ACCEPTED_POLISH_V2_METADATA_PATH),
+      `the accepted metadata authority moved; if every input moved legitimately, re-mint with: ${REMINT_COMMAND}`,
+    ).toBe(ACCEPTED_POLISH_V2_METADATA_SHA256);
+    expect(
+      ACCEPTED_POLISH_V2_PROVENANCE.fingerprint,
+      `the sealed composite fingerprint moved; if every input moved legitimately, re-mint with: ${REMINT_COMMAND}`,
+    ).toBe(ACCEPTED_POLISH_V2_COMPOSITE_PROVENANCE);
   });
 
   // The frozen polish-v2 evidence intentionally predates the bank rebuild: it
@@ -1515,9 +1526,10 @@ describe('Eastbrook polish performance and contact evidence', () => {
     // matched the merged tree, and no capture was retaken here.
     // Re-pinned for the integrated v0.35 renderer on AAA-enhancements and
     // recomputed by remint_polish_provenance.mjs.
-    expect(fingerprint.digest('hex')).toBe(
-      '4fd9c844d07805ba75c6749ae76ee139838d5f3f389fe2b20266671f7afb4cd0',
-    );
+    expect(
+      fingerprint.digest('hex'),
+      `the second-order performance digest moved; if every input moved legitimately, re-mint with: ${REMINT_COMMAND} (it recomputes this literal LAST, from the swept files)`,
+    ).toBe('4fd9c844d07805ba75c6749ae76ee139838d5f3f389fe2b20266671f7afb4cd0');
   });
 
   it('binds every historical after record to its accepted source and asset provenance', () => {

--- a/tests/eastbrook_polish_capture_contract.test.ts
+++ b/tests/eastbrook_polish_capture_contract.test.ts
@@ -43,18 +43,24 @@ interface AttributionTargetFixture {
 }
 
 // The live composite pin. Mint history (kept from the previous in-place
-// comments): re-pinned across the pnpm-lock migration, PR #2720's
+// comments): re-pinned across the pnpm-lock migration (which moved the
+// three GLB *SourceFingerprint leaves, since the lockfile is a hashed input
+// of every GLB source fingerprint), and then across PR #2720's
 // fence-removal layout evidence, the v0.34.0 Bear Form rig (#2842), the live
 // graphics rebuild (#2799), far-field impostors and fog-free vista (#2793),
 // brood shout/flourish wiring, the worldObjectBurning fire-burst cue, the
 // Thornhollow renderer sync, and the release/v0.35.0 into AAA-enhancements
-// merge; every one of those moved a runtimeRender leaf (usually
-// src/render/renderer.ts) and re-minted the composite with
+// merge, each of which moved a runtimeRender leaf (usually
+// src/render/renderer.ts); every mint used
 // scripts/assets/eastbrook_grand_armoury/remint_polish_provenance.mjs.
-// Re-derive whenever renderer.ts changes. On a mismatch the test prints the
-// full diagnostics (moved leaves, dirty-input verdict, the one-step remint
-// command) instead of a raw object diff; see provenance_diagnostics.mjs for
-// the 2026-08-05 stale-mint root cause this legibility exists to prevent.
+// Across all of those mints no GLB pipeline input or geometry value changed
+// and no capture was retaken here: Eastbrook itself is untouched, and the
+// one capture retake (by the release) was adopted verbatim with its swept
+// metadata and performance JSONs. Re-derive whenever renderer.ts changes.
+// On a mismatch the test prints the full diagnostics (moved leaves,
+// dirty-input verdict, the one-step remint command) instead of a raw object
+// diff; see provenance_diagnostics.mjs for the 2026-08-05 stale-mint root
+// cause this legibility exists to prevent.
 const PINNED_POLISH_COMPOSITE_FINGERPRINT =
   'f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9';
 
@@ -382,32 +388,21 @@ describe('Eastbrook polish capture contract', () => {
         import('../scripts/assets/eastbrook_grand_armoury/provenance_diagnostics.mjs'),
         import('node:url'),
       ]);
-      const seal = JSON.parse(
-        await readFile(
-          new URL(
-            'docs/screenshots/eastbrook-vale-rebuild/polish/metadata/after-desktop-ultra.json',
-            repoRoot,
-          ),
-          'utf8',
-        ),
-      );
-      const inputPaths = diagnostics.collectPolishProvenanceInputPaths({
-        inputs: EASTBROOK_POLISH_PROVENANCE_INPUTS,
-        sourceFileLists: [
-          townFingerprint.EASTBROOK_TOWN_SOURCE_FILES,
-          mailboxFingerprint.EASTBROOK_MAILBOX_SOURCE_FILES,
-          noticeboardFingerprint.EASTBROOK_NOTICEBOARD_SOURCE_FILES,
-        ],
-      });
+      // The whole composition (seal read, path collection, git verdict,
+      // formatting) lives in the builder so the glue that only ever runs
+      // when a pin is already stale stays unit-tested with injected
+      // seal-reader and git (tests/eastbrook_provenance_diagnostics.test.ts).
       expect.fail(
-        diagnostics.formatPolishProvenanceMismatch({
+        diagnostics.buildPolishProvenanceMismatchReport({
           pinnedFingerprint: PINNED_POLISH_COMPOSITE_FINGERPRINT,
           computed: provenance,
-          sealedComponents: seal.polishProvenance?.components ?? null,
-          dirtyStatusLines: diagnostics.gitDirtyStatusLines({
-            repoRoot: fileURLToPath(repoRoot),
-            paths: inputPaths,
-          }),
+          repoRoot: fileURLToPath(repoRoot),
+          inputs: EASTBROOK_POLISH_PROVENANCE_INPUTS,
+          sourceFileLists: [
+            townFingerprint.EASTBROOK_TOWN_SOURCE_FILES,
+            mailboxFingerprint.EASTBROOK_MAILBOX_SOURCE_FILES,
+            noticeboardFingerprint.EASTBROOK_NOTICEBOARD_SOURCE_FILES,
+          ],
         }),
       );
     }

--- a/tests/eastbrook_polish_capture_contract.test.ts
+++ b/tests/eastbrook_polish_capture_contract.test.ts
@@ -42,6 +42,22 @@ interface AttributionTargetFixture {
   childMeshCount: number;
 }
 
+// The live composite pin. Mint history (kept from the previous in-place
+// comments): re-pinned across the pnpm-lock migration, PR #2720's
+// fence-removal layout evidence, the v0.34.0 Bear Form rig (#2842), the live
+// graphics rebuild (#2799), far-field impostors and fog-free vista (#2793),
+// brood shout/flourish wiring, the worldObjectBurning fire-burst cue, the
+// Thornhollow renderer sync, and the release/v0.35.0 into AAA-enhancements
+// merge; every one of those moved a runtimeRender leaf (usually
+// src/render/renderer.ts) and re-minted the composite with
+// scripts/assets/eastbrook_grand_armoury/remint_polish_provenance.mjs.
+// Re-derive whenever renderer.ts changes. On a mismatch the test prints the
+// full diagnostics (moved leaves, dirty-input verdict, the one-step remint
+// command) instead of a raw object diff; see provenance_diagnostics.mjs for
+// the 2026-08-05 stale-mint root cause this legibility exists to prevent.
+const PINNED_POLISH_COMPOSITE_FINGERPRINT =
+  'f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9';
+
 function validPolishAttributionTargets(): AttributionTargetFixture[] {
   return [
     {
@@ -355,37 +371,52 @@ describe('Eastbrook polish capture contract', () => {
       noticeboardSourceFingerprint: noticeboardFingerprint.eastbrookNoticeboardSourceFingerprint(),
       noticeboardGlbSha256: await fileSha256(EASTBROOK_POLISH_PROVENANCE_INPUTS.noticeboardGlb),
     });
+    // On a mismatch the diagnostics module names the moved leaf against the
+    // committed evidence seal, reports whether any fingerprinted input is
+    // dirty vs HEAD (the stale-mint hazard: the 2026-08-05 craft-cast pin
+    // was minted and then renderer.ts moved again before commit, so the pin
+    // matched no tree), and prints the one-step remint command. The plain
+    // toMatchObject diff buried all three of those answers.
+    if (provenance.fingerprint !== PINNED_POLISH_COMPOSITE_FINGERPRINT) {
+      const [diagnostics, { fileURLToPath }] = await Promise.all([
+        import('../scripts/assets/eastbrook_grand_armoury/provenance_diagnostics.mjs'),
+        import('node:url'),
+      ]);
+      const seal = JSON.parse(
+        await readFile(
+          new URL(
+            'docs/screenshots/eastbrook-vale-rebuild/polish/metadata/after-desktop-ultra.json',
+            repoRoot,
+          ),
+          'utf8',
+        ),
+      );
+      const inputPaths = diagnostics.collectPolishProvenanceInputPaths({
+        inputs: EASTBROOK_POLISH_PROVENANCE_INPUTS,
+        sourceFileLists: [
+          townFingerprint.EASTBROOK_TOWN_SOURCE_FILES,
+          mailboxFingerprint.EASTBROOK_MAILBOX_SOURCE_FILES,
+          noticeboardFingerprint.EASTBROOK_NOTICEBOARD_SOURCE_FILES,
+        ],
+      });
+      expect.fail(
+        diagnostics.formatPolishProvenanceMismatch({
+          pinnedFingerprint: PINNED_POLISH_COMPOSITE_FINGERPRINT,
+          computed: provenance,
+          sealedComponents: seal.polishProvenance?.components ?? null,
+          dirtyStatusLines: diagnostics.gitDirtyStatusLines({
+            repoRoot: fileURLToPath(repoRoot),
+            paths: inputPaths,
+          }),
+        }),
+      );
+    }
     expect(provenance).toMatchObject({
       schemaVersion: 1,
       mode: 'composite-sha256',
       algorithm: 'sha256',
       baselineRevision: EASTBROOK_POLISH_BASELINE_REVISION,
-      // Deliberately re-pinned, and this mint stacks every leaf move on both sides
-      // of the merge onto src/render/renderer.ts, the rendererIntegration leaf of
-      // this composite: the pnpm-lock migration (a hashed input to every GLB source
-      // fingerprint), PR #2720's fence-removal layout evidence, release/v0.34.0's
-      // Bear Form quadruped rig (PR #2842), live graphics rebuild (context recycle
-      // plus profile-aware Eastbrook runtime inputs, PR #2799), far-field sprite
-      // impostors and fog-free vista (PR #2793), and brood shout/flourish wiring;
-      // and from this branch the worldObjectBurning fire-burst cue (torched murloc
-      // huts, q_deepfen_purge). The release also retook the polish captures and
-      // re-swept their metadata and performance JSONs, and those files are adopted
-      // verbatim here. Each move shifts the leaf's own sha256 and with it the
-      // composite, so the merged tree mints one fingerprint matching neither
-      // parent's literal. No GLB source fingerprint moved, not one pipeline input
-      // or geometry value changed, and no capture was retaken: Eastbrook itself is
-      // untouched by all of it. Re-minted with
-      // scripts/assets/eastbrook_grand_armoury/remint_polish_provenance.mjs.
-      // Re-pinned at the Thornhollow branch sync: that branch edits
-      // src/render/renderer.ts (battleground occluder fade and ward state),
-      // the renderer-integration leaf, so the composite re-mints. Re-derive
-      // whenever renderer.ts changes.
-      // Re-pinned for the merge of release/v0.35.0 into AAA-enhancements: both
-      // sides moved the renderer-integration leaf (this branch's integrated v0.35
-      // renderer; the release's bounded ground-object reuse pool), so the merged
-      // tree mints a composite matching neither parent. Regenerated via
-      // scripts/assets/eastbrook_grand_armoury/remint_polish_provenance.mjs.
-      fingerprint: 'f748c054b28d4e30f80dbb41b52a47e590d24f6bd262cf800b4febe0535c83d9',
+      fingerprint: PINNED_POLISH_COMPOSITE_FINGERPRINT,
       components: {
         captureContract: {
           id: 'polish-v2',

--- a/tests/eastbrook_provenance_diagnostics.test.ts
+++ b/tests/eastbrook_provenance_diagnostics.test.ts
@@ -1,0 +1,217 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const diagnostics = await import(
+  '../scripts/assets/eastbrook_grand_armoury/provenance_diagnostics.mjs'
+);
+const {
+  REMINT_COMMAND,
+  collectPolishProvenanceInputPaths,
+  diffProvenanceComponents,
+  formatPolishProvenanceMismatch,
+  gitDirtyStatusLines,
+} = diagnostics;
+
+// Phase 6 of the CI/CD performance packet: the 2026-08-05 provenance
+// incident (the craft-cast merge committed pin 628f66e2... while its own
+// committed tree computes 09f6f78b..., one leaf apart on
+// runtimeRender.renderer.sha256) burned hours because the failure said
+// nothing about WHICH input moved, whether the tree was dirty, or how to
+// re-mint. These tests pin the diagnostics that now answer all three.
+
+const SEALED = {
+  townAsset: { source: 'scripts/x.mjs', sourceFingerprint: 'a'.repeat(64) },
+  runtimeRender: {
+    renderer: { path: 'src/render/renderer.ts', sha256: 'b'.repeat(64) },
+    town: { path: 'src/render/eastbrook_town.ts', sha256: 'c'.repeat(64) },
+  },
+};
+
+describe('diffProvenanceComponents', () => {
+  it('names the exact diverged leaf with dotted keys, the craft-cast analysis', () => {
+    const computed = structuredClone(SEALED);
+    computed.runtimeRender.renderer.sha256 = 'd'.repeat(64);
+    expect(diffProvenanceComponents(SEALED, computed)).toEqual([
+      { key: 'runtimeRender.renderer.sha256', sealed: 'b'.repeat(64), computed: 'd'.repeat(64) },
+    ]);
+  });
+
+  it('returns empty for identical trees and reports missing branches leaf by leaf', () => {
+    expect(diffProvenanceComponents(SEALED, structuredClone(SEALED))).toEqual([]);
+    const missingBranch = { townAsset: SEALED.townAsset };
+    expect(
+      diffProvenanceComponents(SEALED, missingBranch as never).map((d: { key: string }) => d.key),
+    ).toEqual([
+      'runtimeRender.renderer.path',
+      'runtimeRender.renderer.sha256',
+      'runtimeRender.town.path',
+      'runtimeRender.town.sha256',
+    ]);
+  });
+});
+
+describe('collectPolishProvenanceInputPaths', () => {
+  it('collects every input path plus the source-fingerprint file lists, minus the contract id', () => {
+    const paths = collectPolishProvenanceInputPaths({
+      inputs: {
+        authoritativeLayout: 'src/sim/eastbrook_layout.ts',
+        rendererIntegration: 'src/render/renderer.ts',
+        captureContract: 'polish-v2',
+      },
+      sourceFileLists: [
+        ['scripts/assets/x/model.js', 'pnpm-lock.yaml'],
+        ['pnpm-lock.yaml', 'scripts/assets/y/model.js'],
+      ],
+    });
+    expect(paths).toEqual([
+      'pnpm-lock.yaml',
+      'scripts/assets/x/model.js',
+      'scripts/assets/y/model.js',
+      'src/render/renderer.ts',
+      'src/sim/eastbrook_layout.ts',
+    ]);
+    expect(paths).not.toContain('polish-v2');
+  });
+
+  it('matches the real provenance input surface: lockfile and renderer both in scope', async () => {
+    const [contract, town, mailbox, notice] = await Promise.all([
+      // @ts-expect-error The executable capture contract intentionally ships as plain Node ESM.
+      import('../scripts/assets/eastbrook_grand_armoury/capture_contract.mjs'),
+      import('../scripts/assets/eastbrook_town/source_fingerprint.mjs'),
+      import('../scripts/assets/eastbrook_mailbox/source_fingerprint.mjs'),
+      import('../scripts/assets/eastbrook_noticeboard/source_fingerprint.mjs'),
+    ]);
+    const paths = collectPolishProvenanceInputPaths({
+      inputs: contract.EASTBROOK_POLISH_PROVENANCE_INPUTS,
+      sourceFileLists: [
+        town.EASTBROOK_TOWN_SOURCE_FILES,
+        mailbox.EASTBROOK_MAILBOX_SOURCE_FILES,
+        notice.EASTBROOK_NOTICEBOARD_SOURCE_FILES,
+      ],
+    });
+    // The two inputs the incident history proves matter most.
+    expect(paths).toContain('src/render/renderer.ts');
+    expect(paths).toContain('pnpm-lock.yaml');
+    expect(paths).not.toContain('polish-v2');
+  });
+});
+
+describe('gitDirtyStatusLines', () => {
+  it('returns porcelain lines from the injected git runner and null on git failure', () => {
+    const calls: string[][] = [];
+    const dirty = gitDirtyStatusLines({
+      repoRoot: '/repo',
+      paths: ['a.ts', 'b.ts'],
+      runGit: (args: string[], cwd: string) => {
+        calls.push([cwd, ...args]);
+        return ' M a.ts\n?? b.ts\n';
+      },
+    });
+    expect(dirty).toEqual([' M a.ts', '?? b.ts']);
+    expect(calls).toEqual([['/repo', 'status', '--porcelain', '--', 'a.ts', 'b.ts']]);
+    expect(
+      gitDirtyStatusLines({
+        repoRoot: '/repo',
+        paths: ['a.ts'],
+        runGit: () => {
+          throw new Error('no git');
+        },
+      }),
+    ).toBeNull();
+    expect(gitDirtyStatusLines({ repoRoot: '/repo', paths: ['a.ts'], runGit: () => '' })).toEqual(
+      [],
+    );
+  });
+});
+
+describe('formatPolishProvenanceMismatch', () => {
+  const computed = {
+    fingerprint: '09f6f78b9c049ba5df01a27ddf054f00928dce957dec2b4d819d5109e83c4d10',
+    components: (() => {
+      const c = structuredClone(SEALED);
+      c.runtimeRender.renderer.sha256 = 'd'.repeat(64);
+      return c;
+    })(),
+  };
+  const pinnedFingerprint = '628f66e2ba22fb456ca64603dfee7311bf766ee5d9ebe71d5e2b2109b01f1d3b';
+
+  it('always prints both fingerprints and the exact one-step remint command', () => {
+    const message = formatPolishProvenanceMismatch({ pinnedFingerprint, computed });
+    expect(message).toContain(computed.fingerprint);
+    expect(message).toContain(pinnedFingerprint);
+    expect(message).toContain(REMINT_COMMAND);
+    expect(REMINT_COMMAND).toBe(
+      'node scripts/assets/eastbrook_grand_armoury/remint_polish_provenance.mjs',
+    );
+  });
+
+  it('names the moved leaf against the sealed components', () => {
+    const message = formatPolishProvenanceMismatch({
+      pinnedFingerprint,
+      computed,
+      sealedComponents: SEALED,
+    });
+    expect(message).toContain('runtimeRender.renderer.sha256');
+    expect(message).toContain('b'.repeat(64));
+    expect(message).toContain('d'.repeat(64));
+  });
+
+  it('separates the dirty-tree hazard from the legitimate-remint verdict', () => {
+    const dirty = formatPolishProvenanceMismatch({
+      pinnedFingerprint,
+      computed,
+      dirtyStatusLines: [' M src/render/renderer.ts'],
+    });
+    expect(dirty).toContain('WARNING: fingerprinted inputs differ from HEAD');
+    expect(dirty).toContain(' M src/render/renderer.ts');
+    expect(dirty).toContain('craft-cast');
+    const clean = formatPolishProvenanceMismatch({
+      pinnedFingerprint,
+      computed,
+      dirtyStatusLines: [],
+    });
+    expect(clean).toContain('a re-mint is legitimate');
+    const unavailable = formatPolishProvenanceMismatch({
+      pinnedFingerprint,
+      computed,
+      dirtyStatusLines: null,
+    });
+    expect(unavailable).toContain('git status unavailable');
+  });
+
+  it('flags a seal-consistent tree as a pin-only hand edit', () => {
+    const message = formatPolishProvenanceMismatch({
+      pinnedFingerprint,
+      computed,
+      sealedComponents: computed.components,
+    });
+    expect(message).toContain('the pin literal alone is stale');
+  });
+});
+
+describe('wiring', () => {
+  it('the capture-contract suite and the remint tool both use the diagnostics', () => {
+    // Comments stripped first (block then line, the ci_workflow.test.ts
+    // idiom) so a commented-out call cannot satisfy the pin.
+    const strip = (source: string) =>
+      source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+    const suite = strip(
+      readFileSync(new URL('./eastbrook_polish_capture_contract.test.ts', import.meta.url), 'utf8'),
+    );
+    expect(suite).toContain('provenance_diagnostics.mjs');
+    expect(suite).toContain('formatPolishProvenanceMismatch');
+    expect(suite).toContain('gitDirtyStatusLines');
+    const remint = strip(
+      readFileSync(
+        new URL(
+          '../scripts/assets/eastbrook_grand_armoury/remint_polish_provenance.mjs',
+          import.meta.url,
+        ),
+        'utf8',
+      ),
+    );
+    expect(remint).toContain('provenance_diagnostics.mjs');
+    expect(remint).toContain('gitDirtyStatusLines');
+    expect(remint).toContain('collectPolishProvenanceInputPaths');
+  });
+});

--- a/tests/eastbrook_provenance_diagnostics.test.ts
+++ b/tests/eastbrook_provenance_diagnostics.test.ts
@@ -255,6 +255,22 @@ describe('formatPolishProvenanceMismatch', () => {
     expect(unavailable).toContain('git status unavailable');
   });
 
+  it('renders an object-valued leaf as JSON, never [object Object]', () => {
+    // Reachable when a leaf changes SHAPE (scalar on the sealed side, object
+    // on the computed side); the audit proved plain interpolation survivable
+    // because every other case has scalars on both sides.
+    const message = formatPolishProvenanceMismatch({
+      pinnedFingerprint,
+      computed: {
+        fingerprint: computed.fingerprint,
+        components: { runtimeRender: { renderer: { path: 'src/render/renderer.ts' } } },
+      },
+      sealedComponents: { runtimeRender: { renderer: 'abc' } },
+    });
+    expect(message).toContain('{"path":"src/render/renderer.ts"}');
+    expect(message).not.toContain('[object Object]');
+  });
+
   it('flags a seal-consistent tree as a pin-only hand edit', () => {
     const message = formatPolishProvenanceMismatch({
       pinnedFingerprint,
@@ -356,5 +372,8 @@ describe('wiring', () => {
     expect(remint).toContain('gitDirtyStatusLines');
     expect(remint).toContain('collectPolishProvenanceInputPaths');
     expect(remint).toContain('POLISH_SEAL_PATH');
+    // Without this token the tool can silently re-inline the verdict logic,
+    // leaving formatMintInputStatus tested but unused.
+    expect(remint).toContain('formatMintInputStatus');
   });
 });

--- a/tests/eastbrook_provenance_diagnostics.test.ts
+++ b/tests/eastbrook_provenance_diagnostics.test.ts
@@ -5,9 +5,13 @@ const diagnostics = await import(
   '../scripts/assets/eastbrook_grand_armoury/provenance_diagnostics.mjs'
 );
 const {
+  POLISH_SEAL_PATH,
   REMINT_COMMAND,
+  buildPolishProvenanceMismatchReport,
   collectPolishProvenanceInputPaths,
+  defaultRunGit,
   diffProvenanceComponents,
+  formatMintInputStatus,
   formatPolishProvenanceMismatch,
   gitDirtyStatusLines,
 } = diagnostics;
@@ -40,13 +44,30 @@ describe('diffProvenanceComponents', () => {
     expect(diffProvenanceComponents(SEALED, structuredClone(SEALED))).toEqual([]);
     const missingBranch = { townAsset: SEALED.townAsset };
     expect(
-      diffProvenanceComponents(SEALED, missingBranch as never).map((d: { key: string }) => d.key),
+      diffProvenanceComponents(SEALED, missingBranch).map((d: { key: string }) => d.key),
     ).toEqual([
       'runtimeRender.renderer.path',
       'runtimeRender.renderer.sha256',
       'runtimeRender.town.path',
       'runtimeRender.town.sha256',
     ]);
+  });
+
+  it('reports leaves that exist only on the COMPUTED side: a gained input is never a hand edit', () => {
+    // The one-directional walk was the review-caught blind spot: a new
+    // fingerprinted input would produce zero diffs and the formatter would
+    // wrongly tell the reader to suspect a hand-edited pin.
+    const computed = structuredClone(SEALED) as Record<string, unknown>;
+    (computed.runtimeRender as Record<string, unknown>).newLeaf = {
+      path: 'src/render/new_thing.ts',
+      sha256: 'e'.repeat(64),
+    };
+    computed.extraTop = 'f'.repeat(64);
+    expect(
+      diffProvenanceComponents(SEALED, computed)
+        .map((d: { key: string }) => d.key)
+        .sort(),
+    ).toEqual(['extraTop', 'runtimeRender.newLeaf.path', 'runtimeRender.newLeaf.sha256']);
   });
 });
 
@@ -71,6 +92,17 @@ describe('collectPolishProvenanceInputPaths', () => {
       'src/sim/eastbrook_layout.ts',
     ]);
     expect(paths).not.toContain('polish-v2');
+  });
+
+  it('shape-guards any future non-path input, not just the known contract id', () => {
+    const paths = collectPolishProvenanceInputPaths({
+      inputs: {
+        rendererIntegration: 'src/render/renderer.ts',
+        captureContract: 'polish-v2',
+        mode: 'strict',
+      },
+    });
+    expect(paths).toEqual(['src/render/renderer.ts']);
   });
 
   it('matches the real provenance input surface: lockfile and renderer both in scope', async () => {
@@ -108,7 +140,11 @@ describe('gitDirtyStatusLines', () => {
       },
     });
     expect(dirty).toEqual([' M a.ts', '?? b.ts']);
-    expect(calls).toEqual([['/repo', 'status', '--porcelain', '--', 'a.ts', 'b.ts']]);
+    // --no-optional-locks is a global option and must precede the
+    // subcommand; it keeps the status read from taking the index lock.
+    expect(calls).toEqual([
+      ['/repo', '--no-optional-locks', 'status', '--porcelain', '--', 'a.ts', 'b.ts'],
+    ]);
     expect(
       gitDirtyStatusLines({
         repoRoot: '/repo',
@@ -121,6 +157,46 @@ describe('gitDirtyStatusLines', () => {
     expect(gitDirtyStatusLines({ repoRoot: '/repo', paths: ['a.ts'], runGit: () => '' })).toEqual(
       [],
     );
+  });
+
+  it('hardens the real runner: bounded, killable, and quiet on stderr', () => {
+    // The mutation audit proved these options unpinnable while every test
+    // injected runGit: a blocked git without the deadline freezes the vitest
+    // worker past its test timeout and loses the diagnostic entirely.
+    const calls: Array<{ file: string; args: string[]; options: Record<string, unknown> }> = [];
+    const execImpl = (file: string, args: string[], options: Record<string, unknown>) => {
+      calls.push({ file, args, options });
+      return 'out';
+    };
+    expect(defaultRunGit(['status'], '/repo', execImpl as never)).toBe('out');
+    expect(calls).toEqual([
+      {
+        file: 'git',
+        args: ['status'],
+        options: {
+          cwd: '/repo',
+          encoding: 'utf8',
+          timeout: 10_000,
+          killSignal: 'SIGKILL',
+          stdio: ['ignore', 'pipe', 'ignore'],
+        },
+      },
+    ]);
+  });
+});
+
+describe('formatMintInputStatus', () => {
+  it('carries the three mint-time verdicts the remint tool prints', () => {
+    const dirty = formatMintInputStatus([' M src/render/renderer.ts']);
+    expect(dirty[0]).toContain('WARNING: fingerprinted inputs differ from HEAD');
+    expect(dirty).toContain('   M src/render/renderer.ts');
+    expect(dirty.join('\n')).toContain('RE-RUN this tool');
+    expect(dirty.join('\n')).toContain('craft-cast');
+    const clean = formatMintInputStatus([]);
+    expect(clean.join('\n')).toContain('reproduces on any checkout');
+    const unavailable = formatMintInputStatus(null);
+    expect(unavailable.join('\n')).toContain('git status unavailable');
+    expect(unavailable.join('\n')).toContain('verify by hand');
   });
 });
 
@@ -189,6 +265,77 @@ describe('formatPolishProvenanceMismatch', () => {
   });
 });
 
+describe('buildPolishProvenanceMismatchReport', () => {
+  const computed = {
+    fingerprint: '09f6f78b9c049ba5df01a27ddf054f00928dce957dec2b4d819d5109e83c4d10',
+    components: (() => {
+      const c = structuredClone(SEALED);
+      c.runtimeRender.renderer.sha256 = 'd'.repeat(64);
+      return c;
+    })(),
+  };
+  const pinnedFingerprint = '628f66e2ba22fb456ca64603dfee7311bf766ee5d9ebe71d5e2b2109b01f1d3b';
+  const inputs = {
+    rendererIntegration: 'src/render/renderer.ts',
+    captureContract: 'polish-v2',
+  };
+
+  it('composes seal read, path collection, git verdict, and formatting: the failure-branch glue', () => {
+    const sealReads: string[] = [];
+    const gitCalls: string[][] = [];
+    const report = buildPolishProvenanceMismatchReport({
+      pinnedFingerprint,
+      computed,
+      repoRoot: '/repo',
+      inputs,
+      sourceFileLists: [['pnpm-lock.yaml']],
+      readSeal: (absolutePath: string) => {
+        sealReads.push(absolutePath);
+        return { polishProvenance: { components: SEALED } };
+      },
+      runGit: (args: string[]) => {
+        gitCalls.push(args);
+        return ' M src/render/renderer.ts\n';
+      },
+    });
+    expect(sealReads).toEqual([`/repo/${POLISH_SEAL_PATH}`]);
+    expect(gitCalls).toHaveLength(1);
+    expect(gitCalls[0].slice(-2)).toEqual(['pnpm-lock.yaml', 'src/render/renderer.ts']);
+    // The composed report carries all four answers: the fingerprints, the
+    // moved leaf, the dirty verdict, and the command.
+    expect(report).toContain(computed.fingerprint);
+    expect(report).toContain(pinnedFingerprint);
+    expect(report).toContain('runtimeRender.renderer.sha256');
+    expect(report).toContain(' M src/render/renderer.ts');
+    expect(report).toContain(REMINT_COMMAND);
+  });
+
+  it('degrades to the no-seal arm on a missing or malformed seal, keeping the diagnostic', () => {
+    const report = buildPolishProvenanceMismatchReport({
+      pinnedFingerprint,
+      computed,
+      repoRoot: '/repo',
+      inputs,
+      readSeal: () => {
+        throw new Error('ENOENT');
+      },
+      runGit: () => '',
+    });
+    expect(report).toContain(computed.fingerprint);
+    expect(report).toContain('a re-mint is legitimate');
+    expect(report).toContain(REMINT_COMMAND);
+    expect(report).not.toContain('ENOENT');
+  });
+
+  it('points at a seal that actually exists in this tree', () => {
+    // The guarded read makes a wrong path SILENT (the no-seal arm), so the
+    // path itself must be pinned to reality here.
+    const sealUrl = new URL(`../${POLISH_SEAL_PATH}`, import.meta.url);
+    const seal = JSON.parse(readFileSync(sealUrl, 'utf8'));
+    expect(seal.polishProvenance?.components).toBeTruthy();
+  });
+});
+
 describe('wiring', () => {
   it('the capture-contract suite and the remint tool both use the diagnostics', () => {
     // Comments stripped first (block then line, the ci_workflow.test.ts
@@ -199,19 +346,15 @@ describe('wiring', () => {
       readFileSync(new URL('./eastbrook_polish_capture_contract.test.ts', import.meta.url), 'utf8'),
     );
     expect(suite).toContain('provenance_diagnostics.mjs');
-    expect(suite).toContain('formatPolishProvenanceMismatch');
-    expect(suite).toContain('gitDirtyStatusLines');
-    const remint = strip(
-      readFileSync(
-        new URL(
-          '../scripts/assets/eastbrook_grand_armoury/remint_polish_provenance.mjs',
-          import.meta.url,
-        ),
-        'utf8',
-      ),
-    );
+    expect(suite).toContain('buildPolishProvenanceMismatchReport');
+    // The tool path is derived FROM the printed command, so a renamed tool
+    // cannot leave the failure messages pointing at a file that no longer
+    // exists while this pin stays green.
+    const remintPath = REMINT_COMMAND.replace(/^node /, '');
+    const remint = strip(readFileSync(new URL(`../${remintPath}`, import.meta.url), 'utf8'));
     expect(remint).toContain('provenance_diagnostics.mjs');
     expect(remint).toContain('gitDirtyStatusLines');
     expect(remint).toContain('collectPolishProvenanceInputPaths');
+    expect(remint).toContain('POLISH_SEAL_PATH');
   });
 });


### PR DESCRIPTION
## Summary

Phase 6 of the CI/CD performance packet, eastbrook provenance determinism. Root cause of the 2026-08-05 "local vs CI" fingerprint divergence, proven by recomputing the craft-cast merge's (#2965) composite from its own committed tree: the merge ran the remint tool, then src/render/renderer.ts moved AGAIN before the merge committed, so the committed pin (628f66e2) matched a tree that never existed, exactly one leaf apart (runtimeRender.renderer.sha256). Every pristine checkout computed 09f6f78b; selective CI runs skipping the polish suites dressed the stale pin up as an environment difference. There was no byte divergence between local and CI at all.

The fix is legibility, not new hashing (no pin value, seal, or fingerprint input changes in this PR; verified three ways by review). On a composite mismatch the test now prints: the computed and pinned fingerprints, the exact leaves that moved against the committed evidence seals, a dirty-vs-HEAD verdict over every fingerprinted input (separating "your tree differs from HEAD, a mint now can go stale" from "the committed tree computes this everywhere, a re-mint is legitimate"), and the one-step remint command. The remint tool prints the same dirty-input tripwire plus all three literals its sweep moves (the metadata authority sha was previously hand-computed) and warns which frozen literal must never be swept. On the clean tree the tool reproduces all three committed literals byte-identically and the sweep changes nothing.

## Type of change

- [x] Bug fix
- [x] Tests

## How was this tested?

- Commands: `node scripts/gate_select.mjs` PASS at the tip (all 12 steps green). All three eastbrook suites green (46 tests), `npx tsc --noEmit` clean. The failure path verified live: dirtying renderer.ts produces the full diagnostic naming the moved leaf, the dirty warning, and the remint command; the remint tool run end-to-end on the clean tree reproduces the committed literals exactly with a byte-identical sweep.
- Reviews: security (subprocess safety: argv-only git with a bounded quiet runner), QA checklist (pin values proven unchanged three independent ways), and a run-proofed mutation audit (27 of 33 mutants red at round 1; all six survivors are now pinned, including the hardened git options and the mint-verdict formatter arms).

## Checklist

### Quality

- [x] **The gate passes.** `node scripts/gate_select.mjs` green at the tip.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings (all new text is dev-channel test/tool output).

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files (the evidence seals are untouched; the remint tool was run only to prove a no-op sweep).
