### PR TITLE
fix(sim): stop a fear dropping a player through the floor they stand on

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -321,6 +321,7 @@ import {
 import * as petAi from './pet/pet_ai';
 import * as petCommands from './pet/pet_commands';
 import type { MatchPetSnapshot } from './pet/pet_match_return';
+import { floorHeightAt } from './physics/character';
 import {
   isSwimming as isSwimmingImpl,
   moveSpeedMult as moveSpeedMultImpl,
@@ -7725,7 +7726,22 @@ export class Sim {
     }
     e.pos.x = bestX;
     e.pos.z = bestZ;
-    const g = groundHeight(bestX, bestZ, this.cfg.seed);
+    // The floor a body rests on, which for a PLAYER includes the standable prop
+    // top underfoot, not just the terrain. Feared players are moved through here
+    // and return early from the player step, so `stepPlayerMotion` and its whole
+    // vertical pass never run for the duration: snapping to raw terrain dropped
+    // anyone feared off a rampart deck several yards INSIDE the rampart, where
+    // swept collision then refused every direction once the fear ended (from
+    // inside a volume every direction is a surface). Same expression the vertical
+    // pass and climb.ts already land against.
+    //
+    // Scoped to players deliberately: mobs and pets keep the terrain snap they
+    // have always had, so their movement, and the parity draw order with it, is
+    // untouched.
+    const g =
+      e.kind === 'player'
+        ? floorHeightAt(this.cfg.seed, bestX, bestZ, BODY_RADIUS, e.pos.y + 1e-3)
+        : groundHeight(bestX, bestZ, this.cfg.seed);
     e.pos.y =
       canSwim && g < waterLevelAt(bestX, bestZ, this.cfg.seed) - SWIM_DEPTH
         ? swimSurfaceY(bestX, bestZ, this.cfg.seed)

--- a/tests/fear_standable_support.test.ts
+++ b/tests/fear_standable_support.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest';
+import { supportHeightAt } from '../src/sim/colliders';
+import { battlegroundOrigin } from '../src/sim/data';
+import { PLAYER_BODY_RADIUS } from '../src/sim/pathfind';
+import { floorHeightAt } from '../src/sim/physics/character';
+import { Sim } from '../src/sim/sim';
+import { groundHeight } from '../src/sim/world';
+
+// A feared player is moved by `moveToward`, the MOB movement path, and returns
+// early from the player step, so `stepPlayerMotion` (and with it the whole
+// vertical pass) never runs for the duration of the fear. That is the setup for
+// the reported battleground bug: fear someone standing on a rampart and they end
+// up inside it, unable to move once the fear ends, because swept collision
+// exists to stop a body crossing surfaces and from inside a volume every
+// direction is a surface.
+//
+// The floor a body rests on is `floorHeightAt` (terrain, or the standable prop
+// top underfoot), which is what the vertical pass lands and snaps against and
+// what climb.ts already reuses. These pin that a fear cannot drop a player
+// through it.
+
+const seed = 42;
+
+/** A spot inside the battleground where a standable top sits well above ground. */
+function rampartSpot(): { x: number; z: number; ground: number; support: number } {
+  const o = battlegroundOrigin(0);
+  for (let dx = -140; dx <= 140; dx += 1) {
+    for (let dz = -140; dz <= 140; dz += 1) {
+      const x = o.x + dx;
+      const z = o.z + dz;
+      const ground = groundHeight(x, z, seed);
+      const support = supportHeightAt(seed, x, z, PLAYER_BODY_RADIUS, ground + 40);
+      if (support > ground + 4) return { x, z, ground, support };
+    }
+  }
+  throw new Error('no standable top found in the battleground band');
+}
+
+function fearedOnRampart(): {
+  sim: Sim;
+  pid: number;
+  spot: ReturnType<typeof rampartSpot>;
+} {
+  const sim = new Sim({ seed, playerClass: 'warrior', noPlayer: true });
+  const pid = sim.addPlayer('priest', 'Feared');
+  const spot = rampartSpot();
+  const e = sim.entities.get(pid)!;
+  // Stand them ON the rampart deck, which is where the report comes from.
+  e.pos = { x: spot.x, y: spot.support, z: spot.z };
+  e.prevPos = { ...e.pos };
+  e.onGround = true;
+  sim.ctx.rebucket(e);
+  // The warrior's fear, as the effect dispatch applies it: an incapacitate aura
+  // whose value is the flee heading.
+  e.auras.push({
+    id: 'fear_incap',
+    name: 'Fear',
+    kind: 'incapacitate',
+    duration: 6,
+    remaining: 6,
+    value: 0,
+  } as never);
+  return { sim, pid, spot };
+}
+
+describe('a fear must not drop a player through the surface they stand on', () => {
+  it('the arrangement is real: the battleground has a standable top well above ground', () => {
+    const spot = rampartSpot();
+    expect(spot.support - spot.ground, 'a rampart deck, not a kerb').toBeGreaterThan(4);
+  });
+
+  it('keeps a feared player on the rampart instead of inside it', () => {
+    const { sim, pid, spot } = fearedOnRampart();
+    const e = sim.entities.get(pid)!;
+
+    sim.tick();
+
+    // The decisive assertion. Before the fix the fear snapped y to the raw
+    // terrain heightfield, planting the body several yards INSIDE the rampart
+    // it was standing on.
+    // Asked from the height the body STOOD at, never from where it ended up:
+    // the query is capped at maxY, so a body that has already sunk can no longer
+    // see the deck it fell through and would vacuously pass.
+    const floor = floorHeightAt(seed, e.pos.x, e.pos.z, PLAYER_BODY_RADIUS, spot.support + 1e-3);
+    expect(e.pos.y, 'the body must rest on its own floor, never below it').toBeGreaterThanOrEqual(
+      floor - 1e-3,
+    );
+    expect(e.pos.y, 'and specifically must not be at the terrain under the deck').toBeGreaterThan(
+      spot.ground + 1,
+    );
+  });
+
+  it('still runs the fear for its whole duration, not just one tick', () => {
+    const { sim, pid, spot } = fearedOnRampart();
+    const e = sim.entities.get(pid)!;
+    const from = { x: e.pos.x, z: e.pos.z };
+
+    for (let i = 0; i < 20 * 2; i++) {
+      sim.tick();
+      const floor = floorHeightAt(seed, e.pos.x, e.pos.z, PLAYER_BODY_RADIUS, spot.support + 1e-3);
+      expect(e.pos.y, `tick ${i}: never below the floor underfoot`).toBeGreaterThanOrEqual(
+        floor - 1e-3,
+      );
+    }
+    // ...and it really did flee, so the pin above is not passing on a body that
+    // simply never moved.
+    expect(Math.hypot(e.pos.x - from.x, e.pos.z - from.z), 'the fear moved them').toBeGreaterThan(
+      1,
+    );
+    expect(spot.support).toBeGreaterThan(spot.ground);
+  });
+
+  it('still drops a feared player who is fled off the edge, rather than pinning them mid-air', () => {
+    // The other half: the fix must not weld a feared body to a height it has
+    // walked off. Standing on open terrain, the floor IS the terrain, so the
+    // same expression has to track it down a slope.
+    const sim = new Sim({ seed, playerClass: 'warrior', noPlayer: true });
+    const pid = sim.addPlayer('priest', 'Runner');
+    const e = sim.entities.get(pid)!;
+    e.pos = { x: 0, y: groundHeight(0, -40, seed), z: -40 };
+    e.prevPos = { ...e.pos };
+    sim.ctx.rebucket(e);
+    e.auras.push({
+      id: 'fear_incap',
+      name: 'Fear',
+      kind: 'incapacitate',
+      duration: 6,
+      remaining: 6,
+      value: 0,
+    } as never);
+
+    for (let i = 0; i < 20; i++) sim.tick();
+
+    expect(e.pos.y).toBeCloseTo(groundHeight(e.pos.x, e.pos.z, seed), 2);
+  });
+});


### PR DESCRIPTION
## Summary

Players reported warrior fear leaving them stuck inside battleground walls,
unable to move.

A feared player is moved by `moveToward`, the MOB movement path, and returns
early from the player step:

```ts
if (this.updateFearMovement(p)) return;
// ...the vertical pass with fall damage moved VERBATIM to player_motion.ts
stepPlayerMotion(this.playerMotionDeps, p, meta.moveInput);
```

So for the whole duration of a fear, `stepPlayerMotion` and its entire vertical
pass never run. `moveToward` then committed the position by snapping y to the raw
terrain heightfield.

Stand on a rampart deck, which the battleground has about 8 yards up, and get
feared: your body teleports down to the ground beneath it, INSIDE the collider.
Once the fear ends, swept collision refuses every direction, because from inside
a volume every direction is a surface. Stuck.

The floor a body rests on is `floorHeightAt` (terrain, or the standable top
underfoot), already exported from `physics/character.ts` and already what the
vertical pass lands against and what `climb.ts` reuses. `moveToward` now uses it
for players.

### Scoped to players deliberately

Every other caller of `moveToward` moves a mob, pet, NPC or companion (the seam
callers in `escort.ts`, `delves/companion.ts`, `pet/pet_ai.ts`,
`encounters/nythraxis.ts`, `mob/locomotion.ts`, plus the pet arm on `Sim`). They
keep the terrain snap they have always had, so their movement, and the rng draw
order with it, is untouched. The player branch is reached only by the fear path,
which makes the blast radius exactly the bug.

## Related issues

N/A

## Type of change

- [x] Bug fix

## How was this tested?

- Commands:
  - `node scripts/gate_select.mjs`: **PASS, all 12 steps green.**
  - `npx vitest run tests/fear_standable_support.test.ts` (4 passed)
  - `npx vitest run tests/parkour.test.ts tests/player_motion.test.ts
    tests/physics_character.test.ts tests/architecture.test.ts` (98 passed)
  - `npx tsc --noEmit`: clean.

Test-first. The repro finds a real standable top inside the battleground band
(the search asserts it is a deck, over 4 yards above the ground, not a kerb),
stands a player on it, applies the fear aura as the effect dispatch does, and
ticks. Before the fix the body was at y 2.06 with the deck at 10.05: eight yards
inside the rampart.

Four cases, and one of them exists to stop the fix overcorrecting: a feared
player on open terrain must still track the ground down, never get welded to a
height they have walked off.

**A trap worth naming, because it cost me a green test.** My first floor
assertion asked `floorHeightAt` from the body's CURRENT height. That query is
capped at `maxY`, so a body which has already sunk can no longer see the deck it
fell through, and the check passed on exactly the state it was written to catch.
It now asks from the height the body stood at.

### Parity

Green. Worth stating why rather than treating it as proof: the change is scoped
to `e.kind === 'player'`, and no golden scenario fears a player standing on a
standable prop, so green here means the mob paths are provably untouched, not
that the fear path is covered. The four new tests are that coverage.

## Screenshots / recordings

Not a visual change.

---

## Checklist

### Quality

- [x] **The full gate passes.** `node scripts/gate_select.mjs`, 12/12 green.
- [x] Determinism: no rng, no clock, no new draw sites. `tests/architecture.test.ts` green.

### Cross-platform

- [x] Pure `src/sim/` change behind existing seams, so the offline browser world,
      the authoritative server and the headless env get identical behavior. No
      `IWorld` member, no wire change.

### Localization (i18n)

- [x] No player-facing string added or changed.

### Hygiene

- [x] No secrets or `.env`; `ALLOW_DEV_COMMANDS` untouched.
- [x] No generated file hand-edited.
