### PR TITLE
perf(render): cut the per-frame cost of combat VFX, and stop weapon-skin rigs popping off

### DIFF
--- a/docs/design/graphics-settings-fairness.md
+++ b/docs/design/graphics-settings-fairness.md
@@ -43,6 +43,22 @@ COSMETIC (may be tiered down on lower presets):
 - Buff-icon overflow when the bar is full. A buff is active whether or not its icon is on
   screen, so hiding a buff icon removes no actionable information.
 - Portrait and HP-bar redraw smoothness within human reaction tolerance (about 200 ms).
+- Weapon-skin VFX richness (`src/render/weapon_vfx_shed_core.ts`). The rarity rig on a
+  VFX-bearing weapon skin (glow, motes, aurora, shell, cast light) FADES on two inputs.
+  Neither reaches zero: what removes a rig is the character LOD swap, which replaces the whole
+  articulated rig with one baked mesh and is shared by the entire render path. The fade exists
+  so that removal is not a pop.
+  - VIEWER DISTANCE, measured against `CHARACTER_LOD_RANGE_SQ`, the articulated-rig range
+    BEFORE the crowd and per-tier factors scale it. Deliberately that fixed constant and not
+    the live band edge: the live edge reads a per-client, per-frame count of visible rigs, so
+    a fade keyed to it would pulse as unrelated players wander past a viewer's frustum and
+    would differ between two viewers standing in the same spot. Against the constant this arm
+    is identical for every player on every preset.
+  - The frame-budget governor's `vfx` bucket, the same lever the pooled particle cloud and the
+    ability VFX already answer to, floored at `WEAPON_VFX_GOVERNOR_FLOOR`. It is the one input
+    that differs between two players looking at the same wearer, and it can only dim.
+  What is faded is decoration ON a weapon. The wearer, their nameplate, their cast bar, their
+  auras, their position and the weapon model itself are untouched at every scale.
 
 The test for any new tier knob: if a knob hides or delays something a player READS AND REACTS
 TO, it is not allowed. If it only reduces visual richness or redraw smoothness, it is fine.
@@ -151,6 +167,19 @@ it, so the boundary cannot creep back in as decoration.
   cap path for the sap).
 - `tests/auras_view.test.ts`: `isAuraDebuff` classifies a negative-value `buff_*` sap identically
   for the Sim aura and its `ClientWorld` mirror.
+- `tests/weapon_vfx_shed.test.ts`: the weapon-skin fade. Neither arm reaches zero and the
+  lever's floor is proven to stay clear of the multiplier at which a part would stop drawing,
+  so the fade can never be mistaken for a cull; the distance arm is anchored to the fixed
+  `CHARACTER_LOD_RANGE_SQ` rather than the live band edge, and the policy is scanned free of
+  any tier, preset or device-profile input and pinned to its two arguments; the applied fade is
+  proven to dim the rig light WITHOUT clearing its `visible` flag, because three counts visible
+  point lights into every lit material's program cache key and dropping one is the open-world
+  recompile freeze; and the far-LOD skip is pinned to require a baked stand-in mesh, since
+  `setFar` leaves the rig drawing when there is none.
+- `tests/drape_lod_core.test.ts`: the ground-VFX drape LOD reads viewer distance and the mark's
+  own geometry only (pinned to its two arguments), every sample it takes is one the exact drape
+  would also have taken, and the marks it is allowed to thin at all are bounded by a world-space
+  sample-spacing cap, so no mark's footprint, radius or position can move with it.
 - `tests/ability_vfx_stun_stars.test.ts`: the overhead stunned-star band (the "why can't I act"
   tell, keyed off aura kind so every stun source reads) occupies the FIRST overlay slots, draws
   identically at vfx quality 0, holds an alpha floor for the aura's whole life, and is bounded

--- a/docs/screenshots/eastbrook-vale-rebuild/polish/metadata/after-desktop-ultra.json
+++ b/docs/screenshots/eastbrook-vale-rebuild/polish/metadata/after-desktop-ultra.json
@@ -11,7 +11,7 @@
     "mode": "composite-sha256",
     "algorithm": "sha256",
     "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-    "fingerprint": "532c7b4b907fc86b1847b415bb8d915428c2e3abac19ac1d1128d51e117b01a6",
+    "fingerprint": "bdb8ece164fb03fcb689e259317e287c04ac2c845d463f37d4993ede77d3439e",
     "components": {
       "townAsset": {
         "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -40,7 +40,7 @@
         },
         "renderer": {
           "path": "src/render/renderer.ts",
-          "sha256": "10f94e9048c7df6728b6d56c7316e153c012f2816af8ef66c1386f833c985edb"
+          "sha256": "ca7cff2a14f5978f2f755d61e91214b0e788adf995b56a1b70e6719be54c481e"
         },
         "viewPriorityPolicy": {
           "path": "src/render/prewarm_policy.ts",
@@ -85,7 +85,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "532c7b4b907fc86b1847b415bb8d915428c2e3abac19ac1d1128d51e117b01a6",
+        "fingerprint": "bdb8ece164fb03fcb689e259317e287c04ac2c845d463f37d4993ede77d3439e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -114,7 +114,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "10f94e9048c7df6728b6d56c7316e153c012f2816af8ef66c1386f833c985edb"
+              "sha256": "ca7cff2a14f5978f2f755d61e91214b0e788adf995b56a1b70e6719be54c481e"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -1377,7 +1377,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "532c7b4b907fc86b1847b415bb8d915428c2e3abac19ac1d1128d51e117b01a6",
+        "fingerprint": "bdb8ece164fb03fcb689e259317e287c04ac2c845d463f37d4993ede77d3439e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -1406,7 +1406,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "10f94e9048c7df6728b6d56c7316e153c012f2816af8ef66c1386f833c985edb"
+              "sha256": "ca7cff2a14f5978f2f755d61e91214b0e788adf995b56a1b70e6719be54c481e"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -2669,7 +2669,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "532c7b4b907fc86b1847b415bb8d915428c2e3abac19ac1d1128d51e117b01a6",
+        "fingerprint": "bdb8ece164fb03fcb689e259317e287c04ac2c845d463f37d4993ede77d3439e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -2698,7 +2698,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "10f94e9048c7df6728b6d56c7316e153c012f2816af8ef66c1386f833c985edb"
+              "sha256": "ca7cff2a14f5978f2f755d61e91214b0e788adf995b56a1b70e6719be54c481e"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -3961,7 +3961,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "532c7b4b907fc86b1847b415bb8d915428c2e3abac19ac1d1128d51e117b01a6",
+        "fingerprint": "bdb8ece164fb03fcb689e259317e287c04ac2c845d463f37d4993ede77d3439e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -3990,7 +3990,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "10f94e9048c7df6728b6d56c7316e153c012f2816af8ef66c1386f833c985edb"
+              "sha256": "ca7cff2a14f5978f2f755d61e91214b0e788adf995b56a1b70e6719be54c481e"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -5253,7 +5253,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "532c7b4b907fc86b1847b415bb8d915428c2e3abac19ac1d1128d51e117b01a6",
+        "fingerprint": "bdb8ece164fb03fcb689e259317e287c04ac2c845d463f37d4993ede77d3439e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -5282,7 +5282,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "10f94e9048c7df6728b6d56c7316e153c012f2816af8ef66c1386f833c985edb"
+              "sha256": "ca7cff2a14f5978f2f755d61e91214b0e788adf995b56a1b70e6719be54c481e"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -6545,7 +6545,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "532c7b4b907fc86b1847b415bb8d915428c2e3abac19ac1d1128d51e117b01a6",
+        "fingerprint": "bdb8ece164fb03fcb689e259317e287c04ac2c845d463f37d4993ede77d3439e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -6574,7 +6574,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "10f94e9048c7df6728b6d56c7316e153c012f2816af8ef66c1386f833c985edb"
+              "sha256": "ca7cff2a14f5978f2f755d61e91214b0e788adf995b56a1b70e6719be54c481e"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -7837,7 +7837,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "532c7b4b907fc86b1847b415bb8d915428c2e3abac19ac1d1128d51e117b01a6",
+        "fingerprint": "bdb8ece164fb03fcb689e259317e287c04ac2c845d463f37d4993ede77d3439e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -7866,7 +7866,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "10f94e9048c7df6728b6d56c7316e153c012f2816af8ef66c1386f833c985edb"
+              "sha256": "ca7cff2a14f5978f2f755d61e91214b0e788adf995b56a1b70e6719be54c481e"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -9129,7 +9129,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "532c7b4b907fc86b1847b415bb8d915428c2e3abac19ac1d1128d51e117b01a6",
+        "fingerprint": "bdb8ece164fb03fcb689e259317e287c04ac2c845d463f37d4993ede77d3439e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -9158,7 +9158,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "10f94e9048c7df6728b6d56c7316e153c012f2816af8ef66c1386f833c985edb"
+              "sha256": "ca7cff2a14f5978f2f755d61e91214b0e788adf995b56a1b70e6719be54c481e"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -10421,7 +10421,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "532c7b4b907fc86b1847b415bb8d915428c2e3abac19ac1d1128d51e117b01a6",
+        "fingerprint": "bdb8ece164fb03fcb689e259317e287c04ac2c845d463f37d4993ede77d3439e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -10450,7 +10450,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "10f94e9048c7df6728b6d56c7316e153c012f2816af8ef66c1386f833c985edb"
+              "sha256": "ca7cff2a14f5978f2f755d61e91214b0e788adf995b56a1b70e6719be54c481e"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -11713,7 +11713,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "532c7b4b907fc86b1847b415bb8d915428c2e3abac19ac1d1128d51e117b01a6",
+        "fingerprint": "bdb8ece164fb03fcb689e259317e287c04ac2c845d463f37d4993ede77d3439e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -11742,7 +11742,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "10f94e9048c7df6728b6d56c7316e153c012f2816af8ef66c1386f833c985edb"
+              "sha256": "ca7cff2a14f5978f2f755d61e91214b0e788adf995b56a1b70e6719be54c481e"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -13005,7 +13005,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "532c7b4b907fc86b1847b415bb8d915428c2e3abac19ac1d1128d51e117b01a6",
+        "fingerprint": "bdb8ece164fb03fcb689e259317e287c04ac2c845d463f37d4993ede77d3439e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -13034,7 +13034,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "10f94e9048c7df6728b6d56c7316e153c012f2816af8ef66c1386f833c985edb"
+              "sha256": "ca7cff2a14f5978f2f755d61e91214b0e788adf995b56a1b70e6719be54c481e"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -14297,7 +14297,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "532c7b4b907fc86b1847b415bb8d915428c2e3abac19ac1d1128d51e117b01a6",
+        "fingerprint": "bdb8ece164fb03fcb689e259317e287c04ac2c845d463f37d4993ede77d3439e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -14326,7 +14326,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "10f94e9048c7df6728b6d56c7316e153c012f2816af8ef66c1386f833c985edb"
+              "sha256": "ca7cff2a14f5978f2f755d61e91214b0e788adf995b56a1b70e6719be54c481e"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -15589,7 +15589,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "532c7b4b907fc86b1847b415bb8d915428c2e3abac19ac1d1128d51e117b01a6",
+        "fingerprint": "bdb8ece164fb03fcb689e259317e287c04ac2c845d463f37d4993ede77d3439e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -15618,7 +15618,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "10f94e9048c7df6728b6d56c7316e153c012f2816af8ef66c1386f833c985edb"
+              "sha256": "ca7cff2a14f5978f2f755d61e91214b0e788adf995b56a1b70e6719be54c481e"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -16881,7 +16881,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "532c7b4b907fc86b1847b415bb8d915428c2e3abac19ac1d1128d51e117b01a6",
+        "fingerprint": "bdb8ece164fb03fcb689e259317e287c04ac2c845d463f37d4993ede77d3439e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -16910,7 +16910,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "10f94e9048c7df6728b6d56c7316e153c012f2816af8ef66c1386f833c985edb"
+              "sha256": "ca7cff2a14f5978f2f755d61e91214b0e788adf995b56a1b70e6719be54c481e"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -19138,7 +19138,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "532c7b4b907fc86b1847b415bb8d915428c2e3abac19ac1d1128d51e117b01a6",
+        "fingerprint": "bdb8ece164fb03fcb689e259317e287c04ac2c845d463f37d4993ede77d3439e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -19167,7 +19167,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "10f94e9048c7df6728b6d56c7316e153c012f2816af8ef66c1386f833c985edb"
+              "sha256": "ca7cff2a14f5978f2f755d61e91214b0e788adf995b56a1b70e6719be54c481e"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -20430,7 +20430,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "532c7b4b907fc86b1847b415bb8d915428c2e3abac19ac1d1128d51e117b01a6",
+        "fingerprint": "bdb8ece164fb03fcb689e259317e287c04ac2c845d463f37d4993ede77d3439e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -20459,7 +20459,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "10f94e9048c7df6728b6d56c7316e153c012f2816af8ef66c1386f833c985edb"
+              "sha256": "ca7cff2a14f5978f2f755d61e91214b0e788adf995b56a1b70e6719be54c481e"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -21722,7 +21722,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "532c7b4b907fc86b1847b415bb8d915428c2e3abac19ac1d1128d51e117b01a6",
+        "fingerprint": "bdb8ece164fb03fcb689e259317e287c04ac2c845d463f37d4993ede77d3439e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -21751,7 +21751,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "10f94e9048c7df6728b6d56c7316e153c012f2816af8ef66c1386f833c985edb"
+              "sha256": "ca7cff2a14f5978f2f755d61e91214b0e788adf995b56a1b70e6719be54c481e"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -23014,7 +23014,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "532c7b4b907fc86b1847b415bb8d915428c2e3abac19ac1d1128d51e117b01a6",
+        "fingerprint": "bdb8ece164fb03fcb689e259317e287c04ac2c845d463f37d4993ede77d3439e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -23043,7 +23043,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "10f94e9048c7df6728b6d56c7316e153c012f2816af8ef66c1386f833c985edb"
+              "sha256": "ca7cff2a14f5978f2f755d61e91214b0e788adf995b56a1b70e6719be54c481e"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -24306,7 +24306,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "532c7b4b907fc86b1847b415bb8d915428c2e3abac19ac1d1128d51e117b01a6",
+        "fingerprint": "bdb8ece164fb03fcb689e259317e287c04ac2c845d463f37d4993ede77d3439e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -24335,7 +24335,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "10f94e9048c7df6728b6d56c7316e153c012f2816af8ef66c1386f833c985edb"
+              "sha256": "ca7cff2a14f5978f2f755d61e91214b0e788adf995b56a1b70e6719be54c481e"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -25598,7 +25598,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "532c7b4b907fc86b1847b415bb8d915428c2e3abac19ac1d1128d51e117b01a6",
+        "fingerprint": "bdb8ece164fb03fcb689e259317e287c04ac2c845d463f37d4993ede77d3439e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -25627,7 +25627,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "10f94e9048c7df6728b6d56c7316e153c012f2816af8ef66c1386f833c985edb"
+              "sha256": "ca7cff2a14f5978f2f755d61e91214b0e788adf995b56a1b70e6719be54c481e"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -26890,7 +26890,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "532c7b4b907fc86b1847b415bb8d915428c2e3abac19ac1d1128d51e117b01a6",
+        "fingerprint": "bdb8ece164fb03fcb689e259317e287c04ac2c845d463f37d4993ede77d3439e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -26919,7 +26919,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "10f94e9048c7df6728b6d56c7316e153c012f2816af8ef66c1386f833c985edb"
+              "sha256": "ca7cff2a14f5978f2f755d61e91214b0e788adf995b56a1b70e6719be54c481e"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -28235,7 +28235,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "532c7b4b907fc86b1847b415bb8d915428c2e3abac19ac1d1128d51e117b01a6",
+        "fingerprint": "bdb8ece164fb03fcb689e259317e287c04ac2c845d463f37d4993ede77d3439e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -28264,7 +28264,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "10f94e9048c7df6728b6d56c7316e153c012f2816af8ef66c1386f833c985edb"
+              "sha256": "ca7cff2a14f5978f2f755d61e91214b0e788adf995b56a1b70e6719be54c481e"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -29527,7 +29527,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "532c7b4b907fc86b1847b415bb8d915428c2e3abac19ac1d1128d51e117b01a6",
+        "fingerprint": "bdb8ece164fb03fcb689e259317e287c04ac2c845d463f37d4993ede77d3439e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -29556,7 +29556,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "10f94e9048c7df6728b6d56c7316e153c012f2816af8ef66c1386f833c985edb"
+              "sha256": "ca7cff2a14f5978f2f755d61e91214b0e788adf995b56a1b70e6719be54c481e"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",

--- a/docs/screenshots/eastbrook-vale-rebuild/polish/metadata/after-mobile-low.json
+++ b/docs/screenshots/eastbrook-vale-rebuild/polish/metadata/after-mobile-low.json
@@ -11,7 +11,7 @@
     "mode": "composite-sha256",
     "algorithm": "sha256",
     "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-    "fingerprint": "532c7b4b907fc86b1847b415bb8d915428c2e3abac19ac1d1128d51e117b01a6",
+    "fingerprint": "bdb8ece164fb03fcb689e259317e287c04ac2c845d463f37d4993ede77d3439e",
     "components": {
       "townAsset": {
         "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -40,7 +40,7 @@
         },
         "renderer": {
           "path": "src/render/renderer.ts",
-          "sha256": "10f94e9048c7df6728b6d56c7316e153c012f2816af8ef66c1386f833c985edb"
+          "sha256": "ca7cff2a14f5978f2f755d61e91214b0e788adf995b56a1b70e6719be54c481e"
         },
         "viewPriorityPolicy": {
           "path": "src/render/prewarm_policy.ts",
@@ -85,7 +85,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "532c7b4b907fc86b1847b415bb8d915428c2e3abac19ac1d1128d51e117b01a6",
+        "fingerprint": "bdb8ece164fb03fcb689e259317e287c04ac2c845d463f37d4993ede77d3439e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -114,7 +114,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "10f94e9048c7df6728b6d56c7316e153c012f2816af8ef66c1386f833c985edb"
+              "sha256": "ca7cff2a14f5978f2f755d61e91214b0e788adf995b56a1b70e6719be54c481e"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -1360,7 +1360,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "532c7b4b907fc86b1847b415bb8d915428c2e3abac19ac1d1128d51e117b01a6",
+        "fingerprint": "bdb8ece164fb03fcb689e259317e287c04ac2c845d463f37d4993ede77d3439e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -1389,7 +1389,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "10f94e9048c7df6728b6d56c7316e153c012f2816af8ef66c1386f833c985edb"
+              "sha256": "ca7cff2a14f5978f2f755d61e91214b0e788adf995b56a1b70e6719be54c481e"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -2635,7 +2635,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "532c7b4b907fc86b1847b415bb8d915428c2e3abac19ac1d1128d51e117b01a6",
+        "fingerprint": "bdb8ece164fb03fcb689e259317e287c04ac2c845d463f37d4993ede77d3439e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -2664,7 +2664,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "10f94e9048c7df6728b6d56c7316e153c012f2816af8ef66c1386f833c985edb"
+              "sha256": "ca7cff2a14f5978f2f755d61e91214b0e788adf995b56a1b70e6719be54c481e"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -3910,7 +3910,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "532c7b4b907fc86b1847b415bb8d915428c2e3abac19ac1d1128d51e117b01a6",
+        "fingerprint": "bdb8ece164fb03fcb689e259317e287c04ac2c845d463f37d4993ede77d3439e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -3939,7 +3939,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "10f94e9048c7df6728b6d56c7316e153c012f2816af8ef66c1386f833c985edb"
+              "sha256": "ca7cff2a14f5978f2f755d61e91214b0e788adf995b56a1b70e6719be54c481e"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -5185,7 +5185,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "532c7b4b907fc86b1847b415bb8d915428c2e3abac19ac1d1128d51e117b01a6",
+        "fingerprint": "bdb8ece164fb03fcb689e259317e287c04ac2c845d463f37d4993ede77d3439e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -5214,7 +5214,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "10f94e9048c7df6728b6d56c7316e153c012f2816af8ef66c1386f833c985edb"
+              "sha256": "ca7cff2a14f5978f2f755d61e91214b0e788adf995b56a1b70e6719be54c481e"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -6460,7 +6460,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "532c7b4b907fc86b1847b415bb8d915428c2e3abac19ac1d1128d51e117b01a6",
+        "fingerprint": "bdb8ece164fb03fcb689e259317e287c04ac2c845d463f37d4993ede77d3439e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -6489,7 +6489,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "10f94e9048c7df6728b6d56c7316e153c012f2816af8ef66c1386f833c985edb"
+              "sha256": "ca7cff2a14f5978f2f755d61e91214b0e788adf995b56a1b70e6719be54c481e"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -7735,7 +7735,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "532c7b4b907fc86b1847b415bb8d915428c2e3abac19ac1d1128d51e117b01a6",
+        "fingerprint": "bdb8ece164fb03fcb689e259317e287c04ac2c845d463f37d4993ede77d3439e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -7764,7 +7764,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "10f94e9048c7df6728b6d56c7316e153c012f2816af8ef66c1386f833c985edb"
+              "sha256": "ca7cff2a14f5978f2f755d61e91214b0e788adf995b56a1b70e6719be54c481e"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -9010,7 +9010,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "532c7b4b907fc86b1847b415bb8d915428c2e3abac19ac1d1128d51e117b01a6",
+        "fingerprint": "bdb8ece164fb03fcb689e259317e287c04ac2c845d463f37d4993ede77d3439e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -9039,7 +9039,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "10f94e9048c7df6728b6d56c7316e153c012f2816af8ef66c1386f833c985edb"
+              "sha256": "ca7cff2a14f5978f2f755d61e91214b0e788adf995b56a1b70e6719be54c481e"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -10285,7 +10285,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "532c7b4b907fc86b1847b415bb8d915428c2e3abac19ac1d1128d51e117b01a6",
+        "fingerprint": "bdb8ece164fb03fcb689e259317e287c04ac2c845d463f37d4993ede77d3439e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -10314,7 +10314,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "10f94e9048c7df6728b6d56c7316e153c012f2816af8ef66c1386f833c985edb"
+              "sha256": "ca7cff2a14f5978f2f755d61e91214b0e788adf995b56a1b70e6719be54c481e"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -11560,7 +11560,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "532c7b4b907fc86b1847b415bb8d915428c2e3abac19ac1d1128d51e117b01a6",
+        "fingerprint": "bdb8ece164fb03fcb689e259317e287c04ac2c845d463f37d4993ede77d3439e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -11589,7 +11589,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "10f94e9048c7df6728b6d56c7316e153c012f2816af8ef66c1386f833c985edb"
+              "sha256": "ca7cff2a14f5978f2f755d61e91214b0e788adf995b56a1b70e6719be54c481e"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -12835,7 +12835,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "532c7b4b907fc86b1847b415bb8d915428c2e3abac19ac1d1128d51e117b01a6",
+        "fingerprint": "bdb8ece164fb03fcb689e259317e287c04ac2c845d463f37d4993ede77d3439e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -12864,7 +12864,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "10f94e9048c7df6728b6d56c7316e153c012f2816af8ef66c1386f833c985edb"
+              "sha256": "ca7cff2a14f5978f2f755d61e91214b0e788adf995b56a1b70e6719be54c481e"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -14110,7 +14110,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "532c7b4b907fc86b1847b415bb8d915428c2e3abac19ac1d1128d51e117b01a6",
+        "fingerprint": "bdb8ece164fb03fcb689e259317e287c04ac2c845d463f37d4993ede77d3439e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -14139,7 +14139,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "10f94e9048c7df6728b6d56c7316e153c012f2816af8ef66c1386f833c985edb"
+              "sha256": "ca7cff2a14f5978f2f755d61e91214b0e788adf995b56a1b70e6719be54c481e"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -15385,7 +15385,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "532c7b4b907fc86b1847b415bb8d915428c2e3abac19ac1d1128d51e117b01a6",
+        "fingerprint": "bdb8ece164fb03fcb689e259317e287c04ac2c845d463f37d4993ede77d3439e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -15414,7 +15414,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "10f94e9048c7df6728b6d56c7316e153c012f2816af8ef66c1386f833c985edb"
+              "sha256": "ca7cff2a14f5978f2f755d61e91214b0e788adf995b56a1b70e6719be54c481e"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -16660,7 +16660,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "532c7b4b907fc86b1847b415bb8d915428c2e3abac19ac1d1128d51e117b01a6",
+        "fingerprint": "bdb8ece164fb03fcb689e259317e287c04ac2c845d463f37d4993ede77d3439e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -16689,7 +16689,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "10f94e9048c7df6728b6d56c7316e153c012f2816af8ef66c1386f833c985edb"
+              "sha256": "ca7cff2a14f5978f2f755d61e91214b0e788adf995b56a1b70e6719be54c481e"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -18900,7 +18900,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "532c7b4b907fc86b1847b415bb8d915428c2e3abac19ac1d1128d51e117b01a6",
+        "fingerprint": "bdb8ece164fb03fcb689e259317e287c04ac2c845d463f37d4993ede77d3439e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -18929,7 +18929,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "10f94e9048c7df6728b6d56c7316e153c012f2816af8ef66c1386f833c985edb"
+              "sha256": "ca7cff2a14f5978f2f755d61e91214b0e788adf995b56a1b70e6719be54c481e"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -20175,7 +20175,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "532c7b4b907fc86b1847b415bb8d915428c2e3abac19ac1d1128d51e117b01a6",
+        "fingerprint": "bdb8ece164fb03fcb689e259317e287c04ac2c845d463f37d4993ede77d3439e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -20204,7 +20204,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "10f94e9048c7df6728b6d56c7316e153c012f2816af8ef66c1386f833c985edb"
+              "sha256": "ca7cff2a14f5978f2f755d61e91214b0e788adf995b56a1b70e6719be54c481e"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -21450,7 +21450,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "532c7b4b907fc86b1847b415bb8d915428c2e3abac19ac1d1128d51e117b01a6",
+        "fingerprint": "bdb8ece164fb03fcb689e259317e287c04ac2c845d463f37d4993ede77d3439e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -21479,7 +21479,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "10f94e9048c7df6728b6d56c7316e153c012f2816af8ef66c1386f833c985edb"
+              "sha256": "ca7cff2a14f5978f2f755d61e91214b0e788adf995b56a1b70e6719be54c481e"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -22725,7 +22725,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "532c7b4b907fc86b1847b415bb8d915428c2e3abac19ac1d1128d51e117b01a6",
+        "fingerprint": "bdb8ece164fb03fcb689e259317e287c04ac2c845d463f37d4993ede77d3439e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -22754,7 +22754,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "10f94e9048c7df6728b6d56c7316e153c012f2816af8ef66c1386f833c985edb"
+              "sha256": "ca7cff2a14f5978f2f755d61e91214b0e788adf995b56a1b70e6719be54c481e"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -24000,7 +24000,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "532c7b4b907fc86b1847b415bb8d915428c2e3abac19ac1d1128d51e117b01a6",
+        "fingerprint": "bdb8ece164fb03fcb689e259317e287c04ac2c845d463f37d4993ede77d3439e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -24029,7 +24029,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "10f94e9048c7df6728b6d56c7316e153c012f2816af8ef66c1386f833c985edb"
+              "sha256": "ca7cff2a14f5978f2f755d61e91214b0e788adf995b56a1b70e6719be54c481e"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -25275,7 +25275,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "532c7b4b907fc86b1847b415bb8d915428c2e3abac19ac1d1128d51e117b01a6",
+        "fingerprint": "bdb8ece164fb03fcb689e259317e287c04ac2c845d463f37d4993ede77d3439e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -25304,7 +25304,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "10f94e9048c7df6728b6d56c7316e153c012f2816af8ef66c1386f833c985edb"
+              "sha256": "ca7cff2a14f5978f2f755d61e91214b0e788adf995b56a1b70e6719be54c481e"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -26550,7 +26550,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "532c7b4b907fc86b1847b415bb8d915428c2e3abac19ac1d1128d51e117b01a6",
+        "fingerprint": "bdb8ece164fb03fcb689e259317e287c04ac2c845d463f37d4993ede77d3439e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -26579,7 +26579,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "10f94e9048c7df6728b6d56c7316e153c012f2816af8ef66c1386f833c985edb"
+              "sha256": "ca7cff2a14f5978f2f755d61e91214b0e788adf995b56a1b70e6719be54c481e"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -27878,7 +27878,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "532c7b4b907fc86b1847b415bb8d915428c2e3abac19ac1d1128d51e117b01a6",
+        "fingerprint": "bdb8ece164fb03fcb689e259317e287c04ac2c845d463f37d4993ede77d3439e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -27907,7 +27907,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "10f94e9048c7df6728b6d56c7316e153c012f2816af8ef66c1386f833c985edb"
+              "sha256": "ca7cff2a14f5978f2f755d61e91214b0e788adf995b56a1b70e6719be54c481e"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -29153,7 +29153,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "532c7b4b907fc86b1847b415bb8d915428c2e3abac19ac1d1128d51e117b01a6",
+        "fingerprint": "bdb8ece164fb03fcb689e259317e287c04ac2c845d463f37d4993ede77d3439e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -29182,7 +29182,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "10f94e9048c7df6728b6d56c7316e153c012f2816af8ef66c1386f833c985edb"
+              "sha256": "ca7cff2a14f5978f2f755d61e91214b0e788adf995b56a1b70e6719be54c481e"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",

--- a/docs/screenshots/eastbrook-vale-rebuild/polish/performance/after-desktop-ultra-town.json
+++ b/docs/screenshots/eastbrook-vale-rebuild/polish/performance/after-desktop-ultra-town.json
@@ -14,7 +14,7 @@
     "mode": "composite-sha256",
     "algorithm": "sha256",
     "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-    "fingerprint": "532c7b4b907fc86b1847b415bb8d915428c2e3abac19ac1d1128d51e117b01a6",
+    "fingerprint": "bdb8ece164fb03fcb689e259317e287c04ac2c845d463f37d4993ede77d3439e",
     "components": {
       "townAsset": {
         "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -43,7 +43,7 @@
         },
         "renderer": {
           "path": "src/render/renderer.ts",
-          "sha256": "10f94e9048c7df6728b6d56c7316e153c012f2816af8ef66c1386f833c985edb"
+          "sha256": "ca7cff2a14f5978f2f755d61e91214b0e788adf995b56a1b70e6719be54c481e"
         },
         "viewPriorityPolicy": {
           "path": "src/render/prewarm_policy.ts",

--- a/docs/screenshots/eastbrook-vale-rebuild/polish/performance/after-mobile-low-town.json
+++ b/docs/screenshots/eastbrook-vale-rebuild/polish/performance/after-mobile-low-town.json
@@ -14,7 +14,7 @@
     "mode": "composite-sha256",
     "algorithm": "sha256",
     "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-    "fingerprint": "532c7b4b907fc86b1847b415bb8d915428c2e3abac19ac1d1128d51e117b01a6",
+    "fingerprint": "bdb8ece164fb03fcb689e259317e287c04ac2c845d463f37d4993ede77d3439e",
     "components": {
       "townAsset": {
         "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -43,7 +43,7 @@
         },
         "renderer": {
           "path": "src/render/renderer.ts",
-          "sha256": "10f94e9048c7df6728b6d56c7316e153c012f2816af8ef66c1386f833c985edb"
+          "sha256": "ca7cff2a14f5978f2f755d61e91214b0e788adf995b56a1b70e6719be54c481e"
         },
         "viewPriorityPolicy": {
           "path": "src/render/prewarm_policy.ts",

--- a/src/render/CLAUDE.md
+++ b/src/render/CLAUDE.md
@@ -212,6 +212,26 @@ collision/movement.
   (material, z-band), share materials via `surfaceMat`, distance-cull/LOD in
   `sync` (see the `*_RANGE_SQ` constants). No per-frame `new THREE.*` in hot paths;
   reuse the `tmpV` scratch vectors / scratch arrays already in `renderer.ts`.
+  The VFX world-anchor seam follows the same rule with an explicit contract:
+  `vfx_anchor.ts` `createVfxAnchor` takes an optional caller-owned destination,
+  so a per-frame path passes its own scratch (the reading is valid only until
+  that scratch is reused) and a one-shot spawn path omits it and gets a fresh
+  retainable vector.
+- **A cosmetic subsystem answers to a lever, and the lever says which job it is
+  doing.** `weapon_vfx_shed_core.ts` is the shape to copy: it FADES (both arms
+  floored above the multiplier at which a part stops drawing) and leaves REMOVAL
+  to the character LOD swap, which already owns it on inputs the whole render
+  path shares. Read its header before adding a shed of your own, including why
+  the distance arm is anchored to the fixed `CHARACTER_LOD_RANGE_SQ` and not to
+  the live crowd-adaptive band edge, and
+  `docs/design/graphics-settings-fairness.md` for why that choice is what keeps
+  a fade fairness-safe.
+- **Work that a hidden subtree cannot show is work not to do.** The far-LOD swap
+  hides `modelWrap`, so anything parented into the rig (a held weapon and its
+  VFX) stops being drawn without any of its own flags changing; a per-frame
+  driver over such a subtree should skip. Check the swap ACTUALLY happened
+  (`CharacterVisual.setFar` keeps the rig visible when no baked mesh exists,
+  while `isFar` reads true either way), never just the intent flag.
 - **Cloning a material? Use `material_clone_hooks.ts`.** `Material.clone()` copies
   userData but silently DROPS `onBeforeCompile`, and three keys its program cache
   on `customProgramCacheKey()`, whose default return value IS

--- a/src/render/ability_vfx/CLAUDE.md
+++ b/src/render/ability_vfx/CLAUDE.md
@@ -39,6 +39,25 @@ layers behind the `index.ts` barrel:
   of the entry. Anything new added to `prewarmSpawn` that a live frame would
   SEE must not be added here.
 
+Steady-state cost rules (what a live fight is allowed to spend per frame):
+- **Anchors resolve into a scratch.** The shared resolver
+  (`../vfx_anchor.ts`) takes an optional caller-owned destination; every
+  PER-FRAME path here passes one and allocates nothing, while the one-shot
+  spawn paths omit it and keep the retainable fresh vector. `tests/
+  ability_vfx_frame_cost.test.ts` drives the real engine and fails on any
+  destination-less resolve inside `update()`.
+- **Immediate-mode buffers upload their prefix, not their capacity.**
+  `ribbons.ts` and `overlay_sprites.ts` `clearUpdateRanges()` +
+  `addUpdateRange(0, used)` before `needsUpdate`, the pooled cloud's idiom
+  (`../vfx.ts` `packRenderCloud`); `setDrawRange` is what makes everything past
+  the prefix unreachable.
+- **The small ground discs thin their terrain drape with distance**
+  (`../drape_lod_core.ts`, consumed by `ground_auras.ts` and `decals.ts`). The
+  wide shock rings deliberately do NOT: a 10 to 20 yard footprint moves by
+  yards under an interpolated drape, which the core's header records with the
+  measured numbers. Every sample taken is one the exact drape would take, so
+  no mark's footprint moves.
+
 Renderer contract: construct `AbilityVfxFx` with (scene, camera, anchor,
 groundY), hand it to `AbilityVfx` via deps (which also wires the Vfx particle
 burst, the pulseAt light delegate, and the probe stat sink), call

--- a/src/render/ability_vfx/decals.ts
+++ b/src/render/ability_vfx/decals.ts
@@ -1,5 +1,5 @@
 import * as THREE from 'three';
-import { drapeRingLocalY } from '../selection_ring';
+import { drapeFanLocalY, drapeStrideFor, fanVertexSpacing } from '../drape_lod_core';
 import type { AbilityVfxTextures } from './fx_textures';
 
 // Fading ground decals (scorch embers, frost rime, arcane runes, earth
@@ -13,9 +13,13 @@ import type { AbilityVfxTextures } from './fx_textures';
 // Slope fix (selection-ring idiom, see ground_auras.ts): a flat disc buries
 // its uphill half on any slope, so each spawn drapes the disc's vertices over
 // the sampled terrain plus a small lift. A decal never moves or rescales, so
-// the drape runs exactly once per spawn - zero steady-state work.
+// the drape runs exactly once per spawn - zero steady-state work. Those samples
+// still thin with camera distance (../drape_lod_core): a far mark samples the
+// rim more coarsely and interpolates between, keeping its world position and
+// radius exactly as they were.
 
 const DECAL_SLOTS = 12;
+const DECAL_SEGMENTS = 24;
 const DRAPE_LIFT = 0.06; // yards above the sampled ground, against z-fighting
 
 export type DecalStyle = 'ember' | 'rime' | 'rune' | 'crack' | 'char';
@@ -36,6 +40,11 @@ export class GroundDecals {
   private maps: Record<DecalStyle, THREE.CanvasTexture>;
   // center-relative XZ of every disc vertex (all slots clone the same base)
   private localXZ: Float32Array;
+  // Latest camera position (pushed once a frame from the fx engine) and whether
+  // one has ever arrived: before the first frame every drape stays exact.
+  private camX = 0;
+  private camZ = 0;
+  private camKnown = false;
 
   constructor(
     scene: THREE.Scene,
@@ -51,7 +60,7 @@ export class GroundDecals {
     };
     // Rotation baked into the geometry (instead of mesh.rotation.x) so the
     // position attribute's Y IS the up-axis the drape writes.
-    const geo = new THREE.CircleGeometry(1, 24);
+    const geo = new THREE.CircleGeometry(1, DECAL_SEGMENTS);
     geo.rotateX(-Math.PI / 2);
     const basePos = geo.getAttribute('position') as THREE.BufferAttribute;
     this.localXZ = new Float32Array(basePos.count * 2);
@@ -123,6 +132,13 @@ export class GroundDecals {
     proto.dispose();
   }
 
+  /** Where the camera is this frame, for the drape distance LOD. */
+  setCameraPosition(x: number, z: number): void {
+    this.camX = x;
+    this.camZ = z;
+    this.camKnown = true;
+  }
+
   spawn(
     x: number,
     y: number,
@@ -146,7 +162,25 @@ export class GroundDecals {
     slot.mesh.scale.setScalar(radius);
     // drape the disc over the terrain so no arc buries on a slope (the lift
     // dodges z-fighting the old flat +0.04 offset handled)
-    drapeRingLocalY(this.localXZ, x, z, y, radius, DRAPE_LIFT, this.groundY, slot.drapeY);
+    const dx = x - this.camX;
+    const dz = z - this.camZ;
+    drapeFanLocalY(
+      this.localXZ,
+      x,
+      z,
+      y,
+      radius,
+      DRAPE_LIFT,
+      this.groundY,
+      slot.drapeY,
+      // -1 reads as "unknown" to drapeStrideFor, which then drapes exactly. A
+      // wide mark's rim vertices are already yards apart, so the spacing cap
+      // there refuses to thin it at all.
+      drapeStrideFor(
+        this.camKnown ? dx * dx + dz * dz : -1,
+        fanVertexSpacing(radius, DECAL_SEGMENTS),
+      ),
+    );
     const pos = slot.mesh.geometry.getAttribute('position') as THREE.BufferAttribute;
     for (let i = 0; i < slot.drapeY.length; i++) pos.setY(i, slot.drapeY[i]);
     pos.needsUpdate = true;

--- a/src/render/ability_vfx/fx.ts
+++ b/src/render/ability_vfx/fx.ts
@@ -24,7 +24,7 @@ import { OverlaySprites } from './overlay_sprites';
 import { LightPillars } from './pillars';
 import { AbilityVfxRibbons, type BoltTrailStyle, type RibbonAnchor } from './ribbons';
 import { ShockRings } from './rings';
-import { ArchetypeSequencer, type SequencerHost } from './sequencer';
+import { ArchetypeSequencer, type SeqPoint, type SequencerHost } from './sequencer';
 import { BuffShells } from './shells';
 import { isCrescendoArchetype, SPECTACLE } from './spectacle';
 import {
@@ -52,6 +52,13 @@ export type ParticleBurst = (
 const camPosScratch = new THREE.Vector3();
 const camRightScratch = new THREE.Vector3();
 const camFwdScratch = new THREE.Vector3();
+// Per-frame anchor scratch (see ../vfx_anchor.ts). Three separate ones because
+// the per-frame draws below hold up to two readings at once (a windup's feet
+// AND head), and the sequencer host delegate must not clobber a reading its
+// caller is still holding.
+const anchorScratchA = new THREE.Vector3();
+const anchorScratchB = new THREE.Vector3();
+const hostAnchorScratch = new THREE.Vector3();
 
 // The Three-side engine of the per-ability VFX system: owns the pooled
 // primitive families ported from the Ability VFX Gallery (ribbon trails, shock
@@ -315,8 +322,8 @@ export class AbilityVfxFx implements SequencerHost {
   // entity, frame-stamp swept exactly like windups/orbits. Drawn for at most
   // the MAX_STUN_STAR_BANDS best-ranked entities per frame (the fixed pick
   // arrays are the selection scratch, reused every frame). hx/hy/hz cache the
-  // frame's resolved head anchor so the draw never re-resolves it (the
-  // renderer's anchor delegate allocates a Vector3 per call).
+  // frame's resolved head anchor so the ranking pass and the draw share one
+  // resolve instead of asking the anchor delegate twice.
   private stunStars = new Map<
     number,
     { remaining: number; stamp: number; hx: number; hy: number; hz: number }
@@ -864,8 +871,17 @@ export class AbilityVfxFx implements SequencerHost {
 
   // ---- SequencerHost surface (sequencer.ts drives these) ------------------
 
-  anchorOf(id: number, frac: number): { x: number; y: number; z: number } | null {
-    return this.anchor(id, frac);
+  anchorOf(id: number, frac: number, out?: SeqPoint): SeqPoint | null {
+    // No destination: keep the historical contract exactly (a fresh vector the
+    // caller may retain). With one, resolve through this engine's scratch and
+    // copy the three floats out, so the sequencer stays Three-free.
+    if (!out) return this.anchor(id, frac);
+    const at = this.anchor(id, frac, hostAnchorScratch);
+    if (!at) return null;
+    out.x = at.x;
+    out.y = at.y;
+    out.z = at.z;
+    return out;
   }
 
   // True when the aura-driven stunned-star band actually WON a draw slot in
@@ -1444,16 +1460,29 @@ export class AbilityVfxFx implements SequencerHost {
       s.t -= dt;
       if (s.t > 0) continue;
       s.active = false;
-      const at = s.entityId >= 0 ? this.anchor(s.entityId, 0.5) : s;
+      const at = s.entityId >= 0 ? this.anchor(s.entityId, 0.5, anchorScratchA) : s;
       if (at) this.screenFxAt(at.x, at.y, at.z, s.strength);
     }
+    // The small ground discs thin their terrain drape with camera distance
+    // (../drape_lod_core), so the decal pool needs this frame's camera before
+    // anything spawns into it. The shock rings deliberately do NOT thin: their
+    // footprints are too wide for an interpolated drape to stay honest.
+    this.decals.setCameraPosition(camPosScratch.x, camPosScratch.z);
     this.ribbons.update(dt, camPosScratch);
     this.rings.update(dt, this.camera.quaternion);
     this.flipbooks.update(dt, this.camera.quaternion);
     this.decals.update(dt);
     this.pillars.update(dt);
     this.shells.update(dt, this.time, this.frame, this.anchor);
-    this.groundAuras.update(dt, this.time, this.frame, this.anchor, this.groundY);
+    this.groundAuras.update(
+      dt,
+      this.time,
+      this.frame,
+      this.anchor,
+      this.groundY,
+      camPosScratch.x,
+      camPosScratch.z,
+    );
     this.spirits.update(dt);
     this.overlay.beginFrame();
     // The stunned-star bands draw FIRST in the frame's overlay batch: the
@@ -1472,7 +1501,7 @@ export class AbilityVfxFx implements SequencerHost {
         this.stunStars.delete(id);
         continue;
       }
-      const head = this.anchorOf(id, 1.0);
+      const head = this.anchorOf(id, 1.0, anchorScratchA);
       if (!head) continue;
       s.hx = head.x;
       s.hy = head.y;
@@ -1590,7 +1619,7 @@ export class AbilityVfxFx implements SequencerHost {
     const q = 0.75 + 0.25 * this.qualityLevel;
     const pulse = 1 + 0.07 * Math.sin(this.time * 14);
     if (style === 'runes') {
-      const feet = this.anchor(entityId, 0.04);
+      const feet = this.anchor(entityId, 0.04, anchorScratchA);
       if (!feet) return;
       const n = 4;
       const r = 1.25 - 0.35 * p;
@@ -1607,7 +1636,7 @@ export class AbilityVfxFx implements SequencerHost {
           2.1,
         );
       }
-      const chest = this.anchor(entityId, 0.58);
+      const chest = this.anchor(entityId, 0.58, anchorScratchB);
       if (chest)
         this.overlay.push(
           chest.x,
@@ -1622,7 +1651,7 @@ export class AbilityVfxFx implements SequencerHost {
       return;
     }
     if (style === 'stance') {
-      const feet = this.anchor(entityId, 0.06);
+      const feet = this.anchor(entityId, 0.06, anchorScratchA);
       if (!feet) return;
       for (let k = 0; k < 3; k++) {
         const a = this.time * 1.1 + k * 2.1 + entityId;
@@ -1641,7 +1670,7 @@ export class AbilityVfxFx implements SequencerHost {
       return;
     }
     if (style === 'weapon') {
-      const hand = this.anchor(entityId, 0.46);
+      const hand = this.anchor(entityId, 0.46, anchorScratchA);
       if (!hand) return;
       this.overlay.push(
         hand.x,
@@ -1666,8 +1695,8 @@ export class AbilityVfxFx implements SequencerHost {
       return;
     }
     if (style === 'ascend') {
-      const feet = this.anchor(entityId, 0.04);
-      const head = this.anchor(entityId, 1.0);
+      const feet = this.anchor(entityId, 0.04, anchorScratchA);
+      const head = this.anchor(entityId, 1.0, anchorScratchB);
       if (!feet || !head) return;
       const span = head.y - feet.y + 0.8;
       for (let k = 0; k < 4; k++) {
@@ -1697,7 +1726,7 @@ export class AbilityVfxFx implements SequencerHost {
       return;
     }
     // orb (default) and vortex share the hand orb; vortex pulls from wider out
-    const at = this.anchor(entityId, 0.58);
+    const at = this.anchor(entityId, 0.58, anchorScratchA);
     if (!at) return;
     const size = (0.28 + 0.5 * p) * pulse * q;
     this.overlay.push(at.x, at.y + 0.12, at.z, colorHex, size, OVERLAY_CELL.glow, 0.85, 1.9);
@@ -1737,7 +1766,7 @@ export class AbilityVfxFx implements SequencerHost {
   // overrides the style DNA so same-band buffs still read as different spells.
   private drawOrbit(entityId: number, band: OrbitBand): void {
     const dna = ORBIT_DNA[band.style];
-    const at = this.anchor(entityId, dna.frac);
+    const at = this.anchor(entityId, dna.frac, anchorScratchA);
     if (!at) return;
     const o = band.o;
     const fade = Math.min(1, band.age / 0.25) * (0.55 + 0.45 * this.qualityLevel);

--- a/src/render/ability_vfx/ground_auras.ts
+++ b/src/render/ability_vfx/ground_auras.ts
@@ -1,5 +1,6 @@
 import * as THREE from 'three';
-import { drapeRingLocalY } from '../selection_ring';
+import { drapeFanLocalY, drapeStrideFor, fanVertexSpacing } from '../drape_lod_core';
+import type { VfxAnchorResolver } from '../vfx_anchor';
 import type { AbilityVfxTextures } from './fx_textures';
 
 // Soft additive ground annuli at a buffed character's feet: the DEFAULT read
@@ -23,6 +24,7 @@ import type { AbilityVfxTextures } from './fx_textures';
 // onto the outermost band, whose hue blends toward the newcomer.
 
 const AURA_SLOTS = 9;
+const AURA_SEGMENTS = 40;
 export const GROUND_AURA_BANDS = 3;
 const BAND_RADIUS = [1.3, 1.55, 1.8];
 // Peak additive opacity: noticeable when you look, invisible when you fight.
@@ -44,10 +46,16 @@ const SPIN_RATE = 0.25;
 const DRAPE_LIFT = 0.08;
 const BAND_LIFT_STEP = 0.015;
 // Re-drape thresholds: skip the per-vertex resample while the wearer stands
-// still and the breath scale drift stays under ~1.5% (the residual height
-// error at that drift is millimeters).
+// still and the breath scale drift stays small. The scale threshold is
+// RELATIVE, and deliberately wider than the breath's own peak-to-peak swing
+// (+-5% at 0.4 Hz): under the old absolute 0.02 yard threshold a character
+// standing perfectly still re-draped all 42 vertices several times a second,
+// forever, per band, to correct heights by (drift x radius x slope), which is
+// centimetres on anything walkable. Now the drape settles once the disc has
+// finished growing in and the breath rides it. Movement still re-drapes at a
+// centimetre, because that IS real new terrain under the disc.
 const DRAPE_MOVE_EPS = 0.01;
-const DRAPE_SCALE_EPS = 0.02;
+const DRAPE_SCALE_REL_EPS = 0.12;
 
 interface AuraSlot {
   mesh: THREE.Mesh;
@@ -71,6 +79,9 @@ interface AuraSlot {
 }
 
 const colorScratch = new THREE.Color();
+// Per-frame anchor scratch (see ../vfx_anchor.ts): update() resolves the wearer
+// once per live band and consumes the reading inside that iteration.
+const anchorScratch = new THREE.Vector3();
 
 export class GroundAuras {
   private slots: AuraSlot[] = [];
@@ -80,7 +91,7 @@ export class GroundAuras {
   constructor(scene: THREE.Scene, tex: AbilityVfxTextures) {
     // Rotation is baked into the geometry (instead of mesh.rotation.x) so the
     // position attribute's Y IS the up-axis the drape writes.
-    const geo = new THREE.CircleGeometry(1, 40);
+    const geo = new THREE.CircleGeometry(1, AURA_SEGMENTS);
     geo.rotateX(-Math.PI / 2);
     const basePos = geo.getAttribute('position') as THREE.BufferAttribute;
     this.localXZ = new Float32Array(basePos.count * 2);
@@ -204,9 +215,12 @@ export class GroundAuras {
     dt: number,
     time: number,
     frame: number,
-    anchor: (id: number, frac: number) => { x: number; y: number; z: number } | null,
+    anchor: VfxAnchorResolver,
     groundY: (x: number, z: number) => number,
+    camX?: number,
+    camZ?: number,
   ): void {
+    const camKnown = camX !== undefined && camZ !== undefined;
     for (const slot of this.slots) {
       if (!slot.active) continue;
       if (slot.release === Number.POSITIVE_INFINITY && slot.stamp !== frame) {
@@ -214,7 +228,7 @@ export class GroundAuras {
         slot.release = slot.age + FADE_OUT;
       }
       slot.age += dt;
-      const at = slot.age < slot.release ? anchor(slot.entityId, 0) : null;
+      const at = slot.age < slot.release ? anchor(slot.entityId, 0, anchorScratch) : null;
       if (!at || slot.age >= slot.release) {
         slot.active = false;
         slot.mesh.visible = false;
@@ -237,12 +251,17 @@ export class GroundAuras {
       if (
         Math.abs(at.x - slot.drapeX) > DRAPE_MOVE_EPS ||
         Math.abs(at.z - slot.drapeZ) > DRAPE_MOVE_EPS ||
-        Math.abs(scale - slot.drapeScale) > DRAPE_SCALE_EPS
+        Math.abs(scale - slot.drapeScale) > slot.drapeScale * DRAPE_SCALE_REL_EPS
       ) {
         slot.drapeX = at.x;
         slot.drapeZ = at.z;
         slot.drapeScale = scale;
-        drapeRingLocalY(
+        // A moving buffed character re-drapes every frame, per band: thin the
+        // sampling with camera distance (../drape_lod_core). Only the vertical
+        // fidelity of a faint cosmetic annulus changes; where it sits does not.
+        const dx = at.x - (camX ?? 0);
+        const dz = at.z - (camZ ?? 0);
+        drapeFanLocalY(
           this.localXZ,
           at.x,
           at.z,
@@ -251,6 +270,7 @@ export class GroundAuras {
           DRAPE_LIFT + slot.band * BAND_LIFT_STEP,
           groundY,
           slot.drapeY,
+          drapeStrideFor(camKnown ? dx * dx + dz * dz : -1, fanVertexSpacing(scale, AURA_SEGMENTS)),
         );
         const pos = slot.mesh.geometry.getAttribute('position') as THREE.BufferAttribute;
         for (let i = 0; i < slot.drapeY.length; i++) pos.setY(i, slot.drapeY[i]);

--- a/src/render/ability_vfx/overlay_sprites.ts
+++ b/src/render/ability_vfx/overlay_sprites.ts
@@ -130,11 +130,23 @@ export class OverlaySprites {
       return;
     }
     this.wasEmpty = false;
-    (this.geo.attributes.position as THREE.BufferAttribute).needsUpdate = true;
-    (this.geo.attributes.aColor as THREE.BufferAttribute).needsUpdate = true;
-    (this.geo.attributes.aSize as THREE.BufferAttribute).needsUpdate = true;
-    (this.geo.attributes.aCell as THREE.BufferAttribute).needsUpdate = true;
-    (this.geo.attributes.aAlpha as THREE.BufferAttribute).needsUpdate = true;
+    // Upload only the prefix this frame wrote (the pooled cloud's idiom,
+    // ../vfx.ts packRenderCloud): a frame showing two windup orbs re-uploaded
+    // all CAPACITY points otherwise. Points past the prefix are stale by
+    // design and unreachable, because setDrawRange below stops at this.count.
+    this.upload(this.geo.attributes.position as THREE.BufferAttribute, this.count * 3);
+    this.upload(this.geo.attributes.aColor as THREE.BufferAttribute, this.count * 3);
+    this.upload(this.geo.attributes.aSize as THREE.BufferAttribute, this.count);
+    this.upload(this.geo.attributes.aCell as THREE.BufferAttribute, this.count);
+    this.upload(this.geo.attributes.aAlpha as THREE.BufferAttribute, this.count);
     this.geo.setDrawRange(0, this.count);
+  }
+
+  // clearUpdateRanges first, so a range queued on a frame this cloud was never
+  // submitted (nothing drawn, nothing uploaded) cannot pile up.
+  private upload(attr: THREE.BufferAttribute, components: number): void {
+    attr.clearUpdateRanges();
+    attr.addUpdateRange(0, components);
+    attr.needsUpdate = true;
   }
 }

--- a/src/render/ability_vfx/ribbons.ts
+++ b/src/render/ability_vfx/ribbons.ts
@@ -1,4 +1,5 @@
 import * as THREE from 'three';
+import type { VfxAnchorResolver } from '../vfx_anchor';
 import { type AbilityVfxTextures, OVERLAY_CELL } from './fx_textures';
 import { slashWidthScale } from './spectacle';
 
@@ -147,7 +148,9 @@ interface ArcSlot {
   pts: THREE.Vector3[];
 }
 
-export type RibbonAnchor = (id: number, heightFrac: number) => THREE.Vector3 | null;
+// The shared VFX anchor resolver (src/render/vfx_anchor.ts). `out` lets a
+// per-frame path resolve into its own scratch instead of allocating.
+export type RibbonAnchor = VfxAnchorResolver;
 
 // Plain world point (structurally satisfied by THREE.Vector3).
 export interface RibbonPoint {
@@ -181,6 +184,12 @@ export class AbilityVfxRibbons {
   private s1 = new THREE.Vector3();
   private s2 = new THREE.Vector3();
   private camPos = new THREE.Vector3();
+  // Per-frame anchor scratch (see ../vfx_anchor.ts): update() resolves a trail's
+  // source or target every frame and genBolt() resolves both ends of a live
+  // bolt. a1/a2 are separate because genBolt holds both readings at once; each
+  // is consumed before the next resolve into it.
+  private a1 = new THREE.Vector3();
+  private a2 = new THREE.Vector3();
   private ordered: THREE.Vector3[] = allocPts(TRAIL_PTS + 1); // scratch, holds refs only
   private coilScratch: THREE.Vector3[] = allocPts(COIL_PTS); // reused for both helices
 
@@ -654,7 +663,7 @@ export class AbilityVfxRibbons {
         // staggered volley follower: ride the caster's hand until launch
         t.delay -= dt;
         t.ttl -= dt;
-        const from = this.anchor(t.sourceId, 0.62);
+        const from = this.anchor(t.sourceId, 0.62, this.a1);
         if (from) {
           t.head.copy(from);
           t.origin.copy(from);
@@ -665,7 +674,7 @@ export class AbilityVfxRibbons {
         continue;
       }
       t.ttl -= dt;
-      const target = t.fixedTarget ? t.fixedTo : this.anchor(t.targetId, 0.5);
+      const target = t.fixedTarget ? t.fixedTo : this.anchor(t.targetId, 0.5, this.a1);
       if (!target || t.ttl <= 0) {
         t.active = false;
         continue;
@@ -885,8 +894,8 @@ export class AbilityVfxRibbons {
 
   // Midpoint displacement into the slot's preallocated points (no branches).
   private genBolt(b: BoltSlot): void {
-    const from = b.fixed ? b.fromP : this.anchor(b.sourceId, 0.62);
-    const to = b.fixed ? b.toP : this.anchor(b.targetId, 0.5);
+    const from = b.fixed ? b.fromP : this.anchor(b.sourceId, 0.62, this.a1);
+    const to = b.fixed ? b.toP : this.anchor(b.targetId, 0.5, this.a2);
     if (!from || !to) {
       b.count = 0;
       return;
@@ -985,10 +994,31 @@ export class AbilityVfxRibbons {
       return;
     }
     this.wasEmpty = false;
-    (this.geo.attributes.position as THREE.BufferAttribute).needsUpdate = true;
-    (this.geo.attributes.aCol as THREE.BufferAttribute).needsUpdate = true;
-    (this.geo.attributes.uv as THREE.BufferAttribute).needsUpdate = true;
-    if (this.geo.index) this.geo.index.needsUpdate = true;
+    // Upload only the prefix this frame actually wrote (the pooled cloud's
+    // idiom, ../vfx.ts packRenderCloud). The buffers are sized for the worst
+    // case (MAX_VERTS is thousands of vertices, ~180 KB across the three
+    // attributes plus the index), while a typical frame draws a handful of
+    // strips: without a range every live ribbon frame re-uploaded the whole
+    // set. Everything past the prefix is stale by design and unreachable,
+    // because setDrawRange below stops at this.i. clearUpdateRanges first, so
+    // a range queued on a frame the mesh was never submitted cannot pile up.
+    const posAttr = this.geo.attributes.position as THREE.BufferAttribute;
+    const colAttr = this.geo.attributes.aCol as THREE.BufferAttribute;
+    const uvAttr = this.geo.attributes.uv as THREE.BufferAttribute;
+    posAttr.clearUpdateRanges();
+    posAttr.addUpdateRange(0, this.v * 3);
+    posAttr.needsUpdate = true;
+    colAttr.clearUpdateRanges();
+    colAttr.addUpdateRange(0, this.v * 3);
+    colAttr.needsUpdate = true;
+    uvAttr.clearUpdateRanges();
+    uvAttr.addUpdateRange(0, this.v * 2);
+    uvAttr.needsUpdate = true;
+    if (this.geo.index) {
+      this.geo.index.clearUpdateRanges();
+      this.geo.index.addUpdateRange(0, this.i);
+      this.geo.index.needsUpdate = true;
+    }
     this.geo.setDrawRange(0, this.i);
   }
 }

--- a/src/render/ability_vfx/sequencer.ts
+++ b/src/render/ability_vfx/sequencer.ts
@@ -31,9 +31,27 @@ const IMPLODE_DUR = 0.42;
 const BARRIER_DUR = 1.35;
 const BARRIER_PLATE_LIFE = 1.1;
 
+// Per-frame anchor scratch for drawTransients (see src/render/vfx_anchor.ts).
+// Its four anchor reads live in mutually exclusive branches and each is spent
+// on plain-number overlay pushes inside its own branch, so one scratch covers
+// them; the one-shot beat paths below keep allocating (they run on an event,
+// not per frame).
+const transientAnchor = { x: 0, y: 0, z: 0 };
+
+/** A mutable world point. Kept structural so this module stays Three-free; a
+ *  THREE.Vector3 satisfies it, which is what the fx engine actually hands back. */
+export interface SeqPoint {
+  x: number;
+  y: number;
+  z: number;
+}
+
 // The host surface fx.ts implements: every primitive the sequences drive.
 export interface SequencerHost {
-  anchorOf(id: number, frac: number): { x: number; y: number; z: number } | null;
+  /** Resolve an entity anchor. Pass `out` from a per-frame path to fill a
+   *  caller-owned point instead of allocating (see src/render/vfx_anchor.ts);
+   *  the reading is only valid until that scratch is reused. */
+  anchorOf(id: number, frac: number, out?: SeqPoint): SeqPoint | null;
   groundYAt(x: number, z: number): number;
   ringAt(
     x: number,
@@ -1675,7 +1693,7 @@ export class ArchetypeSequencer {
     const flashDur = boost ? SPECTACLE.releaseDur : 0.1;
     const sinceRelease = slot.t - slot.releaseAt;
     if (sinceRelease >= 0 && sinceRelease < flashDur) {
-      const caster = host.anchorOf(slot.casterId, 0.58);
+      const caster = host.anchorOf(slot.casterId, 0.58, transientAnchor);
       if (caster) {
         const rp = sinceRelease / flashDur;
         const size = (0.6 + 1.1 * rp) * slot.power * (boost ? SPECTACLE.releaseStar : 1);
@@ -1812,7 +1830,7 @@ export class ArchetypeSequencer {
     // inward; tier 1 runs a smaller, sparser pull)
     if (slot.implode > 0) {
       slot.implode -= dt;
-      const caster = host.anchorOf(slot.casterId, 0.55);
+      const caster = host.anchorOf(slot.casterId, 0.55, transientAnchor);
       if (caster) {
         const motes = slot.tier === 0 ? 8 : 4;
         const pull = Math.max(0, slot.implode / IMPLODE_DUR);
@@ -1835,7 +1853,7 @@ export class ArchetypeSequencer {
     // barrier plates snapping into a guarding arc (staggered in, long fade)
     if (slot.barrierT > 0) {
       slot.barrierT -= dt;
-      const center = host.anchorOf(slot.casterId, 0.55);
+      const center = host.anchorOf(slot.casterId, 0.55, transientAnchor);
       if (center) {
         const elapsed = BARRIER_DUR - slot.barrierT;
         for (let k = 0; k < 5; k++) {
@@ -1866,7 +1884,9 @@ export class ArchetypeSequencer {
     // aura-less cases (strike.stars flourishes, a cc read with no worn aura).
     if (slot.ccStars > 0) {
       slot.ccStars -= dt;
-      const head = host.heldStunStars(slot.targetId) ? null : host.anchorOf(slot.targetId, 1.0);
+      const head = host.heldStunStars(slot.targetId)
+        ? null
+        : host.anchorOf(slot.targetId, 1.0, transientAnchor);
       if (head) {
         for (let k = 0; k < STUN_STAR_COUNT; k++) {
           const a = host.timeNow() * STUN_STAR_RATE + (k / STUN_STAR_COUNT) * Math.PI * 2;

--- a/src/render/ability_vfx/shells.ts
+++ b/src/render/ability_vfx/shells.ts
@@ -1,4 +1,5 @@
 import * as THREE from 'three';
+import type { VfxAnchorResolver } from '../vfx_anchor';
 
 // Translucent buff/barrier shells (the gallery's receiver shell): a soft
 // additive sphere with a fresnel-style rim (rim term in the shader) wrapped
@@ -6,6 +7,11 @@ import * as THREE from 'three';
 // a buff lands. Fixed slot pool; materials cloned once at construction.
 
 const SHELL_SLOTS = 8;
+
+// Per-frame anchor scratch (see ../vfx_anchor.ts): update() resolves one anchor
+// per live shell and consumes it before the next resolve. Module-level because
+// there is exactly one shell pool per fx engine.
+const anchorScratch = new THREE.Vector3();
 
 interface ShellSlot {
   mesh: THREE.Mesh;
@@ -102,12 +108,7 @@ export class BuffShells {
     slot.mesh.visible = true;
   }
 
-  update(
-    dt: number,
-    time: number,
-    frame: number,
-    anchor: (id: number, frac: number) => { x: number; y: number; z: number } | null,
-  ): void {
+  update(dt: number, time: number, frame: number, anchor: VfxAnchorResolver): void {
     for (const slot of this.slots) {
       if (!slot.active) continue;
       slot.age += dt;
@@ -121,7 +122,7 @@ export class BuffShells {
         slot.mesh.visible = false;
         continue;
       }
-      const at = anchor(slot.entityId, 0.5);
+      const at = anchor(slot.entityId, 0.5, anchorScratch);
       if (!at) {
         slot.active = false;
         slot.mesh.visible = false;

--- a/src/render/characters/visual.ts
+++ b/src/render/characters/visual.ts
@@ -9,7 +9,14 @@ import { WEAPON_SKINS } from '../../sim/content/weapon_skins';
 import type { OverheadEmoteId } from '../../world_api';
 import { GFX } from '../gfx';
 import { cloneMaterialWithHooks } from '../material_clone_hooks';
-import { createWeaponVfx, WEAPON_VFX, type WeaponVfxHandle } from '../weapon_vfx';
+import {
+  createWeaponVfx,
+  DEFAULT_TUNING,
+  WEAPON_VFX,
+  type WeaponVfxHandle,
+  type WeaponVfxTuning,
+} from '../weapon_vfx';
+import { scaleWeaponVfxTuning } from '../weapon_vfx_shed_core';
 import { weaponVfxTuningFor } from '../weapon_vfx_tuning';
 import {
   type AnimActionWeight,
@@ -380,6 +387,12 @@ export class CharacterVisual {
   }
   private weaponSkinId: string | null = null;
   private weaponVfx: WeaponVfxHandle[] = [];
+  // The skin's authored tuning row (the rig's 1.0 look) plus the shed
+  // multiplier last applied over it, and one scratch the scaled row is written
+  // into so a shed step allocates nothing.
+  private weaponVfxAuthored: Partial<WeaponVfxTuning> = {};
+  private weaponVfxShed = 1;
+  private readonly weaponVfxTuningScratch: WeaponVfxTuning = { ...DEFAULT_TUNING };
   /** Long-hair secondary motion (modular styles with sway morphs; empty and
    *  free on every other rig). */
   private hairSway = new HairSwayDriver();
@@ -1707,10 +1720,14 @@ export class CharacterVisual {
     const skin = this.weaponSkinId ? WEAPON_SKINS[this.weaponSkinId] : null;
     const spec = skin ? (WEAPON_VFX[skin.model] ?? null) : null;
     if (!skin || !spec) return;
+    // The authored row is the rig's 1.0 look; the shed lever below re-derives
+    // from it, so it must be kept rather than only pushed once.
+    this.weaponVfxAuthored = weaponVfxTuningFor(skin.model, spec.tier);
+    this.weaponVfxShed = 1;
     for (const payload of payloads) {
       const handle = createWeaponVfx(payload, spec, { grounded: false });
       handle.setBackdropVisible(false);
-      handle.setTuning(weaponVfxTuningFor(skin.model, spec.tier));
+      handle.setTuning(this.weaponVfxAuthored);
       handle.setPixelScale(weaponVfxViewportHeight * this.weaponVfxSpriteScale);
       // Tag the rig's own scene nodes: applyMaterials must never tint its
       // ShaderMaterials and the shadow pass has no business with sprite shells.
@@ -1733,10 +1750,48 @@ export class CharacterVisual {
 
   /** Advance the weapon-skin VFX (shader time, pulse, flicker). Cheap no-op
    *  without an active skin; the renderer calls it once per entity per frame.
-   *  Also re-pins bow payload orientation (see reattachHeldWeapon). */
-  updateWeaponVfx(dt: number): void {
+   *  Also re-pins bow payload orientation (see reattachHeldWeapon).
+   *
+   *  `shed` is the rig-strength multiplier from `weaponVfxShedScale` (viewer
+   *  distance plus the frame-budget governor's vfx lever); 1 is the authored
+   *  look. It only ever DIMS; what removes a rig is the far-LOD swap below.
+   *
+   *  The rig's point light deliberately keeps its `visible` flag at every
+   *  scale: three counts visible point lights into every lit material's program
+   *  cache key, so clearing one mid-flight is the open-world recompile freeze.
+   *  Dimming drives its intensity down instead, which is the look without the
+   *  hazard. */
+  updateWeaponVfx(dt: number, shed = 1): void {
     this.applySkinOrientation(dt);
+    if (this.weaponVfx.length === 0) return;
+    // A rig that the far-LOD swap has taken off screen still cost a full tick
+    // of uniform writes, emissive pulse and light flicker every frame, for
+    // something no pixel can show: `setFar` hides `modelWrap`, and a held
+    // weapon (with its rig) hangs off a bone INSIDE it.
+    //
+    // Gated on farMesh as well as `far`, and that is the load-bearing half:
+    // `setFar` leaves `modelWrap` VISIBLE when there is no baked mesh to stand
+    // in for it, while `isFar` reads true either way. Skipping on `far` alone
+    // would freeze a rig that is still drawing, leaving its motes hanging in
+    // the air and its light stuck at whatever the last flicker wrote.
+    if (this.far && this.farMesh) return;
+    this.applyWeaponVfxShed(shed);
     for (const handle of this.weaponVfx) handle.update(dt);
+  }
+
+  // Write-elided: setTuning walks every part and rewrites its materials, so the
+  // quantized scale is compared first and an unchanged frame costs nothing.
+  private applyWeaponVfxShed(shed: number): void {
+    const next = Number.isFinite(shed) ? Math.min(1, Math.max(0, shed)) : 1;
+    if (next === this.weaponVfxShed) return;
+    this.weaponVfxShed = next;
+    scaleWeaponVfxTuning(this.weaponVfxAuthored, next, this.weaponVfxTuningScratch);
+    for (const handle of this.weaponVfx) handle.setTuning(this.weaponVfxTuningScratch);
+  }
+
+  /** Dev/test probe: the shed multiplier currently applied to the skin rigs. */
+  weaponVfxShedLevel(): number {
+    return this.weaponVfxShed;
   }
 
   /** Blend pinned skin payloads between the authored grip glue and their

--- a/src/render/crowd_lod.ts
+++ b/src/render/crowd_lod.ts
@@ -27,6 +27,24 @@ const CROWD_LOD_HARD_RIGS = 48;
 const CROWD_LOD_MIN_SCALE = 0.6;
 
 /**
+ * The articulated-rig range BEFORE the crowd and per-tier factors below scale it:
+ * the one distance in this policy that is the same number on every client, in
+ * every scene, on every preset.
+ *
+ * Everything else here is deliberately adaptive, which makes it the wrong anchor
+ * for anything a second client must agree with: `crowdLodScaleSq` reads a
+ * PER-CLIENT, per-frame count of visible rigs, so the live band edges swing by
+ * more than 2x as unrelated players wander in and out of one viewer's frustum,
+ * and two viewers standing in the same spot do not even compute the same edge.
+ * A cosmetic fade keyed to the live edge would therefore pulse on crowd churn
+ * and differ between viewers; keyed to THIS it cannot do either
+ * (`weapon_vfx_shed_core.ts` is the consumer, and its header says why that
+ * matters for graphics-settings fairness).
+ */
+export const CHARACTER_LOD_RANGE = 58;
+export const CHARACTER_LOD_RANGE_SQ = CHARACTER_LOD_RANGE * CHARACTER_LOD_RANGE;
+
+/**
  * Ceiling on the linear range multiplier the animated far band may add on top of
  * the articulated band (58yd base * 1.3 = ~75yd, just inside the 80yd draw cap).
  * `gfx.ts` picks the per-tier value; this module clamps to it so no caller can

--- a/src/render/drape_lod_core.ts
+++ b/src/render/drape_lod_core.ts
@@ -1,0 +1,141 @@
+// Distance LOD for the small ground-VFX terrain drapes.
+//
+// The ability-VFX ground marks ride the selection-ring drape idiom: every
+// vertex of the mesh samples its own terrain height so the mark follows a slope
+// instead of burying its uphill half (see ./selection_ring). That drape is the
+// single most expensive thing those pools do, because the sampler is the sim's
+// real `groundHeight` chain, at roughly 3 microseconds a sample on desktop and
+// several times that on a phone. A buff ground aura re-drapes a 42-vertex disc
+// EVERY frame its wearer moves, per band, per buffed character in view, which
+// is the one steady-state drape cost in a fight.
+//
+// This module thins that sampling with camera distance: sample a subset of the
+// rim exactly and fill the vertices between two samples by interpolating in the
+// disc's own angular parameter space.
+//
+// SCOPE, and it is deliberate: this is for the SMALL discs only (buff auras and
+// dissolve decals, one to a few yards across). The wide shockwave rings keep
+// their exact per-vertex drape. Measured over the walkable overworld, thinning
+// a 1.5 yard aura disc costs a p99 of about 11 cm of vertical drape error and a
+// p95 of 4 cm, invisible on a 0.18-opacity annulus 20+ yards away; the same
+// treatment on a 10 to 20 yard shockwave footprint costs YARDS, because at that
+// span the exact mesh is already the coarsest honest description of the ground.
+// The `maxSampleSpacing` cap below is what enforces that split by construction:
+// a mark whose vertices are already far apart in world space cannot be thinned
+// at all, whatever its distance.
+//
+// Two further properties are load-bearing and pinned by
+// tests/drape_lod_core.test.ts:
+//
+//   1. Only the drape's vertical fidelity changes. Every sampled vertex keeps
+//      its exact world XZ, and every sample taken is one the exact drape would
+//      also have taken, so a mark's footprint, radius and position are
+//      byte-identical at every stride. Nothing a player reads and reacts to
+//      (where an AoE wavefront actually is) moves.
+//   2. The policy reads camera DISTANCE and the mark's own geometry, and
+//      nothing else: no graphics tier, no preset, no frame-budget governor. Two
+//      players standing in the same spot get the same drape whatever their
+//      settings, which keeps this well clear of
+//      docs/design/graphics-settings-fairness.md.
+//
+// Three/DOM-free and deterministic (a registered RENDER_PURE_CORE).
+
+import { drapeRingLocalY, type HeightSampler } from './selection_ring';
+
+/** Squared camera distances at which the drape steps down one stride. Inside
+ *  the first band the drape is always exact. */
+const STRIDE_BANDS_SQ = [20 * 20, 40 * 40, 70 * 70];
+export const MAX_DRAPE_STRIDE = 4;
+
+/** How far apart, in yards, two consecutive SAMPLED vertices may end up. The
+ *  interpolation fills the gap with a straight line, so this is the length of
+ *  terrain a fill is allowed to span; past about 40 yards from the camera the
+ *  looser bound applies. Both are well inside the aura and decal geometries and
+ *  well outside the wide shockwave footprints, which is the point. */
+const MAX_SAMPLE_SPACING_NEAR = 0.6;
+const MAX_SAMPLE_SPACING_FAR = 1;
+
+/** Never decimate a rim below this many sampled points, whatever the numbers
+ *  above say: a disc described by fewer than this stops reading as a disc. */
+const MIN_FAN_SAMPLES = 8;
+
+/**
+ * Drape stride for a mark whose center is `distanceSq` (squared yards) from the
+ * camera and whose adjacent vertices sit `vertexSpacing` yards apart: 1 is the
+ * exact per-vertex drape, N samples every Nth vertex.
+ *
+ * An unknown distance (negative or non-finite) means "assume it is right in
+ * front of the player" and drapes exactly, so a caller that has not seen a
+ * camera yet can never look worse than the old code.
+ */
+export function drapeStrideFor(distanceSq: number, vertexSpacing: number): number {
+  if (!Number.isFinite(distanceSq) || distanceSq < 0) return 1;
+  if (!Number.isFinite(vertexSpacing) || vertexSpacing <= 0) return 1;
+  let byDistance = 1;
+  for (const band of STRIDE_BANDS_SQ) {
+    if (distanceSq <= band) break;
+    byDistance++;
+  }
+  const maxSpacing =
+    distanceSq > STRIDE_BANDS_SQ[1] ? MAX_SAMPLE_SPACING_FAR : MAX_SAMPLE_SPACING_NEAR;
+  const bySpacing = Math.floor(maxSpacing / vertexSpacing);
+  return Math.max(1, Math.min(MAX_DRAPE_STRIDE, byDistance, bySpacing));
+}
+
+/** Yards between two adjacent rim vertices of a `segments`-sided disc of the
+ *  given radius: the input `drapeStrideFor` needs to bound its fills. */
+export function fanVertexSpacing(radius: number, segments: number): number {
+  return (2 * Math.PI * Math.abs(radius)) / Math.max(1, segments);
+}
+
+function clampFanStride(stride: number, rimSpan: number): number {
+  if (!Number.isFinite(stride) || stride <= 1) return 1;
+  const maxStride = Math.floor(rimSpan / Math.max(1, MIN_FAN_SAMPLES - 1));
+  return Math.max(1, Math.min(Math.floor(stride), maxStride));
+}
+
+/**
+ * Drape a triangle-fan disc (three's CircleGeometry layout: index 0 is the
+ * center, indices 1..n-1 walk the rim in angular order and the last one closes
+ * the seam on the first).
+ *
+ * `stride` 1 is exactly `drapeRingLocalY`. Above that, the center and every
+ * `stride`-th rim vertex are sampled (the seam-closing last index always is),
+ * and the rim vertices between two samples are linearly interpolated.
+ */
+export function drapeFanLocalY(
+  localXZ: ArrayLike<number>,
+  cx: number,
+  cz: number,
+  baseY: number,
+  scale: number,
+  lift: number,
+  sample: HeightSampler,
+  outY: Float32Array,
+  stride = 1,
+): Float32Array {
+  const n = outY.length;
+  const rimSpan = n - 1; // rim indices 1..n-1
+  const step = clampFanStride(stride, rimSpan);
+  if (step <= 1 || rimSpan < 2) {
+    return drapeRingLocalY(localXZ, cx, cz, baseY, scale, lift, sample, outY);
+  }
+  const invScale = scale !== 0 ? 1 / scale : 1;
+  const sampleInto = (i: number): void => {
+    const h = sample(cx + scale * localXZ[i * 2], cz + scale * localXZ[i * 2 + 1]);
+    outY[i] = (h + lift - baseY) * invScale;
+  };
+  sampleInto(0);
+  sampleInto(1);
+  let prev = 1;
+  const last = n - 1;
+  while (prev < last) {
+    const next = Math.min(prev + step, last);
+    sampleInto(next);
+    const spanY = outY[next] - outY[prev];
+    const invSpan = 1 / (next - prev);
+    for (let j = prev + 1; j < next; j++) outY[j] = outY[prev] + spanY * (j - prev) * invSpan;
+    prev = next;
+  }
+  return outY;
+}

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -148,6 +148,7 @@ import { trackWebGLContext } from './context_release';
 import {
   animatesEveryFrame,
   animCadenceFrames,
+  CHARACTER_LOD_RANGE_SQ,
   type CharacterLodBands,
   characterLodBandsInto,
   showsStaticFarMesh,
@@ -432,6 +433,7 @@ import { ValeCupPracticeSky } from './vale_cup_practice_sky';
 import { buildValeCupStadium, type ValeCupStadiumView } from './vale_cup_stadium';
 import { buildValeCupTeamRings, type ValeCupTeamRingsView } from './vale_cup_team_ring';
 import { SCHOOL_COLORS, Vfx } from './vfx';
+import { createVfxAnchor } from './vfx_anchor';
 import {
   finishViewCandidates,
   type ViewCandidate,
@@ -457,6 +459,7 @@ import {
   type WeaponSkinApplyDecision,
   WeaponSkinApplyQueue,
 } from './weapon_vfx_apply_queue_core';
+import { weaponVfxShedScale } from './weapon_vfx_shed_core';
 import { Weather } from './weather';
 import { precipForBiome } from './weather_field_core';
 import { buildWorldAmbientSources, crowdAmbienceAt, footstepSurfaceAt } from './world_audio';
@@ -547,7 +550,8 @@ const SPARKLE_DRAW_RANGE_SQ = 40 * 40;
 // beyond this, the articulated rig swaps for its single-draw merged far LOD.
 // Keep the full rig just past nameplate range so nearby characters and held
 // weapons stay readable on low while the 80u draw cap still bounds total cost.
-const ENTITY_LOD_RANGE_SQ = 58 * 58;
+// The literal lives in `crowd_lod.ts` beside the factors that scale it.
+const ENTITY_LOD_RANGE_SQ = CHARACTER_LOD_RANGE_SQ;
 
 // Crowd-adaptive character LOD (articulated-rig + shadow ranges, and the mid-band
 // animation cadence) lives in `crowd_lod.ts`: pure policy, unit-tested there.
@@ -2759,13 +2763,16 @@ export class Renderer {
     this.temporalHourglassGroundVisuals = new TemporalHourglassGroundVisuals(this.scene, (x, z) =>
       groundHeight(x, z, this.sim.cfg.seed),
     );
-    const vfxAnchor = (id: number, frac: number) => {
+    const vfxAnchor = createVfxAnchor((id, pose) => {
       const v = this.views.get(id);
-      if (!v) return null;
+      if (!v) return false;
       const e = this.sim.entities.get(id);
-      const h = v.height * (e?.scale ?? 1) * frac;
-      return new THREE.Vector3(v.group.position.x, v.group.position.y + h, v.group.position.z);
-    };
+      pose.x = v.group.position.x;
+      pose.y = v.group.position.y;
+      pose.z = v.group.position.z;
+      pose.height = v.height * (e?.scale ?? 1);
+      return true;
+    });
     this.vfx = new Vfx(this.scene, vfxAnchor);
     this.vfx.setViewportScale(this.webgl.domElement.clientHeight * this.webgl.getPixelRatio(), 60);
     this.bgFx = new BattlegroundFx(this.sim, this.views, this.vfx);
@@ -10127,8 +10134,12 @@ export class Renderer {
       if (runCharacterPresentation) active.update(dt, st, animate);
       else active.advanceOffscreen(dt);
       // Weapon-skin VFX ride the humanoid rig's held weapon. Hidden cosmetic
-      // rigs skip their uniform writes until they return to view.
-      if (runCharacterPresentation) v.visual.updateWeaponVfx(dt);
+      // rigs skip their uniform writes until they return to view; the visible
+      // ones shed with camera distance and the frame-budget governor's vfx
+      // lever (weapon_vfx_shed_core owns why that split is fairness-safe).
+      if (runCharacterPresentation) {
+        v.visual.updateWeaponVfx(dt, weaponVfxShedScale(d2, this.appliedBudgetLevels?.vfx ?? 1));
+      }
       // The sheathe swap is deferred to the gesture midpoint, so the rig (and any
       // skin VFX point light on it) is rebuilt inside update(), not at the diff.
       if (v.visual.consumeWeaponGraphDirty()) this.reconcileViewLights(v);

--- a/src/render/vfx.ts
+++ b/src/render/vfx.ts
@@ -2,6 +2,7 @@ import * as THREE from 'three';
 import { loadTexture, releaseTexture } from './assets/loader';
 import { registerDeferredPreload } from './assets/preload';
 import { GFX } from './gfx';
+import type { VfxAnchorResolver } from './vfx_anchor';
 import {
   insertActiveParticleSlot,
   pointSpriteBoundingRadius,
@@ -271,7 +272,9 @@ function projectileSprites(school: string): { core: number; trail: number } {
     : { core: SPR.glowCore, trail: SPR.sparkle };
 }
 
-export type EntityAnchor = (id: number, heightFrac: number) => THREE.Vector3 | null;
+// The world-anchor resolver (src/render/vfx_anchor.ts owns the contract and the
+// allocation-free `out` parameter).
+export type EntityAnchor = VfxAnchorResolver;
 
 export class Vfx {
   private points: THREE.Points;
@@ -302,6 +305,14 @@ export class Vfx {
   private tmpColor = new THREE.Color();
   private tmpDirection = new THREE.Vector3();
   private readonly beamUp = new THREE.Vector3(0, 1, 0);
+  // Per-frame anchor scratch (see vfx_anchor.ts): update() resolves a bubble
+  // beam's two endpoints and each projectile's target every frame. Each reading
+  // is consumed before its scratch is reused, and the beam pair needs two
+  // because both endpoints are live at once.
+  private readonly beamFromScratch = new THREE.Vector3();
+  private readonly beamToScratch = new THREE.Vector3();
+  private readonly homingScratch = new THREE.Vector3();
+  private readonly homingDir = new THREE.Vector3();
   // fireworkBurst palette scratch, reused across shells (spawn() copies
   // components, never retaining the reference): a goal volley allocates
   // no Color objects.
@@ -1606,8 +1617,8 @@ export class Vfx {
     for (let i = this.bubbleBeams.length - 1; i >= 0; i--) {
       const stream = this.bubbleBeams[i];
       stream.remaining -= dt;
-      const from = this.anchor(stream.sourceId, 0.58);
-      const to = this.anchor(stream.targetId, 0.52);
+      const from = this.anchor(stream.sourceId, 0.58, this.beamFromScratch);
+      const to = this.anchor(stream.targetId, 0.52, this.beamToScratch);
       if (!from || !to || stream.remaining <= 0) {
         this.removeBubbleBeam(i);
         continue;
@@ -1664,12 +1675,12 @@ export class Vfx {
     for (let i = this.projectiles.length - 1; i >= 0; i--) {
       const pr = this.projectiles[i];
       pr.ttl -= dt;
-      const target = this.anchor(pr.targetId, 0.5);
+      const target = this.anchor(pr.targetId, 0.5, this.homingScratch);
       if (!target || pr.ttl <= 0) {
         this.projectiles.splice(i, 1);
         continue;
       }
-      const dir = target.clone().sub(pr.pos);
+      const dir = this.homingDir.subVectors(target, pr.pos);
       const dist = dir.length();
       const step = pr.speed * dt;
       if (dist <= Math.max(0.7, step)) {

--- a/src/render/vfx_anchor.ts
+++ b/src/render/vfx_anchor.ts
@@ -1,0 +1,68 @@
+import * as THREE from 'three';
+
+// The one world-anchor resolver every VFX subsystem shares: "give me the world
+// point at `frac` of entity `id`'s displayed height". The renderer used to
+// close over this inline and return a fresh THREE.Vector3 on every call, which
+// is fine for a one-shot spawn and expensive per frame: ribbons, shells, ground
+// auras, windups, orbit bands and the sequencer's transients all resolve
+// anchors EVERY frame, so a busy fight allocated on the order of a hundred
+// vectors per frame purely to read three floats (the periodic multi-ms GC
+// hitch, and a "no per-frame new THREE.*" break, see src/render/CLAUDE.md).
+//
+// The resolver therefore takes an optional caller-owned destination. Per-frame
+// callers pass their own scratch vector and allocate nothing; one-shot spawn
+// callers omit it and keep the old contract exactly (a fresh vector they may
+// retain). The returned vector is ALWAYS the destination when one is given, so
+// a caller that passes a scratch must consume the reading before its next call
+// with that same scratch.
+//
+// Host-agnostic on purpose (it knows nothing about Sim, views, or the scene
+// graph): the renderer supplies the pose lookup, and tests/vfx_anchor.test.ts
+// drives it directly.
+
+/**
+ * Resolve the world point at `heightFrac` of an entity's displayed height, or
+ * null when the entity has no live view.
+ *
+ * Pass `out` from a per-frame path to resolve without allocating; the reading is
+ * then only valid until that same scratch is reused. Omit it from a one-shot
+ * spawn path to get a fresh vector you may retain.
+ */
+export type VfxAnchorResolver = (
+  id: number,
+  heightFrac: number,
+  out?: THREE.Vector3,
+) => THREE.Vector3 | null;
+
+/** A displayed entity pose: the view group's world position plus the height
+ *  the anchor fraction is measured against (rig height x entity scale). */
+export interface VfxAnchorPose {
+  x: number;
+  y: number;
+  z: number;
+  height: number;
+}
+
+/**
+ * Fill `out` with the displayed pose of `id`. Returns false when the entity has
+ * no live view, which the anchor reports as a null reading. Implementations MUST
+ * write into `out` rather than returning a new object: the whole point is that
+ * resolving an anchor allocates nothing.
+ */
+export type VfxAnchorPoseFill = (id: number, out: VfxAnchorPose) => boolean;
+
+/**
+ * Build the shared anchor resolver over a pose lookup.
+ *
+ * `anchor(id, frac)` returns a NEW vector (the historical contract, safe to
+ * retain); `anchor(id, frac, out)` writes into `out` and returns it, so a
+ * per-frame path can resolve anchors without touching the heap.
+ */
+export function createVfxAnchor(fill: VfxAnchorPoseFill): VfxAnchorResolver {
+  const pose: VfxAnchorPose = { x: 0, y: 0, z: 0, height: 0 };
+  return (id: number, frac: number, out?: THREE.Vector3): THREE.Vector3 | null => {
+    if (!fill(id, pose)) return null;
+    const target = out ?? new THREE.Vector3();
+    return target.set(pose.x, pose.y + pose.height * frac, pose.z);
+  };
+}

--- a/src/render/weapon_vfx.ts
+++ b/src/render/weapon_vfx.ts
@@ -2829,6 +2829,10 @@ export interface WeaponVfxCreateOptions {
   backdrop?: boolean;
 }
 
+/** Scene-census bucket for every weapon-skin VFX rig (the `?perf` overlay's
+ *  `renderCategory`). Diagnostics only: nothing reads it to decide a draw. */
+export const WEAPON_VFX_RENDER_CATEGORY = 'weaponvfx';
+
 export interface WeaponVfxHandle {
   group: THREE.Group;
   sceneExtras: THREE.Group;
@@ -2854,6 +2858,13 @@ export function createWeaponVfx(
   group.name = 'weapon_vfx';
   const sceneExtras = new THREE.Group();
   sceneExtras.name = 'weapon_vfx_extras';
+  // Diagnostics-only label the `?perf` scene census buckets by (the renderer's
+  // setRenderCategory writes the same key, and the census inherits it down the
+  // subtree). Without it a rig's 6 to 10 additive draws landed in the character
+  // rig's own bucket, so the overlay could not see what a skin actually costs.
+  // NEVER a behaviour or visibility gate.
+  group.userData.renderCategory = WEAPON_VFX_RENDER_CATEGORY;
+  sceneExtras.userData.renderCategory = WEAPON_VFX_RENDER_CATEGORY;
 
   const parts: VfxPart[] = [];
   const emissives: EmissiveEntry[] = [];
@@ -3124,6 +3135,10 @@ export function buildWeaponVfxPrewarmGroup(): THREE.Group {
   // are part of every program cache key: one extra point light here and the
   // whole boot compile warms keys no live frame ever asks for.
   handle.light.visible = false;
+  // The boot prewarm group is census-tagged 'prewarm' as a whole; keep this
+  // synthetic rig inside that bucket rather than reporting as a live skin.
+  handle.group.userData.renderCategory = 'prewarm';
+  handle.sceneExtras.userData.renderCategory = 'prewarm';
   group.add(host);
   group.add(handle.sceneExtras);
   return group;

--- a/src/render/weapon_vfx_shed_core.ts
+++ b/src/render/weapon_vfx_shed_core.ts
@@ -1,0 +1,133 @@
+// How strongly to draw a weapon-skin VFX rig.
+//
+// A skin's rig is 6 to 10 additive transparent nodes riding the wearer's held
+// weapon. Until now they answered to no lever at all: the `weapons` bucket in
+// GFX_BUCKET_BANDS is pinned ungovernable at 1.0 on every tier, so a rig drew at
+// its full authored strength whatever the scene was doing.
+//
+// WHAT THIS IS, AND IS NOT. It is a FADE, not a cull. `createWeaponVfx`'s
+// applyTuning only stops drawing a part at a multiplier of 0.01 or less, and the
+// smallest multiplier this can produce (MIN_DISTANCE_SCALE x GOVERNOR_FLOOR,
+// against the smallest authored channel that ships) stays comfortably above
+// that, on purpose. So nothing here removes a draw call, and dimming an additive
+// transparent quad does not reduce its fill cost either. What removes the rig is
+// the character LOD swap: past `showsStaticFarMesh` the whole articulated rig
+// (weapon and rig included) is replaced by one baked mesh, somewhere between
+// about 35 and 75 yards depending on crowd and tier.
+//
+// This exists so that removal is not a POP. Before it, a legendary skin drew at
+// full authored strength right up to the swap and then vanished mid-stride. The
+// fade is therefore product polish on purchased cosmetics, plus one genuine
+// courtesy: a client under frame-budget pressure can turn other players' weapon
+// glare down.
+//
+// TWO INPUTS, AND THE SPLIT IS THE FAIRNESS ARGUMENT
+// (docs/design/graphics-settings-fairness.md):
+//
+//   - VIEWER DISTANCE (squared distance from the local player, the measure the
+//     crowd LOD bands already rank rigs by), against the FIXED anchor
+//     `CHARACTER_LOD_RANGE_SQ`. Deliberately the pre-scaling constant and not
+//     the live band edge: the live edge reads a per-client, per-frame count of
+//     visible rigs, so keying a fade to it would make a wearer's glow pulse as
+//     unrelated players wander past, and would give two viewers standing in the
+//     same spot different results. Against the constant, this arm is identical
+//     for every player on every preset, so it can move no one's information
+//     relative to anyone else's.
+//   - The frame-budget governor's `vfx` bucket, the same lever the pooled
+//     particle cloud and the ability VFX already answer to. It is the one input
+//     that differs between two viewers, and it is floored at `GOVERNOR_FLOOR`
+//     so it can only dim.
+//
+// Neither arm reaches zero, by construction. Nothing here can take a rig away;
+// the LOD swap owns that, and it owns it on inputs the whole render path already
+// shares. What is faded is decoration ON a weapon: the wearer, their nameplate,
+// their cast bar, their auras, their position and the weapon model itself are
+// untouched at every scale.
+//
+// Three/DOM-free and deterministic (a registered RENDER_PURE_CORE).
+
+import { CHARACTER_LOD_RANGE_SQ } from './crowd_lod';
+import type { WeaponVfxTuning } from './weapon_vfx';
+
+/** Fraction of the anchor inside which the rig draws at its authored strength. */
+const FULL_STRENGTH_FRACTION = 0.4;
+/** Where the distance fade bottoms out, at and beyond the anchor. */
+const MIN_DISTANCE_SCALE = 0.4;
+
+/** The governor may dim a rig to this fraction of its authored strength and no
+ *  further, so a low frame rate never changes what one viewer can make out. */
+export const WEAPON_VFX_GOVERNOR_FLOOR = 0.35;
+
+/** Scales are quantized to this step before they are applied, so the per-frame
+ *  caller can elide the write whenever the plan has not really moved. At a 0.05
+ *  step the fade advances in increments no eye resolves on a glow. */
+const SCALE_STEP = 0.05;
+
+/** Every tuning channel, so a scale reaches all of them and a new channel
+ *  cannot silently escape the lever (pinned against `DEFAULT_TUNING`). */
+export const WEAPON_VFX_TUNING_CHANNELS = [
+  'glow',
+  'bloom',
+  'light',
+  'core',
+  'motes',
+  'aurora',
+  'mist',
+  'sparkle',
+  'shell',
+  'pool',
+] as const satisfies readonly (keyof WeaponVfxTuning)[];
+
+const FULL_STRENGTH_SQ = CHARACTER_LOD_RANGE_SQ * FULL_STRENGTH_FRACTION * FULL_STRENGTH_FRACTION;
+
+/**
+ * The distance half of the fade: 1 inside `FULL_STRENGTH_FRACTION` of the
+ * anchor, easing to `MIN_DISTANCE_SCALE` at the anchor and holding there.
+ *
+ * Eased rather than linear in the squared domain so the ramp reads evenly as the
+ * viewer walks: distance-squared grows quadratically, and a linear fade over it
+ * would dump most of the change into the last few yards.
+ */
+function distanceScale(distanceSq: number): number {
+  if (!Number.isFinite(distanceSq) || distanceSq <= FULL_STRENGTH_SQ) return 1;
+  if (distanceSq >= CHARACTER_LOD_RANGE_SQ) return MIN_DISTANCE_SCALE;
+  const t =
+    (Math.sqrt(distanceSq) - Math.sqrt(FULL_STRENGTH_SQ)) /
+    (Math.sqrt(CHARACTER_LOD_RANGE_SQ) - Math.sqrt(FULL_STRENGTH_SQ));
+  return 1 - t * (1 - MIN_DISTANCE_SCALE);
+}
+
+/**
+ * The multiplier to fold onto a skin's authored tuning: 1 is the full authored
+ * look. Never 0; see the header for why removal is not this module's job.
+ *
+ * `vfxLevel` is the frame-budget governor's vfx bucket level (1 when it is not
+ * shedding). A non-finite level reads as "no pressure".
+ */
+export function weaponVfxShedScale(distanceSq: number, vfxLevel: number): number {
+  const byDistance = distanceScale(Math.max(0, distanceSq));
+  const level = Number.isFinite(vfxLevel) ? Math.min(1, Math.max(0, vfxLevel)) : 1;
+  const byGovernor = WEAPON_VFX_GOVERNOR_FLOOR + (1 - WEAPON_VFX_GOVERNOR_FLOOR) * level;
+  return Math.round((byDistance * byGovernor) / SCALE_STEP) * SCALE_STEP;
+}
+
+/** The floor of the whole lever: what a rig still draws at under the worst
+ *  combination of distance and governor pressure. Exported so a test can prove
+ *  it stays clear of the multiplier at which a part would stop drawing. */
+export const WEAPON_VFX_MIN_SHED_SCALE = MIN_DISTANCE_SCALE * WEAPON_VFX_GOVERNOR_FLOOR;
+
+/**
+ * Fold `scale` onto the skin's authored tuning row into a caller-owned object
+ * (an absent authored channel is the 1.0 default, exactly as `createWeaponVfx`
+ * reads it). Returns `out` so the caller can hand it straight to `setTuning`.
+ */
+export function scaleWeaponVfxTuning(
+  authored: Partial<WeaponVfxTuning>,
+  scale: number,
+  out: WeaponVfxTuning,
+): WeaponVfxTuning {
+  for (const channel of WEAPON_VFX_TUNING_CHANNELS) {
+    out[channel] = (authored[channel] ?? 1) * scale;
+  }
+  return out;
+}

--- a/tests/ability_vfx_frame_cost.test.ts
+++ b/tests/ability_vfx_frame_cost.test.ts
@@ -1,0 +1,242 @@
+import * as THREE from 'three';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { AbilityVfxFx } from '../src/render/ability_vfx/fx';
+import { abilityVfxTextures } from '../src/render/ability_vfx/fx_textures';
+import { GroundAuras } from '../src/render/ability_vfx/ground_auras';
+import { OverlaySprites } from '../src/render/ability_vfx/overlay_sprites';
+import { AbilityVfxRibbons } from '../src/render/ability_vfx/ribbons';
+import { ABILITY_VFX_FULL_SPECS } from '../src/render/ability_vfx_full_specs';
+import { createVfxAnchor } from '../src/render/vfx_anchor';
+
+// The steady-state combat cost of the ability-VFX subsystem: anchors resolved
+// every frame must not allocate, and the two immediate-mode buffers must upload
+// only the prefix the frame wrote instead of their whole worst-case capacity.
+// Both are driven through the REAL classes here (not a stub), because the
+// regression these guard against is a call site quietly dropping its scratch or
+// its update range, which only shows up when the live update() walk runs.
+
+const FIREBALL_SPEC = ABILITY_VFX_FULL_SPECS.fireball;
+
+function installCanvasStub(): void {
+  const noop = () => {};
+  const gradient = { addColorStop: noop };
+  const context = {
+    arc: noop,
+    beginPath: noop,
+    clip: noop,
+    closePath: noop,
+    createImageData: (width: number, height: number) => ({
+      data: new Uint8ClampedArray(width * height * 4),
+    }),
+    createLinearGradient: () => gradient,
+    createRadialGradient: () => gradient,
+    ellipse: noop,
+    fill: noop,
+    fillRect: noop,
+    lineTo: noop,
+    moveTo: noop,
+    putImageData: noop,
+    rect: noop,
+    restore: noop,
+    rotate: noop,
+    save: noop,
+    scale: noop,
+    stroke: noop,
+    translate: noop,
+  };
+  vi.stubGlobal('document', {
+    createElement: () => ({ width: 0, height: 0, getContext: () => context }),
+  });
+}
+
+/** The renderer's real anchor, wrapped to record how each resolve was made. */
+function countingAnchor(heightById: (id: number) => number | null) {
+  const counts = { withScratch: 0, allocating: 0 };
+  const base = createVfxAnchor((id, pose) => {
+    const height = heightById(id);
+    if (height === null) return false;
+    pose.x = id * 2;
+    pose.y = 0;
+    pose.z = -5;
+    pose.height = height;
+    return true;
+  });
+  const anchor = (id: number, frac: number, out?: THREE.Vector3) => {
+    if (out) counts.withScratch++;
+    else counts.allocating++;
+    return base(id, frac, out);
+  };
+  return { anchor, counts };
+}
+
+function rangeOf(attr: THREE.BufferAttribute): { start: number; count: number } | null {
+  const ranges = attr.updateRanges;
+  return ranges.length === 1 ? { start: ranges[0].start, count: ranges[0].count } : null;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('ability VFX steady-state frame cost', () => {
+  it('resolves every per-frame anchor into a scratch vector, allocating none', () => {
+    installCanvasStub();
+    const camera = new THREE.PerspectiveCamera(60, 1, 0.1, 100);
+    camera.updateMatrixWorld();
+    const { anchor, counts } = countingAnchor(() => 2);
+    const fx = new AbilityVfxFx(new THREE.Scene(), camera, anchor, () => 0);
+    fx.setDelegates(vi.fn(), vi.fn(), vi.fn(), vi.fn());
+
+    // The held families are frame-stamped, so the painter re-holds them every
+    // frame: mirror that, or the pools sweep themselves and the walk goes quiet.
+    const holdHeldFamilies = () => {
+      for (const id of [7, 8]) {
+        fx.windup(id, 0xff0000, 0.5, 'runes');
+        fx.orbit(id, 'runes', 0x00ff00);
+        fx.holdShell(id, 0x0000ff);
+        fx.holdGroundAura(id, 0, 0x00ffff, true);
+        fx.holdStunStars(id, 3);
+      }
+    };
+    holdHeldFamilies();
+    // travelling ribbons (both anchored ends) and a live sequence, whose
+    // per-frame transients (the release flash) anchor the caster every frame
+    fx.cometTrail(7, 8, 0xffff00, 0.2, false);
+    fx.jaggedBolt(7, 8, 0xffffff);
+    fx.sequenceInstant('fireball', FIREBALL_SPEC, 7, 8, 0xff8800, 0);
+
+    fx.update(1 / 60);
+    counts.withScratch = 0;
+    counts.allocating = 0;
+    // three more frames of the same live state: the steady state is what costs
+    for (let i = 0; i < 3; i++) {
+      holdHeldFamilies();
+      fx.update(1 / 60);
+    }
+
+    expect(counts.withScratch).toBeGreaterThan(20);
+    expect(counts.allocating).toBe(0);
+  });
+
+  it('drops a per-frame anchor cleanly when the entity loses its view', () => {
+    installCanvasStub();
+    const camera = new THREE.PerspectiveCamera(60, 1, 0.1, 100);
+    camera.updateMatrixWorld();
+    const alive = new Set([7, 8]);
+    const { anchor, counts } = countingAnchor((id) => (alive.has(id) ? 2 : null));
+    const fx = new AbilityVfxFx(new THREE.Scene(), camera, anchor, () => 0);
+    fx.setDelegates(vi.fn(), vi.fn(), vi.fn(), vi.fn());
+    fx.holdShell(8, 0x0000ff);
+    fx.holdGroundAura(8, 0, 0x00ffff, true);
+    fx.update(1 / 60);
+    expect(fx.groundAuraCountOf(8)).toBe(1);
+
+    alive.delete(8);
+    fx.update(1 / 60);
+    // the null reading releases the pools rather than drawing at a stale point
+    expect(fx.groundAuraCountOf(8)).toBe(0);
+    expect(counts.allocating).toBe(0);
+  });
+
+  it('stops re-draping a standing wearer once, instead of chasing the breath', () => {
+    installCanvasStub();
+    const auras = new GroundAuras(new THREE.Scene(), abilityVfxTextures());
+    let samples = 0;
+    const groundY = () => {
+      samples++;
+      return 0;
+    };
+    const { anchor } = countingAnchor(() => 2);
+    auras.hold(7, 0, 0x00ffff, true, 0);
+    // Four seconds of a perfectly still wearer: more than a full breath cycle
+    // (0.4 Hz), which used to cross the old absolute scale threshold several
+    // times a second and re-drape all 42 vertices each time.
+    let settledFrom = 0;
+    for (let frame = 1; frame <= 240; frame++) {
+      auras.hold(7, 0, 0x00ffff, true, frame);
+      auras.update(1 / 60, frame / 60, frame, anchor, groundY, 0, 0);
+      if (frame === 120) settledFrom = samples;
+    }
+    // the disc drapes while it grows in, then settles: the whole second half is
+    // one center-height read per frame and not a single vertex resample
+    expect(samples - settledFrom).toBe(120);
+    // 3 drapes in all, every one of them inside the 0.4s grow-in, at the full
+    // 42 vertices (this disc is 15 yards from the camera, inside the exact band)
+    expect(samples).toBe(240 + 3 * 42);
+
+    // ...and real movement still re-drapes: the terrain under the disc changed
+    let moved = 0;
+    const movingAnchor = (id: number, frac: number, out?: THREE.Vector3) => {
+      const at = anchor(id, frac, out);
+      if (at) at.x += moved;
+      return at;
+    };
+    const before = samples;
+    for (let frame = 241; frame <= 250; frame++) {
+      moved += 0.4;
+      auras.hold(7, 0, 0x00ffff, true, frame);
+      auras.update(1 / 60, frame / 60, frame, movingAnchor, groundY, 0, 0);
+    }
+    expect(samples - before).toBeGreaterThan(100);
+  });
+
+  it('uploads only the ribbon prefix the frame wrote', () => {
+    installCanvasStub();
+    const { anchor } = countingAnchor(() => 2);
+    const scene = new THREE.Scene();
+    const ribbons = new AbilityVfxRibbons(scene, anchor, abilityVfxTextures());
+    const geo = (ribbons as unknown as { geo: THREE.BufferGeometry }).geo;
+    const pos = geo.attributes.position as THREE.BufferAttribute;
+    const col = geo.attributes.aCol as THREE.BufferAttribute;
+    const uv = geo.attributes.uv as THREE.BufferAttribute;
+    const index = geo.index as THREE.BufferAttribute;
+
+    ribbons.spawnBoltPoints(0, 0, 0, 4, 0, 0, 0xffffff, 0.5, 0.1, 1);
+    ribbons.update(1 / 60, new THREE.Vector3(0, 2, 8));
+
+    const drawn = geo.drawRange.count;
+    expect(drawn).toBeGreaterThan(0);
+    // the strip is two vertices per point, and the index prefix IS the draw range
+    const verts = (rangeOf(pos)?.count ?? 0) / 3;
+    expect(verts).toBeGreaterThan(0);
+    expect(rangeOf(pos)).toEqual({ start: 0, count: verts * 3 });
+    expect(rangeOf(col)).toEqual({ start: 0, count: verts * 3 });
+    expect(rangeOf(uv)).toEqual({ start: 0, count: verts * 2 });
+    expect(rangeOf(index)).toEqual({ start: 0, count: drawn });
+    // and that prefix is a small fraction of the worst-case buffers it lives in
+    expect(verts * 3).toBeLessThan(pos.array.length / 4);
+
+    // a second frame REPLACES the range instead of stacking one per frame
+    ribbons.update(1 / 60, new THREE.Vector3(0, 2, 8));
+    expect(pos.updateRanges.length).toBe(1);
+    expect(index.updateRanges.length).toBe(1);
+  });
+
+  it('uploads only the overlay sprites the frame pushed', () => {
+    installCanvasStub();
+    const overlay = new OverlaySprites(new THREE.Scene(), abilityVfxTextures());
+    const geo = (overlay as unknown as { geo: THREE.BufferGeometry }).geo;
+    const pos = geo.attributes.position as THREE.BufferAttribute;
+    const size = geo.attributes.aSize as THREE.BufferAttribute;
+    const capacity = pos.array.length / 3;
+
+    overlay.beginFrame();
+    for (let i = 0; i < 3; i++) overlay.push(i, 1, 0, 0xffffff, 0.3, 0, 1);
+    overlay.commit();
+    expect(geo.drawRange.count).toBe(3);
+    expect(rangeOf(pos)).toEqual({ start: 0, count: 9 });
+    expect(rangeOf(size)).toEqual({ start: 0, count: 3 });
+    expect(capacity).toBeGreaterThan(3);
+
+    // a busier frame widens the range; a quieter one narrows it back
+    overlay.beginFrame();
+    for (let i = 0; i < 40; i++) overlay.push(i, 1, 0, 0xffffff, 0.3, 0, 1);
+    overlay.commit();
+    expect(rangeOf(pos)).toEqual({ start: 0, count: 120 });
+    overlay.beginFrame();
+    overlay.push(0, 1, 0, 0xffffff, 0.3, 0, 1);
+    overlay.commit();
+    expect(rangeOf(pos)).toEqual({ start: 0, count: 3 });
+    expect(pos.updateRanges.length).toBe(1);
+  });
+});

--- a/tests/architecture.test.ts
+++ b/tests/architecture.test.ts
@@ -433,6 +433,8 @@ const RENDER_PURE_CORES = [
   'src/render/chunk_residency_core.ts',
   'src/render/cliff_scree_core.ts',
   'src/render/detail_horizon_core.ts',
+  'src/render/drape_lod_core.ts',
+  'src/render/weapon_vfx_shed_core.ts',
   'src/render/draw_stats_core.ts',
   'src/render/fishing_bobber_core.ts',
   'src/render/foliage_core.ts',

--- a/tests/character_presentation_wiring.test.ts
+++ b/tests/character_presentation_wiring.test.ts
@@ -20,7 +20,12 @@ describe('character presentation sleep wiring', () => {
     );
     expect(renderer).toContain('if (runCharacterPresentation) active.update(dt, st, animate);');
     expect(renderer).toContain('else active.advanceOffscreen(dt);');
-    expect(renderer).toContain('if (runCharacterPresentation) v.visual.updateWeaponVfx(dt);');
+    // The weapon-skin rig is still gated on presentation (a hidden rig writes no
+    // uniforms), and a visible one now carries its shed multiplier: the pin
+    // covers both halves so neither can be dropped.
+    expect(renderer).toContain(
+      'if (runCharacterPresentation) {\n        v.visual.updateWeaponVfx(dt, weaponVfxShedScale(d2, this.appliedBudgetLevels?.vfx ?? 1));\n      }',
+    );
     expect(renderer).toContain('v.mountVisual.advanceOffscreen(dt);');
   });
 

--- a/tests/drape_lod_core.test.ts
+++ b/tests/drape_lod_core.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, it } from 'vitest';
+import {
+  drapeFanLocalY,
+  drapeStrideFor,
+  fanVertexSpacing,
+  MAX_DRAPE_STRIDE,
+} from '../src/render/drape_lod_core';
+import { drapeRingLocalY } from '../src/render/selection_ring';
+import { groundHeight, terrainHeight } from '../src/sim/world';
+
+// The small ground-VFX drape distance LOD. Three contracts matter beyond "it is
+// cheaper": every sample it takes is one the exact drape would have taken too
+// (so a mark's footprint never moves), a wide mark is refused thinning
+// outright, and the interpolated heights stay within a measured bound of the
+// exact drape on the real walkable overworld.
+
+const SEED = 12345;
+const AURA_SEGMENTS = 40; // ground_auras.ts
+const DECAL_SEGMENTS = 24; // decals.ts
+
+/** three's CircleGeometry layout: index 0 is the center, 1..segments+1 walk the
+ *  rim, the last closing the seam on the first. */
+function circleFanLocalXZ(segments: number): Float32Array {
+  const out = new Float32Array((segments + 2) * 2);
+  out[0] = 0;
+  out[1] = 0;
+  for (let s = 0; s <= segments; s++) {
+    const theta = (s / segments) * Math.PI * 2;
+    out[(s + 1) * 2] = Math.cos(theta);
+    out[(s + 1) * 2 + 1] = Math.sin(theta);
+  }
+  return out;
+}
+
+/** A deterministic sampler that also records exactly where it was asked. */
+function recordingSampler(inner: (x: number, z: number) => number) {
+  const seen: [number, number][] = [];
+  const sample = (x: number, z: number) => {
+    seen.push([x, z]);
+    return inner(x, z);
+  };
+  return { sample, seen, count: () => seen.length };
+}
+
+/** Local drape Y is expressed in mesh-local units; the visible error is in
+ *  world yards, so scale it back up before comparing. */
+function maxWorldDelta(a: Float32Array, b: Float32Array, scale: number): number {
+  let worst = 0;
+  for (let i = 0; i < a.length; i++) worst = Math.max(worst, Math.abs(a[i] - b[i]) * scale);
+  return worst;
+}
+
+function percentile(values: number[], p: number): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  return sorted[Math.min(sorted.length - 1, Math.floor((sorted.length - 1) * p))];
+}
+
+/** Height spread of an 8-point ring around a spot: the cheap "is this a cliff
+ *  or a hard step" filter, so the error sweep below measures the ground these
+ *  marks actually land on rather than sheer rock nobody fights on. */
+function localRelief(x: number, z: number, radius: number): number {
+  let lo = Number.POSITIVE_INFINITY;
+  let hi = Number.NEGATIVE_INFINITY;
+  for (let a = 0; a < 8; a++) {
+    const theta = (a / 8) * Math.PI * 2;
+    const h = groundHeight(x + Math.cos(theta) * radius, z + Math.sin(theta) * radius, SEED);
+    lo = Math.min(lo, h);
+    hi = Math.max(hi, h);
+  }
+  return hi - lo;
+}
+
+describe('drapeStrideFor', () => {
+  const auraSpacing = fanVertexSpacing(1.55, AURA_SEGMENTS);
+
+  it('drapes exactly up close and steps down in bounded distance bands', () => {
+    expect(drapeStrideFor(0, auraSpacing)).toBe(1);
+    expect(drapeStrideFor(20 * 20, auraSpacing)).toBe(1);
+    expect(drapeStrideFor(21 * 21, auraSpacing)).toBe(2);
+    expect(drapeStrideFor(41 * 41, auraSpacing)).toBe(3);
+    expect(drapeStrideFor(71 * 71, auraSpacing)).toBe(4);
+    expect(drapeStrideFor(4000 * 4000, auraSpacing)).toBe(MAX_DRAPE_STRIDE);
+  });
+
+  it('never decreases as the mark gets further away', () => {
+    let previous = 0;
+    for (let d = 0; d <= 300; d++) {
+      const stride = drapeStrideFor(d * d, auraSpacing);
+      expect(stride).toBeGreaterThanOrEqual(previous);
+      previous = stride;
+    }
+  });
+
+  it('refuses to thin a mark whose vertices are already far apart', () => {
+    // A 10 yard shockwave footprint, at any distance: the fill would span
+    // yards of terrain, which is the case the measurement below rules out.
+    const wide = fanVertexSpacing(10, DECAL_SEGMENTS);
+    expect(wide).toBeGreaterThan(1);
+    for (const d of [30, 60, 120, 400]) expect(drapeStrideFor(d * d, wide)).toBe(1);
+    // and the cap bites before the distance band does for a mid-size mark
+    const mid = fanVertexSpacing(2.5, DECAL_SEGMENTS);
+    expect(drapeStrideFor(200 * 200, mid)).toBeLessThan(MAX_DRAPE_STRIDE);
+  });
+
+  it('bounds how much terrain any single fill spans, at every distance', () => {
+    for (const segments of [DECAL_SEGMENTS, AURA_SEGMENTS]) {
+      for (let radius = 0.25; radius <= 12; radius += 0.25) {
+        const spacing = fanVertexSpacing(radius, segments);
+        for (const d of [10, 25, 50, 90, 300]) {
+          const stride = drapeStrideFor(d * d, spacing);
+          // 1 yard is the loosest bound the policy allows itself
+          if (stride > 1) expect(stride * spacing).toBeLessThanOrEqual(1);
+        }
+      }
+    }
+  });
+
+  it('drapes exactly for an unknown distance or a degenerate mark', () => {
+    expect(drapeStrideFor(-1, auraSpacing)).toBe(1);
+    expect(drapeStrideFor(Number.NaN, auraSpacing)).toBe(1);
+    expect(drapeStrideFor(10000, 0)).toBe(1);
+    expect(drapeStrideFor(10000, Number.NaN)).toBe(1);
+  });
+
+  it('reads nothing but distance and geometry (no tier, preset or governor)', () => {
+    // A one-signature policy is the fairness guarantee: two players in the same
+    // spot cannot get different drapes. Pinned as an arity so a settings input
+    // cannot be threaded in without this failing.
+    expect(drapeStrideFor.length).toBe(2);
+  });
+});
+
+describe('drapeFanLocalY', () => {
+  const localXZ = circleFanLocalXZ(AURA_SEGMENTS);
+  const out = new Float32Array(AURA_SEGMENTS + 2);
+  const exact = new Float32Array(AURA_SEGMENTS + 2);
+
+  it('reproduces the exact drape byte for byte at stride 1', () => {
+    const sampler = (x: number, z: number) => terrainHeight(x, z, SEED);
+    drapeRingLocalY(localXZ, 120, -40, 2, 1.3, 0.08, sampler, exact);
+    drapeFanLocalY(localXZ, 120, -40, 2, 1.3, 0.08, sampler, out, 1);
+    expect(Array.from(out)).toEqual(Array.from(exact));
+  });
+
+  it('samples fewer points as the stride grows, always the center and the seam', () => {
+    const counts: number[] = [];
+    for (const stride of [1, 2, 3, 4]) {
+      const rec = recordingSampler((x, z) => terrainHeight(x, z, SEED));
+      drapeFanLocalY(localXZ, 120, 240, 5, 1.3, 0.08, rec.sample, out, stride);
+      counts.push(rec.count());
+      expect(rec.seen[0]).toEqual([120, 240]);
+      const lastX = 120 + 1.3 * localXZ[(AURA_SEGMENTS + 1) * 2];
+      const lastZ = 240 + 1.3 * localXZ[(AURA_SEGMENTS + 1) * 2 + 1];
+      expect(rec.seen.some(([x, z]) => x === lastX && z === lastZ)).toBe(true);
+    }
+    expect(counts[0]).toBe(AURA_SEGMENTS + 2);
+    expect(counts[1]).toBeLessThan(counts[0]);
+    expect(counts[2]).toBeLessThan(counts[1]);
+    expect(counts[3]).toBeLessThan(counts[2]);
+    expect(counts[3]).toBeLessThan(counts[0] / 3);
+  });
+
+  it('samples only points the exact drape would also have sampled', () => {
+    const all = recordingSampler((x, z) => terrainHeight(x, z, SEED));
+    drapeRingLocalY(localXZ, 120, 240, 5, 1.3, 0.08, all.sample, exact);
+    const exactSet = new Set(all.seen.map(([x, z]) => `${x}|${z}`));
+    for (const stride of [2, 3, 4]) {
+      const thinned = recordingSampler((x, z) => terrainHeight(x, z, SEED));
+      drapeFanLocalY(localXZ, 120, 240, 5, 1.3, 0.08, thinned.sample, out, stride);
+      for (const [x, z] of thinned.seen) expect(exactSet.has(`${x}|${z}`)).toBe(true);
+    }
+  });
+
+  it('on a plane, errs by at most the chord sagitta times the slope', () => {
+    // The closed-form bound the whole scheme rests on. A fill runs straight
+    // between two rim samples while the rim itself bows out by the sagitta
+    // r * (1 - cos(theta / 2)), so on a constant slope the worst a filled
+    // vertex can be off is that bow times the gradient. Nothing about the real
+    // terrain sweep below can be smaller than this.
+    const slopeX = 0.3;
+    const slopeZ = 0.2;
+    const plane = (x: number, z: number) => slopeX * x + slopeZ * z;
+    const radius = 1.55;
+    const gradient = Math.hypot(slopeX, slopeZ);
+    drapeRingLocalY(localXZ, 50, -20, 1, radius, 0.08, plane, exact);
+    for (const stride of [2, 3, 4]) {
+      drapeFanLocalY(localXZ, 50, -20, 1, radius, 0.08, plane, out, stride);
+      const theta = (stride / AURA_SEGMENTS) * Math.PI * 2;
+      const bound = radius * (1 - Math.cos(theta / 2)) * gradient;
+      const worst = maxWorldDelta(out, exact, radius);
+      expect(worst).toBeLessThanOrEqual(bound + 1e-6);
+      expect(worst).toBeGreaterThan(0); // the fill really is doing something
+    }
+    // and that bound is millimetres at the aura's size
+    expect(radius * (1 - Math.cos(Math.PI / AURA_SEGMENTS / 0.5)) * gradient).toBeLessThan(0.03);
+  });
+
+  it('stays within centimetres of the exact drape on the walkable overworld', () => {
+    // A buff aura band (1.3 to 1.8 yd) at the widest stride, swept over the
+    // open world minus cliffs and hard steps (localRelief filter): the ground
+    // these actually land on. The numbers are the reason the wide shockwave
+    // rings were left exact, so pin them as literals.
+    const errors: number[] = [];
+    const sampler = (x: number, z: number) => groundHeight(x, z, SEED);
+    const scale = 1.55;
+    for (let x = 60; x <= 900; x += 13) {
+      for (let z = -400; z <= 400; z += 17) {
+        if (localRelief(x, z, scale) > scale * 0.9) continue;
+        const baseY = sampler(x, z);
+        drapeRingLocalY(localXZ, x, z, baseY, scale, 0.08, sampler, exact);
+        drapeFanLocalY(localXZ, x, z, baseY, scale, 0.08, sampler, out, MAX_DRAPE_STRIDE);
+        errors.push(maxWorldDelta(out, exact, scale));
+      }
+    }
+    expect(errors.length).toBeGreaterThan(1000);
+    expect(percentile(errors, 0.5)).toBeLessThan(0.02);
+    expect(percentile(errors, 0.95)).toBeLessThan(0.15);
+    expect(percentile(errors, 0.99)).toBeLessThan(0.3);
+    // and the widest stride only ever runs 70+ yards out
+    expect(drapeStrideFor(70 * 70, fanVertexSpacing(scale, AURA_SEGMENTS))).toBeLessThan(
+      MAX_DRAPE_STRIDE,
+    );
+  });
+
+  it('refuses to decimate a rim that is already coarse', () => {
+    const coarse = circleFanLocalXZ(8);
+    const coarseOut = new Float32Array(10);
+    const rec = recordingSampler((x, z) => terrainHeight(x, z, SEED));
+    drapeFanLocalY(coarse, 100, 100, 0, 1, 0.08, rec.sample, coarseOut, MAX_DRAPE_STRIDE);
+    // 9 rim points cannot lose samples without the fill outrunning the chord
+    expect(rec.count()).toBe(10);
+  });
+});

--- a/tests/eastbrook_polish_artifact_integrity.test.ts
+++ b/tests/eastbrook_polish_artifact_integrity.test.ts
@@ -662,10 +662,13 @@ const ACCEPTED_POLISH_V2_METADATA_PATH = path.join(REPO_ROOT, POLISH_SEAL_PATH);
 // the rendererIntegration leaf, so all three literals mint to values matching
 // neither parent. No capture was retaken on either side (the two parents'
 // evidence differs only in its provenance bytes).
+// Re-minted for the VFX per-frame cost work: the rendererIntegration leaf
+// follows the anchor seam, the weapon-skin fade and the census tag. No capture
+// was retaken; every measured value is adopted verbatim.
 const ACCEPTED_POLISH_V2_METADATA_SHA256 =
-  'b18b6ec0e529aac5cb112f58ea5083c7ff1c726977390cb3ae5ccffd8116b78f';
+  '4cfd014d2f40bdc006587335a65099ea9e64abd895caa6c3458684133131a876';
 const ACCEPTED_POLISH_V2_COMPOSITE_PROVENANCE =
-  '532c7b4b907fc86b1847b415bb8d915428c2e3abac19ac1d1128d51e117b01a6';
+  'bdb8ece164fb03fcb689e259317e287c04ac2c845d463f37d4993ede77d3439e';
 const ACCEPTED_POLISH_V2_METADATA = readJsonFile<CaptureMetadata>(ACCEPTED_POLISH_V2_METADATA_PATH);
 const ACCEPTED_POLISH_V2_PROVENANCE = ACCEPTED_POLISH_V2_METADATA.polishProvenance;
 const ACCEPTED_POLISH_V2_TOWN_CONTRACT = ACCEPTED_POLISH_V2_METADATA.records[0]?.townContract;
@@ -1551,10 +1554,14 @@ describe('Eastbrook polish performance and contact evidence', () => {
     // reverted renderer while preserving PR #2982's prewarm-policy leaf.
     // Re-pinned for the PR #2983 re-land: the swept evidence follows the
     // re-landed renderer, itself on top of the release's bow-aim edit.
+    // Re-pinned for the VFX per-frame cost work: the first-order composite
+    // follows the renderer's anchor seam, weapon-skin fade and census tag,
+    // then this second-order seal follows the swept evidence bytes. No capture
+    // was retaken.
     expect(
       fingerprint.digest('hex'),
       `the second-order performance digest moved; if every input moved legitimately, re-mint with: ${REMINT_COMMAND} (it recomputes this literal LAST, from the swept files)`,
-    ).toBe('107fa586c47240588c7f72c4048bbc3abcca66743682679a5b0f2f61c30bdd48');
+    ).toBe('12e5ebb79b08e28af06e3b854302845e415440d70f5ddcee0b2cdb91abe8ab1a');
   });
 
   it('binds every historical after record to its accepted source and asset provenance', () => {

--- a/tests/eastbrook_polish_capture_contract.test.ts
+++ b/tests/eastbrook_polish_capture_contract.test.ts
@@ -78,8 +78,11 @@ interface AttributionTargetFixture {
 // the rendererIntegration leaf (the release's PR #2983 re-land, this branch's
 // creator review pass), so the merged tree mints a value matching neither
 // parent. Captures adopted verbatim; no measured value moved on either side.
+// Re-minted for the VFX per-frame cost work: the rendererIntegration leaf
+// follows the anchor seam, the weapon-skin fade and the census tag. No capture
+// was retaken; every measured value is adopted verbatim.
 const PINNED_POLISH_COMPOSITE_FINGERPRINT =
-  '532c7b4b907fc86b1847b415bb8d915428c2e3abac19ac1d1128d51e117b01a6';
+  'bdb8ece164fb03fcb689e259317e287c04ac2c845d463f37d4993ede77d3439e';
 
 function validPolishAttributionTargets(): AttributionTargetFixture[] {
   return [

--- a/tests/vfx_anchor.test.ts
+++ b/tests/vfx_anchor.test.ts
@@ -1,0 +1,107 @@
+import * as THREE from 'three';
+import { describe, expect, it } from 'vitest';
+import { createVfxAnchor, type VfxAnchorPose } from '../src/render/vfx_anchor';
+
+// The shared VFX world-anchor resolver (src/render/vfx_anchor.ts). The
+// per-frame VFX paths (ribbons, shells, ground auras, windups, orbit bands, the
+// sequencer transients) resolve anchors every frame, so the contract that
+// matters here is: with a destination it writes into THAT vector and allocates
+// nothing; without one it still hands back a fresh vector the caller may keep.
+
+type Poses = Record<number, { x: number; y: number; z: number; height: number }>;
+
+function anchorOver(poses: Poses) {
+  let calls = 0;
+  const resolver = createVfxAnchor((id: number, out: VfxAnchorPose) => {
+    calls++;
+    const pose = poses[id];
+    if (!pose) return false;
+    out.x = pose.x;
+    out.y = pose.y;
+    out.z = pose.z;
+    out.height = pose.height;
+    return true;
+  });
+  return { resolver, fills: () => calls };
+}
+
+describe('createVfxAnchor', () => {
+  it('lifts the view position by the fraction of the displayed height', () => {
+    const { resolver } = anchorOver({ 7: { x: 10, y: 4, z: -6, height: 2.5 } });
+    const feet = resolver(7, 0);
+    const chest = resolver(7, 0.58);
+    const head = resolver(7, 1);
+    expect(feet).not.toBeNull();
+    expect([feet?.x, feet?.y, feet?.z]).toEqual([10, 4, -6]);
+    expect(chest?.y).toBeCloseTo(4 + 2.5 * 0.58, 10);
+    expect(head?.y).toBeCloseTo(6.5, 10);
+    // the horizontal read never depends on the fraction
+    expect(head?.x).toBe(10);
+    expect(head?.z).toBe(-6);
+  });
+
+  it('reports a missing view as a null reading, with or without a destination', () => {
+    const { resolver } = anchorOver({ 1: { x: 0, y: 0, z: 0, height: 2 } });
+    const out = new THREE.Vector3(1, 2, 3);
+    expect(resolver(99, 0.5)).toBeNull();
+    expect(resolver(99, 0.5, out)).toBeNull();
+    // a refused reading leaves the caller's scratch untouched, so a caller that
+    // ignores the null cannot read a half-written point
+    expect(out.toArray()).toEqual([1, 2, 3]);
+  });
+
+  it('writes into the caller destination and returns that same vector', () => {
+    const { resolver } = anchorOver({ 3: { x: 1, y: 2, z: 3, height: 4 } });
+    const out = new THREE.Vector3();
+    const got = resolver(3, 0.5, out);
+    expect(got).toBe(out);
+    expect(out.toArray()).toEqual([1, 4, 3]);
+  });
+
+  it('allocates a fresh, independent vector when no destination is given', () => {
+    const { resolver } = anchorOver({
+      3: { x: 1, y: 0, z: 0, height: 2 },
+      4: { x: 9, y: 0, z: 0, height: 2 },
+    });
+    const first = resolver(3, 1);
+    const second = resolver(4, 1);
+    // the historical contract every one-shot spawn path relies on: two readings
+    // are two objects, so a spawner may retain the first
+    expect(first).not.toBe(second);
+    expect(first?.x).toBe(1);
+    expect(second?.x).toBe(9);
+  });
+
+  it('reuses one pose record across resolves (the lookup never allocates)', () => {
+    const seen = new Set<VfxAnchorPose>();
+    const resolver = createVfxAnchor((_id, out) => {
+      seen.add(out);
+      out.x = 0;
+      out.y = 0;
+      out.z = 0;
+      out.height = 1;
+      return true;
+    });
+    const scratch = new THREE.Vector3();
+    for (let i = 0; i < 32; i++) resolver(i, 0.5, scratch);
+    expect(seen.size).toBe(1);
+  });
+
+  it('resolving into a scratch in a per-frame loop never allocates a vector', () => {
+    const { resolver } = anchorOver({ 5: { x: 2, y: 3, z: 4, height: 2 } });
+    const scratch = new THREE.Vector3();
+    const results = new Set<THREE.Vector3>();
+    for (let frame = 0; frame < 240; frame++) {
+      const at = resolver(5, frame / 240);
+      // the destination-less arm is what the old code did every frame
+      if (at) results.add(at);
+    }
+    expect(results.size).toBe(240);
+    results.clear();
+    for (let frame = 0; frame < 240; frame++) {
+      const at = resolver(5, frame / 240, scratch);
+      if (at) results.add(at);
+    }
+    expect(results.size).toBe(1);
+  });
+});

--- a/tests/weapon_vfx_shed.test.ts
+++ b/tests/weapon_vfx_shed.test.ts
@@ -1,0 +1,336 @@
+import { readFileSync } from 'node:fs';
+import * as THREE from 'three';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { CHARACTER_LOD_RANGE_SQ } from '../src/render/crowd_lod';
+import {
+  buildWeaponVfxPrewarmGroup,
+  createWeaponVfx,
+  DEFAULT_TUNING,
+  WEAPON_VFX,
+  WEAPON_VFX_RENDER_CATEGORY,
+  type WeaponVfxTuning,
+} from '../src/render/weapon_vfx';
+import {
+  scaleWeaponVfxTuning,
+  WEAPON_VFX_GOVERNOR_FLOOR,
+  WEAPON_VFX_MIN_SHED_SCALE,
+  WEAPON_VFX_TUNING_CHANNELS,
+  weaponVfxShedScale,
+} from '../src/render/weapon_vfx_shed_core';
+import { WEAPON_VFX_TUNING } from '../src/render/weapon_vfx_tuning';
+
+/** The distance arm's floor, pinned as a literal here so a retune in the core
+ *  has to be restated rather than silently adopted by the assertions. */
+const MIN_DISTANCE_SCALE_PIN = 0.4;
+
+// The weapon-skin VFX rigs answer to a lever at last (viewer distance plus the
+// frame-budget governor's vfx bucket), and they are visible to the ?perf scene
+// census.
+//
+// The lever is a FADE and never a cull: `createWeaponVfx`'s applyTuning only
+// stops drawing a part below a multiplier of 0.01, and the assertions below pin
+// that the lever's floor stays clear of that against every shipped skin. What
+// removes a rig is the character LOD swap, on inputs the whole render path
+// already shares. Several cases here exist because a banded first draft failed
+// in playtesting: the hard 1.0 -> 0.7 step at a boundary read as the rig
+// switching off, so the fade is now continuous and anchored to the fixed
+// pre-scaling LOD range rather than to the live crowd-adaptive band edge.
+
+// The module draws its sprite textures on a 2d canvas; everything else in it is
+// plain Three + math (same stub shape as weapon_vfx_rig_build.test.ts).
+let priorDocument: unknown;
+
+function stubContext() {
+  const gradient = { addColorStop: () => {} };
+  return {
+    fillStyle: '',
+    createLinearGradient: () => gradient,
+    createRadialGradient: () => gradient,
+    fillRect: () => {},
+    beginPath: () => {},
+    arc: () => {},
+    fill: () => {},
+    save: () => {},
+    restore: () => {},
+    translate: () => {},
+    rotate: () => {},
+    drawImage: () => {},
+    createImageData: (w: number, h: number) => ({
+      data: new Uint8ClampedArray(w * h * 4),
+      width: w,
+      height: h,
+    }),
+    getImageData: (_x: number, _y: number, w: number, h: number) => ({
+      data: new Uint8ClampedArray(w * h * 4),
+      width: w,
+      height: h,
+    }),
+    putImageData: () => {},
+  };
+}
+
+beforeAll(() => {
+  const globals = globalThis as { document?: unknown };
+  priorDocument = globals.document;
+  globals.document = {
+    createElement: () => ({ width: 0, height: 0, getContext: () => stubContext() }),
+  };
+});
+
+afterAll(() => {
+  (globalThis as { document?: unknown }).document = priorDocument;
+});
+
+function weaponStub(): THREE.Object3D {
+  const root = new THREE.Object3D();
+  const mesh = new THREE.Mesh(
+    new THREE.BoxGeometry(0.1, 1, 0.1),
+    new THREE.MeshStandardMaterial({ color: 0xffffff }),
+  );
+  root.add(mesh);
+  return root;
+}
+
+describe('weaponVfxShedScale', () => {
+  const anchor = Math.sqrt(CHARACTER_LOD_RANGE_SQ);
+
+  it('holds the authored look in close, then fades to its floor by the anchor', () => {
+    expect(weaponVfxShedScale(0, 1)).toBe(1);
+    // full strength out to 40% of the anchor, then easing
+    expect(weaponVfxShedScale((anchor * 0.4) ** 2, 1)).toBe(1);
+    const mid = weaponVfxShedScale((anchor * 0.7) ** 2, 1);
+    expect(mid).toBeLessThan(1);
+    expect(mid).toBeGreaterThan(0.4);
+    expect(weaponVfxShedScale(CHARACTER_LOD_RANGE_SQ, 1)).toBeCloseTo(0.4, 5);
+  });
+
+  it('never increases as the wearer gets further away', () => {
+    let previous = Number.POSITIVE_INFINITY;
+    for (let d = 0; d <= 200; d += 0.5) {
+      const scale = weaponVfxShedScale(d * d, 1);
+      expect(scale).toBeLessThanOrEqual(previous);
+      previous = scale;
+    }
+  });
+
+  it('advances in steps too small to read, so the fade cannot pop', () => {
+    // The regression this guards is the one playtesting found in the banded
+    // draft: a hard 1.0 -> 0.7 step at a boundary reads as the rig switching
+    // off. No single yard of travel may move the scale by more than one
+    // quantization step.
+    let previous = weaponVfxShedScale(0, 1);
+    for (let d = 1; d <= 120; d++) {
+      const scale = weaponVfxShedScale(d * d, 1);
+      expect(previous - scale).toBeLessThanOrEqual(0.05 + 1e-9);
+      previous = scale;
+    }
+  });
+
+  it('is anchored to the fixed LOD range, not to a live crowd-adaptive edge', () => {
+    // Keying the fade to the live band edge would make a wearer's glow pulse on
+    // crowd churn and differ between two viewers in the same spot; the anchor is
+    // the pre-scaling constant precisely so it cannot.
+    // still ramping a little inside the anchor (quantization has the last yard
+    // or so already sitting on the floor, which is the point of quantizing)
+    expect(weaponVfxShedScale((anchor * 0.85) ** 2, 1)).toBeGreaterThan(MIN_DISTANCE_SCALE_PIN);
+    expect(weaponVfxShedScale(CHARACTER_LOD_RANGE_SQ, 1)).toBeCloseTo(MIN_DISTANCE_SCALE_PIN, 5);
+    expect(weaponVfxShedScale(CHARACTER_LOD_RANGE_SQ * 1.001, 1)).toBeCloseTo(
+      MIN_DISTANCE_SCALE_PIN,
+      5,
+    );
+    // ...and it holds there however far out you go
+    expect(weaponVfxShedScale(400 * 400, 1)).toBeCloseTo(MIN_DISTANCE_SCALE_PIN, 5);
+  });
+
+  it('never reaches zero on either arm: this fades, it does not cull', () => {
+    // The far-LOD swap owns removal. A lever that could also remove would be
+    // doing the same job on per-client inputs, which is what the fairness split
+    // exists to avoid.
+    for (const distanceSq of [0, 40 * 40, 80 * 80, 500 * 500]) {
+      for (const level of [1, 0.5, 0]) {
+        expect(weaponVfxShedScale(distanceSq, level)).toBeGreaterThanOrEqual(
+          WEAPON_VFX_MIN_SHED_SCALE - 1e-9,
+        );
+      }
+    }
+  });
+
+  it('lets the governor DIM a rig but never remove one', () => {
+    for (const distanceSq of [0, 40 * 40, 80 * 80]) {
+      const full = weaponVfxShedScale(distanceSq, 1);
+      const crushed = weaponVfxShedScale(distanceSq, 0);
+      expect(crushed).toBeGreaterThan(0);
+      expect(crushed).toBeLessThan(full);
+      expect(crushed / full).toBeCloseTo(WEAPON_VFX_GOVERNOR_FLOOR, 1);
+    }
+  });
+
+  it('treats an absent or nonsense governor level as no pressure', () => {
+    expect(weaponVfxShedScale(0, Number.NaN)).toBe(1);
+    expect(weaponVfxShedScale(0, 5)).toBe(1);
+    expect(weaponVfxShedScale(-1, 1)).toBe(1);
+  });
+
+  it('quantizes, so an unchanged frame elides the tuning write', () => {
+    const a = weaponVfxShedScale(40 * 40, 0.831);
+    const b = weaponVfxShedScale(40 * 40, 0.833);
+    expect(a).toBe(b);
+    expect(Math.round(a * 20)).toBeCloseTo(a * 20, 9);
+  });
+});
+
+describe('the fade floor stays clear of the cull threshold', () => {
+  it('cannot silently stop a part drawing, whatever the skin authored', () => {
+    // applyTuning stops drawing a part at multiplier <= 0.01. The lever is a
+    // FADE, so the smallest multiplier it can produce against the smallest
+    // authored channel that ships must stay above that; if this ever fails the
+    // lever has quietly become a cull and the module header is a lie.
+    const authoredValues = Object.values(WEAPON_VFX_TUNING).flatMap((row) =>
+      Object.values(row).filter((v): v is number => typeof v === 'number' && v > 0),
+    );
+    expect(authoredValues.length).toBeGreaterThan(20);
+    const smallestAuthored = Math.min(...authoredValues);
+    expect(smallestAuthored * WEAPON_VFX_MIN_SHED_SCALE).toBeGreaterThan(0.01);
+  });
+});
+
+describe('scaleWeaponVfxTuning', () => {
+  it('covers every tuning channel the rig defines', () => {
+    expect([...WEAPON_VFX_TUNING_CHANNELS].sort()).toEqual(Object.keys(DEFAULT_TUNING).sort());
+  });
+
+  it('scales an authored row and defaults an absent channel to 1', () => {
+    const authored: Partial<WeaponVfxTuning> = { glow: 2, light: 0.5 };
+    const out = { ...DEFAULT_TUNING };
+    scaleWeaponVfxTuning(authored, 0.4, out);
+    expect(out.glow).toBeCloseTo(0.8, 6);
+    expect(out.light).toBeCloseTo(0.2, 6);
+    expect(out.motes).toBeCloseTo(0.4, 6);
+    // re-deriving from the authored row never compounds
+    scaleWeaponVfxTuning(authored, 1, out);
+    expect(out.glow).toBe(2);
+    expect(out.motes).toBe(1);
+  });
+
+  it('zeroes every channel at scale 0', () => {
+    const out = { ...DEFAULT_TUNING };
+    scaleWeaponVfxTuning({ glow: 2, shell: 1.5 }, 0, out);
+    for (const channel of WEAPON_VFX_TUNING_CHANNELS) expect(out[channel]).toBe(0);
+  });
+});
+
+describe('the shed applied to a live rig', () => {
+  const spec = WEAPON_VFX.ice_fang;
+
+  it('keeps every rig node drawing across the whole range of the lever', () => {
+    // The lever is a fade: at its own floor the rig must still be drawing, or
+    // it has become a cull competing with the far-LOD swap.
+    expect(spec).toBeTruthy();
+    const handle = createWeaponVfx(weaponStub(), spec, { grounded: false, backdrop: false });
+    const nodes: THREE.Object3D[] = [];
+    handle.group.traverse((o) => {
+      if ((o as THREE.Mesh).isMesh || (o as THREE.Points).isPoints) nodes.push(o);
+    });
+    expect(nodes.length).toBeGreaterThan(0);
+
+    const authored = WEAPON_VFX_TUNING.ice_fang;
+    const scaled = { ...DEFAULT_TUNING };
+    for (const scale of [1, 0.7, WEAPON_VFX_MIN_SHED_SCALE]) {
+      handle.setTuning(scaleWeaponVfxTuning(authored, scale, scaled));
+      handle.update(1 / 60);
+      expect(nodes.every((n) => n.visible)).toBe(true);
+      // the light dims WITHOUT losing its visible flag: three counts visible
+      // point lights into every lit material's program cache key
+      expect(handle.light.intensity).toBeGreaterThan(0);
+      expect(handle.light.visible).toBe(true);
+    }
+    handle.dispose();
+  });
+
+  it('dims rather than hides at a partial scale', () => {
+    const handle = createWeaponVfx(weaponStub(), spec, { grounded: false, backdrop: false });
+    const scaled = { ...DEFAULT_TUNING };
+    handle.setTuning(scaleWeaponVfxTuning({}, 1, scaled));
+    handle.update(1 / 60);
+    const bright = handle.light.intensity;
+    handle.setTuning(scaleWeaponVfxTuning({}, 0.4, scaled));
+    handle.update(1 / 60);
+    expect(handle.light.intensity).toBeGreaterThan(0);
+    expect(handle.light.intensity).toBeLessThan(bright);
+    let visible = 0;
+    handle.group.traverse((o) => {
+      if ((o as THREE.Mesh).isMesh || (o as THREE.Points).isPoints) visible += o.visible ? 1 : 0;
+    });
+    expect(visible).toBeGreaterThan(0);
+    handle.dispose();
+  });
+});
+
+describe('scene-census tagging', () => {
+  it('buckets a live rig under its own render category', () => {
+    const handle = createWeaponVfx(weaponStub(), WEAPON_VFX.ice_fang, { grounded: false });
+    expect(handle.group.userData.renderCategory).toBe(WEAPON_VFX_RENDER_CATEGORY);
+    expect(handle.sceneExtras.userData.renderCategory).toBe(WEAPON_VFX_RENDER_CATEGORY);
+    // the census inherits the tag down the subtree, so tagging the rig root is
+    // what makes every additive node it owns countable
+    expect(handle.group.children.length).toBeGreaterThan(0);
+    handle.dispose();
+  });
+
+  it('leaves the boot prewarm rig in the prewarm bucket', () => {
+    // Otherwise the synthetic warm-up rig would report as a live weapon skin
+    // and the overlay would show a wearer nobody can see.
+    const group = buildWeaponVfxPrewarmGroup();
+    const categories = new Set<string>();
+    group.traverse((o) => {
+      const c = o.userData.renderCategory;
+      if (typeof c === 'string') categories.add(c);
+    });
+    expect(categories.has(WEAPON_VFX_RENDER_CATEGORY)).toBe(false);
+    expect(categories).toEqual(new Set(['prewarm']));
+  });
+});
+
+describe('graphics-settings fairness', () => {
+  it('sheds nothing but decoration: the renderer never hides the rig or its light', () => {
+    // The rig's point light must keep its `visible` flag no matter how hard the
+    // shed bites (three's visible point-light count is part of every lit
+    // material's program cache key: dropping one recompiles the world). Pinned
+    // as a source scan because the hazard is a future edit, not today's code.
+    const visual = readFileSync('src/render/characters/visual.ts', 'utf8');
+    const shedBlock = visual.slice(
+      visual.indexOf('private applyWeaponVfxShed'),
+      visual.indexOf('weaponVfxShedLevel'),
+    );
+    expect(shedBlock.length).toBeGreaterThan(0);
+    expect(shedBlock).not.toMatch(/\.visible\s*=/);
+    expect(shedBlock).toMatch(/setTuning/);
+  });
+
+  it('reads viewer distance and the vfx lever only, never a preset or tier', () => {
+    const source = readFileSync('src/render/weapon_vfx_shed_core.ts', 'utf8');
+    // no graphics tier, preset, or device profile reaches the policy
+    expect(source).not.toMatch(/\bGFX\b|ui_effects_profile|gfx'|isMobile/);
+    expect(weaponVfxShedScale.length).toBe(2);
+    // ...nor the crowd-adaptive band plan, whose edges are per-client and
+    // per-frame: only the fixed pre-scaling anchor may be read
+    expect(source).toContain('CHARACTER_LOD_RANGE_SQ');
+    expect(source).not.toMatch(/staticRangeSq|characterLodBands|crowdLodScaleSq|visibleRigs/);
+  });
+
+  it('skips a far rig only once a baked mesh is actually standing in for it', () => {
+    // setFar leaves modelWrap VISIBLE when there is no baked mesh, while isFar
+    // reads true either way: skipping on the flag alone would freeze a rig that
+    // is still drawing. Pinned as a source scan because constructing a real
+    // CharacterVisual needs the GLB assets.
+    const visual = readFileSync('src/render/characters/visual.ts', 'utf8');
+    const start = visual.indexOf('updateWeaponVfx(dt: number');
+    const body = visual.slice(start, visual.indexOf('\n  }', start));
+    expect(start).toBeGreaterThan(-1);
+    expect(body).toContain('if (this.far && this.farMesh) return;');
+    // the orientation pins must keep running while far, or a bow snaps on return
+    expect(body.indexOf('applySkinOrientation')).toBeLessThan(
+      body.indexOf('if (this.far && this.farMesh) return;'),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Two parts of the VFX render path, each with its own section below.

**PART A: the ability-VFX per-frame cost.** The subsystem is well pooled at construction
time, but three per-frame costs had accumulated in the paths that run while the pools are
live. None of them is a stall you can point at; together they are the low-grade sawtooth
under a busy fight. All three are CPU and memory-traffic wins.

**PART B: weapon-skin rigs.** A CPU win (a rig the character LOD swap has taken off screen
stops ticking entirely), plus polish and diagnostics. No GPU win, and part B says so in its
own words rather than leaving a reviewer to work it out.

---

## Part A: what a fight costs every frame

**Anchors allocated a vector per resolve.** `vfxAnchor` returned a fresh `THREE.Vector3`
on every call, and it is called per ribbon trail, bolt, shell, ground aura, windup, orbit
band, stunned-star band and sequencer transient, every frame: on the order of a hundred
heap allocations a frame in a busy fight. That is the classic source of periodic multi-ms
GC hitches, and it breaks the `src/render/CLAUDE.md` "no per-frame `new THREE.*` in hot
paths" rule.

The resolver moves out of `renderer.ts` into its own `src/render/vfx_anchor.ts` and takes
an optional caller-owned destination. Every per-frame path now passes its own scratch and
allocates nothing; every one-shot spawn path omits it and keeps the historical contract
(a fresh vector it may retain) byte for byte. That split is deliberate: a spawn path runs
on an event, not on a frame, and several of them do retain the reading. The sequencer
stays Three-free through a structural `SeqPoint`.

**Two immediate-mode buffers uploaded their whole capacity.**
`ability_vfx/ribbons.ts` set `needsUpdate` on all attributes plus the index with no update
range, so roughly 180 KB was re-uploaded every frame any ribbon was live, however few
vertices the frame actually wrote. `ability_vfx/overlay_sprites.ts` had the same gap at a
smaller size. Both now `clearUpdateRanges()` + `addUpdateRange(0, used)` before
`needsUpdate`, which is the idiom the pooled particle cloud (`vfx.ts` `packRenderCloud`)
already uses. Everything past the prefix is stale by design and unreachable, because
`setDrawRange` stops there.

**The terrain drape resampled more than it needed to.** The ground marks (buff auras,
dissolve decals, shock rings) drape their meshes over the terrain so they follow a slope
instead of burying their uphill half, and the sampler is the sim's real `groundHeight`
chain: about 3 microseconds a sample on desktop, several times that on a phone.

- A buff ground aura re-draped a 42-vertex disc, per band, per wearer, several times a
  SECOND while a character stood perfectly still. The re-drape threshold was an absolute
  0.02 yards against a breath that swings the disc plus or minus 5% at 0.4 Hz, so the
  threshold could never be satisfied. It is now RELATIVE and wider than the breath's own
  swing, so the drape settles once the disc has grown in. Movement still re-drapes at a
  centimetre, because that is real new terrain under the disc.
- The small discs (auras, decals) now thin their drape with viewer distance through a new
  `src/render/drape_lod_core.ts`: sample a subset of the rim exactly, fill the vertices
  between two samples by interpolating in the disc's own angular parameter space.

The wide shock rings deliberately KEEP their exact 81-sample drape, and that is a measured
decision rather than a conservative one. Over the walkable overworld, thinning a 1.5 yard
aura disc costs a p50 of 3 mm, a p95 of 4 cm and a p99 of 11 cm of vertical drape error,
and only past 20 yards. The same treatment on a 10 to 20 yard shockwave footprint costs
YARDS, because at that span the exact mesh is already the coarsest honest description of
the ground. `drapeStrideFor`'s world-space sample-spacing cap enforces that split by
construction rather than by convention: a mark whose vertices are already far apart in
world space cannot be thinned at any distance, so the rule cannot be lost to a later edit.

---

## Part B: weapon-skin rigs

A rarity rig on a VFX-bearing weapon skin is 6 to 10 additive transparent nodes riding the
wearer's held weapon. The `weapons` bucket in `GFX_BUCKET_BANDS` is pinned ungovernable at
1.0 on every tier, so a rig drew at its full authored strength right up to the character
LOD swap and then disappeared in one frame, at full strength, along with the articulated
rig. The rigs also carried no `renderCategory`, so the `?perf` scene census could not
measure what a skin costs.

**What this part is, stated plainly, because an earlier draft of this PR got it wrong: a
CPU saving, and no GPU saving.** Both halves of that matter to a reviewer, so both are up
front:

1. **A real CPU win.** A rig the LOD swap has taken off screen no longer ticks at all.
   `setFar` hides `modelWrap`, and a held weapon (with its rig) hangs off a bone INSIDE it,
   so every frame was spending uniform writes across each part material, an emissive pulse
   and a light flicker on something no pixel could show. That is per rig, per frame, for
   every skinned wearer in the scene past the swap.
2. **No GPU win, and none is claimed.** `createWeaponVfx`'s `applyTuning` only stops
   drawing a part below a multiplier of 0.01, and the new lever's floor sits deliberately
   well above that, so the fade removes no draw call; dimming an additive transparent quad
   does not reduce its fill cost either. Removing a rig already belonged to the LOD swap,
   and this part deliberately leaves it there (see the fade section for why competing with
   it would break the fairness split).
3. **Polish on purchased cosmetics.** A legendary skin now fades out instead of vanishing
   mid-stride at full strength.
4. **A courtesy under load.** A client fighting for frames can turn other players' weapon
   glare down. This is the arm the ungovernable `weapons` bucket previously denied.
5. **Measurability.** The census can attribute a skin's cost for the first time.

### The fade

`src/render/weapon_vfx_shed_core.ts` folds one multiplier onto the skin's authored tuning
row, from two inputs. Neither reaches zero, by construction: removal stays with the LOD
swap, which already owns it on inputs the whole render path shares. The split between the
two arms is the fairness argument rather than an implementation detail:

- VIEWER DISTANCE (the squared distance from the local player, the measure the crowd LOD
  bands already rank rigs by), against the FIXED `CHARACTER_LOD_RANGE_SQ`, the
  articulated-rig range before the crowd and per-tier factors scale it. Deliberately that
  constant and not the live band edge: the live edge reads a per-client, per-frame count of
  visible rigs, so a fade keyed to it would pulse as unrelated players wander past one
  viewer's frustum, and two viewers standing in the same spot would not even compute the
  same edge. Against the constant this arm is identical for every player on every preset.
- The frame-budget governor's `vfx` bucket, the same lever the pooled particle cloud and
  the ability VFX already answer to, floored at `WEAPON_VFX_GOVERNOR_FLOOR`. It is the one
  input that differs between two players looking at the same wearer, and it can only dim.

What is faded is decoration ON a weapon. The wearer, their nameplate, their cast bar, their
auras, their position and the weapon model itself are untouched at every scale.
`docs/design/graphics-settings-fairness.md` records this under COSMETIC with the split
spelled out.

`CharacterVisual` keeps the authored row and re-derives from it (never compounding),
write-elided on the quantized scale so an unchanged frame costs nothing, and the fade is a
continuous ramp quantized to 0.05 so no single yard of travel can move it by more than one
imperceptible step. Two implementation notes worth a reviewer's eye:

- The rig's point light keeps its `visible` flag at every scale ON PURPOSE. Three counts
  visible point lights into every lit material's program cache key, so clearing one
  mid-flight is the open-world recompile freeze. Dimming drives its intensity down instead.
- The far-LOD skip is gated on `this.far && this.farMesh`, not on `far` alone. `setFar`
  leaves `modelWrap` VISIBLE when there is no baked mesh to stand in for it, while `isFar`
  reads true either way; skipping on the flag alone would freeze a rig that is still
  drawing, with its motes hanging in the air.

### Measurability

The rigs now carry a `renderCategory` (`weaponvfx`) so the `?perf` census can measure them.
Diagnostics only, never a draw gate; the boot prewarm rig is held in the `prewarm` bucket
so a synthetic warm-up cannot report as a live wearer.

---

Docs across both parts: `docs/design/graphics-settings-fairness.md` gains the weapon-skin
fade and both new guards; `src/render/CLAUDE.md` and `src/render/ability_vfx/CLAUDE.md`
gain the anchor-scratch contract, the prefix-upload rule, the drape-LOD scope with the
reason the shock rings are out of it, and the rule that a per-frame driver over a subtree
the LOD may hide must check the swap actually happened rather than the intent flag.

## Related issues

Based on `release/v0.36.0`. Continues the weapon-skin VFX performance work that landed for
v0.35.0 (#2983 and its re-land #3046, which removed the connection-time stall). This PR is
disjoint from that code: it touches the per-frame paths and the fade lever, not the rig
build path.

## Type of change

- [ ] Feature: new functionality
- [ ] Bug fix
- [x] Refactor or performance (no behavior change)
- [x] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `node scripts/gate_select.mjs`, then `npm run check:types` and all three host builds
    (`build`, `build:server`, `build:env`) separately, since the gate stops before its build
    steps on any test failure. Type-check and all three builds are clean.
  - Full suite: 32217 passing, 2 failing. Both failures are
    `tests/anim_pipeline_hunter_ghost.test.ts`, and both are PRE-EXISTING on
    `release/v0.36.0` rather than caused by this branch. They assert an anchor
    `player_hunter: {` in `src/render/characters/manifest.ts`, which appears zero times
    there; this branch leaves that file byte-identical to the base
    (`git diff upstream/release/v0.36.0..HEAD -- src/render/characters/manifest.ts` is
    empty), and checking the base out on its own reproduces both failures. Worth flagging
    to whoever owns that work: the release branch is red on it.
  - `npx vitest run tests/vfx_anchor.test.ts tests/ability_vfx_frame_cost.test.ts
    tests/drape_lod_core.test.ts tests/weapon_vfx_shed.test.ts`
  - `npx vitest run tests/architecture.test.ts tests/character_presentation_wiring.test.ts
    tests/ability_vfx_fx_sleep.test.ts tests/ability_vfx_stun_stars.test.ts
    tests/selection_ring.test.ts tests/player_aura_rings.test.ts tests/vfx.test.ts`
  - `npx tsc --noEmit`
- New decisive coverage, PART A:
  - `tests/vfx_anchor.test.ts`: the resolver's height math, its null reading (with and
    without a destination, and that a refused reading leaves the caller's scratch
    untouched), destination identity, and that the destination-less arm still hands back
    independent vectors a spawn path may retain.
  - `tests/ability_vfx_frame_cost.test.ts`: drives the REAL `AbilityVfxFx` over four frames
    of a live fight (windups, orbit bands, shells, ground auras, stunned-star bands,
    travelling ribbons, a live sequence) and fails on any destination-less anchor resolve
    inside `update()`. Verified decisive: dropping the scratch at ONE call site
    (`shells.ts`) turns it red. It also pins the ribbon and overlay update ranges
    (proportional to the vertices the frame wrote, and REPLACED rather than stacked per
    frame), and that a standing aura wearer costs 3 drapes in total, every one inside the
    0.4s grow-in, and not one vertex resample over the following two seconds.
  - `tests/drape_lod_core.test.ts`: the stride policy's distance bands and monotonicity,
    the spacing cap refusing to thin a wide mark at ANY distance, the closed-form
    chord-sagitta error bound on a plane, that every sample taken is one the exact drape
    would also have taken (so no footprint can move), and a percentile sweep of the real
    walkable overworld with p50/p95/p99 pinned as literals.
- New decisive coverage, PART B:
  - `tests/weapon_vfx_shed.test.ts`: the fade's shape and monotonicity; that no yard of
    travel moves it by more than one quantization step (the regression playtesting found in
    an earlier banded draft, where a hard 1.0 to 0.7 step at a boundary read as the rig
    switching off); that NEITHER arm reaches zero and the lever's floor stays clear of the
    multiplier at which `applyTuning` stops drawing a part, computed against the smallest
    channel any shipped skin authors, so the fade can never quietly become a cull; that the
    channel list matches `DEFAULT_TUNING` exactly; the applied fade on a real `ice_fang` rig
    keeping every node drawing at the floor while the light dims WITHOUT losing its
    `visible` flag; the census tags; and three source scans (the shed path touches no
    `.visible`, the policy reads no tier/preset/profile AND no crowd-adaptive band input,
    and the far skip requires a baked stand-in mesh).
- Pins updated because they read the changed source:
  - `tests/character_presentation_wiring.test.ts`: the weapon-VFX call site is still gated
    on `runCharacterPresentation`, and the pin now covers the shed argument too.
  - `tests/eastbrook_polish_*`: `renderer.ts` is a fingerprinted provenance input. Re-minted
    with `node scripts/assets/eastbrook_grand_armoury/remint_polish_provenance.mjs`; no
    capture was retaken and no measured value moved. Note for whoever lands this: those
    three literals seal the exact `renderer.ts` bytes on this branch, so they must stay in
    the same commit as it.
- Manual steps: walked in a live client next to another player wearing a VFX skin, at a
  measured range of distances. That is what caught an earlier draft of the weapon fade: it
  used hard distance bands, and the 1.0 to 0.7 step read as the rig switching off. It also
  turned up the scoping error noted at the top (the LOD swap, not interest range, is what
  bounds a rig's GPU cost), which is why the fade is now a continuous ramp anchored to that
  swap's own base range. The drape work needs no live check: its visual delta is bounded and
  measured in `tests/drape_lod_core.test.ts` rather than eyeballed.
  Reviewers who want to see the fade: stand near a wearer of `ice_fang` / `hoarfrost_vigil`
  and walk away. The rig eases down from about 23 yards and is at its floor by 58; past the
  LOD swap (somewhere between about 35 and 75 yards depending on crowd and tier) the whole
  articulated rig is replaced by its baked mesh, which is pre-existing behaviour.

## Screenshots / recordings

N/A as committed artifacts (this repo does not version PR screenshots). Nothing changes
inside the near band: the drape LOD is exact under 20 yards, the weapon-skin shed is 1.0
under 30 yards, and the anchor and upload work is invisible by construction.

---

## Checklist

### Quality

- [x] **The gate passes**, with one caveat stated in full above: every step is green and
      all three host builds and the type-check are clean, but the full suite carries two
      failures inherited from `release/v0.36.0` in a file this branch does not touch.
      Decisive tests added for every changed behaviour, including a negative check that the
      anchor guard fails when a single call site drops its scratch.

### Cross-platform

- [x] **Tested on desktop and mobile.** ~Viewport verification~ N/A: no UI surface, no DOM,
      no touch target changes. The change is mobile-relevant in the other direction (the
      drape and GC costs it removes are several times larger on a phone), and the shed
      policy is device-independent by design.
- [x] N/A. **Accessible.** No UI added or edited.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed; `ALLOW_DEV_COMMANDS` untouched.
- [x] No generated file hand-edited. The Eastbrook provenance evidence was regenerated by
      its own mint tool, and its three test literals updated from that tool's output.