### PR TITLE
perf(main): overlap boot-time locale fetch with deferred asset preload

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1238,25 +1238,30 @@ async function startGame(
   // now reads as checkpoint=assets-await instead of masquerading as a scene-build
   // death (start() stamps scene-build-start; the real one is re-stamped below).
   entryDiagnostics.checkpoint('assets-await', baseEntryDiagnostics());
+  // Open the deferred preload lane BEFORE the locale fetch below, not after: the
+  // world's assets are local bundle files while the locale/deed chunks are a real
+  // network request, so starting both together overlaps two independent boot-time
+  // fetches instead of paying their durations back to back. This must still run
+  // before the assetsReady() await further down, which snapshots the task list, so
+  // the Renderer still cannot outrun a load (the world's assets do not fetch at
+  // module import any more, because decoding them merely to show the LAUNCHER
+  // crossed WKWebView's per-process ceiling: a 12 GB iPhone 17 Pro was killed
+  // 1.6 s in and reloaded forever).
+  const deferredStarted = beginDeferredPreloads();
+  console.info(`[entry-guard] world assets: started ${deferredStarted} deferred preloads`);
   // Lazy locale flip: fetch the active locale's chunk (plus the deed locale chunk the HUD's
   // deed surfaces read) and make both resident before the HUD renders (mountGameUi ->
   // translatePage fans out hundreds of t() calls). It sits behind the loading screen (already
   // painted above), so a stored non-en visitor never sees an English flash. This is now a
   // REAL per-locale network request, so guard it: startGame is void-invoked (see the call
   // sites) with no .catch, and English is always resident, so a failed fetch must fall back
-  // to English and keep booting rather than reject unhandled.
+  // to English and keep booting rather than reject unhandled. Runs concurrently with the
+  // deferred asset preloads started just above.
   try {
     await Promise.all([ensureLocaleLoaded(getLanguage()), ensureDeedLocalesLoaded(getLanguage())]);
   } catch {
     // Soft fallback: English is statically resident; boot in English (the picker can retry).
   }
-  // Open the deferred preload lane: the world's assets do not fetch at module
-  // import any more, because decoding them merely to show the LAUNCHER crossed
-  // WKWebView's per-process ceiling (a 12 GB iPhone 17 Pro was killed 1.6 s in and
-  // reloaded forever). This must run BEFORE the await below, which snapshots the
-  // task list, so the Renderer still cannot outrun a load.
-  const deferredStarted = beginDeferredPreloads();
-  console.info(`[entry-guard] world assets: started ${deferredStarted} deferred preloads`);
   try {
     await assetsReady((done, total) => setLoadingProgressRange(done, total, 0, 35));
   } catch (err) {

--- a/tests/defer_launcher_preloads.test.ts
+++ b/tests/defer_launcher_preloads.test.ts
@@ -118,6 +118,18 @@ describe('startGame wiring', () => {
     expect(awaitAt).toBeGreaterThan(beginAt);
     expect(rendererAt).toBeGreaterThan(awaitAt);
   });
+
+  // The locale/deed chunk fetch and the deferred world-asset preloads are
+  // independent boot-time network/decode phases (one remote, one bundled
+  // local). Opening the deferred lane before awaiting the locale fetch lets
+  // both run concurrently instead of paying their durations back to back;
+  // opening it after would silently reintroduce the serialization.
+  it('opens the deferred preload lane BEFORE awaiting the locale fetch', () => {
+    const beginAt = mainSource.indexOf('beginDeferredPreloads()');
+    const localeAwaitAt = mainSource.indexOf('await Promise.all([ensureLocaleLoaded(');
+    expect(beginAt).toBeGreaterThan(-1);
+    expect(localeAwaitAt).toBeGreaterThan(beginAt);
+  });
 });
 
 describe('editor viewport wiring', () => {


### PR DESCRIPTION
## Summary
- Overlap two independent boot-time fetches instead of running them back to back: the deferred world-asset preload lane (`beginDeferredPreloads()`, local bundle files) now opens *before* the locale/deed-locale chunk fetch is awaited, instead of after. Previously `startGame()` fully awaited the locale fetch and only then started the world-asset preloads that gate the Renderer, serializing a real network request ahead of local decode work that has zero dependency on it.
- No behavior change: the Renderer is still constructed only after `assetsReady()` resolves, the deferred lane still opens strictly before that await (pinned by `tests/defer_launcher_preloads.test.ts`), and a failed locale fetch still soft-falls back to English.

## Why
`docs/performance-feel-audit.md` already covers the heavy asset-budget/LOD/deferred-preload work on this boot path. This closes a smaller, previously-unaddressed gap: the locale-chunk network round trip and the deferred asset preloads were needlessly serialized on the critical path to first playable frame, for every player regardless of locale or device.

## Boot sequence, before vs after

```mermaid
sequenceDiagram
    participant P as Player
    participant M as startGame() (main.ts)
    participant L as locale/deed chunk fetch (network)
    participant A as deferred asset preload (local GLB/texture decode)
    participant R as new Renderer(...)

    Note over M,A: Before: serialized
    P->>M: Enter World
    M->>L: await locale + deed chunk fetch
    L-->>M: resolved (or soft English fallback)
    M->>A: beginDeferredPreloads()
    M->>A: await assetsReady()
    A-->>M: resolved
    M->>R: construct Renderer

    Note over M,A: After: overlapped
    P->>M: Enter World
    M->>A: beginDeferredPreloads() (starts local decode immediately)
    par locale fetch
        M->>L: await locale + deed chunk fetch
        L-->>M: resolved (or soft English fallback)
    and asset decode
        A-->>A: local GLB/texture/HDR decode running concurrently
    end
    M->>A: await assetsReady()
    A-->>M: resolved
    M->>R: construct Renderer
```

## Change
- `src/main.ts`: reorder `beginDeferredPreloads()` to run before `await Promise.all([ensureLocaleLoaded(...), ensureDeedLocalesLoaded(...)])` in `startGame()`.
- `tests/defer_launcher_preloads.test.ts`: new pin asserting the deferred preload lane opens before the locale-fetch await, so the overlap can't silently regress back to serialized fetches.

## Screenshots
Not applicable: this is a pure timing/ordering change with no rendering or UI diff (verified: nothing else in the diff touches `render/`, `ui/`, or `styles/`), so before/after screenshots would be pixel-identical.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx vitest run tests/defer_launcher_preloads.test.ts` (11/11, including the new pin)
- [x] `npx vitest run tests/entry_crash_guard.test.ts tests/entry_diagnostics.test.ts tests/entry_guard_banner.test.ts tests/entry_window_parity.test.ts tests/ios_entry_diagnostics.test.ts tests/ios_entry_memory.test.ts tests/perf_tour_entry.test.ts tests/i18n_pseudo_locale.test.ts` (93/93)
- [x] `npx @biomejs/biome check --write` on changed files (no diffs)
- [x] `npm run gate` (full CI-equivalent gate): 2 pre-existing, unrelated failures reproduced identically on unmodified `release/v0.35.0` (`tests/ci_shard_plan.test.ts` battleground-file-naming assumption, and a `tests/professions_fishing.test.ts` timeout that passes when run in isolation, i.e. flaky under full-suite contention). Neither touches `main.ts`, the preload registry, or locale loading.
- [x] Pre-push QA floor (`.githooks/pre-push`: `tsc`, guard tests, biome, copy scan) green on push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)