### PR TITLE
fix(ui): badge party frames at the range a heal actually reaches

### DIFF
--- a/src/ui/party_frames.ts
+++ b/src/ui/party_frames.ts
@@ -2,7 +2,24 @@ import { isPartyFrameRelevantAura } from '../sim/aura_classify';
 import type { PartyInfo, PartyMemberInfo } from '../world_api';
 import type { PartyPetInfo } from './pet_frame_view';
 
-export const PARTY_FRAME_RANGE_YD = 100;
+/**
+ * The distance past which a party/raid row is badged out of range.
+ *
+ * This is the healer's ONLY signal for "can I reach them", so it has to be the
+ * range they can actually cast at, not the range at which the client still knows
+ * the body exists. It was 100, close to the interest radius, while every
+ * friendly-targeted ability in the game is 30: a member anywhere from 30 to 100
+ * yards away showed a clean row and refused every heal with "Out of range",
+ * which is exactly what battleground healers reported.
+ *
+ * Pinned against the real ability table by `tests/party_frames.test.ts`, so
+ * retuning heal range fails the test rather than silently desyncing the badge.
+ *
+ * What it still cannot tell you is LINE OF SIGHT: a member in range behind a
+ * wall reads as reachable and the cast refuses. That is a separate surface, not
+ * something a distance threshold can express.
+ */
+export const PARTY_FRAME_RANGE_YD = 30;
 
 /** A member row's data. `pet` is attached CLIENT-SIDE from the entity roster
  *  (findPetsByOwner), not from the party wire: absent when the member has no pet,

--- a/tests/party_frames.test.ts
+++ b/tests/party_frames.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
+import { ABILITIES } from '../src/sim/data';
 import {
   DEFAULT_PARTY_FRAME_DISPLAY,
+  PARTY_FRAME_RANGE_YD,
   partyFrameAuraIsRelevant,
   partyFrameHealthText,
   partyFrameSignature,
@@ -350,14 +352,16 @@ describe('ClientWorld-vs-Sim out-of-range parity', () => {
     }
   });
 
-  it('pins the accepted divergence at the exact 100yd boundary (sub-cm rounding flips oor)', () => {
-    // dist 100.003: the full-precision Sim is out of range (100.003 > 100); the mirror
-    // rounds the coordinate to 100.00, which is NOT > 100, so it reads in range. This
+  it('pins the accepted divergence at the exact range boundary (sub-cm rounding flips oor)', () => {
+    // Just past the threshold: the full-precision Sim is out of range; the mirror
+    // rounds the coordinate back onto it, which is NOT > the threshold, so it reads
+    // in range. Taken FROM the constant rather than spelled as a literal, which is how
+    // this test came to pin a 100yd boundary that no ability could reach. This
     // ~2cm knife-edge disagreement at the threshold is the accepted
     // tolerance (like the absorb case). Pinning it gives the parity block teeth: a change
     // to the comparison (> vs >=), the range constant, or the mirror's rounding model
     // would move this boundary and fail here, where the ~50yd cases cannot.
-    const dist = 100.003;
+    const dist = PARTY_FRAME_RANGE_YD + 0.003;
     const sim: PartyInfo = {
       leader: 1,
       raid: false,
@@ -532,5 +536,35 @@ describe('party pets in the selector and the signature', () => {
     expect(partyFrameSignature(party, 1, pos, undefined, DEFAULT_PARTY_FRAME_DISPLAY, pets())).toBe(
       partyFrameSignature(party, 1, pos, undefined, DEFAULT_PARTY_FRAME_DISPLAY, pets()),
     );
+  });
+
+  it('badges at the range a helpful spell actually reaches, taken from the ability table', () => {
+    // The bug this fixes: the badge fired at 100 yards while every friendly cast
+    // is 30, so a member from 30 to 100 yards out showed a clean row and refused
+    // every heal. Derived from the real table, never a second copy of the number,
+    // so retuning heal range fails HERE instead of silently desyncing the badge.
+    const castable = Object.values(ABILITIES).filter(
+      (a) => a.requiresTarget && (a.targetType === 'friendly' || a.targetType === 'any'),
+    );
+    expect(castable.length, 'the table really does declare friendly targets').toBeGreaterThan(10);
+    const longest = Math.max(...castable.map((a) => a.range));
+    expect(PARTY_FRAME_RANGE_YD).toBe(longest);
+  });
+
+  it('badges a member past that range, and does not badge one inside it', () => {
+    const pos = { x: 0, z: 0 };
+    const at = (d: number) => {
+      const info: PartyInfo = {
+        leader: 1,
+        raid: false,
+        master: { enabled: false, looter: 0, threshold: 'uncommon' },
+        members: [member(1, 1), member(2, 1, d, 0)],
+      };
+      return selectPartyFrameMembers(info, 1, pos).find((m) => m.pid === 2)?.oor;
+    };
+    expect(at(PARTY_FRAME_RANGE_YD - 1), 'inside the cast range: reachable').toBe(false);
+    expect(at(PARTY_FRAME_RANGE_YD + 1), 'past it: badged').toBe(true);
+    // The old threshold, which is the middle of the reported dead zone.
+    expect(at(60), 'the 60yd case healers complained about now badges').toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Battleground healers reported frames that look reachable and heals that bounce:
"targets in raid frame seems to be in range but they arent... his frame is like
close to me but he isnt".

The out-of-range badge is the healer's only signal for "can I reach them", and it
fired at **100 yards**. Every friendly-targeted ability in the game is **30**:

```
targetType 'friendly': 27 abilities, every one of them range 30
targetType 'any'     :  3 abilities, range 30
longest targeted range in the entire game: 35 (an enemy spell)
```

So a party member anywhere from 30 to 100 yards away showed a clean row, no
badge, looking perfectly reachable, and refused every heal with "Out of range".
A 70-yard dead zone with nothing on screen explaining it.

100 is close to the interest radius, so the number reads like it was chosen for
"is this person loaded in my world bubble" rather than "can I cast on them".

## What it still cannot tell you

Line of sight. A member in range behind a wall reads as reachable and the cast
refuses. A distance threshold cannot express that, and it is noted at the
constant so the next reader does not assume the badge covers it.

## Related issues

N/A

## Type of change

- [x] Bug fix

## How was this tested?

- Commands:
  - `node scripts/gate_select.mjs`: **PASS, all 12 steps green.**
  - `npx vitest run tests/party_frames.test.ts` (26 passed)
  - `npx vitest run tests/party_frame_info.test.ts tests/party_frame_projection.test.ts
    tests/party_frames_painter.test.ts tests/unit_frame.test.ts tests/hud_frames.test.ts
    tests/architecture.test.ts` (117 passed)
  - `npx tsc --noEmit`: clean.

The new pin derives the threshold from the REAL ability table rather than
restating the number, so retuning heal range fails here instead of silently
desyncing the badge again:

```ts
const castable = Object.values(ABILITIES).filter(
  (a) => a.requiresTarget && (a.targetType === 'friendly' || a.targetType === 'any'),
);
expect(PARTY_FRAME_RANGE_YD).toBe(Math.max(...castable.map((a) => a.range)));
```

...guarded by a vacuity floor, since a filter that matched nothing would make the
`Math.max` assertion meaningless. Plus a behavioral case: inside the range no
badge, past it a badge, and specifically that the 60-yard case healers
complained about now badges.

**Why the drift survived this long is worth noting for the reviewer.** The
existing boundary test spelled the old threshold as a literal (`const dist =
100.003`), so it pinned the wrong number as hard as the right one would have
been. It now takes the value from the constant, which is what lets that test
catch the next drift instead of enshrining it.

## Screenshots / recordings

Not captured. The change is one threshold on an existing badge with no new
visual: showing it needs two partied players 60 yards apart, which the offline
capture rig cannot stage. The behavior is pinned by the tests above instead.

---

## Checklist

### Quality

- [x] **The full gate passes.** `node scripts/gate_select.mjs`, 12/12 green.

### Cross-platform

- [x] Pure UI core change; the selector and the signature both already took
      `rangeYd` as a parameter, so Sim and ClientWorld are affected identically
      (the mirror/full-precision parity block covers both).

### Localization (i18n)

- [x] No new string. The badge reuses `hud.errors.outOfRange`.

### Hygiene

- [x] No secrets or `.env`; `ALLOW_DEV_COMMANDS` untouched.
- [x] No generated file hand-edited.
