### PR TITLE
fix(desktop): serve app:// byte-range requests so game music plays

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -24,6 +24,7 @@ const {
   withCspHeader,
   ALLOWED_PERMISSIONS,
 } = require('./shell_guards.cjs');
+const { rangedFileResponse } = require('./media_range.cjs');
 const { resolveDesktopConfig, walletConnectionSupported } = require('./desktop_config.cjs');
 const { createSteamShell } = require('./steam.cjs');
 const { createEpicShell } = require('./epic.cjs');
@@ -205,6 +206,18 @@ function registerAppProtocol() {
         : path.join(distDir, 'index.html');
     if (!fs.existsSync(filePath) || !fileInside(distDir, filePath)) {
       return notFound();
+    }
+    // Chromium's media stack requests <audio>/<video> sources with a Range header
+    // and rejects a plain 200 re-wrap as a format error, which left every streamed
+    // music cue silent in the shipped shell. Serve those as proper 206 slices (or
+    // a 416 for a past-EOF range) via electron/media_range.cjs; a null (non-media
+    // file, malformed range, unreadable file) falls through to the full response.
+    const rangeValue = request.headers.get('range');
+    if (rangeValue) {
+      const ranged = await rangedFileResponse(filePath, rangeValue, {
+        'Content-Security-Policy': csp,
+      });
+      if (ranged) return ranged;
     }
     // Every served path (asset or the SPA index.html fallback) gets the CSP header;
     // net.fetch's own Response has immutable headers, so withCspHeader builds a fresh

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -24,7 +24,7 @@ const {
   withCspHeader,
   ALLOWED_PERMISSIONS,
 } = require('./shell_guards.cjs');
-const { rangedFileResponse } = require('./media_range.cjs');
+const { rangeContentType, rangedFileResponse } = require('./media_range.cjs');
 const { resolveDesktopConfig, walletConnectionSupported } = require('./desktop_config.cjs');
 const { createSteamShell } = require('./steam.cjs');
 const { createEpicShell } = require('./epic.cjs');
@@ -221,9 +221,13 @@ function registerAppProtocol() {
     }
     // Every served path (asset or the SPA index.html fallback) gets the CSP header;
     // net.fetch's own Response has immutable headers, so withCspHeader builds a fresh
-    // one that preserves the body, status, statusText, and Content-Type.
+    // one that preserves the body, status, statusText, and Content-Type. Media files
+    // also advertise Accept-Ranges here, so range support is visible to a client
+    // that probes the full response before sending its first ranged request.
     const response = await net.fetch(pathToFileURL(filePath).toString());
-    return withCspHeader(response, csp);
+    const full = withCspHeader(response, csp);
+    if (rangeContentType(filePath)) full.headers.set('Accept-Ranges', 'bytes');
+    return full;
   });
 }
 

--- a/electron/media_range.cjs
+++ b/electron/media_range.cjs
@@ -68,17 +68,25 @@ function rangeResponseHeaders(range, size, contentType) {
   };
 }
 
-// A syntactically valid single range whose start sits at or past EOF. Distinct
-// from a malformed header (which the handler may ignore per RFC 9110): this
-// one earns a 416 with the real bounds, because falling back to a plain 200
-// would recreate the exact demuxer format error this module exists to fix,
-// silently, e.g. against a truncated or replaced asset.
+// A syntactically valid single range that no byte of the resource satisfies:
+// an absolute start at or past EOF (EOF included, so a file truncated to zero
+// bytes still counts), a zero-length suffix (bytes=-0), or any well-formed
+// range against an empty file. Distinct from a malformed header (which the
+// handler may ignore per RFC 9110): these earn a 416 with the real bounds,
+// because falling back to a plain 200 would recreate the exact demuxer format
+// error this module exists to fix, silently, e.g. against a truncated or
+// replaced asset.
 function isUnsatisfiableRange(rangeValue, size) {
-  if (typeof rangeValue !== 'string' || !Number.isInteger(size) || size <= 0) return false;
-  const match = /^bytes=(\d+)-(\d*)$/.exec(rangeValue.trim());
+  if (typeof rangeValue !== 'string' || !Number.isInteger(size) || size < 0) return false;
+  const value = rangeValue.trim();
+  const suffix = /^bytes=-(\d+)$/.exec(value);
+  if (suffix) return Number(suffix[1]) === 0 || size === 0;
+  const match = /^bytes=(\d+)-(\d*)$/.exec(value);
   if (!match) return false;
   const start = Number(match[1]);
-  const end = match[2] === '' ? Number.MAX_SAFE_INTEGER : Number(match[2]);
+  // An open end is unbounded: Infinity keeps end >= start true for any start,
+  // so a start past even Number.MAX_SAFE_INTEGER still resolves to the 416.
+  const end = match[2] === '' ? Infinity : Number(match[2]);
   return start >= size && end >= start;
 }
 

--- a/electron/media_range.cjs
+++ b/electron/media_range.cjs
@@ -1,0 +1,124 @@
+// Byte-range support for the app:// protocol handler (electron/main.cjs).
+//
+// Chromium's media stack loads <audio>/<video> resources with a Range request
+// (the first one is always "Range: bytes=0-") and requires a well-formed
+// 206 Partial Content answer (Content-Range plus the exact body slice). The
+// handler used to ignore the header and re-wrap net.fetch's plain 200, which
+// the media demuxer rejects outright (MEDIA_ELEMENT_ERROR: Format error, so
+// element.play() rejects with NotSupportedError). The result: every streamed
+// music cue (the looping media elements in src/game/music.ts, plus the boss,
+// Sowfield, landing-theme, and voice elements) was silent in the desktop
+// shell while fetch+decodeAudioData SFX kept working. Honoring the range also
+// makes seeking work, which el.loop and the currentTime resets depend on.
+//
+// No Electron imports: plain Node, so tests/electron_media_range.test.ts can
+// exercise the parser, the header shapes, and the real Response end to end.
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { Readable } = require('node:stream');
+
+// Content types for the ranged path: the media containers the client ships or
+// could ship. Ranged serving is deliberately limited to these; any other file
+// type (including the extension-less SPA fallback to index.html) returns null
+// so the handler's full-response path keeps its net.fetch-derived MIME type.
+const RANGE_CONTENT_TYPES = {
+  '.mp3': 'audio/mpeg',
+  '.m4a': 'audio/mp4',
+  '.mp4': 'video/mp4',
+  '.ogg': 'audio/ogg',
+  '.opus': 'audio/ogg',
+  '.wav': 'audio/wav',
+  '.webm': 'video/webm',
+};
+
+function rangeContentType(filePath) {
+  return RANGE_CONTENT_TYPES[path.extname(filePath).toLowerCase()] ?? null;
+}
+
+// Parse a single-range Range header value against a known resource size.
+// Returns inclusive byte offsets, or null when the header is absent,
+// malformed, multi-range, or unsatisfiable. A null caller falls back to the
+// full 200 response, which RFC 9110 permits (a server MAY ignore Range).
+function parseByteRange(rangeValue, size) {
+  if (typeof rangeValue !== 'string' || !Number.isInteger(size) || size <= 0) return null;
+  const match = /^bytes=(\d*)-(\d*)$/.exec(rangeValue.trim());
+  if (!match) return null;
+  const [, startRaw, endRaw] = match;
+  if (startRaw === '' && endRaw === '') return null;
+  if (startRaw === '') {
+    // suffix form (bytes=-N): the final N bytes
+    const suffix = Number(endRaw);
+    if (suffix <= 0) return null;
+    return { start: Math.max(0, size - suffix), end: size - 1 };
+  }
+  const start = Number(startRaw);
+  if (start >= size) return null;
+  const end = endRaw === '' ? size - 1 : Math.min(Number(endRaw), size - 1);
+  if (end < start) return null;
+  return { start, end };
+}
+
+function rangeResponseHeaders(range, size, contentType) {
+  return {
+    'Content-Type': contentType,
+    'Content-Length': String(range.end - range.start + 1),
+    'Content-Range': `bytes ${range.start}-${range.end}/${size}`,
+    'Accept-Ranges': 'bytes',
+  };
+}
+
+// A syntactically valid single range whose start sits at or past EOF. Distinct
+// from a malformed header (which the handler may ignore per RFC 9110): this
+// one earns a 416 with the real bounds, because falling back to a plain 200
+// would recreate the exact demuxer format error this module exists to fix,
+// silently, e.g. against a truncated or replaced asset.
+function isUnsatisfiableRange(rangeValue, size) {
+  if (typeof rangeValue !== 'string' || !Number.isInteger(size) || size <= 0) return false;
+  const match = /^bytes=(\d+)-(\d*)$/.exec(rangeValue.trim());
+  if (!match) return false;
+  const start = Number(match[1]);
+  const end = match[2] === '' ? Number.MAX_SAFE_INTEGER : Number(match[2]);
+  return start >= size && end >= start;
+}
+
+// Build the 206 Partial Content response for a ranged media request, streaming
+// only the requested slice; an unsatisfiable range gets the RFC 9110 416
+// answer instead. Returns null when the file is not a rangeable media type, is
+// unreadable, or the range header does not parse, so the caller keeps its
+// existing full-response path. extraHeaders lets the app:// handler keep its
+// every-response CSP invariant.
+async function rangedFileResponse(filePath, rangeValue, extraHeaders = {}) {
+  const contentType = rangeContentType(filePath);
+  if (!contentType) return null;
+  let size;
+  try {
+    const stat = await fs.promises.stat(filePath);
+    if (!stat.isFile()) return null;
+    size = stat.size;
+  } catch {
+    return null;
+  }
+  if (isUnsatisfiableRange(rangeValue, size)) {
+    return new Response(null, {
+      status: 416,
+      headers: { 'Content-Range': `bytes */${size}`, ...extraHeaders },
+    });
+  }
+  const range = parseByteRange(rangeValue, size);
+  if (!range) return null;
+  const stream = fs.createReadStream(filePath, { start: range.start, end: range.end });
+  const headers = {
+    ...rangeResponseHeaders(range, size, contentType),
+    ...extraHeaders,
+  };
+  return new Response(Readable.toWeb(stream), { status: 206, headers });
+}
+
+module.exports = {
+  isUnsatisfiableRange,
+  parseByteRange,
+  rangeContentType,
+  rangeResponseHeaders,
+  rangedFileResponse,
+};

--- a/electron/media_range.d.cts
+++ b/electron/media_range.d.cts
@@ -1,0 +1,22 @@
+// Type declarations for the CommonJS byte-range helpers (electron/media_range.cjs),
+// which electron/main.cjs consumes at runtime and tests/electron_media_range.test.ts
+// exercises directly. main.cjs itself runs outside tsc; these types serve the test.
+
+export interface ByteRange {
+  start: number;
+  end: number;
+}
+
+export function isUnsatisfiableRange(rangeValue: unknown, size: number): boolean;
+export function parseByteRange(rangeValue: unknown, size: number): ByteRange | null;
+export function rangeContentType(filePath: string): string | null;
+export function rangeResponseHeaders(
+  range: ByteRange,
+  size: number,
+  contentType: string,
+): Record<string, string>;
+export function rangedFileResponse(
+  filePath: string,
+  rangeValue: string,
+  extraHeaders?: Record<string, string>,
+): Promise<Response | null>;

--- a/tests/electron_media_range.test.ts
+++ b/tests/electron_media_range.test.ts
@@ -82,6 +82,15 @@ describe('isUnsatisfiableRange', () => {
   it('detects a well-formed range starting at or past EOF', () => {
     expect(isUnsatisfiableRange('bytes=1000-', 1000)).toBe(true);
     expect(isUnsatisfiableRange('bytes=1500-2000', 1000)).toBe(true);
+    // an open end is unbounded, so a start past 2^53 still resolves to a 416
+    expect(isUnsatisfiableRange('bytes=99999999999999999999999-', 1000)).toBe(true);
+  });
+
+  it('detects the zero-length suffix and any well-formed range on an empty file', () => {
+    expect(isUnsatisfiableRange('bytes=-0', 1000)).toBe(true);
+    expect(isUnsatisfiableRange('bytes=0-', 0)).toBe(true);
+    expect(isUnsatisfiableRange('bytes=1000-', 0)).toBe(true);
+    expect(isUnsatisfiableRange('bytes=-5', 0)).toBe(true);
   });
 
   it('stays false for satisfiable, malformed, or inverted ranges', () => {
@@ -90,7 +99,6 @@ describe('isUnsatisfiableRange', () => {
     expect(isUnsatisfiableRange('bytes=2000-1500', 1000)).toBe(false);
     expect(isUnsatisfiableRange('bytes=-100', 1000)).toBe(false);
     expect(isUnsatisfiableRange(null, 1000)).toBe(false);
-    expect(isUnsatisfiableRange('bytes=1000-', 0)).toBe(false);
   });
 });
 
@@ -131,6 +139,21 @@ describe('rangedFileResponse', () => {
     expect(res?.headers.get('Content-Range')).toBe('bytes 0-9/10');
   });
 
+  it('clamps a past-EOF end and keeps body, length, and range in agreement', async () => {
+    const res = await rangedFileResponse(filePath, 'bytes=5-99999');
+    expect(res?.status).toBe(206);
+    expect(await res?.text()).toBe('56789');
+    expect(res?.headers.get('Content-Length')).toBe('5');
+    expect(res?.headers.get('Content-Range')).toBe('bytes 5-9/10');
+  });
+
+  it('serves the suffix form as a 206 of the final N bytes', async () => {
+    const res = await rangedFileResponse(filePath, 'bytes=-3');
+    expect(res?.status).toBe(206);
+    expect(await res?.text()).toBe('789');
+    expect(res?.headers.get('Content-Range')).toBe('bytes 7-9/10');
+  });
+
   it('carries extra headers so the handler keeps its every-response CSP rule', async () => {
     const res = await rangedFileResponse(filePath, 'bytes=0-', {
       'Content-Security-Policy': "default-src 'self'",
@@ -150,6 +173,30 @@ describe('rangedFileResponse', () => {
     expect(res?.status).toBe(416);
     expect(res?.headers.get('Content-Range')).toBe('bytes */10');
     expect(res?.headers.get('Content-Security-Policy')).toBe("default-src 'self'");
+    // the 416 is bounds-only: no body, no stale media headers
+    expect(await res?.text()).toBe('');
+    expect(res?.headers.get('Content-Type')).toBeNull();
+    expect(res?.headers.get('Accept-Ranges')).toBeNull();
+  });
+
+  it('answers a start past 2^53 with 416, never the full-200 fallback', async () => {
+    const res = await rangedFileResponse(filePath, 'bytes=99999999999999999999999-');
+    expect(res?.status).toBe(416);
+    expect(res?.headers.get('Content-Range')).toBe('bytes */10');
+  });
+
+  it('answers a zero-byte media file with 416 instead of an empty 200', async () => {
+    const emptyPath = join(dir, 'empty.mp3');
+    writeFileSync(emptyPath, '');
+    const res = await rangedFileResponse(emptyPath, 'bytes=0-');
+    expect(res?.status).toBe(416);
+    expect(res?.headers.get('Content-Range')).toBe('bytes */0');
+  });
+
+  it('answers the zero-length suffix with 416 and the real bounds', async () => {
+    const res = await rangedFileResponse(filePath, 'bytes=-0');
+    expect(res?.status).toBe(416);
+    expect(res?.headers.get('Content-Range')).toBe('bytes */10');
   });
 
   it('returns null for a non-media extension so the full path keeps its MIME type', async () => {
@@ -168,24 +215,46 @@ describe('rangedFileResponse', () => {
 
 describe('app:// handler wiring (electron/main.cjs)', () => {
   const main = readFileSync(join(__dirname, '..', 'electron', 'main.cjs'), 'utf8');
+  const handlerStart = main.indexOf("protocol.handle('app'");
+  // the first close at the registration's own indent ends THE handler body
+  const handlerEnd = main.indexOf('\n  });', handlerStart);
+  const handler = main.slice(handlerStart, handlerEnd);
 
-  it('imports the range helper', () => {
-    expect(main).toContain("require('./media_range.cjs')");
+  it('imports the range helpers as live code, not a comment', () => {
+    expect(main).toMatch(
+      /^const \{ rangeContentType, rangedFileResponse \} = require\('\.\/media_range\.cjs'\);$/m,
+    );
   });
 
-  it('answers ranged requests before the full-response fallback inside the app handler', () => {
-    const handlerStart = main.indexOf("protocol.handle('app'");
-    const handlerEnd = main.indexOf('function lockDownPermissions');
+  it('slices exactly one registered app handler', () => {
     expect(handlerStart).toBeGreaterThan(-1);
     expect(handlerEnd).toBeGreaterThan(handlerStart);
-    // one registration only, so the slice below is THE handler body
     expect(main.split("protocol.handle('app'").length - 1).toBe(1);
-    const handler = main.slice(handlerStart, handlerEnd);
+  });
+
+  it('answers ranged requests after the path guards and before the full-response fallback', () => {
+    const guardCheck = handler.indexOf('fileInside(distDir, filePath)');
     const rangeRead = handler.indexOf("request.headers.get('range')");
     const rangedCall = handler.indexOf('rangedFileResponse(');
     const fullFallback = handler.indexOf('net.fetch(pathToFileURL(filePath)');
-    expect(rangeRead).toBeGreaterThan(-1);
+    expect(guardCheck).toBeGreaterThan(-1);
+    expect(rangeRead).toBeGreaterThan(guardCheck);
     expect(rangedCall).toBeGreaterThan(rangeRead);
     expect(fullFallback).toBeGreaterThan(rangedCall);
+  });
+
+  // Indentation-anchored shape pins: a commented-out line shifts its indent and
+  // kills the match, so a revert, a dropped return, a dropped CSP argument, or
+  // swapped arguments all fail here even though the unit suite stays green.
+  it('keeps the range branch live: awaited, CSP-carrying, and returned', () => {
+    expect(handler).toMatch(
+      /\n {4}const rangeValue = request\.headers\.get\('range'\);\n {4}if \(rangeValue\) \{\n {6}const ranged = await rangedFileResponse\(filePath, rangeValue, \{\n {8}'Content-Security-Policy': csp,\n {6}\}\);\n {6}if \(ranged\) return ranged;\n {4}\}\n/,
+    );
+  });
+
+  it('advertises Accept-Ranges for media on the full-response fallback', () => {
+    expect(handler).toMatch(
+      /\n {4}const full = withCspHeader\(response, csp\);\n {4}if \(rangeContentType\(filePath\)\) full\.headers\.set\('Accept-Ranges', 'bytes'\);\n {4}return full;/,
+    );
   });
 });

--- a/tests/electron_media_range.test.ts
+++ b/tests/electron_media_range.test.ts
@@ -1,0 +1,191 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, describe, expect, it } from 'vitest';
+import {
+  isUnsatisfiableRange,
+  parseByteRange,
+  rangeContentType,
+  rangedFileResponse,
+  rangeResponseHeaders,
+} from '../electron/media_range.cjs';
+
+// Byte-range support for the app:// protocol handler. Chromium's media stack
+// requests <audio>/<video> sources with "Range: bytes=0-" and rejects a plain
+// 200 re-wrap as MEDIA_ELEMENT_ERROR: Format error, which left every streamed
+// music cue silent in the desktop shell while fetch+decodeAudioData SFX kept
+// working. These tests pin the parser, the header wire shapes, the real 206
+// Response, and the main.cjs handler wiring.
+
+describe('parseByteRange', () => {
+  it('parses the open-ended form Chromium media always sends first', () => {
+    expect(parseByteRange('bytes=0-', 1000)).toEqual({ start: 0, end: 999 });
+    expect(parseByteRange('bytes=500-', 1000)).toEqual({ start: 500, end: 999 });
+  });
+
+  it('parses explicit ranges and clamps the end to the file size', () => {
+    expect(parseByteRange('bytes=200-399', 1000)).toEqual({ start: 200, end: 399 });
+    expect(parseByteRange('bytes=200-99999', 1000)).toEqual({ start: 200, end: 999 });
+    expect(parseByteRange('bytes=0-0', 1000)).toEqual({ start: 0, end: 0 });
+  });
+
+  it('parses the suffix form as the final N bytes, clamped to the whole file', () => {
+    expect(parseByteRange('bytes=-100', 1000)).toEqual({ start: 900, end: 999 });
+    expect(parseByteRange('bytes=-5000', 1000)).toEqual({ start: 0, end: 999 });
+  });
+
+  it('tolerates surrounding whitespace', () => {
+    expect(parseByteRange('  bytes=0-  ', 10)).toEqual({ start: 0, end: 9 });
+  });
+
+  it('rejects absent, malformed, foreign-unit, and multi-range values', () => {
+    expect(parseByteRange(null, 1000)).toBeNull();
+    expect(parseByteRange(undefined, 1000)).toBeNull();
+    expect(parseByteRange('', 1000)).toBeNull();
+    expect(parseByteRange('bytes=', 1000)).toBeNull();
+    expect(parseByteRange('bytes=-0', 1000)).toBeNull();
+    expect(parseByteRange('bytes=abc-', 1000)).toBeNull();
+    expect(parseByteRange('items=0-1', 1000)).toBeNull();
+    expect(parseByteRange('bytes=0-1,5-9', 1000)).toBeNull();
+  });
+
+  it('rejects unsatisfiable ranges and empty or invalid sizes', () => {
+    expect(parseByteRange('bytes=1000-', 1000)).toBeNull();
+    expect(parseByteRange('bytes=9-2', 1000)).toBeNull();
+    expect(parseByteRange('bytes=0-', 0)).toBeNull();
+    expect(parseByteRange('bytes=0-', -5)).toBeNull();
+    expect(parseByteRange('bytes=0-', Number.NaN)).toBeNull();
+    expect(parseByteRange('bytes=0-', 10.5)).toBeNull();
+  });
+});
+
+describe('rangeContentType', () => {
+  it('maps the shipped media containers to their literal MIME types', () => {
+    expect(rangeContentType('audio/music/vale.mp3')).toBe('audio/mpeg');
+    expect(rangeContentType('AUDIO/LOUD.MP3')).toBe('audio/mpeg');
+    expect(rangeContentType('a.m4a')).toBe('audio/mp4');
+    expect(rangeContentType('a.mp4')).toBe('video/mp4');
+    expect(rangeContentType('a.ogg')).toBe('audio/ogg');
+    expect(rangeContentType('a.opus')).toBe('audio/ogg');
+    expect(rangeContentType('a.wav')).toBe('audio/wav');
+    expect(rangeContentType('a.webm')).toBe('video/webm');
+  });
+
+  it('returns null for non-media types so they keep the full-response MIME', () => {
+    expect(rangeContentType('models/foliage/pine_2.glb')).toBeNull();
+    expect(rangeContentType('index.html')).toBeNull();
+    expect(rangeContentType('no_extension')).toBeNull();
+  });
+});
+
+describe('isUnsatisfiableRange', () => {
+  it('detects a well-formed range starting at or past EOF', () => {
+    expect(isUnsatisfiableRange('bytes=1000-', 1000)).toBe(true);
+    expect(isUnsatisfiableRange('bytes=1500-2000', 1000)).toBe(true);
+  });
+
+  it('stays false for satisfiable, malformed, or inverted ranges', () => {
+    expect(isUnsatisfiableRange('bytes=999-', 1000)).toBe(false);
+    expect(isUnsatisfiableRange('bytes=', 1000)).toBe(false);
+    expect(isUnsatisfiableRange('bytes=2000-1500', 1000)).toBe(false);
+    expect(isUnsatisfiableRange('bytes=-100', 1000)).toBe(false);
+    expect(isUnsatisfiableRange(null, 1000)).toBe(false);
+    expect(isUnsatisfiableRange('bytes=1000-', 0)).toBe(false);
+  });
+});
+
+describe('rangeResponseHeaders', () => {
+  it('builds the exact 206 wire headers', () => {
+    expect(rangeResponseHeaders({ start: 2, end: 5 }, 10, 'audio/mpeg')).toEqual({
+      'Content-Type': 'audio/mpeg',
+      'Content-Length': '4',
+      'Content-Range': 'bytes 2-5/10',
+      'Accept-Ranges': 'bytes',
+    });
+  });
+});
+
+describe('rangedFileResponse', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'wocc-media-range-'));
+  const filePath = join(dir, 'ten.mp3');
+  writeFileSync(filePath, '0123456789');
+  afterAll(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('serves a 206 with the exact body slice and range headers', async () => {
+    const res = await rangedFileResponse(filePath, 'bytes=2-5');
+    expect(res).not.toBeNull();
+    expect(res?.status).toBe(206);
+    expect(await res?.text()).toBe('2345');
+    expect(res?.headers.get('Content-Range')).toBe('bytes 2-5/10');
+    expect(res?.headers.get('Content-Length')).toBe('4');
+    expect(res?.headers.get('Accept-Ranges')).toBe('bytes');
+    expect(res?.headers.get('Content-Type')).toBe('audio/mpeg');
+  });
+
+  it('serves the whole file for the open-ended first media request', async () => {
+    const res = await rangedFileResponse(filePath, 'bytes=0-');
+    expect(res?.status).toBe(206);
+    expect(await res?.text()).toBe('0123456789');
+    expect(res?.headers.get('Content-Range')).toBe('bytes 0-9/10');
+  });
+
+  it('carries extra headers so the handler keeps its every-response CSP rule', async () => {
+    const res = await rangedFileResponse(filePath, 'bytes=0-', {
+      'Content-Security-Policy': "default-src 'self'",
+    });
+    expect(res?.headers.get('Content-Security-Policy')).toBe("default-src 'self'");
+  });
+
+  it('returns null on a malformed range so the caller serves the full 200', async () => {
+    expect(await rangedFileResponse(filePath, 'bytes=')).toBeNull();
+    expect(await rangedFileResponse(filePath, 'bytes=9-2')).toBeNull();
+  });
+
+  it('answers a past-EOF range with 416 and the real bounds, never a bare 200', async () => {
+    const res = await rangedFileResponse(filePath, 'bytes=10-', {
+      'Content-Security-Policy': "default-src 'self'",
+    });
+    expect(res?.status).toBe(416);
+    expect(res?.headers.get('Content-Range')).toBe('bytes */10');
+    expect(res?.headers.get('Content-Security-Policy')).toBe("default-src 'self'");
+  });
+
+  it('returns null for a non-media extension so the full path keeps its MIME type', async () => {
+    const htmlPath = join(dir, 'index.html');
+    writeFileSync(htmlPath, '<!doctype html>');
+    expect(await rangedFileResponse(htmlPath, 'bytes=0-')).toBeNull();
+  });
+
+  it('returns null for a missing file or a directory', async () => {
+    expect(await rangedFileResponse(join(dir, 'absent.mp3'), 'bytes=0-')).toBeNull();
+    const sub = join(dir, 'sub.mp3');
+    mkdirSync(sub);
+    expect(await rangedFileResponse(sub, 'bytes=0-')).toBeNull();
+  });
+});
+
+describe('app:// handler wiring (electron/main.cjs)', () => {
+  const main = readFileSync(join(__dirname, '..', 'electron', 'main.cjs'), 'utf8');
+
+  it('imports the range helper', () => {
+    expect(main).toContain("require('./media_range.cjs')");
+  });
+
+  it('answers ranged requests before the full-response fallback inside the app handler', () => {
+    const handlerStart = main.indexOf("protocol.handle('app'");
+    const handlerEnd = main.indexOf('function lockDownPermissions');
+    expect(handlerStart).toBeGreaterThan(-1);
+    expect(handlerEnd).toBeGreaterThan(handlerStart);
+    // one registration only, so the slice below is THE handler body
+    expect(main.split("protocol.handle('app'").length - 1).toBe(1);
+    const handler = main.slice(handlerStart, handlerEnd);
+    const rangeRead = handler.indexOf("request.headers.get('range')");
+    const rangedCall = handler.indexOf('rangedFileResponse(');
+    const fullFallback = handler.indexOf('net.fetch(pathToFileURL(filePath)');
+    expect(rangeRead).toBeGreaterThan(-1);
+    expect(rangedCall).toBeGreaterThan(rangeRead);
+    expect(fullFallback).toBeGreaterThan(rangedCall);
+  });
+});


### PR DESCRIPTION
## Summary

Game music was completely silent in the Electron desktop client while SFX played fine. Root cause, reproduced empirically against Electron 43: Chromium's media stack loads `<audio>`/`<video>` sources with a `Range: bytes=0-` request, and the `app://` protocol handler in `electron/main.cjs` ignored that header and returned a re-wrapped plain 200. The media demuxer rejects that response outright (`MEDIA_ELEMENT_ERROR: Format error`, so `element.play()` rejects with `NotSupportedError`). Music streams through looping media elements plus `createMediaElementSource` (`src/game/music.ts`), so every streamed cue (zone, combat, boss, Sowfield, landing theme, voice) hit this; SFX use `fetch` + `decodeAudioData`, a plain fetch, which is why they kept working. Browsers were unaffected because the Vite dev server and production HTTP both honor Range.

The fix is a new pure CommonJS module, `electron/media_range.cjs` (with `.d.cts` typings for the test), wired into the `app://` handler:

- Ranged requests for the shipped media types are answered with a proper `206 Partial Content` slice (`Content-Range`, `Accept-Ranges`, exact byte window, streamed from disk). This also makes seeking work, which `el.loop` and the `currentTime` resets depend on.
- A well-formed range starting at or past EOF gets the RFC 9110 `416` answer with the real bounds, so a truncated or replaced asset cannot silently recreate the format-error mode. This covers the whole unsatisfiable family: an open-ended start past 2^53, a media file truncated to zero bytes, and the `bytes=-0` suffix.
- Media files also advertise `Accept-Ranges: bytes` on the full response, so range support is visible to a client that probes before sending its first ranged request.
- Everything else (non-media file, malformed or multi-range header, unreadable file) falls through to the existing full-response path unchanged, keeping its `net.fetch`-derived MIME type.
- The ranged path runs after the existing `fileInside` guards, serves the same guarded `filePath`, and carries the same CSP header as every other `app://` response.

## Type of change

- [x] Bug fix

## How was this tested?

- Commands:
  - `npx vitest run tests/electron_media_range.test.ts` (29 tests: parser cases, literal 206/416 header pins, behavioral `Response` assertions against a real file including the exact body slice, and comment-immune shape pins on the `main.cjs` wiring; replaying the revert, dropped-return, dropped-CSP, swapped-argument, and dropped-import mutants fails a named test for each)
  - `node scripts/gate_select.mjs`: PASS, all 12 steps green
  - `npx tsc --noEmit` clean; changed-files biome clean
- Manual steps:
  - Built a minimal Electron 43 harness replicating the shell's exact `app://` handler (same privileged scheme registration, same CSP re-wrap) serving a real `public/audio/music/*.mp3`.
  - Before the fix: the media element request (`Range: bytes=0-`) got the 200 re-wrap and failed with `MEDIA_ELEMENT_ERROR: Format error` / `NotSupportedError`, while the fetch+`decodeAudioData` path succeeded, matching the reported symptom exactly.
  - After the fix (importing the real `electron/media_range.cjs`): the handler serves `206 bytes 0-2436146/2436147`, the element reaches `playing`, an `AnalyserNode` on the `createMediaElementSource` graph reads non-zero RMS (audio genuinely flows through the WebAudio mix), and seeking to 0 (what looping needs) succeeds.
- Verified against the production asar layout: packed the media into an `app.asar` and ran the module through Electron 43.1.1's asar fs layer (`ELECTRON_RUN_AS_NODE`). Exact byte slices on a real mp3 (mid-file seek and suffix ranges included, compared against a direct read) and correct `416` bounds for the zero-byte, past-EOF, and `bytes=-0` cases.

---

## Checklist

### Quality

- [x] **The gate passes.** `node scripts/gate_select.mjs` is green. I added decisive tests for the changed behavior and recorded the manual checks above.

### Cross-platform

- ~Tested on desktop and mobile.~ Desktop-shell-only change (`electron/`); no UI, browser, or mobile surface is touched.
- ~Accessible.~ No UI change.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files.

