### PR TITLE
test(ci): enumerate the workflow directory for the Node major pin

### DIFF
--- a/.github/workflows/ota-publish.yml
+++ b/.github/workflows/ota-publish.yml
@@ -71,7 +71,12 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          # Node 26 to match the repo target (tests/deploy_node_version.test.ts):
+          # the bundle is built by the same pnpm + vite chain every CI run and the
+          # node:26-slim Dockerfile already prove on 26. The 22 here was inherited
+          # from desktop-publish, whose hold is a recorded decision; this one was
+          # not, so it follows the target (maintainer call, 2026-08-07).
+          node-version: 26
           cache: pnpm
 
       - name: Install dependencies

--- a/tests/deploy_node_version.test.ts
+++ b/tests/deploy_node_version.test.ts
@@ -1,4 +1,5 @@
-import { readFileSync } from 'node:fs';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 // The Node major every deploy and CI carrier must agree on, and the exact runtime
@@ -147,6 +148,60 @@ describe('deploy and CI Node version pin', () => {
   // lies about the image the healthcheck runs in.
   it('keeps the docker-compose healthcheck comment on the target base tag', () => {
     expect(compose).toContain(`(${TARGET_TAG})`);
+  });
+
+  // The whole-directory closer: the per-file arms above each pin a KNOWN carrier, so a
+  // NEW workflow carrying its own Node toolchain would land unpinned and drift silently.
+  // ota-publish.yml did exactly that (Node 22 with no recorded decision, inherited from
+  // desktop-publish, until the 2026-08-07 bump). Enumerate .github/workflows and hold
+  // every declared node-version to the target major unless the file is in the named
+  // exemption list below. The read is single-level by GitHub's own contract: Actions
+  // registers only top-level workflow files, so a YAML parked in a subdirectory is inert
+  // to CI and a flat read matches the real registration surface rather than narrowing it.
+  const WORKFLOW_DIR = '.github/workflows';
+  const workflowFiles = readdirSync(WORKFLOW_DIR)
+    .filter((name) => /\.ya?ml$/.test(name))
+    .sort();
+
+  // Workflows allowed off the target major, each with its recorded reason. An entry must
+  // BOTH exist and still diverge (second test below), so an exemption cannot rot into a
+  // blanket waiver after the divergence it covered is gone.
+  const NODE_MAJOR_EXEMPTIONS: Record<string, string> = {
+    'desktop-publish.yml':
+      'Steam/Electron publish path deliberately held on Node 22 until separately revisited',
+  };
+
+  it('holds every workflow node-version to the target major or a named exemption', () => {
+    // Vacuity floor: the enumeration must see the known carriers before "every" means much.
+    expect(workflowFiles).toContain('ci.yml');
+    expect(workflowFiles).toContain('desktop-publish.yml');
+    expect(workflowFiles).toContain('ota-publish.yml');
+    for (const file of workflowFiles) {
+      if (file in NODE_MAJOR_EXEMPTIONS) continue;
+      const values = nodeVersionValues(readFileSync(join(WORKFLOW_DIR, file), 'utf8'));
+      for (const value of values) {
+        expect(
+          value,
+          `${file} declares node-version ${value}; the target major is ${TARGET_MAJOR}. ` +
+            'Bump it or add a reasoned NODE_MAJOR_EXEMPTIONS entry.',
+        ).toBe(TARGET_MAJOR);
+      }
+    }
+  });
+
+  it('keeps every exemption naming a real, still-divergent workflow', () => {
+    for (const [file, reason] of Object.entries(NODE_MAJOR_EXEMPTIONS)) {
+      expect(reason.trim().length, `${file} exemption needs a recorded reason`).toBeGreaterThan(0);
+      expect(workflowFiles, `stale exemption: ${file} is not in ${WORKFLOW_DIR}`).toContain(file);
+      const values = nodeVersionValues(readFileSync(join(WORKFLOW_DIR, file), 'utf8'));
+      expect(values.length, `${file} declares no node-version; drop the exemption`).toBeGreaterThan(
+        0,
+      );
+      expect(
+        values.some((value) => value !== TARGET_MAJOR),
+        `${file} sits on the target major now; drop the exemption`,
+      ).toBe(true);
+    }
   });
 
   // DEPLOY.md's tsc-gate carries a prose aside for the host that already has Node on PATH

--- a/tests/deploy_node_version.test.ts
+++ b/tests/deploy_node_version.test.ts
@@ -132,7 +132,8 @@ describe('deploy and CI Node version pin', () => {
   // positive pin locks that intentional divergence: it reds if desktop-publish.yml is
   // accidentally swept to the target major with the rest, forcing a conscious decision
   // (and an update here) rather than a silent bump. If the publish path is later moved
-  // to the target too, fold it into nodeVersionValues above and delete this.
+  // to the target too, fold it into nodeVersionValues above, delete this, and drop its
+  // NODE_MAJOR_EXEMPTIONS entry below.
   it('keeps desktop-publish.yml on Node 22, not the target major', () => {
     const values = nodeVersionValues(desktopWorkflow);
     expect(values.length).toBeGreaterThan(0);
@@ -158,9 +159,22 @@ describe('deploy and CI Node version pin', () => {
   // exemption list below. The read is single-level by GitHub's own contract: Actions
   // registers only top-level workflow files, so a YAML parked in a subdirectory is inert
   // to CI and a flat read matches the real registration surface rather than narrowing it.
+  // The read still checks that premise (tests/CLAUDE.md, scan-guard rules): the day this
+  // directory grows a subdirectory, refuse loudly instead of quietly skipping whatever
+  // sits inside it, because a workflow parked there would also silently never run in CI.
   const WORKFLOW_DIR = '.github/workflows';
-  const workflowFiles = readdirSync(WORKFLOW_DIR)
-    .filter((name) => /\.ya?ml$/.test(name))
+  const workflowEntries = readdirSync(WORKFLOW_DIR, { withFileTypes: true });
+  const workflowSubdirs = workflowEntries.filter((e) => e.isDirectory()).map((e) => e.name);
+  if (workflowSubdirs.length > 0) {
+    throw new Error(
+      `${WORKFLOW_DIR} grew subdirectories (${workflowSubdirs.join(', ')}): a workflow file ` +
+        'in there is inert to Actions and invisible to this scan; move it to the top level ' +
+        'or extend this scan consciously.',
+    );
+  }
+  const workflowFiles = workflowEntries
+    .filter((e) => e.isFile() && /\.ya?ml$/.test(e.name))
+    .map((e) => e.name)
     .sort();
 
   // Workflows allowed off the target major, each with its recorded reason. An entry must
@@ -176,9 +190,26 @@ describe('deploy and CI Node version pin', () => {
     expect(workflowFiles).toContain('ci.yml');
     expect(workflowFiles).toContain('desktop-publish.yml');
     expect(workflowFiles).toContain('ota-publish.yml');
+    const filesWithValues = new Set<string>();
     for (const file of workflowFiles) {
       if (file in NODE_MAJOR_EXEMPTIONS) continue;
-      const values = nodeVersionValues(readFileSync(join(WORKFLOW_DIR, file), 'utf8'));
+      const text = readFileSync(join(WORKFLOW_DIR, file), 'utf8');
+      // Only a literal numeric node-version is pinnable by extraction, so the
+      // non-literal carriers must be banned here or a new workflow could ride
+      // node-version-file, an expression, or lts/latest straight past the pin.
+      expect(
+        text.includes('node-version-file:'),
+        `${file} uses node-version-file; pin a literal node-version or exempt it with a reason`,
+      ).toBe(false);
+      for (const m of text.matchAll(/^\s*node-version:\s*(.*)$/gm)) {
+        expect(
+          /^['"]?\d+['"]?$/.test(m[1].trim()),
+          `${file} carries a non-literal node-version "${m[1].trim()}"; only a plain major ` +
+            'is pinnable here. Use a literal or exempt the file with a reason.',
+        ).toBe(true);
+      }
+      const values = nodeVersionValues(text);
+      if (values.length > 0) filesWithValues.add(file);
       for (const value of values) {
         expect(
           value,
@@ -187,6 +218,14 @@ describe('deploy and CI Node version pin', () => {
         ).toBe(TARGET_MAJOR);
       }
     }
+    // Per-file vacuity floor for the carrier this arm exists to hold: dropping the
+    // explicit version to ride the runner default is exactly the silent-drift shape,
+    // so a known carrier losing all its node-version lines must red, not pass empty.
+    // (ci.yml, audit.yml, and nightly.yml have their own non-empty guards above.)
+    expect(
+      filesWithValues,
+      'ota-publish.yml no longer declares any node-version; the runner default is unpinned',
+    ).toContain('ota-publish.yml');
   });
 
   it('keeps every exemption naming a real, still-divergent workflow', () => {


### PR DESCRIPTION
## Summary

The deferred Phase 7 follow-up from the CI/CD performance packet: tests/deploy_node_version.test.ts pins a hardcoded list of Node-toolchain carriers, so a new workflow could carry its own Node version and drift unpinned. ota-publish.yml did exactly that: node-version 22 with no recorded decision, inherited from desktop-publish when the file was authored.

Two commits plus a fix-round application:

- ota-publish.yml bumps to the Node 26 target (maintainer call, 2026-08-07: the bundle is built by the same pnpm and vite chain every CI run and the node:26-slim Dockerfile already prove on 26, and the OTA artifact is a web bundle with no Node runtime; the first live proof comes at the next dry-run dispatch).
- The test gains the directory closer: enumerate .github/workflows and hold every declared node-version to the target major unless the file is in a reasoned exemption list (currently desktop-publish.yml alone, whose Node 22 hold is a recorded decision). Each exemption must exist AND still diverge AND carry a reason, so a stale entry cannot become a blanket waiver.
- Fix-round findings applied: a known carrier losing every node-version line reds (per-file floor; riding the runner default is the silent-drift shape), the flat read refuses loudly if the directory ever grows a subdirectory, and the non-literal toolchain forms (node-version-file, expressions, lts tags) are banned for non-exempt workflows since only a literal major is pinnable by extraction.

## Type of change

- [x] Tests
- [x] Build, CI, or tooling

## How was this tested?

- Commands: `npx vitest run tests/deploy_node_version.test.ts` (11 passed); mutation checks each proven red then restored (ota back to 22; ota losing its node-version line; a new workflow at node-version 24, quoted '22', node-version-file, and a matrix expression; a ghost exemption entry; an exemption for a conforming file; a subdirectory workflow, which throws naming the directory); `npx tsc --noEmit` exit 0; biome clean on the changed test; `node scripts/gate_select.mjs` green (recorded below).
- Manual steps: verified nothing else in tests/ pins ota-publish's node version, and the six neighbouring workflow-reading suites stay green on the bumped tree.

---

## Checklist

### Quality

- [x] **The gate passes.** `node scripts/gate_select.mjs` is green. Decisive tests added for the changed behavior, every arm mutation-proven.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files.
