### PR TITLE
fix(pvp): roll dailies on the realm reset, not midnight UTC

### DIFF
--- a/server/game.ts
+++ b/server/game.ts
@@ -288,7 +288,7 @@ import {
 } from './parse';
 import { PartyFrameProjectionCache } from './party_frame_projection';
 import { applyBoostKitToPlayer, pbeBoostEnabled } from './pbe_boost';
-import { nextRaidResetMs } from './raid_reset';
+import { nextRaidResetMs, resetDayKey } from './raid_reset';
 import { REALM, REALM_PUBLIC_ORIGIN, REALM_RESET_TIME_ZONE } from './realm';
 import { createRealmReadoutMemo, realmReadoutJson, realmReadoutObject } from './realm_readout_memo';
 import { RiftAssetCoordinator, riftAssetConfigFromEnv } from './rift_assets';
@@ -2616,9 +2616,16 @@ export class GameServer {
           last = now;
           if (dt > 0.5) dt = 0.5;
           acc += dt;
-          // Feed the authoritative UTC day to the sim so the delve daily reset (FR-5.1)
-          // works without the sim reading the wall clock itself (determinism invariant).
-          this.sim.utcDay = new Date().toISOString().slice(0, 10);
+          // Feed the authoritative calendar to the sim so its daily windows work
+          // without the sim reading the wall clock itself (determinism invariant).
+          // Two values, two questions: `utcDay` stamps WHEN something happened
+          // (the deed earn date), while `resetDay` is the daily-rollover window,
+          // derived from this realm's own reset boundary so the first
+          // battleground win of the day turns over with the raid lockouts rather
+          // than at midnight UTC (5 PM Pacific, mid-evening).
+          const calendarNowMs = Date.now();
+          this.sim.utcDay = new Date(calendarNowMs).toISOString().slice(0, 10);
+          this.sim.resetDay = resetDayKey(calendarNowMs, REALM_RESET_TIME_ZONE);
           this.bcastGridNs = 0n;
           this.bcastSelfNs = 0n;
           this.bcSerializeNs = 0n;

--- a/server/raid_reset.ts
+++ b/server/raid_reset.ts
@@ -22,7 +22,7 @@ export const DEFAULT_RAID_RESET_TIME_ZONE = 'America/New_York';
 // Deliberately off midnight so the boundary is never a wall-clock time a spring-forward
 // DST transition skips: the common zones jump 02:00 -> 03:00 (so 03:00 always exists),
 // whereas a handful of zones skip 00:00 entirely.
-const RAID_RESET_HOUR = 3;
+export const RAID_RESET_HOUR = 3;
 
 // Whether the host ICU database can resolve the given IANA zone. A Node built without
 // full ICU throws here even for a valid zone, so callers can validate config and fail
@@ -119,4 +119,34 @@ export function nextRaidResetMs(
   const { y, mo, d } = zoneDate(nowMs, zone);
   const today = zoneResetInstant(y, mo, d, zone);
   return today > nowMs ? today : zoneResetInstant(y, mo, d + 1, zone);
+}
+
+function pad2(n: number): string {
+  return n < 10 ? `0${n}` : `${n}`;
+}
+
+/**
+ * The daily-reset WINDOW an instant falls in, as `YYYY-MM-DD`: the civil date of
+ * the reset that opened it. This is the key the sim compares to decide whether a
+ * daily has rolled over (the first battleground win, arena honor DR, the delve
+ * daily), and it deliberately answers the SAME question the raid lockout answers
+ * through `nextRaidResetMs`, so a realm has ONE daily boundary rather than two.
+ *
+ * The alternative it replaces was the UTC calendar date, which put the rollover
+ * at midnight UTC: 5 PM Pacific, in the middle of an evening's play, with no
+ * relation to when the realm's raids reset. Between midnight and the reset hour
+ * the day still belongs to the window that opened yesterday, exactly as
+ * `nextRaidResetMs` treats it for lockouts.
+ *
+ * Pure in (instant, zone), like every other export here: no live clock read, no
+ * randomness. A caller reads the clock and passes the instant in, which is what
+ * keeps the sim deterministic.
+ */
+export function resetDayKey(nowMs: number, zone: string = DEFAULT_RAID_RESET_TIME_ZONE): string {
+  const { y, mo, d } = zoneDate(nowMs, zone);
+  // Date.UTC normalizes the day-before rollback across month and year edges. The
+  // arithmetic is on a pure calendar triple, never on an instant, so no offset or
+  // DST transition can shift which date comes out.
+  const at = new Date(Date.UTC(y, mo - 1, zoneHour(nowMs, zone) < RAID_RESET_HOUR ? d - 1 : d));
+  return `${at.getUTCFullYear()}-${pad2(at.getUTCMonth() + 1)}-${pad2(at.getUTCDate())}`;
 }

--- a/src/game/utc_day.ts
+++ b/src/game/utc_day.ts
@@ -1,16 +1,59 @@
-// The offline sim wants the wall-clock UTC day (delve daily reset) but must not
-// read the clock itself, so the frame loop supplies it. Building the string is a
-// Date allocation plus an ISO serialization; at 60 Hz that is pure churn for a
-// value that changes once a day, so cache it and re-derive at most once a second.
+// The offline sim wants two wall-clock day strings but must not read the clock
+// itself, so the frame loop supplies them: `currentUtcDay` stamps WHEN something
+// happened (the Book of Deeds earn date) and `currentResetDay` says which daily
+// window we are in (the first battleground win, honor DR, the delve daily).
+// Building either string is a Date allocation plus some formatting; at 60 Hz that
+// is pure churn for a value that changes once a day, so cache and re-derive at
+// most once a second.
+
+// The civil hour a daily window opens. Mirrors RAID_RESET_HOUR in
+// server/raid_reset.ts, which is the authority for the online realm; the two are
+// pinned equal by tests/raid_reset.test.ts. Offline there is no realm, so the
+// boundary is the player's OWN local 3 AM, which is the same promise the realm
+// makes its players: a daily never turns over in the middle of an evening.
+export const DAILY_RESET_HOUR = 3;
+
 let cachedDay = '';
-let nextRefreshAtMs = 0;
+let dayRefreshAtMs = 0;
+let cachedResetDay = '';
+let resetRefreshAtMs = 0;
 
 /** Current UTC day as `YYYY-MM-DD`, recomputed at most once per second. */
 export function currentUtcDay(): string {
   const now = Date.now();
-  if (now >= nextRefreshAtMs) {
+  if (now >= dayRefreshAtMs) {
     cachedDay = new Date(now).toISOString().slice(0, 10);
-    nextRefreshAtMs = now + 1000;
+    dayRefreshAtMs = now + 1000;
   }
   return cachedDay;
+}
+
+function pad2(n: number): string {
+  return n < 10 ? `0${n}` : `${n}`;
+}
+
+/**
+ * The daily-reset window an instant falls in, as `YYYY-MM-DD`: the LOCAL civil
+ * date of the reset that opened it. Between local midnight and the reset hour the
+ * window still belongs to the previous date, the same rule `resetDayKey` applies
+ * on the server with a realm's configured zone instead of the player's own.
+ *
+ * Clock-free (the caller supplies the instant) and expressed entirely in local
+ * `Date` terms, so month, year, and DST edges are the platform's arithmetic
+ * rather than ours, and a test can drive it without touching the process zone.
+ */
+export function resetDayOf(at: Date): string {
+  const d = new Date(at.getTime());
+  if (d.getHours() < DAILY_RESET_HOUR) d.setDate(d.getDate() - 1);
+  return `${d.getFullYear()}-${pad2(d.getMonth() + 1)}-${pad2(d.getDate())}`;
+}
+
+/** The current daily-reset window, recomputed at most once per second. */
+export function currentResetDay(): string {
+  const now = Date.now();
+  if (now >= resetRefreshAtMs) {
+    cachedResetDay = resetDayOf(new Date(now));
+    resetRefreshAtMs = now + 1000;
+  }
+  return cachedResetDay;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -137,7 +137,7 @@ import {
 import { safeStartupGraphicsPreset } from './game/startup_graphics_safety';
 import { shouldClearTargetOnGroundClick } from './game/target_click';
 import { loadingCurtainFadeMs, resolveUiEffectsProfile } from './game/ui_effects_profile';
-import { currentUtcDay } from './game/utc_day';
+import { currentResetDay, currentUtcDay } from './game/utc_day';
 import { voice } from './game/voice';
 import { telemetryZoneId } from './game/world_telemetry';
 import { zoneWarmupMode } from './game/zone_transition';
@@ -4167,6 +4167,7 @@ async function startGame(
       // Supply the UTC day for the delve daily reset (the sim never reads the wall
       // clock itself, to stay deterministic).
       offlineSim.utcDay = currentUtcDay();
+      offlineSim.resetDay = currentResetDay();
       while (acc >= DT) {
         const { mi, facing } = resolveMove(
           mouselook,

--- a/src/sim/delves/runs.ts
+++ b/src/sim/delves/runs.ts
@@ -302,10 +302,12 @@ export function delveRunForMob(ctx: SimContext, mobId: number): DelveRun | null 
 }
 
 export function refreshDelveDaily(ctx: SimContext, meta: PlayerMeta): void {
-  // `utcDay` is supplied by the host (never read from the wall clock here, so the
-  // sim stays deterministic). When unknown (''), the daily window does not roll
-  // over, same-seed replays stay reproducible.
-  const today = ctx.utcDay;
+  // `resetDay` is supplied by the host (never read from the wall clock here, so
+  // the sim stays deterministic), and is the realm's own daily boundary rather
+  // than a UTC calendar date, so the delve daily rolls over with every other
+  // daily. When unknown (''), the window does not roll over, same-seed replays
+  // stay reproducible.
+  const today = ctx.resetDay;
   if (today && meta.delveDaily.date !== today) {
     meta.delveDaily = { date: today, firstClearXp: new Set(), markClears: 0 };
   }

--- a/src/sim/pvp/honor.ts
+++ b/src/sim/pvp/honor.ts
@@ -165,15 +165,15 @@ function dailyWindow(ctx: SimContext, meta: PlayerMeta) {
   let daily = meta.honorArenaDaily;
   if (!daily) {
     daily = {
-      date: ctx.utcDay,
+      date: ctx.resetDay,
       winsByOpponent: {},
       fiestaCompletionsByOpponent: {},
       totalWins: 0,
     };
     meta.honorArenaDaily = daily;
   }
-  if (ctx.utcDay && daily.date !== ctx.utcDay) {
-    daily.date = ctx.utcDay;
+  if (ctx.resetDay && daily.date !== ctx.resetDay) {
+    daily.date = ctx.resetDay;
     daily.winsByOpponent = {};
     daily.fiestaCompletionsByOpponent = {};
     // Back to `undefined` (not `{}`) so an untouched day stays byte-equal in
@@ -193,13 +193,13 @@ function dailyWindow(ctx: SimContext, meta: PlayerMeta) {
  * The READ-ONLY twin of the rollover in `dailyWindow` above, for the readouts
  * (`bgInfoFor`) that must never mutate the window they report on: a stored date
  * that is not today reads as re-armed without writing the rollover, which the
- * next actual award does. `utcDay === ''` means the host set no calendar, so
+ * next actual award does. `resetDay === ''` means the host set no calendar, so
  * the window never rolls over and the stored flag is the whole answer.
  */
-export function bgFirstWinBonusAvailable(utcDay: string, meta: PlayerMeta): boolean {
+export function bgFirstWinBonusAvailable(resetDay: string, meta: PlayerMeta): boolean {
   const daily = meta.honorArenaDaily;
   if (!daily) return true;
-  if (utcDay && daily.date !== utcDay) return true;
+  if (resetDay && daily.date !== resetDay) return true;
   return daily.bgFirstWinClaimed !== true;
 }
 

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -1993,6 +1993,13 @@ export class Sim {
   // "no calendar known" (headless/replay), the daily window then never rolls over,
   // keeping same-seed runs reproducible. Tests may set it to pin a date.
   utcDay = '';
+  // The daily-reset WINDOW key ('YYYY-MM-DD' of the reset that opened it), set by
+  // the host each tick alongside utcDay. Every daily rollover reads THIS, not the
+  // calendar date: the server derives it from the realm's own 3 AM reset boundary
+  // (server/raid_reset.ts `resetDayKey`), the offline client from the player's
+  // local one, so a daily never rolls over mid-evening the way midnight UTC did.
+  // Empty string = "no calendar known" (headless/replay), same contract as utcDay.
+  resetDay = '';
   // the World Market (the Merchant's auction house): the Market instance owns the
   // listing book, per-seller collections, the id counter, and the Merchant entity
   // id. Constructed in the ctor after the SimContext (it consumes the seam); Sim
@@ -4943,6 +4950,9 @@ export class Sim {
       },
       get delvePetStash() {
         return sim.delvePetStash;
+      },
+      get resetDay() {
+        return sim.resetDay;
       },
       get utcDay() {
         return sim.utcDay;

--- a/src/sim/sim_context.ts
+++ b/src/sim/sim_context.ts
@@ -224,8 +224,18 @@ export interface SimContextPrimitives {
   // P1b's nextId dedupes with I1's declaration above.)
   readonly delveRuns: DelveRun[];
   readonly delvePetStash: Map<number, PetState>;
-  // Host-supplied UTC day string ('' = unknown) gating the delve daily reset.
+  // Host-supplied UTC calendar day ('' = unknown). A CALENDAR DATE, used to stamp
+  // when something happened (the Book of Deeds earn date). For "has the daily
+  // rolled over", read `resetDay` below instead: the two answer different
+  // questions and no longer share a boundary.
   readonly utcDay: string;
+  // Host-supplied daily-reset WINDOW key ('' = unknown), gating every daily
+  // rollover: the first battleground win of the day, arena/fiesta honor DR, and
+  // the delve daily. The host derives it from the realm's own reset boundary (the
+  // same 3 AM realm-local instant the raid lockouts expire on), so a realm has ONE
+  // daily boundary. '' means the host set no calendar, so nothing ever rolls over
+  // and same-seed replays stay reproducible.
+  readonly resetDay: string;
   // Wild-respawn queue (P1b: completeTame pushes the tamed beast's respawn). Live view;
   // the backing array stays on Sim, mutated in place (push), so read-only ref.
   readonly pendingMobRespawns: PendingMobRespawn[];
@@ -1240,6 +1250,9 @@ export function createSimContext(host: SimContextHost): SimContext {
     },
     get delvePetStash() {
       return host.delvePetStash;
+    },
+    get resetDay() {
+      return host.resetDay;
     },
     get utcDay() {
       return host.utcDay;

--- a/src/sim/social/battleground.ts
+++ b/src/sim/social/battleground.ts
@@ -1796,7 +1796,7 @@ export function bgInfoFor(
     // A READ, never the rollover: `bgFirstWinBonusAvailable` reports a stored
     // date that is not today as re-armed without writing anything, because a
     // per-viewer wire builder must not mutate the daily window it reports on.
-    firstWinBonusReady: bgFirstWinBonusAvailable(ctx.utcDay, meta),
+    firstWinBonusReady: bgFirstWinBonusAvailable(ctx.resetDay, meta),
     match: matchInfo,
     ladder: ladder ?? bgLadder(ctx),
   };

--- a/tests/arena_online.test.ts
+++ b/tests/arena_online.test.ts
@@ -188,7 +188,7 @@ describe('arena: online integration (GameServer)', () => {
     const fcB = fakeWs();
     const sa = joinServer(server, fcA, 30, 'Deserter', 'warrior');
     const sb = joinServer(server, fcB, 31, 'Victor', 'mage');
-    server.sim.utcDay = '2026-07-11';
+    server.sim.resetDay = '2026-07-11';
     teleport(server.sim, sa.pid, 0, -40);
     teleport(server.sim, sb.pid, 4, -40);
     server.handleMessage(sa, JSON.stringify({ t: 'cmd', cmd: 'arena_queue' }));

--- a/tests/battleground.test.ts
+++ b/tests/battleground.test.ts
@@ -1927,7 +1927,7 @@ describe('Thornhollow Fields: review-hardening pins', () => {
 
   it('the honor DR window round-trips through CharacterState and clears on UTC rollover', () => {
     const { sim, pids } = tenInQueue();
-    sim.utcDay = '2026-07-26';
+    sim.resetDay = '2026-07-26';
     const match = sim.bgMatchFor(pids[0])!;
     toActive(sim, match);
     const winner = match.teams[0][0];
@@ -1940,7 +1940,7 @@ describe('Thornhollow Fields: review-hardening pins', () => {
     // the full price again (the reset arm in pvp/honor.ts dailyWindow)
     const honorAfterDayOne = sim.meta(winner)!.honor;
     for (let i = 0; i < 20 * (BG_END_HOLD + 1); i++) sim.tick(); // run out the result screen
-    sim.utcDay = '2026-07-27';
+    sim.resetDay = '2026-07-27';
     for (const pid of pids) sim.bgQueueJoin(pid);
     sim.tick();
     const rematch = sim.bgMatchFor(winner)!;
@@ -2346,9 +2346,9 @@ describe('Thornhollow Fields: the first win of the day pays a bonus', () => {
     expect(firstWin / BATTLEGROUND_WIN_HONOR).toBeLessThan(1.5);
   });
 
-  it('pays exactly once per UTC day, under its own honor reason', () => {
+  it('pays exactly once per reset day, under its own honor reason', () => {
     const { sim, pids } = tenInQueue();
-    sim.utcDay = '2026-07-26';
+    sim.resetDay = '2026-07-26';
     const match = sim.bgMatchFor(pids[0])!;
     toActive(sim, match);
     const winner = match.teams[0][0];
@@ -2370,7 +2370,7 @@ describe('Thornhollow Fields: the first win of the day pays a bonus', () => {
 
   it('a SECOND win the same day pays the base award only', () => {
     const { sim, pids } = tenInQueue();
-    sim.utcDay = '2026-07-26';
+    sim.resetDay = '2026-07-26';
     const match = sim.bgMatchFor(pids[0])!;
     toActive(sim, match);
     const winner = match.teams[0][0];
@@ -2397,7 +2397,7 @@ describe('Thornhollow Fields: the first win of the day pays a bonus', () => {
 
   it('the UTC rollover re-arms it, and the claim survives a save/load round trip', () => {
     const { sim, pids } = tenInQueue();
-    sim.utcDay = '2026-07-26';
+    sim.resetDay = '2026-07-26';
     const match = sim.bgMatchFor(pids[0])!;
     toActive(sim, match);
     const winner = match.teams[0][0];
@@ -2408,12 +2408,12 @@ describe('Thornhollow Fields: the first win of the day pays a bonus', () => {
     const state = sim.serializeCharacter(winner)!;
     expect(state.honorArenaDaily!.bgFirstWinClaimed).toBe(true);
     const sim2 = makeWorld();
-    sim2.utcDay = '2026-07-26';
+    sim2.resetDay = '2026-07-26';
     const reloaded = sim2.addPlayer('warrior', 'Reload', { state });
     expect(sim2.meta(reloaded)!.honorArenaDaily!.bgFirstWinClaimed).toBe(true);
     expect(sim2.bgInfoFor(reloaded)!.firstWinBonusReady, 'still spent after a relog').toBe(false);
     // ...and the NEXT day re-arms it without any award having run.
-    sim2.utcDay = '2026-07-27';
+    sim2.resetDay = '2026-07-27';
     expect(sim2.bgInfoFor(reloaded)!.firstWinBonusReady).toBe(true);
 
     // A clean character writes NOTHING (byte-stable saves): absent until claimed.
@@ -2422,7 +2422,7 @@ describe('Thornhollow Fields: the first win of the day pays a bonus', () => {
     expect(sim3.serializeCharacter(clean)!.honorArenaDaily?.bgFirstWinClaimed).toBeUndefined();
 
     for (let i = 0; i < 20 * (BG_END_HOLD + 1); i++) sim.tick();
-    sim.utcDay = '2026-07-27';
+    sim.resetDay = '2026-07-27';
     expect(sim.bgInfoFor(winner)!.firstWinBonusReady, 'a new day re-arms the chip').toBe(true);
     const before = sim.meta(winner)!.honor;
     startBgMatch(sim.ctx, [...match.teams[0]], [...match.teams[1]]);
@@ -2437,9 +2437,37 @@ describe('Thornhollow Fields: the first win of the day pays a bonus', () => {
     );
   });
 
+  it('re-arms on the RESET window, and never on the UTC calendar date alone', () => {
+    // The reported bug: the banner read "First win of the day" at 6 PM Pacific to
+    // a player who had already won that afternoon, because midnight UTC had
+    // passed at 5 PM and rolled the window mid-evening. The two clocks are now
+    // separate fields, so moving the calendar date must do nothing at all.
+    const { sim, pids } = tenInQueue();
+    sim.resetDay = '2026-08-07';
+    sim.utcDay = '2026-08-07';
+    const match = sim.bgMatchFor(pids[0])!;
+    toActive(sim, match);
+    const winner = match.teams[0][0];
+    playedOutWin(sim, match, winner);
+    expect(sim.bgInfoFor(winner)!.firstWinBonusReady, 'claimed by the win').toBe(false);
+
+    // 6 PM Pacific: the UTC calendar has ticked over to the 8th, the realm's own
+    // reset (3 AM Eastern) has not.
+    sim.utcDay = '2026-08-08';
+    expect(
+      sim.bgInfoFor(winner)!.firstWinBonusReady,
+      'a UTC rollover must not re-arm the day',
+    ).toBe(false);
+    expect(sim.meta(winner)!.honorArenaDaily!.bgFirstWinClaimed).toBe(true);
+
+    // The realm's reset is what re-arms it.
+    sim.resetDay = '2026-08-08';
+    expect(sim.bgInfoFor(winner)!.firstWinBonusReady, 'the realm reset re-arms it').toBe(true);
+  });
+
   it('an UNRATED dev match never claims it', () => {
     const sim = makeWorld();
-    sim.utcDay = '2026-07-26';
+    sim.resetDay = '2026-07-26';
     const pids: number[] = [];
     for (let i = 0; i < 4; i++) {
       const p = sim.addPlayer('warrior', `D${i}`);
@@ -2463,7 +2491,7 @@ describe('Thornhollow Fields: the first win of the day pays a bonus', () => {
 
   it('a FORFEIT win never claims it (forfeits pay no honor at all)', () => {
     const { sim, pids } = tenInQueue();
-    sim.utcDay = '2026-07-26';
+    sim.resetDay = '2026-07-26';
     const match = sim.bgMatchFor(pids[0])!;
     toActive(sim, match);
     const winner = match.teams[0][0];
@@ -2477,7 +2505,7 @@ describe('Thornhollow Fields: the first win of the day pays a bonus', () => {
 
   it('a DRAW never claims it', () => {
     const { sim, pids } = tenInQueue();
-    sim.utcDay = '2026-07-26';
+    sim.resetDay = '2026-07-26';
     const match = sim.bgMatchFor(pids[0])!;
     toActive(sim, match);
     const pid = match.teams[0][0];
@@ -2490,7 +2518,7 @@ describe('Thornhollow Fields: the first win of the day pays a bonus', () => {
 
   it('the bgEnd event carries the bonus so the finish surface can name it', () => {
     const { sim, pids } = tenInQueue();
-    sim.utcDay = '2026-07-26';
+    sim.resetDay = '2026-07-26';
     const match = sim.bgMatchFor(pids[0])!;
     toActive(sim, match);
     const winner = match.teams[0][0];
@@ -2508,12 +2536,12 @@ describe('Thornhollow Fields: the first win of the day pays a bonus', () => {
     // stored date reads as re-armed, and the stored date is left for the next
     // real award to roll over.
     const { sim, pids } = tenInQueue();
-    sim.utcDay = '2026-07-26';
+    sim.resetDay = '2026-07-26';
     const match = sim.bgMatchFor(pids[0])!;
     toActive(sim, match);
     const winner = match.teams[0][0];
     playedOutWin(sim, match, winner);
-    sim.utcDay = '2026-07-27';
+    sim.resetDay = '2026-07-27';
     expect(sim.bgInfoFor(winner)!.firstWinBonusReady).toBe(true);
     expect(sim.meta(winner)!.honorArenaDaily!.date, 'the read wrote nothing').toBe('2026-07-26');
     expect(sim.meta(winner)!.honorArenaDaily!.bgFirstWinClaimed).toBe(true);
@@ -2834,7 +2862,7 @@ describe('Thornhollow Fields: the honor award reports what it paid', () => {
     // The bgEnd event needs the BONUS on its own (the finish surface names it),
     // and the caller needs the total to stay honest about what was credited.
     const sim = makeWorld();
-    sim.utcDay = '2026-07-26';
+    sim.resetDay = '2026-07-26';
     const pid = sim.addPlayer('warrior', 'Champ');
     const meta = sim.meta(pid)!;
 
@@ -2860,7 +2888,7 @@ describe('Thornhollow Fields: the honor award reports what it paid', () => {
     // grantHonor credits zero once a purse is at the honor ceiling; spending the
     // day's one bonus for zero honor is the wrong way to lose that race.
     const sim = makeWorld();
-    sim.utcDay = '2026-07-26';
+    sim.resetDay = '2026-07-26';
     const pid = sim.addPlayer('warrior', 'Capped');
     const meta = sim.meta(pid)!;
     meta.honor = Number.MAX_SAFE_INTEGER;

--- a/tests/delves.test.ts
+++ b/tests/delves.test.ts
@@ -1225,7 +1225,7 @@ describe('delve reward chest + surface exit flow', () => {
 
   it('daily reset + first-vs-repeat XP keys off the injected UTC day (deterministic)', () => {
     const sim = makeSim();
-    sim.utcDay = '2026-06-18';
+    sim.resetDay = '2026-06-18';
     sim.setPlayerLevel(DELVES.collapsed_reliquary.minLevel);
     const meta = (sim as any).players.get(sim.playerId);
     const rewards = DELVES.collapsed_reliquary.baseRewards;
@@ -1259,7 +1259,7 @@ describe('delve reward chest + surface exit flow', () => {
     (sim as any).freeDelveRun(run);
 
     // Day rollover: the daily window resets (firstClearXp cleared, markClears 0).
-    sim.utcDay = '2026-06-19';
+    sim.resetDay = '2026-06-19';
     run = enterFinale(sim);
     killBoss(sim, run);
     lastXp = 0;
@@ -1269,10 +1269,10 @@ describe('delve reward chest + surface exit flow', () => {
     expect(lastXp).toBe(rewards.firstClearXp); // first clear again after reset
   });
 
-  it('refreshDelveDaily never reads the wall clock (no reset when utcDay unset)', () => {
+  it('refreshDelveDaily never reads the wall clock (no reset when resetDay unset)', () => {
     const sim = makeSim();
-    // utcDay defaults to '' (deterministic / headless): the window must not roll over.
-    expect(sim.utcDay).toBe('');
+    // resetDay defaults to '' (deterministic / headless): the window must not roll over.
+    expect(sim.resetDay).toBe('');
     sim.setPlayerLevel(DELVES.collapsed_reliquary.minLevel);
     const meta = (sim as any).players.get(sim.playerId);
     meta.delveDaily = { date: 'pinned', firstClearXp: new Set(['x']), markClears: 2 };
@@ -1307,7 +1307,7 @@ describe('delve reward chest + surface exit flow', () => {
 
   it('unlocks one lore journal entry per clear, capped at five (PRD §6.4)', () => {
     const sim = makeSim();
-    sim.utcDay = '2026-06-18';
+    sim.resetDay = '2026-06-18';
     sim.setPlayerLevel(DELVES.collapsed_reliquary.minLevel);
     const meta = (sim as any).players.get(sim.playerId);
     const order = [

--- a/tests/delves_runs.test.ts
+++ b/tests/delves_runs.test.ts
@@ -123,9 +123,9 @@ describe('refreshDelveDaily', () => {
       delveDaily: { date, firstClearXp: new Set(['x']), markClears: 4 },
     }) as unknown as PlayerMeta;
 
-  it('rolls over to a fresh window on a new UTC day', () => {
+  it('rolls over to a fresh window on a new reset day', () => {
     const m = meta('2099-01-01');
-    refreshDelveDaily({ utcDay: '2099-01-02' } as unknown as SimContext, m);
+    refreshDelveDaily({ resetDay: '2099-01-02' } as unknown as SimContext, m);
     expect(m.delveDaily.date).toBe('2099-01-02');
     expect(m.delveDaily.firstClearXp.size).toBe(0);
     expect(m.delveDaily.markClears).toBe(0);
@@ -133,10 +133,10 @@ describe('refreshDelveDaily', () => {
 
   it('is a no-op on the same day or when the day is unknown', () => {
     const same = meta('2099-01-01');
-    refreshDelveDaily({ utcDay: '2099-01-01' } as unknown as SimContext, same);
+    refreshDelveDaily({ resetDay: '2099-01-01' } as unknown as SimContext, same);
     expect(same.delveDaily.markClears).toBe(4);
     const unknown = meta('2099-01-01');
-    refreshDelveDaily({ utcDay: '' } as unknown as SimContext, unknown);
+    refreshDelveDaily({ resetDay: '' } as unknown as SimContext, unknown);
     expect(unknown.delveDaily.date).toBe('2099-01-01');
     expect(unknown.delveDaily.markClears).toBe(4);
   });

--- a/tests/entity_roster.test.ts
+++ b/tests/entity_roster.test.ts
@@ -143,6 +143,7 @@ function makeCtx() {
     delveRuns: [],
     delvePetStash: new Map(),
     utcDay: '',
+    resetDay: '',
     pendingMobRespawns: [],
     partyInvites: new Map(),
     readyChecks: new Map(),

--- a/tests/honor.test.ts
+++ b/tests/honor.test.ts
@@ -33,7 +33,7 @@ function world(): Sim {
 
 function liveArena(): { sim: Sim; a: number; b: number; match: ArenaMatch } {
   const sim = world();
-  sim.utcDay = '2026-07-11';
+  sim.resetDay = '2026-07-11';
   const a = sim.addPlayer('warrior', 'Aleph', { characterId: 101 });
   const b = sim.addPlayer('mage', 'Bet', { characterId: 202 });
   sim.setPlayerLevel(arena.ARENA_MIN_LEVEL, a);
@@ -50,7 +50,7 @@ function liveArena(): { sim: Sim; a: number; b: number; match: ArenaMatch } {
 
 function liveArena2v2(): { sim: Sim; match: ArenaMatch } {
   const sim = world();
-  sim.utcDay = '2026-07-11';
+  sim.resetDay = '2026-07-11';
   const classes = ['warrior', 'mage', 'rogue', 'priest'] as const;
   const pids = classes.map((cls, i) => sim.addPlayer(cls, `Ranked${i}`, { characterId: 500 + i }));
   for (const pid of pids) sim.setPlayerLevel(arena.ARENA_MIN_LEVEL, pid);
@@ -65,7 +65,7 @@ function liveArena2v2(): { sim: Sim; match: ArenaMatch } {
 
 function liveFiesta(): { sim: Sim; match: ArenaMatch; pids: number[] } {
   const sim = world();
-  sim.utcDay = '2026-07-11';
+  sim.resetDay = '2026-07-11';
   const classes = ['warrior', 'mage', 'rogue', 'priest'] as const;
   const pids = classes.map((cls, i) => sim.addPlayer(cls, `Fiesta${i}`, { characterId: 300 + i }));
   for (const pid of pids) sim.arenaQueueJoin(pid, 'fiesta');
@@ -209,7 +209,7 @@ describe('ranked Arena honor', () => {
 
   it('applies repeat-opponent DR, the daily taper, and UTC rollover deterministically', () => {
     const sim = world();
-    sim.utcDay = '2026-07-11';
+    sim.resetDay = '2026-07-11';
     const pid = sim.addPlayer('warrior', 'Climber');
     const meta = sim.meta(pid)!;
 
@@ -219,7 +219,7 @@ describe('ranked Arena honor', () => {
     expect(repeat).toEqual([25, 0, 0, 0]);
 
     const fresh = world();
-    fresh.utcDay = '2026-07-11';
+    fresh.resetDay = '2026-07-11';
     const freshPid = fresh.addPlayer('warrior', 'Taper');
     const freshMeta = fresh.meta(freshPid)!;
     for (let i = 0; i < ARENA_DAILY_TAPER_START; i++) {
@@ -227,18 +227,18 @@ describe('ranked Arena honor', () => {
     }
     expect(awardRankedArenaWinHonor(fresh.ctx, freshMeta, '1v1', '["character:next"]')).toBe(12);
 
-    fresh.utcDay = '2026-07-12';
+    fresh.resetDay = '2026-07-12';
     expect(awardRankedArenaWinHonor(fresh.ctx, freshMeta, '1v1', '["character:next"]')).toBe(25);
   });
 
   it('does not reset a persisted daily window when the host has no UTC day', () => {
     const sim = world();
-    sim.utcDay = '2026-07-11';
+    sim.resetDay = '2026-07-11';
     const pid = sim.addPlayer('warrior', 'Replay');
     const meta = sim.meta(pid)!;
     const key = '["name:opponent"]';
     expect(awardRankedArenaWinHonor(sim.ctx, meta, '1v1', key)).toBe(25);
-    sim.utcDay = '';
+    sim.resetDay = '';
     expect(awardRankedArenaWinHonor(sim.ctx, meta, '1v1', key)).toBe(0);
   });
 });
@@ -265,7 +265,7 @@ describe('Fiesta honor', () => {
 
   it('applies per-victim kill DR and repeat-opposition completion DR', () => {
     const sim = world();
-    sim.utcDay = '2026-07-11';
+    sim.resetDay = '2026-07-11';
     const pid = sim.addPlayer('rogue', 'Fighter');
     const meta = sim.meta(pid)!;
     const pairs = new Map<string, number>();
@@ -322,7 +322,7 @@ describe('Fiesta honor', () => {
 describe('Thornhollow Fields honor income', () => {
   function bgPlayer(): { sim: Sim; meta: NonNullable<ReturnType<Sim['meta']>> } {
     const sim = world();
-    sim.utcDay = '2026-08-06';
+    sim.resetDay = '2026-08-06';
     const pid = sim.addPlayer('warrior', 'Fielder', { characterId: 700 });
     return { sim, meta: sim.meta(pid)! };
   }
@@ -402,7 +402,7 @@ describe('Thornhollow Fields honor income', () => {
 
   it('leaves Fiesta awards on the shared zero-floor curve', () => {
     const sim = world();
-    sim.utcDay = '2026-08-06';
+    sim.resetDay = '2026-08-06';
     const pid = sim.addPlayer('rogue', 'Partygoer', { characterId: 701 });
     const meta = sim.meta(pid)!;
     const pairs = new Map<string, number>();

--- a/tests/parity/scenarios.ts
+++ b/tests/parity/scenarios.ts
@@ -2896,8 +2896,12 @@ function delveProgression(): Scenario {
       meta.copper = 100000;
       sim.delveBuyShopItem('collapsed_reliquary', 'reliquary_legs');
       sim.companionUpgrade('companion_tessa');
-      // Daily rollover: a fresh UTC day resets firstClearXp/markClears.
+      // Daily rollover: a fresh reset window resets firstClearXp/markClears.
+      // `resetDay` is the realm's own daily boundary, which is what every daily
+      // window now reads; `utcDay` stays the calendar stamp beside it, moved in
+      // step so the scenario keeps describing one instant rather than two.
       meta.delveDaily = { date: '2099-01-01', firstClearXp: new Set(['seed']), markClears: 2 };
+      sim.resetDay = '2099-06-25';
       sim.utcDay = '2099-06-25';
       sim.delveDailyWire(sim.playerId);
       rec.snapshot('shop-daily');

--- a/tests/raid_reset.test.ts
+++ b/tests/raid_reset.test.ts
@@ -3,8 +3,11 @@ import {
   DEFAULT_RAID_RESET_TIME_ZONE,
   isSupportedTimeZone,
   nextRaidResetMs,
+  RAID_RESET_HOUR,
+  resetDayKey,
 } from '../server/raid_reset';
 import { resolveRaidResetTimeZone } from '../server/realm';
+import { DAILY_RESET_HOUR } from '../src/game/utc_day';
 
 // The daily raid reset lands at 03:00 (3 AM, the classic daily-reset hour) in the realm's
 // civil time zone (default US Eastern, America/New_York), so a realm shares one
@@ -135,6 +138,63 @@ describe('isSupportedTimeZone', () => {
   it('rejects unknown or empty zones', () => {
     expect(isSupportedTimeZone('Not/AZone')).toBe(false);
     expect(isSupportedTimeZone('')).toBe(false);
+  });
+});
+
+describe('resetDayKey: the ONE daily boundary a realm turns over on', () => {
+  it('holds one key across a whole evening of play, where midnight UTC split it', () => {
+    // The reported bug, as instants. Both are 2026-08-07 in US Pacific, either
+    // side of midnight UTC (5 PM Pacific in August), and the player won a
+    // battleground before the first and saw "first win of the day" after the
+    // second.
+    const morning = Date.UTC(2026, 7, 7, 17, 0, 0); // 10:00 Pacific, 13:00 Eastern
+    const evening = Date.UTC(2026, 7, 8, 1, 11, 0); // 18:11 Pacific, 21:11 Eastern
+
+    expect(resetDayKey(morning)).toBe(resetDayKey(evening));
+    // ...and it is a real regression test only because the OLD key differed.
+    const utcKey = (ms: number) => new Date(ms).toISOString().slice(0, 10);
+    expect(utcKey(morning)).not.toBe(utcKey(evening));
+  });
+
+  it('turns over exactly at the reset hour, not at local midnight', () => {
+    // 02:59 and 03:00 Eastern on the same civil date: the reset hour is the cut,
+    // so the earlier instant still belongs to the PREVIOUS day's window.
+    const beforeReset = Date.UTC(2026, 7, 7, 6, 59, 0); // 02:59 Eastern (EDT, UTC-4)
+    const afterReset = Date.UTC(2026, 7, 7, 7, 0, 0); // 03:00 Eastern
+    expect(resetDayKey(beforeReset)).toBe('2026-08-06');
+    expect(resetDayKey(afterReset)).toBe('2026-08-07');
+  });
+
+  it('rolls the month and the year back across an edge', () => {
+    // 01:00 Eastern on the 1st belongs to the last day of the previous month,
+    // and on Jan 1 to the previous YEAR. Date.UTC owns that arithmetic.
+    expect(resetDayKey(Date.UTC(2026, 7, 1, 5, 0, 0))).toBe('2026-07-31');
+    expect(resetDayKey(Date.UTC(2026, 0, 1, 6, 0, 0))).toBe('2025-12-31');
+  });
+
+  it('agrees with the lockout boundary: the key changes exactly when a reset passes', () => {
+    // The whole point of sharing RAID_RESET_HOUR. Step across the next raid
+    // reset and the day key must change on the same instant the lockout expires.
+    const now = Date.UTC(2026, 7, 7, 20, 0, 0);
+    const reset = nextRaidResetMs(now);
+    expect(resetDayKey(reset - 1)).toBe(resetDayKey(now));
+    expect(resetDayKey(reset)).not.toBe(resetDayKey(now));
+  });
+
+  it('is pure and zone-parameterized, like the rest of this module', () => {
+    const now = Date.UTC(2026, 7, 8, 1, 11, 0);
+    expect(resetDayKey(now)).toBe(resetDayKey(now));
+    // 18:11 Pacific on the 7th is already 10:11 on the 8th in Tokyo, past its
+    // own 3 AM, so a realm in that zone is legitimately a day ahead.
+    expect(resetDayKey(now, 'Asia/Tokyo')).toBe('2026-08-08');
+    expect(resetDayKey(now, DEFAULT_RAID_RESET_TIME_ZONE)).toBe('2026-08-07');
+  });
+
+  it('shares its reset hour with the offline client, which has no realm zone', () => {
+    // Offline there is no realm, so src/game/utc_day.ts applies the same rule in
+    // the player's OWN local zone. The hour is the promise both make ("a daily
+    // never turns over mid-evening"), so a drift between them is a bug.
+    expect(DAILY_RESET_HOUR).toBe(RAID_RESET_HOUR);
   });
 });
 

--- a/tests/sim_context.test.ts
+++ b/tests/sim_context.test.ts
@@ -323,6 +323,7 @@ function makeFakeHost() {
     delveRuns: [],
     delvePetStash: new Map(),
     utcDay: '',
+    resetDay: '',
     pendingMobRespawns: [],
     partyInvites: new Map(),
     readyChecks: new Map(),

--- a/tests/utc_day.test.ts
+++ b/tests/utc_day.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { currentUtcDay } from '../src/game/utc_day';
+import { currentResetDay, currentUtcDay, DAILY_RESET_HOUR, resetDayOf } from '../src/game/utc_day';
 
 describe('currentUtcDay', () => {
   afterEach(() => {
@@ -22,5 +22,64 @@ describe('currentUtcDay', () => {
     // past the window: the next read re-derives and sees the new day
     vi.setSystemTime(new Date('2026-07-02T00:00:00.800Z'));
     expect(currentUtcDay()).toBe('2026-07-02');
+  });
+});
+
+// Offline there is no realm, so the daily window turns over at the player's OWN
+// local reset hour. `resetDayOf` is expressed entirely in local civil terms, so
+// every case below is built with the LOCAL Date constructor and holds in any
+// process zone. The server's zone-parameterized twin is `resetDayKey`
+// (tests/raid_reset.test.ts), and the two share DAILY_RESET_HOUR.
+describe('resetDayOf', () => {
+  it('holds one key across an evening that midnight UTC would have split', () => {
+    // The shape the realm bug was reported in: a win in the morning and the
+    // banner re-arming that same evening.
+    const morning = new Date(2026, 7, 7, 10, 0);
+    const evening = new Date(2026, 7, 7, 18, 11);
+    expect(resetDayOf(morning)).toBe('2026-08-07');
+    expect(resetDayOf(evening)).toBe('2026-08-07');
+  });
+
+  it('turns over at the local reset hour, not at local midnight', () => {
+    expect(resetDayOf(new Date(2026, 7, 7, 0, 1)), 'just past midnight').toBe('2026-08-06');
+    expect(resetDayOf(new Date(2026, 7, 7, 2, 59)), 'the last minute before').toBe('2026-08-06');
+    expect(resetDayOf(new Date(2026, 7, 7, 3, 0)), 'the reset hour opens it').toBe('2026-08-07');
+  });
+
+  it('rolls the month and the year back across an edge', () => {
+    expect(resetDayOf(new Date(2026, 7, 1, 1, 0))).toBe('2026-07-31');
+    expect(resetDayOf(new Date(2026, 0, 1, 2, 0))).toBe('2025-12-31');
+  });
+
+  it('zero-pads so keys compare and sort as strings', () => {
+    expect(resetDayOf(new Date(2026, 0, 5, 12, 0))).toBe('2026-01-05');
+  });
+
+  it('does not mutate the Date it is handed', () => {
+    const at = new Date(2026, 7, 7, 1, 0);
+    const before = at.getTime();
+    resetDayOf(at);
+    expect(at.getTime()).toBe(before);
+  });
+
+  it('exports the reset hour it applies, so the server can be pinned against it', () => {
+    expect(DAILY_RESET_HOUR).toBe(3);
+  });
+});
+
+describe('currentResetDay', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('reads the clock through resetDayOf and caches for a second', () => {
+    vi.useFakeTimers();
+    const beforeReset = new Date(2026, 7, 7, 2, 59, 59, 700);
+    vi.setSystemTime(beforeReset);
+    expect(currentResetDay()).toBe('2026-08-06');
+    vi.setSystemTime(new Date(2026, 7, 7, 3, 0, 0, 100));
+    expect(currentResetDay(), 'inside the 1s window, the cached key is served').toBe('2026-08-06');
+    vi.setSystemTime(new Date(2026, 7, 7, 3, 0, 0, 800));
+    expect(currentResetDay(), 'past it, the next read re-derives').toBe('2026-08-07');
   });
 });


### PR DESCRIPTION
## Summary

The Thornhollow Fields window offered "First win of the day" to a player who had
already won that day. Not a claim-tracking bug: the daily window rolled over at
**midnight UTC**, which in August is 5 PM Pacific. The report came in at 6:11 PM
Pacific, about seventy minutes after the reset had fired mid-evening.

The realm already had a better boundary and the dailies were not using it. Raid
lockouts expire through `nextRaidResetMs` at `RAID_RESET_HOUR` (03:00) in the
realm's own civil zone, US Eastern by default, which is midnight Pacific. So
there were two daily clocks in one realm.

### The fix

`resetDayKey(nowMs, zone)` joins `server/raid_reset.ts` beside `nextRaidResetMs`,
sharing its `RAID_RESET_HOUR` and its existing zone helpers. It answers "which
daily window is this instant in", and the host feeds it to the sim each tick.

### Two fields, not one renamed field

`utcDay` stays, and `resetDay` is added beside it, for two reasons.

The `SimContext` seam is documented append-only ("add callbacks, never rename or
repurpose one"), and quietly changing what a field named `utcDay` contains is the
repurposing that rule exists to prevent.

More importantly they answer different questions, and folding them would have
been wrong even if the seam allowed it. A Book of Deeds entry stamps the CALENDAR
DATE something was earned on; putting that on a 3 AM boundary would date a deed
earned at 1 AM to the previous day. So:

- `resetDay` (new): every daily ROLLOVER. The first battleground win of the day,
  arena/fiesta honor DR, the delve daily.
- `utcDay` (unchanged): the calendar STAMP. The deed earn date, its only consumer.

### Offline

There is no realm and no configured zone, so the client applies the same rule in
the player's OWN local zone (`resetDayOf` in `src/game/utc_day.ts`). The reset
hour is the promise both make, so `tests/raid_reset.test.ts` pins the client
constant equal to the server's rather than letting them drift.

## Related issues

N/A

## Type of change

- [x] Bug fix

## How was this tested?

- Commands:
  - `node scripts/gate_select.mjs`: **PASS, all 12 steps green.**
  - `npx vitest run tests/raid_reset.test.ts tests/utc_day.test.ts` (32 passed)
  - `npx vitest run tests/honor.test.ts tests/delves.test.ts
    tests/battleground.test.ts tests/arena_online.test.ts tests/world_boss.test.ts
    tests/rift_portals.test.ts tests/rift_race.test.ts` (372 passed)
  - `npx tsc --noEmit`: clean.

The reported bug is a regression test twice over, once per host. Both use the
real instants: 10 AM and 6:11 PM Pacific on 2026-08-07, either side of midnight
UTC. Each asserts the two produce ONE key, and each also asserts the old UTC key
DIFFERED across them, so the case cannot pass vacuously.

Beyond that: the turnover is at the reset hour rather than local midnight (02:59
against 03:00), month and year rollbacks, a non-default zone (`Asia/Tokyo` is
legitimately a day ahead at that instant), purity, and the agreement pin that
matters most, that the day key changes on exactly the instant `nextRaidResetMs`
expires a lockout.

`resetDayOf` was extracted as a clock-free core precisely so its cases could be
built with the local `Date` constructor and hold in any process zone. Driving
`process.env.TZ` did not work (Node caches the zone), and a test that silently
falls back to the machine's own zone is not the test it appears to be.

One decisive pin for the reported symptom lives in `tests/battleground.test.ts`:
after a win, moving `utcDay` forward does NOTHING, and only moving `resetDay`
re-arms the bonus. That is the two-clock split stated as behavior.

### Parity: green, with the golden UNCHANGED

Worth saying precisely, because a re-record would have been the weaker outcome.
`delve_progression` drives a delve daily rollover and did go red, since it moved
only the field the sim no longer reads. Moving both fields together in the
scenario (which is what the host does every tick) turned it green against the
COMMITTED golden, byte for byte. That is evidence the behavior is genuinely
identical under a coherent calendar and only the field being read changed, which
re-recording could not have told us.

## Screenshots / recordings

Not a visual change: no HUD, render, or styles file is touched. The banner this
fixes is the existing `firstWinBonusReady` chip, whose shape is unchanged.

---

## Checklist

### Quality

- [x] **The full gate passes.** `node scripts/gate_select.mjs`, all 12 steps green.
- [x] Determinism holds: the sim reads no clock and no zone database. It compares
      an opaque string the host supplies, exactly as it did before.

### Cross-platform

- [x] Both hosts feed the new field: the server from the realm's configured zone,
      the offline client from the player's local one. The headless/replay host
      sets neither, so `resetDay` stays `''` and nothing rolls over, which is the
      same contract `utcDay` already had.

### Localization (i18n)

- [x] No player-facing string added or changed.

### Hygiene

- [x] No secrets or `.env`; `ALLOW_DEV_COMMANDS` untouched.
- [x] No generated file hand-edited.

## Notes for the reviewer

The wiring itself (`this.sim.resetDay = resetDayKey(...)` in the `game.ts` loop)
is one assignment beside the pre-existing `utcDay` one and carries no test of its
own. That matches the coverage `utcDay` already had: no suite asserts the server
loop sets it either. The MATH is unit-tested; what is untested is the same single
line that was untested before.
