### PR TITLE
perf(market): memoize the browse sort and gate the market wire on change + cadence

### DIFF
--- a/server/game.ts
+++ b/server/game.ts
@@ -52,7 +52,7 @@ import {
 } from '../src/sim/jail';
 import type { PickAction } from '../src/sim/lockpick';
 import { lootHasGoneFfa } from '../src/sim/loot/loot_ffa';
-import { sanitizeMarketQuery } from '../src/sim/market_query';
+import { type MarketQuery, sanitizeMarketQuery } from '../src/sim/market_query';
 import { parseMoveInputFrame } from '../src/sim/move_input';
 import {
   partyFrameAbsorb,
@@ -546,6 +546,27 @@ const VC_WIRE_INTERVAL_TICKS = Math.max(1, Math.round(1 / (DT * VC_WIRE_HZ)));
 // the same cadence and only re-sends when a listing actually changes.
 const DF_WIRE_HZ = 2;
 const DF_WIRE_INTERVAL_TICKS = Math.max(1, Math.round(1 / (DT * DF_WIRE_HZ)));
+// World Market browse readout cadence. The browse view is a filter + page over
+// the whole listing book, the single most expensive per-viewer read in
+// selfWireJson on a grown book, and nothing in it carries a sub-second clock,
+// so 4 Hz keeps the window feeling live while capping the rebuild rate. The
+// viewer's OWN market commands re-arm the gate (MARKET_WIRE_PROMPT_CMDS) so
+// their search/buy/cancel feedback still lands on the next snapshot. On top of
+// the cadence, a rebuild-only-on-change gate (sim.marketBrowseRevFor plus the
+// query object identity) skips the rebuild entirely while nothing changed;
+// MARKET_BROWSE_REFRESH_TICKS is its staleness backstop, the heavy-gate
+// refresh idea applied here.
+const MARKET_WIRE_HZ = 4;
+const MARKET_WIRE_INTERVAL_TICKS = Math.max(1, Math.round(1 / (DT * MARKET_WIRE_HZ)));
+const MARKET_BROWSE_REFRESH_TICKS = 40;
+const MARKET_WIRE_PROMPT_CMDS = new Set<string>([
+  'market_search',
+  'market_list',
+  'market_list_instance',
+  'market_buy',
+  'market_cancel',
+  'market_collect',
+]);
 
 type ClientMessage = Record<string, unknown> & {
   ability?: string;
@@ -911,6 +932,14 @@ export interface ClientSession {
   lastBgWireTick: number;
   // Dungeon Finder readout, same idea at its own cadence (DF_WIRE_HZ)
   lastDfWireTick: number;
+  // World Market browse readout, same idea at its own cadence (MARKET_WIRE_HZ),
+  // plus the rebuild-only-on-change state: the sim browse revision and the
+  // query object last built for, and the tick of the last rebuild (the
+  // MARKET_BROWSE_REFRESH_TICKS staleness backstop's tracker).
+  lastMarketWireTick: number;
+  lastMarketBrowseRev: number | null;
+  lastMarketQueryRef: MarketQuery | null;
+  lastMarketRebuildTick: number;
   // set when a command or sim event that can change a heavy self field (bags,
   // gear, quests, talents, stats, ...) lands for this session, so the next
   // snapshot re-diffs those fields. Otherwise they're skipped (see
@@ -2077,6 +2106,10 @@ export class GameServer {
     moderator.lastSent = {};
     moderator.lastArenaWireTick = -ARENA_WIRE_INTERVAL_TICKS;
     moderator.lastDfWireTick = -DF_WIRE_INTERVAL_TICKS;
+    moderator.lastMarketWireTick = -MARKET_WIRE_INTERVAL_TICKS;
+    moderator.lastMarketBrowseRev = null;
+    moderator.lastMarketQueryRef = null;
+    moderator.lastMarketRebuildTick = 0;
     moderator.sentEnts.clear();
     // force the heavy self block (tal/inv/equip/bags/...) to re-run next
     // snapshot: it is gated on meta.wireRev vs session.lastWireRev, and that
@@ -2107,6 +2140,10 @@ export class GameServer {
     moderator.lastSent = {};
     moderator.lastArenaWireTick = -ARENA_WIRE_INTERVAL_TICKS;
     moderator.lastDfWireTick = -DF_WIRE_INTERVAL_TICKS;
+    moderator.lastMarketWireTick = -MARKET_WIRE_INTERVAL_TICKS;
+    moderator.lastMarketBrowseRev = null;
+    moderator.lastMarketQueryRef = null;
+    moderator.lastMarketRebuildTick = 0;
     moderator.sentEnts.clear();
     // same as enterSpectate: force the heavy self block to re-run so the
     // moderator's OWN talents/inventory/equip/etc. resend immediately
@@ -3514,6 +3551,10 @@ export class GameServer {
       lastArenaWireTick: -ARENA_WIRE_INTERVAL_TICKS,
       lastBgWireTick: -BG_WIRE_INTERVAL_TICKS,
       lastDfWireTick: -DF_WIRE_INTERVAL_TICKS,
+      lastMarketWireTick: -MARKET_WIRE_INTERVAL_TICKS,
+      lastMarketBrowseRev: null,
+      lastMarketQueryRef: null,
+      lastMarketRebuildTick: 0,
       selfHeavyDirty: true,
       lastWireRev: -1,
       sentEnts: new Map(),
@@ -6088,6 +6129,12 @@ export class GameServer {
     // re-diff those fields (combat-only commands like cast/target/attack do not,
     // which is what keeps the gating a win during a fight).
     if (typeof msg.cmd === 'string' && HEAVY_SELF_CMDS.has(msg.cmd)) session.selfHeavyDirty = true;
+    // The viewer's own market commands re-arm the market wire gate so their
+    // search/list/buy/cancel/collect feedback lands on the next snapshot
+    // instead of waiting out the MARKET_WIRE_HZ cadence.
+    if (typeof msg.cmd === 'string' && MARKET_WIRE_PROMPT_CMDS.has(msg.cmd)) {
+      session.lastMarketWireTick = -MARKET_WIRE_INTERVAL_TICKS;
+    }
     switch (command) {
       case 'castSlot':
         if (typeof msg.slot === 'number') sim.castAbilityBySlot(msg.slot | 0, pid);
@@ -8357,8 +8404,40 @@ export class GameServer {
       );
     }
     // market info is null unless the player is standing at the Merchant, so it
-    // only rides the wire for players actually browsing the World Market
-    maybe('market', this.sim.marketInfoFor(anchorSession.pid));
+    // only rides the wire for players actually browsing the World Market.
+    // Rebuilding that view is a filter plus a page over the WHOLE listing book,
+    // so it runs at its own cadence (MARKET_WIRE_HZ; the viewer's own market
+    // commands re-arm the gate for next-snapshot feedback) and, within the
+    // cadence, only when something it reads actually changed: the sim's browse
+    // revision (listings or collections), the viewer's query object (replaced
+    // wholesale by marketSearch, so identity is the change signal), or the
+    // staleness backstop coming due. Profiled: on a grown book the unconditional
+    // per-tick rebuild was the dominant bcastSelf cost.
+    const marketDue =
+      this.sim.tickCount - session.lastMarketWireTick >= MARKET_WIRE_INTERVAL_TICKS ||
+      sent.market === undefined;
+    if (marketDue) {
+      session.lastMarketWireTick = this.sim.tickCount;
+      const browseRev = this.sim.marketBrowseRevFor(anchorSession.pid);
+      if (browseRev === null) {
+        maybe('market', null);
+        session.lastMarketBrowseRev = null;
+      } else if (
+        sent.market === undefined ||
+        browseRev !== session.lastMarketBrowseRev ||
+        meta.marketQuery !== session.lastMarketQueryRef ||
+        this.sim.tickCount - session.lastMarketRebuildTick >= MARKET_BROWSE_REFRESH_TICKS
+      ) {
+        session.lastMarketQueryRef = meta.marketQuery;
+        session.lastMarketRebuildTick = this.sim.tickCount;
+        maybe('market', this.sim.marketInfoFor(anchorSession.pid));
+        // Stamp AFTER the rebuild: marketInfoFor can advance the revision as a
+        // read side effect (the legacy name-keyed collection merge), and a
+        // pre-rebuild stamp would leave this one behind, costing a redundant
+        // rebuild on the next due pass.
+        session.lastMarketBrowseRev = this.sim.marketBrowseRevFor(anchorSession.pid) ?? browseRev;
+      }
+    }
     // the lightweight collect-indicator bit streams ALWAYS (the mailU pattern),
     // so the minimap badge lights anywhere while proceeds/items wait
     maybe('mktU', this.sim.marketCollectPendingFor(anchorSession.pid) ? 1 : 0);

--- a/src/sim/market.ts
+++ b/src/sim/market.ts
@@ -172,7 +172,71 @@ export class Market {
   // auction house at whichever auctioneer is closest.
   merchantIds: number[] = [];
 
+  // Browse-view revision counters. bookRev advances on any change to the
+  // LISTINGS set and keys the sorted-book memo below; browseRev advances on any
+  // change a browse snapshot can observe (listings AND collections) and is what
+  // the server's rebuild-only-on-change gate reads through browseRevFor. Every
+  // mutation site must go through bumpBook/bumpCollections or the memo and the
+  // server gate serve stale views; the wire-reachable mutating verbs (list,
+  // list-instance, buy, cancel, collect, expiry, rekey, purge, load) are each
+  // pinned against exactly that in tests/market_browse_cache.test.ts.
+  private bookRev = 0;
+  private browseRev = 0;
+  private sortedBookCache: { rev: number; source: MarketListing[]; rows: MarketListing[] } | null =
+    null;
+
   constructor(private readonly ctx: SimContext) {}
+
+  private bumpBook(): void {
+    this.bookRev++;
+    this.browseRev++;
+  }
+
+  private bumpCollections(): void {
+    this.browseRev++;
+  }
+
+  // The whole book, name-then-price sorted, memoized per bookRev. The sort is
+  // viewer-independent, and re-running the ICU localeCompare comparator
+  // n log n times per viewer per tick was the dominant broadcast cost on a
+  // grown book (the bcastSelf hot spot). Per-viewer reads FILTER this stably
+  // sorted book, which yields the exact sequence the old filter-then-sort
+  // produced: a stable sort with an element-only comparator commutes with
+  // filter. The source/length guards catch only a wholesale array replacement
+  // or a row added/removed without a bump (the test-harness push case); an
+  // equal-length swap or an in-place sort-key edit is invisible to them, so
+  // correctness rests on every real writer living in this module and riding a
+  // bump site (the module sweep in the fix review verified exactly that).
+  private sortedBook(): readonly MarketListing[] {
+    const c = this.sortedBookCache;
+    if (
+      c &&
+      c.rev === this.bookRev &&
+      c.source === this.marketListings &&
+      c.rows.length === this.marketListings.length
+    ) {
+      return c.rows;
+    }
+    const rows = [...this.marketListings].sort((a, b) => {
+      const na = ITEMS[a.itemId]?.name ?? a.itemId;
+      const nb = ITEMS[b.itemId]?.name ?? b.itemId;
+      return na.localeCompare(nb) || a.price - b.price;
+    });
+    this.sortedBookCache = { rev: this.bookRev, source: this.marketListings, rows };
+    return rows;
+  }
+
+  // The change signal the server's snapshot gate polls instead of rebuilding
+  // the browse view every tick: null while this player is not at a Merchant
+  // (the same gate marketInfoFor applies), else the current browse revision.
+  // Server-only (never IWorld), the guildBankInfoForGuild precedent.
+  browseRevFor(pid: number): number | null {
+    const meta = this.ctx.players.get(pid);
+    const e = this.ctx.entities.get(pid);
+    if (!meta || !e) return null;
+    if (!this.nearMerchant(e)) return null;
+    return this.browseRev;
+  }
 
   // Public ctor-seed entry: the Sim ctor calls this right after the NPC loop sets
   // `merchantId`, replacing the inline `this.seedHouseListings()`.
@@ -230,6 +294,7 @@ export class Market {
     // merged-away bucket and the surviving one.
     to.items.push(...from.items.map(cloneInvSlot));
     this.marketCollections.delete(fromKey);
+    this.bumpCollections();
     return true;
   }
 
@@ -267,6 +332,13 @@ export class Market {
     for (const slot of collection?.items ?? []) {
       if (rekeySigner(slot.instance, oldName, newName)) changed = true;
     }
+    // In-place listing edits (sellerName/signer) that the length guard on the
+    // sorted-book memo cannot catch, so the bump is what invalidates here.
+    // Unconditional on purpose: the browse view also reads meta.name (the
+    // isMine sellerName projection), which just moved even when no row
+    // matched, and a rename is far too rare for the over-invalidation to
+    // matter.
+    this.bumpBook();
     return changed;
   }
 
@@ -296,6 +368,7 @@ export class Market {
     }
     if (this.marketCollections.delete(key)) changed = true;
     if (name !== '' && name !== key && this.marketCollections.delete(name)) changed = true;
+    if (changed) this.bumpBook();
     return changed;
   }
 
@@ -320,6 +393,7 @@ export class Market {
     // never persisted, so without the floor a grown stock table reissues ids an
     // older build already handed to persisted player listings (#2463).
     this.nextListingId = playerListingIdFloor(this.marketListings.map((l) => l.id));
+    this.bumpBook();
   }
 
   // List a stack from your bags for sale. The goods are escrowed (pulled from
@@ -330,7 +404,17 @@ export class Market {
   marketSearch(query: MarketQuery, pid?: number): void {
     const r = this.ctx.resolve(pid);
     if (!r) return;
-    r.meta.marketQuery = sanitizeMarketQuery(query);
+    const next = sanitizeMarketQuery(query);
+    // Keep the previous object when nothing changed: the server's snapshot gate
+    // uses the query object's IDENTITY as its change signal, so replacing it
+    // wholesale on a byte-identical re-send (a client re-firing the same
+    // search every command window) would force a full browse rebuild per
+    // re-send, re-opening the per-viewer cost the sorted-book memo closes.
+    // Both objects come out of sanitizeMarketQuery/defaultMarketQuery with the
+    // same flat fixed shape, so the stringify compare covers every field,
+    // including ones added later.
+    if (JSON.stringify(r.meta.marketQuery) === JSON.stringify(next)) return;
+    r.meta.marketQuery = next;
   }
 
   marketList(itemId: string, count: number, price: number, pid?: number): void {
@@ -465,6 +549,7 @@ export class Market {
         ...(craftedRecipeId === undefined ? {} : { craftedRecipeId }),
       });
     });
+    this.bumpBook();
     this.ctx.emit({
       type: 'loot',
       // biome-ignore lint/style/useTemplate: keep this scanner-friendly shape for i18n extraction.
@@ -555,6 +640,7 @@ export class Market {
         ? {}
         : { craftedRecipeId: escrowed.craftedRecipeId }),
     });
+    this.bumpBook();
     this.ctx.emit({
       type: 'loot',
       text: `Listed ${def.name} on the World Market for ${formatMoney(ask)}.`,
@@ -621,6 +707,7 @@ export class Market {
       const proceeds = Math.max(0, Math.floor(listing.price * (1 - MARKET_CUT)));
       this.collectionFor(listing.sellerKey).copper += proceeds;
       this.marketListings.splice(idx, 1);
+      this.bumpBook();
       const sellerMeta = this.metaByMarketSellerKey(listing.sellerKey);
       if (sellerMeta) {
         this.ctx.emit({
@@ -668,6 +755,7 @@ export class Market {
       return;
     }
     this.marketListings.splice(idx, 1);
+    this.bumpBook();
     grantCopies(
       this.ctx,
       meta.entityId,
@@ -700,6 +788,9 @@ export class Market {
       this.ctx.error(meta.entityId, 'You have nothing to collect.');
       return;
     }
+    // Every path past the guard mutates the collection (gold zeroed, items
+    // granted or kept), so bump once up front.
+    this.bumpCollections();
     if (col.copper > 0) {
       meta.copper += col.copper;
       this.ctx.emit({
@@ -746,6 +837,7 @@ export class Market {
       const l = this.marketListings[i];
       if (l.house || this.ctx.time < l.expiresAt) continue;
       this.marketListings.splice(i, 1);
+      this.bumpBook();
       // Conditional spread: a plain row must not grow an `instance: undefined`/
       // `craftedRecipeId: undefined` key (rows are persisted and diffed
       // byte-for-byte). BOTH are spread independently because a row can carry
@@ -796,12 +888,9 @@ export class Market {
     // the client over a single wire window) is what lets a player page through and
     // filter every listing, not just the first MARKET_WIRE_LIMIT.
     const query: MarketQuery = meta.marketQuery;
-    const matched = this.marketListings.filter((l) => marketItemMatches(l.itemId, query));
-    const sorted = [...matched].sort((a, b) => {
-      const na = ITEMS[a.itemId]?.name ?? a.itemId;
-      const nb = ITEMS[b.itemId]?.name ?? b.itemId;
-      return na.localeCompare(nb) || a.price - b.price;
-    });
+    // Filter the memoized sorted book instead of sorting the filtered book:
+    // identical sequence (see sortedBook), without the per-viewer sort.
+    const sorted = this.sortedBook().filter((l) => marketItemMatches(l.itemId, query));
     // The viewer's own listings are always wired (so they can reclaim from the Browse
     // tab without hunting for the right page); other sellers' listings are paged. Own
     // count (<= MARKET_MAX_LISTINGS = 12) plus one page (MARKET_PAGE_SIZE = 50) stays
@@ -839,7 +928,7 @@ export class Market {
       listings,
       // Every listing matching the filter (the viewer's own plus all others), so the
       // SELL/notes read true counts; `pageCount` below paginates the others.
-      totalCount: matched.length,
+      totalCount: sorted.length,
       filter: query.search,
       // Echo every filter axis, not just the search text: a fresh join (post-
       // linkdead-grace reconnect) resets this session-only query to default, and
@@ -1020,6 +1109,7 @@ export class Market {
       );
     }
     this.reclaimSoulboundListings();
+    this.bumpBook();
   }
 
   // Migration for a listing whose item became SOULBOUND after it was listed (a
@@ -1030,6 +1120,8 @@ export class Market {
   // expired-listing return (updateMarket). Runs once at load and is idempotent
   // (a returned listing is removed, so the next save has none; new listings of a
   // soulbound item are already blocked at list time).
+  // Bump-site note: relies on its single caller (loadMarket) bumping bookRev
+  // after it returns; a second caller must bump for itself.
   private reclaimSoulboundListings(): void {
     for (let i = this.marketListings.length - 1; i >= 0; i--) {
       const l = this.marketListings[i];

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -10448,6 +10448,13 @@ export class Sim {
     return this.market.marketInfoFor(pid);
   }
 
+  // Server-only broadcast helper (never IWorld, the guildBankInfoForGuild
+  // precedent): the cheap change signal server/game.ts polls before paying for
+  // a marketInfoFor rebuild. Null while the player is not at a Merchant.
+  marketBrowseRevFor(pid: number): number | null {
+    return this.market.browseRevFor(pid);
+  }
+
   // The always-streamed collect-indicator bit (the mailUnreadFor pattern):
   // server/game.ts ships it on every snapshot as `mktU`.
   marketCollectPendingFor(pid: number): boolean {

--- a/tests/market_browse_cache.test.ts
+++ b/tests/market_browse_cache.test.ts
@@ -1,0 +1,308 @@
+// The World Market browse read's sorted-book memo and browse-revision signal
+// (the tick-budget fix: rebuilding filter+sort of the whole book per viewer per
+// tick was the production broadcast hot spot). Pins three claims:
+//   1. filtering the memoized sorted book yields the EXACT sequence the old
+//      filter-then-sort pipeline produced (an independent oracle, not a copy);
+//   2. the sort really is memoized: the sorted rows are reference-stable across
+//      reads and viewers until the book changes, and rebuild after;
+//   3. every wire-reachable mutating verb advances the browse revision the
+//      server gate polls (list, list-instance, buy, cancel, collect, expiry,
+//      rekey, purge, load), so a rebuild-only-on-change gate can never serve a
+//      stale view.
+import { describe, expect, it } from 'vitest';
+import { ITEMS } from '../src/sim/data';
+import type { MarketQuery } from '../src/sim/market_query';
+import { Sim } from '../src/sim/sim';
+import type { Entity } from '../src/sim/types';
+import { groundHeight } from '../src/sim/world';
+
+type MarketListing = Sim['marketListings'][number];
+
+function makeWorld() {
+  return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+}
+
+function q(search = '', extra: Partial<MarketQuery> = {}): MarketQuery {
+  return {
+    search,
+    itemType: 'all',
+    subtype: 'all',
+    armorClass: 'all',
+    primaryStat: 'all',
+    rarity: 'all',
+    page: 0,
+    ...extra,
+  };
+}
+
+function merchant(sim: Sim): Entity {
+  for (const e of sim.entities.values()) if (e.templateId === 'the_merchant') return e;
+  throw new Error('the Merchant was not spawned');
+}
+
+function standAtMerchant(sim: Sim, pid: number) {
+  const m = merchant(sim);
+  const e = sim.entities.get(pid);
+  if (!e) throw new Error(`missing entity ${pid}`);
+  e.pos.x = m.pos.x;
+  e.pos.z = m.pos.z;
+  e.pos.y = groundHeight(e.pos.x, e.pos.z, sim.cfg.seed);
+  e.prevPos = { ...e.pos };
+}
+
+function marketInfo(sim: Sim, pid: number) {
+  const info = sim.marketInfoFor(pid);
+  if (!info) throw new Error(`missing market info for ${pid}`);
+  return info;
+}
+
+// The PRE-FIX browse pipeline, reimplemented as the ordering oracle: filter the
+// raw (unsorted) book, then sort the matches name-then-price with the same
+// localeCompare comparator marketInfoFor used before the memo.
+function oldPipelineIds(sim: Sim, matches: (l: MarketListing) => boolean): number[] {
+  return sim.marketListings
+    .filter(matches)
+    .sort((a, b) => {
+      const na = ITEMS[a.itemId]?.name ?? a.itemId;
+      const nb = ITEMS[b.itemId]?.name ?? b.itemId;
+      return na.localeCompare(nb) || a.price - b.price;
+    })
+    .map((l) => l.id);
+}
+
+function sortedRowsRef(sim: Sim): MarketListing[] {
+  // biome-ignore lint/suspicious/noExplicitAny: reaching the private memo is the point of these pins
+  return (sim as any).market.sortedBook();
+}
+
+describe('World Market sorted-book memo', () => {
+  it('yields the exact sequence the old filter-then-sort pipeline produced', () => {
+    const sim = makeWorld();
+    const seller = sim.addPlayer('warrior', 'Seller');
+    standAtMerchant(sim, seller);
+    sim.addItem('wolf_fang', 3, seller);
+    sim.addItem('bone_fragments', 2, seller);
+    // Distinct prices so the price tie-break inside one name is exercised too.
+    sim.marketList('wolf_fang', 1, 300, seller);
+    sim.marketList('wolf_fang', 1, 100, seller);
+    sim.marketList('wolf_fang', 1, 200, seller);
+    sim.marketList('bone_fragments', 2, 150, seller);
+
+    const viewer = sim.addPlayer('mage', 'Viewer');
+    standAtMerchant(sim, viewer);
+
+    // Unfiltered: the viewer owns nothing, so the wired page IS the sorted
+    // others sequence (house stock included), exactly the old pipeline's order.
+    const all = marketInfo(sim, viewer);
+    expect(all.totalCount).toBe(sim.marketListings.length);
+    expect(all.listings.map((l) => l.id)).toEqual(oldPipelineIds(sim, () => true));
+
+    // Filtered: same claim on a narrowed book.
+    sim.marketSearch(q('wolf'), viewer);
+    const filtered = marketInfo(sim, viewer);
+    expect(filtered.listings.length).toBeGreaterThan(0);
+    expect(filtered.listings.map((l) => l.id)).toEqual(
+      oldPipelineIds(sim, (l) =>
+        (ITEMS[l.itemId]?.name ?? l.itemId).toLowerCase().includes('wolf'),
+      ),
+    );
+
+    // The seller's own goods still lead their view, page order preserved.
+    const mineFirst = marketInfo(sim, seller);
+    const mineIds = sim.marketListings
+      .filter((l) => !l.house && l.sellerKey === String(seller))
+      .map((l) => l.id);
+    expect(mineFirst.listings.slice(0, mineIds.length).every((l) => l.mine)).toBe(true);
+  });
+
+  it('resolves full ties (same name, same price) by book order, like the old pipeline', () => {
+    const sim = makeWorld();
+    const seller = sim.addPlayer('warrior', 'Seller');
+    standAtMerchant(sim, seller);
+    sim.addItem('wolf_fang', 2, seller);
+    sim.addItem('bone_fragments', 1, seller);
+    // Two wolf_fang rows at the IDENTICAL price, separated by another row in
+    // book order: the order between them is decided purely by sort stability
+    // relative to the original index, the one input class the commute argument
+    // hinges on.
+    sim.marketList('wolf_fang', 1, 100, seller);
+    sim.marketList('bone_fragments', 1, 100, seller);
+    sim.marketList('wolf_fang', 1, 100, seller);
+    const viewer = sim.addPlayer('mage', 'Viewer');
+    standAtMerchant(sim, viewer);
+    sim.marketSearch(q('wolf'), viewer);
+    const ids = marketInfo(sim, viewer).listings.map((l) => l.id);
+    expect(ids).toHaveLength(2);
+    expect(ids).toEqual(
+      oldPipelineIds(sim, (l) =>
+        (ITEMS[l.itemId]?.name ?? l.itemId).toLowerCase().includes('wolf'),
+      ),
+    );
+  });
+
+  it('memoizes the sort across reads and viewers, and rebuilds when the book changes', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Alta');
+    const b = sim.addPlayer('mage', 'Bruna');
+    standAtMerchant(sim, a);
+    standAtMerchant(sim, b);
+
+    marketInfo(sim, a);
+    const rows1 = sortedRowsRef(sim);
+    marketInfo(sim, a);
+    marketInfo(sim, b);
+    expect(sortedRowsRef(sim)).toBe(rows1);
+
+    sim.addItem('wolf_fang', 1, a);
+    sim.marketList('wolf_fang', 1, 100, a);
+    marketInfo(sim, a);
+    const rows2 = sortedRowsRef(sim);
+    expect(rows2).not.toBe(rows1);
+    expect(rows2.length).toBe(rows1.length + 1);
+  });
+
+  it('serves a fresh view when tests mutate the listings array directly (length guard)', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Alta');
+    standAtMerchant(sim, a);
+    const before = marketInfo(sim, a).totalCount;
+    // Direct push, no bump site: the memo's length guard must still invalidate.
+    sim.marketListings.push({
+      id: 999_999,
+      sellerKey: 'someone-else',
+      sellerName: 'Someone',
+      itemId: 'wolf_fang',
+      count: 1,
+      price: 123,
+      expiresAt: Number.POSITIVE_INFINITY,
+      house: false,
+    });
+    expect(marketInfo(sim, a).totalCount).toBe(before + 1);
+  });
+});
+
+describe('World Market browse revision (the server rebuild gate signal)', () => {
+  it('is null away from the Merchant and a number beside one', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Alta');
+    expect(sim.marketBrowseRevFor(a)).toBeNull();
+    standAtMerchant(sim, a);
+    expect(sim.marketBrowseRevFor(a)).toBeTypeOf('number');
+  });
+
+  it('holds steady across idle ticks and advances on every wire-visible verb', () => {
+    const sim = makeWorld();
+    const seller = sim.addPlayer('warrior', 'Seller');
+    const buyer = sim.addPlayer('mage', 'Buyer');
+    standAtMerchant(sim, seller);
+    standAtMerchant(sim, buyer);
+    sim.addItem('wolf_fang', 2, seller);
+    const buyerMeta = sim.players.get(buyer);
+    if (!buyerMeta) throw new Error('missing buyer meta');
+    buyerMeta.copper = 100_000;
+
+    const at = () => {
+      const rev = sim.marketBrowseRevFor(seller);
+      if (rev === null) throw new Error('seller left the Merchant');
+      return rev;
+    };
+
+    // Idle ticks (which run the once-a-second updateMarket sweep) move nothing.
+    const idle = at();
+    for (let i = 0; i < 40; i++) sim.tick();
+    expect(at()).toBe(idle);
+
+    // list
+    let rev = at();
+    sim.marketList('wolf_fang', 1, 100, seller);
+    expect(at()).toBeGreaterThan(rev);
+
+    // buy (a player listing: the row leaves the book, proceeds credit the seller)
+    rev = at();
+    const mine = sim.marketListings.find((l) => !l.house && l.sellerKey === String(seller));
+    if (!mine) throw new Error('missing seller listing');
+    sim.marketBuy(mine.id, buyer);
+    expect(at()).toBeGreaterThan(rev);
+
+    // collect (the seller takes the proceeds the buy just credited)
+    rev = at();
+    sim.marketCollect(seller);
+    expect(at()).toBeGreaterThan(rev);
+
+    // cancel (list again, then reclaim)
+    sim.marketList('wolf_fang', 1, 100, seller);
+    rev = at();
+    const relisted = sim.marketListings.find((l) => !l.house && l.sellerKey === String(seller));
+    if (!relisted) throw new Error('missing relisted row');
+    sim.marketCancel(relisted.id, seller);
+    expect(at()).toBeGreaterThan(rev);
+
+    // expiry (the once-a-second sweep returns the row to the collection)
+    sim.addItem('wolf_fang', 1, seller);
+    sim.marketList('wolf_fang', 1, 100, seller);
+    const expiring = sim.marketListings.find((l) => !l.house && l.sellerKey === String(seller));
+    if (!expiring) throw new Error('missing expiring row');
+    expiring.expiresAt = 0;
+    rev = at();
+    for (let i = 0; i < 21; i++) sim.tick();
+    expect(at()).toBeGreaterThan(rev);
+    expect(sim.marketListings.some((l) => l.id === expiring.id)).toBe(false);
+  });
+
+  it('advances on the remaining wire-reachable verbs: list-instance, rekey, purge, load', () => {
+    const sim = makeWorld();
+    const seller = sim.addPlayer('warrior', 'Seller');
+    standAtMerchant(sim, seller);
+
+    const at = () => {
+      const rev = sim.marketBrowseRevFor(seller);
+      if (rev === null) throw new Error('seller left the Merchant');
+      return rev;
+    };
+
+    // list-instance (its own push site, independent of marketList's)
+    sim.addItem('oiled_boots', 1, seller);
+    sim.addItemInstance('oiled_boots', { enchant: 'ench_stat_str' }, seller);
+    let rev = at();
+    sim.marketListInstance('oiled_boots', 500, { enchant: 'ench_stat_str' }, seller);
+    expect(at()).toBeGreaterThan(rev);
+    expect(sim.marketListings.some((l) => l.instance !== undefined)).toBe(true);
+
+    // rekey (in-place sellerName edits the memo's length guard cannot see)
+    rev = at();
+    sim.rekeyMarketSeller(seller, 'Seller', 'Renamed');
+    expect(at()).toBeGreaterThan(rev);
+    expect(sim.marketListings.some((l) => l.sellerName === 'Renamed')).toBe(true);
+
+    // purge (removes the seller's rows and collection)
+    rev = at();
+    sim.purgeMarketSeller(seller, 'Renamed');
+    expect(at()).toBeGreaterThan(rev);
+    expect(sim.marketListings.some((l) => !l.house)).toBe(false);
+
+    // load (rebuilds the whole book)
+    rev = at();
+    sim.loadMarket({ listings: [], collections: [], nextListingId: 1_000_000 });
+    expect(at()).toBeGreaterThan(rev);
+  });
+
+  it('a viewer browsing right after a buy sees the row gone (no stale memo end to end)', () => {
+    const sim = makeWorld();
+    const seller = sim.addPlayer('warrior', 'Seller');
+    const buyer = sim.addPlayer('mage', 'Buyer');
+    standAtMerchant(sim, seller);
+    standAtMerchant(sim, buyer);
+    sim.addItem('wolf_fang', 1, seller);
+    sim.marketList('wolf_fang', 1, 100, seller);
+    const buyerMeta = sim.players.get(buyer);
+    if (!buyerMeta) throw new Error('missing buyer meta');
+    buyerMeta.copper = 1_000;
+
+    const listed = sim.marketListings.find((l) => !l.house && l.itemId === 'wolf_fang');
+    if (!listed) throw new Error('missing listing');
+    // Warm the memo with a browse, then buy, then browse again.
+    expect(marketInfo(sim, buyer).listings.some((l) => l.id === listed.id)).toBe(true);
+    sim.marketBuy(listed.id, buyer);
+    expect(marketInfo(sim, buyer).listings.some((l) => l.id === listed.id)).toBe(false);
+  });
+});

--- a/tests/market_wire_cadence.test.ts
+++ b/tests/market_wire_cadence.test.ts
@@ -1,0 +1,196 @@
+// The `market` self key's cadence + rebuild-only-on-change gate (the
+// tick-budget fix). The expensive call is sim.marketInfoFor (a filter + page
+// over the whole listing book), so the decisive pin is a SPY on it: within the
+// MARKET_WIRE_HZ cadence the server polls the cheap browse revision and must
+// not rebuild while nothing changed; a book change, a query change, the
+// viewer's own market command, and the staleness backstop each bring exactly
+// the rebuilds they promise.
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../server/db', () => ({
+  pool: { query: vi.fn(async () => ({ rows: [] })) },
+  saveCharacterState: vi.fn(async () => {}),
+  saveCharacterAndMarketState: vi.fn(async () => {}),
+  saveMarketState: vi.fn(async () => {}),
+  saveMailState: vi.fn(async () => {}),
+  loadMarketState: vi.fn(async () => null),
+  loadMailState: vi.fn(async () => null),
+  openPlaySession: vi.fn(async () => 1),
+  touchCharacterLogin: vi.fn(async () => {}),
+  closePlaySession: vi.fn(async () => {}),
+  insertChatLogs: vi.fn(async () => {}),
+  walletForAccount: vi.fn(async () => null),
+  markAccountQuestComplete: vi.fn(async () => ({ completedQuestIds: [], mechChromaIds: [] })),
+  grantAccountMechChroma: vi.fn(async () => ({ completedQuestIds: [], mechChromaIds: [] })),
+  revokeAccountMechChroma: vi.fn(async () => ({ completedQuestIds: [], mechChromaIds: [] })),
+  insertBankLedgerRow: vi.fn(async () => {}),
+  acquireCharacterLease: vi.fn(async () => true),
+  releaseCharacterLease: vi.fn(async () => {}),
+  heartbeatCharacterLeases: vi.fn(async () => {}),
+  releaseAllCharacterLeases: vi.fn(async () => {}),
+  setCharacterHotbarLayout: vi.fn(async () => {}),
+}));
+
+import { type ClientSession, GameServer } from '../server/game';
+import { groundHeight } from '../src/sim/world';
+import { broadcast, type FakeClient, fakeWs, joinServer, lastSnap } from './helpers/bare_client';
+
+// Mirrors MARKET_WIRE_HZ = 4 / MARKET_BROWSE_REFRESH_TICKS in server/game.ts.
+const MARKET_WIRE_INTERVAL_TICKS = 5;
+const MARKET_BROWSE_REFRESH_TICKS = 40;
+
+function placeAtMerchant(server: GameServer, pid: number): void {
+  let m = null;
+  for (const e of server.sim.entities.values()) {
+    if (e.templateId === 'the_merchant') {
+      m = e;
+      break;
+    }
+  }
+  if (!m) throw new Error('the Merchant was not spawned');
+  const e = server.sim.entities.get(pid);
+  if (!e) throw new Error(`missing entity ${pid}`);
+  e.pos.x = m.pos.x;
+  e.pos.z = m.pos.z;
+  e.pos.y = groundHeight(e.pos.x, e.pos.z, server.sim.cfg.seed);
+  e.prevPos = { ...e.pos };
+}
+
+function placeFarAway(server: GameServer, pid: number): void {
+  const e = server.sim.entities.get(pid);
+  if (!e) throw new Error(`missing entity ${pid}`);
+  e.pos.x = 400;
+  e.pos.z = 400;
+  e.pos.y = groundHeight(400, 400, server.sim.cfg.seed);
+  e.prevPos = { ...e.pos };
+}
+
+function duePass(server: GameServer): void {
+  for (let i = 0; i < MARKET_WIRE_INTERVAL_TICKS; i++) server.sim.tick();
+  broadcast(server);
+}
+
+function marketSnaps(sent: unknown[], from: number): unknown[] {
+  // biome-ignore lint/suspicious/noExplicitAny: untyped wire JSON, the harness idiom
+  return (sent as any[]).slice(from).filter((m) => m.t === 'snap' && m.self && 'market' in m.self);
+}
+
+function browseServer(): { server: GameServer; fc: FakeClient; session: ClientSession } {
+  const server = new GameServer();
+  const fc = fakeWs();
+  const session = joinServer(server, fc, 71, 'Browser');
+  placeAtMerchant(server, session.pid);
+  return { server, fc, session };
+}
+
+describe('market wire cadence + rebuild-only-on-change', () => {
+  it('rebuilds once for the join, then never again while nothing changes (until the backstop)', () => {
+    const { server, fc } = browseServer();
+    const spy = vi.spyOn(server.sim, 'marketInfoFor');
+    broadcast(server);
+    expect(spy).toHaveBeenCalledTimes(1);
+    const first = lastSnap(fc.sent);
+    expect(first.self.market).not.toBeNull();
+    expect(first.self.market.listings.length).toBeGreaterThan(0); // house stock
+
+    // Every due pass up to one interval SHORT of the backstop, with no book,
+    // query, or position change: the gate polls the browse revision and skips
+    // the rebuild every time, tight boundary included. The pre-fix behavior
+    // was one rebuild per TICK.
+    const passesToBackstop = Math.ceil(MARKET_BROWSE_REFRESH_TICKS / MARKET_WIRE_INTERVAL_TICKS);
+    const sent = fc.sent.length;
+    for (let pass = 0; pass < passesToBackstop - 1; pass++) duePass(server);
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(marketSnaps(fc.sent, sent)).toHaveLength(0); // nothing re-shipped either
+
+    // The next due pass crosses the staleness backstop: exactly one more
+    // rebuild lands (and, being unchanged, still elides from the wire).
+    duePass(server);
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(marketSnaps(fc.sent, sent)).toHaveLength(0);
+  });
+
+  it('re-sending a byte-identical market_search does not force rebuilds', () => {
+    const { server, fc, session } = browseServer();
+    broadcast(server);
+    server.handleMessage(
+      session,
+      JSON.stringify({ t: 'cmd', cmd: 'market_search', q: 'wolf', page: 0 }),
+    );
+    broadcast(server);
+    // The query is now applied; identical re-sends (a client re-firing the same
+    // search every command window) re-arm the cadence gate but must not
+    // replace the query object, so the identity check skips every rebuild.
+    const spy = vi.spyOn(server.sim, 'marketInfoFor');
+    const sent = fc.sent.length;
+    for (let round = 0; round < 3; round++) {
+      server.handleMessage(
+        session,
+        JSON.stringify({ t: 'cmd', cmd: 'market_search', q: 'wolf', page: 0 }),
+      );
+      server.sim.tick();
+      broadcast(server);
+    }
+    expect(spy).not.toHaveBeenCalled();
+    expect(marketSnaps(fc.sent, sent)).toHaveLength(0);
+  });
+
+  it('a book change reaches the viewer on their next due pass', () => {
+    const { server, fc, session } = browseServer();
+    broadcast(server);
+    const spy = vi.spyOn(server.sim, 'marketInfoFor');
+
+    const fc2 = fakeWs();
+    const seller = joinServer(server, fc2, 72, 'Seller');
+    placeAtMerchant(server, seller.pid);
+    server.sim.addItem('wolf_fang', 1, seller.pid);
+    server.sim.marketList('wolf_fang', 1, 100, seller.pid);
+
+    const sent = fc.sent.length;
+    duePass(server);
+    const snaps = marketSnaps(fc.sent, sent);
+    expect(snaps).toHaveLength(1);
+    // biome-ignore lint/suspicious/noExplicitAny: untyped wire JSON
+    const listings = (snaps[0] as any).self.market.listings;
+    expect(listings.some((l: { itemId: string }) => l.itemId === 'wolf_fang')).toBe(true);
+    expect(spy.mock.calls.filter(([pid]) => pid === session.pid).length).toBe(1);
+  });
+
+  it("the viewer's own market_search lands on the next snapshot, not a cadence later", () => {
+    const { server, fc, session } = browseServer();
+    broadcast(server);
+    server.sim.tick(); // one tick only: the plain cadence gate is NOT due yet
+
+    server.handleMessage(
+      session,
+      JSON.stringify({ t: 'cmd', cmd: 'market_search', q: 'wolf', page: 0 }),
+    );
+    const sent = fc.sent.length;
+    broadcast(server);
+    const snaps = marketSnaps(fc.sent, sent);
+    expect(snaps).toHaveLength(1);
+    // biome-ignore lint/suspicious/noExplicitAny: untyped wire JSON
+    expect((snaps[0] as any).self.market.filter).toBe('wolf');
+  });
+
+  it('walking away nulls the key at cadence; returning re-ships the full view', () => {
+    const { server, fc, session } = browseServer();
+    broadcast(server);
+
+    placeFarAway(server, session.pid);
+    let sent = fc.sent.length;
+    duePass(server);
+    let snaps = marketSnaps(fc.sent, sent);
+    expect(snaps).toHaveLength(1);
+    // biome-ignore lint/suspicious/noExplicitAny: untyped wire JSON
+    expect((snaps[0] as any).self.market).toBeNull();
+
+    placeAtMerchant(server, session.pid);
+    sent = fc.sent.length;
+    duePass(server);
+    snaps = marketSnaps(fc.sent, sent);
+    expect(snaps).toHaveLength(1);
+    // biome-ignore lint/suspicious/noExplicitAny: untyped wire JSON
+    expect((snaps[0] as any).self.market.listings.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

After investigating CPU overconsumption issues in production (the world loop
running over its 50 ms tick budget at a modest player count), we found that the
dominant cost was the World Market browse read inside the broadcast phase.
`selfWireJson` called `sim.marketInfoFor(pid)` every tick for every player
standing within 7 yd of a Merchant, and that read re-filtered and re-sorted the
WHOLE listing book per call, with an ICU `localeCompare` comparator inside the
sort. The cost grows with the size of the book, which is why the drift was slow
and organic rather than tied to any release: the admin Tick Profiler showed the
`bcastSelf` phase carrying most of the budget, and at ~3,000 listings the read
costs ~0.8 ms per browsing viewer per tick.

Three complementary changes, none of which alters a single wire byte of the
browse view itself:

1. **Sim: memoize the name-sorted book** (`src/sim/market.ts`). The sort is
   viewer-independent, so it now runs once per book change (a `bookRev` counter
   bumped at every mutation site) instead of once per viewer per tick. Per-viewer
   reads filter the stably sorted book, which produces the exact sequence the old
   filter-then-sort pipeline produced (stable sort with an element-only
   comparator commutes with filter; pinned by an independent oracle test).

2. **Server: rebuild only on change** (`server/game.ts` + a server-only
   `Sim.marketBrowseRevFor`). The snapshot loop now polls a cheap browse
   revision (listings + collections, bumped by every mutating verb) plus the
   viewer's query object identity, and skips the `marketInfoFor` rebuild
   entirely while neither moved. `marketSearch` keeps the previous query object
   when a re-sent query is byte-identical, so a client re-firing the same
   search cannot force per-snapshot rebuilds (the identity signal stays
   sound). The revision is re-read AFTER a rebuild (the read path can bump it
   once through the legacy collection merge), and a 40-tick staleness backstop
   (the heavy-gate refresh idea) bounds any missed-bump bug at 2 s.

3. **Server: cadence-gate the `market` key at 4 Hz** (`MARKET_WIRE_HZ`, the
   `DF_WIRE_HZ` pattern). Nothing in the browse view carries a sub-second clock.
   The viewer's own market commands (`market_search`, `market_list`,
   `market_list_instance`, `market_buy`, `market_cancel`, `market_collect`)
   re-arm the gate so search, page flips, and buy feedback still land on the
   very next snapshot.

### Measurements

Micro-benchmark of `marketInfoFor` per call (same query, warm memo):

| Book size | before | after |
|---|---|---|
| 1,000 | 0.41 ms | 0.05 ms |
| 2,000 | 0.80 ms | 0.10 ms |
| 5,000 | 2.24 ms | 0.19 ms |
| 10,000 | 4.76 ms | 0.38 ms |

Full-stack: local server, 70 bots clustered at the Merchant
(`scripts/server_load_jitter.mjs`), 3,000 seeded listings, `/api/perf` means:

| | tick | broadcast | total |
|---|---|---|---|
| before | 3.8 ms | 37.4 ms | 41.6 ms |
| after | 6.6 ms | 5.6 ms | 12.9 ms |

(The tick column difference between the two runs is run-to-run combat variance
in the bot crowd; the broadcast column is the fix.)

## Type of change

- [x] Bug fix
- [x] Refactor or performance (no behavior change)
- [x] Tests

## How was this tested?

- Commands:
  - `npx vitest run tests/market_browse_cache.test.ts` (new, 8 tests): an
    independent-oracle pin that the memoized pipeline reproduces the old
    filter-then-sort sequence exactly (price tie-break, the full same-name
    same-price tie decided by sort stability, and the mine-first page),
    reference-identity pins that the sort is shared across reads and viewers
    and invalidates on book change, a direct-mutation length guard, and
    per-verb browse-revision pins for every wire-reachable verb (list,
    list-instance, buy, cancel, collect, expiry, rekey, purge, load) plus an
    end-to-end no-stale-view case.
  - `npx vitest run tests/market_wire_cadence.test.ts` (new, 5 tests): a spy on
    `sim.marketInfoFor` proves ONE rebuild at join, ZERO rebuilds across every
    due pass up to the backstop's tight boundary (loop counts derived from the
    mirrored constants), exactly one more at the 40-tick backstop; a
    byte-identical `market_search` re-send spammed across rounds forces ZERO
    rebuilds; a book change reaches the viewer on their next due pass; the
    viewer's own `market_search` lands on the next snapshot (prompt re-arm);
    walking away nulls the key and returning re-ships the full view.
  - `npx vitest run tests/market.test.ts tests/market_instance.test.ts
    tests/market_filler_listings.test.ts tests/market_query_game.test.ts
    tests/snapshots.test.ts tests/bandwidth.test.ts` (270 tests, green).
  - `npx vitest run tests/architecture.test.ts tests/localization_fixes.test.ts
    tests/parity` (green; the change draws no rng and moves no tick phase).
  - `npx tsc --noEmit`, `node scripts/gate_select.mjs` (green).
- Manual steps: the before/after load measurements above (70 bots at the
  Merchant against a seeded 3,000-listing book, dev DB).

## Screenshots / recordings

N/A: no visual change. The browse window shows byte-identical content; only its
refresh cadence changes (20 Hz to 4 Hz for changes initiated by OTHERS, still
next-snapshot for the viewer's own actions).

---

## Checklist

### Quality

- [x] **The gate passes.** `node scripts/gate_select.mjs` is green. Decisive
      tests added for the memo, the revision signal, and the wire gate.

### Cross-platform

- ~Tested on desktop and mobile.~ N/A: no UI change.
- ~Accessible.~ N/A.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings (all market emit strings are
      untouched; `tests/localization_fixes.test.ts` green).

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] No generated files hand-edited.

---

### Notes for the reviewer

- The diff was reviewed by the repo's qa-checklist and architecture-reviewer
  agents (verdict READY, zero blocking). Every SHOULD-FIX they raised is
  applied in this diff: the byte-identical `market_search` re-send skip, the
  unconditional `rekeyMarketSeller` bump (the browse view reads `meta.name`),
  the post-rebuild revision re-stamp, the tight-boundary backstop assertion
  driven by the mirrored constants, `lastMarketQueryRef` typed
  `MarketQuery | null`, `sortedBook()` returning `readonly`, and the per-verb
  revision pins extended to rekey/purge/load/list-instance.
- Two acknowledged trade-offs, deliberate: `browseRev` is realm-global, so on
  a Merchant with continuous listing churn the change gate degrades toward the
  plain 4 Hz cadence (still 5x fewer rebuilds than before, each one 12x
  cheaper thanks to the memo). And the no-locale `localeCompare` comparator is
  pre-existing behavior, moved verbatim into the memo, not changed here.
- The one risk class this design carries is a MISSED bump site leaving a stale
  browse view. Three independent nets: every wire-reachable mutating verb is
  pinned by a revision test, the sorted-book memo also guards on array
  identity + length (so a test-harness push without a bump still invalidates),
  and the server gate carries the 40-tick staleness backstop.
- `marketBrowseRevFor` is deliberately server-only (never an `IWorld` member),
  the `guildBankInfoForGuild` precedent, so there is no parity-pin change and
  no `ClientWorld` counterpart to implement.
- The offline host benefits from the sort memo too (`marketInfo` is read per
  frame by the HUD while browsing); the cadence + revision gate is server-only.
- Deploy expectation on the affected realm: `bcastSelf` should drop from ~35 ms
  to low single digits at current population, and the avg tick from ~61 ms back
  under the 50 ms budget with headroom. The two confirmation queries from the
  investigation report still apply if you want to verify book size first:
  `select key, jsonb_array_length(data->'listings') from world_state where key like 'market:%';`