### PR TITLE
fix(ota): offer updates to devices reporting a native build number

### DIFF
--- a/docs/ota-updates.md
+++ b/docs/ota-updates.md
@@ -25,7 +25,13 @@ The plugin itself is MPL-2.0; self-hosting is a documented, supported mode.
    `OTA_MANIFEST_URL` through a 60 s single-flight cache, compares the
    manifest against the device's reported bundle/native versions, and answers
    either `{ version, url, checksum }` or the plugin's documented no-update
-   body. `OTA_MANIFEST_URL` unset (or not https) keeps the whole feature dark
+   body. **The device reports two different kinds of value and they are not
+   interchangeable:** `version_name` is the currently applied BUNDLE version
+   (a semver) or the literal `builtin` when the device still runs
+   store-shipped assets, and `version_build` is the NATIVE BUILD NUMBER (iOS
+   CFBundleVersion, Android versionCode), a plain integer like `47`, never a
+   semver. A `builtin` device therefore offers no semver at all, and is
+   resolved through `server/ota_native_build.ts` (see below). `OTA_MANIFEST_URL` unset (or not https) keeps the whole feature dark
    (always "no update"). Manifest validation is strict and fail-closed: the
    bundle URL must be https AND live on the manifest's own origin (so a write
    into the manifest alone can never redirect installs to another host), the
@@ -234,11 +240,18 @@ feed. Keep it scoped to the one bucket and rotate it on any suspicion.
 ## Verifying an update end to end
 
 1. `curl -s $OTA_MANIFEST_URL` shows the new version/url/checksum.
-2. `curl -s -X POST https://worldofclaudecraft.com/api/ota/updates \
+2. Probe the endpoint the way a REAL device does, with a native BUILD NUMBER
+   in `version_build`, not a marketing version. Use a number BELOW this
+   release's `CURRENT_PROJECT_VERSION` (an older store build):
+   `curl -s -X POST https://worldofclaudecraft.com/api/ota/updates \
    -H 'content-type: application/json' \
-   -d '{"platform":"ios","version_name":"builtin","version_build":"0.31.0"}'`
-   answers the offer; posting the published version back answers the
-   no-update body.
+   -d '{"platform":"ios","version_name":"builtin","version_build":"46"}'`
+   answers the offer. Then check BOTH other arms: this release's build number
+   answers the no-update body (its built-in assets already ARE the bundle),
+   and posting the published version back as `version_name` does too.
+   A probe that sends `"version_build":"0.35.0"` proves nothing: no shipped
+   device sends that shape, and using it here is exactly how a total OTA
+   outage went unnoticed once already.
 3. On a device or simulator build: launch, background the app, foreground it;
    the footer version (`appVersionInfo`) shows the new bundle version. A
    deliberate bad bundle (e.g. a zip whose JS throws before boot) must revert
@@ -248,7 +261,14 @@ feed. Keep it scoped to the one bucket and rotate it on any suspicion.
 ## Tests that pin this feature
 
 - `tests/server/ota_updates.test.ts`: the endpoint (offer/no-update/gating,
-  cache single-flight, fail-closed env gate, rate limiting, invalid input).
+  cache single-flight, fail-closed env gate, rate limiting, invalid input),
+  including the store-fresh cases that send a native BUILD NUMBER rather than
+  a semver. Keep those: the suite was previously green while the feature was
+  dark, because every case fed `version_build` a marketing version instead.
+- `tests/server/ota_native_build.test.ts`: pins `NATIVE_BUILD_BRIDGE` against
+  package.json, build.gradle and project.pbxproj. Nothing else notices the
+  bridge going stale, and a stale bridge does not crash, it silently stops
+  offering updates to store-fresh devices.
 - `tests/native_ota.test.ts`: the `notifyAppReady` glue plus source pins on
   the `src/main.ts` wiring, `capacitor.config.ts` plugin block, and the
   `package.json` dependency.

--- a/scripts/release_version.d.mts
+++ b/scripts/release_version.d.mts
@@ -19,6 +19,7 @@ export function planReleaseVersion(input: {
   gradle: string;
   pbxproj: string;
   desktopModule: string;
+  otaNativeBuild: string;
   htmlFiles: Record<string, string>;
   readmeFiles: Record<string, string>;
 }): {
@@ -26,6 +27,7 @@ export function planReleaseVersion(input: {
   gradle: string;
   pbxproj: string;
   desktopModule: string;
+  otaNativeBuild: string;
   htmlFiles: Record<string, string>;
   readmeFiles: Record<string, string>;
 };
@@ -36,6 +38,25 @@ export function collectReleaseVersionFailures(input: {
   gradle: string;
   pbxproj: string;
   desktopModule: string;
+  otaNativeBuild: string;
   htmlFiles: Record<string, string>;
   readmeFiles: Record<string, string>;
 }): string[];
+
+export function setNativeBuildBridge(
+  source: string,
+  version: string,
+  iosBuild: number,
+  androidBuild: number,
+): string;
+
+export function readNativeBuildBridge(source: string): {
+  version: string | null;
+  ios: number | null;
+  android: number | null;
+};
+
+export function readNativeBuildNumbers(
+  gradle: string,
+  pbxproj: string,
+): { ios: number | null; android: number | null };

--- a/scripts/release_version.mjs
+++ b/scripts/release_version.mjs
@@ -31,6 +31,7 @@ const PATHS = {
   gradle: 'android/app/build.gradle',
   pbxproj: 'ios/App/App.xcodeproj/project.pbxproj',
   desktopModule: 'src/game/desktop_download.ts',
+  otaNativeBuild: 'server/ota_native_build.ts',
   htmlFiles: ['index.html', 'play.html'],
   readmeRoot: 'README.md',
   readmeDir: 'docs/i18n',
@@ -135,17 +136,67 @@ export function setReadmeVersionBadge(markdown, version, path) {
   );
 }
 
+const BRIDGE_VERSION_RE = /(version:\s*')(\d+\.\d+\.\d+)(')/;
+const BRIDGE_IOS_RE = /(ios:\s*)(\d+)/;
+const BRIDGE_ANDROID_RE = /(android:\s*)(\d+)/;
+
+/**
+ * Keep server/ota_native_build.ts in lockstep with the native build numbers.
+ * The OTA endpoint uses it to map a device's build NUMBER (which is all a
+ * store-fresh device reports) onto a marketing version; a stale bridge stops
+ * offering updates silently, so it is a release surface like any other.
+ */
+export function setNativeBuildBridge(source, version, iosBuild, androidBuild) {
+  for (const [name, re] of [
+    ['version', BRIDGE_VERSION_RE],
+    ['ios', BRIDGE_IOS_RE],
+    ['android', BRIDGE_ANDROID_RE],
+  ]) {
+    if (!re.test(source)) {
+      throw new Error(`${PATHS.otaNativeBuild} is missing its ${name} field`);
+    }
+  }
+  return source
+    .replace(BRIDGE_VERSION_RE, `$1${normalizeVersion(version)}$3`)
+    .replace(BRIDGE_IOS_RE, `$1${iosBuild}`)
+    .replace(BRIDGE_ANDROID_RE, `$1${androidBuild}`);
+}
+
+export function readNativeBuildBridge(source) {
+  const version = BRIDGE_VERSION_RE.exec(source)?.[2] ?? null;
+  const ios = BRIDGE_IOS_RE.exec(source)?.[2] ?? null;
+  const android = BRIDGE_ANDROID_RE.exec(source)?.[2] ?? null;
+  return {
+    version,
+    ios: ios === null ? null : Number(ios),
+    android: android === null ? null : Number(android),
+  };
+}
+
+export function readNativeBuildNumbers(gradle, pbxproj) {
+  const android = /^\s*versionCode\s+(\d+)/m.exec(gradle)?.[1] ?? null;
+  const iosMatches = [...pbxproj.matchAll(/CURRENT_PROJECT_VERSION\s*=\s*(\d+)\s*;/g)].map((m) =>
+    Number(m[1]),
+  );
+  const ios = iosMatches.length > 0 && new Set(iosMatches).size === 1 ? iosMatches[0] : null;
+  return { ios, android: android === null ? null : Number(android) };
+}
+
 export function planReleaseVersion({
   version,
   packageJson,
   gradle,
   pbxproj,
   desktopModule,
+  otaNativeBuild,
   htmlFiles,
   readmeFiles,
 }) {
   const normalized = normalizeVersion(version);
   const nativePlan = planVersionSync({ version: normalized, gradle, pbxproj });
+  // Read the build numbers back out of the BUMPED files so the bridge records
+  // what actually shipped, never the pre-bump values.
+  const bumped = readNativeBuildNumbers(nativePlan.gradle, nativePlan.pbxproj);
   const nextHtmlFiles = Object.fromEntries(
     Object.entries(htmlFiles).map(([path, html]) => [
       path,
@@ -164,6 +215,7 @@ export function planReleaseVersion({
     gradle: nativePlan.gradle,
     pbxproj: nativePlan.pbxproj,
     desktopModule: setDesktopModuleVersion(desktopModule, normalized, PATHS.desktopModule),
+    otaNativeBuild: setNativeBuildBridge(otaNativeBuild, normalized, bumped.ios, bumped.android),
     htmlFiles: nextHtmlFiles,
     readmeFiles: nextReadmeFiles,
   };
@@ -193,6 +245,7 @@ export function collectReleaseVersionFailures({
   gradle,
   pbxproj,
   desktopModule,
+  otaNativeBuild,
   htmlFiles,
   readmeFiles,
 }) {
@@ -227,6 +280,30 @@ export function collectReleaseVersionFailures({
   if (desktopVersion !== expected) {
     failures.push(
       `${PATHS.desktopModule} DESKTOP_VERSION is ${desktopVersion}, expected ${expected}`,
+    );
+  }
+
+  // The OTA build bridge: a stale one silently stops offering updates to every
+  // store-fresh device, so it is checked against the SAME files it maps between.
+  const bridge = readNativeBuildBridge(otaNativeBuild);
+  const native = readNativeBuildNumbers(gradle, pbxproj);
+  if (bridge.version !== expected) {
+    failures.push(`${PATHS.otaNativeBuild} version is ${bridge.version}, expected ${expected}`);
+  }
+  if (native.ios === null) {
+    failures.push(
+      'ios/App/App.xcodeproj/project.pbxproj CURRENT_PROJECT_VERSION is missing or inconsistent',
+    );
+  } else if (bridge.ios !== native.ios) {
+    failures.push(
+      `${PATHS.otaNativeBuild} ios build is ${bridge.ios}, expected ${native.ios} (CURRENT_PROJECT_VERSION)`,
+    );
+  }
+  if (native.android === null) {
+    failures.push('android/app/build.gradle versionCode is missing');
+  } else if (bridge.android !== native.android) {
+    failures.push(
+      `${PATHS.otaNativeBuild} android build is ${bridge.android}, expected ${native.android} (versionCode)`,
     );
   }
 
@@ -289,6 +366,7 @@ function readReleaseFiles() {
     gradle: readFileSync(resolve(ROOT, PATHS.gradle), 'utf8'),
     pbxproj: readFileSync(resolve(ROOT, PATHS.pbxproj), 'utf8'),
     desktopModule: readFileSync(resolve(ROOT, PATHS.desktopModule), 'utf8'),
+    otaNativeBuild: readFileSync(resolve(ROOT, PATHS.otaNativeBuild), 'utf8'),
     htmlFiles: Object.fromEntries(
       PATHS.htmlFiles.map((path) => [path, readFileSync(resolve(ROOT, path), 'utf8')]),
     ),
@@ -303,6 +381,7 @@ function writeReleaseFiles(plan) {
   writeFileSync(resolve(ROOT, PATHS.gradle), plan.gradle);
   writeFileSync(resolve(ROOT, PATHS.pbxproj), plan.pbxproj);
   writeFileSync(resolve(ROOT, PATHS.desktopModule), plan.desktopModule);
+  writeFileSync(resolve(ROOT, PATHS.otaNativeBuild), plan.otaNativeBuild);
   for (const [path, html] of Object.entries(plan.htmlFiles)) {
     writeFileSync(resolve(ROOT, path), html);
   }

--- a/server/CLAUDE.md
+++ b/server/CLAUDE.md
@@ -51,6 +51,7 @@ logic module pairs with a `<domain>_db.ts` that owns its SQL).
 | `realm.ts` | `REALM`, `REALM_DIRECTORY`, `REALM_ORIGINS` from `REALM_NAME`/`REALMS` env |
 | `ratelimit.ts` | per-IP sliding-window limiter + `X-Forwarded-For` resolution |
 | `internal.ts` | secret-gated `/internal/*` ops endpoints (e.g. restart-countdown trigger) |
+| `ota_updates.ts` / `ota_native_build.ts` | self-hosted OTA update check for the native shells (`POST /api/ota/updates`): reads the published manifest through a single-flight cache and decides the offer / the build bridge it decides against. A device reports `version_build` as a native BUILD NUMBER (CFBundleVersion, versionCode), never a semver, so a store-fresh device (`version_name: 'builtin'`) is only comparable through the bridge; `scripts/release_version.mjs` writes the bridge on `release:prepare` and fails `release:check` when it drifts. A stale or bypassed bridge does not error, it silently stops offering updates to every store install. Details: `docs/ota-updates.md` |
 | `woc_balance.ts` | the sole Solana RPC reader: holder-tier flair and connected-wallet balance, cached |
 | `player_card.ts` | shareable player-card PNGs, Open Graph unfurl, referral capture |
 | `bank_ledger.ts` | append-only `bank_ledger` observer: diffs `Sim.bankInfoFor` around each bank dispatch and writes the moved delta via a fire-and-forget FIFO (audited offline by `scripts/bank_audit.mjs`) |

--- a/server/ota_native_build.ts
+++ b/server/ota_native_build.ts
@@ -1,0 +1,33 @@
+// The bridge between a native BUILD NUMBER and a marketing version.
+//
+// Capgo reports `version_build` as the native build identifier, never a semver:
+// on iOS that is CFBundleVersion (= CURRENT_PROJECT_VERSION, an integer that
+// increments once per release), and on Android it is versionCode. A device
+// still running store-shipped assets sends `version_name: 'builtin'`, so the
+// only version information the server gets about it is that integer. Comparing
+// it against a semver manifest is impossible without knowing which marketing
+// version a given build number shipped as, and without that bridge every
+// store-fresh install is silently told "no new version available" forever.
+//
+// ONE data point is enough. Build numbers are monotonic, so any build BELOW
+// this release's is an older store build (and therefore older than any bundle
+// we would publish), and any build at or above it is running this release's
+// assets. `scripts/release_version.mjs` keeps these in lockstep with the
+// project files, and tests/server/ota_native_build.test.ts pins them against
+// package.json, build.gradle and project.pbxproj, so a release version sync
+// that forgets to update them fails the release gate rather than going dark.
+
+export interface NativeBuildBridge {
+  /** The marketing version this checkout ships as (package.json version). */
+  version: string;
+  /** iOS CURRENT_PROJECT_VERSION / CFBundleVersion at that marketing version. */
+  ios: number;
+  /** Android versionCode at that marketing version. */
+  android: number;
+}
+
+export const NATIVE_BUILD_BRIDGE: NativeBuildBridge = {
+  version: '0.35.1',
+  ios: 47,
+  android: 39,
+};

--- a/server/ota_updates.ts
+++ b/server/ota_updates.ts
@@ -23,6 +23,7 @@ import { withBody } from './http/middleware/body';
 import { type Infer, object, optional, str } from './http/schema';
 import type { Ctx, Middleware, RouteDef } from './http/types';
 import { json } from './http_util';
+import { NATIVE_BUILD_BRIDGE, type NativeBuildBridge } from './ota_native_build';
 import { publicReadRateLimited } from './ratelimit';
 
 /** The stable machine code this domain emits on invalid input (see error_codes.ts). */
@@ -141,6 +142,9 @@ export function resetOtaUpdatesRuntimeForTests(): void {
   manifestCacheUrl = null;
 }
 
+/** Older than every published bundle: an unrecognised, pre-bridge store build. */
+const OLDEST_VERSION: [number, number, number] = [0, 0, 0];
+
 /** Parse a strict MAJOR.MINOR.PATCH version; null on anything else. */
 export function parseSemver(value: unknown): [number, number, number] | null {
   if (typeof value !== 'string') return null;
@@ -192,6 +196,30 @@ export function normalizeOtaManifest(value: unknown, expectedOrigin?: string): O
 }
 
 /**
+ * The device's current asset version, as a comparable semver.
+ *
+ * `version_build` is a native BUILD NUMBER (iOS CFBundleVersion, Android
+ * versionCode), not a version string, so it is resolved through
+ * NATIVE_BUILD_BRIDGE: at or above this release's build number the device runs
+ * this release's assets, and anything below it is an older store build and so
+ * older than any bundle we publish. A marketing-style value is still accepted
+ * verbatim, which keeps older shells and the simulator working. Anything else
+ * (a non-numeric build such as 'dev') stays null and the caller fails safe.
+ */
+export function resolveNativeVersion(
+  platform: 'ios' | 'android',
+  versionBuild: string | undefined,
+  bridge: NativeBuildBridge = NATIVE_BUILD_BRIDGE,
+): [number, number, number] | null {
+  const asSemver = parseSemver(versionBuild);
+  if (asSemver !== null) return asSemver;
+  const raw = typeof versionBuild === 'string' ? versionBuild.trim() : '';
+  if (!/^\d+$/.test(raw)) return null;
+  const bridgeBuild = platform === 'ios' ? bridge.ios : bridge.android;
+  return Number(raw) >= bridgeBuild ? parseSemver(bridge.version) : OLDEST_VERSION;
+}
+
+/**
  * The pure update decision: given the published manifest and one device's
  * check-in, return the offer or null for "no update". Every unparseable or
  * unexpected input decides null (fail-safe: a device we cannot reason about
@@ -200,19 +228,23 @@ export function normalizeOtaManifest(value: unknown, expectedOrigin?: string): O
 export function planOtaUpdate(
   manifest: OtaManifest,
   req: { platform: string; versionName?: string; versionBuild?: string },
+  bridge: NativeBuildBridge = NATIVE_BUILD_BRIDGE,
 ): OtaUpdateOffer | null {
   if (req.platform !== 'ios' && req.platform !== 'android') return null;
   // version_name is the currently applied OTA bundle, or 'builtin' when the
-  // device still runs the store-shipped assets; the store bundle's version IS
-  // the native version (scripts/version_sync.mjs keeps them in lockstep).
-  const currentRaw =
-    req.versionName && req.versionName !== 'builtin' ? req.versionName : req.versionBuild;
-  const current = parseSemver(currentRaw);
+  // device still runs the store-shipped assets. A builtin device reports only a
+  // native BUILD NUMBER, so it resolves through the build bridge rather than
+  // parseSemver, which used to reject it and silently offer nothing forever.
+  const applied = req.versionName && req.versionName !== 'builtin' ? req.versionName : null;
+  const current =
+    applied !== null
+      ? parseSemver(applied)
+      : resolveNativeVersion(req.platform, req.versionBuild, bridge);
   const published = parseSemver(manifest.version);
   if (current === null || published === null) return null;
   if (manifest.minNativeVersion !== undefined) {
     const min = parseSemver(manifest.minNativeVersion);
-    const native = parseSemver(req.versionBuild);
+    const native = resolveNativeVersion(req.platform, req.versionBuild, bridge);
     if (min === null || native === null || compareSemver(native, min) < 0) return null;
   }
   if (compareSemver(published, current) <= 0) return null;

--- a/tests/release_version.test.ts
+++ b/tests/release_version.test.ts
@@ -42,6 +42,12 @@ const PLAY_HTML = `<a href="https://updates.worldofclaudecraft.com/desktop/world
 <a href="https://updates.worldofclaudecraft.com/desktop/world-of-claudecraft-0.20.0-win-x64.exe">Download</a>
 <div id="game-version">v0.10</div>`;
 
+const OTA_NATIVE_BUILD_TS = `export const NATIVE_BUILD_BRIDGE: NativeBuildBridge = {
+  version: '0.20.0',
+  ios: 4,
+  android: 4,
+};`;
+
 const DESKTOP_TS = `export const DESKTOP_VERSION = '0.20.0';
 const DESKTOP_HOST = 'https://updates.worldofclaudecraft.com/desktop';`;
 
@@ -174,6 +180,7 @@ describe('planReleaseVersion', () => {
       gradle: GRADLE,
       pbxproj: PBXPROJ,
       desktopModule: DESKTOP_TS,
+      otaNativeBuild: OTA_NATIVE_BUILD_TS,
       htmlFiles: {
         'index.html': INDEX_HTML,
         'play.html': PLAY_HTML,
@@ -195,6 +202,12 @@ describe('planReleaseVersion', () => {
     expect(plan.htmlFiles['play.html']).toContain('<div id="game-version">v0.21.0</div>');
     expect(plan.desktopModule).toContain("export const DESKTOP_VERSION = '0.21.0';");
     expect(plan.readmeFiles['README.md']).toContain('version-0.21.0-blue');
+    // The OTA build bridge must carry the BUMPED build numbers (4 -> 5), not the
+    // pre-bump ones: a bridge one release behind silently stops offering updates
+    // to every store-fresh device.
+    expect(plan.otaNativeBuild).toContain("version: '0.21.0'");
+    expect(plan.otaNativeBuild).toContain('ios: 5');
+    expect(plan.otaNativeBuild).toContain('android: 5');
   });
 });
 
@@ -206,6 +219,7 @@ describe('collectReleaseVersionFailures', () => {
       gradle: GRADLE,
       pbxproj: PBXPROJ,
       desktopModule: DESKTOP_TS,
+      otaNativeBuild: OTA_NATIVE_BUILD_TS,
       htmlFiles: {
         'index.html': INDEX_HTML,
         'play.html': '<div class="coming-soon-badge">Coming Soon...</div>',
@@ -238,6 +252,7 @@ describe('collectReleaseVersionFailures', () => {
       gradle: GRADLE,
       pbxproj: PBXPROJ,
       desktopModule: DESKTOP_TS,
+      otaNativeBuild: OTA_NATIVE_BUILD_TS,
       htmlFiles: {
         'play.html': PLAY_HTML,
       },
@@ -256,6 +271,7 @@ describe('collectReleaseVersionFailures', () => {
       gradle: GRADLE,
       pbxproj: PBXPROJ,
       desktopModule: DESKTOP_TS,
+      otaNativeBuild: OTA_NATIVE_BUILD_TS,
       htmlFiles: {
         'index.html': setGameVersionText(LEGACY_WINDOWS_HTML, '0.21.0', 'index.html').replace(
           'world-of-claudecraft-0.20.0-mac-universal.dmg',

--- a/tests/server/ota_native_build.test.ts
+++ b/tests/server/ota_native_build.test.ts
@@ -1,0 +1,48 @@
+// The build bridge is only correct while it matches the real project files, and
+// nothing else in the tree would notice it going stale: a wrong bridge does not
+// crash, it silently stops offering updates to store-fresh devices, which is
+// exactly the outage this file exists to prevent recurring. A release version
+// sync bumps versionCode and CURRENT_PROJECT_VERSION monotonically, so these
+// pins go red on the next release until the bridge is updated with them.
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { NATIVE_BUILD_BRIDGE } from '../../server/ota_native_build';
+
+const ROOT = path.resolve(import.meta.dirname, '..', '..');
+const read = (rel: string) => readFileSync(path.join(ROOT, rel), 'utf8');
+
+describe('NATIVE_BUILD_BRIDGE tracks the real release surfaces', () => {
+  it('carries the marketing version from package.json', () => {
+    const pkg = JSON.parse(read('package.json')) as { version: string };
+    expect(NATIVE_BUILD_BRIDGE.version).toBe(pkg.version);
+  });
+
+  it('carries the Android versionCode from build.gradle', () => {
+    const match = /^\s*versionCode\s+(\d+)/m.exec(read('android/app/build.gradle'));
+    expect(match, 'versionCode not found in build.gradle').not.toBeNull();
+    expect(NATIVE_BUILD_BRIDGE.android).toBe(Number(match?.[1]));
+  });
+
+  it('carries the iOS CURRENT_PROJECT_VERSION from project.pbxproj', () => {
+    const pbxproj = read('ios/App/App.xcodeproj/project.pbxproj');
+    const builds = [...pbxproj.matchAll(/CURRENT_PROJECT_VERSION\s*=\s*(\d+)\s*;/g)].map((m) =>
+      Number(m[1]),
+    );
+    expect(builds.length, 'no CURRENT_PROJECT_VERSION in project.pbxproj').toBeGreaterThan(0);
+    // version_sync writes every occurrence together, so they must agree; a split
+    // value would make the bridge right for one target and wrong for another.
+    expect(new Set(builds).size, `CURRENT_PROJECT_VERSION disagrees: ${builds.join(', ')}`).toBe(1);
+    expect(NATIVE_BUILD_BRIDGE.ios).toBe(builds[0]);
+  });
+
+  it('pins build numbers as plain integers, never a version string', () => {
+    // The whole point: these are CFBundleVersion / versionCode, which are the
+    // values Capgo sends as version_build. A semver here would reintroduce the
+    // bug by making the bridge unreachable.
+    expect(Number.isInteger(NATIVE_BUILD_BRIDGE.ios)).toBe(true);
+    expect(Number.isInteger(NATIVE_BUILD_BRIDGE.android)).toBe(true);
+    expect(NATIVE_BUILD_BRIDGE.ios).toBeGreaterThan(0);
+    expect(NATIVE_BUILD_BRIDGE.android).toBeGreaterThan(0);
+  });
+});

--- a/tests/server/ota_updates.test.ts
+++ b/tests/server/ota_updates.test.ts
@@ -227,6 +227,124 @@ describe('planOtaUpdate', () => {
     // A gate with no parseable native version fails closed.
     expect(planOtaUpdate(gated, { platform: 'ios', versionName: '0.32.0' })).toBeNull();
   });
+  // THE REGRESSION THIS SUITE MISSED. Every case above hands version_build a
+  // marketing-style semver, but Capgo sends the native BUILD NUMBER: iOS
+  // CFBundleVersion (= CURRENT_PROJECT_VERSION) and Android versionCode, plain
+  // integers. Before the build bridge those parsed as null, so a store-fresh
+  // device (version_name 'builtin') was told "no new version available" at HTTP
+  // 200, forever, and no test noticed because none of them sent a real value.
+  describe('store-fresh devices reporting a native build NUMBER', () => {
+    const BRIDGE = { version: '0.33.0', ios: 40, android: 33 };
+
+    it('offers the bundle to a device on an older store build', () => {
+      for (const [platform, build] of [
+        ['ios', '39'],
+        ['android', '32'],
+      ] as const) {
+        expect(
+          planOtaUpdate(
+            MANIFEST,
+            { platform, versionName: 'builtin', versionBuild: build },
+            BRIDGE,
+          ),
+          `${platform} build ${build} must be offered the update`,
+        ).toEqual({ version: '0.33.0', url: MANIFEST.url, checksum: 'ab12cd34' });
+      }
+    });
+
+    it("offers nothing to a device already on this release's store build", () => {
+      // Its built-in assets ARE the published bundle: offering here would push a
+      // multi-hundred-megabyte download of bytes the device already has.
+      expect(
+        planOtaUpdate(
+          MANIFEST,
+          { platform: 'ios', versionName: 'builtin', versionBuild: '40' },
+          BRIDGE,
+        ),
+      ).toBeNull();
+      expect(
+        planOtaUpdate(
+          MANIFEST,
+          { platform: 'android', versionName: 'builtin', versionBuild: '33' },
+          BRIDGE,
+        ),
+      ).toBeNull();
+    });
+
+    it("offers a newer bundle to a device on this release's store build", () => {
+      const newer: OtaManifest = { ...MANIFEST, version: '0.33.1' };
+      expect(
+        planOtaUpdate(
+          newer,
+          { platform: 'ios', versionName: 'builtin', versionBuild: '40' },
+          BRIDGE,
+        ),
+      ).toEqual({ version: '0.33.1', url: newer.url, checksum: 'ab12cd34' });
+    });
+
+    it("reads each platform's own build ladder, never the other", () => {
+      // iOS 33 is an OLD ios build (bridge 40) even though 33 is the CURRENT
+      // android build: mixing the ladders would wrongly withhold the update.
+      expect(
+        planOtaUpdate(
+          MANIFEST,
+          { platform: 'ios', versionName: 'builtin', versionBuild: '33' },
+          BRIDGE,
+        ),
+      ).toEqual({ version: '0.33.0', url: MANIFEST.url, checksum: 'ab12cd34' });
+    });
+
+    it('still honours an applied bundle version over the native build', () => {
+      expect(
+        planOtaUpdate(
+          MANIFEST,
+          { platform: 'ios', versionName: '0.33.0', versionBuild: '39' },
+          BRIDGE,
+        ),
+      ).toBeNull();
+    });
+
+    it('keeps failing safe on a build it cannot read', () => {
+      for (const versionBuild of ['dev', '', '1.2', 'v40', '40.0']) {
+        expect(
+          planOtaUpdate(
+            MANIFEST,
+            { platform: 'ios', versionName: 'builtin', versionBuild },
+            BRIDGE,
+          ),
+          `version_build ${JSON.stringify(versionBuild)} must fail safe`,
+        ).toBeNull();
+      }
+    });
+
+    it('gates minNativeVersion on the resolved native version', () => {
+      const gated: OtaManifest = { ...MANIFEST, minNativeVersion: '0.33.0' };
+      // An older store build resolves below every minimum, so it stays blocked.
+      expect(
+        planOtaUpdate(
+          gated,
+          { platform: 'ios', versionName: 'builtin', versionBuild: '39' },
+          BRIDGE,
+        ),
+      ).toBeNull();
+      // The current store build satisfies a gate pinned at this release.
+      expect(
+        planOtaUpdate(
+          gated,
+          { platform: 'ios', versionName: 'builtin', versionBuild: '40' },
+          BRIDGE,
+        ),
+      ).toBeNull();
+      const openGate: OtaManifest = { ...MANIFEST, version: '0.33.1', minNativeVersion: '0.33.0' };
+      expect(
+        planOtaUpdate(
+          openGate,
+          { platform: 'ios', versionName: 'builtin', versionBuild: '40' },
+          BRIDGE,
+        ),
+      ).toEqual({ version: '0.33.1', url: openGate.url, checksum: 'ab12cd34' });
+    });
+  });
 });
 
 describe('POST /api/ota/updates handler', () => {


### PR DESCRIPTION
## Summary

Self-hosted OTA has never reached a store-fresh device. The bundle publishes fine, the
manifest is correct, and the server then refuses to offer it.

Capgo sends `version_build` as the native BUILD identifier (iOS `CFBundleVersion` =
`CURRENT_PROJECT_VERSION`, Android `versionCode`), a plain integer like `47`, never a
semver. A device that has not yet applied a bundle sends `version_name: 'builtin'`, which
makes `planOtaUpdate` fall back to exactly that field. `parseSemver` accepts only
`MAJOR.MINOR.PATCH`, so the value parsed to `null` and the endpoint answered
`no_new_version_available` at HTTP 200: silent, and indistinguishable from being up to date.

Reproduced against live production before the fix:

| request | response |
| --- | --- |
| `builtin` + `"46"` (real iOS build) | No new version available |
| `builtin` + `"38"` (real Android build) | No new version available |
| `builtin` + `"0.34.0"` (the only shape the tests used) | offers 0.35.0 |

A build number cannot be compared against a semver manifest without knowing which marketing
version a given build shipped as. `server/ota_native_build.ts` supplies that one data point.
Build numbers are monotonic, so one point is enough: below it the device is on an older store
build and gets the bundle, at or above it the device runs this release's assets and is
compared normally. That second arm matters, because without it a device on the current store
build would re-download a 552 MB bundle byte-identical to the assets it shipped with.

The bridge is a release surface now: `release_version.mjs prepare` writes it from the BUMPED
native numbers and `check` verifies it against the same project files, so a release that
forgets it fails the release version gate instead of going dark. `minNativeVersion` resolves
through the same path, since it carried the identical semver assumption.

This must ship server-side. `src/net/native_ota.ts` only calls `notifyAppReady()`; the update
check itself is native and config-driven, so there is no JS hook to change what the device
sends without a store release, and a store release cannot help the installs already out there.

**Why CI never caught it.** Every case in `tests/server/ota_updates.test.ts` fed
`version_build` a marketing-style semver, and one explicitly pinned a non-numeric build
resolving to `null` as correct. The suite encoded the wrong assumption, so it stayed green
while the product was dark. The new cases use real build numbers, and I verified they fail
against the old behaviour (4 red) before making them pass.

Docs were updated only where they actively taught the wrong model. The end-to-end
verification runbook in `docs/ota-updates.md` told you to probe with
`"version_build":"0.31.0"`, so following it exactly would confirm a working OTA on a server
that offers nothing to real devices.

## Related issues

N/A. Found while verifying the v0.35.0 OTA publish after the production deploy.

## Type of change

- [x] Bug fix
- [x] Documentation
- [x] Tests
- [x] Build, CI, or tooling

## How was this tested?

- Commands:
  - `npx vitest run tests/server/ota_updates.test.ts tests/server/ota_native_build.test.ts tests/release_version.test.ts tests/version_sync.test.ts tests/deploy_ota_updates.test.ts` (75 passed)
  - `npx tsc --noEmit` (clean)
  - `node scripts/release_version.mjs check --version 0.35.1` (synchronized)
  - `node scripts/gate_select.mjs` (running at the time of opening; will confirm in a comment)
- Manual steps:
  - Reproduced the outage against live prod with `POST /api/ota/updates` using real iOS and
    Android build numbers, as in the table above.
  - Mutation-checked the new tests: reverted `resolveNativeVersion` to the old
    `parseSemver`-only behaviour and confirmed 4 of the new cases go red, including
    "offers the bundle to a device on an older store build".
  - Mutation-checked the release gate: set the bridge's iOS build to 46 and confirmed
    `release:check` fails with `expected 47 (CURRENT_PROJECT_VERSION)`.

## Screenshots / recordings

N/A. No player-visible surface changes.

---

## Checklist

### Quality

- [x] **The gate passes.** Targeted suites, `tsc` and `release:check` are green; the full
      `gate_select` run was still in flight when this was opened and its result will be
      posted as a comment. Decisive tests added and mutation-checked (see above).

### Cross-platform

- [x] N/A. Server-side decision logic, no UI.
- [x] Both native platforms are covered: the resolution reads each platform's own build
      ladder, with a test pinning that iOS and Android numbers are never crossed.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings. The endpoint returns the plugin's
      documented machine-readable body, not prose.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is untouched.
- [x] No generated files hand-edited. `server/ota_native_build.ts` is hand-authored but
      written by `release:prepare` and gated by `release:check` from here on.

## Remaining risk, stated plainly

One inference is not proven by packet capture: that Capgo sends `CFBundleVersion` rather
than `CFBundleShortVersionString` as `version_build`. The field naming, the native project
definitions, and the observed symptom all point the same way, and the endpoint does no
request logging, so there is no traffic to read. The fix is safe either way (a
marketing-style value is still accepted verbatim), but the cheap way to make it airtight is
one log line on that endpoint and a single real request.

The download-and-boot leg still needs a real device. Everything up to the offer is now
curl-testable, and I will re-probe production with `builtin` + `46` and `builtin` + `47`
after this deploys.
