### PR TITLE
perf(mail): index the Ravenpost book and gate the mail wire field

### DIFF
--- a/server/game.ts
+++ b/server/game.ts
@@ -568,6 +568,24 @@ const MARKET_WIRE_PROMPT_CMDS = new Set<string>([
   'market_cancel',
   'market_collect',
 ]);
+// Ravenpost mailbox readout cadence, the market gate applied to `mail`: the
+// view is a full projection of the viewer's delivered letters (bodies
+// included) that used to re-serialize at 20 Hz for anyone standing at a raven
+// pillar, and nothing in it carries a sub-second clock. On top of the cadence,
+// a rebuild-only-on-change gate (sim.mailRevFor) skips the rebuild while
+// nothing changed; MAIL_REFRESH_TICKS is its staleness backstop, and the
+// viewer's OWN mail commands re-arm the gate so their take/delete/read
+// feedback still lands on the next snapshot. The always-streamed O(1) `mailU`
+// envelope count is deliberately NOT gated.
+const MAIL_WIRE_HZ = 4;
+const MAIL_WIRE_INTERVAL_TICKS = Math.max(1, Math.round(1 / (DT * MAIL_WIRE_HZ)));
+const MAIL_REFRESH_TICKS = 40;
+const MAIL_WIRE_PROMPT_CMDS = new Set<string>([
+  'mail_send',
+  'mail_take',
+  'mail_delete',
+  'mail_read',
+]);
 
 type ClientMessage = Record<string, unknown> & {
   ability?: string;
@@ -941,6 +959,12 @@ export interface ClientSession {
   lastMarketBrowseRev: number | null;
   lastMarketQueryRef: MarketQuery | null;
   lastMarketRebuildTick: number;
+  // Ravenpost mailbox readout, the market shape at its own cadence
+  // (MAIL_WIRE_HZ): the sim mail revision last built for and the tick of the
+  // last rebuild (the MAIL_REFRESH_TICKS staleness backstop's tracker).
+  lastMailWireTick: number;
+  lastMailRev: number | null;
+  lastMailRebuildTick: number;
   // set when a command or sim event that can change a heavy self field (bags,
   // gear, quests, talents, stats, ...) lands for this session, so the next
   // snapshot re-diffs those fields. Otherwise they're skipped (see
@@ -2112,6 +2136,9 @@ export class GameServer {
     moderator.lastMarketBrowseRev = null;
     moderator.lastMarketQueryRef = null;
     moderator.lastMarketRebuildTick = 0;
+    moderator.lastMailWireTick = -MAIL_WIRE_INTERVAL_TICKS;
+    moderator.lastMailRev = null;
+    moderator.lastMailRebuildTick = 0;
     moderator.sentEnts.clear();
     // force the heavy self block (tal/inv/equip/bags/...) to re-run next
     // snapshot: it is gated on meta.wireRev vs session.lastWireRev, and that
@@ -2146,6 +2173,9 @@ export class GameServer {
     moderator.lastMarketBrowseRev = null;
     moderator.lastMarketQueryRef = null;
     moderator.lastMarketRebuildTick = 0;
+    moderator.lastMailWireTick = -MAIL_WIRE_INTERVAL_TICKS;
+    moderator.lastMailRev = null;
+    moderator.lastMailRebuildTick = 0;
     moderator.sentEnts.clear();
     // same as enterSpectate: force the heavy self block to re-run so the
     // moderator's OWN talents/inventory/equip/etc. resend immediately
@@ -3557,6 +3587,9 @@ export class GameServer {
       lastMarketBrowseRev: null,
       lastMarketQueryRef: null,
       lastMarketRebuildTick: 0,
+      lastMailWireTick: -MAIL_WIRE_INTERVAL_TICKS,
+      lastMailRev: null,
+      lastMailRebuildTick: 0,
       selfHeavyDirty: true,
       lastWireRev: -1,
       sentEnts: new Map(),
@@ -6138,6 +6171,12 @@ export class GameServer {
     if (typeof msg.cmd === 'string' && MARKET_WIRE_PROMPT_CMDS.has(msg.cmd)) {
       session.lastMarketWireTick = -MARKET_WIRE_INTERVAL_TICKS;
     }
+    // Same re-arm for the viewer's own mail commands (send/take/delete/read):
+    // their mailbox feedback lands on the next snapshot instead of waiting out
+    // the MAIL_WIRE_HZ cadence.
+    if (typeof msg.cmd === 'string' && MAIL_WIRE_PROMPT_CMDS.has(msg.cmd)) {
+      session.lastMailWireTick = -MAIL_WIRE_INTERVAL_TICKS;
+    }
     switch (command) {
       case 'castSlot':
         if (typeof msg.slot === 'number') sim.castAbilityBySlot(msg.slot | 0, pid);
@@ -8460,7 +8499,32 @@ export class GameServer {
     // the lightweight collect-indicator bit streams ALWAYS (the mailU pattern),
     // so the minimap badge lights anywhere while proceeds/items wait
     maybe('mktU', this.sim.marketCollectPendingFor(anchorSession.pid) ? 1 : 0);
-    maybe('mail', this.sim.mailInfoFor(anchorSession.pid));
+    // The Ravenpost mailbox view rides the market gate's exact shape: on the
+    // MAIL_WIRE_HZ cadence (re-armed by the viewer's own mail commands), only
+    // when the sim's mail revision moved since the last build, with
+    // MAIL_REFRESH_TICKS as the staleness backstop. The full projection
+    // (letter bodies included) used to re-serialize at 20 Hz for every player
+    // at a raven pillar; nothing in it carries a sub-second clock. Null (not
+    // at a pillar) still ships promptly on the cadence so the window closes.
+    const mailDue =
+      this.sim.tickCount - session.lastMailWireTick >= MAIL_WIRE_INTERVAL_TICKS ||
+      sent.mail === undefined;
+    if (mailDue) {
+      session.lastMailWireTick = this.sim.tickCount;
+      const mailRev = this.sim.mailRevFor(anchorSession.pid);
+      if (mailRev === null) {
+        maybe('mail', null);
+        session.lastMailRev = null;
+      } else if (
+        sent.mail === undefined ||
+        mailRev !== session.lastMailRev ||
+        this.sim.tickCount - session.lastMailRebuildTick >= MAIL_REFRESH_TICKS
+      ) {
+        session.lastMailRebuildTick = this.sim.tickCount;
+        maybe('mail', this.sim.mailInfoFor(anchorSession.pid));
+        session.lastMailRev = mailRev;
+      }
+    }
     maybe('mailU', this.sim.mailUnreadFor(anchorSession.pid));
     // bank info is null unless the player is standing at a banker, so it only
     // rides the wire for players actually browsing their deposit box (the mail

--- a/src/sim/mail/mail_index.ts
+++ b/src/sim/mail/mail_index.ts
@@ -1,0 +1,156 @@
+// The Ravenpost's derived lookup state: per-recipient letter buckets, the
+// delivered-and-unread counts, and the in-flight set, kept in lockstep with the
+// canonical book (PostOffice.mail) by routing every membership or key mutation
+// through this class. Extracted so the book reads that used to scan the whole
+// global array per player per tick (deliveredFor, storedCountFor,
+// mailboxHoldsItem: the production broadcast hot spot on a grown book) become
+// bucket lookups, the same treatment mailUnreadFor's unread index already got
+// (Finding 4). The book array itself stays canonical on PostOffice: iteration
+// order, the expiry sweep, and the mailArrived emit order are untouched, and
+// everything here is derived, rebuilt from the book on load, never persisted.
+//
+// Contract: PostOffice calls track(m) after adding a letter to the book,
+// untrack(m) before splicing one out, rekey(m, newKey) for a recipient change,
+// and markRead(m) for the read flip; a mutation that re-arms delivery or the
+// read flag wholesale (the return flight) brackets its field writes with
+// untrack/track. Bucket order is book order per bucket; readers must not
+// depend on cross-bucket order (every current consumer sorts on a total order,
+// finds by unique id, or counts).
+//
+// `src/sim`-pure and clock-free: sim time is passed into every call, no rng,
+// no imports beyond types (enforced by tests/architecture.test.ts).
+
+// The three letter fields the index accounts by. Structural (not the concrete
+// MailMessage) so the unit test drives the index with minimal fakes.
+export interface IndexedLetter {
+  recipientKey: string;
+  read: boolean;
+  deliverAt: number;
+}
+
+// Shared empty result for recipients with no letters; never mutated.
+const EMPTY_BUCKET: never[] = [];
+
+export class MailIndex<M extends IndexedLetter> {
+  // Every letter in the book, bucketed by its recipientKey (each letter has
+  // exactly one key, so buckets never overlap and a dual-key read is a clean
+  // union). Bucket arrays hold letters in book (insertion) order.
+  private buckets = new Map<string, M[]>();
+  // Delivered-and-unread counts per recipientKey (the mailUnreadFor read).
+  private unread = new Map<string, number>();
+  // The small set of still-in-flight letters, so a delivery transition updates
+  // the unread count at the exact tick the old per-call scan would have.
+  private undelivered = new Set<M>();
+
+  // Fold a freshly booked or loaded letter in: an already-due letter counts as
+  // unread now (unless read); one still on the wing waits in `undelivered`
+  // until deliverDue lands it.
+  track(m: M, now: number): void {
+    this.bucketAdd(m);
+    if (now >= m.deliverAt) {
+      if (!m.read) this.inc(m.recipientKey);
+    } else {
+      this.undelivered.add(m);
+    }
+  }
+
+  // Drop a letter's every contribution (the sweep/delete arm, and the first
+  // half of an untrack/track mutation bracket).
+  untrack(m: M, now: number): void {
+    this.bucketRemove(m);
+    if (!m.read && now >= m.deliverAt) this.dec(m.recipientKey);
+    this.undelivered.delete(m);
+  }
+
+  // Recipient change (rename rekey, purge normalization): moves the letter's
+  // bucket entry and its delivered-and-unread contribution, then stamps the
+  // new key on the letter. A same-key call refreshes nothing and costs nothing.
+  rekey(m: M, newKey: string, now: number): void {
+    if (m.recipientKey === newKey) return;
+    this.bucketRemove(m);
+    if (!m.read && now >= m.deliverAt) {
+      this.dec(m.recipientKey);
+      this.inc(newKey);
+    }
+    m.recipientKey = newKey;
+    this.bucketAdd(m);
+  }
+
+  // The read flip (mailTake, mailMarkRead): drops the letter's unread
+  // contribution once and marks it read. Callers only reach delivered letters
+  // (deliveredFor gates them), so the deliverAt guard is belt-and-braces.
+  markRead(m: M, now: number): void {
+    if (m.read) return;
+    if (now >= m.deliverAt) this.dec(m.recipientKey);
+    m.read = true;
+  }
+
+  // Per-tick: land any in-flight letter whose delivery time has arrived,
+  // moving it from `undelivered` into the unread count. Returns how many
+  // landed so the caller can advance its wire revision only when the visible
+  // mailbox contents actually changed. Draws no rng and emits nothing (the
+  // arrival toast stays on its own per-second cadence in PostOffice.update()),
+  // so it never perturbs the deterministic event/rng stream.
+  deliverDue(now: number): number {
+    if (this.undelivered.size === 0) return 0;
+    let landed = 0;
+    for (const m of this.undelivered) {
+      if (now < m.deliverAt) continue;
+      this.undelivered.delete(m);
+      if (!m.read) this.inc(m.recipientKey);
+      landed++;
+    }
+    return landed;
+  }
+
+  // Rebuild everything from the canonical book (after a deserialize/load, so
+  // none of this state is ever persisted).
+  rebuild(book: readonly M[], now: number): void {
+    this.buckets.clear();
+    this.unread.clear();
+    this.undelivered.clear();
+    for (const m of book) this.track(m, now);
+  }
+
+  // Delivered-and-unread count for one key bucket (callers union the stable
+  // key and the display name themselves, exactly as mailUnreadFor documents).
+  unreadFor(key: string): number {
+    return this.unread.get(key) ?? 0;
+  }
+
+  // Every letter addressed to this key, delivered or not, in book order.
+  // A live read-only view: callers filter/copy, never mutate.
+  bucketFor(key: string): readonly M[] {
+    return this.buckets.get(key) ?? EMPTY_BUCKET;
+  }
+
+  // Stored-letter count for one key (the mailbox-full gate).
+  countFor(key: string): number {
+    return this.buckets.get(key)?.length ?? 0;
+  }
+
+  private bucketAdd(m: M): void {
+    const bucket = this.buckets.get(m.recipientKey);
+    if (bucket) bucket.push(m);
+    else this.buckets.set(m.recipientKey, [m]);
+  }
+
+  private bucketRemove(m: M): void {
+    const bucket = this.buckets.get(m.recipientKey);
+    if (!bucket) return;
+    const i = bucket.indexOf(m);
+    if (i < 0) return;
+    if (bucket.length === 1) this.buckets.delete(m.recipientKey);
+    else bucket.splice(i, 1);
+  }
+
+  private inc(key: string): void {
+    this.unread.set(key, (this.unread.get(key) ?? 0) + 1);
+  }
+
+  private dec(key: string): void {
+    const next = (this.unread.get(key) ?? 0) - 1;
+    if (next > 0) this.unread.set(key, next);
+    else this.unread.delete(key);
+  }
+}

--- a/src/sim/mail/post_office.ts
+++ b/src/sim/mail/post_office.ts
@@ -46,6 +46,7 @@ import {
   type InvSlot,
   type MailResultCode,
 } from '../types';
+import { MailIndex } from './mail_index';
 
 const MAIL_RANGE = INTERACT_RANGE + 2; // you must stand at a raven pillar to tend your post
 export const MAIL_POSTAGE = 30; // copper per letter
@@ -127,17 +128,41 @@ export class PostOffice {
   // to tend your post.
   mailboxIds: number[] = [];
 
-  // Finding 4 (perf): a maintained count of delivered-and-unread letters per
-  // recipientKey (the same key deliveredFor/belongsTo match on). mailUnreadFor
-  // reads it in O(1) rather than scanning the whole book once per online session
-  // per tick. `undelivered` is the small set of still-in-flight letters, so a
-  // delivery transition updates the index at the exact tick the old scan would
-  // have counted it. Both are derived state, rebuilt from the book on load and
+  // Finding 4 (perf), extended: the derived lookup state (per-recipient letter
+  // buckets, the delivered-and-unread counts, the in-flight set) lives in
+  // MailIndex, kept in lockstep by routing every membership or recipient-key
+  // mutation through it. deliveredFor/storedCountFor/mailboxHoldsItem read
+  // buckets, and mailUnreadFor reads the maintained count, instead of scanning
+  // the whole global book per player per call (the production broadcast hot
+  // spot on a grown book). Derived state only: rebuilt from the book on load,
   // never persisted.
-  private unreadIndex = new Map<string, number>();
-  private undelivered = new Set<MailMessage>();
+  private index = new MailIndex<MailMessage>();
+
+  // Wire revision: advances on every mutation a mailbox view can observe
+  // (booking, a delivery landing, expiry/return, take, read, delete, rekey,
+  // purge, load), so the server's snapshot gate rebuilds a viewer's
+  // mailInfoFor only when something actually changed (the market browseRev
+  // pattern). Every wire-reachable mutating verb must ride a bump or the gate
+  // serves a stale view; tests/mail_wire_cache.test.ts pins each one.
+  private rev = 0;
 
   constructor(private readonly ctx: SimContext) {}
+
+  private bumpRev(): void {
+    this.rev++;
+  }
+
+  // The change signal the server's snapshot gate polls instead of rebuilding
+  // the mailbox view every tick: null while this player is not at a raven
+  // pillar (the same gate mailInfoFor applies), else the current revision.
+  // Server-only, never IWorld (the market browseRevFor precedent).
+  mailRevFor(pid: number): number | null {
+    const meta = this.ctx.players.get(pid);
+    const e = this.ctx.entities.get(pid);
+    if (!meta || !e) return null;
+    if (!this.nearMailbox(e)) return null;
+    return this.rev;
+  }
 
   // Public tick entry: the Sim tick calls this in the end-of-tick system block
   // (after market.update()). Once a second: land due letters, prune expired ones.
@@ -146,8 +171,11 @@ export class PostOffice {
     // time into the unread index, so mailUnreadFor stays byte-identical to the
     // former per-call scan at the exact tick (never a per-second lag). Iterates
     // only the small in-flight set, not the whole book, and touches no rng/event
-    // stream (the arrival toast keeps its own per-second cadence below).
-    this.deliverDue();
+    // stream (the arrival toast keeps its own per-second cadence below). A
+    // landing changes what mailInfoFor shows purely by time passing, so it is
+    // a rev bump like any other mutation (the wire gate would otherwise serve
+    // the pre-landing view until its staleness backstop).
+    if (this.index.deliverDue(this.ctx.time) > 0) this.bumpRev();
     if (this.ctx.tickCount % 20 !== 0) return;
     const now = this.ctx.time;
     for (let i = this.mail.length - 1; i >= 0; i--) {
@@ -173,19 +201,20 @@ export class PostOffice {
       if (m.kind === 'player' && now >= m.expiresAt && (m.items.length > 0 || m.copper > 0)) {
         if (m.returned) {
           // The one sanctioned destruction: the return flight already happened.
-          if (!m.read && now >= m.deliverAt) this.indexDec(m.recipientKey);
-          this.undelivered.delete(m);
+          this.index.untrack(m, now);
           this.mail.splice(i, 1);
+          this.bumpRev();
         } else {
           this.returnToSender(m, now);
         }
         continue;
       }
       if (now >= m.expiresAt && m.items.length === 0 && m.copper <= 0) {
-        // A delivered-and-unread letter that expires leaves the unread index.
-        if (!m.read && now >= m.deliverAt) this.indexDec(m.recipientKey);
-        this.undelivered.delete(m);
+        // An expired letter leaves the buckets and, if delivered-and-unread,
+        // the unread count (untrack re-derives both from the letter's state).
+        this.index.untrack(m, now);
         this.mail.splice(i, 1);
+        this.bumpRev();
       }
     }
   }
@@ -203,9 +232,11 @@ export class PostOffice {
   // always stable-id by construction (booked that way, or by a prior return),
   // so a letter that bounces back and forth stays stable-id-keyed on both ends.
   private returnToSender(m: MailMessage, now: number): void {
-    // Move the delivered-and-unread contribution out of the old bucket
-    // (exactly what the index counts; the rekeyMailOwner shape).
-    if (!m.read && now >= m.deliverAt) this.indexDec(m.recipientKey);
+    // A wholesale mutation (recipient, read flag, delivery re-arm), so it is
+    // bracketed with untrack/track: every index contribution (bucket, unread
+    // count, in-flight set) is dropped under the old state and re-derived from
+    // the new one (the MailIndex contract).
+    this.index.untrack(m, now);
     const homeKey = m.senderKey ?? m.senderName;
     const homeName = m.senderName;
     m.senderKey = m.recipientKey;
@@ -219,7 +250,8 @@ export class PostOffice {
     m.deliverAt = now + MAIL_DELIVERY_SECONDS;
     // The second window: one more chance to claim, then the sweep deletes.
     m.expiresAt = now + MAIL_ATTACHMENT_EXPIRY_SECONDS;
-    this.trackDelivery(m);
+    this.index.track(m, now);
+    this.bumpRev();
   }
 
   private nearMailbox(e: Entity): boolean {
@@ -239,11 +271,14 @@ export class PostOffice {
   // mailbox and nowhere else). The quest re-grant predicate
   // (quests/quest_item_presence.ts) reads this: an item waiting in the
   // mailbox is recoverable through mailTake, so a re-accept must not mint a
-  // duplicate. Pure read, no rng, no mutation.
+  // duplicate. Pure read, no rng, no mutation; a bucket union (the dual-key
+  // rule) instead of the whole-book scan it replaced.
   mailboxHoldsItem(meta: PlayerMeta, itemId: string): boolean {
-    return this.mail.some(
-      (m) => this.belongsTo(m, meta) && m.items.some((s) => s.itemId === itemId && s.count > 0),
-    );
+    const holds = (m: MailMessage): boolean =>
+      m.items.some((s) => s.itemId === itemId && s.count > 0);
+    const key = this.mailKeyFor(meta);
+    if (this.index.bucketFor(key).some(holds)) return true;
+    return meta.name !== key && this.index.bucketFor(meta.name).some(holds);
   }
 
   // Structured outcome (the lockpick convention: the sim emits data only, the
@@ -264,68 +299,29 @@ export class PostOffice {
     return null;
   }
 
-  private belongsTo(m: MailMessage, meta: PlayerMeta): boolean {
-    return m.recipientKey === this.mailKeyFor(meta) || m.recipientKey === meta.name;
-  }
-
+  // Everything delivered to this player, via the bucket union (their stable
+  // mail key plus their display name, the historical belongsTo dual-key rule).
+  // A letter carries exactly one recipientKey, so the buckets never overlap
+  // and the union is duplicate-free. Cross-bucket order can differ from book
+  // order only when a player has legacy name-keyed letters; every consumer is
+  // order-insensitive (mailInfoFor sorts on a total order, take/read find by
+  // unique id, the rest count), pinned by tests/mail_index.test.ts and the
+  // mail suites. The ordering invariant the old per-call scan documented still
+  // holds: update() (which lands due letters) runs to completion inside tick()
+  // before any mail command or snapshot read observes a newly-due letter.
   private deliveredFor(meta: PlayerMeta): MailMessage[] {
     const now = this.ctx.time;
-    return this.mail.filter((m) => this.belongsTo(m, meta) && now >= m.deliverAt);
+    const key = this.mailKeyFor(meta);
+    const out: MailMessage[] = [];
+    for (const m of this.index.bucketFor(key)) if (now >= m.deliverAt) out.push(m);
+    if (meta.name !== key) {
+      for (const m of this.index.bucketFor(meta.name)) if (now >= m.deliverAt) out.push(m);
+    }
+    return out;
   }
 
   private storedCountFor(key: string, name: string): number {
-    return this.mail.reduce(
-      (n, m) => n + (m.recipientKey === key || m.recipientKey === name ? 1 : 0),
-      0,
-    );
-  }
-
-  private indexInc(key: string): void {
-    this.unreadIndex.set(key, (this.unreadIndex.get(key) ?? 0) + 1);
-  }
-
-  private indexDec(key: string): void {
-    const next = (this.unreadIndex.get(key) ?? 0) - 1;
-    if (next > 0) this.unreadIndex.set(key, next);
-    else this.unreadIndex.delete(key);
-  }
-
-  // Fold a freshly booked or loaded letter into the unread index and the
-  // in-flight set: an already-due letter counts as unread now (unless read); one
-  // still on the wing waits in `undelivered` until deliverDue lands it.
-  private trackDelivery(m: MailMessage): void {
-    if (this.ctx.time >= m.deliverAt) {
-      if (!m.read) this.indexInc(m.recipientKey);
-    } else {
-      this.undelivered.add(m);
-    }
-  }
-
-  // Per-tick: land any in-flight letter whose delivery time has arrived, moving
-  // it from `undelivered` into the unread index. Draws no rng and emits nothing
-  // (the arrival toast stays on its own per-second cadence in update()), so it
-  // never perturbs the deterministic event/rng stream. Correctness rests on the
-  // ordering invariant that update() (which calls this) runs to completion inside
-  // tick() before any mail command or mailUnreadFor observes a newly-due letter:
-  // tick() invokes no mail mutator mid-loop, and all commands/snapshots run
-  // between ticks, so a command's deliveredFor never sees a due-but-unfolded
-  // letter that indexDec could turn into a phantom under-count.
-  private deliverDue(): void {
-    if (this.undelivered.size === 0) return;
-    const now = this.ctx.time;
-    for (const m of this.undelivered) {
-      if (now < m.deliverAt) continue;
-      this.undelivered.delete(m);
-      if (!m.read) this.indexInc(m.recipientKey);
-    }
-  }
-
-  // Rebuild the unread index + in-flight set from the current book (used after a
-  // deserialize/load so neither is ever persisted).
-  private rebuildUnreadIndex(): void {
-    this.unreadIndex.clear();
-    this.undelivered.clear();
-    for (const m of this.mail) this.trackDelivery(m);
+    return this.index.countFor(key) + (name !== key ? this.index.countFor(name) : 0);
   }
 
   mailUnreadFor(pid: number): number {
@@ -338,8 +334,8 @@ export class PostOffice {
     const meta = this.ctx.players.get(pid);
     if (!meta) return 0;
     const key = this.mailKeyFor(meta);
-    let unread = this.unreadIndex.get(key) ?? 0;
-    if (meta.name !== key) unread += this.unreadIndex.get(meta.name) ?? 0;
+    let unread = this.index.unreadFor(key);
+    if (meta.name !== key) unread += this.index.unreadFor(meta.name);
     return unread;
   }
 
@@ -592,10 +588,10 @@ export class PostOffice {
     }
     m.items = kept;
     // Tending the letter marks it read (drops it from the unread index once).
-    if (!m.read) {
-      this.indexDec(m.recipientKey);
-      m.read = true;
-    }
+    this.index.markRead(m, this.ctx.time);
+    // One bump covers every take outcome (coin collected, parcels granted or
+    // kept, the read flip): each changes what mailInfoFor shows.
+    this.bumpRev();
     if (kept.length > 0) {
       // Attachments remain: expiresAt is untouched here, so the letter's
       // existing clock keeps running. That is Infinity for system/npc mail
@@ -622,21 +618,23 @@ export class PostOffice {
       this.result(meta.entityId, 'tooFar');
       return;
     }
-    const idx = this.mail.findIndex(
-      (x) => x.id === mailId && this.belongsTo(x, meta) && this.ctx.time >= x.deliverAt,
-    );
-    if (idx < 0) {
+    // Same match the old whole-book findIndex made (id + ownership +
+    // delivered), resolved through the buckets; the book splice still needs
+    // the array position, and a user-command-rate indexOf is fine.
+    const m = this.deliveredFor(meta).find((x) => x.id === mailId);
+    if (!m) {
       this.result(meta.entityId, 'letterGone');
       return;
     }
-    const m = this.mail[idx];
     if (m.items.length > 0 || m.copper > 0) {
       this.result(meta.entityId, 'takeParcelsFirst');
       return;
     }
-    // A delivered-and-unread letter deleted before it is read leaves the index.
-    if (!m.read) this.indexDec(m.recipientKey);
-    this.mail.splice(idx, 1);
+    // A delivered-and-unread letter deleted before it is read leaves the
+    // unread count too (untrack re-derives every contribution).
+    this.index.untrack(m, this.ctx.time);
+    this.mail.splice(this.mail.indexOf(m), 1);
+    this.bumpRev();
   }
 
   mailMarkRead(mailId: number, pid?: number): void {
@@ -644,8 +642,8 @@ export class PostOffice {
     if (!r) return;
     const m = this.deliveredFor(r.meta).find((x) => x.id === mailId);
     if (m && !m.read) {
-      this.indexDec(m.recipientKey);
-      m.read = true;
+      this.index.markRead(m, this.ctx.time);
+      this.bumpRev();
     }
   }
 
@@ -737,7 +735,8 @@ export class PostOffice {
       announced: false,
     };
     this.mail.push(msg);
-    this.trackDelivery(msg);
+    this.index.track(msg, this.ctx.time);
+    this.bumpRev();
   }
 
   mailInfoFor(pid: number): import('../../world_api').MailInfo | null {
@@ -802,15 +801,10 @@ export class PostOffice {
       }
       if (m.recipientKey === key || m.recipientKey === oldName || m.recipientKey === newName) {
         if (m.recipientKey !== key || m.recipientName !== newName) changed = true;
-        const oldKey = m.recipientKey;
-        // Move this letter's unread contribution from its old key bucket to the
-        // stable id key when the key actually changes (delivered-and-unread only,
-        // matching exactly what the index counts).
-        if (oldKey !== key && !m.read && this.ctx.time >= m.deliverAt) {
-          this.indexDec(oldKey);
-          this.indexInc(key);
-        }
-        m.recipientKey = key;
+        // Move this letter's bucket entry and its unread contribution to the
+        // stable id key when the key actually changes (the MailIndex rekey
+        // contract: delivered-and-unread only, a same-key call is a no-op).
+        this.index.rekey(m, key, this.ctx.time);
         m.recipientName = newName;
       }
       // The escrowed payloads follow their owner through the rename the same
@@ -827,6 +821,7 @@ export class PostOffice {
         }
       }
     }
+    if (changed) this.bumpRev();
     return changed;
   }
 
@@ -893,27 +888,24 @@ export class PostOffice {
         // Normalize a legacy name-keyed address to the stable id BEFORE the
         // flight: returnToSender records the outgoing address as the new
         // senderKey, and that field must never hold a reclaimable display
-        // name (its own comment promises stable-id by construction). Move
-        // the letter's delivered-and-unread contribution with the key (the
-        // rekeyMailOwner shape), because returnToSender's own decrement
-        // reads the field this walk just overwrote; without the move the
-        // name bucket keeps a phantom unread the freed name's next holder
-        // reads forever. No CURRENT producer books a name-keyed unreturned
-        // player letter (returns set `returned`, sends key by id), so this
-        // arm serves blobs loadMail preserves verbatim: legacy defense,
-        // same standing as the dual-key purge arms themselves.
-        if (m.recipientKey !== key && !m.read && now >= m.deliverAt) {
-          this.indexDec(m.recipientKey);
-          this.indexInc(key);
-        }
-        m.recipientKey = key;
+        // name (its own comment promises stable-id by construction). The
+        // index rekey moves the letter's bucket entry and its
+        // delivered-and-unread contribution with the key, because
+        // returnToSender's own untrack reads the field this walk just
+        // overwrote; without the move the name bucket keeps a phantom entry
+        // the freed name's next holder reads forever. No CURRENT producer
+        // books a name-keyed unreturned player letter (returns set
+        // `returned`, sends key by id), so this arm serves blobs loadMail
+        // preserves verbatim: legacy defense, same standing as the dual-key
+        // purge arms themselves.
+        this.index.rekey(m, key, now);
         this.returnToSender(m, now);
         continue;
       }
-      if (!m.read && now >= m.deliverAt) this.indexDec(m.recipientKey);
-      this.undelivered.delete(m);
+      this.index.untrack(m, now);
       this.mail.splice(i, 1);
     }
+    if (changed) this.bumpRev();
     return changed;
   }
 
@@ -1062,8 +1054,11 @@ export class PostOffice {
     const maxId = this.mail.reduce((mx, m) => Math.max(mx, m.id + 1), 1);
     this.nextMailId = Math.max(this.nextMailId, save.nextMailId ?? 1, maxId);
     for (const parcel of returnedParcels) this.book(parcel);
-    // The unread index is derived state, never persisted: rebuild it from the
-    // freshly loaded book.
-    this.rebuildUnreadIndex();
+    // Buckets, unread counts, and the in-flight set are derived state, never
+    // persisted: rebuild them from the freshly loaded book. The wire revision
+    // advances too (book() above already bumped for any returned parcel, but a
+    // plain load must invalidate viewers as well).
+    this.index.rebuild(this.mail, this.ctx.time);
+    this.bumpRev();
   }
 }

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -10707,6 +10707,13 @@ export class Sim {
     return this.postOffice.mailInfoFor(pid);
   }
 
+  // Server-only broadcast helper (never IWorld, the marketBrowseRevFor shape):
+  // the cheap change signal server/game.ts polls before paying for a
+  // mailInfoFor rebuild. Null while the player is not at a raven pillar.
+  mailRevFor(pid: number): number | null {
+    return this.postOffice.mailRevFor(pid);
+  }
+
   mailUnreadFor(pid: number): number {
     return this.postOffice.mailUnreadFor(pid);
   }

--- a/tests/mail.test.ts
+++ b/tests/mail.test.ts
@@ -903,7 +903,7 @@ describe('purgeMailOwner - deleting a character', () => {
     // phantom-producing seed evaporates and the pin below turns vacuous.
     tickFor(sim, MAIL_DELIVERY_SECONDS + 2);
     // biome-ignore lint/suspicious/noExplicitAny: read the raw index directly.
-    expect((sim.postOffice as any).unreadIndex.get('Doomed')).toBe(1);
+    expect((sim.postOffice as any).index.unread.get('Doomed')).toBe(1);
     expect(sim.purgeMailOwner(DOOMED_ID, 'Doomed')).toBe(true);
     // The parcel flew home to its live sender rather than being destroyed.
     const flown = letterBy(sim, (m) => m.subject === 'LegacyDelivered', 'returned parcel');
@@ -915,7 +915,7 @@ describe('purgeMailOwner - deleting a character', () => {
     // here), and the next holder of the name reads exactly the truth (their
     // own welcome letter, nothing inherited).
     // biome-ignore lint/suspicious/noExplicitAny: read the raw index directly.
-    expect((sim.postOffice as any).unreadIndex.has('Doomed')).toBe(false);
+    expect((sim.postOffice as any).index.unread.has('Doomed')).toBe(false);
     const nextHolder = sim.addPlayer('mage', 'Doomed', { characterId: 999 });
     expect(sim.mailUnreadFor(nextHolder)).toBe(unreadOracle(sim, nextHolder));
     expect(sim.mailUnreadFor(alice)).toBe(unreadOracle(sim, alice));
@@ -1143,7 +1143,7 @@ describe('purgeMailOwner - deleting a character', () => {
 
     expect(sim.purgeMailOwner(DOOMED_ID, 'Doomed')).toBe(true);
     // biome-ignore lint/suspicious/noExplicitAny: the in-flight set is module-private.
-    const undelivered = (sim.postOffice as any).undelivered as Set<unknown>;
+    const undelivered = (sim.postOffice as any).index.undelivered as Set<unknown>;
     expect(undelivered.has(note)).toBe(false);
     // Flying past the old delivery time must not resurrect it in the unread index.
     tickFor(sim, MAIL_DELIVERY_SECONDS + 2);

--- a/tests/mail_index.test.ts
+++ b/tests/mail_index.test.ts
@@ -1,0 +1,211 @@
+// MailIndex (src/sim/mail/mail_index.ts): the Ravenpost's derived lookup state
+// (per-recipient buckets, delivered-and-unread counts, the in-flight set).
+// Drives the index with minimal fake letters against a naive full-scan
+// reference model (an independent oracle, the market_browse_cache shape): after
+// every scripted mutation, bucketFor/countFor/unreadFor must agree with a scan
+// of the canonical book, so the bucketed reads can never drift from the
+// full-array scans they replaced.
+
+import { describe, expect, it } from 'vitest';
+import { type IndexedLetter, MailIndex } from '../src/sim/mail/mail_index';
+
+interface FakeLetter extends IndexedLetter {
+  id: number;
+}
+
+function letter(
+  id: number,
+  recipientKey: string,
+  opts: { read?: boolean; deliverAt?: number } = {},
+): FakeLetter {
+  return {
+    id,
+    recipientKey,
+    read: opts.read ?? false,
+    deliverAt: opts.deliverAt ?? 0,
+  };
+}
+
+// The naive reference: what the pre-index full scans computed from the book.
+function refBucket(book: FakeLetter[], key: string): FakeLetter[] {
+  return book.filter((m) => m.recipientKey === key);
+}
+
+function refUnread(book: FakeLetter[], key: string, now: number): number {
+  return book.filter((m) => m.recipientKey === key && !m.read && now >= m.deliverAt).length;
+}
+
+// Assert the index agrees with the reference model for every key present.
+function expectMatchesBook(index: MailIndex<FakeLetter>, book: FakeLetter[], now: number): void {
+  const keys = new Set(book.map((m) => m.recipientKey));
+  for (const key of keys) {
+    expect(index.bucketFor(key), `bucket ${key}`).toEqual(refBucket(book, key));
+    expect(index.countFor(key), `count ${key}`).toBe(refBucket(book, key).length);
+    expect(index.unreadFor(key), `unread ${key}`).toBe(refUnread(book, key, now));
+  }
+}
+
+describe('MailIndex buckets and unread counts', () => {
+  it('tracks delivered and in-flight letters under their recipient keys', () => {
+    const index = new MailIndex<FakeLetter>();
+    const book: FakeLetter[] = [];
+    const now = 100;
+    for (const m of [
+      letter(1, 'alice'),
+      letter(2, 'alice', { read: true }),
+      letter(3, 'bob'),
+      letter(4, 'alice', { deliverAt: 150 }), // still on the wing
+    ]) {
+      book.push(m);
+      index.track(m, now);
+    }
+    expectMatchesBook(index, book, now);
+    expect(index.unreadFor('alice')).toBe(1); // in-flight letter not counted yet
+    expect(index.countFor('alice')).toBe(3); // but it is stored in the bucket
+    expect(index.bucketFor('missing')).toEqual([]);
+    expect(index.unreadFor('missing')).toBe(0);
+  });
+
+  it('lands due letters through deliverDue and reports how many landed', () => {
+    const index = new MailIndex<FakeLetter>();
+    const book = [letter(1, 'alice', { deliverAt: 50 }), letter(2, 'bob', { deliverAt: 200 })];
+    for (const m of book) index.track(m, 0);
+    expect(index.unreadFor('alice')).toBe(0);
+    expect(index.deliverDue(40)).toBe(0);
+    expect(index.deliverDue(60)).toBe(1); // alice's letter lands, bob's still flies
+    expectMatchesBook(index, book, 60);
+    expect(index.deliverDue(60)).toBe(0); // idempotent: nothing new to land
+    expect(index.deliverDue(250)).toBe(1); // bob's lands
+    expectMatchesBook(index, book, 250);
+  });
+
+  it('untrack removes every contribution: bucket, unread count, in-flight set', () => {
+    const index = new MailIndex<FakeLetter>();
+    const now = 100;
+    const delivered = letter(1, 'alice');
+    const inFlight = letter(2, 'alice', { deliverAt: 150 });
+    const read = letter(3, 'alice', { read: true });
+    const book = [delivered, inFlight, read];
+    for (const m of book) index.track(m, now);
+
+    index.untrack(inFlight, now);
+    book.splice(book.indexOf(inFlight), 1);
+    expectMatchesBook(index, book, now);
+    // The untracked in-flight letter never lands.
+    expect(index.deliverDue(200)).toBe(0);
+
+    index.untrack(delivered, now);
+    book.splice(book.indexOf(delivered), 1);
+    expectMatchesBook(index, book, now);
+    expect(index.unreadFor('alice')).toBe(0);
+
+    index.untrack(read, now);
+    expect(index.countFor('alice')).toBe(0);
+    expect(index.bucketFor('alice')).toEqual([]);
+  });
+
+  it('rekey moves the bucket entry and the unread contribution to the new key', () => {
+    const index = new MailIndex<FakeLetter>();
+    const now = 100;
+    const unreadLetter = letter(1, 'Ghost');
+    const readLetter = letter(2, 'Ghost', { read: true });
+    const flying = letter(3, 'Ghost', { deliverAt: 150 });
+    const book = [unreadLetter, readLetter, flying];
+    for (const m of book) index.track(m, now);
+
+    index.rekey(unreadLetter, '7', now);
+    index.rekey(readLetter, '7', now);
+    index.rekey(flying, '7', now);
+    expect(unreadLetter.recipientKey).toBe('7');
+    expectMatchesBook(index, book, now);
+    expect(index.unreadFor('Ghost')).toBe(0);
+    expect(index.unreadFor('7')).toBe(1); // the read and in-flight letters do not count
+    expect(index.countFor('7')).toBe(3);
+
+    // The rekeyed in-flight letter still lands, under the new key.
+    expect(index.deliverDue(200)).toBe(1);
+    expect(index.unreadFor('7')).toBe(2);
+  });
+
+  it('rekey to the same key is a no-op', () => {
+    const index = new MailIndex<FakeLetter>();
+    const m = letter(1, 'alice');
+    index.track(m, 100);
+    const bucketBefore = index.bucketFor('alice');
+    index.rekey(m, 'alice', 100);
+    expect(index.bucketFor('alice')).toBe(bucketBefore);
+    expect(index.unreadFor('alice')).toBe(1);
+  });
+
+  it('markRead drops the unread contribution exactly once', () => {
+    const index = new MailIndex<FakeLetter>();
+    const now = 100;
+    const m = letter(1, 'alice');
+    const other = letter(2, 'alice');
+    const book = [m, other];
+    for (const x of book) index.track(x, now);
+    expect(index.unreadFor('alice')).toBe(2);
+
+    index.markRead(m, now);
+    expect(m.read).toBe(true);
+    expect(index.unreadFor('alice')).toBe(1);
+    index.markRead(m, now); // repeat is a no-op
+    expect(index.unreadFor('alice')).toBe(1);
+    expectMatchesBook(index, book, now);
+  });
+
+  it('an untrack/track bracket re-accounts a wholesale mutation (the return flight)', () => {
+    const index = new MailIndex<FakeLetter>();
+    const now = 100;
+    const m = letter(1, 'bob', { read: true });
+    const book = [m];
+    index.track(m, now);
+    expect(index.unreadFor('bob')).toBe(0);
+
+    // The return flight: back to the sender, unread again, delivery re-armed.
+    index.untrack(m, now);
+    m.recipientKey = 'alice';
+    m.read = false;
+    m.deliverAt = now + 45;
+    index.track(m, now);
+
+    expectMatchesBook(index, book, now);
+    expect(index.countFor('bob')).toBe(0);
+    expect(index.countFor('alice')).toBe(1);
+    expect(index.unreadFor('alice')).toBe(0); // on the wing again
+    expect(index.deliverDue(now + 50)).toBe(1);
+    expect(index.unreadFor('alice')).toBe(1);
+  });
+
+  it('rebuild reconstructs everything from the canonical book', () => {
+    const index = new MailIndex<FakeLetter>();
+    const now = 100;
+    // Seed with junk state that a rebuild must wipe.
+    index.track(letter(99, 'stale'), now);
+    const book = [
+      letter(1, 'alice'),
+      letter(2, 'alice', { read: true }),
+      letter(3, 'bob', { deliverAt: 150 }),
+    ];
+    index.rebuild(book, now);
+    expectMatchesBook(index, book, now);
+    expect(index.countFor('stale')).toBe(0);
+    expect(index.unreadFor('stale')).toBe(0);
+    // The rebuilt in-flight set still lands bob's letter.
+    expect(index.deliverDue(200)).toBe(1);
+    expect(index.unreadFor('bob')).toBe(1);
+  });
+
+  it('bucket order is book (insertion) order', () => {
+    const index = new MailIndex<FakeLetter>();
+    const a = letter(1, 'alice');
+    const b = letter(2, 'alice');
+    const c = letter(3, 'alice');
+    for (const m of [a, b, c]) index.track(m, 0);
+    expect(index.bucketFor('alice').map((m) => m.id)).toEqual([1, 2, 3]);
+    index.untrack(b, 0);
+    expect(index.bucketFor('alice').map((m) => m.id)).toEqual([1, 3]);
+    index.track(b, 0);
+    expect(index.bucketFor('alice').map((m) => m.id)).toEqual([1, 3, 2]);
+  });
+});

--- a/tests/mail_wire_cache.test.ts
+++ b/tests/mail_wire_cache.test.ts
@@ -1,0 +1,257 @@
+// The Ravenpost mail revision (src/sim/mail/post_office.ts mailRevFor): the
+// change signal the server's snapshot gate polls before paying for a
+// mailInfoFor rebuild (the market browseRev shape). Pins three claims:
+//   1. the signal is null away from a raven pillar and a number beside one,
+//      and holds steady across idle ticks while nothing changes;
+//   2. every wire-reachable mutating verb advances it (booking, the delivery
+//      landing, take, read, delete, the expiry sweep, the return flight,
+//      rekey, purge, load), so a rebuild-only-on-change gate can never serve
+//      a stale mailbox;
+//   3. the bucketed deliveredFor union serves the same view the old
+//      whole-book scan produced, dual-key (legacy name-keyed) letters
+//      included, against an independent full-scan oracle.
+import { describe, expect, it } from 'vitest';
+import { BUILTIN_WORLD } from '../src/sim/data';
+import { MAIL_DELIVERY_SECONDS, MAIL_POSTAGE } from '../src/sim/mail/post_office';
+import { Sim } from '../src/sim/sim';
+import type { SimEvent, WorldContent } from '../src/sim/types';
+
+// Mailboxes are system-owned and still spawn with this fixture (the mail.test
+// convention): ambient camps, NPCs and quest objects are irrelevant to the
+// revision signal and would turn every simulated minute into an AI benchmark.
+const MAIL_TEST_WORLD: WorldContent = {
+  ...BUILTIN_WORLD,
+  camps: [],
+  npcs: {},
+  groundObjects: [],
+};
+
+const makeWorld = () =>
+  new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true, world: MAIL_TEST_WORLD });
+
+function moveToMailbox(sim: Sim, pid: number): void {
+  const box = sim.entities.get(sim.postOffice.mailboxIds[0]);
+  const p = sim.entities.get(pid);
+  if (!box || !p) throw new Error('missing mailbox or player');
+  p.pos = { ...box.pos };
+  p.prevPos = { ...p.pos };
+  sim.rebucket(p);
+}
+
+function moveAwayFromMailboxes(sim: Sim, pid: number): void {
+  const p = sim.entities.get(pid);
+  if (!p) throw new Error('missing player');
+  p.pos = sim.groundPos(50, 0);
+  p.prevPos = { ...p.pos };
+  sim.rebucket(p);
+}
+
+function tickFor(sim: Sim, seconds: number): SimEvent[] {
+  const out: SimEvent[] = [];
+  for (let i = 0; i < Math.ceil(seconds * 20); i++) out.push(...sim.tick());
+  return out;
+}
+
+// The raw revision counter, position-independent (mailRevFor gates on the
+// pillar; the mutation pins must not depend on where the mutating player is).
+// biome-ignore lint/suspicious/noExplicitAny: read the module-private counter.
+const rawRev = (sim: Sim): number => (sim.postOffice as any).rev;
+
+// biome-ignore lint/suspicious/noExplicitAny: the book is module-internal.
+const bookOf = (sim: Sim): any[] => (sim.postOffice as any).mail;
+
+function makeSender(sim: Sim, name = 'Alice'): number {
+  const pid = sim.addPlayer('warrior', name);
+  const meta = sim.meta(pid);
+  if (!meta) throw new Error('no meta');
+  meta.copper = 10_000;
+  moveToMailbox(sim, pid);
+  return pid;
+}
+
+describe('the mail revision signal (mailRevFor)', () => {
+  it('is null away from a raven pillar and a number beside one', () => {
+    const sim = makeWorld();
+    const pid = sim.addPlayer('warrior', 'Postie');
+    // The town spawn point sits within mail range of its pillar, so walk out
+    // of range first: the null arm must be pinned away from every mailbox.
+    moveAwayFromMailboxes(sim, pid);
+    expect(sim.mailRevFor(pid)).toBeNull();
+    moveToMailbox(sim, pid);
+    expect(typeof sim.mailRevFor(pid)).toBe('number');
+    expect(sim.mailRevFor(pid)).toBe(rawRev(sim));
+    expect(sim.mailRevFor(999_999)).toBeNull(); // unknown pid stays null
+  });
+
+  it('holds steady across idle ticks while nothing changes', () => {
+    const sim = makeWorld();
+    const pid = sim.addPlayer('warrior', 'Postie');
+    moveToMailbox(sim, pid);
+    // Settle the welcome letter's announce sweep first (announced is a
+    // runtime flag, not a view change, and must not advance the revision).
+    tickFor(sim, 2);
+    const rev = rawRev(sim);
+    tickFor(sim, 5);
+    expect(rawRev(sim)).toBe(rev);
+  });
+
+  it('advances on booking, on the delivery landing, and on take/read/delete', () => {
+    const sim = makeWorld();
+    const alice = makeSender(sim);
+    const bob = sim.addPlayer('mage', 'Bob');
+    tickFor(sim, 2);
+
+    // Booking: the sender pays postage, the letter enters the book in flight.
+    let rev = rawRev(sim);
+    sim.mailSendResolved({ key: String(bob), name: 'Bob' }, 'Note', 'Words.', 0, [], alice);
+    expect(rawRev(sim)).toBeGreaterThan(rev);
+
+    // The landing: no command runs, yet the recipient's view changes the tick
+    // the raven arrives, so the revision must move again (the deliverDue arm).
+    rev = rawRev(sim);
+    tickFor(sim, MAIL_DELIVERY_SECONDS + 2);
+    expect(rawRev(sim)).toBeGreaterThan(rev);
+
+    // Take (the welcome letter's coin), read, then delete, each from the box.
+    moveToMailbox(sim, bob);
+    const info = sim.mailInfoFor(bob);
+    if (!info) throw new Error('no mailbox view');
+    const note = info.messages.find((m) => m.subject === 'Note');
+    const welcome = info.messages.find((m) => m.letterId === 'ravenpost_welcome');
+    if (!note || !welcome) throw new Error('missing letters');
+
+    rev = rawRev(sim);
+    sim.mailTake(welcome.id, bob);
+    expect(rawRev(sim)).toBeGreaterThan(rev);
+
+    rev = rawRev(sim);
+    sim.mailMarkRead(note.id, bob);
+    expect(rawRev(sim)).toBeGreaterThan(rev);
+    rev = rawRev(sim);
+    sim.mailMarkRead(note.id, bob); // already read: no view change, no bump
+    expect(rawRev(sim)).toBe(rev);
+
+    rev = rawRev(sim);
+    sim.mailDelete(note.id, bob);
+    expect(rawRev(sim)).toBeGreaterThan(rev);
+  });
+
+  it('advances when the sweep expires a letter and when a parcel flies home', () => {
+    const sim = makeWorld();
+    const alice = makeSender(sim);
+    const bob = sim.addPlayer('mage', 'Bob');
+    sim.mailSendResolved({ key: String(bob), name: 'Bob' }, 'Plain', 'Words.', 0, [], alice);
+    sim.mailSendResolved({ key: String(bob), name: 'Bob' }, 'Coin', 'Yours.', 300, [], alice);
+    tickFor(sim, MAIL_DELIVERY_SECONDS + 2);
+
+    // Force the bare note past its window: the sweep deletes it.
+    const plain = bookOf(sim).find((m) => m.subject === 'Plain');
+    if (!plain) throw new Error('missing note');
+    plain.expiresAt = sim.time;
+    let rev = rawRev(sim);
+    tickFor(sim, 2);
+    expect(bookOf(sim).some((m) => m.subject === 'Plain')).toBe(false);
+    expect(rawRev(sim)).toBeGreaterThan(rev);
+
+    // Force the coin parcel past its attachment window: it flies home to
+    // Alice (returnToSender), which changes BOTH mailboxes' views.
+    const coin = bookOf(sim).find((m) => m.subject === 'Coin');
+    if (!coin) throw new Error('missing parcel');
+    coin.expiresAt = sim.time;
+    rev = rawRev(sim);
+    tickFor(sim, 2);
+    expect(bookOf(sim).find((m) => m.subject === 'Coin')?.returned).toBe(true);
+    expect(rawRev(sim)).toBeGreaterThan(rev);
+  });
+
+  it('advances on rekey and purge only when something actually changed', () => {
+    const sim = makeWorld();
+    const alice = makeSender(sim);
+    sim.mailSendResolved({ key: 'Ghost', name: 'Ghost' }, 'Hi', 'There.', 0, [], alice);
+    tickFor(sim, MAIL_DELIVERY_SECONDS + 2);
+
+    let rev = rawRev(sim);
+    expect(sim.rekeyMailOwner(777, 'Nobody', 'StillNobody')).toBe(false);
+    expect(rawRev(sim)).toBe(rev); // no letter touched: no bump
+
+    rev = rawRev(sim);
+    expect(sim.rekeyMailOwner(777, 'Ghost', 'Spook')).toBe(true);
+    expect(rawRev(sim)).toBeGreaterThan(rev);
+
+    rev = rawRev(sim);
+    expect(sim.purgeMailOwner(888, 'NobodyEither')).toBe(false);
+    expect(rawRev(sim)).toBe(rev);
+
+    rev = rawRev(sim);
+    expect(sim.purgeMailOwner(777, 'Spook')).toBe(true);
+    expect(rawRev(sim)).toBeGreaterThan(rev);
+  });
+
+  it('advances on load, and the loaded book serves bucketed reads', () => {
+    const sim = makeWorld();
+    const alice = makeSender(sim);
+    // A legacy name-keyed letter (the pre-stable-id shape a persisted blob can
+    // carry): sim2's Bob has a different entity id, so it is the name-bucket
+    // half of the rebuilt dual-key union that must find it after the load.
+    sim.mailSendResolved({ key: 'Bob', name: 'Bob' }, 'Kept', 'Words.', 0, [], alice);
+    tickFor(sim, MAIL_DELIVERY_SECONDS + 2);
+    const save = JSON.parse(JSON.stringify(sim.serializeMail()));
+
+    const sim2 = makeWorld();
+    const bob2 = sim2.addPlayer('mage', 'Bob');
+    const rev = rawRev(sim2);
+    sim2.loadMail(save);
+    expect(rawRev(sim2)).toBeGreaterThan(rev);
+    moveToMailbox(sim2, bob2);
+    const info = sim2.mailInfoFor(bob2);
+    expect(info?.messages.some((m) => m.subject === 'Kept')).toBe(true);
+  });
+});
+
+describe('bucketed deliveredFor vs the whole-book scan', () => {
+  it('serves the same view the old scan produced, dual-key letters included', () => {
+    const sim = makeWorld();
+    const alice = makeSender(sim);
+    const bob = sim.addPlayer('mage', 'Bob');
+    const bobMeta = sim.meta(bob);
+    if (!bobMeta) throw new Error('no meta');
+    // One letter on the stable id key, one legacy letter keyed by display
+    // name: the union must show both, the old belongsTo dual-key rule.
+    sim.mailSendResolved({ key: String(bob), name: 'Bob' }, 'ById', 'Words.', 0, [], alice);
+    sim.mailSendResolved({ key: 'Bob', name: 'Bob' }, 'ByName', 'Words.', 0, [], alice);
+    // A stranger's letter must stay invisible to Bob.
+    sim.mailSendResolved({ key: 'Someone', name: 'Someone' }, 'Other', 'Words.', 0, [], alice);
+    tickFor(sim, MAIL_DELIVERY_SECONDS + 2);
+
+    // The pre-index pipeline, reimplemented as the oracle: filter the whole
+    // book on the dual key + delivered, count and collect ids.
+    const now = sim.time;
+    const key = String(bobMeta.characterId ?? bobMeta.entityId);
+    const oracle = bookOf(sim)
+      .filter(
+        (m) => (m.recipientKey === key || m.recipientKey === bobMeta.name) && now >= m.deliverAt,
+      )
+      .map((m) => m.id)
+      .sort((a, b) => a - b);
+
+    moveToMailbox(sim, bob);
+    const info = sim.mailInfoFor(bob);
+    if (!info) throw new Error('no mailbox view');
+    expect(info.totalCount).toBe(oracle.length);
+    expect(info.messages.map((m) => m.id).sort((a, b) => a - b)).toEqual(oracle);
+    expect(info.messages.some((m) => m.subject === 'ById')).toBe(true);
+    expect(info.messages.some((m) => m.subject === 'ByName')).toBe(true);
+    expect(info.messages.some((m) => m.subject === 'Other')).toBe(false);
+    // The unread count agrees with the same oracle's unread half.
+    expect(sim.mailUnreadFor(bob)).toBe(
+      bookOf(sim).filter(
+        (m) =>
+          (m.recipientKey === key || m.recipientKey === bobMeta.name) &&
+          !m.read &&
+          now >= m.deliverAt,
+      ).length,
+    );
+    // Postage really was charged per letter (three sends).
+    expect(sim.meta(alice)?.copper).toBe(10_000 - 3 * MAIL_POSTAGE);
+  });
+});

--- a/tests/mail_wire_cadence.test.ts
+++ b/tests/mail_wire_cadence.test.ts
@@ -1,0 +1,184 @@
+// The `mail` self key's cadence + rebuild-only-on-change gate (the market
+// gate's shape applied to the Ravenpost). The expensive call is
+// sim.mailInfoFor (the full mailbox projection, letter bodies included, which
+// used to re-serialize at 20 Hz for every player at a raven pillar), so the
+// decisive pin is a SPY on it: within the MAIL_WIRE_HZ cadence the server
+// polls the cheap mail revision and must not rebuild while nothing changed; a
+// book change, the delivery landing, the viewer's own mail command, and the
+// staleness backstop each bring exactly the rebuilds they promise.
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../server/db', () => ({
+  pool: { query: vi.fn(async () => ({ rows: [] })) },
+  saveCharacterState: vi.fn(async () => {}),
+  saveCharacterAndMarketState: vi.fn(async () => {}),
+  saveMarketState: vi.fn(async () => {}),
+  saveMailState: vi.fn(async () => {}),
+  loadMarketState: vi.fn(async () => null),
+  loadMailState: vi.fn(async () => null),
+  openPlaySession: vi.fn(async () => 1),
+  touchCharacterLogin: vi.fn(async () => {}),
+  closePlaySession: vi.fn(async () => {}),
+  insertChatLogs: vi.fn(async () => {}),
+  walletForAccount: vi.fn(async () => null),
+  markAccountQuestComplete: vi.fn(async () => ({ completedQuestIds: [], mechChromaIds: [] })),
+  grantAccountMechChroma: vi.fn(async () => ({ completedQuestIds: [], mechChromaIds: [] })),
+  revokeAccountMechChroma: vi.fn(async () => ({ completedQuestIds: [], mechChromaIds: [] })),
+  insertBankLedgerRow: vi.fn(async () => {}),
+  acquireCharacterLease: vi.fn(async () => true),
+  releaseCharacterLease: vi.fn(async () => {}),
+  heartbeatCharacterLeases: vi.fn(async () => {}),
+  releaseAllCharacterLeases: vi.fn(async () => {}),
+  setCharacterHotbarLayout: vi.fn(async () => {}),
+}));
+
+import { type ClientSession, GameServer } from '../server/game';
+import { groundHeight } from '../src/sim/world';
+import { broadcast, type FakeClient, fakeWs, joinServer, lastSnap } from './helpers/bare_client';
+
+// Mirrors MAIL_WIRE_HZ = 4 / MAIL_REFRESH_TICKS in server/game.ts.
+const MAIL_WIRE_INTERVAL_TICKS = 5;
+const MAIL_REFRESH_TICKS = 40;
+
+function placeAtMailbox(server: GameServer, pid: number): void {
+  const box = server.sim.entities.get(server.sim.postOffice.mailboxIds[0]);
+  if (!box) throw new Error('no mailbox spawned');
+  const e = server.sim.entities.get(pid);
+  if (!e) throw new Error(`missing entity ${pid}`);
+  e.pos.x = box.pos.x;
+  e.pos.z = box.pos.z;
+  e.pos.y = groundHeight(e.pos.x, e.pos.z, server.sim.cfg.seed);
+  e.prevPos = { ...e.pos };
+}
+
+function placeFarAway(server: GameServer, pid: number): void {
+  const e = server.sim.entities.get(pid);
+  if (!e) throw new Error(`missing entity ${pid}`);
+  e.pos.x = 400;
+  e.pos.z = 400;
+  e.pos.y = groundHeight(400, 400, server.sim.cfg.seed);
+  e.prevPos = { ...e.pos };
+}
+
+function duePass(server: GameServer): void {
+  for (let i = 0; i < MAIL_WIRE_INTERVAL_TICKS; i++) server.sim.tick();
+  broadcast(server);
+}
+
+function mailSnaps(sent: unknown[], from: number): unknown[] {
+  // biome-ignore lint/suspicious/noExplicitAny: untyped wire JSON, the harness idiom
+  return (sent as any[]).slice(from).filter((m) => m.t === 'snap' && m.self && 'mail' in m.self);
+}
+
+function mailboxServer(): { server: GameServer; fc: FakeClient; session: ClientSession } {
+  const server = new GameServer();
+  const fc = fakeWs();
+  const session = joinServer(server, fc, 71, 'Postie');
+  placeAtMailbox(server, session.pid);
+  return { server, fc, session };
+}
+
+describe('mail wire cadence + rebuild-only-on-change', () => {
+  it('rebuilds once for the join, then never again while nothing changes (until the backstop)', () => {
+    const { server, fc } = mailboxServer();
+    // Settle the welcome letter's announce sweep first: it flips a runtime
+    // flag, never the revision, and the pin below depends on that.
+    for (let i = 0; i < 40; i++) server.sim.tick();
+    const spy = vi.spyOn(server.sim, 'mailInfoFor');
+    broadcast(server);
+    expect(spy).toHaveBeenCalledTimes(1);
+    const first = lastSnap(fc.sent);
+    expect(first.self.mail).not.toBeNull();
+    expect(first.self.mail.messages.length).toBe(1); // the welcome letter
+
+    // Every due pass up to one interval SHORT of the backstop, with no book
+    // or position change: the gate polls the mail revision and skips the
+    // rebuild every time. The pre-fix behavior was one rebuild per TICK.
+    const passesToBackstop = Math.ceil(MAIL_REFRESH_TICKS / MAIL_WIRE_INTERVAL_TICKS);
+    const sent = fc.sent.length;
+    for (let pass = 0; pass < passesToBackstop - 1; pass++) duePass(server);
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(mailSnaps(fc.sent, sent)).toHaveLength(0); // nothing re-shipped either
+
+    // The next due pass crosses the staleness backstop: exactly one more
+    // rebuild lands (and, being unchanged, still elides from the wire).
+    duePass(server);
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(mailSnaps(fc.sent, sent)).toHaveLength(0);
+  });
+
+  it('a delivered letter reaches the viewer on their next due pass, with no command', () => {
+    const { server, fc, session } = mailboxServer();
+    broadcast(server);
+    const spy = vi.spyOn(server.sim, 'mailInfoFor');
+
+    // A second player mails the viewer, booked straight through the sim (the
+    // wire mail_send resolves recipients against the character DB, mocked
+    // empty here; the claim under test is the LANDING, not the send path).
+    // The letter rides the 45 s raven, so the viewer's view changes when it
+    // lands with NO command in between: the deliverDue revision bump is the
+    // only thing that can carry it through the gate.
+    const fc2 = fakeWs();
+    const sender = joinServer(server, fc2, 72, 'Scribe');
+    placeAtMailbox(server, sender.pid);
+    const senderMeta = server.sim.meta(sender.pid);
+    const viewerMeta = server.sim.meta(session.pid);
+    if (!senderMeta || !viewerMeta) throw new Error('missing meta');
+    senderMeta.copper = 10_000;
+    server.sim.mailSendResolved(
+      { key: server.sim.postOffice.mailKeyFor(viewerMeta), name: 'Postie' },
+      'Hi',
+      'There.',
+      0,
+      [],
+      sender.pid,
+    );
+
+    // Fly the raven home: 45 sim-seconds of ticks, broadcasting on cadence.
+    for (let i = 0; i < 46 * 20; i++) server.sim.tick();
+    const sent = fc.sent.length;
+    duePass(server);
+    const snaps = mailSnaps(fc.sent, sent);
+    expect(snaps).toHaveLength(1);
+    // biome-ignore lint/suspicious/noExplicitAny: untyped wire JSON
+    const messages = (snaps[0] as any).self.mail.messages;
+    expect(messages.some((m: { subject: string }) => m.subject === 'Hi')).toBe(true);
+    expect(spy.mock.calls.filter(([pid]) => pid === session.pid).length).toBeGreaterThan(0);
+  });
+
+  it("the viewer's own mail_read lands on the next snapshot, not a cadence later", () => {
+    const { server, fc, session } = mailboxServer();
+    broadcast(server);
+    const welcomeId = lastSnap(fc.sent).self.mail.messages[0].id;
+    server.sim.tick(); // one tick only: the plain cadence gate is NOT due yet
+
+    server.handleMessage(session, JSON.stringify({ t: 'cmd', cmd: 'mail_read', id: welcomeId }));
+    const sent = fc.sent.length;
+    broadcast(server);
+    const snaps = mailSnaps(fc.sent, sent);
+    expect(snaps).toHaveLength(1);
+    // biome-ignore lint/suspicious/noExplicitAny: untyped wire JSON
+    expect((snaps[0] as any).self.mail.messages[0].read).toBe(true);
+  });
+
+  it('walking away nulls the key at cadence; returning re-ships the full view', () => {
+    const { server, fc, session } = mailboxServer();
+    broadcast(server);
+
+    placeFarAway(server, session.pid);
+    let sent = fc.sent.length;
+    duePass(server);
+    let snaps = mailSnaps(fc.sent, sent);
+    expect(snaps).toHaveLength(1);
+    // biome-ignore lint/suspicious/noExplicitAny: untyped wire JSON
+    expect((snaps[0] as any).self.mail).toBeNull();
+
+    placeAtMailbox(server, session.pid);
+    sent = fc.sent.length;
+    duePass(server);
+    snaps = mailSnaps(fc.sent, sent);
+    expect(snaps).toHaveLength(1);
+    // biome-ignore lint/suspicious/noExplicitAny: untyped wire JSON
+    expect((snaps[0] as any).self.mail.messages.length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

The production CPU profile (30s, 28,221 samples, 2026-08-08) attributed roughly a quarter of all real work to the Ravenpost: `mailInfoFor` at 21.9% inclusive, with `belongsTo` the hottest single function in the process. Two compounding causes, both fixed here:

1. **Every mail read scanned the whole global book.** `deliveredFor`, `storedCountFor`, and `mailboxHoldsItem` filtered all 98k letters per player per call, recomputing `mailKeyFor` per message. New `src/sim/mail/mail_index.ts`: a `MailIndex` owning per-recipient buckets alongside the existing unread counts and in-flight set (the Finding 4 pattern, extended). Every membership, rekey, and read mutation routes through it; the reads become dual-key bucket unions. Behavior is byte-identical: the parity golden traces are untouched.

2. **The `mail` snapshot field re-serialized the full mailbox (letter bodies included) at 20 Hz** for anyone standing at a raven pillar; the delta cache suppressed only the send, never the stringify. It now rides the market gate's exact shape: `MAIL_WIRE_HZ = 4` cadence re-armed by the viewer's own mail commands, rebuild-only-on-change via a new `sim.mailRevFor` revision signal (bumped by every verb a mailbox view can observe, delivery landings included), and a 40-tick staleness backstop. The O(1) `mailU` envelope count deliberately stays per-tick.

Benchmark on a prod-shaped book (98,041 letters, 70k recipients): the old whole-book scan costs 1.58 ms per call, which is 31.6 ms/second per mailbox camper at 20 Hz; the bucketed path is 2.1 us per call (about 740x on the scan alone, before the wire gate removes most of the calls entirely).

Deliberately out of scope, per the investigation writeup: pagination of the unbounded `MailInfo` wire (the removed 50-cap), the immortal welcome-letter flow (`expiresAt = Infinity` on system mail with attachments), and any prod data cleanup of the existing 82k letters. Those are follow-ups.

## Type of change

- [x] Refactor or performance (no behavior change)
- [x] Tests

## How was this tested?

- Commands:
  - `node scripts/gate_select.mjs`: PASS, all 12 steps green
  - `npx vitest run tests/mail_index.test.ts tests/mail_wire_cache.test.ts tests/mail_wire_cadence.test.ts` (20 new tests: index-vs-full-scan oracle equivalence, a rev-bump pin per wire-reachable mutating verb, and the server gate's cadence/backstop/re-arm/walk-away behavior on a spied `mailInfoFor`)
  - `npx vitest run tests/mail.test.ts tests/mail_expiry.test.ts tests/mail_instance.test.ts tests/mail_block.test.ts tests/snapshots.test.ts tests/bandwidth.test.ts tests/parity tests/architecture.test.ts` plus the mailbox UI and characters suites: all green
  - Two `tests/mail.test.ts` probes of the module-private unread index/in-flight set were repointed at their new home inside `MailIndex` (same assertions, moved internals)
- Manual steps: scratch benchmark against a prod-shaped 98k-letter book (numbers above)

## Screenshots / recordings

N/A, no UI change.

---

## Checklist

### Quality

- [x] **The gate passes.** `node scripts/gate_select.mjs` is green. I added or updated decisive tests for changed behavior and recorded any manual checks above.

### Cross-platform

- N/A, no UI change.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files. They're regenerated by the build.
