### PR TITLE
feat(battleground): hold the queue spot through death and dungeon pulls

### DIFF
--- a/src/sim/dev_commands.ts
+++ b/src/sim/dev_commands.ts
@@ -347,8 +347,10 @@ export function handleDevChat(
       return null;
     }
     bgQueueJoin(ctx, pid, { bypassLevel: true });
-    // The join can refuse (dead, inside an instance, oversize party); it
-    // already told the caller why, so bail before padding leaks a bot.
+    // The join can still refuse (an arena match, an oversize party, queueing a
+    // party you do not lead); it already told the caller why, so bail before
+    // padding leaks a bot. Dying and standing inside a dungeon are no longer
+    // among them: a queue now survives both.
     if (!ctx.bgQueue.some((g) => g.pids.includes(pid))) return null;
     if (bgQueueSize(ctx) < 2) {
       // Solo walk-around: pad the queue with one stationary dev bot (reusing an

--- a/src/sim/instances/dungeons.ts
+++ b/src/sim/instances/dungeons.ts
@@ -536,20 +536,46 @@ export function leaveDungeon(ctx: SimContext, pid?: number): boolean {
       return false;
     }
   }
-  // Stepping out of the instance removes the leaver (and anything they own,
-  // e.g. their pet) from every inside mob's hate table: dancing in and out of
-  // the exit portal cannot be used to kite a pull to the door and back.
-  // Re-entering means earning aggro from scratch.
-  const inst = ctx.instances.find((i) => i.partyKey !== null && instanceClaimContains(i, p.pos));
-  if (inst) scrubInstanceThreat(ctx, inst, p.id);
-  cancelProfessionSessionOnDisplacement(ctx, p);
-  p.pos = ctx.groundPos(dungeon.doorPos.x, dungeon.doorPos.z - 4);
+  const door = detachFromDungeon(ctx, p);
+  if (!door) return false; // unreachable: dungeonAt already answered above
+  p.pos = ctx.groundPos(door.x, door.z);
   p.prevPos = { ...p.pos };
   ctx.rebucket(p);
   p.targetId = null;
   p.autoAttack = false;
   ctx.emit({ type: 'log', text: dungeon.leaveText, color: '#b9f', pid: r.meta.entityId });
   return true;
+}
+
+// How far outside the door an exiting player is set down, so they do not land
+// inside the trigger volume they just came through.
+const DUNGEON_DOOR_RETURN_INSET = 4;
+
+/**
+ * Detach a player from the dungeon instance they stand in WITHOUT moving them,
+ * and report the outside door they belong at. Returns null when they are not
+ * inside a dungeon, so a caller gets the "are they instanced" question and the
+ * cleanup in one step.
+ *
+ * Stepping out of the instance removes the leaver (and anything they own, e.g.
+ * their pet) from every inside mob's hate table: dancing in and out of the exit
+ * portal cannot be used to kite a pull to the door and back. Re-entering means
+ * earning aggro from scratch.
+ *
+ * The scrub and the profession teardown are exactly `leaveDungeon`'s; what
+ * differs is who performs the displacement. `leaveDungeon` walks the player to
+ * the door itself, while a battleground queue pop teleports them to the field
+ * and needs the door only as the point to set them back down at when the match
+ * ends. Sending them back to their raw interior coordinates instead would drop
+ * them into an instance claim that may no longer exist by then.
+ */
+export function detachFromDungeon(ctx: SimContext, p: Entity): { x: number; z: number } | null {
+  const dungeon = dungeonAt(p.pos.x);
+  if (!dungeon) return null;
+  const inst = ctx.instances.find((i) => i.partyKey !== null && instanceClaimContains(i, p.pos));
+  if (inst) scrubInstanceThreat(ctx, inst, p.id);
+  cancelProfessionSessionOnDisplacement(ctx, p);
+  return { x: dungeon.doorPos.x, z: dungeon.doorPos.z - DUNGEON_DOOR_RETURN_INSET };
 }
 
 // Drop one departing player (and every entity they own) from the hate tables of

--- a/src/sim/social/battleground.ts
+++ b/src/sim/social/battleground.ts
@@ -27,8 +27,9 @@ import {
   keepInteriorBounds,
 } from '../battleground_layout';
 import { applyGreaterInvisibilityAftereffect } from '../combat/greater_invisibility';
-import { BG_SLOT_COUNT, battlegroundOrigin, DUNGEON_X_THRESHOLD } from '../data';
+import { BG_SLOT_COUNT, battlegroundOrigin } from '../data';
 import { createGroundObject } from '../entity';
+import { detachFromDungeon } from '../instances/dungeons';
 import {
   awardBattlegroundAssistHonor,
   awardBattlegroundHonor,
@@ -295,20 +296,18 @@ export function bgQueueJoin(ctx: SimContext, pid?: number, opts?: { bypassLevel?
     ctx.error(id, 'You are already in a battleground.');
     return;
   }
-  if (r.e.dead) {
-    ctx.error(id, 'You cannot queue for Thornhollow Fields while dead.');
-    return;
-  }
+  // Dying and stepping into a dungeon are deliberately NOT refusals. Waiting in
+  // line is not an activity, so it should survive whatever the player does with
+  // the wait; a corpse run or a dungeon pull that silently cancelled the queue
+  // was the single most common way players lost a spot without noticing. The
+  // seat handles both: placeInBg revives and clears the spirit arm, and the pop
+  // detaches an instanced fighter through the dungeon door (startBgMatch).
   if (ctx.arenaMatches.has(id)) {
     ctx.error(id, 'You cannot queue for Thornhollow Fields while in another match.');
     return;
   }
   if (!opts?.bypassLevel && r.e.level < BG_MIN_LEVEL) {
     ctx.error(id, `Thornhollow Fields requires level ${BG_MIN_LEVEL}.`);
-    return;
-  }
-  if (r.e.pos.x > DUNGEON_X_THRESHOLD) {
-    ctx.error(id, 'You cannot queue from inside an instance.');
     return;
   }
   const existing = bgGroupContaining(ctx, id);
@@ -546,22 +545,26 @@ function tickCountdown(ctx: SimContext, match: BgMatch): void {
 }
 
 function matchmakeBg(ctx: SimContext): void {
-  // Drop members who went offline, died, entered a match, or walked into
-  // instanced content while waiting; tell the survivors they fell out of
-  // line instead of silently flipping their window back to idle.
+  // Waiting in line survives whatever the player does with the wait: dying and
+  // walking into a dungeon USED to drop them here, which is how players lost a
+  // spot without noticing. Exactly three things still end the wait, and only the
+  // last of them is the player's own doing worth a line of text:
+  //   offline        the entity is gone, so there is nobody left to tell
+  //   already seated a match claimed them (backfill, /dev); silent by design
+  //   arena match    they committed to a different rated fight
+  // Anything else HOLDS the spot, and the pop cleans up after them instead.
   for (const g of ctx.bgQueue) {
     g.pids = g.pids.filter((p) => {
       const e = ctx.entities.get(p);
-      if (e && !e.dead && !ctx.bgMatches.has(p) && e.pos.x <= DUNGEON_X_THRESHOLD) return true;
-      if (e && !ctx.bgMatches.has(p)) {
-        ctx.emit({ type: 'bgUnqueued', pid: p });
-        ctx.emit({
-          type: 'log',
-          text: 'You leave the Thornhollow Fields queue.',
-          color: '#7fd4ff',
-          pid: p,
-        });
-      }
+      if (!e || ctx.bgMatches.has(p)) return false;
+      if (!ctx.arenaMatches.has(p)) return true;
+      ctx.emit({ type: 'bgUnqueued', pid: p });
+      ctx.emit({
+        type: 'log',
+        text: 'You leave the Thornhollow Fields queue.',
+        color: '#7fd4ff',
+        pid: p,
+      });
       return false;
     });
   }
@@ -726,7 +729,13 @@ export function startBgMatch(
   for (const pid of [...teamA, ...teamB]) {
     const e = ctx.entities.get(pid);
     if (!e) continue;
-    returns.set(pid, { x: e.pos.x, z: e.pos.z, facing: e.facing });
+    // A fighter popped out of a dungeon is detached from it here: their claim's
+    // hate tables are scrubbed exactly as walking out of the door would, and
+    // their return point becomes that door rather than the interior coordinates
+    // they were standing on, which may belong to no live claim by the time the
+    // match ends. Everyone else returns to the spot they were pulled from.
+    const door = detachFromDungeon(ctx, e);
+    returns.set(pid, { x: door?.x ?? e.pos.x, z: door?.z ?? e.pos.z, facing: e.facing });
     preMatchPools.set(pid, snapshotArenaReturnPools(e));
   }
   const flags = ([0, 1] as BgTeam[]).map((team) => {

--- a/tests/battleground.test.ts
+++ b/tests/battleground.test.ts
@@ -5,7 +5,8 @@ import { isDispellableAura } from '../src/sim/aura_classify';
 import { BG_GRAVEYARDS, BG_POWER_RUNES, BG_SPEED_RUNES } from '../src/sim/battleground_layout';
 import { GREATER_INVISIBILITY_DR_AURA_ID } from '../src/sim/combat/greater_invisibility';
 import { offerResurrection } from '../src/sim/combat/resurrection_offer';
-import { battlegroundOrigin, instanceOrigin, isBgPos } from '../src/sim/data';
+import { battlegroundOrigin, DUNGEON_X_THRESHOLD, instanceOrigin, isBgPos } from '../src/sim/data';
+import { enterDungeon } from '../src/sim/instances/dungeons';
 import { summonMountItem, toggleMount } from '../src/sim/mounts';
 import {
   awardBattlegroundHonor,
@@ -49,6 +50,7 @@ import {
   drainBgOutcomes,
   recordBgOutcome,
 } from '../src/sim/social/battleground_outcomes';
+import { addThreat } from '../src/sim/threat';
 import { DT, type SimEvent } from '../src/sim/types';
 import { groundHeight } from '../src/sim/world';
 
@@ -356,19 +358,25 @@ describe('Thornhollow Fields: queue + matchmaking', () => {
     for (const m of party) expect(match.teams[teamOfLeader]).toContain(m);
   });
 
-  it('refuses to queue from inside an instance, while dead, or twice', () => {
+  it('queues while dead and from inside an instance, and still refuses a double queue', () => {
     const sim = makeWorld();
     const a = sim.addPlayer('warrior', 'A');
     sim.entities.get(a)!.level = BG_MIN_LEVEL;
     const dungeonInstance = instanceOrigin(0, 0);
     tp(sim, a, dungeonInstance.x, dungeonInstance.z); // a dungeon instance band
     sim.bgQueueJoin(a);
-    expect(sim.bgInfoFor(a)!.queued).toBe(false);
+    expect(sim.bgInfoFor(a)!.queued, 'a dungeon pull must not cost the spot').toBe(true);
+    sim.bgQueueLeave(a);
 
     tp(sim, a, 0, -40);
     kill(sim, a);
     sim.bgQueueJoin(a);
-    expect(sim.bgInfoFor(a)!.queued).toBe(false);
+    expect(sim.bgInfoFor(a)!.queued, 'a corpse run must not cost the spot').toBe(true);
+    // The matchmaker tick is where the old eviction happened, so the wait has to
+    // survive one: pressing Queue and being dropped a tick later is the bug.
+    sim.tick();
+    expect(sim.bgInfoFor(a)!.queued, 'the matchmaker tick must not evict a corpse').toBe(true);
+    sim.bgQueueLeave(a);
 
     const b = sim.addPlayer('mage', 'B');
     tp(sim, b, 0, -40);
@@ -379,6 +387,115 @@ describe('Thornhollow Fields: queue + matchmaking', () => {
     expect(sim.bgInfoFor(b)!.queueSize).toBe(1);
     sim.bgQueueLeave(b);
     expect(sim.bgInfoFor(b)!.queued).toBe(false);
+  });
+});
+
+// Ten queued champions on ONE tick short of seating, so a caller can do
+// something to one of them (kill them, walk them into a dungeon) and then let
+// the pop land on that state.
+function tenQueuedUnseated(): { sim: Sim; pids: number[] } {
+  const sim = makeWorld();
+  const pids: number[] = [];
+  const classes = ['warrior', 'mage', 'priest', 'rogue', 'hunter'] as const;
+  for (let i = 0; i < 10; i++) {
+    const pid = sim.addPlayer(classes[i % 5], `Q${i}`);
+    tp(sim, pid, (i % 5) * 2 - 4, -40);
+    sim.entities.get(pid)!.level = BG_MIN_LEVEL;
+    pids.push(pid);
+    sim.bgQueueJoin(pid);
+  }
+  return { sim, pids };
+}
+
+describe('Thornhollow Fields: the queue survives the wait', () => {
+  it('seats a fighter who died waiting, alive and whole rather than as a corpse', () => {
+    const { sim, pids } = tenQueuedUnseated();
+    const corpse = pids[3];
+    kill(sim, corpse);
+    const dead = sim.entities.get(corpse)!;
+    expect(dead.dead, 'the arrangement itself must hold').toBe(true);
+
+    sim.tick(); // the pop
+    const match = sim.bgMatchFor(corpse);
+    expect(match, 'dying while waiting must not cost the seat').toBeTruthy();
+    expect(bgAllPids(match!)).toContain(corpse);
+    // Seated alive: every arm of the spirit state, since ghost implies dead
+    // everywhere else and a stale corpsePos would strand a rez prompt on the field.
+    expect(dead.dead).toBe(false);
+    expect(dead.ghost).toBe(false);
+    expect(dead.corpsePos).toBeNull();
+    expect(dead.hp).toBe(dead.maxHp);
+    expect(isBgPos(dead.pos.x)).toBe(true);
+
+    // ...and they go home ALIVE, not back to the corpse they left behind. The
+    // match is a parenthesis: pools are handed back as carried in, and a corpse
+    // carried in nothing, so the floor of 1 hp is what they leave with. That is
+    // the deliberate cost of the free trip past a corpse run, and the reason we
+    // do not restore the death: a stale corpsePos outlives the body it named.
+    endBgMatch(sim.ctx, match!, 0, 'caps');
+    expect(dead.dead).toBe(false);
+    expect(dead.ghost).toBe(false);
+    expect(dead.hp).toBe(1);
+    expect(isBgPos(dead.pos.x)).toBe(false);
+  });
+
+  it('holds the spot through a dungeon pull, then detaches the fighter at the door', () => {
+    const { sim, pids } = tenQueuedUnseated();
+    const diver = pids[6];
+    enterDungeon(sim.ctx, 'gravewyrm_sanctum', diver);
+    const e = sim.entities.get(diver)!;
+    expect(e.pos.x, 'the arrangement itself must hold').toBeGreaterThan(DUNGEON_X_THRESHOLD);
+
+    // Put the diver on a live hate table so the scrub has something to undo.
+    const inst = sim.ctx.instances.find((i) => i.partyKey !== null)!;
+    const mob = inst.mobIds.map((id) => sim.entities.get(id)).find((m) => m && !m.dead)!;
+    addThreat(mob, diver, 500);
+    expect(mob.threat.get(diver)).toBe(500);
+
+    sim.tick(); // the pop
+    const match = sim.bgMatchFor(diver);
+    expect(match, 'a dungeon pull must not cost the seat').toBeTruthy();
+    expect(isBgPos(e.pos.x)).toBe(true);
+
+    // Leaving through the battleground must cost exactly what leaving through
+    // the door costs: the instance no longer holds any aggro on them.
+    expect(mob.threat.has(diver), 'the pop must scrub instance threat').toBe(false);
+
+    // ...and the return point is the door OUTSIDE, never the interior
+    // coordinates, whose claim may be gone by the time the match ends.
+    const ret = match!.returns.get(diver)!;
+    expect(ret.x).toBeLessThanOrEqual(DUNGEON_X_THRESHOLD);
+    endBgMatch(sim.ctx, match!, 0, 'caps');
+    expect(e.pos.x, 'the fighter must not be sent back inside').toBeLessThanOrEqual(
+      DUNGEON_X_THRESHOLD,
+    );
+    expect(e.dead).toBe(false);
+  });
+
+  it('still drops a waiting player who commits to an arena match, and says so', () => {
+    const { sim, pids } = tenQueuedUnseated();
+    const defector = pids[2];
+    const opponent = sim.addPlayer('warrior', 'ArenaFoe');
+    tp(sim, opponent, 0, -40);
+    sim.entities.get(opponent)!.level = BG_MIN_LEVEL;
+    sim.arenaQueueJoin(defector);
+    sim.arenaQueueJoin(opponent);
+
+    const events: SimEvent[] = [];
+    for (let i = 0; i < 20 * 60 && !sim.ctx.arenaMatches.has(defector); i++) {
+      events.push(...sim.tick());
+    }
+    expect(sim.ctx.arenaMatches.has(defector), 'the arrangement itself must hold').toBe(true);
+
+    // The instance-position check used to do this job as a side effect (the
+    // arena band sits past DUNGEON_X_THRESHOLD); it is now explicit, so pin it.
+    expect(sim.bgInfoFor(defector)!.queued).toBe(false);
+    expect(sim.bgMatchFor(defector)).toBeNull();
+    expect(logPidsFor(events, 'You leave the Thornhollow Fields queue.')).toContain(defector);
+    // Only the defector: the other nine keep waiting.
+    for (const pid of pids.filter((p) => p !== defector)) {
+      expect(sim.bgInfoFor(pid)!.queued).toBe(true);
+    }
   });
 });
 
@@ -1899,7 +2016,7 @@ describe('Thornhollow Fields: review-hardening pins', () => {
     expect(sim.bgInfoFor(leader)!.queueSize).toBe(0);
   });
 
-  it('a queued player who walks into an instance is evicted with the leave notice', () => {
+  it('a queued player who walks into an instance keeps the spot, silently', () => {
     const sim = makeWorld();
     const a = sim.addPlayer('warrior', 'A');
     tp(sim, a, 0, -40);
@@ -1910,8 +2027,10 @@ describe('Thornhollow Fields: review-hardening pins', () => {
     const dungeonInstance = instanceOrigin(0, 0);
     tp(sim, a, dungeonInstance.x, dungeonInstance.z); // a dungeon instance band
     const evs = sim.tick();
-    expect(sim.bgInfoFor(a)!.queued).toBe(false);
-    expect(evs.some((e) => e.type === 'bgUnqueued' && e.pid === a)).toBe(true);
+    expect(sim.bgInfoFor(a)!.queued).toBe(true);
+    // Nothing happened, so nothing is announced: the un-queue notice is now
+    // reserved for the one cause that is still a real eviction (an arena match).
+    expect(evs.some((e) => e.type === 'bgUnqueued' && e.pid === a)).toBe(false);
   });
 
   it('a live participant cannot enter a delve mid-match', () => {

--- a/tests/dev_commands.test.ts
+++ b/tests/dev_commands.test.ts
@@ -224,15 +224,33 @@ describe('/dev bg (Thornhollow Fields force-start)', () => {
     expect(errors).toContain('[dev] You are already in a battleground.');
   });
 
-  it('a refused queue join (dead caller) starts nothing and leaks no bot', () => {
+  it('a refused queue join (not the party leader) starts nothing and leaks no bot', () => {
+    const sim = devSim();
+    // A dead caller used to be the refusal this pinned. Dying no longer cancels
+    // a queue, so the bail-before-padding path is exercised through a refusal
+    // that survives: only a party's leader may commit it to the queue.
+    const leader = sim.addPlayer('priest', 'Leader');
+    sim.partyInvite(sim.playerId, leader);
+    sim.partyAccept(sim.playerId);
+    expect(sim.partyOf(sim.playerId)!.leader).not.toBe(sim.playerId);
+
+    sim.chat('/dev bg');
+
+    expect(sim.bgMatchFor(sim.playerId)).toBeNull();
+    expect([...sim.players.values()].filter((m) => m.isDevBot)).toHaveLength(0);
+  });
+
+  it('force-starts for a dead caller, who is seated alive', () => {
     const sim = devSim();
     sim.player.hp = 0;
     sim.player.dead = true;
 
     sim.chat('/dev bg');
 
-    expect(sim.bgMatchFor(sim.playerId)).toBeNull();
-    expect([...sim.players.values()].filter((m) => m.isDevBot)).toHaveLength(0);
+    expect(sim.bgMatchFor(sim.playerId), 'dying must not cancel the queue').toBeTruthy();
+    expect(sim.player.dead).toBe(false);
+    expect(sim.player.ghost).toBe(false);
+    expect(sim.player.hp).toBe(sim.player.maxHp);
   });
 
   it('reuses an idle leftover dev bot instead of spawning another', () => {


### PR DESCRIPTION
## Summary

Dying and stepping into a dungeon each silently dropped a player out of the
Thornhollow Fields queue. Both are gone. Waiting in line is not an activity, so
it should survive whatever the player does with the wait; losing a spot to a
corpse run or a dungeon pull was the most common way people fell out without
noticing.

One predicate in `matchmakeBg` welded four reasons into a single boolean:

```ts
if (e && !e.dead && !ctx.bgMatches.has(p) && e.pos.x <= DUNGEON_X_THRESHOLD) return true;
```

It is now three named causes, and only one of them is still worth announcing.

### Death was nearly free, because the seat already handled it

`placeInBg` calls `readyArenaFighter` (revives, full HP) and then clears the
spirit arm explicitly, with a comment saying exactly why:

```ts
// readyArenaFighter revives but does NOT clear the spirit arm: a fighter
// seated (or re-seated by the form-up hold) must never stay a ghost.
```

So the `!e.dead` filter was guarding against a case the seating path already
resolved. Removing it, and the matching refusal in `bgQueueJoin`, is the whole
death half.

**On the return:** everyone already comes home alive unconditionally
(`endBgMatch` and the desertion path both clear `dead`/`ghost`/`corpsePos`), so
returning a dead-queued player as a ghost would have meant inventing state to
capture and restore, including a `corpsePos` that may be stale by then. Instead
the existing rule decides it: the match hands your pools back exactly as you
carried them in, and a corpse carried in nothing, so the `Math.max(1, ...)` floor
lands you at 1 HP where your ghost stood. That is a real cost for skipping a
corpse run rather than a free full heal, and it is now pinned rather than
emergent.

### Dungeons needed the real work

Two things death did not:

- **Threat.** `leaveDungeon` scrubs the leaver off every inside mob's hate table
  so the exit portal cannot be used to kite a pull to the door and back.
  Teleporting a fighter to the battleground without that leaves them on those
  tables while they stand 100k units away.
- **Where they come back.** `returns` stored raw coordinates, which for an
  instanced fighter means interior coordinates whose claim may not exist when
  the match ends.

`detachFromDungeon` is extracted out of `leaveDungeon` (a move, not a rewrite) so
the scrub and the profession-session teardown have ONE owner, and it reports the
outside door without performing the displacement itself. `leaveDungeon` walks the
player there; `startBgMatch` teleports them to the field and records the door as
their return point. The Nythraxis seal check deliberately stays in `leaveDungeon`
only: a queue pop must not be refusable by a boss door.

### The trap: that position check was doing three jobs

`DUNGEON_X_THRESHOLD` is 100000 and `ARENA_X` is 103600, so
`e.pos.x <= DUNGEON_X_THRESHOLD` was ALSO what kept a battleground pop from
yanking a fighter out of a live rated arena match. Deleting it without a
replacement would have opened that hole silently. The arena guard is now
explicit and has its own test.

Delves are unaffected either way: the delve band (x 4773 to 8773) sits below the
threshold, so a queued delver was never evicted by this predicate to begin with.

## Related issues

N/A

## Type of change

- [x] Bug fix
- [x] Feature

## How was this tested?

- Commands:
  - `node scripts/gate_select.mjs`: **PASS, all 12 steps green.**
  - `npx vitest run tests/battleground.test.ts tests/arena.test.ts
    tests/arena_module.test.ts tests/dungeon_instance_disconnect_reset.test.ts
    tests/boss_add_leash.test.ts tests/architecture.test.ts` (238 passed)
  - `npx vitest run tests/localization_fixes.test.ts tests/parity` (233 passed)
  - `npx tsc --noEmit`: clean.

Three new cases in `tests/battleground.test.ts` drive the real `matchmakeBg` and
`startBgMatch` paths through a staged 5v5, plus the two existing tests that
pinned the OLD behavior, rewritten:

- A fighter who died waiting is seated alive, with every arm of the spirit state
  checked (`dead`, `ghost`, `corpsePos`, HP), then returned alive at 1 HP.
- A fighter pulled from `gravewyrm_sanctum` is seated, the mob holding 500 threat
  on them loses that entry, and their return point is outside the instance band.
  `endBgMatch` sets them down outside, not back in the interior.
- A waiting player who commits to an arena match still leaves the queue, gets the
  notice, and the other nine keep waiting.

**Decisiveness was measured, not assumed.** Stubbing `detachFromDungeon` out of
`startBgMatch` fails the dungeon test on the threat assertion specifically
(`the pop must scrub instance threat: expected true to be false`), so that pin is
not passing on threat that would have been dropped anyway.

The first gate run caught a real one: `tests/dev_commands.test.ts` used a dead
caller as a convenient refusal to prove `/dev bg` bails before spawning a padding
bot. Death is no longer a refusal, so the test was rewired to one that survives
(only a party's leader may queue it) with the bot-leak assertion intact, plus the
inverse pin that a dead caller now force-starts and is seated alive. The stale
comment in `dev_commands.ts` listing "dead, inside an instance" was corrected in
the same change.

### Parity

Green, and worth saying WHY: this change adds and removes no rng draw, and
`detachFromDungeon` early-returns before any work for a player who is not
inside a dungeon, so the ordinary seat path is untouched. The goldens contain no
scenario where a queued player dies or zones into an instance, so green here
means "not exercised", not "proven equivalent". The three new tests are what
actually cover the change.

### Deliberately left behind

`sim_i18n.ts` keeps its `errQueueDead` entry
(`'You cannot queue for Thornhollow Fields while dead.'`), now orphaned. Removing
a matcher key means deleting it from all 21 locale blocks, a wider diff than this
change in files that already hold real translations, and an unused entry costs
nothing at runtime. `'You cannot queue from inside an instance.'` is NOT orphaned:
the arena queue still emits it.

## Screenshots / recordings

Not a visual change. No HUD, render, or styles file is touched; the battleground
window reflects queue state through the existing `bgQueued`/`bgUnqueued` events,
whose shapes are unchanged.

---

## Checklist

### Quality

- [x] **The full gate passes.** `node scripts/gate_select.mjs`, all 12 steps green.
- [x] Sim purity and determinism: no new rng, clock, or DOM reach
      (`tests/architecture.test.ts` green).

### Cross-platform

- [x] Sim-only change behind existing seams, so the offline browser world, the
      authoritative server, and the headless env get identical behavior. No
      `IWorld` member added, no wire shape changed, no `ClientWorld` work needed.

### Localization (i18n)

- [x] No new player-facing string. Two refusals were REMOVED and the one
      remaining eviction reuses the existing
      `'You leave the Thornhollow Fields queue.'` literal verbatim, so the sim
      matcher needs no entry and the S3 guard stays green.

### Hygiene

- [x] No secrets or `.env`; `ALLOW_DEV_COMMANDS` gating untouched.
- [x] No generated file hand-edited.
