### PR TITLE
fix(ci): report every required shard context on docs-only and release-to-main PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -367,13 +367,24 @@ jobs:
   # script's step list in sync when adding or removing a step in either job.
   pr-gate:
     name: PR gate (English-only legal)
-    # Compose release-to-main exclusion with the code path filter (D10). Do not
-    # drop either arm: release-to-main must still select release-*, and docs-only
-    # PRs must skip this matrix. needs.changes only; no needs edge to pr-checks.
-    # merge_group always lands here (the queue bar is the full PR tier; the
-    # release-to-main exclusion is a pull_request-arm concern and cannot match).
+    # Two-level gate, split on purpose (docs/merge-queue.md, "The required-check
+    # contract"). The JOB if carries only the event routing, so every
+    # pull_request and merge_group run expands the matrix and reports all eight
+    # suffixed check runs; the STEP gate on every step below carries the
+    # release-to-main exclusion and the code path filter (D10), so a leg the
+    # run does not apply to starts, skips all of its steps, and completes green
+    # in seconds. A job-level skip of a MATRIX job would instead collapse to
+    # ONE check run named without the (N) suffix, which string-matches none of
+    # the required shard contexts and leaves them "expected" forever: under the
+    # branch ruleset a docs-only or release-to-main PR could then never be
+    # queued or merged (observed live on the Phase 3 queue drills, PR #3038:
+    # "8 of 13 required status checks are expected"). Do not drop either step
+    # gate arm: release-to-main must still select release-*, and docs-only PRs
+    # must still skip the suite work. needs.changes only; no needs edge to
+    # pr-checks. merge_group always runs the work (the queue bar is the full
+    # PR tier; neither gate arm can match a merge_group event).
     needs: changes
-    if: ((github.event_name == 'pull_request' && (github.base_ref != 'main' || !startsWith(github.head_ref, 'release/'))) || (github.event_name == 'push' && !startsWith(github.ref, 'refs/heads/release/')) || github.event_name == 'workflow_dispatch' || github.event_name == 'merge_group') && needs.changes.outputs.code != 'false'
+    if: github.event_name == 'pull_request' || (github.event_name == 'push' && !startsWith(github.ref, 'refs/heads/release/')) || github.event_name == 'workflow_dispatch' || github.event_name == 'merge_group'
     # Fail fast on the runner-side checkout-stall class instead of burning
     # tail: on 2026-08-06 thirteen shard, lane, and browser jobs across seven
     # runs sat 9.6 to 24.4 minutes inside actions/checkout before completing
@@ -405,21 +416,31 @@ jobs:
         shard: [1, 2, 3, 4, 5, 6, 7, 8]
 
     steps:
+      # The step gate (see the job comment): identical on every step of this
+      # job, pinned that way by tests/ci_workflow.test.ts. A leg that this run
+      # does not apply to (docs-only PR, release-to-main PR) skips every step
+      # and reports green under its required suffixed name. The code arm stays
+      # != 'false' so a missing or empty classifier output runs the suite,
+      # never skips it (fail closed).
       - name: Check out repository
+        if: (github.event_name != 'pull_request' || github.base_ref != 'main' || !startsWith(github.head_ref, 'release/')) && needs.changes.outputs.code != 'false'
         uses: actions/checkout@v6
 
       - name: Set up pnpm
+        if: (github.event_name != 'pull_request' || github.base_ref != 'main' || !startsWith(github.head_ref, 'release/')) && needs.changes.outputs.code != 'false'
         uses: pnpm/action-setup@v4
         with:
           version: 10.34.5
 
       - name: Set up Node.js
+        if: (github.event_name != 'pull_request' || github.base_ref != 'main' || !startsWith(github.head_ref, 'release/')) && needs.changes.outputs.code != 'false'
         uses: actions/setup-node@v6
         with:
           node-version: 26
           cache: pnpm
 
       - name: Install dependencies
+        if: (github.event_name != 'pull_request' || github.base_ref != 'main' || !startsWith(github.head_ref, 'release/')) && needs.changes.outputs.code != 'false'
         run: pnpm install --frozen-lockfile
 
       # Persist the vitest transform cache across runs (vite.config.ts enables
@@ -475,6 +496,7 @@ jobs:
       # legs and the full replay read the same store: every leg is vitest
       # under the same config.
       - name: Cache vitest transform cache
+        if: (github.event_name != 'pull_request' || github.base_ref != 'main' || !startsWith(github.head_ref, 'release/')) && needs.changes.outputs.code != 'false'
         uses: actions/cache@v4
         with:
           path: node_modules/.experimental-vitest-cache
@@ -497,6 +519,7 @@ jobs:
       # Release-gate below keeps the unconditional full run line; the nightly
       # workflow re-proves the full suite daily (docs/qa-gate.md).
       - name: Run tests (PR tier, shard ${{ matrix.shard }} of 8)
+        if: (github.event_name != 'pull_request' || github.base_ref != 'main' || !startsWith(github.head_ref, 'release/')) && needs.changes.outputs.code != 'false'
         env:
           TEST_MODE: ${{ needs.changes.outputs.test_mode }}
           TEST_MODE_REASON: ${{ needs.changes.outputs.test_mode_reason }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,8 +88,11 @@ concurrency:
 #
 # Path filters (D10): a cheap `changes` job classifies pull_request diffs as
 # code vs docs-only. Docs/markdown/screenshot-only PRs keep lint (and any
-# other always-on cheap jobs) but skip pr-gate, pr-long-sims, pr-checks, and
-# browser-gate. Any touch of the code path set forces the full PR tier. push
+# other always-on cheap jobs) and skip the PR-tier work: pr-long-sims,
+# pr-checks, and browser-gate skip at JOB level, while pr-gate's matrix legs
+# start and skip at STEP level so all eight suffixed required check runs
+# still report (see the pr-gate job comment for why that difference is
+# load-bearing). Any touch of the code path set forces the full PR tier. push
 # to main/dev-*, workflow_dispatch, and merge_group queue runs always report
 # code=true (full PR tier when unsure).
 # Release/** pushes and release-to-main PRs never consult the filter:
@@ -382,7 +385,9 @@ jobs:
     # gate arm: release-to-main must still select release-*, and docs-only PRs
     # must still skip the suite work. needs.changes only; no needs edge to
     # pr-checks. merge_group always runs the work (the queue bar is the full
-    # PR tier; neither gate arm can match a merge_group event).
+    # PR tier): the release arm cannot match the event, and the classifier
+    # always reports code=true off a pull_request event, so neither gate arm
+    # can gate off a queue run.
     needs: changes
     if: github.event_name == 'pull_request' || (github.event_name == 'push' && !startsWith(github.ref, 'refs/heads/release/')) || github.event_name == 'workflow_dispatch' || github.event_name == 'merge_group'
     # Fail fast on the runner-side checkout-stall class instead of burning
@@ -472,9 +477,12 @@ jobs:
       # decays as sources drift until the next rotation (start there if the
       # speedup fades). The binding budget is GitHub's 10 GB per-repo cache
       # quota with LRU eviction: about 0.5 GB per toolchain state per scope
-      # (8 entries at 57-73 MB; no single scope holds both matrices, since
-      # their if arms are exact complements on the events that could share a
-      # ref), roughly 1 GB across the two long-lived producer scopes (main
+      # (8 entries at 57-73 MB; no single scope holds both matrices: on the
+      # one event both jobs now see, a release-to-main PR, pr-gate's copy of
+      # this step is gated off by the step gate above, so release-gate's
+      # matrix is the only producer on that ref; the separation lives in the
+      # STEP gate, not in the job routing), roughly 1 GB across the two
+      # long-lived producer scopes (main
       # plus the release branch) beside the pnpm store, Playwright, and tsc
       # caches. If hot-entry eviction is ever observed, the lever is
       # restricting this step's save to push events, never restore-keys

--- a/docs/merge-queue.md
+++ b/docs/merge-queue.md
@@ -79,7 +79,8 @@ Required on both `main` and `release/**`, all sourced from GitHub Actions:
   its non-matrix dependents report skipped under their exact names, and branch
   protection treats skipped as satisfied (the shard matrix instead collapses to
   an unsuffixed check run, which blocks by accident rather than by decision).
-  Requiring the job that decides closes that hole for a classifier FAILURE. The residual is inherent to CI-config-in-repo: a queue run executes
+  Requiring the job that decides closes that hole for a classifier FAILURE.
+  The residual is inherent to CI-config-in-repo: a queue run executes
   the queued tree's own copy of ci.yml and the classifier, so an honest
   mistake there is caught only because the workflow files
   (`.github/workflows/`) and the selection pipeline's own scripts are

--- a/docs/merge-queue.md
+++ b/docs/merge-queue.md
@@ -76,21 +76,31 @@ the Checks tab (filter by event: merge_group).
 Required on both `main` and `release/**`, all sourced from GitHub Actions:
 
 - `Detect code path changes`. Required itself, and load-bearing: when it fails,
-  its dependents report skipped, and branch protection treats skipped as
-  satisfied. Requiring the job that decides closes that hole for a classifier
-  FAILURE. The residual is inherent to CI-config-in-repo: a queue run executes
+  its non-matrix dependents report skipped under their exact names, and branch
+  protection treats skipped as satisfied (the shard matrix instead collapses to
+  an unsuffixed check run, which blocks by accident rather than by decision).
+  Requiring the job that decides closes that hole for a classifier FAILURE. The residual is inherent to CI-config-in-repo: a queue run executes
   the queued tree's own copy of ci.yml and the classifier, so an honest
   mistake there is caught only because the workflow files
   (`.github/workflows/`) and the selection pipeline's own scripts are
   themselves fail-closed triggers (always `code=true`, always full mode); a
   hostile edit is a review problem, not something protection can solve.
 - `PR gate (English-only legal) (1)` through `(8)`: the sharded test suite.
+  The matrix legs START on every `pull_request` and `merge_group` run and gate
+  their work at STEP level: on a run the suite does not apply to (a docs-only
+  PR, a release-to-main PR) each leg skips its steps and reports green in
+  seconds under its suffixed name. This is deliberate, not waste: a job-level
+  skip of a MATRIX job collapses to one check run WITHOUT the `(N)` suffix,
+  which string-matches none of these required contexts and leaves them
+  "expected" forever, so the PR could never be queued or merged (observed live
+  on the Phase 3 queue drills).
 - `PR gate (long sims)`: the dedicated lane for the long rotation sims
   (`CI_LONG_SUITES` in `scripts/lib/ci_shard_plan.mjs`). The shard matrix
   deliberately excludes those files, so this job carries coverage nothing else
   in the run has: it is required for the same reason the shards are. It runs
-  (or docs-only-skips) on every `pull_request` and `merge_group` run, exactly
-  like the shards.
+  (or docs-only-skips) on every `pull_request` and `merge_group` run; unlike
+  the shard matrix, a job-level skip is safe here because a non-matrix job's
+  skipped check run keeps its exact required name, which satisfies protection.
 - `PR checks (freshness, typecheck, builds)`.
 - `Format + lint (Biome, changed files)`: deterministic, diff-scoped, minutes
   long, and a red here is always a real defect in the changed files. On queue
@@ -114,7 +124,10 @@ Never require these, deliberately:
 
 The same rule generalizes: a check may only join the required list if ci.yml
 produces (or explicitly skips) it on every `pull_request` AND every
-`merge_group` run. Anything else deadlocks the queue. And required-check names
+`merge_group` run. Anything else deadlocks the queue. For a MATRIX job the bar
+is stricter: an explicit job-level skip is NOT enough, because the skipped
+check run drops the `(N)` suffix and satisfies nothing; the legs must start
+and no-op at step level, as the shard matrix does. And required-check names
 are string-matched: renaming a CI job silently un-requires it, so treat the job
 names above as pinned (`tests/ci_workflow.test.ts` holds each name to ci.yml
 and to this doc, including the shard-count suffix range).

--- a/tests/ci_workflow.test.ts
+++ b/tests/ci_workflow.test.ts
@@ -401,12 +401,16 @@ describe('CI workflow parity', () => {
     // PR_GATE_JOB_IF_LINE). Exactly one job-level if, equal to the event-only
     // literal; the step gate on EVERY step, count pinned to the parsed step
     // list so a new step cannot land ungated and silently run (or leak work)
-    // on a docs-only or release-to-main leg.
+    // on a docs-only or release-to-main leg. Space classes are literal spaces,
+    // not \s, so a blank line cannot be absorbed into an indent match; and the
+    // step count matches EVERY list item start, named or not, because a
+    // nameless `- uses:` step is legal YAML and a `- name: `-only sweep would
+    // let it land ungated (fix-round mutation M7).
     {
-      const jobIfLines = prGate.match(/^\s{4}if: .+$/gm) ?? [];
+      const jobIfLines = prGate.match(/^ {4}if: .+$/gm) ?? [];
       expect(jobIfLines).toEqual([PR_GATE_JOB_IF_LINE]);
-      const stepIfLines = prGate.match(/^\s{8}if: .+$/gm) ?? [];
-      const stepStarts = prGate.match(/^\s{6}- name: /gm) ?? [];
+      const stepIfLines = prGate.match(/^ {8}if: .+$/gm) ?? [];
+      const stepStarts = prGate.match(/^ {6}- /gm) ?? [];
       // Vacuity floor near the real step count (checkout, pnpm, node,
       // install, cache, run): an empty parse must never pass the sweep.
       expect(stepStarts.length).toBeGreaterThanOrEqual(6);
@@ -463,7 +467,7 @@ describe('CI workflow parity', () => {
       // Anchored to the start of a step line, so a YAML-commented-out step
       // (`#        run: npm run build:server`) cannot satisfy it: the substring
       // survives the comment, the anchored form does not.
-      expect(prChecks).toMatch(new RegExp(`\\n {8}${step.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`));
+      expect(prChecks).toMatch(new RegExp(`\\n {8}${escapeRe(step)}`));
       expect(prGate).not.toContain(step);
       expect(prLongSims).not.toContain(step);
     }
@@ -500,9 +504,7 @@ describe('CI workflow parity', () => {
     for (const step of CHECK_RUN_STEPS) {
       // Same anchored form as the PR-tier loop: a YAML-commented-out step must
       // not satisfy the pin.
-      expect(releaseChecks).toMatch(
-        new RegExp(`\\n {8}${step.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`),
-      );
+      expect(releaseChecks).toMatch(new RegExp(`\\n {8}${escapeRe(step)}`));
       expect(releaseGate).not.toContain(step);
     }
     // Named-step count: checkout, setup-pnpm, setup-node, pnpm install, plus ten

--- a/tests/ci_workflow.test.ts
+++ b/tests/ci_workflow.test.ts
@@ -95,6 +95,30 @@ const PR_TIER_EVENT_FRAGMENT =
 // via needs regardless, which requiring "Detect code path changes" closes.)
 const PR_TIER_IF_LINE = `    if: (${PR_TIER_EVENT_FRAGMENT}) && needs.changes.outputs.code != 'false'`;
 
+// pr-gate alone splits those two arms across levels (the docs-only matrix
+// collapse fix): the JOB if carries only the event routing, so every
+// pull_request and merge_group run expands the shard matrix and reports all
+// eight suffixed check runs, and EVERY step carries the release-to-main
+// exclusion plus the code arm, so a leg the run does not apply to no-ops
+// green under its required suffixed name. A job-level skip of a MATRIX job
+// collapses to one check run WITHOUT the (N) suffix, which string-matches
+// none of the required shard contexts and leaves them "expected" forever
+// (observed live on the Phase 3 queue drills, PR #3038), which is why the
+// job if must never regain either gate arm. The step gate keeps the
+// != 'false' fail-closed polarity for the same reason PR_TIER_IF_LINE does.
+const PR_GATE_JOB_IF_LINE =
+  "    if: github.event_name == 'pull_request' || (github.event_name == 'push' && !startsWith(github.ref, 'refs/heads/release/')) || github.event_name == 'workflow_dispatch' || github.event_name == 'merge_group'";
+const PR_GATE_STEP_GATE_LINE =
+  "        if: (github.event_name != 'pull_request' || github.base_ref != 'main' || !startsWith(github.head_ref, 'release/')) && needs.changes.outputs.code != 'false'";
+
+/** Escape a literal for embedding in a RegExp source. */
+const escapeRe = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+// The step gate as an anchored regex segment for the step-shape pins below:
+// the EXACT literal, escaped and newline-terminated, so an anchored step pin
+// on pr-gate admits precisely the gate and nothing else (an `if: false`
+// neutering mutation still breaks the shape).
+const PR_GATE_STEP_GATE_RE_SEGMENT = `${escapeRe(PR_GATE_STEP_GATE_LINE)}\n`;
+
 // Minimum code path set the changes job must classify as code=true (D10).
 // Each row pairs the original inline-YAML glob with a representative path;
 // the pin is behavioral (through scripts/lib/ci_change_classify.mjs) because
@@ -362,14 +386,32 @@ describe('CI workflow parity', () => {
     const prChecks = jobSource('pr-checks');
     const releaseGate = jobSource('release-gate');
     const releaseChecks = jobSource('release-checks');
-    for (const job of [prGate, prLongSims, prChecks]) {
+    for (const job of [prLongSims, prChecks]) {
       // Exact composed if: event routing AND code path filter (D10). Dropping
-      // either arm breaks release-to-main exclusion or docs-only skip.
+      // either arm breaks release-to-main exclusion or docs-only skip. These
+      // two are non-matrix jobs, so a job-level skip keeps the exact required
+      // name and satisfies protection; only pr-gate needs the split below.
       const ifLines = job.match(/^\s{4}if: .+$/gm) ?? [];
       expect(ifLines).toEqual([PR_TIER_IF_LINE]);
       expect(job).toContain(PR_TIER_EVENT_FRAGMENT);
       expect(job).toContain("needs.changes.outputs.code != 'false'");
       expect(job).not.toContain('I18N_RELEASE_TIER');
+    }
+    // pr-gate: the same two arms, split across levels (see
+    // PR_GATE_JOB_IF_LINE). Exactly one job-level if, equal to the event-only
+    // literal; the step gate on EVERY step, count pinned to the parsed step
+    // list so a new step cannot land ungated and silently run (or leak work)
+    // on a docs-only or release-to-main leg.
+    {
+      const jobIfLines = prGate.match(/^\s{4}if: .+$/gm) ?? [];
+      expect(jobIfLines).toEqual([PR_GATE_JOB_IF_LINE]);
+      const stepIfLines = prGate.match(/^\s{8}if: .+$/gm) ?? [];
+      const stepStarts = prGate.match(/^\s{6}- name: /gm) ?? [];
+      // Vacuity floor near the real step count (checkout, pnpm, node,
+      // install, cache, run): an empty parse must never pass the sweep.
+      expect(stepStarts.length).toBeGreaterThanOrEqual(6);
+      expect(stepIfLines).toEqual(stepStarts.map(() => PR_GATE_STEP_GATE_LINE));
+      expect(prGate).not.toContain('I18N_RELEASE_TIER');
     }
     // Both release jobs share the exact same job-level if line so they skip or
     // run together. Exact-line match (not bare toContain of the fragment) so a
@@ -870,6 +912,7 @@ describe('CI workflow parity', () => {
     expect(prGate).toMatch(
       new RegExp(
         String.raw`- name: Run tests \(PR tier, shard \$\{\{ matrix\.shard \}\} of ${SHARD_N}\)\n` +
+          PR_GATE_STEP_GATE_RE_SEGMENT +
           String.raw` {8}env:\n` +
           String.raw` {10}TEST_MODE: \$\{\{ needs\.changes\.outputs\.test_mode \}\}\n` +
           String.raw` {10}TEST_MODE_REASON: \$\{\{ needs\.changes\.outputs\.test_mode_reason \}\}\n` +
@@ -986,23 +1029,35 @@ describe('CI workflow parity', () => {
     // Name-to-uses adjacency plus the path and key lines, TERMINATED BY THE
     // BLANK LINE THAT ENDS THE STEP: a YAML-commented-out copy cannot satisfy
     // it, and neither can a step neutered by an appended `if:` or any other
-    // trailing key (the mutation that beat the pin's first draft).
-    // One shared prefix and hashFiles tail for every copy of the step, so
-    // the shard and lane regexes cannot drift apart: an edit to the key's
-    // input list either moves all three ci.yml key lines or goes red here.
-    const cacheStepPrefix = String.raw`- name: Cache vitest transform cache\n(?: {8}#[^\n]*\n)* {8}uses: actions\/cache@v(?:[4-9]|\d{2,})[^\n]*\n {8}with:\n {10}path: node_modules\/\.experimental-vitest-cache\n {10}key: vitest-fsmodule-\$\{\{ runner\.os \}\}-`;
+    // trailing key (the mutation that beat the pin's first draft). pr-gate's
+    // copy is the one exception, and only for the EXACT step gate literal
+    // (PR_GATE_STEP_GATE_LINE, required by its shape here): any other if,
+    // including an `if: false` neuter, still breaks the pin, and release-gate
+    // and the lane still admit no if at all.
+    // One shared name line, body, and hashFiles tail for every copy of the
+    // step, so the shard and lane regexes cannot drift apart: an edit to the
+    // key's input list either moves all three ci.yml key lines or goes red
+    // here.
+    const cacheStepName = String.raw`- name: Cache vitest transform cache\n`;
+    const cacheStepBody = String.raw`(?: {8}#[^\n]*\n)* {8}uses: actions\/cache@v(?:[4-9]|\d{2,})[^\n]*\n {8}with:\n {10}path: node_modules\/\.experimental-vitest-cache\n {10}key: vitest-fsmodule-\$\{\{ runner\.os \}\}-`;
     const cacheKeyTail = String.raw`-\$\{\{ hashFiles\('pnpm-lock\.yaml', 'vite\.config\.ts', '\.npmrc', 'package\.json'\) \}\}\n\n`;
-    const cacheStepRe = new RegExp(
-      `${cacheStepPrefix}${String.raw`shard\$\{\{ matrix\.shard \}\}`}${cacheKeyTail}`,
+    const shardKeySegment = String.raw`shard\$\{\{ matrix\.shard \}\}`;
+    const prGateCacheStepRe = new RegExp(
+      `${cacheStepName}${PR_GATE_STEP_GATE_RE_SEGMENT}${cacheStepBody}${shardKeySegment}${cacheKeyTail}`,
+    );
+    const releaseCacheStepRe = new RegExp(
+      `${cacheStepName}${cacheStepBody}${shardKeySegment}${cacheKeyTail}`,
     );
     // The lane job (Phase 4 rider) carries the same step with a lane key
     // segment where the matrices carry shard${{ matrix.shard }}: the lane has
     // no matrix, so the shard expression would render empty there, and the
     // lane's store earns its own entry rather than borrowing a shard's.
-    const laneCacheStepRe = new RegExp(`${cacheStepPrefix}lane-long-sims${cacheKeyTail}`);
+    const laneCacheStepRe = new RegExp(
+      `${cacheStepName}${cacheStepBody}lane-long-sims${cacheKeyTail}`,
+    );
     for (const [name, stepRe] of [
-      ['pr-gate', cacheStepRe],
-      ['release-gate', cacheStepRe],
+      ['pr-gate', prGateCacheStepRe],
+      ['release-gate', releaseCacheStepRe],
       ['pr-long-sims', laneCacheStepRe],
     ] as const) {
       const job = jobSource(name);


### PR DESCRIPTION
## Summary

Fixes a real gap the Phase 3 merge-queue drills found in the newly applied branch ruleset: a job-level skip of the pr-gate MATRIX collapses to one check run named "PR gate (English-only legal)" without the (N) suffix, which string-matches none of the eight required shard contexts. They sit "expected" forever, so a docs-only PR could never be queued or merged into release/** without admin bypass (observed live on drill PR #3038: enqueuePullRequest returned "8 of 13 required status checks are expected"). The same collapse would hit release-to-main PRs when main joins the ruleset.

The fix splits pr-gate's gate across two levels: the job if keeps only the event routing, so every pull_request and merge_group run expands the matrix and reports all eight suffixed check runs, and every step carries the release-to-main exclusion plus the code arm, so a leg the run does not apply to starts, skips its steps, and completes green in seconds under its required suffixed name. The two conditions are provably equivalent case by case over every event shape (table in the fix-round review record); the fail-closed polarity (code arm != 'false') is unchanged. Cost: eight short runner spin-ups per docs-only PR.

Non-matrix PR-tier jobs (long-sims lane, pr-checks, browser-gate) are untouched: their job-level skips keep their exact required names, which satisfies protection. docs/merge-queue.md records the corrected narrative and the stricter matrix-specific rule for future required checks; tests/ci_workflow.test.ts pins the event-only job if, the identical gate on EVERY step (counting nameless step starts too), and the step-shape pins that admit exactly the gate literal on pr-gate while release-gate and the lane still admit no if at all.

Note for the first CI run: these step gates are the first step-level use of the needs context in this repo's workflows (GitHub documents needs as available in steps.if); the PR's own run confirms it live.

## Type of change

- [x] Bug fix
- [x] Build, CI, or tooling

## How was this tested?

- Commands: `npx vitest run tests/ci_workflow.test.ts` (21 passed) plus the 13 ci.yml-reading suites (301 tests, all green); js-yaml parse of the workflow; 11 mutations run and proven red (gate removed from a step; a new named step ungated; a new NAMELESS step ungated; polarity flipped to == 'true'; code arm re-added to the job if; the release-to-main arm re-added to the job if, the exact bug shape; if: false on release-gate's cache step; gate moved after uses:/env:; gate leaked onto the lane's cache step); `npx tsc --noEmit` exit 0; biome clean; `node scripts/gate_select.mjs` green (recorded below).
- Manual steps: semantic-equivalence table over all seven event shapes verified by an independent fix-round reviewer; confirmed no step sets continue-on-error, pr-gate has no job outputs, and nothing needs: pr-gate, so an all-steps-skipped leg concludes SUCCESS.

---

## Checklist

### Quality

- [x] **The gate passes.** `node scripts/gate_select.mjs` is green. Decisive tests updated for the changed behavior, mutation-proven.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files.
