### PR TITLE
fix(rift): carry a corpse forward when the party descends a floor (re-land #2977)

### DIFF
--- a/src/sim/rift/runs.ts
+++ b/src/sim/rift/runs.ts
@@ -142,17 +142,24 @@ function floorForInstance(inst: RiftInstance, floorIndex = inst.floorIndex) {
   return generateRiftFloor(inst.seed, inst.baseLevel, floorIndex, inst.upgrade);
 }
 
+/** Is `pos` inside the detection region of the floor anchored at `origin`? Floors are
+ * z-stacked far enough apart (RIFT_FLOOR_SPACING in ../data) that these regions never
+ * overlap, so a position belongs to at most one floor of one slot. This converges the
+ * copies inside THIS module; two more of the same predicate live outside it
+ * (spirit.ts ghostGraveyard's rift arm, colliders.ts riftRegionAt), which would want
+ * this hoisted beside riftInstanceOrigin in ../data to converge as well. */
+function inRiftFloorRegion(pos: { x: number; z: number }, origin: { x: number; z: number }) {
+  return (
+    Math.abs(pos.x - origin.x) <= RIFT_REGION_HALF_X &&
+    Math.abs(pos.z - origin.z) <= RIFT_REGION_HALF_Z
+  );
+}
+
 /** The rift instance whose region contains `pos`, or null. */
 export function riftInstanceAtPos(ctx: SimContext, pos: Vec3): RiftInstance | null {
   for (const inst of ctx.riftInstances) {
     if (inst.partyKey === null) continue;
-    const o = riftInstanceOrigin(inst.slot, inst.floorIndex);
-    if (
-      Math.abs(pos.x - o.x) <= RIFT_REGION_HALF_X &&
-      Math.abs(pos.z - o.z) <= RIFT_REGION_HALF_Z
-    ) {
-      return inst;
-    }
+    if (inRiftFloorRegion(pos, riftInstanceOrigin(inst.slot, inst.floorIndex))) return inst;
   }
   return null;
 }
@@ -762,6 +769,9 @@ export function descendRift(ctx: SimContext, pid?: number): void {
   // Collect everyone currently standing in this floor's region before we tear it
   // down, so the whole party descends together.
   const descenders = instancePlayerIds(ctx, inst);
+  // The floor we are about to abandon, captured BEFORE floorIndex advances: it is
+  // what decides which corpses belong to it (see the corpse sweep below).
+  const oldOrigin = riftInstanceOrigin(inst.slot, inst.floorIndex);
 
   freeRiftFloorEntities(ctx, inst);
   inst.floorIndex += 1;
@@ -770,13 +780,42 @@ export function descendRift(ctx: SimContext, pid?: number): void {
   // The next floor has its own z-stacked origin: teleport descenders THERE.
   const newOrigin = riftInstanceOrigin(inst.slot, inst.floorIndex);
   const floor = floorForInstance(inst);
+  // One arrival point for the whole descent (groundPos is a pure function of the seed
+  // and x/z, drawing no rng, so hoisting it moves no draw order). Every assignment
+  // below spread-CLONES it: handing the same Vec3 to several entities would alias
+  // one position across the party and a corpse.
+  const entryPos = ctx.groundPos(newOrigin.x + floor.entry.x, newOrigin.z + floor.entry.z);
+
+  // A corpse left on the floor we just tore down comes FORWARD with the run.
+  // Otherwise it is orphaned a floor behind in a region that now holds no live
+  // instance (no beacon, no exit), while enterRift lands its returning ghost on the
+  // CURRENT floor, far outside CORPSE_REZ_RANGE: the corpse run enterRift's
+  // dead-entry arm exists to serve becomes unreachable through no fault of the
+  // player. Swept over the run's whole roster, not just the descenders, because the
+  // member this strands is precisely the one NOT standing in the region: a released
+  // spirit waits at an overworld graveyard (the rift arm of spirit.ts ghostGraveyard)
+  // while their body stays behind. An UNRELEASED body needs nothing here; it rides
+  // the descent as an ordinary descender and stamps its corpse on arrival.
+  //
+  // Two orphan routes this deliberately does NOT cover, because they are reached
+  // without a descent and want their own fix: a member who LOGGED OUT while dead has
+  // no live entity to sweep (their corpsePos persists and reloads onto the abandoned
+  // floor), and a run that ends by expiry or a lost race tears down without moving
+  // anything. Both leave the same stranded corpse this sweep exists to prevent.
+  for (const id of inst.memberIds) {
+    const member = ctx.entities.get(id);
+    if (!member?.corpsePos) continue;
+    if (!inRiftFloorRegion(member.corpsePos, oldOrigin)) continue;
+    member.corpsePos = { ...entryPos };
+  }
+
   for (const id of descenders) {
     const e = ctx.entities.get(id);
     if (!e) continue;
     // Same every-teleport teardown as the entry above: a descender can be
     // mid-cast at the moment the floor advances under the whole party.
     cancelProfessionSessionOnDisplacement(ctx, e);
-    e.pos = ctx.groundPos(newOrigin.x + floor.entry.x, newOrigin.z + floor.entry.z);
+    e.pos = { ...entryPos };
     e.prevPos = { ...e.pos };
     ctx.rebucket(e);
     e.facing = 0;
@@ -837,10 +876,7 @@ function forceExitRiftPlayer(
   const p = ctx.entities.get(pid);
   if (!p) return;
   const origin = riftInstanceOrigin(inst.slot, inst.floorIndex);
-  const isInside =
-    Math.abs(p.pos.x - origin.x) <= RIFT_REGION_HALF_X &&
-    Math.abs(p.pos.z - origin.z) <= RIFT_REGION_HALF_Z;
-  if (!isInside && forced) return;
+  if (!inRiftFloorRegion(p.pos, origin) && forced) return;
   const dest = inst.returnPos;
   // Walk-in grace so the overworld portal cannot re-swallow the player the
   // tick they land next to it (clicking it deliberately still re-enters).
@@ -1470,13 +1506,7 @@ export function instancePlayerIds(ctx: SimContext, inst: RiftInstance): number[]
       : new Set([...ctx.players.values()].map((m) => m.entityId));
   for (const pid of candidates) {
     const e = ctx.entities.get(pid);
-    if (
-      e &&
-      Math.abs(e.pos.x - origin.x) <= RIFT_REGION_HALF_X &&
-      Math.abs(e.pos.z - origin.z) <= RIFT_REGION_HALF_Z
-    ) {
-      out.push(pid);
-    }
+    if (e && inRiftFloorRegion(e.pos, origin)) out.push(pid);
   }
   return out;
 }

--- a/tests/rift_corpse_descent.test.ts
+++ b/tests/rift_corpse_descent.test.ts
@@ -1,0 +1,226 @@
+// A rift corpse must come FORWARD with the run when the party descends.
+//
+// Rift floors are separate z-stacked regions (RIFT_FLOOR_SPACING in src/sim/data.ts,
+// detection regions deliberately non-overlapping), and a rift death sends the ghost
+// OUT to an overworld graveyard while the body stays on the floor. Before this fix
+// descendRift advanced inst.floorIndex and touched no corpsePos, so a member who was
+// dead when the party moved on had their corpse orphaned a whole floor behind: the
+// region holds no live instance (riftInstanceAtPos returns null there, so no beacon
+// and no exit), and enterRift always lands a returning ghost on the CURRENT floor,
+// far outside CORPSE_REZ_RANGE. The corpse run is a first-class flow here (enterRift
+// has a dedicated dead-entry arm), so losing it silently is a defect, not a rule.
+//
+// Both death states are covered, because they reach the new floor by different routes:
+// a RELEASED spirit already carries corpsePos and is usually standing outside the
+// region, so only the new sweep saves it. An UNRELEASED body rides the descent as an
+// ordinary descender and stamps its corpse on arrival, which already worked before
+// this fix; that case is pinned here as a REGRESSION guard, not as new behavior.
+import { describe, expect, it } from 'vitest';
+import { BUILTIN_WORLD, isRiftPos, riftInstanceOrigin } from '../src/sim/data';
+import { spawnNaturalRiftPortal } from '../src/sim/rift/portals';
+import { descendRift, riftInstanceAtPos, updateRiftInstances } from '../src/sim/rift/runs';
+import type { RiftInstance } from '../src/sim/rift/types';
+import { Sim } from '../src/sim/sim';
+import { CORPSE_REZ_RANGE } from '../src/sim/spirit';
+import { dist2d, type Entity, PARTY_XP_RANGE } from '../src/sim/types';
+
+const TEST_WORLD = { ...BUILTIN_WORLD, camps: [], npcs: {}, groundObjects: [] };
+
+function makeSim(): Sim {
+  return new Sim({
+    seed: 99117,
+    playerClass: 'warrior',
+    noPlayer: true,
+    autoEquip: true,
+    devCommands: true,
+    riftPortals: true,
+    world: TEST_WORLD,
+  });
+}
+
+/** A duo inside one shared run on floor 0, plus the portal they walked through. */
+function enterAsParty(): {
+  sim: Sim;
+  leader: number;
+  victim: number;
+  run: RiftInstance;
+  portal: Entity;
+} {
+  const sim = makeSim();
+  const leader = sim.addPlayer('warrior', 'Leader');
+  const victim = sim.addPlayer('warrior', 'Victim');
+  sim.setPlayerLevel(20, leader);
+  sim.setPlayerLevel(20, victim);
+  expect(spawnNaturalRiftPortal(sim.ctx, 0)).toBe(true);
+  const portal = sim.entities.get(sim.naturalRiftPortals[0].id)!;
+  sim.partyInvite(victim, leader);
+  sim.partyAccept(victim);
+  sim.enterRift(portal.riftSeed!, portal.riftBaseLevel!, leader, undefined, portal);
+  sim.enterRift(portal.riftSeed!, portal.riftBaseLevel!, victim, undefined, portal);
+  const run = sim.riftInstances.find((i) => i.partyKey !== null)!;
+  expect(run.floorIndex, 'the duo starts on floor 0').toBe(0);
+  expect(run.memberIds.has(victim), 'both are bound to the run').toBe(true);
+  return { sim, leader, victim, run, portal };
+}
+
+/** Clear the floor for real so the descent opens (the rift_binding.test.ts recipe). */
+function openDescent(sim: Sim, run: RiftInstance): void {
+  for (const id of run.mobIds) {
+    const mob = sim.entities.get(id);
+    if (mob) {
+      mob.hp = 0;
+      mob.dead = true;
+    }
+  }
+  run.litPylons = new Set(run.pylonIds);
+  run.puzzleSolved = true;
+  sim.tickCount += (20 - (sim.tickCount % 20)) % 20;
+  updateRiftInstances(sim.ctx);
+  expect(run.descentOpen, 'a cleared floor opens its descent').toBe(true);
+}
+
+function kill(sim: Sim, pid: number): Entity {
+  const e = sim.entities.get(pid)!;
+  e.hp = 0;
+  e.dead = true;
+  return e;
+}
+
+describe('a rift corpse follows the run when the party descends', () => {
+  it('carries a RELEASED spirit corpse forward, so the ghost can still corpse-run', () => {
+    const { sim, leader, victim, run, portal } = enterAsParty();
+    const body = kill(sim, victim);
+    sim.releaseSpirit(victim);
+    expect(body.ghost, 'the spirit released').toBe(true);
+    const oldFloorOrigin = riftInstanceOrigin(run.slot, 0);
+    expect(
+      Math.abs(body.corpsePos!.z - oldFloorOrigin.z),
+      'the corpse starts inside the floor 0 region',
+    ).toBeLessThan(160);
+
+    openDescent(sim, run);
+    descendRift(sim.ctx, leader);
+    expect(run.floorIndex, 'the party moved on').toBe(1);
+
+    // The corpse came with the run: it now sits in the live floor 1 region.
+    const corpse = body.corpsePos!;
+    expect(riftInstanceAtPos(sim.ctx, corpse), 'the corpse is in a LIVE region').toBe(run);
+    const newFloorOrigin = riftInstanceOrigin(run.slot, 1);
+    expect(Math.abs(corpse.z - newFloorOrigin.z)).toBeLessThan(160);
+
+    // Which makes the corpse run work again: re-enter, land on the current floor,
+    // and the body is right there rather than a whole floor behind.
+    sim.time += 10; // clear the re-entry grace
+    sim.enterRift(portal.riftSeed!, portal.riftBaseLevel!, victim, undefined, portal);
+    expect(body.dead, 'entry never resurrects').toBe(true);
+    expect(
+      dist2d(body.pos, corpse),
+      'the returning ghost lands within corpse-rez range',
+    ).toBeLessThanOrEqual(CORPSE_REZ_RANGE);
+    sim.resurrectAtCorpse(victim);
+    expect(body.dead, 'the corpse rez lands').toBe(false);
+    expect(body.ghost).toBe(false);
+  });
+
+  it('carries an UNRELEASED body forward, so its later corpse lands on the new floor', () => {
+    const { sim, leader, victim, run } = enterAsParty();
+    const body = kill(sim, victim);
+    expect(body.ghost, 'no release yet: still a body on the floor').toBe(false);
+    expect(body.corpsePos, 'an unreleased body has stamped no corpse').toBeFalsy();
+
+    openDescent(sim, run);
+    descendRift(sim.ctx, leader);
+
+    const newFloorOrigin = riftInstanceOrigin(run.slot, 1);
+    expect(
+      Math.abs(body.pos.z - newFloorOrigin.z),
+      'the dead body rode the descent with the party',
+    ).toBeLessThan(160);
+
+    // Releasing now stamps the corpse where the body actually is: the NEW floor.
+    sim.releaseSpirit(victim);
+    expect(body.ghost).toBe(true);
+    expect(riftInstanceAtPos(sim.ctx, body.corpsePos!), 'corpse in the live region').toBe(run);
+  });
+
+  it('gives the moved corpse and every descender their OWN position object', () => {
+    // The descent resolves ONE arrival point and hands it to the whole party plus any
+    // moved corpse. Sharing that Vec3 by reference instead of cloning it would tie a
+    // corpse marker to a living player's position: the first step off the entry would
+    // drag the corpse along, and a corpse run could never end. Nothing else in the
+    // suite can see that, because aliased objects START with equal values, so this
+    // asserts identity and then MUTATES to prove the values are genuinely independent.
+    const { sim, leader, victim, run } = enterAsParty();
+    const body = kill(sim, victim);
+    sim.releaseSpirit(victim);
+    const leaderEntity = sim.entities.get(leader)!;
+
+    openDescent(sim, run);
+    descendRift(sim.ctx, leader);
+
+    const corpse = body.corpsePos!;
+    expect(corpse, 'the corpse is not the leader position object').not.toBe(leaderEntity.pos);
+    expect(corpse, 'nor the leader prevPos object').not.toBe(leaderEntity.prevPos);
+    expect(leaderEntity.pos, 'pos and prevPos are distinct objects').not.toBe(leaderEntity.prevPos);
+
+    // Walking away must not drag the corpse (or prevPos) with it.
+    const corpseX = corpse.x;
+    leaderEntity.pos.x += 25;
+    expect(body.corpsePos!.x, 'the corpse stayed put').toBe(corpseX);
+    expect(leaderEntity.prevPos.x, 'prevPos stayed put').not.toBe(leaderEntity.pos.x);
+  });
+
+  it('restores LOOT-ROLL eligibility for the graveyard-parked ghost (stated, not incidental)', () => {
+    // A CONSEQUENCE of moving the corpse, pinned here so it is deliberate rather than
+    // silent. combat/damage.ts uses a released member's corpsePos as their kill-time
+    // participation position within PARTY_XP_RANGE, on purpose ("releasing during the
+    // final seconds does not erase XP, loot-roll, or Heroic Mark rights"), and for a
+    // rift the instance arm of that check never binds (instanceClaimIdAt scans dungeon
+    // slots only), so the corpse arm always applies. That rule already held WITHIN a
+    // floor; before this fix a descent silently revoked it by stranding the corpse
+    // 340u back. Restoring it is the point, but it does mean a ghost parked at an
+    // overworld graveyard keeps loot rights on kills near each new floor's entry.
+    //
+    // Asserted on lootRecipientIds, NOT on xp: RIFT_MIN_LEVEL equals MAX_LEVEL (both
+    // 20), so every rift participant is at the cap by construction and the xp half of
+    // that credit is always zero inside a rift. Loot and Mark rights are what the arm
+    // actually decides here.
+    const { sim, leader, victim, run } = enterAsParty();
+    const body = kill(sim, victim);
+    sim.releaseSpirit(victim);
+    openDescent(sim, run);
+    descendRift(sim.ctx, leader);
+    expect(isRiftPos(body.pos.x), 'the ghost itself is out in the overworld').toBe(false);
+
+    const corpse = body.corpsePos!;
+    const mob = run.mobIds.map((id) => sim.entities.get(id)).find((m) => m && !m.dead)!;
+    mob.pos = { x: corpse.x + 5, y: corpse.y, z: corpse.z };
+    expect(dist2d(mob.pos, corpse)).toBeLessThanOrEqual(PARTY_XP_RANGE);
+
+    const leaderEntity = sim.entities.get(leader)!;
+    sim.dealDamage(leaderEntity, mob, 999999, false, 'physical', 'Strike', 'hit', true);
+    expect(mob.dead, 'the mob died to the living member').toBe(true);
+    expect(
+      mob.lootRecipientIds,
+      'the ghost is a kill-time loot recipient through their moved corpse',
+    ).toContain(victim);
+  });
+
+  it('leaves a corpse OUTSIDE the torn-down floor alone', () => {
+    const { sim, leader, victim, run } = enterAsParty();
+    // A corpse from an earlier overworld death: it belongs to no rift floor, so the
+    // descent must not drag it into the rift band. Pins the region test itself, not
+    // just "some corpse moved".
+    const body = sim.entities.get(victim)!;
+    const overworldCorpse = { x: 12, y: 0, z: -34 };
+    body.dead = true;
+    body.ghost = true;
+    body.corpsePos = { ...overworldCorpse };
+
+    openDescent(sim, run);
+    descendRift(sim.ctx, leader);
+
+    expect(run.floorIndex).toBe(1);
+    expect(body.corpsePos, 'an off-floor corpse is untouched').toEqual(overworldCorpse);
+  });
+});


### PR DESCRIPTION
## Summary

**Re-land of #2977**, which merged on 2026-08-06 at 08:43 UTC and was reverted five hours later by `5755412d30` ("Revert \"merge: PR #2977 into release\""). That revert carried no review comment, no revert PR, and an auto-generated message, and it landed in a cluster alongside reverts of #2982 and #2960 (with #2983, #2884, #2953, #2932, #2911 and others rolled back in the same window). It reads as branch churn rather than a defect in this change, so this re-lands it unchanged.

The code is a clean cherry-pick: `src/sim/rift/runs.ts` is byte-identical to the original base and nothing has touched it since the revert, so there were no conflicts. Re-verified in full on the current tip.

### The bug

A rift party member who is dead when the group descends a floor has their corpse orphaned on the floor left behind, making the corpse run impossible.

Rift floors are separate z-stacked regions (`RIFT_FLOOR_SPACING = 340`, detection regions `+/-160`, deliberately non-overlapping). A rift death sends the ghost OUT to an overworld graveyard (the rift arm of `ghostGraveyard` in `src/sim/spirit.ts`) and leaves the body on the floor. `descendRift` advanced `inst.floorIndex` and never touched `corpsePos`, while `enterRift` always lands a returning ghost on the CURRENT floor. Measured gap after one descent: **340u against a 35u `CORPSE_REZ_RANGE`**. The abandoned region holds no live instance either (`riftInstanceAtPos` returns null there), so it has no beacon and no exit portal.

This is not a design rule: the corpse run is a first-class flow here. `enterRift` has a dedicated dead-entry arm with anti-zerg combat gating, and `tests/rift_portals.test.ts` already pins "a ghost member re-enters a WON run for their corpse instead of forced rez sickness". Nothing covered descent-while-dead.

### The fix

On descent, sweep the run's whole roster (`inst.memberIds`, not just the positional descenders, because the member who gets stranded is precisely the one NOT standing in the region) and re-anchor any `corpsePos` still inside the floor being torn down to the new floor's entry.

Both death states are handled, by different routes:
- **Released spirit** carries `corpsePos` and waits outside at a graveyard, so only the new sweep saves it. This is the actual bug.
- **Unreleased body** already rides the descent as an ordinary descender and stamps its corpse on arrival. That already worked; it is pinned here as a regression guard, not as new behavior.

### Secondary effect, stated deliberately

Moving the corpse also restores kill-time **loot-roll and Heroic Mark rights**. `src/sim/combat/damage.ts` uses a released member's `corpsePos` as their participation position within `PARTY_XP_RANGE`, by design ("releasing during the final seconds does not erase XP, loot-roll, or Heroic Mark rights"), and for a rift the instance arm of that check never binds (`instanceClaimIdAt` scans dungeon slots only), so the corpse arm always applies. That rule already held within a floor; a descent had been silently revoking it via the same orphaning bug. It is pinned by a test so it reads as deliberate.

Note this is **loot and Marks only, never XP**: `RIFT_MIN_LEVEL` equals `MAX_LEVEL` (both 20), so every rift participant is at the cap by construction and the XP half is always zero inside a rift.

### Known gaps, deliberately not fixed here

Two other routes reach the same orphaned corpse without a descent. Both are documented in the code comment rather than left silent:

1. A member who **logged out while dead** has no live entity to sweep; their `corpsePos` persists and reloads onto the abandoned floor.
2. A run that ends by **expiry or a lost race** tears down without moving anything.

Also adjacent and not touched: `leaveRift` bails on `r.e.dead`, and both the beacon and the exit portal route through it, so a ghost who re-enters a rift cannot walk back out. This fix makes that far less reachable (the corpse is now on the floor they land on) but does not remove it.

## Related issues

Re-lands #2977. Found while investigating a player report.

## Type of change

- [x] Bug fix

## How was this tested?

Everything below was re-run on the current base (`ab86e9adfe`), not carried over from the original PR.

- Commands:
  - `npx vitest run tests/rift_corpse_descent.test.ts` (5 tests) - passed.
  - 14 rift and adjacent suites (`rift_binding`, `rift_sim`, `rift_portals`, `rift_race`, `rift_combat_exit`, `rift_infernal`, `rift_mechanics`, `rift_progression`, `rift_deeds`, `architecture`, `instance_exit_memory`, `professions_session_teardown`, `server/community_rifts`): **215 passed**.
  - `npx vitest run tests/parity`: **193 passed, 1 skipped**. This phase draws no rng, so no golden moved and none was regenerated.
  - `npx tsc --noEmit`: clean.
  - `npx @biomejs/biome ci` on both changed files: **0 errors** (`ci`, not `check`: only `ci` fails on format diffs).
  - `node scripts/gate_select.mjs`: every step passed. The run exits 1 on the **sanctioned teardown-rpc known flake**, not a test failure: all 887 test files and 14,132 tests passed, with `Errors  2 errors`, both of them `EnvironmentTeardownError: [vitest-worker]: Closing rpc while \"onUserConsoleLog\" was pending` originating in `tests/town_focus_repaint_gate.test.ts` (unrelated to this diff, which adds no logging). Confirmed by the repo's own detector rather than by eye: `isTeardownRpcFlake({ status: 1, tail })` from `scripts/lib/teardown_rpc_flake.mjs` returns `true` for this log, which is the exact predicate `ci_leg_runner.mjs` auto-retries on.

- Decisiveness check: the **aliasing** assertion was re-verified to fail on the real regression on this base. Replacing `{ ...entryPos }` with a bare `= entryPos` turns the new test red; restoring it turns it green. Without that test the whole suite stays green with the aliasing bug present.

- Manual steps: none. Sim-only change with no visual surface, so no screenshots.

## Checklist

### Quality

- [x] Tests added for the changed behavior, with the decisiveness of the fragile one verified by deliberately reintroducing the bug. `gate_select` green.

### Cross-platform

- [x] N/A. `src/sim/` only, no UI surface.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings. `tests/localization_fixes.test.ts` passes.

### Hygiene

- [x] No secrets, no `ALLOW_DEV_COMMANDS`, no hand-edited generated files.
