### PR TITLE
fix(dev): stop the dev server reloading for agent worktree files

### DIFF
--- a/tests/vite_dev_watch.test.ts
+++ b/tests/vite_dev_watch.test.ts
@@ -1,0 +1,145 @@
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+
+// Guards `server.watch.ignored` in vite.config.ts, the only thing keeping the dev
+// server from reloading the served game for a file that cannot reach it.
+//
+// Vite's own default ignore list is just .git, node_modules, test-results, cacheDir
+// and outDir, so without this the watcher descends into every agent runtime directory
+// at the repo root. A linked worktree parked under one of those is a second full
+// checkout, and two of its files reload the page even though neither is in the module
+// graph: ANY watched *.html sends a full-reload, and ANY watched tsconfig.json sends a
+// full-reload after invalidating every module graph. Creating a worktree, deleting it,
+// or switching its branch rewrites all of them at once.
+//
+// The list therefore has to hold three properties at once, one `it` each: it names the
+// agent and scratch directories, it stays directory-scoped so it can only ever prune a
+// directory, and none of the directories it prunes holds a file the dev server serves.
+
+const root = fileURLToPath(new URL('..', import.meta.url));
+const configPath = fileURLToPath(new URL('../vite.config.ts', import.meta.url));
+const config = ts.createSourceFile(
+  'vite.config.ts',
+  readFileSync(configPath, 'utf8'),
+  ts.ScriptTarget.Latest,
+  true,
+);
+
+function defineConfigObject(): ts.ObjectLiteralExpression {
+  let found: ts.ObjectLiteralExpression | undefined;
+  const visit = (node: ts.Node): void => {
+    if (
+      !found &&
+      ts.isCallExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === 'defineConfig' &&
+      node.arguments.length === 1 &&
+      ts.isObjectLiteralExpression(node.arguments[0])
+    ) {
+      found = node.arguments[0];
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(config);
+  if (!found) throw new Error('vite.config.ts: no defineConfig({ ... }) object literal found');
+  return found;
+}
+
+function propertyValue(obj: ts.ObjectLiteralExpression, name: string): ts.Expression {
+  for (const prop of obj.properties) {
+    if (!ts.isPropertyAssignment(prop)) continue;
+    const key = ts.isIdentifier(prop.name) || ts.isStringLiteral(prop.name) ? prop.name.text : '';
+    if (key === name) return prop.initializer;
+  }
+  throw new Error(`vite.config.ts: property "${name}" not found`);
+}
+
+// Reads a string[] at a dotted path under defineConfig({ ... }). Parsed from the AST
+// rather than imported: vite.config.ts sits outside tsconfig `include` on purpose (it
+// imports untyped scripts/*.mjs helpers), so importing it here would drag it into the
+// type-checked program.
+function stringArrayAt(path: string): string[] {
+  const segments = path.split('.');
+  let node: ts.Expression = defineConfigObject();
+  for (const segment of segments) {
+    if (!ts.isObjectLiteralExpression(node)) {
+      throw new Error(`vite.config.ts: "${path}" traverses a non-object at "${segment}"`);
+    }
+    node = propertyValue(node, segment);
+  }
+  if (!ts.isArrayLiteralExpression(node)) throw new Error(`vite.config.ts: "${path}" is not array`);
+  return node.elements.map((element) => {
+    if (!ts.isStringLiteral(element)) {
+      throw new Error(`vite.config.ts: "${path}" holds a non-literal element`);
+    }
+    return element.text;
+  });
+}
+
+// '**/.claude/**' and 'tmp/**' both name one directory; anything else returns undefined
+// so a future non-directory pattern cannot be silently read as a directory name.
+const DIRECTORY_GLOB = /^(?:\*\*\/)?([^*/]+)\/\*\*$/;
+const directoryOf = (glob: string): string | undefined => DIRECTORY_GLOB.exec(glob)?.[1];
+
+const watchIgnored = stringArrayAt('server.watch.ignored');
+const watchIgnoredDirs = watchIgnored.map(directoryOf).filter((dir) => dir !== undefined);
+
+describe('vite dev-server watch ignore list', () => {
+  it('unwatches every agent runtime and scratch directory', () => {
+    expect(new Set(watchIgnored)).toEqual(
+      new Set([
+        '**/.claude/**',
+        '**/.codex/**',
+        '**/.agents/**',
+        '**/.worktrees/**',
+        '**/.venv/**',
+        '**/tmp/**',
+      ]),
+    );
+  });
+
+  // The same directories vitest already refuses to collect tests from, for the same
+  // stated reason (a linked worktree parked under one of them is a second checkout).
+  // Adding a new agent directory to one list and not the other is the drift this pins:
+  // vitest would stop running its frozen copy while Vite kept reloading the game for it.
+  it('covers every agent directory that test.exclude already lists', () => {
+    const excluded = stringArrayAt('test.exclude')
+      .map(directoryOf)
+      .filter((dir) => dir !== undefined)
+      .filter((dir) => dir.startsWith('.') || dir === 'tmp');
+    expect(excluded.length).toBeGreaterThanOrEqual(6);
+    for (const dir of excluded) expect(watchIgnoredDirs).toContain(dir);
+  });
+
+  // A pattern that is not `**/<dir>/**` could match files scattered anywhere, and an
+  // over-broad one would silently kill HMR for real sources instead of merely quieting
+  // it. Keeping every entry directory-scoped is what makes the next check total.
+  it('keeps every pattern directory-scoped, and never over a source root', () => {
+    for (const glob of watchIgnored) expect(directoryOf(glob)).toBeDefined();
+    for (const sourceRoot of ['src', 'server', 'public', 'scripts', 'headless', 'electron']) {
+      expect(watchIgnoredDirs).not.toContain(sourceRoot);
+    }
+  });
+
+  // The load-bearing one. Ignoring a directory is only safe while nothing the dev server
+  // would serve lives in it: the moment a tracked module, stylesheet or HTML entry lands
+  // under one of these, editing it stops triggering HMR and the change looks like it did
+  // not apply. Tracked files only, so the untracked worktree copies stay out of the walk.
+  it('prunes no directory that holds a file the dev server would serve', () => {
+    const tracked = execFileSync('git', ['ls-files', '-z', '--', ...watchIgnoredDirs], {
+      cwd: root,
+      encoding: 'utf8',
+      maxBuffer: 64 * 1024 * 1024,
+    })
+      .split('\0')
+      .filter(Boolean);
+    expect(tracked.length).toBeGreaterThan(0);
+    expect(tracked.filter((file) => /\.(ts|tsx|js|mjs|cjs|css|html|svelte)$/.test(file))).toEqual(
+      [],
+    );
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -323,6 +323,26 @@ export default defineConfig({
   },
   server: {
     port: 5173,
+    // Vite's default watch ignore list is only .git, node_modules, test-results,
+    // cacheDir and outDir, so the dev watcher otherwise descends into every agent
+    // runtime directory at the repo root. A linked worktree parked under one of them
+    // is a full second checkout: its 7 root *.html entries each trigger a page reload
+    // on change (Vite reloads for ANY watched .html, in the module graph or not), and
+    // its tsconfig.json triggers a full reload plus a moduleGraph.invalidateAll().
+    // Creating, deleting, or switching branches inside such a worktree rewrites all of
+    // them at once, so the served game reloads for edits that cannot reach it. Same
+    // rows as `test.exclude` below (see its comment), for the same reason; pinned by
+    // tests/vite_dev_watch.test.ts.
+    watch: {
+      ignored: [
+        '**/.claude/**',
+        '**/.codex/**',
+        '**/.agents/**',
+        '**/.worktrees/**',
+        '**/.venv/**',
+        '**/tmp/**',
+      ],
+    },
     proxy: {
       '/api': { target: apiProxyTarget, changeOrigin: true },
       '/admin/api': { target: apiProxyTarget, changeOrigin: true },


### PR DESCRIPTION
## Summary

`npm run dev` reloaded the served game for files that cannot reach it. The cause is
that `vite.config.ts` never set `server.watch`, and Vite's own default ignore list is
only `**/.git/**`, `**/node_modules/**`, `**/test-results/**`, the cacheDir and the
outDir. Everything else under the repo root is watched, including any linked git
worktree parked in an agent runtime directory.

That matters because two file kinds trigger a reload even when they are **not in the
module graph**:

- any watched `*.html` sends a `full-reload`
- any watched `tsconfig.json` sends a `full-reload` after `moduleGraph.invalidateAll()`

A worktree checked out under `.claude/worktrees/` is a second full checkout: it carries
its own 7 root `*.html` entries and its own `tsconfig.json`. Creating one, deleting one,
or switching its branch rewrites all of them at once, so the game reloaded while an
agent was working in a completely separate tree.

On the reporting machine the watcher was walking 59923 files, 39392 of them (66 percent,
7.4 GB) worktree copies, and 130 of the 137 watched `*.html` files lived under `.claude/`.

This adds `server.watch.ignored` with the same agent-runtime and scratch directories
`test.exclude` already lists a few lines below, for the same stated reason.

Deliberately **not** ignored: `docs/`, `android/`, `ios/` and `dist-*/`. They can host
`.html` too, but they are ordinary tracked or build output rather than agent scratch, and
keeping the list to one motivation keeps it reviewable.

### What this does not change

Editing a test file never triggered a reload, and still does not. Verified against a
minimal Vite 8.1.4 project:

| watched file changed | reload before | reload after |
| --- | --- | --- |
| `.claude/worktrees/x/tests/foo.test.ts` (edit, create, delete) | no | no |
| `.claude/worktrees/x/src/sim.ts` (edit, and tmp + rename) | no | no |
| `tests/bar.test.ts` at the served root | no | no |
| `public/asset.txt` | no | no |
| `.claude/worktrees/x/index.html` | **yes** | no |
| `.claude/worktrees/x/tsconfig.json` | **yes**, plus cache invalidation | no |
| `src/main.ts` (control) | yes | **yes**, unchanged |

`npm test` still reloads the page once, and that is out of scope here: `pretest`
regenerates the i18n and guide artifacts, which really are in the module graph. It is an
npm lifecycle hook, so a targeted `npx vitest run tests/<file>.test.ts` does not trigger it.

## Related issues

N/A

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [x] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx vitest run tests/vite_dev_watch.test.ts` (the new guard, 4 cases)
  - `npx vitest run tests/duplicate_test_blocks.test.ts tests/styles_extraction.test.ts tests/architecture.test.ts tests/ci_change_classify.test.ts tests/gate_select_plan.test.ts tests/ci_test_select.test.ts`
  - `npx tsc --noEmit`
  - `npx @biomejs/biome check vite.config.ts tests/vite_dev_watch.test.ts`
  - `node scripts/gate_select.mjs`
- Manual steps:
  - Built a minimal Vite 8.1.4 project with a fake worktree under `.claude/worktrees/`
    and touched each file kind in turn, reading `page reload <path>` off the dev-server
    log. Produced the before column of the table above, then re-ran the identical
    sequence with the ignore list applied to produce the after column. The control
    (`src/main.ts`) still reloads, so HMR is quieted for the worktree only.
  - Mutated `server.watch.ignored` three ways to confirm the new guard is not vacuous:
    adding `**/tests/**` fails it with 2410 servable tracked files, adding `**/src/**`
    fails the source-root check, and dropping `**/.codex/**` fails the `test.exclude`
    coupling check.

## Screenshots / recordings

N/A. Nothing a player or operator sees changes.

---

## Checklist

### Quality

- [x] **The gate passes.** `node scripts/gate_select.mjs` is green. I added or updated
      decisive tests for changed behavior and recorded any manual checks above.

### Cross-platform

- [x] ~Tested on desktop and mobile.~ N/A, dev-server tooling only.
- [x] ~Accessible.~ N/A, no UI.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not
      enabled in any production path.
- [x] I didn't hand-edit generated files.