### PR TITLE
test(render): re-anchor hunter ghost manifest pins to the swims() wrap

### DIFF
--- a/tests/anim_pipeline_hunter_ghost.test.ts
+++ b/tests/anim_pipeline_hunter_ghost.test.ts
@@ -57,7 +57,7 @@ describe('hunter ability-specific attacks (issue #2889 follow-up batch)', () => 
   });
 
   it('wires both donor GLBs (the pre-existing bow_anims.glb and the new one) and an attackByAbility override for every mapped ability', () => {
-    const block = manifestBlock('player_hunter: {', 'player_rogue: {');
+    const block = manifestBlock('player_hunter: swims({', 'player_rogue: swims({');
     expect(block).toContain('bow_anims.glb');
     expect(block).toContain('hunter_ability_anims.glb');
     expect(block).toContain('attackByAbility');
@@ -65,7 +65,7 @@ describe('hunter ability-specific attacks (issue #2889 follow-up batch)', () => 
   });
 
   it('every mapped ability id is a real hunter ability, and every referenced clip is shipped or an existing rig clip', () => {
-    const hunterBlock = manifestBlock('player_hunter: {', 'player_rogue: {');
+    const hunterBlock = manifestBlock('player_hunter: swims({', 'player_rogue: swims({');
     const abilityStart = hunterBlock.indexOf('attackByAbility: {');
     expect(abilityStart).toBeGreaterThanOrEqual(0);
     const abilityEnd = hunterBlock.indexOf('\n      },', abilityStart);


### PR DESCRIPTION
## Summary

`release/v0.36.0` is red on two tests in `tests/anim_pipeline_hunter_ghost.test.ts`: both anchor their manifest-source slice on `player_hunter: {`, a shape the player entries in `src/render/characters/manifest.ts` lost when they were wrapped in the `swims()` helper. The anchors now read `player_hunter: swims({` and `player_rogue: swims({`, which is exactly how `tests/anim_pipeline_batch1.test.ts` already anchors the mage block. No manifest or behavior change; the pinned content (both donor GLBs, the full attackByAbility map) is intact and the assertions over it are untouched.

First flagged by the author of #3106, whose full-suite run inherited the two failures from the base.

## Related issues

Repairs the red tip on `release/v0.36.0` (the anchors landed in #2958 against the pre-`swims()` manifest shape).

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands: `npx vitest run tests/anim_pipeline_hunter_ghost.test.ts tests/anim_pipeline_batch1.test.ts` (10 passed; the hunter ghost pair fails on the base tip before this change), `npx @biomejs/biome check` on the touched file.
- The two previously failing tests now locate the hunter block and re-verify every pinned clip mapping against the live manifest.

## Screenshots / recordings

N/A: test-only change.

## Checklist

### Quality

- [x] Targeted tests pass; the change is two anchor literals in one test file.

### Cross-platform

- [x] N/A: no runtime code touched.

### Localization (i18n)

- [x] N/A. No player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed; `ALLOW_DEV_COMMANDS` untouched.
- [x] No generated file hand-edited.
