### PR TITLE
docs(farming): add the farming phased implementation packet

### DIFF
--- a/docs/farming/README.md
+++ b/docs/farming/README.md
@@ -1,0 +1,42 @@
+# Farming packet
+
+Farming: the fifth gathering profession. OSRS-style shared garden patches in four hub
+zones, per-player crops with offline wall-clock growth, front-loaded tending (two
+visits per cycle, nothing ever rots), skill-scaled survival and yield, an insurance
+economy (compost, farmer's watch, growth tonic, withered husks), cooking and alchemy
+integration up to well-fed buff dishes and a placeable shared feast, the Harvest
+Journal timer window, and a procedural-first art pass with a swap-ready handoff list.
+
+Orient here, then read in this order:
+
+- `state.md`: THE cheat sheet. Locked decisions D1 to D24, constraints, blast-radius
+  and seam references, validation matrix, ledgers, OPEN items. Every session reads
+  this first.
+- `implementation-plan.md`: phase index with live-surface notes, the canonical
+  per-phase workflow, the Review Dispatch Matrix (the one canonical copy), scaling and
+  hygiene rules.
+- `progress.md`: status table and per-phase checklists.
+- `brainstorm.md`: vision, research digest, reuse map, wave-2 parking lot.
+- `qa-checklist.md`: the whole-feature integration matrix for the final phase.
+
+Phase files, in order (each implementation phase has a QA twin):
+
+1. `phase-01-foundation.md` / `phase-01-qa.md`
+2. `phase-02-patches-and-plots.md` / `phase-02-qa.md`
+3. `phase-03-growth-engine.md` / `phase-03-qa.md`
+4. `phase-04-knobs.md` / `phase-04-qa.md`
+5. `phase-05-crops-and-tools.md` / `phase-05-qa.md`
+6. `phase-06-economy-hooks.md` / `phase-06-qa.md`
+7. `phase-07-render-and-juice.md` / `phase-07-qa.md`
+8. `phase-08-harvest-journal.md` / `phase-08-qa.md`
+9. `phase-09-world-presence.md` / `phase-09-qa.md` (go-live)
+10. `phase-10-celebrations.md` / `phase-10-qa.md`
+11. `phase-11-well-fed-food.md` / `phase-11-qa.md`
+12. `phase-12-shared-feast.md` / `phase-12-qa.md`
+13. `phase-13-integration-polish.md` / `phase-13-qa.md` (offers packet teardown)
+
+Working agreements: all farming work happens in the persistent worktree
+`~/Documents/woc-farming-plan`; every phase re-resolves the newest `release/**`
+branch at session start; each phase is its own PR; the packet docs never ship (the
+final QA phase offers teardown; the asset handoff manifest lives in
+`docs/design/farming-asset-manifest.json` so it survives).

--- a/docs/farming/brainstorm.md
+++ b/docs/farming/brainstorm.md
@@ -1,0 +1,80 @@
+# Farming: vision and research brief
+
+## The vision
+
+Farming is the fifth gathering profession and the game's first between-sessions
+mechanic: plant at a shared garden patch in a hub, make every decision up front
+(compost, farmer's watch, tonic), leave and play the game, and come back whenever you
+like to a harvest that never rots. It serves the players who skill rather than quest
+or raid, converts logins into progress, and gives the world stewardship: the only
+skill where the world holds YOUR state. The fun contract: two visits per cycle, risk
+only where the player chose thrift over insurance, yields that visibly climb with
+skill, and a rare golden harvest the whole zone hears about.
+
+## Research digest (2026-08-07, four commissioned reports; lessons baked into state.md)
+
+- OSRS Farming (the model): wall-clock offline growth with NO spoilage is the line
+  between a beloved check-in ritual and a chore. The farm run is overlay content
+  layered on other play. Harvest-lives yield (guaranteed floor, skill-scaled save
+  chance, rare highs). Compost and protection payments form an insurance market.
+  Vanilla shipping no patch timers made a third-party timer stack de facto mandatory:
+  ship the timer UI in-game (the Harvest Journal).
+- RS3 Player-Owned Farm and the dailyscape purge (the warning): punishing absence
+  (decay) plus best-in-slot rewards turns offline growth into a leash; Jagex nerfed
+  POF within a month and later deleted nine daily systems. No daily resets anywhere in
+  farming.
+- WoW Sunsong Ranch (the warm precedent): a farm in a shared market town, plots grown
+  as an earned reward, chore texture with personality, NPC friendship. WoD garrisons
+  (the economy killer): removing travel, profession investment, and shared-world
+  scarcity while keeping rewards shattered the materials market and emptied the world.
+  Farming stays IN the hubs, on a travel circuit, feeding the shared market.
+- Stardew Valley (the feel bible): the field is the progress UI (visible growth
+  stages, wet soil, harvest pops); chores are bounded so they end before they sour;
+  automation is earned and stops before full passivity.
+- Wider MMO survey: solve land with abundance (shared patches, per-player state),
+  never auctions or housing gates (ArcheAge land rushes, FFXIV housing lottery); bound
+  output by patch count and cycle length, not daily budgets or punishment (FarmVille
+  wither is the anti-pattern); embodied verbs on a visible plot, never menu farming
+  (FFXIV Island Sanctuary's failure); adjacency puzzles add optimizer depth as pure
+  data (Palia; parked to wave 2).
+
+Game and system names in this digest are research citations only, never candidate
+names for anything in this game (the D17 IP-safety rule).
+
+## What we reuse (verified against release/v0.36.0)
+
+The gathering profession chassis (content record, proficiency map, gain queue, bands,
+tools, wield gate, tool effects), the fishing integration shape (own driver module,
+own zone side table, own content tables, no GatherNodeType), the wall-clock seam
+(`ctx.lockoutNowMs`, the raidLockouts idiom), the pre-rolled hidden-outcome template
+(fishing bite delay), the per-viewer patch-state precedent (node readiness), the
+elixir aura arm (well-fed), the entity snapshot (the feast), the banner queue and the
+`gatherRareEvent` notice shape, the deeds catalog, the work-order cadence and payout
+guard, the market, the wiki generator, the procedural icon system, the image-to-glb
+pipeline, and the pr-screenshots and i18n toolchains.
+
+## What is genuinely new
+
+The FARM_PATCHES table and its placement guard suite; per-player plot state with
+epoch-ms growth deadlines; the plant/harvest command pair and growth script; the
+knobs (compost, watch, tonic, husks); the farming rollout arms in R37; a farming
+objective arm for quests; the wellfed ItemDef arm; the placeable shared feast; the
+Harvest Journal window; farm props and crop growth-stage meshes; the ready notices.
+
+## Design decisions
+
+All locked decisions live in `docs/farming/state.md` (D1 to D24). Do not restate them
+here; this file is background.
+
+## OPEN items
+
+See the OPEN list in state.md: crop display-name lore pass, tuning constants
+(proposed per phase, maintainer-flagged), the any-profession deed consequence,
+seed-back rates, feast charges.
+
+## Wave 2 parking lot (approved directions, explicitly out of this packet)
+
+Crop-adjacency buffs (spatial optimizer depth as pure crop data); cultivated herbs
+for alchemy WITH the displacement guardrail (complement wild herbalism, never a second
+faucet of the identical item; the garrison lesson); premium compost tiers; per-bed
+social presence (a lightweight occupied flag so other players' tending is visible).

--- a/docs/farming/implementation-plan.md
+++ b/docs/farming/implementation-plan.md
@@ -1,0 +1,161 @@
+# Farming: implementation plan (TOC + canonical workflow)
+
+Farming is the fifth gathering profession: OSRS-style patch farming with offline
+wall-clock growth, front-loaded tending, and an anti-chore contract. The design
+authority is `docs/farming/state.md` (locked decisions D1 to D24). This file is the
+table of contents, the canonical per-phase workflow, and the one canonical copy of the
+Review Dispatch Matrix. Each phase is a self-contained session prompt in its own file.
+
+## Phase index
+
+| Phase | File | One line | Live surface after merge |
+|---|---|---|---|
+| 1 | `phase-01-foundation.md` | Register farming as the fifth gathering profession; sweep every silent-miss site; icon; pins; deliberate full golden regen | Farming row visible at 0 skill; nothing gainable |
+| 1 QA | `phase-01-qa.md` | Verify Phase 1 | |
+| 2 | `phase-02-patches-and-plots.md` | FARM_PATCHES content + farming_zones side table + placement guard suite + PlayerMeta/CharacterState plot state + IWorldFarming facet reads + the fplot self key | Dormant (no commands yet) |
+| 2 QA | `phase-02-qa.md` | Verify Phase 2 | |
+| 3 | `phase-03-growth-engine.md` | Plant and harvest commands, pre-rolled growth script, survival and yield resolution, gain schedule, updateFarming driver, draw-count contract, farming_session parity scenario | Dormant online (no seeds obtainable); testable via dev commands |
+| 3 QA | `phase-03-qa.md` | Verify Phase 3 | |
+| 4 | `phase-04-knobs.md` | Compost, farmer's watch (produce fee), growth tonic application, withered husks, husk-to-compost conversion | Dormant: knob items exist with no faucet until Phase 9 |
+| 4 QA | `phase-04-qa.md` | Verify Phase 4 | |
+| 5 | `phase-05-crops-and-tools.md` | The eight crops (seed + produce + fine twin), hoe ladder, seed faucets, the farming rollout arms in R37 | Dormant by choice: seeds deliberately unstocked until Phase 9 |
+| 5 QA | `phase-05-qa.md` | Verify Phase 5 | |
+| 6 | `phase-06-economy-hooks.md` | Cooking dishes (plain), the alchemy tonic recipe, recipe economy and market conformance | Dormant: recipes visible but inputs unobtainable |
+| 6 QA | `phase-06-qa.md` | Verify Phase 6 | |
+| 7 | `phase-07-render-and-juice.md` | Procedural swap-ready beds and crop growth stages, plant and harvest VFX, placeholder SFX | Beds visible in the four hubs, decorative until go-live |
+| 7 QA | `phase-07-qa.md` | Verify Phase 7 | |
+| 8 | `phase-08-harvest-journal.md` | The Harvest Journal window (view core + painter), map and minimap pins, live countdowns, the login and online ready notices | The timer surface exists; empty states until go-live |
+| 8 QA | `phase-08-qa.md` | Verify Phase 8 | |
+| 9 | `phase-09-world-presence.md` | The farmer NPCs (Jessica at Eastbrook), the intro quest and its objective arm, vendor stock, work orders, the deliberate NPC golden regen | GO-LIVE: the full loop opens with visuals and timers already shipped |
+| 9 QA | `phase-09-qa.md` | Verify Phase 9 | |
+| 10 | `phase-10-celebrations.md` | golden_harvest rare event, farming deeds and the farming-100 title | LIVE |
+| 10 QA | `phase-10-qa.md` | Verify Phase 10 | |
+| 11 | `phase-11-well-fed-food.md` | The wellfed ItemDef arm, buff dishes per tier, aura naming and tooltips | LIVE |
+| 11 QA | `phase-11-qa.md` | Verify Phase 11 | |
+| 12 | `phase-12-shared-feast.md` | The placeable tier-4 feast entity: charges, per-player ledger, expiry, interaction | LIVE |
+| 12 QA | `phase-12-qa.md` | Verify Phase 12 | |
+| 13 | `phase-13-integration-polish.md` | Wiki prose, screenshots, the asset handoff manifest in docs/design, whole-feature QA sweep | LIVE, complete |
+| 13 QA | `phase-13-qa.md` | Final QA; offers packet teardown | |
+
+Dormancy rule: a phase may merge with its surface dormant (players cannot reach it)
+but never half-reachable. Each phase file's Live-surface note is binding; the QA twin
+verifies it.
+
+Ordering rationale: visuals (Phase 7) and the timer surface (Phase 8) deliberately
+land BEFORE go-live (Phase 9), deviating from the usual polish-last ordering, because
+farming must never ship blind (invisible beds) or timerless (the OSRS third-party
+timer lesson). Go-live is the moment seeds reach vendors and the intro quest exists,
+and by then the experience is already beautiful and legible.
+
+## Canonical per-phase workflow
+
+Every phase runs as a fresh Claude Code session on Opus 4.8 at xhigh effort (1m
+context variant where the file load demands it; add `ultracode` to the starter prompt
+for the batch-heavy phases where the file says so).
+
+- Step 0, pre-flight: work in `~/Documents/woc-farming-plan` ONLY (the persistent
+  farming worktree; other sessions share the main checkout). `git status` must be
+  clean. Re-resolve the NEWEST `release/**` branch by version sort (`git branch -r
+  --list 'origin/release/*' | sort -V`), fetch, and branch this phase off its tip
+  (`fix/farming-phase-NN-<slug>` or `feature/...` per the change). If the branch is
+  long-lived and release moved mid-phase, merge release in and run the
+  release-merge-audit skill. Scan Claude Code memory (`MEMORY.md` index, the
+  farming-skill-program entry, and any domain-matching entries).
+- Step 1, load context: spawn an Explore agent to read and summarize
+  `docs/farming/state.md`, `docs/farming/progress.md`, this phase's file, and the
+  phase-listed source files plus the relevant `CLAUDE.md` files. The orchestrator does
+  not read large docs or coordinator monoliths directly.
+- Step 2, execute: pick the lightest orchestration (Explore for recon, parallel Agent
+  fan-out for independent vertical slices capped at about 5, an `ultracode` Workflow
+  past that). Request fan-out explicitly; give each agent only the Explore summary and
+  its own slice. Each agent owns a complete vertical slice including its tests.
+- Step 3, validate + review: run the state.md validation matrix rows the diff demands.
+  Then check `git diff --name-only` against the phase-start commit and spawn ONLY the
+  review agents whose Dispatch Matrix row matches. Prompt every review agent for
+  COVERAGE, not filtering ("report every issue including low-severity and uncertain
+  ones; ranking happens later"), give each a hard 30-tool-call budget and
+  report-first instructions, and resume a truncated agent with: "Stop reading more
+  files. Output the full report now based on what you have already seen. No more tool
+  calls. Format: BLOCKING / SHOULD-FIX / NICE-TO-HAVE / VERDICT." Do not commit until
+  no BLOCKING remains.
+- Step 4, docs + memory: update `docs/farming/progress.md` and `docs/farming/state.md`
+  (ledgers, deviations, drift notes; sweep the QA twin whenever a phase file is
+  amended). Record surprises in Claude Code memory. Commit docs with the
+  implementation using EXPLICIT paths, never `git add -A`.
+- Delivery: gate with `node scripts/gate_select.mjs` (deep check: `npm run gate`;
+  the armory browser red is the standing environmental exception, PR CI is the
+  arbiter), push, open the PR against the release branch the phase was based on,
+  following `.github/PULL_REQUEST_TEMPLATE.md`. Visual phases attach before/after
+  screenshots via the pr-screenshots skill. No Claude attribution or session links in
+  commits or PR text.
+
+## Review Dispatch Matrix (the one canonical copy; starter prompts reference it)
+
+Match the change surface to the agent. Spawn an agent ONLY when its row matches the
+diff:
+
+| Agent | Spawn ONLY when the diff touches | Skip it for |
+|-------|----------------------------------|-------------|
+| `privacy-security-review` | `server/`, `src/admin/`, `src/net/`, a deploy/secret file, OR introduces SQL / auth / a secret / `ALLOW_DEV_COMMANDS` / a new `Math.random`, `Date.now`, or `performance.now` in `src/sim/` | a pure `src/ui` / `src/render` / `src/game` / `src/sim/content` / docs / test change |
+| `migration-safety` | `server/db.ts`, `server/social_db.ts`, a `server/*_db.ts`, or a `characters.state` JSONB serialize/deserialize path | any diff with no DDL and no persisted-state shape change |
+| `database-performance-reviewer` | SQL or a database call site, schema/indexes, query cadence or cardinality, pool/lock/timeout behavior, scheduled database work, or stored-data growth | any diff that cannot change database work or growth |
+| `cross-platform-sync` | `src/world_api.ts` or `src/world_api/**`, `src/sim/` behavior/`SimEvent`s, `src/net/online.ts`, `server/game.ts` wire/dispatch, the matchers `src/ui/sim_i18n.ts` / `src/ui/server_i18n.ts`, or the RL surface | a pure i18n catalog refactor with `t()` keys unchanged |
+| `architecture-reviewer` | a `src/sim/` change: determinism, rng draw order, tick-phase order, the `SimContext` seam, or a relocation | a non-sim change, or a pure data/content/test change |
+| `frontend-seam-reviewer` | `src/ui/`, `src/render/`, `src/game/`, or `src/styles/` | a diff with no frontend surface |
+| `qa-checklist` | a phase / deliverable set is COMPLETE | per-commit or mid-phase work, or a docs/test-only change |
+
+If NO row matches (docs-only, test-only, comments), spawn NO review agent. Do not
+default to running `privacy-security-review` anyway.
+
+## Agent scaling
+
+The starter prompts suggest a default split; assess the real workload and scale.
+Split when a single agent would own four or more independent concerns or ten or more
+deliverables; merge when one side is one or two trivial changes; dedicated test agents
+only for genuinely complex multi-suite coverage; past about five parallel agents,
+write an `ultracode` Workflow (pipeline plus adversarial verify) instead of
+hand-spawning. Split by domain (a slice plus its tests), never by file type. Use
+`isolation: "worktree"` only when agents mutate overlapping files in parallel.
+
+## Code hygiene (every phase)
+
+Module-first behind existing seams; never grow a coordinator. Every new system,
+command, IWorld member, endpoint, and behavior gets tests, including a same-seed
+determinism pin for sim logic. Fix bugs test-first. Update or remove tests you break;
+no orphaned tests, no dead code, no unused imports, no commented-out code, no
+hand-edits to generated files (regenerate via the owning build step). The sim import
+invariant holds: `src/sim/` imports nothing from render, ui, game, or net, and has no
+DOM or Three imports.
+
+## Persistence phases
+
+Farming's persisted state is JSONB character state only (no DDL is planned). Any
+phase that touches the save shape: fields are OPTIONAL with defaults so pre-farming
+saves load cleanly; add a save-then-load round-trip test; loading must clamp and
+sanitize (the `normalizeGatheringProficiency` pattern). If a phase ever does need
+DDL, it is additive and idempotent (`IF NOT EXISTS`) in the inline schema, with
+`migration-safety` dispatched.
+
+## Mobile and performance (every client phase)
+
+Touch controls and safe areas respected; verify with the mobile screenshot scripts
+against a phone viewport. Comfortable tap targets; no hover-only information. Sim work
+stays inside the 20 Hz budget with no per-tick allocation in hot paths; snapshots stay
+interest-scoped and delta-guarded; per-frame painters are write-elided and sorted by
+`tests/hud_perf_budget.test.ts`. Graphics settings stay gameplay-neutral: the Harvest
+Journal timers and ready notices are actionable information and may never be shed by a
+tier knob.
+
+## Deploys
+
+No phase deploys. Deploy is a deliberate separate step per `DEPLOY.md`, gated on a
+green `npm run gate` (release-tier on a `release/**` branch) and never with
+`ALLOW_DEV_COMMANDS=1`.
+
+## Packet teardown
+
+The final QA phase, once everything is green, surfaces every deferred item and then
+asks explicitly: "All phases are complete and green. OK to delete `docs/farming/`
+(the planning scaffolding) before the PR?" Delete only on explicit confirmation, only
+that directory, with explicit paths. The asset handoff manifest lives in
+`docs/design/farming-asset-manifest.json` precisely so it survives this teardown.

--- a/docs/farming/phase-01-foundation.md
+++ b/docs/farming/phase-01-foundation.md
@@ -1,0 +1,253 @@
+# Phase 1: Foundation: the fifth gathering profession
+
+This phase registers farming everywhere the profession chassis looks: the id union,
+the profession record, the id list, the UI name and denial copy, the procedural icon,
+the wiki, and every test pin that moves when a fifth gathering profession appears. It
+adds no gameplay: no patches, no commands, no way to gain skill. The design authority
+is `docs/farming/state.md` (D1, D23, the blast-radius reference); this file cites it
+rather than re-deriving anything.
+
+Live-surface note (binding): after this phase merges, the farming row renders at 0 in
+the professions window gathering section and the character sheet, the wiki farming page
+exists, and there is deliberately NO way to gain farming skill yet. Nothing else is
+player-reachable.
+
+### Starter Prompt
+
+```
+This is Phase 1 of the Farming feature: "Foundation: the fifth gathering profession".
+Model: Opus 4.8, xhigh effort (1m context variant where the file load demands it).
+Harness: Claude Code.
+
+Goal: farming exists everywhere the profession chassis looks, with every silent-miss
+site swept and every moved pin re-pinned, and with zero rng change proven by the
+parity fingerprint before the deliberate full golden regen.
+
+STEP 0 - PRE-FLIGHT
+- Work ONLY in the persistent worktree ~/Documents/woc-farming-plan. Never touch the
+  main checkout. Use git -C /home/fernandoramirez/Documents/woc-farming-plan for every
+  git command (the Bash cwd drifts).
+- git status must be clean. If it is not, stop and surface it.
+- Re-resolve the NEWEST release branch: git fetch origin --prune, then
+  git branch -r --list 'origin/release/*' | sort -V and take the last row. Create
+  branch fix/farming-phase-01-foundation off its tip. Record the phase-start commit
+  hash for the STEP 3 diff. If release moves mid-phase and this branch goes
+  long-lived, merge release in and run the release-merge-audit skill.
+- Scan Claude Code memory: the MEMORY.md index, the farming-skill-program entry, plus
+  these phase-relevant topics: node25-breaks-jsdom-gate (the standing armory browser
+  gate red), i18n-semantic-regressions-gate-trap, big-diff-reviewer-turn-budgets,
+  worktree-cwd-drift-misroutes-git, mutation-checks-commit-first.
+
+STEP 1 - LOAD CONTEXT
+Spawn ONE Explore agent (breadth: very thorough) to read and summarize:
+- docs/farming/state.md (all of it: locked decisions, the blast-radius reference, the
+  validation matrix) and docs/farming/progress.md.
+- This phase file, docs/farming/phase-01-foundation.md.
+- The source surface for this phase: the module exporting GatheringProfessionId,
+  GATHERING_PROFESSIONS, and GATHERING_PROFESSION_IDS (locate by exported symbol);
+  src/ui/gathering_profession_name.ts (GATHERING_PROFESSION_NAME_KEYS);
+  src/ui/gathering_view.ts (gatherDeniedLineKey, gatherToolNoNodeKey);
+  src/ui/i18n.catalog/hud_chrome.ts; the procedural icon module the existing gather_*
+  icons live in (locate by icon id); tests/professions_contracts.test.ts;
+  tests/profession_icons.test.ts; tests/snapshots.test.ts (the proficiency round-trip
+  literal); tests/professions_skill_caps.test.ts; tests/professions_blob_growth.test.ts;
+  the parity harness entry under tests/parity (how goldens sample proficiency and
+  where the rng draw-order fingerprint lives in the digest).
+- CLAUDE.md files: the root CLAUDE.md, src/sim/CLAUDE.md, src/sim/professions/CLAUDE.md,
+  src/ui/CLAUDE.md.
+The orchestrator never reads planning docs or coordinator monoliths directly; it works
+from this summary. The summary MUST return: (1) the resolved path of the profession id
+module, the exact current union member order, and the append-last iteration-order
+comment text; (2) the full shape of the fishing GATHERING_PROFESSIONS row to copy;
+(3) the current arms and fallthrough behavior of gatherDeniedLineKey and
+gatherToolNoNodeKey; (4) the hud_chrome.ts key naming pattern for the four
+per-profession families (toolTierUnmet, toolRequired, wieldUnmet, noNodeNearby) and
+the display-name key for an existing profession, plus what the M16 wordiness rule
+triggers on; (5) the gather_* icon recipe: file, registration, and what
+tests/profession_icons.test.ts demands; (6) every pinned literal that must move, with
+its current value (the contracts exact-order skills array, the snapshots round-trip
+literal, skill caps, blob growth); (7) how the parity digest samples proficiency and
+where the rng fingerprint sits, plus the UPDATE_PARITY regen command shape; (8) every
+file containing a literal object typed GatheringProficiency; (9) the CLAUDE.md
+constraints that bind this phase; (10) anything in state.md or progress.md that
+contradicts this brief.
+
+STEP 2 - CHOOSE ORCHESTRATION + EXECUTE
+Request fan-out explicitly: spawn the three agents below in parallel, give each agent
+ONLY the Explore summary plus its own slice brief, and never put a teammate in plan
+mode. Each agent owns its vertical slice including its tests. The slices are
+file-disjoint by design; if two agents would touch the same file, serialize them.
+Assess the real workload and merge slices if one turns out trivial.
+
+Agent A, sim registration and contract re-pins:
+- Append 'farming' LAST to the GatheringProfessionId union (D1).
+- Add the GATHERING_PROFESSIONS record row: maxSkill 100, name/icon/description
+  following the fishing row's exact shape (icon id gather_farming).
+- Append 'farming' LAST to GATHERING_PROFESSION_IDS; keep the append-last
+  iteration-order comment (the fishing precedent).
+- Never touch CRAFT_RING (D1: farming is a gathering profession, not an eleventh craft).
+- Re-pin tests/professions_contracts.test.ts: the exact-order skills array gains a
+  fifth row, farming last.
+- Re-pin tests/professions_skill_caps.test.ts and tests/professions_blob_growth.test.ts
+  (the worst-case save blob grows).
+- Run npx tsc --noEmit and add the farming key to every literal GatheringProficiency
+  fixture map it surfaces (mostly test fixtures; farming: 0 unless the fixture's
+  intent demands otherwise).
+
+Agent B, UI sweep (the silent-miss sites; every one of these misses silently at
+runtime today, no compile error):
+- src/ui/gathering_profession_name.ts: a GATHERING_PROFESSION_NAME_KEYS row for
+  farming (an unlisted id renders NO row).
+- src/ui/gathering_view.ts: farming arms in gatherDeniedLineKey and
+  gatherToolNoNodeKey with farming-appropriate English copy; today they silently fall
+  through to the corpse line and the mining line respectively. Add pins that fail on
+  fallthrough: assert the farming id returns a farming-specific key, not the corpse
+  or mining key.
+- src/ui/i18n.catalog/hud_chrome.ts: the farming display name plus all four
+  per-profession key families: toolTierUnmet, toolRequired, wieldUnmet, noNodeNearby.
+  English only; never edit locale overlays, with the one M16 exception: every new
+  value wordy enough to trip M16 also ships its five non-Latin overlay fills in the
+  same change.
+- The gather_farming procedural icon following the existing gather_* recipe;
+  tests/profession_icons.test.ts demands the id and must go green.
+
+Agent C, wire and wiki:
+- tests/snapshots.test.ts: the proficiency round-trip literal gains farming: 0 (the
+  gprof key carries the fifth entry for free, wholesale-replace mirror; verify the
+  suite proves it round-trips).
+- Run npm run wiki:content and stage the regenerated guide content: the farming page
+  auto-appears and the gathering summary line updates. npx vitest run
+  tests/guide.test.ts must go green.
+
+The orchestrator itself owns the parity verify-then-regen sequence in STEP 3: it is
+sequencing-critical and lands as its own isolated commit over the finished tree.
+
+INVARIANTS THIS PHASE MUST KEEP
+- Zero rng change is itself an acceptance criterion: every parity golden may move ONLY
+  by the mechanical farming field add, and the rng draw-order fingerprint in every
+  digest must be identical before the regen.
+- Every player-visible string added this phase is a t() key in ENGLISH ONLY in the
+  matching src/ui/i18n.catalog/ module; every M16-wordy value ships its five non-Latin
+  overlay fills in the same change; no other overlay edit of any kind.
+- Sim purity holds in every touched sim file: zero DOM/browser/Three imports, no
+  imports from render/ui/game/net, no Math.random, Date.now, or performance.now
+  (tests/architecture.test.ts guards it).
+- Every moved test pin is re-pinned deliberately to its new literal, never loosened.
+- All work happens in ~/Documents/woc-farming-plan; every commit uses explicit paths,
+  never git add -A.
+
+Out of scope (do NOT do in this phase):
+- No patches, no plot state, no FARM_PATCHES content.
+- No commands (plant, harvest), no growth logic, no gain schedule, no way to gain
+  farming skill at all.
+- No items (seeds, produce, hoes, husks), no vendors, no recipes.
+- No NPCs, no quests, no windows, no render work, no map pins.
+- No deeds rows (the deeds phase owns them).
+
+STEP 3 - VALIDATION + MULTI-AGENT REVIEW
+Run, in order, and record each result:
+- npx tsc --noEmit
+- npx vitest run tests/professions_contracts.test.ts tests/profession_icons.test.ts
+  tests/snapshots.test.ts tests/architecture.test.ts tests/localization_fixes.test.ts
+- npx vitest run tests/professions_skill_caps.test.ts tests/professions_blob_growth.test.ts
+- The parity verify-then-regen sequence, exactly this order:
+  1. npx vitest run tests/parity BEFORE touching any golden.
+  2. Inspect the failure output: the red must be confined to the mechanical farming
+     field add in the sampled proficiency map, and the rng draw-order fingerprint in
+     every digest must be IDENTICAL. Any other movement means behavior changed: STOP
+     (see STOPPING RULES).
+  3. UPDATE_PARITY=1 npx vitest run tests/parity to regenerate, then npx vitest run
+     tests/parity again to confirm green.
+  4. The regen goes in its OWN commit containing nothing but tests/parity/golden/**.
+- npx vitest run tests/guide.test.ts
+- npm run ci:changed (fix findings with a SCOPED npx @biomejs/biome check --write
+  <file>, never whole-tree)
+- node scripts/gate_select.mjs
+Then run git diff --name-only <phase-start-commit>..HEAD and dispatch ONLY the Review
+Dispatch Matrix rows in docs/farming/implementation-plan.md that match the diff.
+Expected matches for this phase: cross-platform-sync (sim registration plus the wire
+literal), architecture-reviewer (src/sim touched), frontend-seam-reviewer (src/ui
+touched), then qa-checklist once the deliverable set is complete. Every review agent
+gets: a hard 30-tool-call budget, report-first instructions, and the coverage
+instruction "report every issue including low-severity and uncertain ones; ranking
+happens later". If an agent truncates or stalls, resume it with exactly: "Stop reading
+more files. Output the full report now based on what you have already seen. No more
+tool calls. Format: BLOCKING / SHOULD-FIX / NICE-TO-HAVE / VERDICT." No commit while a
+BLOCKING stands.
+
+STEP 4 - COMMIT CADENCE
+Five Conventional Commits, each with a scope and a body (what changed and why, 1 to 4
+sentences after a blank line), explicit paths only, never git add -A, no session links
+or Claude attribution anywhere:
+1. feat(professions): register farming as the fifth gathering profession (union,
+   record row, id list; plus the wiki:content regen output this row caused).
+2. feat(ui): farming name keys, denial copy arms, catalog families, and the
+   gather_farming icon.
+3. test(professions): the re-pin sweep (contracts order, snapshots literal, skill
+   caps, blob growth, proficiency fixtures).
+4. test(parity): the isolated golden regen, nothing but tests/parity/golden/**.
+5. docs(farming): progress and state updates.
+
+STEP 5 - ACCEPTANCE CRITERIA
+- [ ] 'farming' is the LAST member of GatheringProfessionId, GATHERING_PROFESSIONS has
+      its row with maxSkill 100, and GATHERING_PROFESSION_IDS appends it last with the
+      iteration-order comment preserved.
+- [ ] Every silent-miss site named in state.md's blast-radius reference has a farming
+      arm with a pin that fails on fallthrough: GATHERING_PROFESSION_NAME_KEYS,
+      gatherDeniedLineKey, gatherToolNoNodeKey, and the hud_chrome.ts display name
+      plus the toolTierUnmet, toolRequired, wieldUnmet, and noNodeNearby families.
+- [ ] The gather_farming procedural icon exists; tests/profession_icons.test.ts green.
+- [ ] tests/professions_contracts.test.ts green with the fifth skills row pinned in
+      exact order.
+- [ ] tests/snapshots.test.ts green with farming: 0 in the round-trip literal.
+- [ ] npx tsc --noEmit clean: every literal GatheringProficiency fixture compiles.
+- [ ] tests/professions_skill_caps.test.ts and tests/professions_blob_growth.test.ts
+      re-pinned and green.
+- [ ] npm run wiki:content ran; the farming wiki page exists; tests/guide.test.ts green.
+- [ ] The pre-regen parity red was ONLY the mechanical field add with the rng
+      draw-order fingerprint identical; post-regen tests/parity green; the regen
+      commit contains nothing but tests/parity/golden/**.
+- [ ] i18n additions are English-only catalog rows (plus the five non-Latin overlay
+      fills for every M16-wordy value); tests/localization_fixes.test.ts green.
+- [ ] There is no way to gain farming skill: no gain schedule exists, no code path
+      grants farming XP, and the row renders 0 in the professions window and the
+      character sheet.
+- [ ] The PR body flags that farming now automatically satisfies existing
+      any-profession gathering deed arms (the accepted default recorded in state.md's
+      OPEN items).
+
+STEP 6 - DOC UPDATES + MEMORY
+- docs/farming/progress.md: flip the Phase 1 row to done with dates, copy the STEP 5
+  acceptance list here with its check states, add a Notes block (surprises,
+  deviations, deferrals with reasons).
+- docs/farming/state.md: append to the per-phase ledgers (new i18n keys this phase;
+  the other ledgers stay empty). Any deviation decided in-phase gets a "Locked
+  deviations" line AND gets swept into docs/farming/phase-01-foundation.md and
+  docs/farming/phase-01-qa.md in the same pass.
+- Record surprises (a silent-miss site not on the list, a pin that behaved
+  unexpectedly, a parity subtlety) in Claude Code memory.
+
+STEP 7 - FINAL RESPONSE FORMAT
+Report exactly: phase status (complete or partial, with reasons); files touched
+(grouped by commit); validation results (each command, pass or fail); review verdicts
+(per agent, with the BLOCKING count at zero); deferrals (each with a reason and owning
+phase); and a one-line handoff for the QA session (branch, PR number, base release
+branch).
+
+STOPPING RULES
+- STOP immediately if the pre-regen parity red shows ANY draw-order change: the rng
+  fingerprint moving means sim behavior changed, which this phase forbids. Surface the
+  trace; do not regen.
+- STOP if you discover a silent-miss site NOT on the state.md blast-radius list: add
+  it to state.md first (with a pin), then proceed.
+- STOP if git status is dirty at STEP 0, or if a BLOCKING review finding cannot be
+  fixed without leaving this phase's scope; surface to the user.
+
+The new professions-window row is a visual change: capture before/after screenshots
+per the pr-screenshots skill (desktop, and mobile where relevant), commit them under
+docs/screenshots, and reference them from the PR body. Then gate via
+node scripts/gate_select.mjs (the armory browser red is the standing environmental
+exception; grep the log for "[gate] FAIL"; PR CI is the arbiter), push, and open the
+PR against the release branch this phase was based on per
+.github/PULL_REQUEST_TEMPLATE.md.
+```

--- a/docs/farming/phase-01-qa.md
+++ b/docs/farming/phase-01-qa.md
@@ -1,0 +1,128 @@
+# Phase 1 QA: Verify Foundation: the fifth gathering profession
+
+This session audits the Phase 1 PR after it is open: registration completeness, the
+silent-miss sweep (real farming copy, never fallthrough), pin quality, i18n
+completeness, the isolated golden regen, and the binding live-surface note (a farming
+row at 0 with no way to gain skill). Fixes ride the same PR branch as separate
+commits. The design authority is `docs/farming/state.md`; the promises under audit are
+`docs/farming/phase-01-foundation.md`.
+
+### QA Starter Prompt
+
+```
+This is Phase 1 QA of the Farming feature: Verify "Foundation: the fifth gathering
+profession".
+Model: Opus 4.8, xhigh effort (1m context variant where the file load demands it).
+Harness: Claude Code.
+
+Goal: audit Phase 1 for correctness, missing tests, dead code, determinism, three-host
+parity, i18n completeness, and the phase's own acceptance criteria.
+
+STEP 0 - PRE-FLIGHT
+- Work ONLY in the persistent worktree ~/Documents/woc-farming-plan; git status must
+  be clean; use git -C with the absolute path on every git command.
+- git fetch origin --prune, then check out the phase PR branch
+  fix/farming-phase-01-foundation.
+- Identify the phase diff: the PR's commits against its base, NEVER
+  everything-since-phase-start (the release tip may have moved concurrently).
+  Preferred: gh pr diff <PR-number> --name-only and gh pr view <PR-number> --json
+  baseRefName,commits. Fallback: BASE=$(git merge-base origin/<base-release-branch>
+  HEAD); git log --oneline $BASE..HEAD; git diff --name-only $BASE..HEAD.
+- Scan Claude Code memory: the MEMORY.md index, the farming-skill-program entry, plus
+  mutation-checks-commit-first, one-probe-outranks-agreeing-agents,
+  mutation-verdicts-need-exit-code-plus-names, big-diff-reviewer-turn-budgets,
+  node25-breaks-jsdom-gate.
+
+STEP 1 - LOAD CONTEXT
+Spawn ONE Explore agent to read and summarize: docs/farming/state.md (locked
+decisions, the blast-radius reference, the validation matrix), the Phase 1 notes in
+docs/farming/progress.md, the promises in docs/farming/phase-01-foundation.md (its
+deliverables, acceptance criteria, and live-surface note), and the git diff
+--name-only file list over the phase diff. The summary must return: the acceptance
+checklist verbatim, the silent-miss site list from state.md, the per-commit file
+grouping of the PR, and every promise the diff appears NOT to touch.
+
+STEP 2 - QA AUDIT
+Spawn three parallel audit agents. Every agent gets a hard 30-tool-call budget,
+report-first instructions, and the coverage instruction "report every issue including
+low-severity and uncertain ones; ranking happens later". If one truncates or stalls,
+resume it with exactly: "Stop reading more files. Output the full report now based on
+what you have already seen. No more tool calls. Format: BLOCKING / SHOULD-FIX /
+NICE-TO-HAVE / VERDICT."
+
+Agent 1, correctness:
+- Verify every deliverable and every acceptance criterion in
+  docs/farming/phase-01-foundation.md is actually met, against the real code, not the
+  PR description.
+- Phase 1 emphasis: every silent-miss arm renders REAL farming copy, not fallthrough.
+  For the farming id, gatherDeniedLineKey must return a farming-specific key (not the
+  corpse key) and gatherToolNoNodeKey a farming-specific key (not the mining key), and
+  src/ui/i18n.catalog/hud_chrome.ts must resolve the display name and all four
+  families (toolTierUnmet, toolRequired, wieldUnmet, noNodeNearby). Confirm the pins
+  would fail on fallthrough.
+- Phase 1 emphasis: the golden regen commit contains ONLY goldens. Run git show
+  --name-only on that commit and confirm every path is under tests/parity/golden/.
+- Verify the live-surface note: the farming row renders 0 (data-driven sites), the
+  wiki page exists, and NO code path grants farming skill (search for any gain
+  schedule or grant call keyed to farming; there must be none).
+- The offline Sim and online ClientWorld paths behave identically for the new
+  proficiency field (the gprof mirror and the snapshots round-trip literal).
+- Edge cases: empty, boundary, and deny arms of every touched helper.
+- Where sim behavior changed (registration only, expected to be behavior-neutral):
+  run live headless-Sim probes via a throwaway vitest file driving real ticks with an
+  injected ADVANCEABLE clock, then delete the file and verify the tree is clean.
+
+Agent 2, test coverage:
+- Every claimed behavior has a DECISIVE assertion that fails on regression; no
+  constant-self-comparison pins (a pin comparing against the same exported constant
+  production uses proves nothing; literals only).
+- Both arms of every either/all claim (the fallthrough pins need the negative arm:
+  farming returns its own key AND the old professions still return theirs).
+- A determinism pin is present where behavior could drift (the parity fingerprint
+  claim: confirm the phase verified the fingerprint before regen, per the progress.md
+  Notes and the commit ordering).
+- Orphaned tests removed; every re-pinned literal moved deliberately, not loosened.
+- Mutation checks ONLY after committing the current work state first
+  (mutation-checks-commit-first); require a nonzero exit code AND named failing tests
+  before claiming a kill.
+
+Agent 3, dead code and cleanup:
+- Unused imports and types across the diff; the sim import invariant
+  (tests/architecture.test.ts scope: no DOM/Three/render/ui/game/net imports in
+  src/sim/); no unresolved TODOs; naming consistency (gather_farming, farming, the
+  key family naming pattern hud_chrome.ts already uses); no leftover throwaway files.
+
+Then dispatch the Review Dispatch Matrix rows in docs/farming/implementation-plan.md
+that match the phase diff (expected: cross-platform-sync, architecture-reviewer,
+frontend-seam-reviewer), plus qa-checklist as the phase-completion gate. Same budget,
+coverage, and truncation-resume rules.
+
+STEP 3 - FIX
+- Apply ALL BLOCKING and SHOULD-FIX findings test-first: reproduce with a failing
+  test, then the smallest change to green.
+- Run the state.md validation matrix rows the diff demands (at minimum: npx tsc
+  --noEmit, the Phase 1 suites, tests/localization_fixes.test.ts, tests/parity,
+  npm run ci:changed).
+- Separate fix commits with explicit paths, Conventional Commits with bodies, never
+  git add -A, no session links or Claude attribution.
+- After fixes: node scripts/gate_select.mjs (the armory browser red is the standing
+  environmental exception; grep the log for "[gate] FAIL"; PR CI is the arbiter), then
+  push the fix commits to the phase PR branch.
+
+STEP 4 - DOC UPDATES
+- docs/farming/progress.md: fill the Phase 1 QA row (status, dates) and append QA
+  findings to the Phase 1 Notes block.
+- docs/farming/state.md: record any drift discovered (ledger corrections, deviations).
+  If the phase file was amended, sweep this QA twin in the same pass.
+
+STEP 5 - FINAL RESPONSE FORMAT
+Report exactly: verdict PASS / PASS-WITH-FOLLOWUPS / FAIL; counts of issues found and
+issues fixed, by severity; deferrals with reasons; and a one-line handoff (merge
+readiness and what Phase 2 should know).
+
+STOPPING RULES
+- STOP and surface if a BLOCKING cannot be fixed without changing phase scope.
+- STOP if the phase diff cannot be identified cleanly (no PR, an ambiguous base, or
+  foreign commits interleaved).
+Packet teardown never happens in this phase; it belongs to Phase 13 QA only.
+```

--- a/docs/farming/phase-02-patches-and-plots.md
+++ b/docs/farming/phase-02-patches-and-plots.md
@@ -1,0 +1,259 @@
+# Phase 2: Patches and plot state
+
+This phase gives the world its garden beds and each player a persistent plot record:
+the FARM_PATCHES content table with its placement guard suite, the farming_zones pure
+leaf, the PlayerMeta.farmPlots map persisted as an optional CharacterState field, the
+read-only IWorldFarming facet, and the fplot self delta key. The wire carries only the
+public projection: the hidden pre-rolled outcome slots and the yield seed (filled by
+Phase 3) never leave the server. The design authority is `docs/farming/state.md`
+(D2, D3, D23, the seam reference).
+
+Live-surface note (binding): dormant. Nothing is player-reachable after this phase
+merges: no commands, no items, no render, no UI. The patch definitions and plot-state
+plumbing exist under the surface only.
+
+### Starter Prompt
+
+```
+This is Phase 2 of the Farming feature: "Patches and plot state".
+Model: Opus 4.8, xhigh effort (1m context variant where the file load demands it).
+Harness: Claude Code.
+
+Goal: the world knows where garden beds are, and each player can persist plot state,
+with the wire carrying only the public projection.
+
+STEP 0 - PRE-FLIGHT
+- Work ONLY in the persistent worktree ~/Documents/woc-farming-plan. Never touch the
+  main checkout. Use git -C /home/fernandoramirez/Documents/woc-farming-plan for every
+  git command (the Bash cwd drifts).
+- git status must be clean. If it is not, stop and surface it.
+- Re-resolve the NEWEST release branch: git fetch origin --prune, then
+  git branch -r --list 'origin/release/*' | sort -V and take the last row. Create
+  branch fix/farming-phase-02-patches-and-plots off its tip. Record the phase-start
+  commit hash for the STEP 3 diff. If release moves mid-phase and this branch goes
+  long-lived, merge release in and run the release-merge-audit skill.
+- Scan Claude Code memory: the MEMORY.md index, the farming-skill-program entry, plus
+  these phase-relevant topics: round-trip-pins-reference-aliasing (build expectation
+  literals fresh, never compare an object to itself), wire-name-constant-pins-need-
+  literals, vacuous-bound-pin-trap, worktree-cwd-drift-misroutes-git,
+  big-diff-reviewer-turn-budgets, node25-breaks-jsdom-gate.
+
+STEP 1 - LOAD CONTEXT
+Spawn ONE Explore agent (breadth: very thorough) to read and summarize:
+- docs/farming/state.md (all of it) and docs/farming/progress.md (including the
+  Phase 1 Notes).
+- This phase file, docs/farming/phase-02-patches-and-plots.md.
+- The source surface for this phase: src/sim/professions/fishing_zones.ts (the pure
+  leaf template, including its header rules); tests/gather_node_placement.test.ts
+  (the physical-safety arms to clone); the module defining PlayerMeta and the
+  Sim.addPlayer initialization site (locate by symbol); the CharacterState serialize
+  and load path plus node_persist.ts (the load-side anti-tamper pattern, locate by
+  filename); src/world_api/professions.ts (the facet file template);
+  tests/world_api_parity.test.ts (the pinned facet and member-name blocks);
+  src/net/online.ts (how an existing self delta key is mirrored); the modules
+  exporting ALL_DELTA_KEYS and TERSE_TO_IWORLD (locate by exported symbol);
+  tests/snapshots.test.ts (an existing self-key round-trip pin and the server-trim
+  negative-pin precedent); the parity sampler (how PlayerMeta is sampled and how a
+  Map canonicalizes).
+- CLAUDE.md files: the root CLAUDE.md, src/sim/CLAUDE.md, src/sim/professions/CLAUDE.md,
+  src/world_api/CLAUDE.md, server/CLAUDE.md.
+The orchestrator never reads planning docs or coordinator monoliths directly; it works
+from this summary. The summary MUST return: (1) the fishing_zones.ts header rules
+verbatim in compressed form and its reader shape; (2) the exact physical-safety arms
+in tests/gather_node_placement.test.ts and the helpers they call; (3) where PlayerMeta
+lives, how addPlayer initializes per-player maps, and how the parity sampler
+canonicalizes an empty Map; (4) the CharacterState serialize/normalize pattern and the
+node_persist.ts anti-tamper moves (clamp, drop-unknown); (5) the facet-file recipe and
+the exact tests/world_api_parity.test.ts blocks a new facet must update; (6) the full
+end-to-end path of one existing self delta key: server emit site, online.ts mirror,
+ALL_DELTA_KEYS, TERSE_TO_IWORLD, and its snapshots round-trip pin, plus the
+server-trim negative-pin shape; (7) the hub-center coordinates and legal-ground
+constraints for eastbrook_vale, mirefen_marsh, thornpeak_heights, and evergarden;
+(8) the CLAUDE.md constraints that bind this phase; (9) anything in state.md or
+progress.md that contradicts this brief.
+
+STEP 2 - CHOOSE ORCHESTRATION + EXECUTE
+Before fan-out, the orchestrator locks the shared interface in the agent briefs: the
+PlotState field names, the public-projection subset, and the bed id scheme, so the
+slices stay file-disjoint. Then request fan-out explicitly: spawn the three agents
+below in parallel, give each ONLY the Explore summary plus its own slice brief, and
+never put a teammate in plan mode. Each agent owns its vertical slice including its
+tests. Merge slices if one turns out trivial.
+
+Agent A, patch content and placement guard:
+- src/sim/content/farm_patches.ts: export FarmPatchDef (id, zoneId, tier, position,
+  and a per-site bed list with STABLE bed ids that never renumber) and FARM_PATCHES
+  covering the four D2 hubs: eastbrook_vale tier 1, mirefen_marsh tier 2,
+  thornpeak_heights tier 3, evergarden tier 4. Positions sit near the hub centers on
+  legal ground. Decide in-phase, state, and document: the concrete positions and the
+  per-site bed count (uniform or tier-scaled); record the choice in progress.md Notes
+  and the state.md ledger.
+- src/sim/professions/farming_zones.ts: a pure leaf per the fishing_zones.ts header
+  rules: the FARMING_ZONES tier ladder, an Object.hasOwn reader, an explicit row per
+  farming zone, and every knob DERIVED from the tier, never an independent constant.
+- tests/farm_patch_placement.test.ts: clone the physical-safety arms from
+  tests/gather_node_placement.test.ts for FARM_PATCHES: dry land, no collider
+  overlap, a reachable stand spot, zone containment, minimum spacing between beds,
+  and hub reachability.
+
+Agent B, plot state and persistence:
+- PlayerMeta.farmPlots: a Map keyed by bed id; an empty Map canonicalizes to an empty
+  array in the parity sampler (D3).
+- The PlotState shape: crop id, planted-at epoch-ms, ready-at epoch-ms, hidden
+  pre-rolled outcome slots (declared now, filled by Phase 3), applied-knob flags
+  (compost, watch, tonic; all default off, wired in Phase 4), and a notified flag
+  (default false; reserved for the Phase 8 ready notices; serialized with the rest).
+- The OPTIONAL CharacterState field with serialize plus normalize-on-load: clamp
+  deadlines, drop unknown bed ids and unknown crop ids, following the node_persist.ts
+  load-side anti-tamper pattern. Every pre-farming save loads cleanly.
+- Sim.addPlayer initialization (an empty map by default).
+- A save-then-load round-trip test in a new suite tests/professions_farming_state.test.ts
+  (a working name; if refined, note the actual name in progress.md), including the
+  tamper arms: a bogus bed id is dropped, an out-of-range deadline is clamped, and a
+  save with no farming field at all loads clean.
+
+Agent C, facet and wire:
+- src/world_api/farming.ts: the IWorldFarming facet, READS ONLY this phase:
+  farmPatches (the static defs) and myFarmPlots (the public projection per the D3
+  contract: ONLY bed id, crop id, planted-at, ready-at, the applied knob flags, the
+  Phase 8 notified flag, and a server-derived status of growing, ready, or withered,
+  with withered surfacing only at or after ready time). Members land in the facet
+  file, never the barrel. Implement in BOTH Sim and ClientWorld in the same change.
+- tests/world_api_parity.test.ts: the new facet and its member-name block pinned.
+- The fplot self delta key: the server emit, the src/net/online.ts mirror, the
+  ALL_DELTA_KEYS and TERSE_TO_IWORLD set-equality updates, and a snapshots round-trip
+  pin (pin the wire name to its LITERAL string, never through the shared constant).
+- State this rule IN CAPS in a comment in src/world_api/farming.ts: THE WIRE
+  PROJECTION NEVER CARRIES THE HIDDEN OUTCOME SLOTS OR THE YIELD SEED. Enforce it
+  with a negative pin following the server-trim precedent: fill the hidden fields in
+  a fixture plot, serialize, and assert the payload lacks them.
+
+INVARIANTS THIS PHASE MUST KEEP
+- Sim purity in every new sim file: zero DOM/browser/Three imports, no imports from
+  render/ui/game/net, no Math.random, Date.now, or performance.now
+  (tests/architecture.test.ts guards it).
+- Zero new rng call sites this phase: patches are static data and plot state is
+  plumbing; nothing rolls anything.
+- Every wire payload carries only the public projection: the hidden outcome slots and
+  the yield seed never cross the wire, on any path, ever.
+- Every new CharacterState field is OPTIONAL with a default; every pre-farming save
+  loads cleanly; every load path clamps and sanitizes (drop every unknown bed id and
+  crop id, clamp every deadline).
+- The facet rule: every new IWorld member lands in src/world_api/farming.ts (never
+  the barrel), is implemented in BOTH Sim and ClientWorld in the same change, and
+  updates the pinned member lists in tests/world_api_parity.test.ts in the same
+  change.
+- All work happens in ~/Documents/woc-farming-plan; every commit uses explicit paths,
+  never git add -A.
+
+Out of scope (do NOT do in this phase):
+- No commands (plant, harvest), no growth logic, no draw of any kind.
+- No items (seeds, produce, husks, hoes), no knobs (compost, watch, tonic) beyond the
+  default-off flags in the shape.
+- No render work, no UI, no map pins, no notices.
+- No NPCs, no vendors, no quests, no deeds.
+
+STEP 3 - VALIDATION + MULTI-AGENT REVIEW
+Run, in order, and record each result:
+- npx tsc --noEmit
+- npx vitest run tests/farm_patch_placement.test.ts tests/professions_farming_state.test.ts
+- npx vitest run tests/snapshots.test.ts tests/env_protocol.test.ts
+  tests/bandwidth.test.ts tests/architecture.test.ts tests/world_api_parity.test.ts
+- npx vitest run tests/parity: expect green with the empty default (an empty Map
+  canonicalizes to an empty array). If the field add alone moves digests, verify the
+  movement is ONLY the mechanical field add with the rng draw-order fingerprint
+  identical, then UPDATE_PARITY=1 regen in one deliberate isolated commit containing
+  nothing but tests/parity/golden/**. Any other movement: STOP.
+- npm run ci:changed (fix findings with a SCOPED npx @biomejs/biome check --write
+  <file>, never whole-tree)
+- node scripts/gate_select.mjs
+Then run git diff --name-only <phase-start-commit>..HEAD and dispatch ONLY the Review
+Dispatch Matrix rows in docs/farming/implementation-plan.md that match the diff.
+Expected matches for this phase: cross-platform-sync (facet, wire, sim state),
+architecture-reviewer (src/sim touched), migration-safety (the characters state shape
+changed), then qa-checklist once the deliverable set is complete. Every review agent
+gets: a hard 30-tool-call budget, report-first instructions, and the coverage
+instruction "report every issue including low-severity and uncertain ones; ranking
+happens later". If an agent truncates or stalls, resume it with exactly: "Stop reading
+more files. Output the full report now based on what you have already seen. No more
+tool calls. Format: BLOCKING / SHOULD-FIX / NICE-TO-HAVE / VERDICT." No commit while a
+BLOCKING stands.
+
+STEP 4 - COMMIT CADENCE
+Four to five Conventional Commits, each with a scope and a body (what changed and
+why), explicit paths only, never git add -A, no session links or Claude attribution:
+1. feat(professions): FARM_PATCHES content, the farming_zones pure leaf, and the
+   placement guard suite.
+2. feat(professions): farmPlots plot state (PlayerMeta, the optional CharacterState
+   field, normalize-on-load, addPlayer init) and the round-trip suite.
+3. feat(net): the IWorldFarming read facet, the fplot self delta key, the wire pins,
+   and the negative leak pin.
+4. test(parity): the isolated golden regen, ONLY if the field add moved digests,
+   containing nothing but tests/parity/golden/**.
+5. docs(farming): progress and state updates.
+
+STEP 5 - ACCEPTANCE CRITERIA
+- [ ] FARM_PATCHES covers exactly the four D2 hubs at the locked tiers, every bed has
+      a stable id, and the chosen positions and bed counts are documented in
+      progress.md Notes.
+- [ ] tests/farm_patch_placement.test.ts is green with every physical-safety arm: dry
+      land, no collider overlap, a reachable stand spot, zone containment, minimum
+      spacing, hub reachability.
+- [ ] src/sim/professions/farming_zones.ts follows the fishing_zones.ts header rules
+      (Object.hasOwn reader, explicit row per zone, derived knobs); no other module
+      hardcodes a farming zone tier.
+- [ ] PlayerMeta.farmPlots exists, initialized empty in addPlayer; the empty Map
+      canonicalizes to an empty array in the parity sampler.
+- [ ] The CharacterState field is optional with a default: a pre-farming save loads
+      cleanly, proven by a test.
+- [ ] Normalize-on-load clamps deadlines and drops unknown bed and crop ids; the
+      tamper arms are tested.
+- [ ] The save-then-load round trip is green, with expectation literals built fresh
+      (no reference-aliased self-comparison).
+- [ ] IWorldFarming exists with reads only, implemented in BOTH Sim and ClientWorld;
+      tests/world_api_parity.test.ts pins updated and green.
+- [ ] fplot is registered in ALL_DELTA_KEYS and TERSE_TO_IWORLD; the snapshots
+      round-trip pin is green and pins the wire name as a literal.
+- [ ] The negative wire-leak pin proves the projection carries neither the hidden
+      outcome slots nor the yield seed.
+- [ ] tests/parity is green (or moved only by the mechanical field add, regenerated
+      in one isolated goldens-only commit).
+- [ ] tests/architecture.test.ts is green (sim purity; zero new rng call sites).
+- [ ] Nothing is player-reachable: no command, no item, no render, no UI (the
+      live-surface note holds).
+
+STEP 6 - DOC UPDATES + MEMORY
+- docs/farming/progress.md: flip the Phase 2 row to done with dates, copy the STEP 5
+  acceptance list here with its check states, add a Notes block including the chosen
+  patch positions and bed counts.
+- docs/farming/state.md: append to the per-phase ledgers (new IWorld members:
+  farmPatches, myFarmPlots; new wire keys: fplot; the actual round-trip suite name if
+  it differs from the working name). Any deviation decided in-phase gets a "Locked
+  deviations" line AND gets swept into docs/farming/phase-02-patches-and-plots.md and
+  docs/farming/phase-02-qa.md in the same pass.
+- Record surprises (a placement constraint that forced a position, a sampler
+  subtlety, a wire-registration gotcha) in Claude Code memory.
+
+STEP 7 - FINAL RESPONSE FORMAT
+Report exactly: phase status (complete or partial, with reasons); files touched
+(grouped by commit); validation results (each command, pass or fail); review verdicts
+(per agent, with the BLOCKING count at zero); deferrals (each with a reason and owning
+phase); and a one-line handoff for the QA session (branch, PR number, base release
+branch).
+
+STOPPING RULES
+- STOP if the public projection cannot avoid leaking the hidden outcome slots or the
+  yield seed without a design change; surface the conflict, do not ship a leak.
+- STOP if no legal-ground position near a hub center can satisfy the placement guard
+  without moving world colliders (that is a content design change, not a farming
+  decision).
+- STOP if tests/parity moves by anything other than the mechanical field add.
+- STOP if git status is dirty at STEP 0, or if a BLOCKING review finding cannot be
+  fixed without leaving this phase's scope; surface to the user.
+
+When every step above is done and no BLOCKING stands: gate via
+node scripts/gate_select.mjs (the armory browser red is the standing environmental
+exception; grep the log for "[gate] FAIL"; PR CI is the arbiter), push, and open the
+PR against the release branch this phase was based on per
+.github/PULL_REQUEST_TEMPLATE.md.
+```

--- a/docs/farming/phase-02-qa.md
+++ b/docs/farming/phase-02-qa.md
@@ -1,0 +1,138 @@
+# Phase 2 QA: Verify Patches and plot state
+
+This session audits the Phase 2 PR after it is open: the patch content and its
+placement guard, the persistence shape and its anti-tamper load path, the read-only
+facet, and above all the wire boundary (the public projection must provably never
+carry the hidden outcome slots or the yield seed). Fixes ride the same PR branch as
+separate commits. The design authority is `docs/farming/state.md`; the promises under
+audit are `docs/farming/phase-02-patches-and-plots.md`.
+
+### QA Starter Prompt
+
+```
+This is Phase 2 QA of the Farming feature: Verify "Patches and plot state".
+Model: Opus 4.8, xhigh effort (1m context variant where the file load demands it).
+Harness: Claude Code.
+
+Goal: audit Phase 2 for correctness, missing tests, dead code, determinism, three-host
+parity, i18n completeness, and the phase's own acceptance criteria.
+
+STEP 0 - PRE-FLIGHT
+- Work ONLY in the persistent worktree ~/Documents/woc-farming-plan; git status must
+  be clean; use git -C with the absolute path on every git command.
+- git fetch origin --prune, then check out the phase PR branch
+  fix/farming-phase-02-patches-and-plots.
+- Identify the phase diff: the PR's commits against its base, NEVER
+  everything-since-phase-start (the release tip may have moved concurrently).
+  Preferred: gh pr diff <PR-number> --name-only and gh pr view <PR-number> --json
+  baseRefName,commits. Fallback: BASE=$(git merge-base origin/<base-release-branch>
+  HEAD); git log --oneline $BASE..HEAD; git diff --name-only $BASE..HEAD.
+- Scan Claude Code memory: the MEMORY.md index, the farming-skill-program entry, plus
+  round-trip-pins-reference-aliasing, wire-name-constant-pins-need-literals,
+  vacuous-bound-pin-trap, mutation-checks-commit-first,
+  big-diff-reviewer-turn-budgets, node25-breaks-jsdom-gate.
+
+STEP 1 - LOAD CONTEXT
+Spawn ONE Explore agent to read and summarize: docs/farming/state.md (locked
+decisions, especially D2, D3, D23, and the seam reference), the Phase 2 notes in
+docs/farming/progress.md, the promises in docs/farming/phase-02-patches-and-plots.md
+(deliverables, acceptance criteria, live-surface note, the documented position and
+bed-count choices), and the git diff --name-only file list over the phase diff. The
+summary must return: the acceptance checklist verbatim, the PlotState public
+projection versus hidden fields split as implemented, the fplot registration sites,
+and every promise the diff appears NOT to touch.
+
+STEP 2 - QA AUDIT
+Spawn three parallel audit agents. Every agent gets a hard 30-tool-call budget,
+report-first instructions, and the coverage instruction "report every issue including
+low-severity and uncertain ones; ranking happens later". If one truncates or stalls,
+resume it with exactly: "Stop reading more files. Output the full report now based on
+what you have already seen. No more tool calls. Format: BLOCKING / SHOULD-FIX /
+NICE-TO-HAVE / VERDICT."
+
+Agent 1, correctness:
+- Verify every deliverable and every acceptance criterion in
+  docs/farming/phase-02-patches-and-plots.md is actually met, against the real code.
+- Phase 2 emphasis, the negative wire-leak pin check: beyond confirming the pin
+  exists, probe the real boundary. Fill the hidden outcome slots and the yield seed
+  in a fixture plot, serialize the fplot payload through the real server emit path,
+  and assert the payload lacks both while carrying the D3 public fields, the
+  notified flag and the derived status among them; confirm status (growing, ready,
+  withered) is derived server-side from the plot's times, never the raw pre-roll.
+  The pin must fail if a hidden field is ever added to the projection.
+- Phase 2 emphasis, the load-tamper probe: construct a save blob with a bogus bed id
+  and a deadline past the clamp bound, load it through the real normalize path, and
+  assert it loads clean: the bogus bed dropped, the deadline clamped, no throw. Use a
+  throwaway vitest file if needed, then delete it and verify the tree is clean.
+- The offline Sim and online ClientWorld paths behave identically: farmPatches and
+  myFarmPlots return the same shapes from both IWorld implementations.
+- Edge cases: the empty default (no plots), the boundary (a deadline exactly at the
+  clamp), and the deny arms of the normalize path (unknown crop id, unknown bed id,
+  a save with no farming field at all).
+- Where sim behavior changed, run live headless-Sim probes via a throwaway vitest
+  file driving real ticks with an injected ADVANCEABLE clock, then delete it and
+  verify the tree is clean.
+- Verify the live-surface note: nothing player-reachable (no command, no item, no
+  render, no UI references the new modules).
+
+Agent 2, test coverage:
+- Every claimed behavior has a DECISIVE assertion that fails on regression; no
+  constant-self-comparison pins: the round-trip test must build its expectation
+  literal fresh (round-trip-pins-reference-aliasing), the fplot wire name must be
+  pinned as a LITERAL string, not through the shared constant, and the round-trip
+  pins must name the notified flag and the derived status among the public fields.
+- Both arms of every either/all claim: the placement suite must fail on a bad
+  position (probe one arm by temporarily breaking a fixture, not the content), the
+  normalize path needs both the accept arm and every drop/clamp arm, the parity
+  sampler claim needs the empty-Map-to-empty-array pin.
+- A determinism pin is present: zero new rng call sites this phase (confirm nothing
+  in the diff calls ctx.rng), and parity either untouched or moved only mechanically.
+- Orphaned tests removed; no vacuous bounds (a clamp test that never reaches the
+  clamp is constant-true; the tamper arm must actually cross the bound).
+- Mutation checks ONLY after committing the current work state first
+  (mutation-checks-commit-first); require a nonzero exit code AND named failing tests
+  before claiming a kill.
+
+Agent 3, dead code and cleanup:
+- Unused imports and types across the diff; the sim import invariant (no
+  DOM/Three/render/ui/game/net imports in src/sim/); no unresolved TODOs (the hidden
+  outcome slots are declared-for-Phase-3 by design, which is a documented forward
+  reference, not a TODO); naming consistency (bed ids, fplot, FarmPatchDef,
+  FARMING_ZONES); no leftover throwaway files.
+
+Then dispatch the Review Dispatch Matrix rows in docs/farming/implementation-plan.md
+that match the phase diff (expected: cross-platform-sync, architecture-reviewer,
+migration-safety), plus qa-checklist as the phase-completion gate. Same budget,
+coverage, and truncation-resume rules.
+
+STEP 3 - FIX
+- Apply ALL BLOCKING and SHOULD-FIX findings test-first: reproduce with a failing
+  test, then the smallest change to green.
+- Run the state.md validation matrix rows the diff demands (at minimum: npx tsc
+  --noEmit, the two Phase 2 suites, the snapshots suites, tests/world_api_parity.test.ts,
+  tests/architecture.test.ts, tests/parity, npm run ci:changed).
+- Separate fix commits with explicit paths, Conventional Commits with bodies, never
+  git add -A, no session links or Claude attribution.
+- After fixes: node scripts/gate_select.mjs (the armory browser red is the standing
+  environmental exception; grep the log for "[gate] FAIL"; PR CI is the arbiter), then
+  push the fix commits to the phase PR branch.
+
+STEP 4 - DOC UPDATES
+- docs/farming/progress.md: fill the Phase 2 QA row (status, dates) and append QA
+  findings to the Phase 2 Notes block.
+- docs/farming/state.md: record any drift discovered (ledger corrections, the actual
+  suite names, deviations). If the phase file was amended, sweep this QA twin in the
+  same pass.
+
+STEP 5 - FINAL RESPONSE FORMAT
+Report exactly: verdict PASS / PASS-WITH-FOLLOWUPS / FAIL; counts of issues found and
+issues fixed, by severity; deferrals with reasons; and a one-line handoff (merge
+readiness and what Phase 3 should know, especially the final PlotState shape).
+
+STOPPING RULES
+- STOP and surface if a BLOCKING cannot be fixed without changing phase scope (in
+  particular, any finding that the projection leaks a hidden field by design).
+- STOP if the phase diff cannot be identified cleanly (no PR, an ambiguous base, or
+  foreign commits interleaved).
+Packet teardown never happens in this phase; it belongs to Phase 13 QA only.
+```

--- a/docs/farming/phase-03-growth-engine.md
+++ b/docs/farming/phase-03-growth-engine.md
@@ -1,0 +1,317 @@
+# Phase 3: The growth engine
+
+This phase makes farming work: the plantCrop and harvestCrop command bodies in the
+src/sim/professions/farming.ts driver behind SimContext, the growth script pre-rolled
+in one contiguous rng block at plant time, wall-clock stage deadlines through
+ctx.lockoutNowMs, harvest-lives yield resolution, the farming gain schedule, the
+updateFarming tick skeleton, a stated and pinned draw-count contract, and a
+farming_session parity scenario that drives a real plant-grow-harvest session. The
+design authority is `docs/farming/state.md` (D3 through D7, the tick and hook points,
+the determinism contract).
+
+Live-surface note (binding): dormant online. No seeds are obtainable by players, so no
+player can reach plant or harvest after this phase merges. The engine is fully
+testable end to end via /dev farm cheats behind ALLOW_DEV_COMMANDS (dev only).
+
+### Starter Prompt
+
+```
+This is Phase 3 of the Farming feature: "The growth engine".
+Model: Opus 4.8, xhigh effort (1m context variant where the file load demands it).
+Harness: Claude Code.
+
+Goal: plant, grow, and harvest work deterministically with a stated, pinned draw
+contract and a parity scenario that drives a real farming session.
+
+STEP 0 - PRE-FLIGHT
+- Work ONLY in the persistent worktree ~/Documents/woc-farming-plan. Never touch the
+  main checkout. Use git -C /home/fernandoramirez/Documents/woc-farming-plan for every
+  git command (the Bash cwd drifts).
+- git status must be clean. If it is not, stop and surface it.
+- Re-resolve the NEWEST release branch: git fetch origin --prune, then
+  git branch -r --list 'origin/release/*' | sort -V and take the last row. Create
+  branch fix/farming-phase-03-growth-engine off its tip. Record the phase-start
+  commit hash for the STEP 3 diff. If release moves mid-phase and this branch goes
+  long-lived, merge release in and run the release-merge-audit skill.
+- Scan Claude Code memory: the MEMORY.md index, the farming-skill-program entry, plus
+  these phase-relevant topics: frozen-clock-rig-hangs-vitest (an injected clock that
+  never advances hangs self-re-arming waits), mutation-checks-commit-first,
+  early-exit-pins-need-work-remaining, joint-coverage-masks-deleted-sites,
+  big-diff-reviewer-turn-budgets, node25-breaks-jsdom-gate,
+  worktree-cwd-drift-misroutes-git.
+
+STEP 1 - LOAD CONTEXT
+Spawn ONE Explore agent (breadth: very thorough) to read and summarize:
+- docs/farming/state.md (all of it, especially D3 through D7, the tick and hook
+  points, and the seam reference) and docs/farming/progress.md (the Phase 1 and
+  Phase 2 Notes, including the final PlotState shape).
+- This phase file, docs/farming/phase-03-growth-engine.md.
+- The source surface for this phase: the fishing driver module under
+  src/sim/professions/ (the command-body gate order, the hidden-bite-delay pre-roll
+  template, the gain schedule shape; locate by the fishing exports); the SimContext
+  seam src/sim/sim_context.ts (ctx.rng, ctx.lockoutNowMs, ctx.applyAura is NOT needed
+  this phase); the shared grant queue exporting queueGatheringGrant and
+  drainGatheringGrants (locate by symbol); the cast machinery: isNonSpellCast and the
+  four id-discriminating sites (completion routing, castingReadout, castBarState, the
+  hud castDisplayName; locate each by symbol); one existing command chain end to end
+  (sim method, IWorld facet member, ClientWorld implementation, server dispatch, the
+  command_facets pins and tests/world_api_parity.test.ts blocks); the /dev command
+  registration pattern behind ALLOW_DEV_COMMANDS; the parity scenario authoring
+  pattern under tests/parity (how a scenario drives commands and time and how a
+  golden is minted); the SimEvent emit pattern plus the S3 matcher rules in
+  src/ui/sim_i18n.ts and tests/localization_fixes.test.ts; the minimal ItemDef shape
+  for an ordinary item; canGatherTier and the wield gate (locate by symbol);
+  src/sim/content/farm_patches.ts, src/sim/professions/farming_zones.ts, and
+  src/world_api/farming.ts as Phase 2 left them; Sim.tick's profession block
+  (updateProfNudges and the deedsMod.updateDeeds call it precedes).
+- CLAUDE.md files: the root CLAUDE.md, src/sim/CLAUDE.md, src/sim/professions/CLAUDE.md,
+  src/ui/CLAUDE.md, src/world_api/CLAUDE.md, server/CLAUDE.md.
+The orchestrator never reads planning docs or coordinator monoliths directly; it works
+from this summary. The summary MUST return: (1) the fishing command body's gate order
+and pre-roll block as the template to scale up; (2) the exact ctx.lockoutNowMs
+semantics and how raidLockouts consumes it; (3) the isNonSpellCast extension recipe
+and the four id-discriminating sites with what each decides; (4) the full wiring of
+one existing command chain including every pin file; (5) the /dev registration
+pattern; (6) the parity scenario recipe (files to add, how the golden is minted, how
+time advances in a scenario); (7) the SimEvent-to-matcher recipe the S3 guard
+enforces; (8) the PlotState shape and hidden-slot names Phase 2 shipped; (9) the tick
+append point between updateProfNudges and updateDeeds; (10) the CLAUDE.md constraints
+that bind this phase; (11) anything in state.md or progress.md that contradicts this
+brief.
+
+STEP 2 - CHOOSE ORCHESTRATION + EXECUTE
+Before fan-out, the orchestrator locks the shared interface in the agent briefs: the
+command signatures, the typed deny result names, the SimEvent ids, the item ids
+(vale_wheat_seed, vale_wheat, fine_vale_wheat, withered_husks), and
+FARMING_CAST_ID, so the slices stay
+file-disjoint. Then request fan-out explicitly: spawn the three agents below in
+parallel, give each ONLY the Explore summary plus its own slice brief, and never put a
+teammate in plan mode. Each agent owns its vertical slice including its tests. Merge
+slices if one turns out trivial; if integration friction appears, serialize B after A.
+
+Agent A, the sim driver and its suite:
+- src/sim/professions/farming.ts behind the SimContext seam, never a method cluster
+  on sim.ts:
+  - plantCrop with gates in this STATED order, checked top to bottom: alive, range to
+    a bed, bed free for this player, farming skill at or above the crop tier
+    threshold, seed in bags, hoe of the required tier via canGatherTier plus the
+    wield gate. Every deny path returns a typed deny result and draws ZERO rng.
+  - Seed consumption on success.
+  - The growth script pre-rolled in ONE contiguous ctx.rng block: the per-stage
+    survival outcomes per D6 (base ramp roughly 85 percent at the gate to 100 percent
+    at the band top, one full band above the threshold always survives) and the yield
+    seed per D7. Decide in-phase, state, and document: the stage count and the exact
+    draw layout.
+  - ready-at set from the crop duration via ctx.lockoutNowMs (epoch-ms, the
+    raidLockouts idiom; growth continues while logged out).
+  - A short plant cast under a new FARMING_CAST_ID that extends isNonSpellCast PLUS
+    the four id-discriminating sites audited and updated: completion routing,
+    castingReadout, castBarState, and the hud castDisplayName.
+- harvestCrop: gates alive, range, my plot, ready or withered. A withered plot grants
+  withered_husks. A ready plot resolves the harvest-lives yield per D7 (a guaranteed
+  floor of picks, base 3; each pick rolls a skill-scaled chance to not consume a
+  life) and grants produce. XP flows through the shared queueGatheringGrant with a
+  farming-owned FARMING_GAIN_SCHEDULE (the fishing pattern; the drain runs earlier in
+  the tick, so an end-of-tick grant lands next tick: expected, documented).
+- Minimal item defs so the phase is testable end to end: vale_wheat_seed, vale_wheat,
+  the fine_vale_wheat twin with its MATERIAL_GRADES row, and withered_husks, per the
+  D11 sanctioned same-phase-consumer exception (consumers explicitly deferred: husks
+  to the Phase 4 convertHusks command, produce to the Phase 6 dishes), with an
+  explicit comment that Phase 5 completes the ladder and may adjust values.
+- The draw-count contract STATED in a comment block at the top of farming.ts AND
+  PINNED in the suite: the exact number of draws at plant, the exact number at
+  harvest, zero on every deny path, zero at expiry, zero at login, zero in the tick.
+  Decide in-phase the exact plant and harvest counts (harvest draws may be zero if
+  yield derives entirely from the pre-rolled yield seed; decide, state, document).
+- The updateFarming(ctx) skeleton APPENDED in Sim.tick after updateProfNudges(this.ctx)
+  and before deedsMod.updateDeeds(this.ctx): append, never reorder (the shared rng
+  stream makes reordering fork every golden). It draws no rng, allocates nothing per
+  tick in the hot path, runs behind an internal 1 Hz guard (ctx.tickCount % 20), and
+  carries a lap marker comment: consumed by Phase 8 (ready notices).
+- Typed deny results and id-carrying, text-free SimEvents for plant, harvest, wither
+  payout, and every deny worth surfacing.
+- tests/professions_farming.test.ts covering: the full lifecycle on real ticks with
+  an injected ADVANCEABLE lockoutNowMs clock (an injected clock that never advances
+  hangs self-re-arming waits: ALWAYS advance it); the survival boundaries (at-gate,
+  band-top, and one-band-above always survives); the draw-count pins (count draws
+  through a counting rng wrapper on every path: plant, harvest, every deny arm,
+  expiry, login, tick); a same-seed determinism pin; a mid-growth save-then-load
+  round trip; every deny arm asserted individually; and the anti-chore pin (a
+  harvest N hours late yields exactly what an on-time harvest yields).
+
+Agent B, the command chain and dev cheats:
+- src/world_api/farming.ts gains the plantCrop and harvestCrop command members beside
+  the Phase 2 reads; implemented in BOTH Sim and ClientWorld in the same change;
+  server dispatch added; the command_facets pins and the tests/world_api_parity.test.ts
+  facet blocks updated in the same change.
+- Server authority: the server validates every id server-side (bed id, crop id
+  against content, ownership); no wire command ingests a client-supplied item
+  payload; outcomes resolve only in the sim on the server.
+- /dev farm cheats behind ALLOW_DEV_COMMANDS following the existing /dev registration
+  pattern: at minimum grow-now, which sets ready-at to now (it writes state and draws
+  NOTHING). Never reachable in production.
+
+Agent C, client rows and the parity scenario:
+- Client catalog rows (English only, the matching src/ui/i18n.catalog/ module) for
+  every new SimEvent and deny result, plus S3 matcher coverage in the same change;
+  npx vitest run tests/localization_fixes.test.ts must go green.
+- The farming_session parity scenario plus its golden: drive plant, time advance, and
+  harvest in a real session (fishing's documented scenario gap is not inherited).
+  Author it in the scenario pattern the Explore summary reports; the new golden mints
+  in this phase's tree and no other golden moves.
+
+INVARIANTS THIS PHASE MUST KEEP
+- All of D4, stated literally: ALL randomness draws at player-action moments through
+  ctx.rng; every draw this phase adds happens inside the plantCrop or harvestCrop
+  command body; the full growth script is pre-rolled in ONE contiguous ctx.rng block
+  at plant time; there are ZERO draws at timer expiry, ZERO in the tick sweep, ZERO
+  at login, and ZERO on every deny path. The draw-count contract is stated and
+  pinned.
+- Server authority: the client never decides an outcome; the hidden outcome slots and
+  the yield seed never cross the wire (the Phase 2 negative pin must still pass).
+- The tick rule: updateFarming APPENDS after updateProfNudges and before updateDeeds
+  and is never reordered.
+- Sim purity in every touched sim file: zero DOM/browser/Three imports, no imports
+  from render/ui/game/net, no Math.random, Date.now, or performance.now; wall clock
+  only through ctx.lockoutNowMs.
+- The anti-chore thesis: nothing rots, no decay after ready, no third required visit;
+  a late harvest costs only opportunity.
+- Every player-visible outcome surfaces as an id-carrying, text-free SimEvent with a
+  client catalog row and S3 matcher coverage in the SAME change.
+- Never set ALLOW_DEV_COMMANDS=1 outside dev.
+- All work happens in ~/Documents/woc-farming-plan; every commit uses explicit paths,
+  never git add -A.
+
+Out of scope (do NOT do in this phase):
+- No compost, no farmer's watch, no growth tonic: the knob slots stay default off
+  (Phase 4).
+- No crops beyond vale_wheat: the other seven crops, their fine twins, and the hoe
+  ladder are Phase 5 (the fine_vale_wheat twin lands here per the D11 exception).
+- No NPCs, no vendors, no quests, no seed faucets of any kind (seeds stay
+  unobtainable online).
+- No ready notices, no UI, no render, no map pins (Phases 7 and 8).
+- No deeds, no rare event (Phase 10).
+
+STEP 3 - VALIDATION + MULTI-AGENT REVIEW
+Run, in order, and record each result:
+- npx tsc --noEmit
+- npx vitest run tests/professions_farming.test.ts
+- npx vitest run tests/architecture.test.ts
+- npx vitest run tests/sim_context.test.ts if the SimContext seam moved (a pure
+  per-tick driver needs NO new callback, the updateCommissionOrders precedent; if you
+  did add one, it touches exactly the five sites plus the pinned CALLBACK_KEYS list
+  and every suite that hand-builds a fake host, per state.md).
+- npx vitest run tests/snapshots.test.ts tests/env_protocol.test.ts tests/bandwidth.test.ts
+- npx vitest run tests/localization_fixes.test.ts
+- npx vitest run tests/recipe_economy.test.ts
+- npx vitest run tests/parity: the farming_session scenario green AND no other golden
+  moved. Any pre-existing golden moving means the shared rng stream or tick order
+  changed: STOP.
+- npm run ci:changed (fix findings with a SCOPED npx @biomejs/biome check --write
+  <file>, never whole-tree)
+- node scripts/gate_select.mjs
+Then run git diff --name-only <phase-start-commit>..HEAD and dispatch ONLY the Review
+Dispatch Matrix rows in docs/farming/implementation-plan.md that match the diff.
+Expected matches for this phase: architecture-reviewer (CRITICAL this phase: rng draw
+order, the contiguous pre-roll block, tick-phase order, the SimContext seam),
+cross-platform-sync (facet, commands, SimEvents, matchers), privacy-security-review
+(the server dispatch and dev-command gating were touched), frontend-seam-reviewer
+(the i18n catalog rows and hud event arms this phase touches match its matrix row),
+then qa-checklist once the deliverable set is complete. Every review agent gets: a
+hard 30-tool-call budget,
+report-first instructions, and the coverage instruction "report every issue including
+low-severity and uncertain ones; ranking happens later". If an agent truncates or
+stalls, resume it with exactly: "Stop reading more files. Output the full report now
+based on what you have already seen. No more tool calls. Format: BLOCKING /
+SHOULD-FIX / NICE-TO-HAVE / VERDICT." No commit while a BLOCKING stands.
+
+STEP 4 - COMMIT CADENCE
+Five Conventional Commits, each with a scope and a body (what changed and why),
+explicit paths only, never git add -A, no session links or Claude attribution:
+1. feat(professions): the farming growth engine (driver module, plant and harvest
+   bodies, growth script, gain schedule, updateFarming skeleton, deny results,
+   SimEvents, minimal items, FARMING_CAST_ID).
+2. feat(net): the command chain (facet members, ClientWorld, server dispatch, the
+   command_facets and parity pins) and the /dev farm cheats.
+3. feat(ui): the SimEvent catalog rows and S3 matcher coverage.
+4. test(professions): the lifecycle suite plus the farming_session parity scenario
+   and its golden.
+5. docs(farming): progress and state updates.
+
+STEP 5 - ACCEPTANCE CRITERIA
+- [ ] plantCrop enforces the gates in the stated order (alive, range, bed free for
+      this player, skill threshold, seed in bags, hoe tier via canGatherTier plus the
+      wield gate); every deny arm is tested individually and draws zero.
+- [ ] Planting consumes the seed and pre-rolls the full growth script in ONE
+      contiguous ctx.rng block (per-stage survival per D6, the yield seed per D7);
+      ready-at derives from the crop duration via ctx.lockoutNowMs.
+- [ ] The plant cast runs under FARMING_CAST_ID; isNonSpellCast is extended; all four
+      id-discriminating sites are audited and correct: completion routing,
+      castingReadout, castBarState, hud castDisplayName.
+- [ ] harvestCrop: withered grants withered_husks; ready resolves the harvest-lives
+      yield with the skill-scaled save chance and grants produce; XP flows through
+      queueGatheringGrant with FARMING_GAIN_SCHEDULE.
+- [ ] The draw-count contract is stated in farming.ts and pinned in the suite: exact
+      draws at plant, exact draws at harvest, zero on every deny path, zero at
+      expiry, zero at login, zero in the tick.
+- [ ] updateFarming(ctx) is appended in Sim.tick after updateProfNudges and before
+      updateDeeds, draws no rng, runs behind an internal 1 Hz guard, and carries the
+      Phase 8 lap marker.
+- [ ] Deny results are typed; SimEvents are id-carrying and text-free; client catalog
+      rows and S3 matcher coverage exist; tests/localization_fixes.test.ts green.
+- [ ] The command chain is wired in all four parts (sim method, IWorldFarming member,
+      ClientWorld implementation, server dispatch) with command_facets and
+      tests/world_api_parity.test.ts pins green.
+- [ ] The /dev farm cheats sit behind ALLOW_DEV_COMMANDS; grow-now writes state and
+      draws nothing.
+- [ ] tests/professions_farming.test.ts is green: lifecycle on real ticks with an
+      advanceable injected clock, survival boundaries (at-gate, band-top,
+      one-band-above always survives), the draw-count pins, a same-seed determinism
+      pin, a mid-growth save-then-load round trip, every deny arm, and the anti-chore
+      pin (a late harvest yields exactly an on-time harvest).
+- [ ] The farming_session parity scenario and its golden are green, and no other
+      golden moved.
+- [ ] The Phase 2 negative wire-leak pin still passes with the hidden slots now
+      filled by real plants.
+- [ ] The proposed tuning constants (the vale_wheat duration inside the D5 tier 1
+      band, the gain schedule, the save-chance endpoints, the plant cast length) are
+      stated in the PR body and flagged for the maintainer per state.md's OPEN items.
+
+STEP 6 - DOC UPDATES + MEMORY
+- docs/farming/progress.md: flip the Phase 3 row to done with dates, copy the STEP 5
+  acceptance list here with its check states, add a Notes block including the decided
+  draw counts, stage count, and tuning constants.
+- docs/farming/state.md: append to the per-phase ledgers (new IWorld members:
+  plantCrop, harvestCrop; new SimEvents; new items: vale_wheat_seed, vale_wheat,
+  fine_vale_wheat, withered_husks; new i18n keys and matcher rows), and record the
+  exact /dev farm cheat names in the "Dev command surface" ledger row (Phases 7 and
+  8 depend on them). Any deviation decided in-phase
+  gets a "Locked deviations" line AND gets swept into
+  docs/farming/phase-03-growth-engine.md and docs/farming/phase-03-qa.md in the same
+  pass.
+- Record surprises (a cast-site subtlety, a draw-layout decision, a parity scenario
+  gotcha) in Claude Code memory.
+
+STEP 7 - FINAL RESPONSE FORMAT
+Report exactly: phase status (complete or partial, with reasons); files touched
+(grouped by commit); validation results (each command, pass or fail); review verdicts
+(per agent, with the BLOCKING count at zero); deferrals (each with a reason and owning
+phase); and a one-line handoff for the QA session (branch, PR number, base release
+branch, the decided draw counts).
+
+STOPPING RULES
+- STOP if determinism cannot hold: if any design detail would force a draw outside a
+  command body (at expiry, in the tick, at login, or on a deny path), surface it; do
+  not ship the draw.
+- STOP if the growth script cannot stay server-private: if any client surface needs
+  the hidden outcomes or the yield seed to function, that is a design change.
+- STOP if any pre-existing parity golden moves.
+- STOP if git status is dirty at STEP 0, or if a BLOCKING review finding cannot be
+  fixed without leaving this phase's scope; surface to the user.
+
+When every step above is done and no BLOCKING stands: gate via
+node scripts/gate_select.mjs (the armory browser red is the standing environmental
+exception; grep the log for "[gate] FAIL"; PR CI is the arbiter), push, and open the
+PR against the release branch this phase was based on per
+.github/PULL_REQUEST_TEMPLATE.md.
+```

--- a/docs/farming/phase-03-qa.md
+++ b/docs/farming/phase-03-qa.md
@@ -1,0 +1,153 @@
+# Phase 3 QA: Verify The growth engine
+
+This session audits the Phase 3 PR after it is open: the gate order, the contiguous
+pre-roll block, the draw-count contract (including a live mutation probe against its
+pins), the anti-chore guarantees, the cast-site audit, the command chain, and the
+farming_session parity scenario. Fixes ride the same PR branch as separate commits.
+The design authority is `docs/farming/state.md`; the promises under audit are
+`docs/farming/phase-03-growth-engine.md`.
+
+### QA Starter Prompt
+
+```
+This is Phase 3 QA of the Farming feature: Verify "The growth engine".
+Model: Opus 4.8, xhigh effort (1m context variant where the file load demands it).
+Harness: Claude Code.
+
+Goal: audit Phase 3 for correctness, missing tests, dead code, determinism, three-host
+parity, i18n completeness, and the phase's own acceptance criteria.
+
+STEP 0 - PRE-FLIGHT
+- Work ONLY in the persistent worktree ~/Documents/woc-farming-plan; git status must
+  be clean; use git -C with the absolute path on every git command.
+- git fetch origin --prune, then check out the phase PR branch
+  fix/farming-phase-03-growth-engine.
+- Identify the phase diff: the PR's commits against its base, NEVER
+  everything-since-phase-start (the release tip may have moved concurrently).
+  Preferred: gh pr diff <PR-number> --name-only and gh pr view <PR-number> --json
+  baseRefName,commits. Fallback: BASE=$(git merge-base origin/<base-release-branch>
+  HEAD); git log --oneline $BASE..HEAD; git diff --name-only $BASE..HEAD.
+- Scan Claude Code memory: the MEMORY.md index, the farming-skill-program entry, plus
+  frozen-clock-rig-hangs-vitest, mutation-checks-commit-first,
+  mutation-verdicts-need-exit-code-plus-names, mutation-edits-need-landing-proof,
+  early-exit-pins-need-work-remaining, unkillable-mutant-diagnosis,
+  big-diff-reviewer-turn-budgets, node25-breaks-jsdom-gate.
+
+STEP 1 - LOAD CONTEXT
+Spawn ONE Explore agent to read and summarize: docs/farming/state.md (locked
+decisions, especially D3 through D7 and the tick and hook points), the Phase 3 notes
+in docs/farming/progress.md (including the decided draw counts, stage count, and
+tuning constants), the promises in docs/farming/phase-03-growth-engine.md
+(deliverables, acceptance criteria, live-surface note, the stated gate order and draw
+contract), and the git diff --name-only file list over the phase diff. The summary
+must return: the acceptance checklist verbatim, the stated draw-count contract (N at
+plant, M at harvest), the gate order as implemented, the SimEvent and deny-result id
+list, and every promise the diff appears NOT to touch.
+
+STEP 2 - QA AUDIT
+Spawn three parallel audit agents. Every agent gets a hard 30-tool-call budget,
+report-first instructions, and the coverage instruction "report every issue including
+low-severity and uncertain ones; ranking happens later". If one truncates or stalls,
+resume it with exactly: "Stop reading more files. Output the full report now based on
+what you have already seen. No more tool calls. Format: BLOCKING / SHOULD-FIX /
+NICE-TO-HAVE / VERDICT."
+
+Agent 1, correctness:
+- Verify every deliverable and every acceptance criterion in
+  docs/farming/phase-03-growth-engine.md is actually met, against the real code.
+- Phase 3 emphasis, the live lifecycle probe: sim behavior changed, so run live
+  headless-Sim probes via a throwaway vitest file driving real ticks with an injected
+  ADVANCEABLE lockoutNowMs clock (a clock that never advances hangs self-re-arming
+  waits: always advance it): plant with a dev-granted seed, advance past ready-at,
+  harvest, and assert produce granted and XP queued; also probe one deny arm and one
+  withered path live. Delete the throwaway file afterward and verify the tree is
+  clean.
+- Phase 3 emphasis, the anti-chore guarantees: the late-harvest pin exists and is
+  decisive (a harvest N hours late yields exactly what an on-time harvest yields),
+  AND audit the code for any path that requires a third visit: no decay after ready,
+  no wither triggered by lateness, no watering, no mid-growth interaction of any
+  kind (D8). Any such path is BLOCKING.
+- The offline Sim and online ClientWorld paths behave identically: the command
+  members exist on both, deny results and events mirror, and the Phase 2 negative
+  wire-leak pin still passes with hidden slots now filled by real plants.
+- Edge cases: empty (no plots, harvest on an empty bed), boundary (skill exactly at
+  the tier threshold, exactly at band top, harvest exactly at ready-at), and every
+  deny arm.
+- Phase 3 emphasis, the D11 minimal slice: verify the fine_vale_wheat twin and its
+  MATERIAL_GRADES row landed beside vale_wheat, and that
+  npx vitest run tests/recipe_economy.test.ts ran green over the new rows.
+- Verify the exact /dev farm cheat names were recorded in the state.md "Dev command
+  surface" ledger row.
+- Verify the live-surface note: no seed is obtainable online (no vendor row, no drop,
+  no faucet), so plant is unreachable by players; the /dev cheats are gated behind
+  ALLOW_DEV_COMMANDS.
+
+Agent 2, test coverage:
+- Every claimed behavior has a DECISIVE assertion that fails on regression; no
+  constant-self-comparison pins (draw counts pinned to literal numbers, not to the
+  same constant the module exports).
+- Both arms of every either/all claim: each gate needs its deny arm AND the pass-
+  through arm (early-exit ordering: failing the LAST gate proves nothing about order;
+  the suite must show an earlier gate short-circuits a later one); survival needs
+  at-gate, band-top, and one-band-above arms; harvest needs ready AND withered arms.
+- A same-seed determinism pin is present and decisive.
+- The draw-count pins cover every path: plant, harvest, each deny arm, expiry, login,
+  and the tick sweep (zero-draw pins must actually traverse the path they claim).
+- Orphaned tests removed; the injected clock in every test actually advances.
+- Phase 3 emphasis, the draw-contract mutation probe, in this exact order
+  (mutation-checks-commit-first): FIRST verify the work state is fully committed
+  (git status clean); THEN add one extra ctx.rng draw inside the plant pre-roll
+  block; run the named draw-count pins and the parity scenario; require a nonzero
+  exit code AND named failing tests (rc alone is not a verdict); grep the mutated
+  line to prove the edit landed where intended; revert the mutation and verify the
+  tree matches the commit exactly (git status clean, git diff empty). A surviving
+  mutant is a BLOCKING coverage gap: diagnose (dead code, unobservable rig, or real
+  gap) before adding a test.
+
+Agent 3, dead code and cleanup:
+- Unused imports and types across the diff; the sim import invariant (no
+  DOM/Three/render/ui/game/net imports in src/sim/); no unresolved TODOs (the
+  Phase 8 lap marker in updateFarming is a documented forward reference, not a
+  TODO); naming consistency (FARMING_CAST_ID, FARMING_GAIN_SCHEDULE, the event and
+  deny ids against the Phase 3 brief); no leftover throwaway probe files; no
+  commented-out code.
+
+Then dispatch the Review Dispatch Matrix rows in docs/farming/implementation-plan.md
+that match the phase diff (expected: architecture-reviewer, cross-platform-sync,
+privacy-security-review, frontend-seam-reviewer), plus qa-checklist as the
+phase-completion gate. Same budget,
+coverage, and truncation-resume rules.
+
+STEP 3 - FIX
+- Apply ALL BLOCKING and SHOULD-FIX findings test-first: reproduce with a failing
+  test, then the smallest change to green.
+- Run the state.md validation matrix rows the diff demands (at minimum: npx tsc
+  --noEmit, tests/professions_farming.test.ts, tests/architecture.test.ts,
+  tests/recipe_economy.test.ts, the snapshots suites,
+  tests/localization_fixes.test.ts, tests/parity with no pre-existing golden moved,
+  npm run ci:changed).
+- Separate fix commits with explicit paths, Conventional Commits with bodies, never
+  git add -A, no session links or Claude attribution.
+- After fixes: node scripts/gate_select.mjs (the armory browser red is the standing
+  environmental exception; grep the log for "[gate] FAIL"; PR CI is the arbiter), then
+  push the fix commits to the phase PR branch.
+
+STEP 4 - DOC UPDATES
+- docs/farming/progress.md: fill the Phase 3 QA row (status, dates) and append QA
+  findings, including the mutation-probe outcome, to the Phase 3 Notes block.
+- docs/farming/state.md: record any drift discovered (ledger corrections, deviations,
+  a draw-count restatement). If the phase file was amended, sweep this QA twin in the
+  same pass.
+
+STEP 5 - FINAL RESPONSE FORMAT
+Report exactly: verdict PASS / PASS-WITH-FOLLOWUPS / FAIL; counts of issues found and
+issues fixed, by severity; deferrals with reasons; and a one-line handoff (merge
+readiness and what Phase 4 should know, especially the knob-slot entry points).
+
+STOPPING RULES
+- STOP and surface if a BLOCKING cannot be fixed without changing phase scope (in
+  particular, any draw living outside a command body or any required third visit).
+- STOP if the phase diff cannot be identified cleanly (no PR, an ambiguous base, or
+  foreign commits interleaved).
+Packet teardown never happens in this phase; it belongs to Phase 13 QA only.
+```

--- a/docs/farming/phase-04-knobs.md
+++ b/docs/farming/phase-04-knobs.md
@@ -1,0 +1,236 @@
+# Phase 4: Knobs and insurance
+
+Phase 3 landed plant and harvest with a pre-rolled growth script and a pinned
+draw-count contract. This phase adds every plant-time choice the design allows:
+compost, farmer's watch, and growth tonic (D6, D7, D8, D9), plus the withered-husk
+conversion that turns failure into the next attempt's insurance. The one hard rule of
+the phase: knobs bend thresholds, never the draw count, so the Phase 3 contract
+survives every combination untouched.
+
+Live-surface note (binding): Dormant. Compost and growth tonic are minted this phase but have
+no vendor row, recipe, loot source, or quest reward until Phase 5 lands crops and
+Phase 9 flips go-live. Withered husks only come from failed crops, and no seed is
+obtainable yet, so convertHusks is unreachable in live play. Nothing player-reachable
+changes when this phase merges.
+
+### Starter Prompt
+
+```
+This is Phase 4 of the Farming feature: Knobs and insurance.
+Model: Opus 4.8, xhigh effort (1m context variant where the file load demands it).
+Harness: Claude Code.
+
+Goal: every plant-time choice exists (compost, farmer's watch, growth tonic) plus the
+husk-to-compost conversion, without changing the number of rng draws in the Phase 3
+contract.
+
+STEP 0 - PRE-FLIGHT
+- Work ONLY in the persistent worktree ~/Documents/woc-farming-plan. Never touch the
+  main checkout. Prefix every git command with git -C ~/Documents/woc-farming-plan.
+- git status must be clean. If it is not, stop and surface.
+- Re-resolve the NEWEST release branch: git fetch origin --prune; git branch -r
+  --list 'origin/release/*' | sort -V. Create branch fix/farming-phase-04-knobs off
+  that tip. Record the phase-start commit (git rev-parse HEAD) for the STEP 3 diff.
+  If the branch goes long-lived and release moves mid-phase, merge release in and run
+  the release-merge-audit skill.
+- Scan Claude Code memory: the MEMORY.md index, the farming-skill-program entry, plus
+  these phase-relevant topics: mutation-checks-commit-first,
+  big-diff-reviewer-turn-budgets, round-trip-pins-reference-aliasing,
+  early-exit-pins-need-work-remaining, fanout-agent-delivery-traps,
+  worktree-cwd-drift-misroutes-git.
+
+STEP 1 - LOAD CONTEXT
+Spawn one Explore agent to read and summarize: docs/farming/state.md,
+docs/farming/progress.md, docs/farming/phase-04-knobs.md, and these source files as
+Phase 3 landed them (state.md's "Key planned files" section records any refined
+names): src/sim/professions/farming.ts, the farming items content module (planned
+src/sim/content/farming_items.ts), src/world_api/farming.ts,
+tests/professions_farming.test.ts and its siblings, the farming_session parity
+scenario under tests/parity, tests/world_api_parity.test.ts (the farming member
+pins). Also the relevant CLAUDE.md files: the root CLAUDE.md, src/sim/CLAUDE.md,
+src/sim/professions/CLAUDE.md, src/sim/content/CLAUDE.md. The orchestrator never
+reads planning docs or coordinator monoliths directly.
+The summary MUST return: the exact plantCrop command signature and payload shape as
+shipped; the draw-count contract as pinned (draws per plant, draws per harvest, zero
+on denial) and where the pin lives; the withered_husks item id and def location; the
+IWorldFarming member list and the parity-pin location; the Phase 3 denial-event idiom
+(stable keys or matcher rows) to copy; the item-def convention for plain
+consumed-by-command items; how the farming_session scenario is recorded and
+re-recorded; any state.md ledger entries or deviations Phases 1 to 3 recorded.
+
+STEP 2 - CHOOSE ORCHESTRATION + EXECUTE
+Split into three agents by vertical slice, each owning its slice plus its tests.
+Request the fan-out explicitly (these models under-spawn by default). Give each agent
+ONLY the Explore summary and its own deliverable list, never the planning docs. Never
+set plan mode on a teammate agent. Agents A and B run in parallel; agent C starts
+after B lands (it consumes B's armed-tonic state). If two agents must mutate the same
+file in parallel, give them isolation: "worktree".
+
+Agent A, items and conversion:
+- Item defs for compost and growth_tonic in the farming items content module, beside
+  withered_husks (which landed in Phase 3). They are plain items consumed by command,
+  referenced from the plant payload, NOT wired through ItemDef.use. State that choice
+  in a comment on the defs. Per D9, compost receives a vendor buyValue in THIS phase
+  (propose the value and flag it for the maintainer in the PR body; the vendor row
+  itself is stocked in Phase 9) and growth_tonic receives NO buyValue (never
+  vendor-stocked, alchemy-crafted, sellValue only). English display-name rows in the
+  matching src/ui/i18n.catalog module; names IP-safe per D17.
+- The convertHusks command on IWorldFarming: N husks yield one compost. Propose a
+  concrete N and flag it for the maintainer in the PR body. Implement in BOTH Sim and
+  ClientWorld in the same change and update the pinned member list in
+  tests/world_api_parity.test.ts. The range gate to a farmer NPC arrives in Phase 9:
+  land the command with a documented permissive gate and a comment naming Phase 9 as
+  the phase that tightens it, phrased without any TODO marker.
+- Tests: conversion arithmetic, the no-husks deny arm, the parity pin.
+
+Agent B, the plant-time knob payload (D6, D7, D8, D9):
+- Extend plantCrop with the knob payload: compost, farmer's watch, growth tonic. The
+  server consumes each requested knob from bags at plant time. A requested knob that
+  cannot be paid denies the WHOLE plant: nothing consumed, zero rng draws, a
+  localized denial line.
+- Compost consumed from bags adds 10 survival points. Farmer's watch consumes a
+  tier-appropriate produce fee and adds 10 survival points. The fee predicate,
+  defined here: any farming produce whose crop tier is at or below the planted crop's
+  tier. Propose the fee amount per tier and flag it for the maintainer in the PR
+  body. Both bonuses stack with the skill-scaled base and cap at 100 survival points.
+- Growth tonic consumed at plant ARMS the yield bonus chance; the bonus is applied at
+  harvest against already-drawn values (the pre-rolled yield seed), never via a new
+  draw.
+- Deny arms: no compost in bags, no fee produce matching the predicate, no tonic in
+  bags, and an already-knobbed replant attempt on an occupied plot.
+- Every player-visible denial emits a stable key plus values (or English re-localized
+  via the client matcher) in the SAME change; the S3 guard
+  (tests/localization_fixes.test.ts) enforces it.
+- Tests: one per knob arm (consume side and deny side), the 100-point cap boundary
+  (a case that would exceed 100 clamps to exactly 100, and a case landing exactly on
+  100), and the fee consumption pin: the exact produce item leaves the bag and
+  nothing else moves.
+
+Agent C, contract and determinism:
+- THE DESIGN RULE, STATED IN CAPS AND KEPT: KNOB EFFECTS NEVER CHANGE THE NUMBER OF
+  RNG DRAWS. THEY CHANGE THRESHOLDS APPLIED TO ALREADY-DRAWN VALUES, SO THE PHASE 3
+  DRAW CONTRACT SURVIVES EVERY KNOB COMBINATION.
+- Restate the draw-count contract in the farming driver's doc comment (draws per
+  plant, draws per harvest, zero on denial) and re-pin it: the pin must count real
+  draws under every knob combination and assert the count is identical with and
+  without each knob.
+- A same-seed determinism pin: identical seed plus identical command sequence yields
+  identical plot outcomes, bag contents, and events.
+- The farming_session golden re-records ONLY if the draw block changed, as its own
+  isolated commit per D23 (UPDATE_PARITY=1, never hand-edited). The expected outcome
+  of this phase is NO re-record; if the scenario is extended to exercise knobs, that
+  extension plus its re-record is the one legitimate cause.
+
+INVARIANTS THIS PHASE MUST KEEP
+- D4, literally: ALL randomness draws at player-action moments through ctx.rng. ZERO
+  draws at timer expiry, in the tick sweep, or at login. EVERY denial draws zero.
+- D8, literally: front-loaded only. EVERY choice (seed, compost, watch, tonic)
+  happens at plant time. NO mid-growth interaction of any kind is added, ever,
+  required or optional.
+- Server authority: the server consumes every item and resolves every outcome; the
+  client never decides; no wire command ingests a client-supplied
+  ItemInstancePayload.
+- Sim purity: no Math.random, Date.now, or performance.now anywhere in src/sim/; no
+  DOM, Three, render, ui, game, or net imports (tests/architecture.test.ts guards).
+- Anti-chore: no knob adds a required visit or punishes absence.
+
+Out of scope (do NOT do in this phase):
+- Vendor stock of any kind (Phase 9).
+- Recipes, including the tonic's alchemy recipe (Phase 6).
+- NPCs and the farmer-NPC range gate for convertHusks (Phase 9).
+- UI: no Harvest Journal work, no new windows (Phase 8).
+- Render: no visuals (Phase 7).
+
+STEP 3 - VALIDATION + MULTI-AGENT REVIEW
+Run, in order:
+- npx tsc --noEmit
+- npx vitest run tests/professions_farming.test.ts tests/architecture.test.ts
+  tests/localization_fixes.test.ts
+- If the plantCrop wire payload or the fplot self key widened: npx vitest run
+  tests/snapshots.test.ts tests/env_protocol.test.ts tests/bandwidth.test.ts
+- npx vitest run tests/parity (BEFORE touching any golden; regen only deliberately)
+- npm run ci:changed
+- node scripts/gate_select.mjs
+Then check git diff --name-only against the phase-start commit and dispatch ONLY the
+matching rows of the Review Dispatch Matrix in docs/farming/implementation-plan.md.
+For this phase's expected diff the matching rows are: architecture-reviewer (sim
+behavior and rng draw order), cross-platform-sync (IWorldFarming grew and the command
+surface moved), and qa-checklist (the phase deliverable set is complete). Dispatch
+others only if the diff actually touches their row. Every review agent gets a hard
+30-tool-call budget, the coverage instruction ("report every issue including
+low-severity and uncertain ones; ranking happens later"), and, if truncation looms,
+the resume line: "Stop reading more files. Output the full report now based on what
+you have already seen. No more tool calls. Format: BLOCKING / SHOULD-FIX /
+NICE-TO-HAVE / VERDICT." No commit while a BLOCKING stands.
+
+STEP 4 - COMMIT CADENCE
+2 to 5 Conventional Commits, each with a scope and a body (what changed and why),
+explicit paths only, never git add -A, no session links or Claude attribution.
+Suggested shape:
+1. feat(farming): compost and growth tonic items plus the convertHusks command
+2. feat(farming): plant-time knob payload, survival points, and the watch fee
+3. test(farming): knob arms, cap boundary, fee pin, draw-contract and determinism pins
+4. Only if the draw block changed: test(parity): re-record farming_session golden
+   (isolated, nothing else in the commit)
+5. docs(farming): progress and state ledger updates
+
+STEP 5 - ACCEPTANCE CRITERIA
+- [ ] compost and growth_tonic exist as plain items with no ItemDef.use, consumed
+      only by command, with a def comment stating the consumed-by-command choice;
+      compost carries a positive vendor buyValue (maintainer-flagged, stocked in
+      Phase 9 per D9) and growth_tonic carries none
+- [ ] plantCrop accepts the knob payload; each requested knob is consumed from bags
+      server-side at plant time; a requested knob that cannot be paid denies the
+      whole plant with nothing consumed and zero draws
+- [ ] compost adds 10 survival points, farmer's watch adds 10, total survival caps at
+      100, with boundary tests at and above the cap
+- [ ] the watch fee predicate is: any farming produce whose crop tier is at or below
+      the planted crop's tier; per-tier amounts proposed and maintainer-flagged in
+      the PR body
+- [ ] a fee consumption pin proves the exact produce leaves the bag
+- [ ] tonic consumed at plant arms a yield bonus applied at harvest against
+      already-drawn values, with no added draw
+- [ ] the draw-count contract is restated and re-pinned, and the pin passes under
+      every knob combination with identical draw counts
+- [ ] convertHusks is on IWorldFarming, implemented in BOTH Sim and ClientWorld, the
+      tests/world_api_parity.test.ts pin updated; N proposed and maintainer-flagged;
+      the permissive gate carries a comment naming Phase 9 with no TODO marker
+- [ ] all four deny arms are tested: no compost, no fee produce, no tonic, an
+      already-knobbed replant attempt
+- [ ] every player-visible denial rides a stable key or a matcher rule added in this
+      change; tests/localization_fixes.test.ts is green
+- [ ] a same-seed determinism pin passes
+- [ ] the farming_session golden was re-recorded ONLY if the draw block changed, in
+      an isolated commit; otherwise it is untouched
+- [ ] the STEP 3 validation list is green and node scripts/gate_select.mjs passes
+      apart from the standing armory browser exception
+- [ ] docs/farming/progress.md and docs/farming/state.md ledgers are updated
+
+STEP 6 - DOC UPDATES + MEMORY
+Update docs/farming/progress.md (Phase 4 status row, the copied acceptance list with
+check states, a Notes block) and the docs/farming/state.md ledgers (new IWorld
+members, new items, new i18n keys and matcher rows, proposed constants awaiting the
+maintainer). Any deviation decided in-phase gets swept into
+docs/farming/phase-04-knobs.md AND docs/farming/phase-04-qa.md in the same pass, plus
+a line in state.md's "Locked deviations" ledger. Record surprises in Claude Code
+memory.
+
+STEP 7 - FINAL RESPONSE FORMAT
+Report: phase status; files touched; validation results (each command, pass or fail);
+review verdicts per agent; deferrals with reasons; and a one-line handoff for the QA
+session.
+
+STOPPING RULES
+- Stop if any knob design would require a draw-count change: the caps rule cannot
+  bend. Surface the conflict to the maintainer instead of shipping it.
+- Stop if git status is not clean at STEP 0 or the newest release branch cannot be
+  resolved.
+- Stop if a BLOCKING review finding cannot be fixed without violating a locked
+  decision (D1 to D24); state.md wins over this file, and a contradiction gets swept,
+  not coded around.
+
+When everything above is done: gate via node scripts/gate_select.mjs (the armory
+browser red is the standing environmental exception; grep the log for "[gate] FAIL";
+PR CI is the arbiter), push, and open the PR against the release branch this phase
+was based on, following .github/PULL_REQUEST_TEMPLATE.md.
+```

--- a/docs/farming/phase-04-qa.md
+++ b/docs/farming/phase-04-qa.md
@@ -1,0 +1,116 @@
+# Phase 4 QA: Verify Knobs and insurance
+
+A fresh-session audit of the Phase 4 PR: the plant-time knobs, the husk conversion,
+and above all the survival of the draw-count contract across every knob combination
+(compost, watch, and tonic each on or off gives eight combinations; the pin must hold
+for all eight). The audit also probes the fee-bootstrap path (a player with zero
+produce must be cleanly denied, never soft-locked) and verifies the binding
+Live-surface note in phase-04-knobs.md: everything this phase minted is unobtainable.
+
+### QA Starter Prompt
+
+```
+This is Phase 4 QA of the Farming feature: Verify Knobs and insurance.
+Model: Opus 4.8, xhigh effort (1m context variant where the file load demands it).
+Harness: Claude Code.
+
+Goal: audit Phase 4 for correctness, missing tests, dead code, determinism,
+three-host parity, i18n completeness, and the phase's own acceptance criteria.
+
+STEP 0 - PRE-FLIGHT
+- Work ONLY in the persistent worktree ~/Documents/woc-farming-plan; prefix every git
+  command with git -C ~/Documents/woc-farming-plan; git status must be clean.
+- Check out the Phase 4 PR branch (fix/farming-phase-04-knobs unless progress.md
+  records another name).
+- Identify the phase diff: the PR's commits against its base (gh pr view for the base,
+  then git merge-base with it). The release tip may have moved concurrently, so the
+  diff is the PR's commits, never everything-since-phase-start. If the diff cannot be
+  identified cleanly, stop and surface.
+- Scan Claude Code memory: the MEMORY.md index, the farming-skill-program entry, plus
+  mutation-checks-commit-first, frozen-clock-rig-hangs-vitest,
+  big-diff-reviewer-turn-budgets, vacuous-bound-pin-trap.
+
+STEP 1 - LOAD CONTEXT
+Spawn one Explore agent to read and summarize: docs/farming/state.md, the Phase 4
+notes in docs/farming/progress.md, the promises in docs/farming/phase-04-knobs.md
+(deliverables, acceptance checklist, any swept deviations), and git diff --name-only
+over the phase diff. The summary MUST return: the acceptance checklist verbatim; the
+pinned draw-count contract values and pin location; the knob payload shape and the
+fee predicate as implemented; the convertHusks gate comment text; the diff file list
+grouped by surface (sim, world_api, net, ui i18n, tests, docs).
+
+STEP 2 - QA AUDIT
+Spawn three parallel audit agents. Each gets a hard 30-tool-call budget and the
+coverage instruction: "report every issue including low-severity and uncertain ones;
+ranking happens later." If one truncates, resume it with: "Stop reading more files.
+Output the full report now based on what you have already seen. No more tool calls.
+Format: BLOCKING / SHOULD-FIX / NICE-TO-HAVE / VERDICT."
+
+Correctness agent:
+- Every deliverable and acceptance criterion in phase-04-knobs.md actually met.
+- The offline Sim and online ClientWorld paths behave identically for the knobbed
+  plantCrop and for convertHusks.
+- Edge cases: empty (no compost, no tonic, no husks), boundary (survival exactly at
+  100; fee produce of tier exactly equal to the crop's tier), and every deny arm.
+- Sim behavior changed, so run live headless-Sim probes: a throwaway vitest file
+  driving real ticks with an injected ADVANCEABLE clock (advance now(), never a
+  frozen clock). Drive a plant-grow-harvest session for EVERY one of the eight knob
+  combinations and count real rng draws each time: the contract pin must hold for all
+  eight. Probe the fee-bootstrap path: a player holding zero farming produce who
+  requests farmer's watch is cleanly denied (nothing consumed, zero draws, a
+  localized denial line), never soft-locked. Then delete the throwaway file and
+  verify the tree is clean (git status).
+- Verify the Live-surface note: no vendorItems row, recipe, loot source, or quest
+  reward yields compost, growth_tonic, withered husks, or any seed.
+- Verify the D9 pricing split: compost carries a positive buyValue on its item def,
+  the growth tonic carries none, and no vendorItems row anywhere gained either item
+  yet.
+
+Test-coverage agent:
+- Every claimed behavior has a decisive assertion that fails on regression.
+- No constant-self-comparison pins: the draw-contract pin must count real draws, not
+  compare an exported constant to itself.
+- Both arms of every either/all claim: each knob has a consume-side test AND a
+  deny-side test; the cap has an at-100 and an above-100 case.
+- A same-seed determinism pin is present and decisive.
+- Orphaned tests removed; no test asserts Phase 3 behavior the knobs replaced.
+- Mutation checks only AFTER committing the work first (never plant a mutation over
+  an uncommitted tree).
+
+Dead-code-and-cleanup agent:
+- Unused imports and types across the diff.
+- The sim import invariant: src/sim/ imports nothing from render, ui, game, or net,
+  and has no DOM or Three imports.
+- No unresolved TODOs anywhere in the diff; the convertHusks Phase 9 gate comment
+  must be TODO-free while still naming Phase 9.
+- Naming consistency with the farming module's existing vocabulary.
+
+Then dispatch the Review Dispatch Matrix rows in docs/farming/implementation-plan.md
+that match the phase diff (expect architecture-reviewer and cross-platform-sync),
+plus qa-checklist as the phase-completion gate, with the same budget, coverage, and
+resume instructions.
+
+STEP 3 - FIX
+Apply ALL BLOCKING and SHOULD-FIX findings test-first: reproduce with a failing test
+that exercises the real code path, then the smallest change that turns it green. Run
+the docs/farming/state.md validation matrix rows the fix diff demands. Land fixes as
+separate Conventional Commits with explicit paths, never git add -A, no session links
+or Claude attribution.
+
+STEP 4 - DOC UPDATES
+Update docs/farming/progress.md (the Phase 4 QA row plus Notes: findings, fixes,
+deferrals) and docs/farming/state.md (any drift discovered, ledger corrections).
+
+STEP 5 - FINAL RESPONSE FORMAT
+Report: verdict PASS / PASS-WITH-FOLLOWUPS / FAIL; counts of issues found and fixed
+per severity; deferrals with reasons; and a one-line handoff.
+
+STOPPING RULES
+- Stop and surface if a BLOCKING cannot be fixed without changing phase scope.
+- Stop if the phase diff cannot be identified cleanly.
+
+When the audit and fixes are done: gate via node scripts/gate_select.mjs (the armory
+browser red is the standing environmental exception; grep the log for "[gate] FAIL";
+PR CI is the arbiter) and push the fix commits to the phase PR branch.
+Packet teardown never happens in this phase; it belongs to Phase 13 QA only.
+```

--- a/docs/farming/phase-05-crops-and-tools.md
+++ b/docs/farming/phase-05-crops-and-tools.md
@@ -1,0 +1,255 @@
+# Phase 5: Crops and tools
+
+With the growth engine and knobs in place, this phase lands the entire content
+surface: the eight-crop ladder across four tiers (seed, produce, fine twin, grades,
+icons, English names), the four-rung hoe ladder, seed-back rolls that make high-tier
+seeds market goods, finalized bed counts per hub, and the farming rollout arms that
+make every integrity guard permanent. It is the batch-heavy content sweep of the
+packet and runs as an ultracode Workflow.
+
+Live-surface note (binding): Dormant BY CHOICE. Tier 1 and 2 seeds and brook_carrot (the
+starter fee vegetable, D9) receive their positive buyValue but are placed on NO
+NpcDef.vendorItems row until Phase 9 flips go-live; tier 3 and 4 seeds come only
+from seed-back rolls on crops nobody can plant yet. Nothing added this phase is
+player-reachable.
+
+### Starter Prompt
+
+```
+This is Phase 5 of the Farming feature: Crops and tools.
+Model: Opus 4.8, xhigh effort (1m context variant where the file load demands it).
+Harness: Claude Code.
+ULTRACODE: add the keyword ultracode to this prompt so the content sweep (many
+uniform item, grade, icon, and i18n rows) runs as a Workflow with pipeline plus
+adversarial verify instead of hand-spawned agents.
+
+Goal: the complete eight-crop ladder and the hoe ladder exist with every integrity
+guard green.
+
+STEP 0 - PRE-FLIGHT
+- Work ONLY in the persistent worktree ~/Documents/woc-farming-plan. Never touch the
+  main checkout. Prefix every git command with git -C ~/Documents/woc-farming-plan.
+- git status must be clean. If it is not, stop and surface.
+- Re-resolve the NEWEST release branch: git fetch origin --prune; git branch -r
+  --list 'origin/release/*' | sort -V. Create branch
+  fix/farming-phase-05-crops-and-tools off that tip. Record the phase-start commit
+  (git rev-parse HEAD) for the STEP 3 diff. If the branch goes long-lived and
+  release moves mid-phase, merge release in and run the release-merge-audit skill.
+- Scan Claude Code memory: the MEMORY.md index, the farming-skill-program entry, plus
+  these phase-relevant topics: workflow-args-stringified,
+  workflow-parallel-missing-await, workflow-agent-sendmessage-duplicates,
+  fanout-agent-delivery-traps, big-diff-reviewer-turn-budgets,
+  i18n-semantic-regressions-gate-trap, worktree-cwd-drift-misroutes-git.
+
+STEP 1 - LOAD CONTEXT
+Spawn one Explore agent to read and summarize: docs/farming/state.md,
+docs/farming/progress.md, docs/farming/phase-05-crops-and-tools.md, and these source
+files as earlier phases landed them (state.md's "Key planned files" section records
+any refined names): src/sim/content/farm_patches.ts,
+src/sim/professions/farming_zones.ts, src/sim/professions/farming.ts, the farming
+items content module (planned src/sim/content/farming_items.ts), the modules
+exporting MATERIAL_GRADES, TOOL_RECIPES, slotToolEffectRefused, and canGatherTier
+(locate them by symbol), an existing gathering profession's material rows as the
+sellValue precedent, tests/professions_zone_rollout.test.ts,
+tests/farm_patch_placement.test.ts, tests/recipe_economy.test.ts,
+tests/professions_farming.test.ts, and the procedural item-icon registry. Also the
+relevant CLAUDE.md files: the root CLAUDE.md, src/sim/CLAUDE.md,
+src/sim/professions/CLAUDE.md, src/sim/content/CLAUDE.md, src/ui/CLAUDE.md. The
+orchestrator never reads planning docs or coordinator monoliths directly.
+The summary MUST return: the materials sellValue convention and the exact fine-twin
+pricing convention as found in code (this file names it the four-times buyValue
+convention; report the precise field the MATERIAL_GRADES precedent scales and flag
+any divergence); the MATERIAL_GRADES row shape; the procedural icon registration
+recipe and the profession-icon precedent; the TOOL_RECIPES row shape and the
+toolworks station id; the shape of the R23 top-rung-unpriced-and-craftable arm;
+slotToolEffectRefused's current policy and where hoes must be admitted; the
+FARM_PATCHES def shape and current bed-count status per hub; the FARMING_ZONES set
+and tiers; where the farming rollout arms belong in
+tests/professions_zone_rollout.test.ts; the draw-count contract pin location and
+current values; the farming_session golden re-record recipe (UPDATE_PARITY=1); the
+wiki regen command and freshness gate.
+
+STEP 2 - CHOOSE ORCHESTRATION + EXECUTE
+This phase orchestrates via the ultracode Workflow (pipeline plus adversarial
+verify), not hand-spawned agents: the uniform row sweep is exactly the shape a
+Workflow batches well. Request the fan-out explicitly. Give every Workflow agent ONLY
+the Explore summary and its own lane brief, never the planning docs. Never set plan
+mode on a teammate agent. Workflow traps from memory: args can arrive
+JSON-STRINGIFIED (normalize with a typeof-string JSON.parse at the top), await every
+parallel(), and never SendMessage a live Workflow agent (it resumes a duplicate that
+re-runs stateful git steps).
+
+Pipeline lane A, the uniform crop rows (fan out per crop, eight items in the batch;
+ids are locked by D11, English display names are proposals for the maintainer lore
+pass, IP-safe per D17): tier 1 vale_wheat and brook_carrot; tier 2 marsh_rice and
+bog_beet; tier 3 highland_barley and frost_gourd; tier 4 gilded_sunmelon and
+evergarden_greens. Per crop:
+- seed item def: tier 1 and 2 seeds get a positive buyValue (for Phase 9 stocking)
+  but NO vendorItems row anywhere; tier 3 and 4 seeds get no vendor pricing: they
+  are market goods fed by harvest seed-back rolls and, once Phase 10 lands, the
+  rare event (D11)
+- produce def: kind 'junk' so it browses under the market's material filter,
+  sellValue per the materials convention in the state.md seam reference,
+  market-listable by default
+- brook_carrot only, the starter fee vegetable per D9: its produce def also
+  receives a buyValue at the four-times-sell convention in THIS phase
+  (vendor-stocked by farmer_jessica in Phase 9), so a day-one player can pay
+  their first watch fee; no other produce receives a buyValue
+- fine_ twin def per the MATERIAL_GRADES requirement, following the four-times
+  buyValue convention (follow the precedent exactly as the Explore summary reports
+  it; note any divergence from this file's wording in progress.md)
+- a MATERIAL_GRADES row, a procedural item icon per item, and English item-name rows
+  in the matching src/ui/i18n.catalog module
+
+Lane B, the crop duration and tier table per D5: tier 1 crops 30 to 60 min, tier 2
+about 2 h, tier 3 about 4 h, tier 4 overnight. Tuning constants live in content with
+a maintainer-flag comment on every value proposing it for adjustment.
+
+Lane C, the hoe ladder (D10): four rungs as ordinary items with
+use: { type: 'gatherTool', professionId: 'farming', tier } at ascending tiers,
+riding canGatherTier and the frozen wield-gate thresholds; TOOL_RECIPES rows at the
+toolworks; rung one gets a buyValue for Phase 9 vendor stocking; the top rung is
+unpriced and craftable per the R23 arm. slotToolEffectRefused admits farming hoes,
+and a pin proves all three existing tool effects slot onto a hoe.
+
+Lane D, seed-back rolls: at harvest, tier 3 and 4 crops roll seed-back (action-time
+draws, allowed by D4). Propose the rates and flag them for the maintainer as
+economy-sensitive (state.md OPEN items). The draw-count contract is RESTATED in the
+driver's doc comment and re-pinned with the new per-harvest count, and the
+farming_session golden re-records in its own isolated commit (UPDATE_PARITY=1, never
+hand-edited).
+
+Lane E, patches and rollout arms: finalize FARM_PATCHES bed counts per hub; add the
+farming rollout arms to tests/professions_zone_rollout.test.ts keyed to
+FARMING_ZONES per D2. Per farming zone the arms assert: patches exist on legal
+ground, a tier-appropriate crop set, seed/produce/twin/icon/name integrity, a hoe
+rung per tier, the top rung unpriced, and every material has a consumer or an
+explicit Phase 6 consumer note. The hub-stocking arm is authored now but states that
+stocking flips in Phase 9 (today it pins the dormant state: no vendor rows).
+
+Adversarial verify stage: re-run the integrity suites over the whole batch, hunt
+row-level drift (a crop missing its twin, an icon or name row skipped, a tier
+mismatch, an IP-unsafe name), and confirm tests/recipe_economy.test.ts is green and
+the wiki regenerated (npm run wiki:content; tests/guide.test.ts freshness).
+
+INVARIANTS THIS PHASE MUST KEEP
+- EVERY new material ships with a consumer or a pinned Phase 6 consumer note (the
+  wolf_fang rule), no exceptions.
+- ALL names are IP-safe per D17: no coined terms from other games, real plant words
+  and original zone-flavored coinages only, audited at authoring time.
+- NO vendor row without a positive buyValue ever ships (the dead-row trap; trivially
+  true this phase since no vendor rows are added at all).
+- D4: ALL randomness draws at player-action moments through ctx.rng; the seed-back
+  roll draws at harvest, never at timer expiry, in the tick sweep, or at login.
+- Crop ids are locked by D11; no id changes for any reason.
+- Anti-chore: EVERY duration constant respects two visits per crop cycle; nothing
+  rots, no third visit.
+
+Out of scope (do NOT do in this phase):
+- Cooking and alchemy recipes (Phase 6).
+- Vendor placement of any item (Phase 9).
+- Deeds (Phase 10).
+- Work orders (Phase 9).
+
+STEP 3 - VALIDATION + MULTI-AGENT REVIEW
+Run, in order:
+- npx tsc --noEmit
+- npx vitest run tests/professions_zone_rollout.test.ts
+  tests/farm_patch_placement.test.ts tests/recipe_economy.test.ts
+  tests/professions_farming.test.ts tests/architecture.test.ts
+  tests/localization_fixes.test.ts tests/guide.test.ts
+- npx vitest run tests/parity (goldens regenerate ONLY in the lane D isolated commit)
+- npm run ci:changed
+- node scripts/gate_select.mjs
+Then check git diff --name-only against the phase-start commit and dispatch ONLY the
+matching rows of the Review Dispatch Matrix in docs/farming/implementation-plan.md.
+For this phase's expected diff the matching rows are: architecture-reviewer (the
+seed-back draws touch sim rng order), frontend-seam-reviewer (the i18n catalog and
+icon touches match its matrix row), and qa-checklist (the phase deliverable set is
+complete); dispatch cross-platform-sync ONLY if any event or wire surface moved
+(pure content rows do not move it). Every review agent gets a hard 30-tool-call
+budget, the coverage instruction ("report every issue including low-severity and
+uncertain ones; ranking happens later"), and, if truncation looms, the resume line:
+"Stop reading more files. Output the full report now based on what you have already
+seen. No more tool calls. Format: BLOCKING / SHOULD-FIX / NICE-TO-HAVE / VERDICT."
+No commit while a BLOCKING stands.
+
+STEP 4 - COMMIT CADENCE
+2 to 5 Conventional Commits, each with a scope and a body (what changed and why),
+explicit paths only, never git add -A, no session links or Claude attribution.
+Suggested shape:
+1. feat(farming): eight-crop content ladder (seeds, produce, fine twins, grades,
+   icons, English names)
+2. feat(farming): hoe ladder, tool-effect admission, crop duration table
+3. feat(farming): tier 3 and 4 seed-back rolls with the re-pinned draw contract
+4. test(parity): re-record farming_session golden after the seed-back draw change
+   (isolated, nothing else in the commit)
+5. test(professions): farming rollout arms, finalized bed counts, wiki regen
+
+STEP 5 - ACCEPTANCE CRITERIA
+- [ ] all eight locked crop ids exist with seed, produce, and fine_ twin defs;
+      produce is kind 'junk' and market-listable; sellValue follows the materials
+      convention; fine twins follow the four-times buyValue convention as the
+      precedent implements it
+- [ ] MATERIAL_GRADES rows, procedural icons, and English name rows exist for every
+      new item; display names are flagged for the maintainer lore pass and audited
+      IP-safe per D17
+- [ ] tier 1 and 2 seeds carry a positive buyValue and appear on NO vendorItems row;
+      tier 3 and 4 seeds carry no vendor pricing and flow from harvest seed-back
+      rolls and, once Phase 10 lands, the rare event (D11)
+- [ ] brook_carrot carries a buyValue at the four-times-sell convention (the starter
+      fee vegetable, D9; stocked in Phase 9) and no other produce carries one
+- [ ] the crop duration and tier table per D5 lives in content with a
+      maintainer-flag comment on every tuning constant
+- [ ] the hoe ladder has four rungs with use: { type: 'gatherTool', professionId:
+      'farming', tier } at ascending tiers, TOOL_RECIPES rows at the toolworks,
+      buyValue on rung one only, and the top rung unpriced and craftable per the
+      R23 arm
+- [ ] slotToolEffectRefused admits farming hoes and a pin proves all three tool
+      effects slot onto a hoe
+- [ ] seed-back rolls for tier 3 and 4 seeds draw at harvest action time; rates are
+      proposed and economy-flagged; the draw-count contract is restated and
+      re-pinned
+- [ ] the farming_session golden re-record is its own isolated commit
+- [ ] FARM_PATCHES bed counts are finalized per hub and
+      tests/farm_patch_placement.test.ts is green
+- [ ] the farming rollout arms in tests/professions_zone_rollout.test.ts pass: per
+      farming zone, patches on legal ground, a tier-appropriate crop set,
+      seed/produce/twin/icon/name integrity, a hoe rung per tier, the top rung
+      unpriced, and every material with a consumer or an explicit Phase 6 consumer
+      note; the hub-stocking arm exists and states that stocking flips in Phase 9
+- [ ] tests/recipe_economy.test.ts is green and the wiki regenerated
+      (tests/guide.test.ts freshness green)
+- [ ] the STEP 3 validation list is green and node scripts/gate_select.mjs passes
+      apart from the standing armory browser exception
+- [ ] docs/farming/progress.md and docs/farming/state.md ledgers are updated
+
+STEP 6 - DOC UPDATES + MEMORY
+Update docs/farming/progress.md (Phase 5 status row, the copied acceptance list with
+check states, a Notes block) and the docs/farming/state.md ledgers (new
+items/recipes, new i18n keys, proposed rates and names awaiting the maintainer, any
+refined file names). Any deviation decided in-phase (including a fine-twin pricing
+convention that differs from this file's wording) gets swept into
+docs/farming/phase-05-crops-and-tools.md AND docs/farming/phase-05-qa.md in the same
+pass, plus a line in state.md's "Locked deviations" ledger. Record surprises in
+Claude Code memory.
+
+STEP 7 - FINAL RESPONSE FORMAT
+Report: phase status; files touched; validation results (each command, pass or fail);
+review verdicts per agent; deferrals with reasons; and a one-line handoff for the QA
+session.
+
+STOPPING RULES
+- Stop if a crop cannot satisfy the integrity arms without changing a locked id: the
+  D11 ids do not move. Surface the conflict to the maintainer instead.
+- Stop if git status is not clean at STEP 0 or the newest release branch cannot be
+  resolved.
+- Stop if a BLOCKING review finding cannot be fixed without violating a locked
+  decision (D1 to D24); state.md wins over this file, and a contradiction gets swept,
+  not coded around.
+
+When everything above is done: gate via node scripts/gate_select.mjs (the armory
+browser red is the standing environmental exception; grep the log for "[gate] FAIL";
+PR CI is the arbiter), push, and open the PR against the release branch this phase
+was based on, following .github/PULL_REQUEST_TEMPLATE.md.
+```

--- a/docs/farming/phase-05-qa.md
+++ b/docs/farming/phase-05-qa.md
@@ -1,0 +1,133 @@
+# Phase 5 QA: Verify Crops and tools
+
+A fresh-session audit of the Phase 5 PR, the big content sweep. The rollout and
+placement suites are the spine of this audit: run them first and treat every farming
+arm as a promise to re-verify by hand. The two sharpest checks: every new material
+satisfies the consumer rule (a real consumer or an explicit Phase 6 consumer note),
+and NO vendorItems row anywhere in the content set gained a farming item, which is
+the binding Live-surface note of phase-05-crops-and-tools.md.
+
+### QA Starter Prompt
+
+```
+This is Phase 5 QA of the Farming feature: Verify Crops and tools.
+Model: Opus 4.8, xhigh effort (1m context variant where the file load demands it).
+Harness: Claude Code.
+
+Goal: audit Phase 5 for correctness, missing tests, dead code, determinism,
+three-host parity, i18n completeness, and the phase's own acceptance criteria.
+
+STEP 0 - PRE-FLIGHT
+- Work ONLY in the persistent worktree ~/Documents/woc-farming-plan; prefix every git
+  command with git -C ~/Documents/woc-farming-plan; git status must be clean.
+- Check out the Phase 5 PR branch (fix/farming-phase-05-crops-and-tools unless
+  progress.md records another name).
+- Identify the phase diff: the PR's commits against its base (gh pr view for the
+  base, then git merge-base with it). The release tip may have moved concurrently,
+  so the diff is the PR's commits, never everything-since-phase-start. If the diff
+  cannot be identified cleanly, stop and surface.
+- Scan Claude Code memory: the MEMORY.md index, the farming-skill-program entry, plus
+  mutation-checks-commit-first, i18n-semantic-regressions-gate-trap,
+  big-diff-reviewer-turn-budgets, vacuous-bound-pin-trap.
+
+STEP 1 - LOAD CONTEXT
+Spawn one Explore agent to read and summarize: docs/farming/state.md, the Phase 5
+notes in docs/farming/progress.md, the promises in
+docs/farming/phase-05-crops-and-tools.md (deliverables, acceptance checklist, any
+swept deviations, the fine-twin pricing convention as actually implemented), and
+git diff --name-only over the phase diff. The summary MUST return: the acceptance
+checklist verbatim; the eight crop ids with their item ids (seed, produce, fine
+twin); the hoe rung ids and pricing; the seed-back rates as proposed; the re-pinned
+draw-count contract values; whether the farming_session golden re-record commit is
+isolated; the diff file list grouped by surface (content, sim, tests, ui i18n, wiki
+artifacts, docs).
+
+STEP 2 - QA AUDIT
+First run the spine yourself: npx vitest run tests/professions_zone_rollout.test.ts
+tests/farm_patch_placement.test.ts. Both must be green before the audit fans out; a
+red here is an immediate BLOCKING.
+Then spawn three parallel audit agents. Each gets a hard 30-tool-call budget and the
+coverage instruction: "report every issue including low-severity and uncertain ones;
+ranking happens later." If one truncates, resume it with: "Stop reading more files.
+Output the full report now based on what you have already seen. No more tool calls.
+Format: BLOCKING / SHOULD-FIX / NICE-TO-HAVE / VERDICT."
+
+Correctness agent:
+- Every deliverable and acceptance criterion in phase-05-crops-and-tools.md actually
+  met: walk all eight crops row by row (seed, produce, fine twin, grade row, icon,
+  English name) and all four hoe rungs (tier, recipe, pricing, top rung unpriced).
+- The offline Sim and online ClientWorld paths behave identically wherever behavior
+  moved (the seed-back roll at harvest is the sim change to probe).
+- Edge cases: empty, boundary, deny arms; a tier 4 harvest rolls seed-back, a tier 1
+  harvest does not (both arms).
+- Sim behavior changed (seed-back draws), so run live headless-Sim probes: a
+  throwaway vitest file driving real ticks with an injected ADVANCEABLE clock,
+  planting and harvesting a tier 3 or 4 crop, counting real rng draws against the
+  re-pinned contract. Then delete the throwaway file and verify the tree is clean
+  (git status).
+- PHASE EMPHASIS, the consumer rule: audit EVERY new material (all produce, all fine
+  twins, and every other new item) for a real consumer or an explicit Phase 6
+  consumer note in the rollout arm; an unnoted orphan material is BLOCKING.
+- PHASE EMPHASIS, the Live-surface note: check that NO NpcDef.vendorItems row
+  anywhere gained a farming item (seeds, produce, fine twins, hoes, compost, growth
+  tonic, husks). Search the whole content set, not just changed files. Also verify
+  tier 1 and 2 seeds carry a positive buyValue with no row (the Phase 9
+  precondition), brook_carrot carries its buyValue at the four-times-sell
+  convention (the starter fee vegetable, D9) while no OTHER produce carries one,
+  and the top hoe rung is unpriced.
+- IP-safety spot audit of every proposed display name per D17.
+
+Test-coverage agent:
+- Every claimed behavior has a decisive assertion that fails on regression; the
+  rollout arms must fail when a row is removed (probe one mentally, or by mutation
+  AFTER the work is committed).
+- No constant-self-comparison pins: integrity arms must read the real content
+  tables, not re-derive expectations from the same object they check.
+- Both arms of every either/all claim: the seed-back roll has a rolls arm (tier 3
+  and 4) and a does-not-roll arm (tier 1 and 2); the tool-effect pin covers all
+  three effects.
+- A determinism pin is present for the changed draw path.
+- Orphaned tests removed; no pin still asserts the pre-Phase-5 draw contract.
+
+Dead-code-and-cleanup agent:
+- Unused imports and types across the diff; no leftover scaffolding from the
+  Workflow sweep.
+- The sim import invariant: src/sim/ imports nothing from render, ui, game, or net,
+  and has no DOM or Three imports.
+- No unresolved TODOs anywhere in the diff (the Phase 6 consumer notes and the
+  Phase 9 stocking note are named-phase comments, not TODO markers).
+- Naming consistency: item ids, i18n keys, and icon keys follow one scheme across
+  all eight crops.
+
+Then dispatch the Review Dispatch Matrix rows in docs/farming/implementation-plan.md
+that match the phase diff (expect architecture-reviewer and frontend-seam-reviewer;
+cross-platform-sync only if an event or wire surface moved), plus qa-checklist as
+the phase-completion gate, with the same budget, coverage, and resume instructions.
+
+STEP 3 - FIX
+Apply ALL BLOCKING and SHOULD-FIX findings test-first: reproduce with a failing test
+that exercises the real code path, then the smallest change that turns it green. Run
+the docs/farming/state.md validation matrix rows the fix diff demands (content
+changes demand the rollout, recipe-economy, and wiki-freshness rows). Land fixes as
+separate Conventional Commits with explicit paths, never git add -A, no session
+links or Claude attribution.
+
+STEP 4 - DOC UPDATES
+Update docs/farming/progress.md (the Phase 5 QA row plus Notes: findings, fixes,
+deferrals) and docs/farming/state.md (any drift discovered, ledger corrections, the
+verified fine-twin pricing convention if it diverged from the phase file's wording).
+
+STEP 5 - FINAL RESPONSE FORMAT
+Report: verdict PASS / PASS-WITH-FOLLOWUPS / FAIL; counts of issues found and fixed
+per severity; deferrals with reasons; and a one-line handoff.
+
+STOPPING RULES
+- Stop and surface if a BLOCKING cannot be fixed without changing phase scope (a
+  locked crop id, a draw-contract change beyond the seed-back extension).
+- Stop if the phase diff cannot be identified cleanly.
+
+When the audit and fixes are done: gate via node scripts/gate_select.mjs (the armory
+browser red is the standing environmental exception; grep the log for "[gate] FAIL";
+PR CI is the arbiter) and push the fix commits to the phase PR branch.
+Packet teardown never happens in this phase; it belongs to Phase 13 QA only.
+```

--- a/docs/farming/phase-06-economy-hooks.md
+++ b/docs/farming/phase-06-economy-hooks.md
@@ -1,0 +1,193 @@
+# Phase 6: Economy hooks
+
+The farm now produces; this phase makes the rest of the economy consume it. Plain
+cooking dishes ladder up beside the existing cooking budget conventions, alchemy
+crafts the growth tonic from herbs (the cross-profession trade of D7), and the
+consumer rule closes over every Phase 5 material: after this phase, every produce and
+the withered husks have a real consumer, not a note.
+
+Live-surface note (binding): Dormant. The new recipes are visible in the crafting window, but
+every one has at least one reagent unobtainable until go-live (farm produce or husks
+nobody can grow yet). The phase verifies explicitly that no new recipe is craftable
+from vendor goods alone.
+
+### Starter Prompt
+
+```
+This is Phase 6 of the Farming feature: Economy hooks.
+Model: Opus 4.8, xhigh effort (1m context variant where the file load demands it).
+Harness: Claude Code.
+
+Goal: cooking and alchemy consume the farm.
+
+STEP 0 - PRE-FLIGHT
+- Work ONLY in the persistent worktree ~/Documents/woc-farming-plan. Never touch the
+  main checkout. Prefix every git command with git -C ~/Documents/woc-farming-plan.
+- git status must be clean. If it is not, stop and surface.
+- Re-resolve the NEWEST release branch: git fetch origin --prune; git branch -r
+  --list 'origin/release/*' | sort -V. Create branch
+  fix/farming-phase-06-economy-hooks off that tip. Record the phase-start commit
+  (git rev-parse HEAD) for the STEP 3 diff. If the branch goes long-lived and
+  release moves mid-phase, merge release in and run the release-merge-audit skill.
+- Scan Claude Code memory: the MEMORY.md index, the farming-skill-program entry, plus
+  these phase-relevant topics: i18n-semantic-regressions-gate-trap,
+  mutation-checks-commit-first, big-diff-reviewer-turn-budgets,
+  fanout-agent-delivery-traps, worktree-cwd-drift-misroutes-git.
+
+STEP 1 - LOAD CONTEXT
+Spawn one Explore agent to read and summarize: docs/farming/state.md,
+docs/farming/progress.md, docs/farming/phase-06-economy-hooks.md, and these source
+files as earlier phases landed them (state.md's "Key planned files" section records
+any refined names): the cooking recipe and dish content modules (locate the existing
+cooking ladder and its budget conventions), the alchemy recipe content module and
+its herb-input conventions, the farming items content module (produce ids, husks,
+growth_tonic), tests/recipe_economy.test.ts, the Phase 5 consumer-note arms in
+tests/professions_zone_rollout.test.ts, the professions training/ladder suites that
+cover recipe skill progression (name them), and the src/ui/i18n.catalog modules that
+carry recipe and item names. Also the relevant CLAUDE.md files: the root CLAUDE.md,
+src/sim/CLAUDE.md, src/sim/professions/CLAUDE.md, src/sim/content/CLAUDE.md,
+src/ui/CLAUDE.md. The orchestrator never reads planning docs or coordinator
+monoliths directly.
+The summary MUST return: the cooking ladder's budget conventions (foodHp per skill
+band, pricing, skillReq laddering) with the exported symbols that carry them; the
+alchemy budget conventions and herb-input precedent; the recipe row shape for both
+professions; the exact list of Phase 5 materials carrying a Phase 6 consumer note;
+the growth_tonic item id and how Phase 4 consumes it; the names of the professions
+recipe suites that must stay green; the recipe-economy invariant's mechanics; the
+wiki regen command and freshness gate.
+
+STEP 2 - CHOOSE ORCHESTRATION + EXECUTE
+Split into three agents by vertical slice, each owning its slice plus its tests.
+Request the fan-out explicitly (these models under-spawn by default). Give each agent
+ONLY the Explore summary and its own deliverable list, never the planning docs. Never
+set plan mode on a teammate agent. Merge slices only if one turns out to be one or
+two trivial changes.
+
+Agent A, cooking dishes:
+- One or two plain dishes per crop tier beside the existing cooking ladder budget
+  conventions: foodHp only, NO buff machinery this phase (well-fed is Phase 11, the
+  ItemDef.wellfed arm does not exist yet and is not added here).
+- Each dish consumes farm produce; vendor staples may join per the ladder
+  convention, but no dish is vendor-only.
+- Recipe rows with laddered skillReq following the cooking ladder's progression.
+- Values proposed and maintainer-flagged in comments (classic-modest, no invented
+  balance claims).
+- English recipe and item-name rows in the matching src/ui/i18n.catalog module;
+  names IP-safe per D17.
+- Tests: the new rows conform to the ladder conventions; the training/ladder suites
+  stay green.
+
+Agent B, the alchemy tonic recipe:
+- The growth_tonic recipe with herb inputs per D7 (crafted by alchemy FROM HERBS,
+  the cross-profession trade), conforming to the alchemy budget conventions.
+- English recipe-name row; tests that the row conforms.
+
+Agent C, closure and dormancy proof:
+- The consumer-rule pin closing every Phase 5 material: each produce and the husks
+  have at least one recipe or command consumer now. Verify and pin it, and replace
+  the Phase 6 consumer notes in the tests/professions_zone_rollout.test.ts farming
+  arms with the real consumers.
+- The vendor-goods-alone negative: verify (and pin) that every new recipe has at
+  least one reagent with no vendor faucet, so nothing new is craftable from vendor
+  goods alone before go-live.
+- tests/recipe_economy.test.ts green over the new rows; wiki regen
+  (npm run wiki:content; tests/guide.test.ts freshness).
+
+INVARIANTS THIS PHASE MUST KEEP
+- The recipe economy invariant: EVERY recipe respects it, nothing vendors above its
+  cheapest achievable inputs (tests/recipe_economy.test.ts is the guard).
+- Classic-modest values everywhere; no invented balance claims; every proposed
+  number is maintainer-flagged.
+- EVERY new material consumer claim is real: after this phase, every Phase 5 produce
+  and the husks have at least one recipe or command consumer, with no remaining
+  Phase 6 notes.
+- EVERY player-visible string is a t() key added in English only to the matching
+  src/ui/i18n.catalog module; never edit locale overlays.
+- Sim purity and determinism are untouched: content rows only; no new rng, no
+  Math.random, Date.now, or performance.now in src/sim/.
+
+Out of scope (do NOT do in this phase):
+- Well-fed buffs and the ItemDef.wellfed arm (Phase 11).
+- The shared feast (Phase 12).
+- Work orders (Phase 9).
+- Vendor stock of any kind (Phase 9).
+
+STEP 3 - VALIDATION + MULTI-AGENT REVIEW
+Run, in order:
+- npx tsc --noEmit
+- npx vitest run tests/recipe_economy.test.ts tests/professions_zone_rollout.test.ts
+  tests/localization_fixes.test.ts tests/guide.test.ts tests/architecture.test.ts
+- npx vitest run over the professions recipe suites the Explore summary names
+- npm run ci:changed
+- node scripts/gate_select.mjs
+Then check git diff --name-only against the phase-start commit and dispatch ONLY the
+matching rows of the Review Dispatch Matrix in docs/farming/implementation-plan.md.
+For this phase's expected diff the matching rows are: architecture-reviewer (any sim
+content change that touches the crafting path), frontend-seam-reviewer (the i18n
+catalog rows match its matrix row), and qa-checklist (the phase deliverable set is
+complete); dispatch cross-platform-sync ONLY if an event or wire surface moved
+(pure recipe rows do not move it). Every review agent gets a hard
+30-tool-call budget, the coverage instruction ("report every issue including
+low-severity and uncertain ones; ranking happens later"), and, if truncation looms,
+the resume line: "Stop reading more files. Output the full report now based on what
+you have already seen. No more tool calls. Format: BLOCKING / SHOULD-FIX /
+NICE-TO-HAVE / VERDICT." No commit while a BLOCKING stands.
+
+STEP 4 - COMMIT CADENCE
+2 to 5 Conventional Commits, each with a scope and a body (what changed and why),
+explicit paths only, never git add -A, no session links or Claude attribution.
+Suggested shape:
+1. feat(cooking): plain farm dishes per tier with laddered skillReq
+2. feat(alchemy): growth tonic recipe from herbs
+3. test(economy): consumer-rule closure and the vendor-goods-alone negative
+4. docs(farming): wiki regen, progress and state ledger updates
+
+STEP 5 - ACCEPTANCE CRITERIA
+- [ ] one or two plain dishes per crop tier exist, consuming farm produce, foodHp
+      only with no buff machinery, recipe rows with laddered skillReq beside the
+      cooking ladder budget conventions; values proposed and maintainer-flagged
+- [ ] the alchemy growth_tonic recipe exists with herb inputs per D7 and conforms to
+      the alchemy budget conventions
+- [ ] the consumer rule is closed: every Phase 5 produce and the withered husks have
+      at least one recipe or command consumer, verified and pinned; the Phase 6
+      consumer notes in the rollout arms are replaced by the real consumers
+- [ ] no new recipe is craftable from vendor goods alone: every one has at least one
+      reagent with no vendor faucet, verified and pinned
+- [ ] English recipe and item-name i18n rows exist for every new dish and the tonic
+      recipe; tests/localization_fixes.test.ts is green
+- [ ] tests/recipe_economy.test.ts and the training/ladder suites are green
+- [ ] the recipe economy invariant holds: nothing vendors above its cheapest
+      achievable inputs
+- [ ] the wiki regenerated and tests/guide.test.ts freshness is green
+- [ ] the STEP 3 validation list is green and node scripts/gate_select.mjs passes
+      apart from the standing armory browser exception
+- [ ] docs/farming/progress.md and docs/farming/state.md ledgers are updated
+
+STEP 6 - DOC UPDATES + MEMORY
+Update docs/farming/progress.md (Phase 6 status row, the copied acceptance list with
+check states, a Notes block) and the docs/farming/state.md ledgers (new recipes, new
+i18n keys, proposed values awaiting the maintainer; mark the consumer notes closed).
+Any deviation decided in-phase gets swept into
+docs/farming/phase-06-economy-hooks.md AND docs/farming/phase-06-qa.md in the same
+pass, plus a line in state.md's "Locked deviations" ledger. Record surprises in
+Claude Code memory.
+
+STEP 7 - FINAL RESPONSE FORMAT
+Report: phase status; files touched; validation results (each command, pass or fail);
+review verdicts per agent; deferrals with reasons; and a one-line handoff for the QA
+session.
+
+STOPPING RULES
+- Stop if a dish or the tonic cannot stay inside the documented budget ceilings
+  without a maintainer call; surface the numbers instead of inventing a new budget.
+- Stop if git status is not clean at STEP 0 or the newest release branch cannot be
+  resolved.
+- Stop if a BLOCKING review finding cannot be fixed without violating a locked
+  decision (D1 to D24); state.md wins over this file, and a contradiction gets swept,
+  not coded around.
+
+When everything above is done: gate via node scripts/gate_select.mjs (the armory
+browser red is the standing environmental exception; grep the log for "[gate] FAIL";
+PR CI is the arbiter), push, and open the PR against the release branch this phase
+was based on, following .github/PULL_REQUEST_TEMPLATE.md.
+```

--- a/docs/farming/phase-06-qa.md
+++ b/docs/farming/phase-06-qa.md
@@ -1,0 +1,127 @@
+# Phase 6 QA: Verify Economy hooks
+
+A fresh-session audit of the Phase 6 PR: the cooking dishes, the alchemy tonic
+recipe, and the two claims that define the phase. First, the dormancy negative from
+the binding Live-surface note: no new recipe is craftable from vendor goods alone.
+Second, chain integrity: every new recipe's reagent chain terminates in Phase 5
+content or existing materials, and the consumer rule over every Phase 5 material is
+now closed with real consumers, not notes.
+
+### QA Starter Prompt
+
+```
+This is Phase 6 QA of the Farming feature: Verify Economy hooks.
+Model: Opus 4.8, xhigh effort (1m context variant where the file load demands it).
+Harness: Claude Code.
+
+Goal: audit Phase 6 for correctness, missing tests, dead code, determinism,
+three-host parity, i18n completeness, and the phase's own acceptance criteria.
+
+STEP 0 - PRE-FLIGHT
+- Work ONLY in the persistent worktree ~/Documents/woc-farming-plan; prefix every git
+  command with git -C ~/Documents/woc-farming-plan; git status must be clean.
+- Check out the Phase 6 PR branch (fix/farming-phase-06-economy-hooks unless
+  progress.md records another name).
+- Identify the phase diff: the PR's commits against its base (gh pr view for the
+  base, then git merge-base with it). The release tip may have moved concurrently,
+  so the diff is the PR's commits, never everything-since-phase-start. If the diff
+  cannot be identified cleanly, stop and surface.
+- Scan Claude Code memory: the MEMORY.md index, the farming-skill-program entry, plus
+  mutation-checks-commit-first, i18n-semantic-regressions-gate-trap,
+  big-diff-reviewer-turn-budgets.
+
+STEP 1 - LOAD CONTEXT
+Spawn one Explore agent to read and summarize: docs/farming/state.md, the Phase 6
+notes in docs/farming/progress.md, the promises in
+docs/farming/phase-06-economy-hooks.md (deliverables, acceptance checklist, any
+swept deviations), and git diff --name-only over the phase diff. The summary MUST
+return: the acceptance checklist verbatim; every new recipe id with its full reagent
+list; the list of Phase 5 materials whose consumer notes were closed and by what
+consumer; the budget conventions the dishes and tonic claim to conform to; the diff
+file list grouped by surface (content, tests, ui i18n, wiki artifacts, docs).
+
+STEP 2 - QA AUDIT
+Spawn three parallel audit agents. Each gets a hard 30-tool-call budget and the
+coverage instruction: "report every issue including low-severity and uncertain ones;
+ranking happens later." If one truncates, resume it with: "Stop reading more files.
+Output the full report now based on what you have already seen. No more tool calls.
+Format: BLOCKING / SHOULD-FIX / NICE-TO-HAVE / VERDICT."
+
+Correctness agent:
+- Every deliverable and acceptance criterion in phase-06-economy-hooks.md actually
+  met; each dish is foodHp only with no buff machinery of any kind.
+- PHASE EMPHASIS, the vendor-goods-alone negative: for EVERY new recipe, walk the
+  reagent chain against the vendor tables; at least one reagent must have no vendor
+  faucet (no vendorItems row anywhere sells it, directly or via a craftable chain of
+  vendor-only inputs). A recipe craftable from vendor goods alone violates the
+  binding Live-surface note and is BLOCKING.
+- PHASE EMPHASIS, chain termination: every new recipe's reagent chain terminates in
+  Phase 5 farming content or existing materials; no reagent id dangles or references
+  unshipped content.
+- The consumer rule is fully closed: every Phase 5 produce and the withered husks
+  now have a real recipe or command consumer, and no Phase 6 consumer note remains
+  in the rollout arms.
+- The offline Sim and online ClientWorld paths behave identically wherever behavior
+  moved; if any sim behavior changed (beyond content rows), run live headless-Sim
+  probes via a throwaway vitest file driving real ticks with an injected ADVANCEABLE
+  clock, then delete it and verify the tree is clean (git status).
+- Edge cases: empty, boundary, deny arms (crafting each new recipe without its farm
+  reagent is denied by the normal recipe machinery).
+- Verify the purity guard ran: tests/architecture.test.ts is green over the phase
+  diff, per the phase's STEP 3 run list.
+
+Test-coverage agent:
+- Every claimed behavior has a decisive assertion that fails on regression: the
+  consumer-rule pin must fail if a consumer row is deleted, and the
+  vendor-goods-alone pin must fail if a reagent gains a vendor faucet.
+- No constant-self-comparison pins: the pins must read the real recipe and vendor
+  tables, never re-derive expectations from the object under test.
+- Both arms of every either/all claim: conforms and violates arms for the budget
+  checks where the suite supports it.
+- A determinism pin is present if any draw path changed (none is expected this
+  phase; flag it if one appears).
+- Orphaned tests removed: no test still asserts a Phase 6 consumer note that this
+  phase replaced.
+- Mutation checks only AFTER committing the work first.
+
+Dead-code-and-cleanup agent:
+- Unused imports and types across the diff.
+- The sim import invariant: src/sim/ imports nothing from render, ui, game, or net,
+  and has no DOM or Three imports.
+- No unresolved TODOs anywhere in the diff.
+- Naming consistency: dish and recipe ids and i18n keys follow the existing cooking
+  and alchemy schemes.
+
+Then dispatch the Review Dispatch Matrix rows in docs/farming/implementation-plan.md
+that match the phase diff (expect architecture-reviewer and frontend-seam-reviewer;
+cross-platform-sync only if an event or wire surface moved), plus qa-checklist as
+the phase-completion gate, with the same budget, coverage, and resume instructions.
+
+STEP 3 - FIX
+Apply ALL BLOCKING and SHOULD-FIX findings test-first: reproduce with a failing test
+that exercises the real code path, then the smallest change that turns it green. Run
+the docs/farming/state.md validation matrix rows the fix diff demands (content
+changes demand the rollout, recipe-economy, and wiki-freshness rows, plus
+tests/architecture.test.ts, the purity guard the phase's STEP 3 runs). Land fixes as
+separate Conventional Commits with explicit paths, never git add -A, no session
+links or Claude attribution.
+
+STEP 4 - DOC UPDATES
+Update docs/farming/progress.md (the Phase 6 QA row plus Notes: findings, fixes,
+deferrals) and docs/farming/state.md (any drift discovered, ledger corrections).
+
+STEP 5 - FINAL RESPONSE FORMAT
+Report: verdict PASS / PASS-WITH-FOLLOWUPS / FAIL; counts of issues found and fixed
+per severity; deferrals with reasons; and a one-line handoff.
+
+STOPPING RULES
+- Stop and surface if a BLOCKING cannot be fixed without changing phase scope (a
+  budget ceiling that needs a maintainer call, a reagent chain that cannot close
+  without new content).
+- Stop if the phase diff cannot be identified cleanly.
+
+When the audit and fixes are done: gate via node scripts/gate_select.mjs (the armory
+browser red is the standing environmental exception; grep the log for "[gate] FAIL";
+PR CI is the arbiter) and push the fix commits to the phase PR branch.
+Packet teardown never happens in this phase; it belongs to Phase 13 QA only.
+```

--- a/docs/farming/phase-07-qa.md
+++ b/docs/farming/phase-07-qa.md
@@ -1,0 +1,130 @@
+# Phase 7 QA: Verify Render and juice
+
+Independent verification of Phase 7 in a fresh session. The emphasis is visual truth:
+the beds actually render at all four hubs with the right tints, growth stages actually
+change on screen for the owning player and ONLY the owning player (the per-viewer model,
+D3), and nothing in the render or SFX wiring violated the fairness, purity, or
+generated-file invariants. The audit runs on the real dev client, not just the suites.
+
+### QA Starter Prompt
+
+```
+This is Phase 7 QA of the Farming feature: Verify Render and juice.
+Model: Opus 4.8, xhigh effort (1m context variant where the file load demands it).
+Harness: Claude Code.
+
+Goal: audit Phase 7 for correctness, missing tests, dead code, determinism,
+three-host parity, i18n completeness, and the phase's own acceptance criteria.
+
+STEP 0 - PRE-FLIGHT
+- Work ONLY in the persistent worktree ~/Documents/woc-farming-plan; git status must
+  be clean. Check out the phase branch fix/farming-phase-07-render-and-juice (QA fix
+  commits land on the phase PR).
+- Identify the phase diff: the PR's commits against its base (git merge-base the PR
+  branch with the release branch it was opened against, then diff that range). The
+  release tip may have moved concurrently, so the diff is the PR's commits, never
+  everything-since-phase-start. Stop if the diff cannot be identified cleanly.
+- Scan Claude Code memory: the MEMORY.md index, the farming-skill-program entry,
+  pr-screenshot-browser-path (browser path, swiftshader flags, overlay traps),
+  frozen-clock-rig-hangs-vitest, mutation-checks-commit-first,
+  big-diff-reviewer-turn-budgets.
+
+STEP 1 - LOAD CONTEXT
+Spawn one Explore agent to read and summarize: docs/farming/state.md; the
+docs/farming/progress.md Phase 7 notes (including any recorded deviation); the
+promises in docs/farming/phase-07-render-and-juice.md (Live-surface note,
+deliverables, acceptance criteria, the documented collider or pad decision); and
+git diff --name-only over the phase diff. The summary must return the acceptance
+list verbatim, the file list, the SimEvent and cue names used, and any deviation the
+phase recorded.
+
+STEP 2 - QA AUDIT
+Spawn three parallel audit agents. Each gets a hard 30-tool-call budget and the
+coverage instruction: "report every issue including low-severity and uncertain ones;
+ranking happens later." If truncated, resume with: "Stop reading more files. Output
+the full report now based on what you have already seen. No more tool calls. Format:
+BLOCKING / SHOULD-FIX / NICE-TO-HAVE / VERDICT."
+
+Agent 1, correctness:
+- Verify every deliverable and every acceptance criterion in the phase file is
+  actually met, not just claimed.
+- Verify the offline Sim and online ClientWorld paths behave identically: the
+  renderer reads the same IWorldFarming members from both, and no farming render
+  read exists on only one world.
+- Drive the real dev client headless (npm run dev, the browser path and swiftshader
+  flags from the pr-screenshot-browser-path memory entry) and verify the on-screen
+  result, dismissing any first-run prompt overlays before clicking: beds render at
+  all four hubs (eastbrook_vale, mirefen_marsh, thornpeak_heights, evergarden) with
+  the correct biome tint at each; with dev commands (ALLOW_DEV_COMMANDS=1, dev
+  only), plant and force growth on MY plots and verify the stage meshes change on
+  screen, the wet-soil tint appears after planting, and the withered silhouette
+  renders for a failed crop.
+- Verify the per-viewer model: another player's plot state must not alter my scene.
+  Check it at the pure-core level (the rebuild signature derives only from the
+  viewing player's plots plus the static patch defs) and, where feasible, live with
+  a second connected client.
+- Verify the projection is the render source of truth per D3: the adapter derives
+  the visual stage from the planted-at and ready-at fractions, the wet-soil tint
+  from planted-at recency, and the withered look from the projection's derived
+  status; confirm no dedicated stage, wet, or withered facet read was added to
+  IWorldFarming.
+- If the phase touched src/sim/ (a collider or pad row): run live headless-Sim
+  probes via a throwaway vitest file driving real ticks with an injected ADVANCEABLE
+  clock (the clock must advance now(); a frozen clock hangs), then delete the file
+  and verify the tree is clean.
+- Edge cases: a patch with zero planted plots, all plots withered, a plot state that
+  arrives after the first scene build (the signature guard must catch it), and tier
+  knob toggling mid-session (VFX shed, beds and stages do not).
+
+Agent 2, test coverage:
+- Every claimed behavior has a decisive assertion that fails on regression; no
+  constant-self-comparison pins (the contract test's fingerprint pins must compare
+  against committed literals, not values recomputed from the same source).
+- Both arms of every either/all claim: tinted and untinted, withered and healthy,
+  shed and unshed VFX, signature-change rebuild and signature-same skip.
+- Orphaned or superseded tests removed; the RENDER_PURE_CORES registration is real
+  (the suite actually imports and runs the core).
+- Mutation checks are allowed only after committing the work first; verify the
+  exporter determinism claim by running it twice and diffing bytes.
+
+Agent 3, dead code and cleanup:
+- Unused imports, types, and exports across the diff; no unresolved TODOs; naming
+  consistency with the farming modules landed in Phases 1 to 6.
+- The sim import invariant: src/sim/ imports nothing from render, ui, game, or net,
+  and src/render/farm_patches.ts imports nothing from src/sim/ beyond the world_api
+  facet.
+- No hand-edits to generated files (media manifest, SFX manifest, runtime pack);
+  regen commands reproduce them byte-identically.
+- No leftover throwaway probe files, screenshots, or scratch scripts in the tree.
+
+Then dispatch the Review Dispatch Matrix rows in
+docs/farming/implementation-plan.md that match the phase diff (expected:
+frontend-seam-reviewer; architecture-reviewer only if src/sim/ moved), plus
+qa-checklist (the phase-completion gate). Same 30-call budget, coverage instruction,
+and resume line for each.
+
+STEP 3 - FIX
+Apply every BLOCKING and SHOULD-FIX finding test-first: reproduce with a failing
+test, then the smallest change that turns it green. Run the docs/farming/state.md
+validation matrix rows the diff demands. Land fixes as separate Conventional Commits
+with explicit paths, never git add -A, no session links or Claude attribution.
+
+STEP 4 - DOC UPDATES
+Update docs/farming/progress.md (the Phase 7 QA row and a Notes block) and
+docs/farming/state.md (any drift found: ledger corrections, decision records).
+If a fix amended the phase file, sweep this QA twin in the same pass.
+
+STEP 5 - FINAL RESPONSE FORMAT
+Verdict: PASS / PASS-WITH-FOLLOWUPS / FAIL. Counts: findings found and findings
+fixed, by severity. Deferrals with reasons. A one-line handoff for the Phase 8
+session.
+
+STOPPING RULES
+- Stop and surface if a BLOCKING cannot be fixed without changing phase scope.
+- Stop if the phase diff cannot be identified cleanly.
+
+Close: re-run node scripts/gate_select.mjs after fixes (the armory browser red is
+the standing environmental exception; grep the log for "[gate] FAIL"; PR CI is the
+arbiter) and push the fix commits to the phase PR.
+Packet teardown never happens in this phase; it belongs to Phase 13 QA only.
+```

--- a/docs/farming/phase-07-render-and-juice.md
+++ b/docs/farming/phase-07-render-and-juice.md
@@ -1,0 +1,240 @@
+# Phase 7: Render and juice
+
+Farming has been fully simulated and fully invisible since Phase 3. This phase gives it a
+body: procedural swap-ready garden beds and crop growth stages at the four farming hubs,
+per-viewer stage rendering per D3, plant and harvest VFX, and placeholder SFX cues. It
+lands BEFORE go-live on purpose (the ordering rationale in
+`docs/farming/implementation-plan.md`): farming must never ship blind. Art follows D19
+(procedural wave 1, fixed footprints and pivots so sourced models drop in later without
+code changes).
+
+Live-surface note (binding): After this phase merges, garden beds are visible at the four
+farming hubs (eastbrook_vale, mirefen_marsh, thornpeak_heights, evergarden): decorative,
+walkable, and non-blocking. A player's own crops render growth stages for that player
+only (the per-viewer model, D3). Plant and harvest VFX fire only for plot states
+reachable via dev commands until go-live (Phase 9). No seeds are obtainable, no UI
+window exists, no map pins, no notices.
+
+### Starter Prompt
+
+```
+This is Phase 7 of the Farming feature: Render and juice.
+Model: Opus 4.8, xhigh effort (1m context variant where the file load demands it).
+Harness: Claude Code.
+
+Goal: make the farm beautiful before it is reachable: swap-ready procedural beds and
+crop growth-stage props at the four farming hubs, a per-viewer render adapter, plant
+and harvest VFX, and placeholder SFX cues, with the asset budget green.
+
+STEP 0 - PRE-FLIGHT
+- Work ONLY in the persistent worktree ~/Documents/woc-farming-plan. Other sessions
+  share the main checkout; never work there.
+- git -C ~/Documents/woc-farming-plan status must be clean. Stop if it is not.
+- Re-resolve the NEWEST release/** branch: git fetch origin --prune; then
+  git branch -r --list 'origin/release/*' | sort -V and take the last row. Create
+  branch fix/farming-phase-07-render-and-juice off its tip.
+- Record the phase-start commit (git rev-parse HEAD) for the STEP 3 diff.
+- Scan Claude Code memory: the MEMORY.md index, the farming-skill-program entry, and
+  the phase-relevant topics: pr-screenshot-browser-path (this is a visual phase),
+  worktree-cwd-drift-misroutes-git, pkill-pattern-matches-own-shell,
+  big-diff-reviewer-turn-budgets, malware-scan-comment-keywords.
+
+STEP 1 - LOAD CONTEXT
+Spawn one Explore agent (thoroughness: very thorough) to read and summarize:
+- docs/farming/state.md (whole file; D2, D3, D19 and the seam reference matter most
+  here) and docs/farming/progress.md (Phase 1 to 6 notes, deviations, name
+  refinements).
+- docs/farming/phase-07-render-and-juice.md (this phase file).
+- The image-to-glb skill (.claude/skills/image-to-glb/SKILL.md) and
+  docs/image-to-glb-asset-workflow.md.
+- Source files for this phase: src/sim/content/farm_patches.ts (FARM_PATCHES and
+  FarmPatchDef as landed in Phase 2; progress.md notes any name refinement),
+  src/sim/professions/farming_zones.ts (FARMING_ZONES, its one home),
+  src/world_api/farming.ts (the IWorldFarming facet as landed), the closest existing
+  scripts/assets/build_*.mjs exporter to use as the template (Explore picks and names
+  it), the best existing src/render adapter precedent for signature-guarded rebuilds
+  (Explore picks and names it), the RENDER_PURE_CORES allowlist in
+  tests/architecture.test.ts, the render VFX entry points and the tier-shedding knob
+  path through src/game/ui_effects_profile.ts, and the SFX wiring sites:
+  src/game/audio.ts (UI_CUES, the UiCue union), scripts/sfx/sfx_prompts.mjs, the hud
+  SimEvent cases, and the completeness guard tests/game_audio.test.ts.
+- CLAUDE.md files: root, src/render/CLAUDE.md, src/ui/CLAUDE.md (for the hud cue
+  case), src/sim/CLAUDE.md and src/sim/professions/CLAUDE.md (only as far as the
+  collider or pad decision could touch sim), plus any scripts/ or scripts/assets/
+  CLAUDE.md that exists.
+The summary MUST return: (1) the exact exported names and shapes of the FARM_PATCHES
+rows and the two IWorldFarming reads the renderer uses (the patch defs and the D3
+public plot projection: bed id, crop id, planted-at, ready-at, knob flags, the
+notified flag, and the derived status); (2) the exporter template to copy and the practiced
+optimizer, media-manifest regen, and parsed-GLB contract-test recipe with the exact
+commands; (3) the render adapter precedent for signature-guarded rebuilds and where
+RENDER_PURE_CORES is pinned; (4) the VFX seam and exactly how existing cosmetic
+effects shed under the tier knob; (5) the full SFX wiring checklist from the state.md
+seam reference with commands; (6) the Phase 3 SimEvent names for plant and harvest;
+(7) which render test suites exist and which this phase must run; (8) any Phase 1 to
+6 deviation recorded in progress.md that touches this phase. The orchestrator never
+reads planning docs or coordinator monoliths directly: work from this summary.
+
+STEP 2 - CHOOSE ORCHESTRATION + EXECUTE
+Request fan-out explicitly (this model under-spawns by default). Give each agent ONLY
+the Explore summary plus its own slice. Never put a teammate agent in plan mode.
+Default split, three agents by vertical slice, each owning its slice AND its tests:
+
+Agent A, assets (scripts/assets/build_farm_props.mjs plus its contract test):
+- The procedural factory plus deterministic exporter, following the image-to-glb
+  skill conventions exactly (factory, exporter, optimizer spec, media-manifest
+  regeneration via the owning build step, never by hand).
+- The bed base: about 3 by 2 yards, low wooden border, four biome tints (vale,
+  marsh, alpine, formal Evergarden).
+- Growth-stage meshes: stage one is a single sprout shared across all families;
+  stage two is per family; stages three and four are per family with the crop
+  identity visible. Families: grain, root-leaf, gourd.
+- A withered variant per family, and the compost bin.
+- EVERY asset swap-ready: fixed footprint and pivot documented in the factory
+  source, in the form the Phase 13 handoff manifest
+  (docs/design/farming-asset-manifest.json) will consume.
+- The parsed-GLB contract test with source-fingerprint pins, plus a
+  determinism check (two exporter runs, identical bytes).
+- npm run asset:budget green over the new assets.
+
+Agent B, render adapter and VFX (src/render/farm_patches.ts):
+- Reads IWorldFarming ONLY, and the Phase 2 public projection is sufficient by
+  design (D3). Beds render for everyone, always. MY plot states drive the stage
+  meshes per the per-viewer model, with the visual stage derived locally from the
+  planted-at and ready-at fractions. The wet-soil tint derives from planted-at
+  recency. The withered look derives from the projection's derived status. No
+  dedicated stage, wet, or withered facet read exists or is added.
+- Signature-guarded rebuilds; zero per-frame allocation; pure logic (stage and
+  variant resolution, signature computation) extracted into a RENDER_PURE_CORES
+  core with its own Node-run suite.
+- The bed ground-pad and collider decision, made in-phase: prefer soft or none (the
+  herb-cluster precedent; the Phase 2 placement suite already guarantees legal
+  ground). Decide, state the choice in your report, and document it in this phase
+  file and state.md. If the choice adds anything under src/sim/, flag it: it changes
+  the STEP 3 review dispatch.
+- Plant and harvest VFX on the Phase 3 events: cosmetic, tier-sheddable per the
+  graphics-settings fairness doctrine (VFX may shed; nothing actionable may).
+
+Agent C, SFX (the two-file wiring from the state.md seam reference):
+- farm_plant and farm_harvest cues: UI_CUES keys plus facade methods in
+  src/game/audio.ts, widening the UiCue union if the family is nested.
+- The hud cases for the Phase 3 plant and harvest events, triggering the cues.
+- Prompt rows in scripts/sfx/sfx_prompts.mjs, marked PLACEHOLDER for the sound
+  engineer.
+- Run npm run sfx:ui, then npm run sfx:manifest, then npm run sfx:check; the
+  completeness guard tests/game_audio.test.ts must pass.
+
+INVARIANTS THIS PHASE MUST KEEP
+- The renderer reads the world and never mutates it: every read in
+  src/render/farm_patches.ts goes through the IWorld facet, and the adapter performs
+  zero writes to world state.
+- src/render/ never imports sim internals beyond IWorld: all farming data enters
+  through src/world_api/farming.ts, never through a src/sim/ import.
+- Every generated artifact (media manifest, optimized GLBs, SFX manifest and runtime
+  pack) is regenerated via its owning build step; none is ever hand-edited.
+- Graphics fairness, stated literally: every tier and preset knob touched by this
+  phase sheds only cosmetic richness. The plant and harvest VFX may shed; the beds
+  and growth-stage meshes render at every tier and no knob may hide or delay them.
+- All sim determinism holds: this phase changes no sim behavior; if the collider or
+  pad decision adds a sim-side row, it draws no rng and moves no tick order, and all
+  randomness anywhere in src/sim/ stays on ctx.rng.
+
+Out of scope (do NOT do in this phase):
+- The farm_ready chime (Phase 8) and the golden_harvest sting (Phase 10).
+- The feast prop (Phase 12).
+- Map and minimap pins (Phase 8).
+- Any UI window or HUD surface (Phase 8).
+- NPCs, vendor stock, quests, or any reachability change (Phase 9).
+
+STEP 3 - VALIDATION + MULTI-AGENT REVIEW
+Run, in order:
+- npx tsc --noEmit
+- npx vitest run <the new parsed-GLB contract test file>
+- npx vitest run tests/architecture.test.ts tests/game_audio.test.ts plus the render
+  suites the Explore summary named
+- npm run asset:budget
+- npm run ci:changed
+Then run git diff --name-only against the phase-start commit and dispatch ONLY the
+matching rows per the Review Dispatch Matrix in docs/farming/implementation-plan.md.
+Expected matches here: frontend-seam-reviewer (src/render, src/game, and the hud case
+changed); architecture-reviewer ONLY if the collider or pad decision touched
+src/sim/; qa-checklist once the deliverable set is complete. Every review agent gets
+a hard 30-tool-call budget, the coverage instruction ("report every issue including
+low-severity and uncertain ones; ranking happens later"), and, if truncated, the
+resume line: "Stop reading more files. Output the full report now based on what you
+have already seen. No more tool calls. Format: BLOCKING / SHOULD-FIX / NICE-TO-HAVE /
+VERDICT." No commit while a BLOCKING stands.
+
+STEP 4 - COMMIT CADENCE
+2 to 5 Conventional Commits with scopes and bodies, EXPLICIT paths, never git add -A,
+no session links or Claude attribution. Suggested cut:
+1. feat(assets): farm prop factory, exporter, contract test, manifest regen.
+2. feat(render): farm_patches adapter, pure core, plant and harvest VFX.
+3. feat(game): farm_plant and farm_harvest placeholder cues and wiring.
+4. docs(farming): progress and state ledger updates, screenshots.
+
+STEP 5 - ACCEPTANCE CRITERIA
+- [ ] scripts/assets/build_farm_props.mjs exists, follows the image-to-glb skill
+      conventions, and exports deterministically (two runs, identical bytes).
+- [ ] The parsed-GLB contract test with source-fingerprint pins passes.
+- [ ] The bed base reads about 3 by 2 yards with a low wooden border and ships all
+      four biome tints (vale, marsh, alpine, formal Evergarden).
+- [ ] Growth stages exist as specified: shared stage-one sprout; per-family stage
+      two; per-family stages three and four with visible crop identity; families
+      grain, root-leaf, gourd; a withered variant per family; the compost bin.
+- [ ] Every asset documents a fixed footprint and pivot in the factory, ready for
+      the Phase 13 handoff manifest.
+- [ ] src/render/farm_patches.ts reads IWorldFarming only; beds render for everyone;
+      MY plots drive stage meshes derived from the projection's planted-at and
+      ready-at fractions (D3); wet-soil tint from planted-at recency; withered
+      silhouette from the derived status; signature-guarded rebuilds; no per-frame
+      allocation; its pure logic is registered in RENDER_PURE_CORES with a passing
+      Node suite.
+- [ ] The ground-pad and collider decision is made, stated, and documented in this
+      phase file and state.md.
+- [ ] Plant and harvest VFX fire on the Phase 3 events and shed cleanly under the
+      cosmetic tier knob; beds and stages do not shed.
+- [ ] farm_plant and farm_harvest are wired end to end and marked PLACEHOLDER;
+      sfx:check and tests/game_audio.test.ts pass.
+- [ ] npm run asset:budget is green.
+- [ ] tsc, the contract test, tests/architecture.test.ts, the named render suites,
+      ci:changed, and gate_select are green (armory browser exception aside).
+- [ ] Before/after screenshots (desktop and mobile) are committed under
+      docs/screenshots.
+
+STEP 6 - DOC UPDATES + MEMORY
+- Update docs/farming/progress.md: the Phase 7 status row, the acceptance list above
+  copied with its check states, and a Notes block (surprises, deviations, deferrals
+  with reasons).
+- Update the docs/farming/state.md ledgers (new i18n keys if any, refined file
+  names, and the collider or pad decision).
+- Any deviation decided in-phase gets swept into
+  docs/farming/phase-07-render-and-juice.md AND docs/farming/phase-07-qa.md in the
+  same pass.
+- Record surprises (pipeline quirks, budget tradeoffs, precedent mismatches) in
+  Claude Code memory.
+
+STEP 7 - FINAL RESPONSE FORMAT
+Report: phase status; files touched; validation results (each command, pass or
+fail); review verdicts per agent; deferrals; and a one-line handoff for the Phase 7
+QA session.
+
+STOPPING RULES
+- Stop if an asset cannot meet the asset budget without dropping a growth stage:
+  surface the tradeoff (the budget figure, the offending asset, the options) instead
+  of silently cutting a stage.
+- The Phase 2 public projection is sufficient by design (D3): derive stage, wet,
+  and withered locally and do NOT widen the facet with dedicated reads for them.
+  Stop only if something genuinely cannot be derived from the projection: that is
+  a design change; surface it before touching the facet.
+- Stop if git status is dirty at session start or the release tip cannot be
+  resolved.
+- Stop if a review BLOCKING cannot be fixed without out-of-scope changes.
+
+Close: gate via node scripts/gate_select.mjs (the armory browser red is the standing
+environmental exception; grep the log for "[gate] FAIL"; PR CI is the arbiter), push,
+and open the PR against the release branch this phase was based on per
+.github/PULL_REQUEST_TEMPLATE.md, with before/after screenshots (desktop and mobile)
+captured via the pr-screenshots skill, committed under docs/screenshots, and
+referenced from the PR body (this is a visual phase).
+```

--- a/docs/farming/phase-08-harvest-journal.md
+++ b/docs/farming/phase-08-harvest-journal.md
@@ -1,0 +1,256 @@
+# Phase 8: The Harvest Journal and ready notices
+
+The timer surface, shipped in-game before go-live: the OSRS lesson in D18, made
+non-negotiable. This phase builds the Harvest Journal window (a DOM-free pure view core
+plus a thin cold window and painter), map and minimap pins for the four patch sites, and
+the ready notices from D14 (the login check plus the 1 Hz online sweep). Countdown
+rendering copies the daily-rewards pattern wholesale. Everything here is actionable
+information; none of it may ever be shed by a graphics tier knob.
+
+Live-surface note (binding): After this phase merges, the Harvest Journal window opens
+with honest empty states, the map and minimap pins mark the four patch sites, and the
+ready notices (banner, chat line, farm_ready cue) fire only for dev-created crops until
+go-live (Phase 9). No seeds are obtainable and no NPC or quest exists.
+
+### Starter Prompt
+
+```
+This is Phase 8 of the Farming feature: The Harvest Journal and ready notices.
+Model: Opus 4.8, xhigh effort (1m context variant where the file load demands it).
+Harness: Claude Code.
+
+Goal: the player always knows what is growing, where, and when it will be ready: the
+Harvest Journal window with live honest countdowns, map and minimap pins for the four
+patch sites, and the login and online ready notices.
+
+STEP 0 - PRE-FLIGHT
+- Work ONLY in the persistent worktree ~/Documents/woc-farming-plan. Other sessions
+  share the main checkout; never work there.
+- git -C ~/Documents/woc-farming-plan status must be clean. Stop if it is not.
+- Re-resolve the NEWEST release/** branch: git fetch origin --prune; then
+  git branch -r --list 'origin/release/*' | sort -V and take the last row. Create
+  branch fix/farming-phase-08-harvest-journal off its tip.
+- Record the phase-start commit (git rev-parse HEAD) for the STEP 3 diff.
+- Scan Claude Code memory: the MEMORY.md index, the farming-skill-program entry, and
+  the phase-relevant topics: pr-screenshot-browser-path (this is a visual phase),
+  pr2177-side-rail-split-review (the rail and the overlay click trap),
+  frozen-clock-rig-hangs-vitest, i18n-semantic-regressions-gate-trap,
+  big-diff-reviewer-turn-budgets, worktree-cwd-drift-misroutes-git.
+
+STEP 1 - LOAD CONTEXT
+Spawn one Explore agent (thoroughness: very thorough) to read and summarize:
+- docs/farming/state.md (whole file; D3, D14, D18, the seam reference on countdowns
+  and notifications, and the wire section on the fplot key matter most) and
+  docs/farming/progress.md (Phase 1 to 7 notes, deviations, name refinements).
+- docs/farming/phase-08-harvest-journal.md (this phase file).
+- Source files for this phase: the daily-rewards window modules (the countdown
+  precedent: dedicated interval, data-attribute rebind, formatDateTime absolutes,
+  the t() clock-token mm:ss template; Explore names the exact files), the
+  UI_PURE_CORES allowlist in tests/architecture.test.ts, the map window view core
+  and minimap markers modules (the map_window_view and minimap_markers patterns;
+  Explore confirms exact paths), tests/hud_perf_budget.test.ts and its painter
+  buckets, tests/crafting_launcher.test.ts (the rail-height budget guard),
+  src/world_api/farming.ts and the fplot self delta key registration
+  (ALL_DELTA_KEYS, TERSE_TO_IWORLD) as landed in Phase 2, the Phase 3 updateFarming
+  driver in src/sim/professions/farming.ts, the Sim.addPlayer hook point (beside the
+  mailWelcomed one-shot and the deeds retro block; summarize, the orchestrator never
+  opens sim.ts), the banner queue and the gatherRareEvent hud case (the canonical
+  text-free-event-to-localized-line shape), src/game/audio.ts (UI_CUES),
+  scripts/sfx/sfx_prompts.mjs, and the S3 matcher seam in src/ui/sim_i18n.ts with
+  tests/localization_fixes.test.ts.
+- CLAUDE.md files: root, src/ui/CLAUDE.md, src/ui/hud/CLAUDE.md, src/styles/
+  CLAUDE.md, src/sim/CLAUDE.md, src/sim/professions/CLAUDE.md.
+The summary MUST return: (1) the daily-rewards countdown recipe, concretely enough
+to copy (interval ownership, rebind attribute, the t() token pattern names); (2) the
+cold-window contracts and which hud_perf_budget bucket a countdown window lands in;
+(3) the exact shape the fplot projection carries today and whether it already
+carries enough for an honest remaining-time under clock skew (a server-now anchor or
+remaining seconds), plus the round-trip pin locations if it must widen; (4) the
+professions-window entry point and keybind seams, and what the rail-height guard
+permits; (5) the map and minimap pin recipes; (6) the addPlayer hook point and the
+1 Hz sweep idiom (ctx.tickCount % 20, the guild_letter idiom); (7) the SimEvent
+registration path and the S3 matcher recipe; (8) the SFX cue checklist; (9) any
+Phase 1 to 7 deviation recorded in progress.md that touches this phase. The
+orchestrator never reads planning docs or coordinator monoliths directly: work from
+this summary.
+
+STEP 2 - CHOOSE ORCHESTRATION + EXECUTE
+Request fan-out explicitly (this model under-spawns by default). Give each agent
+ONLY the Explore summary plus its own slice. Never put a teammate agent in plan
+mode. Default split, three agents by vertical slice, each owning its slice AND its
+tests:
+
+Agent A, the Harvest Journal window:
+- src/ui/harvest_journal_view.ts (or the hud-domain directory form per
+  src/ui/hud/CLAUDE.md; follow what Phases 1 to 7 established): a DOM-free pure
+  view core registered in the UI_PURE_CORES allowlist. Rows: every plot with crop,
+  stage, remaining time, and applied knobs (compost, watch, tonic). Honest
+  empty-state copy for the no-plots and no-farming-skill cases.
+- Remaining time derives from the wired fplot projection with clock skew handled
+  per the state.md seam reference: the client renders server-anchored remaining
+  time, never raw local wall clock against a server deadline.
+- Time formatting through the t() clock-token pattern and formatDateTime, never a
+  hand-built colon string.
+- The thin window and painter honoring the cold-window contracts (no forced-reflow
+  layout read, no repeating driver of its own), where the ONE sanctioned
+  self-driver is the dedicated countdown interval with data-attribute rebind (the
+  daily-rewards precedent). tests/hud_perf_budget.test.ts sorts every painter:
+  land in the right bucket.
+- The open-surface decision, made in-phase, with the side-rail capacity trap
+  flagged EXPLICITLY: the rail is at capacity; prefer a professions-window entry
+  point plus a keybind; check the rail-height budget guard in
+  tests/crafting_launcher.test.ts BEFORE adding any rail button. Decide, state the
+  choice, document it.
+- English i18n rows for all window copy; the view-core suite.
+
+Agent B, map presence:
+- Map and minimap pins for the four patch sites, following the map_window_view and
+  minimap_markers patterns the Explore summary names.
+- English i18n rows for pin labels and tooltips; tests beside the patterns'
+  existing suites.
+
+Agent C, ready notices (sim, wire, and hud arms):
+- The login check inside Sim.addPlayer immediately after saved state restore:
+  state-derived, NO rng, a personal text-free farmReady SimEvent carrying ready
+  counts, the flag-flip-before-emit idiom via the per-plot notified flag Phase 2
+  LANDED in PlotState (default false, serialized with the rest; this phase only
+  consumes it, so no save-shape change is expected; the flag persists, so relog
+  never respams).
+- The 1 Hz online sweep inside the Phase 3 updateFarming skeleton, emitting once
+  per plot transition (ready and not yet notified: flip the flag, then emit).
+- The hud arms: an ambient-class banner via the banner queue, a chat line, and a
+  new farm_ready cue (UI_CUES key, facade method, hud case, prompt row, placeholder
+  clip via npm run sfx:ui then sfx:manifest then sfx:check).
+- S3 matcher coverage for the event's player-visible text
+  (tests/localization_fixes.test.ts stays green) and English i18n rows.
+- If honest countdowns need the fplot projection widened (remaining seconds or a
+  server-now anchor), extend it WITH round-trip pins in the snapshots suites.
+  The rule, stated literally: client UI code may use Date.now; src/sim/ may not,
+  ever (wall clock only via ctx.lockoutNowMs).
+- Determinism tests: the login check and sweep draw zero rng; a same-seed pin; a
+  once-per-transition test driving real ticks across a ready boundary.
+
+INVARIANTS THIS PHASE MUST KEEP
+- The timer surface is actionable information: every element this phase ships (the
+  journal rows, the countdowns, the map and minimap pins, the ready banner, the
+  chat line) renders at every graphics tier and preset, and no tier knob may shed,
+  hide, delay, or coarsen any of it. Only the cue audio follows the normal audio
+  settings.
+- i18n: every player-visible string added in this phase is a t() key added in
+  ENGLISH ONLY to the matching src/ui/i18n.catalog/ module; all sim-side player
+  text is a text-free id-carrying SimEvent re-localized client-side; the S3 guard
+  covers every new emit in the SAME change.
+- Determinism: all sim additions (the addPlayer check, the sweep, the notified
+  flag) draw zero rng, and all randomness anywhere in src/sim/ stays on ctx.rng;
+  no Date.now, Math.random, or performance.now enters src/sim/.
+- Mobile: safe areas and comfortable tap targets on the window, its entry point,
+  and the pins, verified with mobile screenshots.
+- The seam: any IWorld or wire change lands in BOTH Sim and ClientWorld in the same
+  change, with the parity pin in tests/world_api_parity.test.ts updated.
+
+Out of scope (do NOT do in this phase):
+- Vendor stock and seed availability (Phase 9).
+- The intro quest and NPCs (Phase 9).
+- Deeds (Phase 10).
+- The golden_harvest rare event (Phase 10).
+
+STEP 3 - VALIDATION + MULTI-AGENT REVIEW
+Run, in order:
+- npx tsc --noEmit
+- npx vitest run <the view-core suite file>
+- npx vitest run tests/hud_perf_budget.test.ts tests/crafting_launcher.test.ts
+  tests/localization_fixes.test.ts tests/architecture.test.ts
+- If the wire widened: npx vitest run tests/snapshots.test.ts
+  tests/env_protocol.test.ts tests/bandwidth.test.ts
+- npx vitest run tests/parity (BEFORE touching any golden; regen only deliberately)
+- A mobile screenshot script against a phone viewport (per the validation matrix)
+- npm run ci:changed
+Then run git diff --name-only against the phase-start commit and dispatch ONLY the
+matching rows per the Review Dispatch Matrix in docs/farming/implementation-plan.md.
+Expected matches here: frontend-seam-reviewer (ui, styles, game); cross-platform-
+sync (a new SimEvent and possibly a widened wire key); architecture-reviewer (the
+addPlayer hook and the sweep are sim changes); migration-safety ONLY if this phase
+widens the fplot projection or otherwise moves the persisted shape (per its matrix
+row; extend the round-trip pins in the same change); qa-checklist once the
+deliverable set is complete. Every review agent gets a hard 30-tool-call budget,
+the coverage instruction ("report every issue including low-severity and uncertain
+ones; ranking happens later"), and, if truncated, the resume line: "Stop reading
+more files.
+Output the full report now based on what you have already seen. No more tool calls.
+Format: BLOCKING / SHOULD-FIX / NICE-TO-HAVE / VERDICT." No commit while a BLOCKING
+stands.
+
+STEP 4 - COMMIT CADENCE
+2 to 5 Conventional Commits with scopes and bodies, EXPLICIT paths, never git add
+-A, no session links or Claude attribution. Suggested cut:
+1. feat(sim): farmReady notices, the Phase 2 notified flag consumed, sweep, and (if
+   widened) the fplot projection with pins.
+2. feat(ui): harvest journal view core, window, painter, countdown driver, entry
+   point.
+3. feat(ui): map and minimap pins for the patch sites.
+4. feat(game): farm_ready cue wiring.
+5. docs(farming): progress and state ledger updates, screenshots.
+
+STEP 5 - ACCEPTANCE CRITERIA
+- [ ] The view core is DOM-free, registered in UI_PURE_CORES, and its Node suite
+      covers rows, knobs, empty states, and remaining-time derivation.
+- [ ] Remaining time is honest under clock skew: a deliberately skewed client clock
+      still renders correct countdowns (server-anchored, not local-wall-clock).
+- [ ] All time formatting goes through the t() clock-token pattern and
+      formatDateTime; no hand-built colon strings anywhere in the diff.
+- [ ] The window honors the cold-window contracts, its one self-driver is the
+      countdown interval with data-attribute rebind, and
+      tests/hud_perf_budget.test.ts sorts it into the correct bucket.
+- [ ] The open-surface decision is made, stated, and documented; if a rail button
+      was added, tests/crafting_launcher.test.ts still passes.
+- [ ] Map and minimap pins mark all four patch sites.
+- [ ] The login check emits one farmReady after saved state restore for ready
+      unnotified plots, draws zero rng, and flips the flag before the emit.
+- [ ] The 1 Hz sweep emits exactly once per plot transition; a real-tick test
+      proves no repeat emit across subsequent ticks and across relog.
+- [ ] The hud arms work: ambient banner, chat line, farm_ready cue; the cue row is
+      marked PLACEHOLDER; sfx:check passes.
+- [ ] Every new player-visible string is an English t() key; S3
+      (tests/localization_fixes.test.ts) passes.
+- [ ] If the wire widened: both worlds implement it, the parity pin is updated, and
+      the snapshots suites pass with new round-trip pins.
+- [ ] tsc, the view-core suite, the named suites, ci:changed, and gate_select are
+      green (armory browser exception aside).
+- [ ] Before/after screenshots (desktop and mobile) are committed under
+      docs/screenshots.
+
+STEP 6 - DOC UPDATES + MEMORY
+- Update docs/farming/progress.md: the Phase 8 status row, the acceptance list
+  above copied with its check states, and a Notes block (surprises, deviations,
+  deferrals with reasons).
+- Update the docs/farming/state.md ledgers: the farmReady SimEvent, any new wire
+  key, new i18n keys and matcher rows, the open-surface decision.
+- Any deviation decided in-phase gets swept into
+  docs/farming/phase-08-harvest-journal.md AND docs/farming/phase-08-qa.md in the
+  same pass.
+- Record surprises (skew handling, rail findings, bucket surprises) in Claude Code
+  memory.
+
+STEP 7 - FINAL RESPONSE FORMAT
+Report: phase status; files touched; validation results (each command, pass or
+fail); review verdicts per agent; deferrals; and a one-line handoff for the Phase 8
+QA session.
+
+STOPPING RULES
+- Stop if the countdown cannot be made honest under clock skew without widening the
+  wire: widening is the sanctioned path, but stop FIRST if the widening is
+  contentious (payload growth on a hot key, a shape change to an existing field)
+  and surface the options before proceeding.
+- Stop if the rail-height guard fails and no non-rail entry point is workable:
+  surface it rather than loosening the guard.
+- Stop if git status is dirty at session start or the release tip cannot be
+  resolved.
+- Stop if a review BLOCKING cannot be fixed without out-of-scope changes.
+
+Close: gate via node scripts/gate_select.mjs (the armory browser red is the
+standing environmental exception; grep the log for "[gate] FAIL"; PR CI is the
+arbiter), push, and open the PR against the release branch this phase was based on
+per .github/PULL_REQUEST_TEMPLATE.md, with before/after screenshots (desktop and
+mobile) captured via the pr-screenshots skill, committed under docs/screenshots,
+and referenced from the PR body (this is a visual phase).
+```

--- a/docs/farming/phase-08-qa.md
+++ b/docs/farming/phase-08-qa.md
@@ -1,0 +1,138 @@
+# Phase 8 QA: Verify The Harvest Journal and ready notices
+
+Independent verification of Phase 8 in a fresh session. The emphasis is honesty and
+restraint: the countdown must be correct under a skewed client clock, the login notice
+must fire exactly once for a ready crop on a fresh session, the online sweep must emit
+exactly once per plot transition with zero banner spam, and no graphics tier knob may
+shed the journal or the notices (they are actionable information, the fairness doctrine's
+hard case).
+
+### QA Starter Prompt
+
+```
+This is Phase 8 QA of the Farming feature: Verify The Harvest Journal and ready
+notices.
+Model: Opus 4.8, xhigh effort (1m context variant where the file load demands it).
+Harness: Claude Code.
+
+Goal: audit Phase 8 for correctness, missing tests, dead code, determinism,
+three-host parity, i18n completeness, and the phase's own acceptance criteria.
+
+STEP 0 - PRE-FLIGHT
+- Work ONLY in the persistent worktree ~/Documents/woc-farming-plan; git status must
+  be clean. Check out the phase branch fix/farming-phase-08-harvest-journal (QA fix
+  commits land on the phase PR).
+- Identify the phase diff: the PR's commits against its base (git merge-base the PR
+  branch with the release branch it was opened against, then diff that range). The
+  release tip may have moved concurrently, so the diff is the PR's commits, never
+  everything-since-phase-start. Stop if the diff cannot be identified cleanly.
+- Scan Claude Code memory: the MEMORY.md index, the farming-skill-program entry,
+  pr-screenshot-browser-path (browser path, swiftshader flags, overlay traps),
+  pr2177-side-rail-split-review, frozen-clock-rig-hangs-vitest,
+  mutation-checks-commit-first, big-diff-reviewer-turn-budgets.
+
+STEP 1 - LOAD CONTEXT
+Spawn one Explore agent to read and summarize: docs/farming/state.md; the
+docs/farming/progress.md Phase 8 notes (including any recorded deviation and the
+open-surface decision); the promises in docs/farming/phase-08-harvest-journal.md
+(Live-surface note, deliverables, acceptance criteria); and git diff --name-only
+over the phase diff. The summary must return the acceptance list verbatim, the file
+list, the farmReady SimEvent name and payload shape, whether the fplot projection
+was widened, and any deviation the phase recorded.
+
+STEP 2 - QA AUDIT
+Spawn three parallel audit agents. Each gets a hard 30-tool-call budget and the
+coverage instruction: "report every issue including low-severity and uncertain ones;
+ranking happens later." If truncated, resume with: "Stop reading more files. Output
+the full report now based on what you have already seen. No more tool calls. Format:
+BLOCKING / SHOULD-FIX / NICE-TO-HAVE / VERDICT."
+
+Agent 1, correctness:
+- Verify every deliverable and every acceptance criterion in the phase file is
+  actually met, not just claimed.
+- Verify the offline Sim and online ClientWorld paths behave identically: the
+  journal reads the same members from both worlds, and the countdown derivation
+  works from both the local Sim and the mirrored fplot projection.
+- The skewed-clock check: skew the client clock deliberately (mock Date.now in the
+  client harness or apply a fixed offset) and verify the rendered remaining time
+  stays correct (server-anchored), never shifted by the skew.
+- The login notice: rig a saved state with a ready, unnotified plot, run
+  Sim.addPlayer on a fresh session, and assert exactly one farmReady with the right
+  counts; assert zero on a second login (the persisted notified flag holds).
+- The save-shape check: the per-plot notified flag was landed by Phase 2, so this
+  phase should move no persisted shape; verify the save shape did not move. If it
+  did (a widened fplot projection or any persisted-shape move), verify
+  migration-safety was dispatched per its matrix row and the round-trip pins were
+  extended in the same change.
+- The once-per-transition guarantee: run live headless-Sim probes via a throwaway
+  vitest file driving real ticks with an injected ADVANCEABLE clock (the clock must
+  advance now(); a frozen clock hangs) across a ready boundary; assert one emit per
+  plot transition and no banner spam across subsequent ticks; then delete the file
+  and verify the tree is clean.
+- The fairness check: audit every consumer of the graphics tier and preset knobs
+  touched by or adjacent to this diff and confirm no tier knob sheds, hides,
+  delays, or coarsens the journal, its countdowns, the pins, the banner, or the
+  chat line.
+- Drive the real dev client headless (the browser path and swiftshader flags from
+  the pr-screenshot-browser-path memory entry), dismissing any first-run prompt
+  overlays before clicking: open the journal via its shipped entry point, verify
+  the empty states, verify a dev-created crop shows a live ticking countdown, and
+  verify the pins on map and minimap.
+- Edge cases: zero plots, all plots ready at once (counts aggregate), a plot
+  becoming ready while the journal is open (the rebind updates), relog mid-growth.
+
+Agent 2, test coverage:
+- Every claimed behavior has a decisive assertion that fails on regression; no
+  constant-self-comparison pins (a remaining-time test must pin expected literals,
+  not recompute through the same helper it tests; wire pins compare against
+  committed literals).
+- Both arms of every either/all claim: notified and unnotified, ready and growing,
+  empty and populated journal, skewed and unskewed clock, rail button present or
+  professions entry (whichever was chosen, its guard has both a pass and a fail
+  arm).
+- The once-per-transition test actually crosses the boundary during the test (not
+  a vacuous pin that never reaches ready).
+- Orphaned or superseded tests removed; the UI_PURE_CORES registration is real.
+- Mutation checks are allowed only after committing the work first.
+
+Agent 3, dead code and cleanup:
+- Unused imports, types, and exports across the diff; no unresolved TODOs; naming
+  consistency with the farming modules landed earlier.
+- The sim import invariant: src/sim/ imports nothing from render, ui, game, or
+  net; no Date.now, Math.random, or performance.now anywhere in src/sim/ additions
+  (Date.now is permitted in client UI code only).
+- No hand-built colon time strings; every player-visible string in the diff is a
+  t() key; no leftover throwaway probe files or scratch scripts.
+
+Then dispatch the Review Dispatch Matrix rows in
+docs/farming/implementation-plan.md that match the phase diff (expected:
+frontend-seam-reviewer, cross-platform-sync, architecture-reviewer; migration-safety
+if the persisted shape moved), plus qa-checklist (the phase-completion gate). Same
+30-call budget, coverage instruction, and resume line for each.
+
+STEP 3 - FIX
+Apply every BLOCKING and SHOULD-FIX finding test-first: reproduce with a failing
+test, then the smallest change that turns it green. Run the docs/farming/state.md
+validation matrix rows the diff demands (including the snapshots suites if the wire
+widened). Land fixes as separate Conventional Commits with explicit paths, never
+git add -A, no session links or Claude attribution.
+
+STEP 4 - DOC UPDATES
+Update docs/farming/progress.md (the Phase 8 QA row and a Notes block) and
+docs/farming/state.md (any drift found: ledger corrections, decision records).
+If a fix amended the phase file, sweep this QA twin in the same pass.
+
+STEP 5 - FINAL RESPONSE FORMAT
+Verdict: PASS / PASS-WITH-FOLLOWUPS / FAIL. Counts: findings found and findings
+fixed, by severity. Deferrals with reasons. A one-line handoff for the Phase 9
+session.
+
+STOPPING RULES
+- Stop and surface if a BLOCKING cannot be fixed without changing phase scope.
+- Stop if the phase diff cannot be identified cleanly.
+
+Close: re-run node scripts/gate_select.mjs after fixes (the armory browser red is
+the standing environmental exception; grep the log for "[gate] FAIL"; PR CI is the
+arbiter) and push the fix commits to the phase PR.
+Packet teardown never happens in this phase; it belongs to Phase 13 QA only.
+```

--- a/docs/farming/phase-09-qa.md
+++ b/docs/farming/phase-09-qa.md
@@ -1,0 +1,145 @@
+# Phase 9 QA: Verify World presence: go-live
+
+Independent verification of the go-live merge in a fresh session. This is the
+highest-stakes QA in the packet: ordinary players can now reach the loop, so the audit
+plays the ENTIRE new-player journey on the live client (the go-live acceptance),
+purchase-tests every vendor row (the dead-row trap leaves no compile error and no test
+red, only a player-facing refusal), confirms the work-order payout arithmetic against
+its guard, and proves the atomicity claim: everything this phase opened is reachable,
+and everything later phases own is still not.
+
+### QA Starter Prompt
+
+```
+This is Phase 9 QA of the Farming feature: Verify World presence: go-live.
+Model: Opus 4.8, xhigh effort (1m context variant where the file load demands it).
+Harness: Claude Code.
+
+Goal: audit Phase 9 for correctness, missing tests, dead code, determinism,
+three-host parity, i18n completeness, and the phase's own acceptance criteria.
+
+STEP 0 - PRE-FLIGHT
+- Work ONLY in the persistent worktree ~/Documents/woc-farming-plan; git status must
+  be clean. Check out the phase branch fix/farming-phase-09-world-presence (QA fix
+  commits land on the phase PR).
+- Identify the phase diff: the PR's commits against its base (git merge-base the PR
+  branch with the release branch it was opened against, then diff that range). The
+  release tip may have moved concurrently, so the diff is the PR's commits, never
+  everything-since-phase-start. Stop if the diff cannot be identified cleanly.
+- Scan Claude Code memory: the MEMORY.md index, the farming-skill-program entry,
+  pr-screenshot-browser-path (browser path, swiftshader flags, overlay traps),
+  frozen-clock-rig-hangs-vitest, mutation-checks-commit-first,
+  big-diff-reviewer-turn-budgets.
+
+STEP 1 - LOAD CONTEXT
+Spawn one Explore agent to read and summarize: docs/farming/state.md; the
+docs/farming/progress.md Phase 9 notes (including the NPC names, the work-order
+crops chosen, and any recorded deviation); the promises in
+docs/farming/phase-09-world-presence.md (Live-surface note, deliverables,
+acceptance criteria); and git diff --name-only over the phase diff. The summary
+must return the acceptance list verbatim, the file list, the four NPC ids and their
+vendor rows, the quest id and objective shape, the work-order rows, and whether the
+parity regen commit is isolated.
+
+STEP 2 - QA AUDIT
+Spawn three parallel audit agents. Each gets a hard 30-tool-call budget and the
+coverage instruction: "report every issue including low-severity and uncertain
+ones; ranking happens later." If truncated, resume with: "Stop reading more files.
+Output the full report now based on what you have already seen. No more tool calls.
+Format: BLOCKING / SHOULD-FIX / NICE-TO-HAVE / VERDICT."
+
+Agent 1, correctness:
+- Verify every deliverable and every acceptance criterion in the phase file is
+  actually met, not just claimed.
+- Play the ENTIRE new-player journey on the live client (the go-live acceptance):
+  start the dev server, drive the real dev client headless (the browser path and
+  swiftshader flags from the pr-screenshot-browser-path memory entry), dismissing
+  any first-run prompt overlays before clicking. As a fresh character: walk to
+  farmer_jessica at Eastbrook, accept q_farm_intro (verify the granted hoe and
+  seed), buy a tier 1 seed, plant with a knob applied, dev-advance growth
+  (ALLOW_DEV_COMMANDS=1, dev only), see the ready banner, harvest, complete the
+  quest (verify the magic sentence appears in the greeting and completion text),
+  pay a watch fee, convert a husk, and cook a Phase 6 dish. Any break in this
+  chain is BLOCKING: atomicity was the phase's one hard rule.
+- Verify EVERY stocked vendor row purchase-tests clean across all four farmers: a
+  live purchase probe per row with sufficient copper must succeed (no dead rows;
+  a row with a missing or non-positive buyValue renders then refuses and no
+  compiler catches it), the brook_carrot (the starter fee vegetable) and compost
+  rows explicitly among the probes. Also verify tier 3 and 4 seeds are stocked
+  nowhere.
+- Verify the offline Sim and online ClientWorld paths behave identically for the
+  new flows (purchase, quest credit, fees, conversion): where sim behavior
+  changed, run live headless-Sim probes via a throwaway vitest file driving real
+  ticks with an injected ADVANCEABLE clock (the clock must advance now(); a
+  frozen clock hangs), then delete the file and verify the tree is clean.
+- Verify the negative space of the Live-surface note: farming deeds, the
+  golden_harvest event, well-fed dishes, and the feast remain unreachable.
+- Verify the parity regen commit is isolated and mechanical: its diff touches
+  goldens only, and the pre-regen red trace showed nothing beyond the entity-id
+  counter shift.
+- Edge cases: quest acceptance with a full inventory, out-of-range husk-conversion
+  attempts refuse while paying a watch fee far from any farmer WORKS (a plant-time
+  bag payment with no NPC range gate, D9), a second quest acceptance does not
+  double-grant.
+
+Agent 2, test coverage:
+- Every claimed behavior has a decisive assertion that fails on regression; no
+  constant-self-comparison pins (the payout guard must recompute
+  floor(WORK_ORDER_PAYOUT_FRACTION times summed vendor sellValue) from the item
+  rows and compare against the literal copperReward, never derive both sides from
+  the same expression; recompute one row by hand to confirm).
+- Both arms of every either/all claim: in-range and out-of-range gates, action
+  credit and inventory non-credit on the quest objective, stocked and unstocked
+  seed tiers, positive-buyValue presence on every row (an each-row assertion, not
+  a some-row assertion).
+- The R37 hub-stocking arms actually assert the flipped-on state (not a vacuous
+  pass that would also pass dormant).
+- Orphaned or superseded tests removed (especially any Phase 5 dormancy pins that
+  asserted seeds were unstocked: they must be updated or deleted, not skipped).
+- Mutation checks are allowed only after committing the work first.
+
+Agent 3, dead code and cleanup:
+- Unused imports, types, and exports across the diff; no unresolved TODOs; naming
+  consistency (npc ids, quest id, item ids match the D11 and D20 locked ids).
+- The sim import invariant: src/sim/ imports nothing from render, ui, game, or
+  net; no Math.random, Date.now, or performance.now anywhere in the sim diff.
+- No English player text in sim or server paths (id-carrying events and t() keys
+  only); no leftover dormancy scaffolding (dead flags or commented-out gates from
+  Phases 4, 5, and 8); no hand-edited goldens or generated files; the throwaway
+  journey probe file is gone.
+
+Then dispatch the Review Dispatch Matrix rows in
+docs/farming/implementation-plan.md that match the phase diff (expected:
+architecture-reviewer, cross-platform-sync, frontend-seam-reviewer;
+privacy-security-review only if any server/ file moved), plus qa-checklist (the
+phase-completion gate). Same 30-call budget, coverage instruction, and resume line
+for each.
+
+STEP 3 - FIX
+Apply every BLOCKING and SHOULD-FIX finding test-first: reproduce with a failing
+test, then the smallest change that turns it green. Run the docs/farming/state.md
+validation matrix rows the diff demands (content rows, quest suites, S3, wiki
+freshness, parity). Land fixes as separate Conventional Commits with explicit
+paths, never git add -A, no session links or Claude attribution.
+
+STEP 4 - DOC UPDATES
+Update docs/farming/progress.md (the Phase 9 QA row and a Notes block) and
+docs/farming/state.md (any drift found: ledger corrections, decision records).
+If a fix amended the phase file, sweep this QA twin in the same pass.
+
+STEP 5 - FINAL RESPONSE FORMAT
+Verdict: PASS / PASS-WITH-FOLLOWUPS / FAIL. Counts: findings found and findings
+fixed, by severity. Deferrals with reasons. A one-line handoff for the Phase 10
+session.
+
+STOPPING RULES
+- Stop and surface if a BLOCKING cannot be fixed without changing phase scope (in
+  particular: if the journey breaks in a way only a Phase 10 to 12 surface could
+  fix, that is a scope problem, not a fix).
+- Stop if the phase diff cannot be identified cleanly.
+
+Close: re-run node scripts/gate_select.mjs after fixes (the armory browser red is
+the standing environmental exception; grep the log for "[gate] FAIL"; PR CI is the
+arbiter) and push the fix commits to the phase PR.
+Packet teardown never happens in this phase; it belongs to Phase 13 QA only.
+```

--- a/docs/farming/phase-09-world-presence.md
+++ b/docs/farming/phase-09-world-presence.md
@@ -1,0 +1,269 @@
+# Phase 9: World presence: go-live
+
+GO-LIVE. Every earlier phase merged dormant or decorative; this is the one merge that
+opens the loop. Farming gets its face (the four farmer NPCs, farmer_jessica at Eastbrook
+(eastbrook_vale) per D20), its front door (the intro quest), and its open sign (vendor
+seeds, work orders, the Phase 4 convertHusks range gate). Visuals (Phase 7) and
+timers (Phase 8) are already shipped, so the loop opens beautiful and legible on day
+one. This is the one phase whose
+dormancy flips must be atomic: a partially reachable loop is worse than a dormant one.
+
+Live-surface note (binding): After this phase merges, seeds become purchasable (tiers 1
+and 2; tiers 3 and 4 stay seed-back-only market goods per D11), the intro quest
+q_farm_intro exists at farmer_jessica, work orders exist, husk conversion is reachable
+at the farmer NPCs, watch fees are payable at plant time from bags (no NPC gate per
+D9), and the full plant-grow-harvest-cook loop is reachable by ordinary players.
+Still unreachable: farming deeds and the golden_harvest event (Phase 10), well-fed
+buff dishes (Phase 11), the shared feast (Phase 12).
+
+### Starter Prompt
+
+```
+This is Phase 9 of the Farming feature: World presence: go-live.
+Model: Opus 4.8, xhigh effort (1m context variant where the file load demands it).
+Harness: Claude Code.
+
+Goal: farming gets its face, its front door, and its open sign in a single merge:
+the four farmer NPCs, the intro quest, vendor stock, work orders, and the
+convertHusks range gate, with every dormancy flip landing atomically in this one PR.
+
+STEP 0 - PRE-FLIGHT
+- Work ONLY in the persistent worktree ~/Documents/woc-farming-plan. Other sessions
+  share the main checkout; never work there.
+- git -C ~/Documents/woc-farming-plan status must be clean. Stop if it is not.
+- Re-resolve the NEWEST release/** branch: git fetch origin --prune; then
+  git branch -r --list 'origin/release/*' | sort -V and take the last row. Create
+  branch fix/farming-phase-09-world-presence off its tip.
+- Record the phase-start commit (git rev-parse HEAD) for the STEP 3 diff.
+- Scan Claude Code memory: the MEMORY.md index, the farming-skill-program entry, and
+  the phase-relevant topics: pr-screenshot-browser-path (this is a visual phase),
+  frozen-clock-rig-hangs-vitest (the journey probe needs an advanceable clock),
+  mutation-checks-commit-first, i18n-semantic-regressions-gate-trap,
+  big-diff-reviewer-turn-budgets, worktree-cwd-drift-misroutes-git.
+
+STEP 1 - LOAD CONTEXT
+Spawn one Explore agent (thoroughness: very thorough) to read and summarize:
+- docs/farming/state.md (whole file; D9, D11, D17, D20, D21, D23, the seam
+  reference on vendors and quests, and the OPEN items list matter most) and
+  docs/farming/progress.md (Phase 1 to 8 notes, deviations, and which Phase 4 gate
+  and Phase 5 stocking pieces were left dormant and how).
+- docs/farming/phase-09-world-presence.md (this phase file).
+- Source files for this phase: src/sim/content/zone1.ts (the q_prof_intro template,
+  including its requiredItems re-grant), the NPC content modules and NpcDef shape
+  (vendorItems, greeting wiring; Explore names the exact files and an existing
+  static vendor NPC to copy), the quest objective arms and the gather objective
+  precedent (the arm that credits an ACTION, not a collect), the quest_targets
+  marker wiring, the work-order content rows near cook_marlow and
+  WORK_ORDER_PAYOUT_FRACTION with tests/professions_work_orders.test.ts, the
+  farming rollout arms in tests/professions_zone_rollout.test.ts (R37) and exactly
+  how the Phase 5 hub-stocking arms were left dormant, the Phase 4 husk-conversion
+  permissive gate and the watch-fee plant-time payment in
+  src/sim/professions/farming.ts, the parity suite
+  layout under tests/parity and the UPDATE_PARITY=1 regen recipe, and the wiki
+  freshness gate (tests/guide.test.ts, npm run wiki:content).
+- CLAUDE.md files: root, src/sim/CLAUDE.md, src/sim/professions/CLAUDE.md,
+  src/ui/CLAUDE.md (quest marker and vendor UI touches), src/guide/CLAUDE.md.
+The summary MUST return: (1) the NpcDef and vendor-row shapes with the exact
+buyValue semantics (the dead-row trap: a stocked row without a positive buyValue
+renders then refuses); (2) the q_prof_intro template anatomy (steps, requiredItems,
+completion text wiring, rev field) and the action-objective precedent to copy; (3)
+the quest_targets marker recipe; (4) the work-order row shape, the payout guard
+arithmetic, and the arithmetic comment convention; (5) the exact dormant R37 arms
+and what flips them on; (6) the Phase 4 gate seam to finalize (range-gating
+convertHusks to farmer NPCs; the watch fee stays a plant-time bag payment with no
+NPC gate per D9); (7) which quest suites exist and which
+this phase must run; (8) the parity regen recipe and what a purely mechanical
+entity-id-counter shift looks like in a red trace; (9) the NPC greeting i18n path;
+(10) any Phase 1 to 8 deviation recorded in progress.md that touches this phase.
+The orchestrator never reads planning docs or coordinator monoliths directly: work
+from this summary.
+
+STEP 2 - CHOOSE ORCHESTRATION + EXECUTE
+Request fan-out explicitly (this model under-spawns by default). Give each agent
+ONLY the Explore summary plus its own slice. Never put a teammate agent in plan
+mode. Default split, three agents by vertical slice, each owning its slice AND its
+tests; the orchestrator itself owns the parity regen and the journey probe
+afterward:
+
+Agent A, NPCs, vendors, and gates:
+- The four farmer NPCs, at the D2 hub anchors. farmer_jessica at Eastbrook
+  (eastbrook_vale), the face of the skill: vendors tier 1 seeds, brook_carrot (the
+  starter fee vegetable, priced in Phase 5 per D9), compost (priced in Phase 4),
+  and the rung-one hoe (priced in Phase 5); gives the intro quest; converts husks
+  (watch fees are paid at plant time from bags per D9: the farmers are the
+  service's flavor and its suppliers, never its gate). A Fenbridge (mirefen_marsh)
+  farmer: vendors tier 2 seeds and compost. The Highwatch (thornpeak_heights) and
+  Evergarden parterre (evergarden) farmers: vendor compost and serve husk
+  conversion ONLY (tier 3 and 4 seeds stay seed-back-only market goods per D11).
+- The three non-Jessica names are decided in-phase: original and IP-safe per D17
+  (real plant words and zone-flavored coinages, audited at authoring time). State
+  the names and the audit result in your report.
+- EVERY stocked vendor row carries a positive buyValue, assigned in its pricing
+  phase (tier 1 and 2 seeds, brook_carrot, and the rung-one hoe: Phase 5; compost:
+  Phase 4; the dead-row trap in the state.md seam reference). Crafted outputs never
+  get buyValue.
+- Greetings as English i18n rows through the established NPC dialog path; the S3
+  guard stays green.
+- Range-gate convertHusks to the farmer NPCs (the Phase 4 handoff), with tests for
+  the in-range and out-of-range arms. The watch fee stays a plant-time bag payment
+  with NO NPC range gate (D8, D9): do not gate it.
+- Flip the R37 hub-stocking arms on; tests/professions_zone_rollout.test.ts
+  passes.
+
+Agent B, the intro quest:
+- q_farm_intro from farmer_jessica on the q_prof_intro template: requiredItems
+  grants the rung-one hoe and one vale wheat seed, so a day-one character is never
+  dead-ended.
+- A NEW farming action objective arm crediting the plant and harvest ACTIONS (the
+  gather-objective precedent: inventory cannot prove the deed), with quest_targets
+  marker wiring.
+- The completion text and Jessica's greeting BOTH state the magic sentence: it
+  keeps growing while you are away, and it never spoils.
+- English i18n rows for all quest text; the quest suites the Explore summary
+  names; a test that the objective credits on the action and not on inventory.
+- This phase only ADDS a new quest; if any EXISTING quest's objective indices
+  would change meaning, stop (the rev rule).
+
+Agent C, work orders and the wiki:
+- One or two produce work-order rows (cook_marlow fits: kitchens consume crops;
+  decide the crops in-phase and state the choice) with the machine-enforced
+  payout arithmetic: copperReward equals floor(WORK_ORDER_PAYOUT_FRACTION times
+  the summed vendor sellValue), guarded by tests/professions_work_orders.test.ts.
+  Keep the arithmetic comment on every row.
+- Wiki regen: npm run wiki:content; the freshness gate (tests/guide.test.ts)
+  passes; farming's page reflects the now-live loop.
+
+Orchestrator-owned, AFTER the agents' work is integrated:
+- The deliberate NPC parity golden regen (D23): static NPCs shift the world-ctor
+  entity-id counter. First run npx vitest run tests/parity and VERIFY the red is
+  mechanical (only id-counter effects, no behavioral drift). Then regen with
+  UPDATE_PARITY=1 in an ISOLATED commit. Never hand-edit a golden.
+- The full new-player journey probe on a live headless sim: a throwaway vitest
+  file driving a real Sim with an injected ADVANCEABLE clock: buy the seed, plant
+  with knobs, advance the clock, the ready banner event fires, harvest, cook a
+  Phase 6 dish. Record the probe transcript in the PR body, then delete the file
+  and verify the tree is clean.
+
+INVARIANTS THIS PHASE MUST KEEP
+- Every dormancy flip in this phase is atomic: the vendor rows, the quest, the
+  gate finalization, and the R37 arm flips ALL land in this single PR, and none of
+  them may be split into a follow-up or merged partially. A player on the merged
+  build reaches the whole loop or (pre-merge) none of it.
+- The server is authoritative: every purchase, quest credit, fee, conversion, and
+  work-order payout resolves server-side; no client ever decides an outcome, and
+  no wire command ingests a client-supplied ItemInstancePayload.
+- No English in sim paths: all player text this phase adds (greetings, quest text,
+  vendor and order strings) reaches the player as t() keys or id-carrying events
+  re-localized client-side; src/sim/ and server/ stay language-agnostic; the S3
+  guard covers every new emit in the SAME change.
+- The quest rev rule: a changed objective index in an EXISTING quest bumps rev;
+  this phase only adds a new quest, so any diff that changes an existing quest's
+  objective order is a stop signal.
+- Determinism: all randomness in every new code path goes through ctx.rng; the
+  NPCs, quest arm, and gates draw no rng outside player-action moments; no
+  Math.random, Date.now, or performance.now enters src/sim/.
+- All parity goldens move only via the deliberate UPDATE_PARITY=1 regen in an
+  isolated commit, never by hand.
+
+Out of scope (do NOT do in this phase):
+- Farming deeds and the golden_harvest rare event (Phase 10).
+- Well-fed buff food (Phase 11).
+- The shared feast (Phase 12).
+- Wiki prose polish and the asset handoff manifest (Phase 13).
+
+STEP 3 - VALIDATION + MULTI-AGENT REVIEW
+Run, in order:
+- npx tsc --noEmit
+- npx vitest run tests/professions_work_orders.test.ts
+  tests/professions_zone_rollout.test.ts tests/localization_fixes.test.ts
+  tests/architecture.test.ts plus the quest suites the Explore summary named
+- The parity verify-then-regen sequence for the NPC id shift (verify mechanical,
+  regen isolated, re-run npx vitest run tests/parity green)
+- npm run wiki:content, then the freshness gate (tests/guide.test.ts)
+- npm run ci:changed
+Then run git diff --name-only against the phase-start commit and dispatch ONLY the
+matching rows per the Review Dispatch Matrix in docs/farming/implementation-plan.md.
+Expected matches here: architecture-reviewer (sim content and gates);
+cross-platform-sync (quest credit and vendor flows cross the wire);
+privacy-security-review ONLY if any server/ file moved; frontend-seam-reviewer
+(quest marker and vendor UI touches); qa-checklist once the deliverable set is
+complete. Every review agent gets a hard 30-tool-call budget, the coverage
+instruction ("report every issue including low-severity and uncertain ones; ranking
+happens later"), and, if truncated, the resume line: "Stop reading more files.
+Output the full report now based on what you have already seen. No more tool calls.
+Format: BLOCKING / SHOULD-FIX / NICE-TO-HAVE / VERDICT." No commit while a BLOCKING
+stands.
+
+STEP 4 - COMMIT CADENCE
+2 to 5 Conventional Commits with scopes and bodies, EXPLICIT paths, never git add
+-A, no session links or Claude attribution. Suggested cut:
+1. feat(content): the four farmer NPCs, vendor stock, finalized gates, R37 flips.
+2. feat(quests): q_farm_intro, the farming action objective arm, markers, i18n.
+3. feat(content): produce work orders and wiki regen.
+4. test(parity): deliberate golden regen for the farmer NPC id shift (isolated).
+5. docs(farming): progress and state ledger updates, screenshots.
+
+STEP 5 - ACCEPTANCE CRITERIA
+- [ ] All four farmer NPCs exist at their hubs with the specified roles; the three
+      new names are original and IP-safe per D17 and recorded in state.md.
+- [ ] Every stocked vendor row has a positive buyValue; a purchase probe of every
+      row succeeds (no dead rows).
+- [ ] Tier 3 and 4 seeds are stocked NOWHERE (seed-back-only per D11).
+- [ ] q_farm_intro is acceptable at Jessica by a fresh character; requiredItems
+      grants the rung-one hoe and one vale wheat seed; the objective credits the
+      plant and harvest actions, not inventory; markers point correctly.
+- [ ] The completion text and Jessica's greeting both contain the magic sentence.
+- [ ] Husk conversion works in range of a farmer NPC and refuses out of range, with
+      tests on both arms; the watch fee stays a plant-time bag payment with NO NPC
+      range gate (D8, D9), and paying a fee far from any farmer works, with a test.
+- [ ] The work-order rows pay floor(WORK_ORDER_PAYOUT_FRACTION times summed vendor
+      sellValue), carry the arithmetic comment, and
+      tests/professions_work_orders.test.ts passes.
+- [ ] The R37 hub-stocking arms are on and tests/professions_zone_rollout.test.ts
+      passes.
+- [ ] The parity regen is verified mechanical and lands as its own commit;
+      tests/parity is green after it.
+- [ ] The full new-player journey probe passed on a live headless sim and its
+      transcript is in the PR body; the throwaway probe file is deleted.
+- [ ] The wiki is regenerated and the freshness gate passes.
+- [ ] Every new player-visible string is an English t() key; S3 passes.
+- [ ] tsc, the named suites, ci:changed, and gate_select are green (armory browser
+      exception aside).
+- [ ] Screenshots (desktop and mobile) of Jessica, the quest dialog, and the
+      vendor grid are committed under docs/screenshots.
+
+STEP 6 - DOC UPDATES + MEMORY
+- Update docs/farming/progress.md: the Phase 9 status row, the acceptance list
+  above copied with its check states, and a Notes block (surprises, deviations,
+  deferrals with reasons, the NPC names chosen, the work-order crops chosen).
+- Update the docs/farming/state.md ledgers: new items and quest, new i18n keys and
+  matcher rows, the NPC names, and mark the live-surface change (farming is LIVE).
+- Any deviation decided in-phase gets swept into
+  docs/farming/phase-09-world-presence.md AND docs/farming/phase-09-qa.md in the
+  same pass.
+- Record surprises (regen findings, quest arm subtleties) in Claude Code memory.
+
+STEP 7 - FINAL RESPONSE FORMAT
+Report: phase status; files touched; validation results (each command, pass or
+fail); review verdicts per agent; deferrals; and a one-line handoff for the Phase 9
+QA session.
+
+STOPPING RULES
+- Stop if any go-live flip cannot be made atomic in this merge: surface the
+  dependency instead of shipping a partially reachable loop.
+- Stop if the NPC parity regen shows ANY non-mechanical golden movement (anything
+  beyond the entity-id counter shift): that is a behavior change, not a regen.
+- Stop if crediting the quest objective would change any existing quest's
+  objective indices (the rev rule).
+- Stop if git status is dirty at session start or the release tip cannot be
+  resolved.
+- Stop if a review BLOCKING cannot be fixed without out-of-scope changes.
+
+Close: gate via node scripts/gate_select.mjs (the armory browser red is the
+standing environmental exception; grep the log for "[gate] FAIL"; PR CI is the
+arbiter), push, and open the PR against the release branch this phase was based on
+per .github/PULL_REQUEST_TEMPLATE.md, with before/after screenshots (desktop and
+mobile) captured via the pr-screenshots skill, committed under docs/screenshots,
+and referenced from the PR body (this is a visual phase: Jessica, the quest dialog,
+the vendor grid).
+```

--- a/docs/farming/phase-10-celebrations.md
+++ b/docs/farming/phase-10-celebrations.md
@@ -1,0 +1,222 @@
+# Phase 10: Celebrations
+
+Farming has been live since Phase 9. This phase adds the lottery moment and the permanent
+records: the golden_harvest rare event per D12 and the farming deeds and title per D13.
+Everything here is celebration: zero power, one new roll at harvest, append-only records.
+docs/farming/state.md is the authority; if this file contradicts it, state.md wins and this
+file plus phase-10-qa.md get swept in the same pass.
+
+Live-surface note (binding): LIVE, additive. The rare event and the deeds join the already-open
+farming loop the moment this merges: any harvesting player can roll golden_harvest, and
+every farming deed and the farming-100 title become earnable immediately. No dormant
+surface, no reachability change to anything that already shipped.
+
+### Starter Prompt
+
+```
+This is Phase 10 of the Farming feature: Celebrations.
+Model: Opus 4.8, xhigh effort (1m context variant where the file load demands it).
+Harness: Claude Code.
+
+Goal: farming gets its lottery moment and its permanent records: the golden_harvest rare
+event rolled at harvest, the farming deeds, and the farming-100 title.
+
+STEP 0 - PRE-FLIGHT
+- Work ONLY in the persistent worktree ~/Documents/woc-farming-plan. Use
+  git -C ~/Documents/woc-farming-plan for every git command (the Bash cwd resets between
+  calls; never rely on cd).
+- git status must be clean. If it is not, stop and surface; never stash or discard WIP
+  that is not yours.
+- Re-resolve the NEWEST release/** branch: git fetch origin --prune, then
+  git branch -r --list 'origin/release/*' | sort -V and take the last row. Create branch
+  fix/farming-phase-10-celebrations off its tip. Record the phase-start commit sha.
+- If release moves mid-phase and this branch turns long-lived, merge release in and run
+  the release-merge-audit skill.
+- Scan Claude Code memory: the MEMORY.md index, the farming-skill-program entry, plus
+  these phase-relevant topics: worktree-cwd-drift-misroutes-git,
+  i18n-semantic-regressions-gate-trap, mutation-checks-commit-first,
+  big-diff-reviewer-turn-budgets, fanout-agent-delivery-traps, no-claude-session-links.
+
+STEP 1 - LOAD CONTEXT
+Spawn one Explore agent (thorough) to read and summarize: docs/farming/state.md,
+docs/farming/progress.md, docs/farming/phase-10-celebrations.md, and these sources:
+src/sim/professions/farming.ts (the harvest action-time draw block, the draw-count
+contract), src/sim/content/deeds.ts (the catalog, the ZONE_FISH earnability template,
+the visit-mark idiom), the module exporting the gatherRareEvent SimEvent flavor union and
+announceGatherRareEvent (locate by symbol), src/ui/hud.ts (the single gatherRareEvent HUD
+case, read by the agent only, never by you), src/game/audio.ts (UI_CUES, the UiCue
+union), scripts/sfx/sfx_prompts.mjs, the deeds i18n module under src/ui/i18n.catalog/,
+tests/deeds_content.test.ts, tests/professions_farming.test.ts (and any sibling matching
+tests/professions_farming*.test.ts), tests/game_audio.test.ts,
+tests/localization_fixes.test.ts, the farming_session scenario under tests/parity, and
+the CLAUDE.md files: root, src/sim/CLAUDE.md, src/sim/professions/CLAUDE.md,
+src/ui/CLAUDE.md, plus docs/design/deeds.md. The orchestrator never reads planning docs
+or coordinator monoliths directly; the summary is your only context.
+The summary must return, explicitly:
+- The file and exported union carrying the gatherRareEvent flavors, the exact flavor
+  shape, and the announceGatherRareEvent signature and fanout semantics (including how
+  instance space is excluded).
+- The harvest action-time draw block's shape in src/sim/professions/farming.ts, the
+  current draw-count contract (draws per plant, draws per harvest, zero on denial) and
+  the test that pins it, and the exported name of the shared rare-event chance constant.
+- The single gatherRareEvent HUD case shape: how the existing flavors localize, the epic
+  color class, and the finder-only achievement cue path.
+- The full SFX cue recipe as implemented: UI_CUES key, facade method, hud case, prompt
+  row, npm run sfx:ui, sfx:manifest, sfx:check, and the completeness guard in
+  tests/game_audio.test.ts.
+- The deeds catalog structure: the ZONE_FISH earnability template, the visit-mark
+  producer idiom, the prog_ deed naming pattern, the title shape, and exactly which
+  totals tests/deeds_content.test.ts pins (deed order length, total renown, title
+  counts).
+- The deeds i18n module and the localization-coverage arms that count deeds.
+- The farming_session parity scenario file and the deliberate regen recipe
+  (UPDATE_PARITY=1, isolated commit).
+- Any progress.md Notes from Phases 1 to 9 that touch harvest, deeds, or the HUD
+  celebration path.
+
+STEP 2 - CHOOSE ORCHESTRATION + EXECUTE
+Spawn three implementation agents by vertical slice, each owning its slice plus its
+tests. Fan-out reminders: request the fan-out explicitly and spawn all three in one
+message so they run in parallel; give each agent ONLY the Explore summary plus its own
+bullets (never a planning doc to read); never run a teammate in plan mode.
+- Agent A, the rare event (sim): add golden_harvest as a fourth flavor on the existing
+  gatherRareEvent SimEvent union (no new SimEvent type); roll it at harvest inside the
+  action-time draw block in src/sim/professions/farming.ts using the shared rare-event
+  chance constant (1 in 90 per D12); five-fold yield; the produce signed; zone-announced
+  through the announceGatherRareEvent path so the HUD case stays single. Agent A owns ALL
+  edits to src/sim/professions/farming.ts, including the farm:<zone> visit-mark producer
+  Agent C's chronicle deeds consume. Restate and re-pin the draw-count contract (harvest
+  gains the rare-event draw; plant unchanged; denial still zero). Tests in
+  tests/professions_farming.test.ts: the roll fires only at harvest, the yield
+  multiplier, the signature, the announcement, the re-stated contract, a same-seed
+  determinism pin.
+- Agent B, the HUD arm and the cue (ui plus game): the localized golden_harvest line in
+  the epic color inside the one gatherRareEvent HUD case; the finder-only achievement cue
+  on the existing path; a NEW golden sting cue: UI_CUES key, facade method in
+  src/game/audio.ts (widen the UiCue union if the family nests), the hud case, a prompt
+  row in scripts/sfx/sfx_prompts.mjs, placeholder clip via npm run sfx:ui, then
+  npm run sfx:manifest and npm run sfx:check; the English t() rows in the matching
+  src/ui/i18n.catalog/ module. Tests: the tests/game_audio.test.ts completeness arm.
+- Agent C, the deeds (content plus i18n): per D13 and docs/design/deeds.md, all
+  append-only, cosmetic, ZERO rng: a first-planting deed; a first-harvest chronicle per
+  farming zone using farm:<zone> visit marks with an earnability table on the ZONE_FISH
+  template (the mark producer itself lands in Agent A's file; coordinate on the mark
+  ids); a golden-harvest deed; prog_farming_100 with the farming title. Re-pin the
+  tests/deeds_content.test.ts totals (deed order length, total renown, title counts)
+  deliberately in the same change. Deed English i18n rows in the matching
+  src/ui/i18n.catalog/ module with the release-tier note for the PR body (English-only
+  passes the PR tier; any M16-wordy string gets its non-Latin fills in the same change).
+  Verify the localization-coverage arms that count deeds.
+After the slices merge, YOU (the orchestrator) re-record the farming_session golden:
+run npx vitest run tests/parity first to see exactly which scenario moved, then
+UPDATE_PARITY=1 regen in an ISOLATED commit containing nothing else, then re-run to
+green and confirm no golden outside the farming scenarios changed.
+
+INVARIANTS THIS PHASE MUST KEEP
+- Every deed draws zero rng, ever; all deeds are append-only and cosmetic (titles and
+  Renown, never power).
+- All randomness in src/sim/ goes through ctx.rng; the new roll happens only inside the
+  harvest action-time draw block, never at expiry, login, or tick.
+- The draw-count contract change is deliberate, stated in the PR body, and isolated: the
+  farming_session re-record is its own UPDATE_PARITY=1 commit, and every golden outside
+  the farming scenarios stays byte-identical.
+- The gatherRareEvent HUD case stays single: all four flavors flow through the one case
+  and the one announceGatherRareEvent path.
+- No English in any sim or server path: every player-visible string added this phase is
+  an English t() key in the matching src/ui/i18n.catalog/ module; every sim emit stays
+  text-free and id-carrying (the S3 guard binds).
+- Every new cue key has a clip, a manifest row, and a green sfx:check.
+- No em dashes, en dashes, or emojis anywhere; every new name is IP-safe per D17.
+
+Out of scope (do NOT do in this phase)
+- Buff food (Phase 11).
+- The shared feast (Phase 12).
+- Wiki prose and the asset manifest (Phase 13).
+- Tuning the shared rare-event chance constant or any yield number outside D12.
+- Any new SimEvent type, any power-granting reward on any deed.
+
+STEP 3 - VALIDATION + MULTI-AGENT REVIEW
+Run, in order, and record each result:
+- npx tsc --noEmit
+- npx vitest run tests/deeds_content.test.ts tests/professions_farming.test.ts
+  tests/architecture.test.ts tests/localization_fixes.test.ts tests/game_audio.test.ts
+- npx vitest run tests/parity (green after the isolated re-record; nothing outside the
+  farming scenarios moved)
+- npm run ci:changed
+- node scripts/gate_select.mjs
+Then check git diff --name-only against the phase-start commit and dispatch ONLY the
+matching rows of the Review Dispatch Matrix in docs/farming/implementation-plan.md
+(expected for this diff: architecture-reviewer, cross-platform-sync,
+frontend-seam-reviewer (the hud case, the src/game/audio.ts cue, and the i18n rows
+match its matrix row), and qa-checklist at phase completion; add none beyond what the
+matrix matches). Every review agent gets a
+hard 30-tool-call budget, the coverage instruction ("report every issue including
+low-severity and uncertain ones; ranking happens later"), and, if truncated, the resume
+line: "Stop reading more files. Output the full report now based on what you have
+already seen. No more tool calls. Format: BLOCKING / SHOULD-FIX / NICE-TO-HAVE /
+VERDICT." No commit while a BLOCKING stands.
+
+STEP 4 - COMMIT CADENCE
+2 to 5 Conventional Commits, each with a scope and a BODY (what changed and why),
+explicit paths only, never git add -A, no session links or Claude attribution:
+- feat(sim): golden_harvest flavor and the harvest roll (union arm, action-time draw,
+  five-fold yield, signed produce, zone announce, re-stated draw-count pin)
+- feat(ui): the epic HUD line, finder-only achievement cue, and the golden sting cue
+  chain (facade, prompt row, placeholder clip, manifest)
+- feat(deeds): the farming deeds, chronicle marks and earnability table,
+  prog_farming_100 and title, totals re-pin, deed i18n rows
+- test(parity): re-record farming_session for the harvest rare-event draw (isolated,
+  UPDATE_PARITY=1, nothing else in the commit)
+- docs(farming): progress and state ledgers for Phase 10
+
+STEP 5 - ACCEPTANCE CRITERIA
+- [ ] golden_harvest is a fourth flavor on the existing gatherRareEvent union; no new
+      SimEvent type; the HUD case remains single.
+- [ ] The roll happens at harvest inside the action-time draw block via the shared
+      rare-event chance constant; five-fold yield; produce signed; zone-announced
+      through announceGatherRareEvent.
+- [ ] The draw-count contract is restated (harvest gains the rare-event draw) and
+      re-pinned so the pin fails if the count drifts.
+- [ ] farming_session re-recorded in an isolated UPDATE_PARITY=1 commit; no golden
+      outside the farming scenarios moved.
+- [ ] Deeds landed per D13: first planting, a first-harvest chronicle per farming zone
+      via farm:<zone> marks with an earnability table, a golden-harvest deed,
+      prog_farming_100 with the farming title; all append-only, cosmetic, zero rng.
+- [ ] tests/deeds_content.test.ts totals re-pinned deliberately in the same change.
+- [ ] Deed English i18n rows landed with the release-tier note in the PR body; the
+      localization-coverage arms that count deeds verified; S3 green.
+- [ ] Golden sting cue complete: UI_CUES key, facade method, hud case, prompt row,
+      placeholder clip, manifest, sfx:check green; tests/game_audio.test.ts green.
+- [ ] The epic-colored line and the achievement cue fire for the finder only; the zone
+      announcement reaches the zone.
+- [ ] Every STEP 3 validation row green; gate_select green modulo the armory exception.
+
+STEP 6 - DOC UPDATES + MEMORY
+Update docs/farming/progress.md (the Phase 10 status row, the acceptance list above
+copied with its check states, a Notes block for surprises, deviations, and deferrals)
+and the docs/farming/state.md ledgers (new SimEvent flavor, new i18n keys, new deeds,
+new cue). Any deviation decided in-phase gets swept into
+docs/farming/phase-10-celebrations.md AND docs/farming/phase-10-qa.md in the same pass.
+Record genuine surprises in Claude Code memory.
+
+STEP 7 - FINAL RESPONSE FORMAT
+Report: phase status (complete or partial with reasons); files touched, grouped by
+surface; validation results per command; review verdicts per agent; deferrals with
+reasons; one line handing off to the Phase 10 QA session.
+
+STOPPING RULES
+- Stop if the fourth flavor cannot land without breaking the single-HUD-case shape (a
+  second case or a forked switch): surface the design instead of forking it.
+- Stop if tests/parity reds outside the farming scenarios after the re-record: the
+  shared draw order forked for another profession; never regen other goldens to silence
+  it.
+- Stop if git status is dirty at STEP 0 or the newest release branch cannot be resolved.
+- Stop while any review BLOCKING stands.
+
+Close: gate via node scripts/gate_select.mjs (the armory browser red is the standing
+environmental exception; grep the log for "[gate] FAIL", never trust a piped exit code;
+PR CI is the arbiter). Push and open the PR against the release branch this phase was
+based on, following .github/PULL_REQUEST_TEMPLATE.md. Screenshots via the pr-screenshots
+skill apply to the visual phases (12 and 13); this phase needs none. No Claude
+attribution or session links in commits or PR text.
+```

--- a/docs/farming/phase-10-qa.md
+++ b/docs/farming/phase-10-qa.md
@@ -1,0 +1,96 @@
+# Phase 10 QA: Verify Celebrations
+
+Audits the Phase 10 PR: the golden_harvest rare event, the farming deeds and title, the
+cue chain, and the deliberately moved pins (draw-count contract, deeds totals, the
+farming_session golden). The special hazards here are pin drift dressed up as
+deliberateness and a rare-event roll that silently forked another profession's draw
+order.
+
+### QA Starter Prompt
+
+```
+This is Phase 10 QA of the Farming feature: Verify Celebrations.
+Model: Opus 4.8, xhigh effort (1m context variant where the file load demands it).
+Harness: Claude Code.
+
+Goal: audit Phase 10 for correctness, missing tests, dead code, determinism, three-host
+parity, i18n completeness, and the phase's own acceptance criteria.
+
+STEP 0 - PRE-FLIGHT
+- Same worktree rules: work ONLY in ~/Documents/woc-farming-plan, use
+  git -C ~/Documents/woc-farming-plan everywhere, git status clean or stop.
+- git fetch origin --prune, then check out the Phase 10 PR branch
+  (fix/farming-phase-10-celebrations).
+- Identify the phase diff: the PR's commits against its base. Use
+  git diff --name-only origin/<base-release-branch>...HEAD (three dots: merge-base
+  semantics). The release tip may have moved concurrently, so the diff is the PR's
+  commits, never everything since phase start. If the diff cannot be identified cleanly,
+  stop and surface.
+- Scan Claude Code memory: the MEMORY.md index, the farming-skill-program entry, plus
+  frozen-clock-rig-hangs-vitest, mutation-checks-commit-first, vacuous-bound-pin-trap,
+  early-exit-pins-need-work-remaining, one-probe-outranks-agreeing-agents.
+
+STEP 1 - LOAD CONTEXT
+Spawn one Explore agent to summarize: docs/farming/state.md, the docs/farming/progress.md
+Phase 10 notes, the promises in docs/farming/phase-10-celebrations.md (acceptance list,
+invariants, any recorded deviation), and git diff --name-only over the phase diff. The
+summary must return the acceptance checklist verbatim, every recorded deviation, the diff
+file list grouped by surface, and the state.md validation matrix rows the diff demands.
+
+STEP 2 - QA AUDIT
+Spawn three parallel audit agents, each with a hard 30-tool-call budget and the coverage
+instruction ("report every issue including low-severity and uncertain ones; ranking
+happens later"); resume any truncated agent with: "Stop reading more files. Output the
+full report now based on what you have already seen. No more tool calls. Format:
+BLOCKING / SHOULD-FIX / NICE-TO-HAVE / VERDICT."
+- Correctness agent: every deliverable and acceptance criterion actually met; the
+  offline Sim and the online ClientWorld paths behave identically; edge cases (denial
+  still draws zero, golden on the final pick, a chronicle mark in every FARMING_ZONES
+  zone). Where sim behavior changed, run live headless-Sim probes via a throwaway vitest
+  file driving real ticks with an injected ADVANCEABLE clock (the clock must advance
+  now() or waits hang), then delete the file and verify the tree is clean. Verify
+  the Live-surface note: LIVE, additive: any harvesting player can roll
+  golden_harvest and every farming deed and the farming-100 title are earnable the
+  moment this merges, with no reachability change to anything that already shipped.
+  Phase 10 emphases, all three mandatory: verify the tests/deeds_content.test.ts
+  totals re-pin is EXACT and deliberate (new pinned totals equal the old totals
+  plus exactly the new records, cross-checked against src/sim/content/deeds.ts, not
+  against the test's own
+  arithmetic); verify the golden-harvest roll changes no other profession's draw order
+  (the parity fingerprint outside the farming scenarios is untouched); verify the zone
+  announcement excludes instance space per the existing announceGatherRareEvent fanout
+  rules.
+- Test-coverage agent: decisive assertions that fail on regression; no
+  constant-self-comparison pins; both arms of every either/all claim (the event fires
+  and does not fire, a deed earnable and not yet earned); orphaned tests removed;
+  mutation checks only AFTER committing the work first.
+- Dead-code-and-cleanup agent: unused imports and types; the sim import invariant
+  (src/sim/ imports nothing from render, ui, game, or net, and has no DOM or Three
+  imports); no unresolved TODOs; naming consistency (golden_harvest, farm:<zone>,
+  prog_farming_100, the cue key).
+Then dispatch the Review Dispatch Matrix rows in docs/farming/implementation-plan.md
+that the phase diff matches, plus qa-checklist (the phase-completion gate), under the
+same budget and format rules.
+
+STEP 3 - FIX
+Apply every BLOCKING and SHOULD-FIX finding test-first (a failing test that exercises
+the real path, then the smallest green change). Run the docs/farming/state.md validation
+matrix rows the diff demands. Separate fix commits with explicit paths, never
+git add -A, no session links or Claude attribution.
+
+STEP 4 - DOC UPDATES
+Update docs/farming/progress.md (the Phase 10 QA row plus Notes) and
+docs/farming/state.md (drift, ledger corrections). Any deviation gets swept into
+docs/farming/phase-10-celebrations.md AND this QA twin in the same pass.
+
+STEP 5
+No teardown step in this phase; packet teardown belongs to Phase 13 QA only.
+
+STEP 6 - FINAL RESPONSE FORMAT
+Verdict PASS / PASS-WITH-FOLLOWUPS / FAIL; counts of issues found and fixed per
+severity; deferrals with reasons; one line handing off to Phase 11.
+
+STOPPING RULES
+- Stop and surface if a BLOCKING cannot be fixed without changing phase scope.
+- Stop if the phase diff cannot be identified cleanly.
+```

--- a/docs/farming/phase-11-qa.md
+++ b/docs/farming/phase-11-qa.md
@@ -1,0 +1,96 @@
+# Phase 11 QA: Verify Well-fed food
+
+Audits the Phase 11 PR: the wellfed ItemDef arm, the four tier dishes, aura naming, and
+the tooltip and buff bar surface. The special hazards here are namespace leakage (a food
+buff clobbering an elixir or the reverse), a stacking rule that holds in only one
+direction, and a timing decision that was made but never pinned.
+
+### QA Starter Prompt
+
+```
+This is Phase 11 QA of the Farming feature: Verify Well-fed food.
+Model: Opus 4.8, xhigh effort (1m context variant where the file load demands it).
+Harness: Claude Code.
+
+Goal: audit Phase 11 for correctness, missing tests, dead code, determinism, three-host
+parity, i18n completeness, and the phase's own acceptance criteria.
+
+STEP 0 - PRE-FLIGHT
+- Same worktree rules: work ONLY in ~/Documents/woc-farming-plan, use
+  git -C ~/Documents/woc-farming-plan everywhere, git status clean or stop.
+- git fetch origin --prune, then check out the Phase 11 PR branch
+  (fix/farming-phase-11-well-fed-food).
+- Identify the phase diff: the PR's commits against its base. Use
+  git diff --name-only origin/<base-release-branch>...HEAD (three dots: merge-base
+  semantics). The release tip may have moved concurrently, so the diff is the PR's
+  commits, never everything since phase start. If the diff cannot be identified cleanly,
+  stop and surface.
+- Scan Claude Code memory: the MEMORY.md index, the farming-skill-program entry, plus
+  frozen-clock-rig-hangs-vitest, mutation-checks-commit-first, vacuous-bound-pin-trap,
+  joint-coverage-masks-deleted-sites, one-probe-outranks-agreeing-agents.
+
+STEP 1 - LOAD CONTEXT
+Spawn one Explore agent to summarize: docs/farming/state.md, the docs/farming/progress.md
+Phase 11 notes (including the recorded timing decision and proposed magnitudes), the
+promises in docs/farming/phase-11-well-fed-food.md (acceptance list, invariants, any
+recorded deviation), and git diff --name-only over the phase diff. The summary must
+return the acceptance checklist verbatim, the timing decision as recorded, every
+recorded deviation, the diff file list grouped by surface, and the state.md validation
+matrix rows the diff demands.
+
+STEP 2 - QA AUDIT
+Spawn three parallel audit agents, each with a hard 30-tool-call budget and the coverage
+instruction ("report every issue including low-severity and uncertain ones; ranking
+happens later"); resume any truncated agent with: "Stop reading more files. Output the
+full report now based on what you have already seen. No more tool calls. Format:
+BLOCKING / SHOULD-FIX / NICE-TO-HAVE / VERDICT."
+- Correctness agent: every deliverable and acceptance criterion actually met; the
+  offline Sim and the online ClientWorld paths behave identically; edge cases (eating a
+  second dish of the same kind, eating during an active elixir, interrupting the
+  sit-restore before completion under the chosen timing). Where sim behavior changed,
+  run live headless-Sim probes via a throwaway vitest file driving real ticks with an
+  injected ADVANCEABLE clock (the clock must advance now() or waits hang), then delete
+  the file and verify the tree is clean. Verify the Live-surface note: LIVE,
+  additive: any player with produce can cook the buff dishes, eat them, and carry a
+  well-fed buff the moment this merges, with the elixir slots and every existing
+  elixir behavior untouched. Phase 11 emphases, both mandatory: run the
+  coexistence probe LIVE (one player with an elixir_<kind> buff and a wellfed buff
+  active simultaneously; drive real ticks, then confirm both appear in the buff bar
+  rows through the auras view chain with correct remaining times); exercise the
+  last-eaten-wins pin live (eat dish A, then dish B; B's aura stands alone in the
+  wellfed namespace and A's is gone, while the elixir is untouched).
+- Test-coverage agent: decisive assertions that fail on regression; no
+  constant-self-comparison pins; both arms of every either/all claim (isolation proven
+  in BOTH directions: wellfed does not clobber elixir AND elixir does not clobber
+  wellfed; stacking denied AND replacement allowed); orphaned tests removed; mutation
+  checks only AFTER committing the work first.
+- Dead-code-and-cleanup agent: unused imports and types; the sim import invariant
+  (src/sim/ imports nothing from render, ui, game, or net, and has no DOM or Three
+  imports); no unresolved TODOs; naming consistency (wellfed_<kind> ids, dish item ids,
+  aura name keys).
+Then dispatch the Review Dispatch Matrix rows in docs/farming/implementation-plan.md
+that the phase diff matches, plus qa-checklist (the phase-completion gate), under the
+same budget and format rules.
+
+STEP 3 - FIX
+Apply every BLOCKING and SHOULD-FIX finding test-first (a failing test that exercises
+the real path, then the smallest green change). Run the docs/farming/state.md validation
+matrix rows the diff demands. Separate fix commits with explicit paths, never
+git add -A, no session links or Claude attribution.
+
+STEP 4 - DOC UPDATES
+Update docs/farming/progress.md (the Phase 11 QA row plus Notes) and
+docs/farming/state.md (drift, ledger corrections). Any deviation gets swept into
+docs/farming/phase-11-well-fed-food.md AND this QA twin in the same pass.
+
+STEP 5
+No teardown step in this phase; packet teardown belongs to Phase 13 QA only.
+
+STEP 6 - FINAL RESPONSE FORMAT
+Verdict PASS / PASS-WITH-FOLLOWUPS / FAIL; counts of issues found and fixed per
+severity; deferrals with reasons; one line handing off to Phase 12.
+
+STOPPING RULES
+- Stop and surface if a BLOCKING cannot be fixed without changing phase scope.
+- Stop if the phase diff cannot be identified cleanly.
+```

--- a/docs/farming/phase-11-well-fed-food.md
+++ b/docs/farming/phase-11-well-fed-food.md
@@ -1,0 +1,196 @@
+# Phase 11: Well-fed food
+
+Farm produce becomes buff food. Per D15, a new ItemDef.wellfed arm mirrors the elixir arm
+exactly: inline aura mint, ctx.applyAura, a distinct wellfed_<kind> namespace so food
+never clobbers elixirs, modest classic-era magnitudes. Four dishes, one per crop tier,
+give the produce ladder a consumer at every rung. docs/farming/state.md is the authority;
+if this file contradicts it, state.md wins and this file plus phase-11-qa.md get swept in
+the same pass.
+
+Live-surface note (binding): LIVE, additive. The buff dishes join cooking the moment this merges:
+any player with produce can cook them, eat them, and carry a well-fed buff. The elixir
+slots and every existing elixir behavior are untouched.
+
+### Starter Prompt
+
+```
+This is Phase 11 of the Farming feature: Well-fed food.
+Model: Opus 4.8, xhigh effort (1m context variant where the file load demands it).
+Harness: Claude Code.
+
+Goal: farm-fed cooking grants classic well-fed buffs through a new ItemDef.wellfed arm
+without touching the elixir slots.
+
+STEP 0 - PRE-FLIGHT
+- Work ONLY in the persistent worktree ~/Documents/woc-farming-plan. Use
+  git -C ~/Documents/woc-farming-plan for every git command.
+- git status must be clean. If it is not, stop and surface; never stash or discard WIP
+  that is not yours.
+- Re-resolve the NEWEST release/** branch: git fetch origin --prune, then
+  git branch -r --list 'origin/release/*' | sort -V and take the last row. Create branch
+  fix/farming-phase-11-well-fed-food off its tip. Record the phase-start commit sha.
+- If release moves mid-phase and this branch turns long-lived, merge release in and run
+  the release-merge-audit skill.
+- Scan Claude Code memory: the MEMORY.md index, the farming-skill-program entry, plus
+  these phase-relevant topics: worktree-cwd-drift-misroutes-git,
+  round-trip-pins-reference-aliasing, i18n-semantic-regressions-gate-trap,
+  mutation-checks-commit-first, big-diff-reviewer-turn-budgets, no-claude-session-links.
+
+STEP 1 - LOAD CONTEXT
+Spawn one Explore agent (thorough) to read and summarize: docs/farming/state.md,
+docs/farming/progress.md, docs/farming/phase-11-well-fed-food.md, and these sources:
+src/sim/items.ts (the useItem food arm with the p.eating / p.drinking sit-restore slots,
+and the elixir arm: inline aura mint from ItemDef.elixir via ctx.applyAura with
+elixir_<kind> ids), the module exporting the ItemDef type (locate by symbol), the auras
+module ctx.applyAura reaches (locate by symbol), the cooking recipe content module
+(locate it), src/ui/sim_i18n.ts (AURA_NAME_KEY), src/ui/auras_view.ts,
+src/ui/auras_painter.ts, src/ui/elixir_tooltip_view.ts,
+tests/professions_farming.test.ts, tests/recipe_economy.test.ts,
+tests/localization_fixes.test.ts, and the CLAUDE.md files: root, src/sim/CLAUDE.md,
+src/sim/professions/CLAUDE.md, src/ui/CLAUDE.md. The orchestrator never reads planning
+docs or coordinator monoliths directly; the summary is your only context.
+The summary must return, explicitly:
+- The exact ItemDef.elixir field shape (aura name, kind, value, duration) and the elixir
+  arm's application code path, so wellfed can mirror it field for field.
+- The food path shape: where consume starts the sit-restore, where completion of the
+  sit-restore is observable, and the candidate auras-module hooks for applying a buff at
+  completion (the timing decision below needs these).
+- The auras module's id semantics: overwrite rules within an id, duration ticking, and
+  what happens to active auras across save and load (the transient behavior this phase
+  must state and pin).
+- How elixir_<kind> namespacing prevents the documented exclusivity-slot clobber, so
+  wellfed_<kind> can copy the mechanism.
+- The AURA_NAME_KEY row shape in src/ui/sim_i18n.ts, the buff display chain
+  (auras_view plus auras_painter), and the tooltip seam beside elixir_tooltip_view.ts.
+- The cooking recipe module, the produce item ids per tier, and where the documented
+  elixir budget ceilings live (the magnitudes must sit at or below them).
+- The names of the aura test suites to run in STEP 3 (list them exactly).
+- Any progress.md Notes from earlier phases touching produce, dishes, or auras.
+
+STEP 2 - CHOOSE ORCHESTRATION + EXECUTE
+Spawn three implementation agents by vertical slice, each owning its slice plus its
+tests. Fan-out reminders: request the fan-out explicitly and spawn all three in one
+message so they run in parallel; give each agent ONLY the Explore summary plus its own
+bullets (never a planning doc to read); never run a teammate in plan mode.
+- Agent A, the wellfed arm (sim): an ItemDef.wellfed shape beside elixir (aura name,
+  kind, value, duration), applied from the food path in src/sim/items.ts via
+  ctx.applyAura with aura ids in the wellfed_<kind> namespace, never through
+  effect_dispatch. Make the application-timing decision IN THIS PHASE: immediate on
+  consume versus on completion of the sit-restore. The recommendation is completion (the
+  sit-through-the-meal ritual); decide, state the choice and the auras-module hook
+  chosen, and document it in the module and in progress.md Notes. Tests: application and
+  timing, the namespace-isolation pin (a wellfed buff and an elixir_<kind> buff of the
+  same kind coexist; neither overwrites the other), last-eaten-wins within the wellfed
+  namespace, duration ticking, and the transient-across-save behavior stated and pinned
+  (whatever the auras module does across save and load, state it and pin it).
+- Agent B, the dishes (content): four buff dishes, one per crop tier, as cooking recipes
+  consuming farm produce. Magnitudes at or below the documented elixir budget ceilings,
+  classic-modest, and flagged for the maintainer in the PR body as tuning proposals (the
+  state.md OPEN item). Tests: recipe economy green (nothing vendors above its cheapest
+  achievable inputs; crafted outputs carry no buyValue), each dish's wellfed field
+  well-formed.
+- Agent C, names and display (ui plus i18n): an AURA_NAME_KEY row in src/ui/sim_i18n.ts
+  for every new aura name; tooltip lines beside the elixir tooltip view
+  (src/ui/elixir_tooltip_view.ts is the template); the buff bar shows the wellfed aura
+  through the existing auras_view plus auras_painter chain; English t() rows in the
+  matching src/ui/i18n.catalog/ module. Tests: S3 (tests/localization_fixes.test.ts) and
+  the i18n coverage arms.
+
+INVARIANTS THIS PHASE MUST KEEP
+- Every dish's magnitude sits at or below the documented elixir budget ceilings; all
+  crafted power stays below the raid floor.
+- One knob one job: no food buff ever stacks with itself; within the wellfed namespace,
+  last eaten always wins (stated and pinned).
+- Every wellfed aura id lives in the wellfed_<kind> namespace; no food buff ever
+  clobbers any elixir_<kind> buff, and no elixir ever clobbers any wellfed buff.
+- No new effect machinery beyond the aura arm: application goes through ctx.applyAura
+  from the food path, never through effect_dispatch.
+- Every new aura name has an AURA_NAME_KEY row; every player-visible string added this
+  phase is an English t() key in the matching src/ui/i18n.catalog/ module.
+- Every existing elixir behavior is preserved unchanged.
+- All randomness in src/sim/ goes through ctx.rng; this phase expects zero new draws
+  (state that in the module).
+- No em dashes, en dashes, or emojis anywhere; every new name is IP-safe per D17.
+
+Out of scope (do NOT do in this phase)
+- The shared feast (Phase 12); the tier-4 feast buff application lands there.
+- Any non-food buff source.
+- Wiki prose and the asset manifest (Phase 13).
+- Any change to the elixir arm, elixir ids, or elixir recipes.
+
+STEP 3 - VALIDATION + MULTI-AGENT REVIEW
+Run, in order, and record each result:
+- npx tsc --noEmit
+- npx vitest run tests/professions_farming.test.ts tests/recipe_economy.test.ts
+  tests/architecture.test.ts tests/localization_fixes.test.ts plus the aura suites the
+  Explore summary named
+- npm run ci:changed
+- node scripts/gate_select.mjs
+Then check git diff --name-only against the phase-start commit and dispatch ONLY the
+matching rows of the Review Dispatch Matrix in docs/farming/implementation-plan.md
+(expected for this diff: architecture-reviewer, cross-platform-sync,
+frontend-seam-reviewer for the tooltip and buff bar surface, and qa-checklist at phase
+completion). Every review agent gets a hard 30-tool-call budget, the coverage
+instruction ("report every issue including low-severity and uncertain ones; ranking
+happens later"), and, if truncated, the resume line: "Stop reading more files. Output
+the full report now based on what you have already seen. No more tool calls. Format:
+BLOCKING / SHOULD-FIX / NICE-TO-HAVE / VERDICT." No commit while a BLOCKING stands.
+
+STEP 4 - COMMIT CADENCE
+2 to 5 Conventional Commits, each with a scope and a BODY, explicit paths only, never
+git add -A, no session links or Claude attribution:
+- feat(sim): the ItemDef.wellfed arm, the application-timing decision, namespace
+  isolation and last-eaten-wins (with the sim tests)
+- feat(content): four tier buff dishes consuming produce (with recipe economy coverage)
+- feat(ui): AURA_NAME_KEY rows and wellfed tooltip lines (with i18n coverage)
+- docs(farming): progress, state ledgers, the timing decision record
+
+STEP 5 - ACCEPTANCE CRITERIA
+- [ ] ItemDef.wellfed exists beside elixir (aura name, kind, value, duration), applied
+      from the food path in src/sim/items.ts via ctx.applyAura with wellfed_<kind> ids,
+      never through effect_dispatch.
+- [ ] The application-timing decision is made, stated, and documented (recommended:
+      completion of the sit-restore), including the auras-module hook chosen.
+- [ ] The namespace-isolation pin is green: a wellfed buff and an elixir_<kind> buff of
+      the same kind coexist and neither overwrites the other.
+- [ ] Last-eaten-wins within the wellfed namespace is stated and pinned; no food buff
+      stacks with itself.
+- [ ] Every new aura name has an AURA_NAME_KEY row.
+- [ ] Tooltip lines render beside the elixir tooltip view; the buff bar shows the
+      wellfed aura with its remaining time.
+- [ ] Four buff dishes, one per crop tier, consume produce; magnitudes at or below the
+      documented elixir budget ceilings and flagged for the maintainer in the PR body.
+- [ ] Tests green: application and timing, isolation, duration ticking, the
+      transient-across-save pin, recipe economy, S3 and i18n coverage.
+- [ ] Every STEP 3 validation row green; gate_select green modulo the armory exception.
+
+STEP 6 - DOC UPDATES + MEMORY
+Update docs/farming/progress.md (the Phase 11 status row, the acceptance list above
+copied with its check states, a Notes block including the timing decision and the
+proposed magnitudes) and the docs/farming/state.md ledgers (new items and recipes, new
+i18n keys and AURA_NAME_KEY rows, the timing decision as a locked deviation entry if it
+refines D15). Any deviation decided in-phase gets swept into
+docs/farming/phase-11-well-fed-food.md AND docs/farming/phase-11-qa.md in the same pass.
+Record genuine surprises in Claude Code memory.
+
+STEP 7 - FINAL RESPONSE FORMAT
+Report: phase status (complete or partial with reasons); files touched, grouped by
+surface; validation results per command; review verdicts per agent; deferrals with
+reasons; one line handing off to the Phase 11 QA session.
+
+STOPPING RULES
+- Stop if a dish cannot stay inside the documented budget ceilings without a maintainer
+  call: propose the magnitudes in the PR body and surface; never invent a higher
+  ceiling.
+- Stop if the auras module offers no clean completion hook and the timing decision would
+  require new effect machinery: surface the design instead of building machinery.
+- Stop if git status is dirty at STEP 0 or the newest release branch cannot be resolved.
+- Stop while any review BLOCKING stands.
+
+Close: gate via node scripts/gate_select.mjs (the armory browser red is the standing
+environmental exception; grep the log for "[gate] FAIL", never trust a piped exit code;
+PR CI is the arbiter). Push and open the PR against the release branch this phase was
+based on, following .github/PULL_REQUEST_TEMPLATE.md. Screenshots via the pr-screenshots
+skill apply to the visual phases (12 and 13); this phase needs none. No Claude
+attribution or session links in commits or PR text.
+```

--- a/docs/farming/phase-12-qa.md
+++ b/docs/farming/phase-12-qa.md
@@ -1,0 +1,102 @@
+# Phase 12 QA: Verify The shared feast
+
+Audits the Phase 12 PR: the placeable feast entity, its charges and per-player ledger,
+the interaction arm, the wire carriage, and the render and audio surface. The special
+hazards here are client-trusted outcomes (a charge or ledger decision leaking to the
+client), ledger state that quietly serializes, and a once-per-player rule that forgets a
+player who left and rejoined.
+
+### QA Starter Prompt
+
+```
+This is Phase 12 QA of the Farming feature: Verify The shared feast.
+Model: Opus 4.8, xhigh effort (1m context variant where the file load demands it).
+Harness: Claude Code.
+
+Goal: audit Phase 12 for correctness, missing tests, dead code, determinism, three-host
+parity, i18n completeness, and the phase's own acceptance criteria.
+
+STEP 0 - PRE-FLIGHT
+- Same worktree rules: work ONLY in ~/Documents/woc-farming-plan, use
+  git -C ~/Documents/woc-farming-plan everywhere, git status clean or stop.
+- git fetch origin --prune, then check out the Phase 12 PR branch
+  (fix/farming-phase-12-shared-feast).
+- Identify the phase diff: the PR's commits against its base. Use
+  git diff --name-only origin/<base-release-branch>...HEAD (three dots: merge-base
+  semantics). The release tip may have moved concurrently, so the diff is the PR's
+  commits, never everything since phase start. If the diff cannot be identified cleanly,
+  stop and surface.
+- Scan Claude Code memory: the MEMORY.md index, the farming-skill-program entry, plus
+  frozen-clock-rig-hangs-vitest, mutation-checks-commit-first,
+  joint-coverage-masks-deleted-sites, early-exit-pins-need-work-remaining,
+  one-probe-outranks-agreeing-agents.
+
+STEP 1 - LOAD CONTEXT
+Spawn one Explore agent to summarize: docs/farming/state.md, the docs/farming/progress.md
+Phase 12 notes (including the recorded anti-abuse rule and the proposed charge count and
+expiry), the promises in docs/farming/phase-12-shared-feast.md (acceptance list,
+invariants, any recorded deviation), and git diff --name-only over the phase diff. The
+summary must return the acceptance checklist verbatim, the anti-abuse rule as recorded,
+every recorded deviation, the diff file list grouped by surface, and the state.md
+validation matrix rows the diff demands.
+
+STEP 2 - QA AUDIT
+Spawn three parallel audit agents, each with a hard 30-tool-call budget and the coverage
+instruction ("report every issue including low-severity and uncertain ones; ranking
+happens later"); resume any truncated agent with: "Stop reading more files. Output the
+full report now based on what you have already seen. No more tool calls. Format:
+BLOCKING / SHOULD-FIX / NICE-TO-HAVE / VERDICT."
+- Correctness agent: every deliverable and acceptance criterion actually met; the
+  offline Sim and the online ClientWorld paths behave identically; edge cases (consume
+  on the last charge, consume exactly at expiry, place under the anti-abuse rule's
+  boundary). Where sim behavior changed, run live headless-Sim probes via a throwaway
+  vitest file driving real ticks with an injected ADVANCEABLE clock (the clock must
+  advance now() or waits hang), then delete the file and verify the tree is clean.
+  Verify the despawn and expiry check rides INSIDE the already-anchored
+  updateFarming driver (the state.md tick anchor), not a second appended sweep.
+  Verify the Live-surface note: LIVE: a player can cook the feast, place it in the
+  world, and every nearby player can eat from it once for the tier-4 well-fed buff
+  the moment this merges, nothing dormant.
+  Phase 12 emphases, all three mandatory: run a three-session probe (the placer places
+  and eats; a guest eats once and is denied a second helping; a latecomer arriving
+  after charges empty is denied); verify the once-per-player ledger survives the guest
+  leaving and rejoining within the feast's life (the rejoined guest is still denied);
+  confirm nothing serializes (no feast field in any CharacterState write, save blob, or
+  database path; grep the serialize and normalize paths, then prove it with a
+  save-then-load probe that shows the feast absent after reload).
+- Test-coverage agent: decisive assertions that fail on regression; no
+  constant-self-comparison pins; both arms of every either/all claim (every deny arm
+  has a matching allow case, and each deny fires at its own site, not just where a
+  second equivalent effect also fires); orphaned tests removed; mutation checks only
+  AFTER committing the work first.
+- Dead-code-and-cleanup agent: unused imports and types; the sim import invariant
+  (src/sim/ imports nothing from render, ui, game, or net, and has no DOM or Three
+  imports); no unresolved TODOs; naming consistency (FeastState fields, the deny event
+  ids, the cue key, the prop name).
+Then dispatch the Review Dispatch Matrix rows in docs/farming/implementation-plan.md
+that the phase diff matches (privacy-security-review is expected here: the diff touches
+the server interaction surface), plus qa-checklist (the phase-completion gate), under
+the same budget and format rules.
+
+STEP 3 - FIX
+Apply every BLOCKING and SHOULD-FIX finding test-first (a failing test that exercises
+the real path, then the smallest green change). Run the docs/farming/state.md validation
+matrix rows the diff demands. Separate fix commits with explicit paths, never
+git add -A, no session links or Claude attribution.
+
+STEP 4 - DOC UPDATES
+Update docs/farming/progress.md (the Phase 12 QA row plus Notes) and
+docs/farming/state.md (drift, ledger corrections). Any deviation gets swept into
+docs/farming/phase-12-shared-feast.md AND this QA twin in the same pass.
+
+STEP 5
+No teardown step in this phase; packet teardown belongs to Phase 13 QA only.
+
+STEP 6 - FINAL RESPONSE FORMAT
+Verdict PASS / PASS-WITH-FOLLOWUPS / FAIL; counts of issues found and fixed per
+severity; deferrals with reasons; one line handing off to Phase 13.
+
+STOPPING RULES
+- Stop and surface if a BLOCKING cannot be fixed without changing phase scope.
+- Stop if the phase diff cannot be identified cleanly.
+```

--- a/docs/farming/phase-12-shared-feast.md
+++ b/docs/farming/phase-12-shared-feast.md
@@ -1,0 +1,251 @@
+# Phase 12: The shared feast
+
+The tier-4 showcase per D16: a placeable feast other players eat from, the communal
+payoff at the top of the crop ladder. The feast is a REAL entity riding the normal entity
+snapshot (the battleground-flag precedent), with server-owned charges, a per-player
+consumed ledger, and tick-domain expiry, transient and never serialized.
+docs/farming/state.md is the authority; if this file contradicts it, state.md wins and
+this file plus phase-12-qa.md get swept in the same pass.
+
+Live-surface note (binding): LIVE. The moment this merges, a player can cook the feast, place it in
+the world, and every nearby player can eat from it once for the tier-4 well-fed buff.
+This is the first farming surface other players consume; it is fully reachable on merge,
+nothing dormant.
+
+### Starter Prompt
+
+```
+This is Phase 12 of the Farming feature: The shared feast.
+Model: Opus 4.8, xhigh effort (1m context variant where the file load demands it).
+Harness: Claude Code.
+
+Goal: a placeable feast other players eat from, the communal payoff at the top of the
+farming ladder.
+
+STEP 0 - PRE-FLIGHT
+- Work ONLY in the persistent worktree ~/Documents/woc-farming-plan. Use
+  git -C ~/Documents/woc-farming-plan for every git command.
+- git status must be clean. If it is not, stop and surface; never stash or discard WIP
+  that is not yours.
+- Re-resolve the NEWEST release/** branch: git fetch origin --prune, then
+  git branch -r --list 'origin/release/*' | sort -V and take the last row. Create branch
+  fix/farming-phase-12-shared-feast off its tip. Record the phase-start commit sha.
+- If release moves mid-phase and this branch turns long-lived, merge release in and run
+  the release-merge-audit skill.
+- Scan Claude Code memory: the MEMORY.md index, the farming-skill-program entry, plus
+  these phase-relevant topics: worktree-cwd-drift-misroutes-git,
+  pr-screenshot-browser-path, joint-coverage-masks-deleted-sites,
+  mutation-checks-commit-first, big-diff-reviewer-turn-budgets,
+  fanout-agent-delivery-traps, no-claude-session-links.
+
+STEP 1 - LOAD CONTEXT
+Spawn one Explore agent (very thorough) to read and summarize: docs/farming/state.md,
+docs/farming/progress.md, docs/farming/phase-12-shared-feast.md, and these sources:
+src/world_api/farming.ts (the IWorldFarming facet as it stands),
+tests/world_api_parity.test.ts (the pinned member lists), src/sim/interaction.ts (the
+interaction arm pattern), src/sim/quests/interact_object_credit.ts (the creditedObjects
+stable-content-key ledger idiom), src/sim/professions/farming.ts (updateFarming and the
+tick append rule context), the entity snapshot path (locate the battleground-flag
+precedent by symbol across src/net/online.ts and server/game.ts), the wellfed
+application arm from Phase 11 in src/sim/items.ts, the cooking recipe content module,
+scripts/assets/build_farm_props.mjs, src/render/farm_patches.ts, src/game/audio.ts plus
+scripts/sfx/sfx_prompts.mjs (the cue recipe), tests/snapshots.test.ts,
+tests/env_protocol.test.ts, tests/bandwidth.test.ts, and the CLAUDE.md files: root,
+src/sim/CLAUDE.md, src/sim/professions/CLAUDE.md, src/ui/CLAUDE.md,
+src/render/CLAUDE.md. The orchestrator never reads planning docs or coordinator
+monoliths directly; the summary is your only context.
+The summary must return, explicitly:
+- The IWorldFarming member list and the command plumbing pattern in BOTH Sim and
+  ClientWorld, plus where tests/world_api_parity.test.ts pins the members.
+- The battleground-flag precedent in full: how a sim-spawned entity enters the entity
+  snapshot, which wire fields it rides, what applyWire needs, and what the renderer
+  needs to draw a new entity kind.
+- The interaction arm pattern in src/sim/interaction.ts and the stable-content-key
+  ledger idiom in src/sim/quests/interact_object_credit.ts, shaped for a per-player
+  consumed ledger.
+- Where updateFarming sits in the tick (the state.md tick anchor) and how the
+  despawn and expiry check rides INSIDE that driver without reordering anything.
+- How to grant the tier-4 wellfed buff from an interaction arm using only the Phase 11
+  machinery (and whether that application owns any rng draw; none is expected).
+- The announce-and-route precedents: which existing test drives multiple online
+  sessions, for the routing test.
+- The build_farm_props.mjs exporter structure and the src/render/farm_patches.ts
+  adapter pattern (footprint and pivot conventions for a swap-ready prop), the VFX
+  seam, and the full SFX cue recipe.
+- The cooking recipe module and the economy pins an expensive produce-heavy tier-4
+  recipe must satisfy.
+- Any progress.md Notes from earlier phases touching entities, snapshots, interaction,
+  or the wellfed arm.
+
+STEP 2 - CHOOSE ORCHESTRATION + EXECUTE
+Spawn four implementation agents by vertical slice, each owning its slice plus its
+tests. Fan-out reminders: request the fan-out explicitly and spawn all four in one
+message so they run in parallel; give each agent ONLY the Explore summary plus its own
+bullets (never a planning doc to read); never run a teammate in plan mode. Agents A and
+B coordinate on the feast module's exported surface; if they must edit the same file in
+parallel, use isolation: worktree per the agent-scaling section of the implementation
+plan.
+- Agent A, the feast core (sim): a NEW module src/sim/professions/feast.ts owning
+  FeastState (owner, charges remaining, tick-domain expiry, a per-player consumed
+  ledger via the stable-content-key idiom). Place draws ZERO rng; state that in the
+  module. The interaction arm in src/sim/interaction.ts: consuming grants the tier-4
+  wellfed buff via the Phase 11 arm, decrements a charge, once per player per feast.
+  Despawn on zero charges or expiry via a check riding INSIDE the already-anchored
+  updateFarming driver (the state.md tick anchor), never a second appended sweep.
+  Every deny arm (no charges, already consumed, expired, out of range, anti-abuse) is a
+  text-free id-carrying SimEvent. Decide the anti-abuse rule IN THIS PHASE: one active
+  feast per player OR a placement cooldown; state the choice and document it in the
+  module and progress.md Notes. Document the transient rationale in the module: the
+  feast is never serialized because tick-domain expiry is not restart-safe (the
+  mobile-station rationale). Tests: place, consume, once-per-player, charges, expiry,
+  every deny arm, a same-seed determinism pin.
+- Agent B, the seam and the wire (world_api plus net plus server): a placeFeast command
+  on IWorldFarming (src/world_api/farming.ts, the facet file, never the barrel),
+  implemented in BOTH Sim and ClientWorld in the same change, with the pinned member
+  list in tests/world_api_parity.test.ts updated. The feast spawns a REAL entity that
+  rides the normal entity snapshot per the battleground-flag precedent; no new wire
+  mechanism. A multi-session online routing test per the announce-and-route precedents
+  (placer places; a second session sees the entity and consumes; the charge decrement
+  routes back). The snapshots suites stay green: tests/snapshots.test.ts,
+  tests/env_protocol.test.ts, tests/bandwidth.test.ts.
+- Agent C, the item and the words (content plus i18n): the feast item as an expensive,
+  produce-heavy tier-4 cooking recipe (recipe economy green; the crafted output carries
+  no buyValue). The placer's name in the feast title as a t() key in the
+  "{name}'s Harvest Feast" shape (the name is a value, the text is the key). English
+  t() rows in the matching src/ui/i18n.catalog/ module; S3 coverage for every new emit.
+- Agent D, the look and the sound (render plus audio): the feast prop added to
+  scripts/assets/build_farm_props.mjs (swap-ready: fixed footprint and pivot per D19),
+  the render surface (default: a small dedicated src/render/feast.ts adapter; an arm
+  inside src/render/farm_patches.ts is acceptable if the phase judges it cohesive;
+  state the choice in progress.md), placement VFX, and a feast
+  cue: UI_CUES key, facade method in src/game/audio.ts, the hud case, a prompt row in
+  scripts/sfx/sfx_prompts.mjs, placeholder clip via npm run sfx:ui, then
+  npm run sfx:manifest and npm run sfx:check. Tests: the tests/game_audio.test.ts
+  completeness arm.
+
+INVARIANTS THIS PHASE MUST KEEP
+- Server authority: every charge decrement and every ledger entry is server state; the
+  client never decides any feast outcome; no wire command ingests a client-supplied
+  ItemInstancePayload.
+- Zero rng in placement and consumption, stated in the module; the tier-4 wellfed
+  application owns no draw either (confirm against the Phase 11 arm and state it).
+- Transient state is never serialized: no feast field enters CharacterState, any save
+  blob, or any database write; the mobile-station rationale is documented in the
+  module.
+- Every deny arm emits a text-free, id-carrying SimEvent localized client-side; every
+  player-visible string added this phase is an English t() key.
+- The feast rides the normal entity snapshot; no new wire mechanism of any kind.
+- All sim work stays inside the 20 Hz budget: the despawn and expiry check inside
+  updateFarming does no per-tick allocation in its hot path.
+- All randomness in src/sim/ goes through ctx.rng.
+- No em dashes, en dashes, or emojis anywhere; every new name is IP-safe per D17.
+
+Out of scope (do NOT do in this phase)
+- Wiki prose and the handoff manifest (Phase 13).
+- Any second placeable object or a general placeable-object framework.
+- Feast persistence of any kind (serialization, restart survival).
+- Trading, mailing, or market-listing a PLACED feast (the item itself follows normal
+  item rules).
+
+STEP 3 - VALIDATION + MULTI-AGENT REVIEW
+Run, in order, and record each result:
+- npx tsc --noEmit
+- npx vitest run over the new feast suite (working name tests/professions_feast.test.ts;
+  record the real name in progress.md)
+- npx vitest run tests/architecture.test.ts tests/localization_fixes.test.ts
+  tests/world_api_parity.test.ts tests/snapshots.test.ts tests/env_protocol.test.ts
+  tests/bandwidth.test.ts tests/game_audio.test.ts
+- npx vitest run tests/parity: this phase draws zero rng, so no golden should move; if
+  the parity scenario set was deliberately extended to cover the feast, record that
+  extension and isolate it in its own commit; any OTHER movement is a defect.
+- npm run ci:changed
+- node scripts/gate_select.mjs
+- Screenshots: this IS a visual phase; capture before/after (desktop and mobile) via
+  the pr-screenshots skill, commit under docs/screenshots, reference from the PR body.
+Then check git diff --name-only against the phase-start commit and dispatch ONLY the
+matching rows of the Review Dispatch Matrix in docs/farming/implementation-plan.md
+(expected for this diff: architecture-reviewer, cross-platform-sync,
+privacy-security-review for the interaction plus server surface, frontend-seam-reviewer,
+and qa-checklist at phase completion). Every review agent gets a hard 30-tool-call
+budget, the coverage instruction ("report every issue including low-severity and
+uncertain ones; ranking happens later"), and, if truncated, the resume line: "Stop
+reading more files. Output the full report now based on what you have already seen. No
+more tool calls. Format: BLOCKING / SHOULD-FIX / NICE-TO-HAVE / VERDICT." No commit
+while a BLOCKING stands.
+
+STEP 4 - COMMIT CADENCE
+2 to 5 Conventional Commits, each with a scope and a BODY, explicit paths only, never
+git add -A, no session links or Claude attribution:
+- feat(sim): the feast module, interaction arm, the updateFarming despawn check,
+  deny arms, and the anti-abuse rule (with the unit suite)
+- feat(net): placeFeast on IWorldFarming in both worlds, entity snapshot carriage,
+  parity pin, the multi-session routing test
+- feat(content): the feast recipe and the title key (with economy and S3 coverage)
+- feat(render): the feast prop, the chosen render adapter, placement VFX, and the
+  feast cue chain
+- docs(farming): progress, state ledgers, and the screenshot references
+
+STEP 5 - ACCEPTANCE CRITERIA
+- [ ] The feast item exists: an expensive, produce-heavy tier-4 cooking recipe; recipe
+      economy green; no buyValue on the crafted output.
+- [ ] placeFeast lands on IWorldFarming, implemented in BOTH Sim and ClientWorld, with
+      the tests/world_api_parity.test.ts pin updated in the same change.
+- [ ] The feast spawns a REAL entity riding the normal entity snapshot; no new wire
+      mechanism anywhere in the diff.
+- [ ] src/sim/professions/feast.ts owns FeastState (owner, charges remaining,
+      tick-domain expiry, per-player consumed ledger via the stable-content-key idiom);
+      place draws zero rng and the module says so.
+- [ ] Consuming grants the tier-4 wellfed buff, decrements a charge, once per player
+      per feast; despawn on zero charges or expiry via the check riding inside the
+      already-anchored updateFarming driver (the state.md tick anchor), not a second
+      sweep.
+- [ ] Feast state is transient and never serialized; the mobile-station rationale is
+      documented in the module.
+- [ ] The anti-abuse rule is decided, stated, and documented (one active feast per
+      player or a placement cooldown).
+- [ ] The prop is in scripts/assets/build_farm_props.mjs (swap-ready), the chosen
+      render adapter draws it (the dedicated src/render/feast.ts default, or the
+      farm_patches.ts arm if judged cohesive, the choice stated in progress.md),
+      placement VFX fire, and the feast cue chain is complete (key, clip, manifest,
+      sfx:check green).
+- [ ] The feast title is a t() key in the "{name}'s Harvest Feast" shape.
+- [ ] Tests green: place, consume, once-per-player, charges, expiry, every deny arm,
+      the multi-session routing test, the determinism pin.
+- [ ] Parity: no golden moved, or the deliberate scenario extension is recorded and
+      isolated in its own commit.
+- [ ] Screenshots (desktop and mobile) committed under docs/screenshots and referenced
+      from the PR body.
+- [ ] Every STEP 3 validation row green; gate_select green modulo the armory exception.
+
+STEP 6 - DOC UPDATES + MEMORY
+Update docs/farming/progress.md (the Phase 12 status row, the acceptance list above
+copied with its check states, a Notes block including the anti-abuse decision and the
+proposed charge count and expiry as maintainer-flagged tuning) and the
+docs/farming/state.md ledgers (new IWorld member placeFeast, new SimEvents, new items
+and recipes, new i18n keys, the anti-abuse rule as a locked deviation entry refining
+D16). Any deviation decided in-phase gets swept into
+docs/farming/phase-12-shared-feast.md AND docs/farming/phase-12-qa.md in the same pass.
+Record genuine surprises in Claude Code memory.
+
+STEP 7 - FINAL RESPONSE FORMAT
+Report: phase status (complete or partial with reasons); files touched, grouped by
+surface; validation results per command; review verdicts per agent; deferrals with
+reasons; one line handing off to the Phase 12 QA session.
+
+STOPPING RULES
+- Stop if the entity route cannot carry the feast without a new wire mechanism: surface
+  the design instead of inventing one.
+- Stop if any path makes serialization unavoidable (a save, a snapshot-of-record, a
+  restart survival requirement): the transient design is broken; surface it.
+- Stop if git status is dirty at STEP 0 or the newest release branch cannot be
+  resolved.
+- Stop while any review BLOCKING stands.
+
+Close: gate via node scripts/gate_select.mjs (the armory browser red is the standing
+environmental exception; grep the log for "[gate] FAIL", never trust a piped exit code;
+PR CI is the arbiter). Push and open the PR against the release branch this phase was
+based on, following .github/PULL_REQUEST_TEMPLATE.md. Screenshots via the pr-screenshots
+skill apply to the visual phases (12 and 13); this phase IS one, so the PR body
+references the committed before/after set. No Claude attribution or session links in
+commits or PR text.
+```

--- a/docs/farming/phase-13-integration-polish.md
+++ b/docs/farming/phase-13-integration-polish.md
@@ -1,0 +1,193 @@
+# Phase 13: Integration polish and the handoff
+
+The closing phase: no new mechanics, only the surfaces that make the feature complete
+and maintainable. The wiki farming page, the full-journey screenshot set, the
+model-sourcing handoff manifest in docs/design (deliberately outside this packet so it
+survives teardown), the deferral sweep, and the whole-feature audit against
+docs/farming/qa-checklist.md. docs/farming/state.md is the authority; if this file
+contradicts it, state.md wins and this file plus phase-13-qa.md get swept in the same
+pass.
+
+Live-surface note (binding): LIVE, complete. No new mechanic ships. This phase merges the wiki
+page, the screenshots, the asset handoff manifest, and the recorded whole-feature audit
+evidence. After it, the feature is done and the packet is ready for the teardown offer
+in Phase 13 QA.
+
+### Starter Prompt
+
+```
+This is Phase 13 of the Farming feature: Integration polish and the handoff.
+Model: Opus 4.8, xhigh effort (1m context variant where the file load demands it).
+Harness: Claude Code.
+
+Goal: the feature is documented, photographed, handoff-ready, and audited whole, with
+zero new mechanics.
+
+STEP 0 - PRE-FLIGHT
+- Work ONLY in the persistent worktree ~/Documents/woc-farming-plan. Use
+  git -C ~/Documents/woc-farming-plan for every git command.
+- git status must be clean. If it is not, stop and surface; never stash or discard WIP
+  that is not yours.
+- Re-resolve the NEWEST release/** branch: git fetch origin --prune, then
+  git branch -r --list 'origin/release/*' | sort -V and take the last row. Create branch
+  fix/farming-phase-13-integration-polish off its tip. Record the phase-start commit
+  sha.
+- If release moves mid-phase and this branch turns long-lived, merge release in and run
+  the release-merge-audit skill.
+- Scan Claude Code memory: the MEMORY.md index, the farming-skill-program entry, plus
+  these phase-relevant topics: pr-screenshot-browser-path, node25-breaks-jsdom-gate,
+  malware-scan-comment-keywords, worktree-cwd-drift-misroutes-git,
+  no-claude-session-links, i18n-semantic-regressions-gate-trap.
+
+STEP 1 - LOAD CONTEXT
+Spawn one Explore agent (very thorough) to read and summarize: docs/farming/state.md,
+docs/farming/progress.md (EVERY phase's Notes block, for the deferral sweep),
+docs/farming/phase-13-integration-polish.md, docs/farming/qa-checklist.md, and these
+sources: src/guide/CLAUDE.md (where guide.* prose keys land and the spoiler-safe
+rules), tests/guide.test.ts (the freshness gate), scripts/assets/build_farm_props.mjs
+(the complete inventory of swap-ready farming assets as authored),
+src/render/farm_patches.ts and the feast adapter arm (footprints, pivots, tints, stage
+lists as consumed), plus the CLAUDE.md files: root, src/ui/CLAUDE.md,
+src/render/CLAUDE.md, and docs/design/deeds.md if the wiki page covers deeds. The
+orchestrator never reads planning docs or coordinator monoliths directly; the summary
+is your only context.
+The summary must return, explicitly:
+- Where guide.* prose keys land, the spoiler-safe rules that bind them, the wiki regen
+  chain (npm run wiki:content) and exactly how tests/guide.test.ts gates freshness.
+- The complete inventory of swap-ready farming assets with their authored parameters:
+  the bed, every growth-stage mesh in every crop family, every withered variant, the
+  compost bin, and the feast, each with footprint, pivot, tints, and stage list as they
+  exist in the exporter and adapters.
+- Every deferral recorded in any progress.md Notes block, verbatim, with its phase.
+- The docs/farming/qa-checklist.md rows and what evidence each demands.
+- The pr-screenshots recipe plus the pr-screenshot-browser-path memory facts.
+- The i18n catalog modules Phases 1 to 12 touched, for the final IP-safe audit.
+
+STEP 2 - CHOOSE ORCHESTRATION + EXECUTE
+Spawn three implementation agents by vertical slice, each owning its slice plus its
+checks. Fan-out reminders: request the fan-out explicitly and spawn all three in one
+message so they run in parallel; give each agent ONLY the Explore summary plus its own
+bullets (never a planning doc to read); never run a teammate in plan mode.
+- Agent A, the wiki page (guide): the guide.* prose keys for the farming page,
+  spoiler-safe per src/guide/CLAUDE.md, regenerated via npm run wiki:content, with the
+  tests/guide.test.ts freshness gate green. Then the final IP-safe naming audit (D17)
+  across EVERY player-visible farming string in the i18n catalog modules the Explore
+  summary listed: real plant words and original zone-flavored coinages only, no coined
+  terms from other games; report each string checked.
+- Agent B, the handoff and the photographs (docs plus screenshots):
+  docs/design/farming-asset-manifest.json listing EVERY swap-ready asset (the bed, each
+  growth-stage mesh per family, the withered variants, the compost bin, the feast),
+  each row carrying footprint, pivot, tints, stage list, and a replacement-intent note
+  (what a sourced model must match to drop in without code changes). Cross-check the
+  manifest against scripts/assets/build_farm_props.mjs and the render adapters: every
+  exporter output and every adapter consumer has a row. This manifest is the
+  maintainer's model-sourcing handoff and lives in docs/design so it SURVIVES packet
+  teardown; it must not reference any docs/farming/ path. Then the full-journey
+  screenshot set (plant, growth stages, harvest, the Harvest Journal, the feast;
+  desktop and mobile) via the pr-screenshots skill, committed under docs/screenshots
+  (git add -f by EXPLICIT path per the memory entry: docs/screenshots is gitignored,
+  so the force-add by explicit path is the sanctioned exception per the repo
+  screenshot workflow; never a bare -A or a tree-wide force) and referenced from the
+  PR body.
+- Agent C, the sweep and the audit (docs): the deferral sweep: every progress.md Notes
+  deferral collected into docs/farming/state.md and staged for the PR body, none lost.
+  Then the full execution of docs/farming/qa-checklist.md, including the anti-chore
+  audit, with evidence recorded per row (a test run, a probe transcript, or a
+  screenshot; never "looks done"); record the evidence in the progress.md Phase 13
+  Notes block.
+After the slices merge, YOU (the orchestrator) run the full npm run gate.
+
+INVARIANTS THIS PHASE MUST KEEP
+- The manifest is complete: every swap-ready asset has a row with footprint, pivot,
+  tints, stage list, and replacement-intent notes; an asset missing from it cannot be
+  replaced later without code archaeology, so a missing row is a defect.
+- No em dashes, en dashes, or emojis in any prose, wiki keys and manifest notes
+  included.
+- Every player-visible farming string passes the final IP-safe audit (D17).
+- No new mechanic, no balance change, no tuning change of any kind.
+- Generated wiki content is never hand-edited: regen via npm run wiki:content only.
+- All commits use explicit paths, never git add -A.
+
+Out of scope (do NOT do in this phase)
+- Any new mechanic, item, recipe, deed, or tuning change.
+- The packet teardown (Phase 13 QA offers it to the user; never delete docs/farming/
+  here).
+- Locale fills beyond the M16 requirement (release-time work via i18n-locale-fill).
+
+STEP 3 - VALIDATION + MULTI-AGENT REVIEW
+Run, in order, and record each result:
+- npx tsc --noEmit
+- npm run wiki:content, then npx vitest run tests/guide.test.ts (freshness green)
+- The full docs/farming/qa-checklist.md matrix with evidence per row (Agent C's record;
+  spot-check it yourself)
+- npm run ci:changed
+- npm run gate (the deep check; the armory browser red is the standing environmental
+  exception; grep the log for "[gate] FAIL")
+Then check git diff --name-only against the phase-start commit and dispatch
+qa-checklist (the phase-completion gate) plus any Review Dispatch Matrix row in
+docs/farming/implementation-plan.md the residual diff matches; if the diff is
+docs-plus-guide only, qa-checklist alone is correct, and no row means no extra agent.
+Every review agent gets a hard 30-tool-call budget, the coverage instruction ("report
+every issue including low-severity and uncertain ones; ranking happens later"), and,
+if truncated, the resume line: "Stop reading more files. Output the full report now
+based on what you have already seen. No more tool calls. Format: BLOCKING /
+SHOULD-FIX / NICE-TO-HAVE / VERDICT." No commit while a BLOCKING stands.
+
+STEP 4 - COMMIT CADENCE
+2 to 5 Conventional Commits, each with a scope and a BODY, explicit paths only, never
+git add -A, no session links or Claude attribution:
+- feat(guide): the farming wiki prose keys and the regenerated content
+- docs(design): the farming asset handoff manifest
+- docs(screenshots): the full-journey desktop and mobile set
+- docs(farming): the deferral sweep, the qa-checklist evidence, progress and state
+  updates
+
+STEP 5 - ACCEPTANCE CRITERIA
+- [ ] The wiki farming page is regenerated via npm run wiki:content, the
+      tests/guide.test.ts freshness gate is green, and the prose is spoiler-safe per
+      src/guide/CLAUDE.md.
+- [ ] docs/design/farming-asset-manifest.json exists and lists every swap-ready asset
+      (the bed, each growth-stage mesh per family, the withered variants, the compost
+      bin, the feast) with footprint, pivot, tints, stage list, and replacement-intent
+      notes, cross-checked against the exporter and adapters.
+- [ ] The manifest references no docs/farming/ path (it must survive teardown intact).
+- [ ] The full-journey screenshot set (desktop and mobile) is committed under
+      docs/screenshots and referenced from the PR body.
+- [ ] Every progress.md Notes deferral is swept into state.md and the PR body.
+- [ ] docs/farming/qa-checklist.md is executed in full, anti-chore audit included, with
+      evidence recorded per row.
+- [ ] The final IP-safe audit covered every player-visible farming string.
+- [ ] No em dashes, en dashes, or emojis anywhere in the new prose.
+- [ ] npm run gate green modulo the armory environmental exception; ci:changed green.
+
+STEP 6 - DOC UPDATES + MEMORY
+Update docs/farming/progress.md (the Phase 13 status row, the acceptance list above
+copied with its check states, a Notes block holding the qa-checklist evidence and any
+last deferrals) and the docs/farming/state.md ledgers (the swept deferrals, any final
+drift). Any deviation decided in-phase gets swept into
+docs/farming/phase-13-integration-polish.md AND docs/farming/phase-13-qa.md in the same
+pass. Record genuine surprises in Claude Code memory.
+
+STEP 7 - FINAL RESPONSE FORMAT
+Report: phase status (complete or partial with reasons); files touched, grouped by
+surface; validation results per command including the qa-checklist row verdicts; review
+verdicts per agent; deferrals with reasons; one line handing off to the Phase 13 QA
+session (the final audit and the teardown offer).
+
+STOPPING RULES
+- Stop if any qa-checklist row fails with evidence: fix it inside phase scope or
+  surface it; never wave a row through, and never add a mechanic to make a row pass.
+- Stop if an asset exists with no manifest row and its parameters cannot be recovered
+  from the exporter or adapters: surface it; never guess a footprint or pivot.
+- Stop if git status is dirty at STEP 0 or the newest release branch cannot be
+  resolved.
+- Stop while any review BLOCKING stands.
+
+Close: gate via node scripts/gate_select.mjs (the armory browser red is the standing
+environmental exception; grep the log for "[gate] FAIL", never trust a piped exit code;
+PR CI is the arbiter). Push and open the PR against the release branch this phase was
+based on, following .github/PULL_REQUEST_TEMPLATE.md. Screenshots via the pr-screenshots
+skill apply to the visual phases (12 and 13); this phase IS one, so the PR body
+references the committed full-journey set. No Claude attribution or session links in
+commits or PR text.
+```

--- a/docs/farming/phase-13-qa.md
+++ b/docs/farming/phase-13-qa.md
@@ -1,0 +1,118 @@
+# Phase 13 QA: Verify Integration polish and the handoff
+
+The final audit of the packet. It verifies the Phase 13 PR (wiki page, manifest,
+screenshots, deferral sweep, audit evidence), re-runs the whole-feature rows any late
+fix touched, and then, uniquely, offers the packet teardown to the user. Note:
+docs/design/farming-asset-manifest.json is deliberately outside the packet and stays
+after teardown; only docs/farming/ is ever offered for deletion.
+
+### QA Starter Prompt
+
+```
+This is Phase 13 QA of the Farming feature: Verify Integration polish and the handoff.
+Model: Opus 4.8, xhigh effort (1m context variant where the file load demands it).
+Harness: Claude Code.
+
+Goal: audit Phase 13 for correctness, missing tests, dead code, determinism, three-host
+parity, i18n completeness, and the phase's own acceptance criteria; then close the
+packet with the teardown offer.
+
+STEP 0 - PRE-FLIGHT
+- Same worktree rules: work ONLY in ~/Documents/woc-farming-plan, use
+  git -C ~/Documents/woc-farming-plan everywhere, git status clean or stop.
+- git fetch origin --prune, then check out the Phase 13 PR branch
+  (fix/farming-phase-13-integration-polish).
+- Identify the phase diff: the PR's commits against its base. Use
+  git diff --name-only origin/<base-release-branch>...HEAD (three dots: merge-base
+  semantics). The release tip may have moved concurrently, so the diff is the PR's
+  commits, never everything since phase start. If the diff cannot be identified cleanly,
+  stop and surface.
+- Scan Claude Code memory: the MEMORY.md index, the farming-skill-program entry, plus
+  mutation-checks-commit-first, pr-screenshot-browser-path, node25-breaks-jsdom-gate,
+  one-probe-outranks-agreeing-agents, no-claude-session-links.
+
+STEP 1 - LOAD CONTEXT
+Spawn one Explore agent to summarize: docs/farming/state.md, the docs/farming/progress.md
+Phase 13 notes (including the recorded qa-checklist evidence), the promises in
+docs/farming/phase-13-integration-polish.md (acceptance list, invariants, any recorded
+deviation), docs/farming/qa-checklist.md, and git diff --name-only over the phase diff.
+The summary must return the acceptance checklist verbatim, the qa-checklist rows with
+their recorded evidence, every deferral recorded anywhere in the packet (every
+progress.md Notes block, the state.md ledgers and OPEN items), the diff file list
+grouped by surface, and the state.md validation matrix rows the diff demands.
+
+STEP 2 - QA AUDIT
+Spawn three parallel audit agents, each with a hard 30-tool-call budget and the coverage
+instruction ("report every issue including low-severity and uncertain ones; ranking
+happens later"); resume any truncated agent with: "Stop reading more files. Output the
+full report now based on what you have already seen. No more tool calls. Format:
+BLOCKING / SHOULD-FIX / NICE-TO-HAVE / VERDICT."
+- Correctness agent: every deliverable and acceptance criterion actually met; the wiki
+  prose is accurate against the shipped mechanics and spoiler-safe; the manifest is
+  complete (cross-check every exporter output in scripts/assets/build_farm_props.mjs
+  and every adapter consumer against the manifest rows; verify footprints, pivots,
+  tints, and stage lists match the authored values) and references no docs/farming/
+  path; the screenshots exist under docs/screenshots and the PR body references them;
+  each qa-checklist evidence row is actually supported by its evidence (re-run a
+  sample, the anti-chore rows in particular). Verify the Live-surface note: LIVE,
+  complete: no new mechanic shipped; the merge is the wiki page, the screenshots,
+  the asset handoff manifest, and the recorded audit evidence only. A sim behavior
+  change in this diff is
+  itself a finding (Phase 13 ships no mechanics); if one exists anyway, probe it with
+  the throwaway-vitest ADVANCEABLE-clock rig (the clock must advance now() or waits
+  hang), then delete the rig and verify the tree is clean.
+- Test-coverage agent: decisive assertions that fail on regression; no
+  constant-self-comparison pins; both arms of every either/all claim; orphaned tests
+  removed; the guide freshness gate really binds the new content; mutation checks only
+  AFTER committing the work first.
+- Dead-code-and-cleanup agent: unused imports and types; the sim import invariant; no
+  unresolved TODOs; naming consistency; teardown safety: nothing OUTSIDE docs/farming/
+  references a docs/farming/ path (such a reference would break when the packet is
+  deleted).
+Then dispatch the Review Dispatch Matrix rows in docs/farming/implementation-plan.md
+that the phase diff matches, plus qa-checklist (the phase-completion gate), under the
+same budget and format rules.
+
+STEP 3 - FIX + WHOLE-FEATURE SWEEP
+Apply every BLOCKING and SHOULD-FIX finding test-first (a failing test that exercises
+the real path, then the smallest green change). Run the docs/farming/state.md
+validation matrix rows the diff demands. Then the whole-feature sweep: re-run the
+docs/farming/qa-checklist.md rows that any post-Phase-13 fix touched, and re-record
+their evidence. Separate fix commits with explicit paths, never git add -A, no session
+links or Claude attribution.
+
+STEP 4 - DOC UPDATES
+Update docs/farming/progress.md (the Phase 13 QA row plus Notes) and
+docs/farming/state.md (drift, final ledger state). Any deviation gets swept into
+docs/farming/phase-13-integration-polish.md AND this QA twin in the same pass.
+
+STEP 5 - PACKET TEARDOWN
+Only after every prior step is green:
+- FIRST surface every deferred follow-up recorded anywhere in the packet (every
+  progress.md Notes block, the state.md ledgers and OPEN items, any phase-file
+  deferral) so nothing tracked only in docs/farming/ is lost. Restate them in your
+  final response and confirm each one lives in the PR body or a filed issue before any
+  deletion.
+- Then ask the user explicitly: "All phases are complete and green. OK to delete
+  docs/farming/ (the planning scaffolding) before the PR?"
+- On explicit confirmation, delete ONLY that directory with explicit paths:
+  git rm -r docs/farming/ and a "docs: remove farming planning scaffolding" commit
+  (with a body) if the docs were committed.
+- If the user declines, leave the packet in place and say so in the final response.
+- Never delete anything else, never fold the deletion into an unrelated commit, never
+  git add -A.
+- docs/design/farming-asset-manifest.json is deliberately outside the packet and
+  stays, whatever the user decides.
+
+STEP 6 - FINAL RESPONSE FORMAT
+Verdict PASS / PASS-WITH-FOLLOWUPS / FAIL; counts of issues found and fixed per
+severity; deferrals, each with where it now lives (PR body or issue); whether the
+packet was removed (yes on confirmation, no with the user's answer otherwise); and the
+closing line: either a one-line handoff for remaining follow-ups or "packet complete".
+
+STOPPING RULES
+- Stop and surface if a BLOCKING cannot be fixed without changing phase scope.
+- Stop if the phase diff cannot be identified cleanly.
+- Never proceed to STEP 5 while any audit finding stands unfixed or any qa-checklist
+  row lacks evidence.
+```

--- a/docs/farming/progress.md
+++ b/docs/farming/progress.md
@@ -1,0 +1,82 @@
+# Farming: progress
+
+## Status
+
+| Phase | Status | Started | Completed |
+|---|---|---|---|
+| Packet authored | done | 2026-08-07 | 2026-08-07 |
+| Packet PR merged | not started | | |
+| Phase 1 (foundation) | not started | | |
+| Phase 1 QA | not started | | |
+| Phase 2 (patches and plots) | not started | | |
+| Phase 2 QA | not started | | |
+| Phase 3 (growth engine) | not started | | |
+| Phase 3 QA | not started | | |
+| Phase 4 (knobs) | not started | | |
+| Phase 4 QA | not started | | |
+| Phase 5 (crops and tools) | not started | | |
+| Phase 5 QA | not started | | |
+| Phase 6 (economy hooks) | not started | | |
+| Phase 6 QA | not started | | |
+| Phase 7 (render and juice) | not started | | |
+| Phase 7 QA | not started | | |
+| Phase 8 (Harvest Journal) | not started | | |
+| Phase 8 QA | not started | | |
+| Phase 9 (world presence, go-live) | not started | | |
+| Phase 9 QA | not started | | |
+| Phase 10 (celebrations) | not started | | |
+| Phase 10 QA | not started | | |
+| Phase 11 (well-fed food) | not started | | |
+| Phase 11 QA | not started | | |
+| Phase 12 (shared feast) | not started | | |
+| Phase 12 QA | not started | | |
+| Phase 13 (integration polish) | not started | | |
+| Phase 13 QA (final; teardown offer) | not started | | |
+
+## Per-phase deliverable checklists
+
+Each phase file's STEP 5 acceptance criteria are the authoritative checklist; this
+section holds the running record. On phase completion, copy the acceptance list here
+with its check states, then add a Notes block (surprises, deviations from the phase
+file, deferrals with reasons, drift discovered). A deviation also gets a line in
+state.md's "Locked deviations" ledger, and an amended phase file always gets its QA
+twin swept in the same pass.
+
+### Phase 1
+(not started)
+
+### Phase 2
+(not started)
+
+### Phase 3
+(not started)
+
+### Phase 4
+(not started)
+
+### Phase 5
+(not started)
+
+### Phase 6
+(not started)
+
+### Phase 7
+(not started)
+
+### Phase 8
+(not started)
+
+### Phase 9
+(not started)
+
+### Phase 10
+(not started)
+
+### Phase 11
+(not started)
+
+### Phase 12
+(not started)
+
+### Phase 13
+(not started)

--- a/docs/farming/qa-checklist.md
+++ b/docs/farming/qa-checklist.md
@@ -1,0 +1,92 @@
+# Farming: whole-feature integration QA matrix
+
+Verified once, at packet completion (Phase 13 QA), on top of the per-phase QA passes.
+Every row gets a verdict with evidence (a test run, a probe transcript, or a
+screenshot), never "looks done."
+
+## The anti-chore audit (farming-specific; the design's load-bearing promise)
+
+- Two visits per cycle: no code path requires or rewards a third visit between plant
+  and harvest. No mid-growth interaction exists.
+- Nothing rots: a fully grown crop waits indefinitely; a late harvest yields exactly
+  what an on-time harvest would. No decay, no wither, no daily reset touches farming.
+- Absence is never punished: logging out never worsens any farming outcome; growth
+  continues on the wall clock; the login notice fires for finished crops.
+- Risk is opt-in: survival below 100 percent only ever occurs at-band without full
+  insurance; one band above the crop tier is always safe; failure yields husks.
+- The timer UI exists and is honest: the Harvest Journal shows every plot, stage,
+  remaining time, and applied knobs; map pins mark patch sites; ready states surface
+  as banners while online and at login.
+
+## Three-host parity
+
+- The offline browser Sim, the online ClientWorld mirror, and the headless env agree
+  on every farming read and command surface (IWorld facet implemented in BOTH worlds;
+  parity pins updated; the farming_session parity scenario green).
+- Offline growth degrades to session-local (the documented taster) without error.
+
+## Determinism
+
+- Same seed, same world: the farming draw-count contract (draws at plant, draws at
+  harvest, zero on denial, zero at expiry/login/tick) is stated and pinned.
+- No Math.random, Date.now, or performance.now anywhere in src/sim/; wall clock only
+  via ctx.lockoutNowMs; tests/architecture.test.ts green.
+- Parity goldens regenerated only in deliberate, isolated commits (the Phase 1 field
+  add, the Phase 3 scenario addition, the Phase 5 seed-back re-record, the Phase 9
+  NPC add, the Phase 10 rare-event re-record), never hand-edited.
+
+## i18n completeness
+
+- Every player-visible farming string is a t() key in English in the matching
+  src/ui/i18n.catalog/ module; locale overlays untouched except M16 fills; aura names
+  have AURA_NAME_KEY rows; sim/server emits are id-carrying events or have matcher
+  rules; tests/localization_fixes.test.ts green; numbers and times go through
+  formatNumber/formatDateTime/the t() clock tokens.
+
+## Economy and fidelity
+
+- No invented balance numbers presented as classic formulas; farming's own constants
+  are flagged as tuning proposals in PR bodies.
+- recipe_economy invariant green (nothing vendors above its cheapest achievable
+  inputs); work-order payout arithmetic green; every new material has a consumer (the
+  wolf_fang rule); EVERY stocked farming vendor row (seeds, compost, hoes, the
+  starter fee vegetable brook_carrot) carries positive buyValue (no dead rows);
+  crafted outputs carry none.
+- Crop produce is market-listable and browses under the material filter; tier 3/4
+  seeds reach the market via seed-back and rare events.
+
+## Server authority and safety
+
+- All plant/harvest/knob/feast outcomes resolve server-side; no client-supplied
+  instance payloads; no new unbounded server state without a retention story; dev
+  cheats stay behind ALLOW_DEV_COMMANDS.
+
+## Persistence
+
+- Pre-farming saves load cleanly (all new CharacterState fields optional with
+  defaults); save-then-load round-trip pins green; load clamps and sanitizes
+  (deadlines, skill, plot ids); no DDL landed (or, if any did, additive and
+  idempotent with migration-safety dispatched).
+
+## Performance and budgets
+
+- updateFarming does no per-tick allocation and no rng; snapshot deltas for fplot
+  fire only on real change; the Harvest Journal painter is write-elided or passes the
+  cold-window contracts per tests/hud_perf_budget.test.ts; npm run asset:budget green
+  after the props land; graphics tiers shed only cosmetics (timers and ready notices
+  are actionable and never shed).
+
+## Copy and content
+
+- No em dashes, en dashes, or emojis anywhere; IP-safe names throughout (D17);
+  deeds pins re-pinned deliberately; the wiki farming page regenerated and accurate;
+  guide freshness gate green.
+
+## Build gate and delivery
+
+- node scripts/gate_select.mjs green per phase; npm run gate green at packet close
+  (armory browser red is the standing environmental exception; PR CI is the arbiter);
+  screenshots committed under docs/screenshots and referenced from PR bodies for the
+  visual phases; the asset handoff manifest exists at
+  docs/design/farming-asset-manifest.json and lists every swap-ready prop with
+  footprint, pivot, and intent.

--- a/docs/farming/state.md
+++ b/docs/farming/state.md
@@ -1,0 +1,362 @@
+# Farming: cross-phase state (the cheat sheet)
+
+Read this file first in every phase session. It is the single authority for locked
+decisions. If a phase file contradicts this file, this file wins and the phase file
+gets swept in the same pass (amend the QA twin too, always).
+
+Current phase: none started. Packet authored 2026-08-07 off release/v0.36.0.
+Working tree: ALL farming work happens in the persistent worktree
+`~/Documents/woc-farming-plan`. Other sessions share the main checkout; never work there.
+
+## Locked design decisions
+
+The fun thesis, stated once: farming is the check-in skill. It converts logins into
+progress, holds the player's state in the world, and NEVER punishes absence. Anti-chore
+is load-bearing: no daily resets, no wither or decay, nothing rots, a late harvest costs
+only opportunity. Two visits per crop cycle, ever. Any phase that adds a third required
+visit or a punishment for lateness is violating the design, not tuning it.
+
+- D1: Farming is the FIFTH gathering profession. `'farming'` appends LAST to the
+  `GatheringProfessionId` union, `GATHERING_PROFESSIONS` (with `maxSkill: 100`), and
+  `GATHERING_PROFESSION_IDS` (append-last preserves iteration order for every consumer,
+  the fishing precedent). Skill tiers gate at 0/25/50/75 (the shared 25-point band math
+  in `src/sim/professions/proficiency_bands.ts`). It is NOT an eleventh craft: never
+  touch `CRAFT_RING`.
+- D2: Fishing-shaped integration, NOT node-shaped. There is NO new `GatherNodeType` and
+  nothing joins `GATHER_NODES`. Patches are their own content table `FARM_PATCHES`
+  (planned: `src/sim/content/farm_patches.ts`) with their own pure-leaf zone side table
+  (planned: `src/sim/professions/farming_zones.ts`, the `fishing_zones.ts` template:
+  `Object.hasOwn` reader, explicit row per zone, derived not independent knobs).
+  Rationale, verified: a new `GatherNodeType` is conscripted by
+  `tests/professions_zone_rollout.test.ts` (R37) and `tests/gather_node_placement.test.ts`
+  into every zone at exact pinned counts. Farming instead adds its OWN rollout arms
+  keyed to an explicit set: `FARMING_ZONES = eastbrook_vale (tier 1), mirefen_marsh
+  (tier 2), thornpeak_heights (tier 3), evergarden (tier 4)`, plus its OWN placement
+  guard suite cloning the physical-safety arms (dry land, no collider overlap, reachable
+  stand spot, zone containment, spacing) for `FARM_PATCHES`. Hub anchors for patch
+  sites and farmer NPCs: eastbrook_vale at Eastbrook, mirefen_marsh at Fenbridge,
+  thornpeak_heights at Highwatch, and evergarden at the formal parterre grounds (the
+  Evergarden has no named hub; the parterre is the anchor). Phase files may use these
+  hub names; this mapping is the anchor.
+- D3: Growth is wall-clock and offline-friendly. Stage deadlines are epoch-ms values
+  evaluated against `ctx.lockoutNowMs()` (the `raidLockouts` idiom, the ONE sanctioned
+  wall-clock seam; server injects the realm clock, the offline browser host degrades to
+  session-local growth, consistent with the documented offline-taster ruling). Plot
+  state is per player: `PlayerMeta.farmPlots` (a `Map`, so an empty one canonicalizes
+  cleanly in the parity sampler) persisted as an OPTIONAL `CharacterState` field with
+  defaults, normalized on load. Patches are shared world fixtures; each player grows
+  their own crops in them (the per-viewer node-readiness precedent). No world
+  persistence, no housing, no land scarcity. The public plot projection (the facet
+  read and the fplot wire key) exposes ONLY: bed id, crop id, planted-at, ready-at,
+  the applied knob flags, the Phase 8 notified flag, and a server-derived status
+  (growing, ready, withered; withered surfaces only at or after ready time). The
+  pre-rolled outcomes and the yield seed never leave the server.
+- D4: Determinism contract. ALL randomness draws at player-action moments through
+  `ctx.rng`. At plant time the full growth script is pre-rolled (per-stage survival
+  outcomes and the yield seed), the fishing hidden-bite-delay template scaled up. ZERO
+  draws at timer expiry, in the tick sweep, or at login. Farming states its draw-count
+  contract (N draws per plant, M per harvest, 0 on denial) and pins it, and ships a
+  parity scenario that drives a real plant-grow-harvest session in the same phase as the
+  growth engine (fishing's documented scenario gap is not inherited).
+- D5: Pacing (tuning constants live in content, maintainer-adjustable): tier 1 crops
+  30 to 60 min, tier 2 about 2 h, tier 3 about 4 h, tier 4 overnight. Growth continues
+  while logged out.
+- D6: Survival. Planting requires farming skill at or above the crop tier threshold.
+  One full band above the threshold survival is 100 percent, always (out-leveling a crop
+  permanently retires its risk). Inside the band, base survival ramps from roughly 85
+  percent at the gate to 100 percent at the band top, scaling with skill. Compost adds
+  10 points, farmer's watch adds 10 points, capped at 100. A failed crop yields withered
+  husks (a real item with a real consumer, the wolf_fang rule): failure composts into
+  the next attempt's insurance.
+- D7: Yield, the harvest-lives model (OSRS reference, our own constants): a plot starts
+  with a guaranteed floor of picks (base 3); each pick rolls a skill-scaled chance to
+  not consume a life. Growth tonic (crafted by alchemy FROM HERBS, the cross-profession
+  trade) adds a chance of bonus picks at harvest. One knob one job: compost is survival,
+  farmer's watch is survival, tonic is yield, skill improves both.
+- D8: Front-loaded only. Every choice (seed, compost, watch, tonic) happens at plant
+  time. There is no mid-growth interaction of any kind, required or optional.
+- D9: Farmer's watch is paid in kind: any farming produce of the patch's tier or
+  below, consumed from bags as a plant-time knob (no NPC range gate: paying is
+  front-loaded at the bed per D8; the farmer NPCs are the FLAVOR of the service and
+  the vendors of its supplies). Bootstrap: brook_carrot doubles as the starter fee
+  vegetable, vendor-stocked by farmer_jessica at Eastbrook with a buyValue at the
+  four-times-sell convention (priced in Phase 5, stocked in Phase 9), so a day-one
+  player can pay their first fee. Compost is likewise vendor-stocked (its buyValue is
+  assigned when the item lands in Phase 4, stocked in Phase 9). The growth tonic is
+  never vendor-stocked (alchemy-crafted, sellValue only). Watch fees are a produce
+  sink supporting crop prices.
+- D10: One tool, the hoe: a four-rung ladder of ordinary items with
+  `use: { type: 'gatherTool', professionId: 'farming', tier }` riding
+  `canGatherTier` and the frozen wield-gate thresholds for free. Recipes follow the
+  `TOOL_RECIPES` pattern; the top rung is unpriced and craftable (the R23 arm). Hoes
+  accept the three existing tool effects (unlike fishing rods; the policy gate in
+  `slotToolEffectRefused` admits farming).
+- D11: Crops, two per tier, eight total (ids locked, display names get a maintainer
+  lore pass): tier 1 `vale_wheat`, `brook_carrot`; tier 2 `marsh_rice`, `bog_beet`;
+  tier 3 `highland_barley`, `frost_gourd`; tier 4 `gilded_sunmelon`,
+  `evergarden_greens`. Every crop ships seed + produce + `fine_` twin (the
+  `MATERIAL_GRADES` requirement) + at least one consumer recipe in the same phase.
+  Produce is `kind: 'junk'` (browses under the market's material filter), sellValue per
+  the materials convention, market-listable by default. Seeds: tiers 1 and 2 are
+  vendor-stocked WITH a positive `buyValue` (the dead-row trap: a vendor row without
+  one renders then refuses); tiers 3 and 4 come from harvest seed-back rolls and the
+  rare event, so high-tier seeds are market goods. Planting consumes the seed.
+  Sanctioned same-phase-consumer exception: Phase 3 lands a minimal testable slice
+  (vale_wheat seed and produce plus the fine_vale_wheat twin and its grades row, and
+  withered_husks) with consumers explicitly deferred (husks to the Phase 4
+  convertHusks command, produce to the Phase 6 dishes); the rule is then enforced for
+  the full crop set by the Phase 5 rollout arms and closed by Phase 6.
+- D12: The rare event is `golden_harvest`: a fourth flavor on the existing
+  `gatherRareEvent` SimEvent shape, rolled at harvest (1/90, the shared constant),
+  five-fold yield, always signed, zone-announced through `announceGatherRareEvent`'s
+  path so the HUD case stays single.
+- D13: Deeds (append-only, cosmetic, zero rng): first planting, a first-harvest
+  chronicle per farming zone (`farm:<zone>` visit marks with an earnability table, the
+  `ZONE_FISH` template), a golden-harvest deed, and a farming-100 title. The
+  `tests/deeds_content.test.ts` totals (deed order length, total renown, title count)
+  re-pin deliberately in the same change.
+- D14: Ready notices. On login: a check inside `Sim.addPlayer` immediately after saved
+  state restore (beside the `mailWelcomed` one-shot and the deeds retro block), obeying
+  the same three rules: no rng, flag-or-state-derived only, personal-only text-free
+  SimEvent. While online: a 1 Hz sweep (`ctx.tickCount % 20`, the guild_letter idiom).
+  Both surface as an ambient-class banner via the banner queue plus a chat line. Never
+  mail (an inbox is an obligation surface).
+- D15: Well-fed buff food follows the elixir arm precedent exactly: minted inline from
+  a new `ItemDef.wellfed` field, applied via `ctx.applyAura` from the food path in
+  `src/sim/items.ts` (never through `effect_dispatch`), with aura ids in a DISTINCT
+  namespace `wellfed_<kind>` so food never clobbers `elixir_<kind>` (the documented
+  exclusivity-slot trap). Every new aura name gets an `AURA_NAME_KEY` row. Magnitudes
+  are modest, classic-era, at or below the existing elixir budget ceilings; crafted
+  power stays below the raid floor.
+- D16: The shared feast (the tier-4 showcase): placed by a player, spawns a REAL entity
+  so the normal entity snapshot carries it to everyone (the battleground flag precedent;
+  the mobile-station `mst` scalar cannot carry a shared world object and has no render
+  seam). Server-side state: charges remaining, a per-player consumed ledger (the
+  `creditedObjects` stable-key idiom), tick-domain expiry. Transient, never serialized
+  (the mobile-station rationale: tick-domain expiry is not restart-safe).
+- D17: IP-safe naming is a standing rule: no coined terms from other games (no
+  supercompost, no borrowed plant names), real plant words and original zone-flavored
+  coinages only. The window is the Harvest Journal (Farmer's Almanac collides with real
+  trademarked publications). Audit every new name at authoring time.
+- D18: UI. The Harvest Journal is a proper HUD window: DOM-free pure view core in
+  `UI_PURE_CORES` plus a thin painter on the `PainterHost` seam, composed by the HUD.
+  It lists every plot, contents, growth stage, time remaining, and applied knobs; map
+  and minimap pins mark the four patch sites. Countdown rendering copies the
+  daily-rewards pattern (dedicated interval, data-attribute rebind, absolute times via
+  `formatDateTime`, mm:ss via a t() token template, buff durations via
+  `compactAuraDuration`). Ship the timer UI in-game: the OSRS lesson, non-negotiable.
+- D19: Art. Wave 1 is procedural, swap-ready GLBs through the image-to-glb pipeline
+  (fixed footprints and pivots so sourced models drop in later without code changes).
+  The replacement handoff manifest lives at `docs/design/farming-asset-manifest.json`
+  (in docs/design so it SURVIVES packet teardown). Growth stages render per crop
+  family (grain, root/leaf, gourd) with shared early stages; the field is the progress
+  UI (visible stage changes, wet-soil plant state, withered silhouettes).
+- D20: The intro quest: farmer_jessica at Eastbrook (the user-required name) gives a
+  two-step quest on the `q_prof_intro` template (accept, plant one vale wheat, return
+  whenever to harvest), with a farming objective arm crediting the ACTION (the gather
+  objective precedent: inventory cannot prove the deed). Her dialog states the magic
+  sentence: it keeps growing while you are away, and it never spoils. No tutorial
+  system beyond this.
+- D21: Work orders: farming produce rows join the repeatable work-order rotation with
+  the machine-enforced payout arithmetic (`copperReward` equals
+  `floor(WORK_ORDER_PAYOUT_FRACTION * summed vendor sellValue)`, guarded by
+  `tests/professions_work_orders.test.ts`; leave the arithmetic comment on every row).
+- D22: Delivery model: the packet docs merge first as their own PR into the newest
+  `release/**` branch; every phase then starts by re-resolving the NEWEST release
+  branch (version sort), branches off it in THIS worktree, and merges release movement
+  in with the release-merge-audit skill when long-lived. Each phase is its own PR.
+  Every phase file carries a Live-surface note stating exactly what players can reach
+  after that phase merges (early sim phases stay dormant: no vendor seeds, no render,
+  no UI entry until their enabling phases land).
+- D23: Parity goldens. Professions fields are sampled into every golden digest, so
+  adding `farming: 0` to the default proficiency map regenerates ALL goldens in Phase 1
+  (deliberate, `UPDATE_PARITY=1`, its own reviewed commit, the Phase 8 professions
+  precedent). `PlayerMeta.farmPlots` is gameplay state: sampled, not excluded. Static
+  farmer NPCs shift the world-ctor entity-id counter: same deliberate-regen recipe in
+  the NPC phase. Never hand-edit a golden; a red trace means behavior changed.
+- D24: Wave 2 parking lot (explicitly OUT of this packet): crop-adjacency buffs
+  (approved, held), cultivated herbs for alchemy (approved WITH the displacement
+  guardrail: complement wild herbalism, never a second faucet of the identical item),
+  premium compost tiers.
+
+## Non-negotiable constraints
+
+- Determinism: all randomness via `ctx.rng`; no `Math.random`, `Date.now`, or
+  `performance.now` in `src/sim/` (guarded by `tests/architecture.test.ts`). Wall clock
+  only through `ctx.lockoutNowMs` / `ctx.raidResetMs`.
+- The seam: extend the `IWorld` facet first (`src/world_api/professions.ts` or a new
+  `src/world_api/farming.ts` facet file, never the barrel), implement in BOTH `Sim` and
+  `ClientWorld` in the same change, update the pinned member lists in
+  `tests/world_api_parity.test.ts`.
+- Server authority: clients never decide outcomes; no wire command ever ingests a
+  client-supplied `ItemInstancePayload`.
+- i18n: every player-visible string is a `t()` key added in ENGLISH ONLY to the matching
+  `src/ui/i18n.catalog/` module (never edit locale overlays; M16 wordy strings also need
+  their five non-Latin fills in the same change). Sim/server player text is id-carrying
+  SimEvents or matcher rules in the SAME change; the S3 guard
+  (`tests/localization_fixes.test.ts`) enforces it. New aura names need `AURA_NAME_KEY`
+  rows in `src/ui/sim_i18n.ts`.
+- Module-first: every new behavior is its own module behind an existing seam
+  (`SimContext` for sim systems, view core + painter for HUD, `src/render/<thing>.ts`
+  for visuals). Never grow `sim.ts`, `hud.ts`, `renderer.ts`, or `main.ts`.
+- No em dashes, en dashes, or emojis anywhere. IP-safe names only (D17).
+- Shared-checkout care: commit with EXPLICIT paths, never `git add -A`. All farming
+  work in `~/Documents/woc-farming-plan`.
+- Never set `ALLOW_DEV_COMMANDS=1` outside dev. Never commit secrets.
+
+## Tick and hook points (verified against release/v0.36.0)
+
+- The per-tick driver `updateFarming(ctx)` APPENDS after `updateProfNudges(this.ctx)`
+  and before `deedsMod.updateDeeds(this.ctx)` in `Sim.tick` (append, never reorder: the
+  shared rng stream makes reordering fork every golden). It draws no rng (D4) and does
+  no per-tick allocation in the hot path.
+- Skill gains go through the shared `queueGatheringGrant` / `drainGatheringGrants`
+  queue with a farming-owned gain schedule (the fishing pattern). The drain runs earlier
+  in the tick than the profession block, so an end-of-tick grant lands next tick:
+  expected, documented.
+- The on-login check lives in `Sim.addPlayer` immediately after saved state restore,
+  beside the `mailWelcomed` one-shot and the deeds retro block. Flag or state derived,
+  no rng, personal events only.
+- SimContext extensions (if any callback is needed) touch exactly FIVE sites plus the
+  pinned `CALLBACK_KEYS` list in `tests/sim_context.test.ts` and every suite that
+  hand-builds a fake host (`tests/world_boss.test.ts`, `tests/dungeons.test.ts`,
+  `tests/entity_roster.test.ts`, `tests/heroic_vendor.test.ts`,
+  `tests/nythraxis_raid_unit.test.ts`). A pure per-tick driver needs NO new callback
+  (the `updateCommissionOrders` precedent).
+
+## Blast-radius reference (verified; phase files cite this, do not re-derive)
+
+Compile-forced by the fifth id: the `GATHERING_PROFESSIONS` record row; any object
+literal typed `GatheringProficiency` (mostly test fixtures).
+
+Silent-miss sites that MUST be swept by hand in Phase 1 (no compile error, wrong or
+missing copy at runtime): `src/ui/gathering_profession_name.ts`
+(`GATHERING_PROFESSION_NAME_KEYS`: an unlisted id renders NO row);
+`src/ui/gathering_view.ts` `gatherDeniedLineKey` (falls through to the corpse line) and
+`gatherToolNoNodeKey` (falls through to the mining line); the four per-profession key
+families in `src/ui/i18n.catalog/hud_chrome.ts` (`toolTierUnmet`, `toolRequired`,
+`wieldUnmet`, `noNodeNearby`) plus the profession display name.
+
+Data-driven sites that just work once the content row exists: `emptyGatheringProficiency`,
+`normalizeGatheringProficiency`, `gatheringSkillsView`, the tools and wield-gate
+walkers, `characterProfessionsSheet`, `buildGatheringProficiencyRows`, the professions
+window gathering section, the wiki generator (auto-adds the farming page; the summary
+line naming four gathering professions updates), and the deeds any-profession arm.
+CONSEQUENCE to flag, not fix: farming automatically becomes a way to satisfy existing
+any-profession-at-N deeds (accepted default).
+
+Wire: `gprof` carries the fifth key for free (wholesale-replace mirror). The
+`tests/snapshots.test.ts` round-trip literal gains `farming: 0`. No new per-entity key;
+plot state rides a NEW self delta key (working name `fplot`) registered in
+`ALL_DELTA_KEYS` + `TERSE_TO_IWORLD` with round-trip pins.
+
+Test pins that move (re-pin deliberately, never loosen):
+`tests/professions_contracts.test.ts` (the exact-order skills array gains a fifth row),
+`tests/profession_icons.test.ts` (demands a `gather_farming` procedural icon),
+`tests/snapshots.test.ts` (literal above), `tests/deeds_content.test.ts` (totals),
+`tests/professions_skill_caps.test.ts` and other suites with literal proficiency maps,
+`tests/professions_blob_growth.test.ts` (worst-case save blob grows), the wiki
+freshness gate (`tests/guide.test.ts`, regen via `npm run wiki:content`), and the full
+parity golden set (D23).
+
+R37 (`tests/professions_zone_rollout.test.ts`): farming adds its OWN arms against
+`FARMING_ZONES` (patch coverage per farming zone, seed/produce/fine-twin integrity,
+hoe rungs at each tier with the hub stocking rule, top rung unpriced and craftable,
+chronicle deeds earnable). The existing node arms are untouched. The farming station
+question does not arise (farming has no station).
+
+## Seam reference (verified; the pattern to copy for each surface)
+
+- Consumables: food/drink sit-restore is `p.eating` / `p.drinking` slots filled in the
+  `useItem` food arm; the ONLY timed-buff consumable is the elixir arm (inline aura from
+  `ItemDef.elixir`, `ctx.applyAura`, id `elixir_<kind>`). Well-fed copies that arm with
+  the `wellfed_` namespace (D15). Buff display: `src/ui/auras_view.ts` +
+  `auras_painter.ts`; tooltips beside `elixir_tooltip_view.ts`.
+- Placeable feast: real entity + entity snapshot (D16); interaction arm in
+  `src/sim/interaction.ts`; charge ledger via the stable-content-key idiom in
+  `src/sim/quests/interact_object_credit.ts`.
+- Quest: `q_prof_intro` in `src/sim/content/zone1.ts` is the intro template (including
+  `requiredItems` re-granting the starter tool). A farming action objective needs a new
+  objective arm crediting the action, not a `collect`. Bump `rev` if an existing
+  quest's objective indices ever change meaning.
+- Vendors: stock is `NpcDef.vendorItems` ids; a row without positive `buyValue` (or
+  `priceHonor`) renders then refuses (the dead-row trap). Crafted outputs never get
+  `buyValue`. Changing a `sellValue` after a work order references it breaks the
+  payout guard: edit both together.
+- Notifications: `Hud.showBanner(text, ..., bannerClass)` on the banner queue
+  (celebrations FIFO, ambient replaces); the `gatherRareEvent` HUD case is the
+  canonical text-free-event-to-localized-line-plus-personal-cue shape; one-shot flags
+  flip BEFORE the emit (`mailWelcomed` idiom).
+- SFX: new cue = `UI_CUES` key + facade method in `src/game/audio.ts` (widen the
+  `UiCue` union for nested families) + the `hud.ts` case + a prompt row in
+  `scripts/sfx/sfx_prompts.mjs` + `npm run sfx:ui` (deterministic placeholder) +
+  `sfx:manifest` + `sfx:check`; the completeness guard in `tests/game_audio.test.ts`
+  fails a key with no file. Placeholder rows are marked for the sound engineer.
+- Countdowns: the daily-rewards window owns the live-countdown pattern (dedicated
+  interval, `[data-...]` rebind, `formatDateTime` absolutes, t() token mm:ss). Copy it;
+  never hand-build a clock string with a literal colon.
+
+## Validation matrix (run what the change type demands)
+
+- Any code change: `npx tsc --noEmit` (fast native TS7) and
+  `npm run ci:changed` (biome on changed files only; fix with a SCOPED
+  `npx @biomejs/biome check --write <file>`, never whole-tree).
+- sim change: the affected `npx vitest run tests/professions_farming*.test.ts` plus
+  `tests/architecture.test.ts` (purity) and `tests/sim_context.test.ts` (if the seam
+  moved); same-seed determinism pins.
+- Player text or emit changed: `npx vitest run tests/localization_fixes.test.ts` (S3).
+- Wire/snapshot change: `npx vitest run tests/snapshots.test.ts
+  tests/env_protocol.test.ts tests/bandwidth.test.ts`.
+- Parity-adjacent change: `npx vitest run tests/parity` BEFORE touching goldens; regen
+  only deliberately (`UPDATE_PARITY=1`) in an isolated commit.
+- Content change: `tests/professions_zone_rollout.test.ts`,
+  `tests/recipe_economy.test.ts`, `tests/professions_work_orders.test.ts`,
+  `tests/deeds_content.test.ts`, `npm run wiki:content` freshness.
+- UI change: the window's own suite + `tests/hud_perf_budget.test.ts` bucket +
+  a mobile screenshot script against a phone viewport.
+- Phase end: `node scripts/gate_select.mjs` (the fast pre-merge gate);
+  `npm run gate` for the deep check. Known environmental red: the armory browser
+  pixel test; grep the log for "[gate] FAIL", never trust a piped exit code, and PR CI
+  is the arbiter.
+
+## Key planned files (working names; a phase may refine with a note here)
+
+- `src/sim/content/farm_patches.ts` (FARM_PATCHES, FarmPatchDef)
+- `src/sim/content/farming_items.ts` or rows in existing item/content modules (seeds,
+  produce, fine twins, compost, husks, tonic, hoes, dishes, feast)
+- `src/sim/professions/farming.ts` (the driver: plant, harvest, growth script,
+  survival/yield resolution, updateFarming, ready-check helpers)
+- `src/sim/professions/farming_zones.ts` (FARMING_ZONES, the zone tier side table:
+  the one home of the zone set; farm_patches.ts never redefines it)
+- `src/world_api/farming.ts` (IWorldFarming facet: patch defs, my plots, commands)
+- `src/ui/harvest_journal_view.ts` + `src/ui/harvest_journal_window.ts` (or the
+  hud-domain directory form per `src/ui/hud/CLAUDE.md`)
+- `src/render/farm_patches.ts` (beds + crop stage props adapter)
+- `scripts/assets/build_farm_props.mjs` (procedural swap-ready GLBs)
+- `docs/design/farming-asset-manifest.json` (the handoff list; survives teardown)
+- `tests/professions_farming*.test.ts`, `tests/farm_patch_placement.test.ts`, a
+  `farming_session` parity scenario
+
+## Per-phase ledgers (append as phases complete)
+
+- New IWorld members: (none yet)
+- New SimEvents: (none yet)
+- New wire keys: (none yet)
+- New i18n keys and matcher rows: (none yet)
+- New items/recipes/deeds: (none yet)
+- Locked deviations from phase files: (none yet)
+- Dev command surface: (Phase 3 records the exact /dev farm cheat names here at
+  completion; Phases 7 and 8 depend on them for dev-created crops)
+
+## OPEN items (maintainer decisions or later-phase calls, never guess)
+
+- Crop display names: ids are locked (D11), English display names get a maintainer
+  lore pass in the content phase PR.
+- Exact tuning constants: growth durations per tier inside the D5 bands, the gain
+  schedule, harvest-lives save-chance endpoints, well-fed magnitudes and durations,
+  feast charge count and expiry. Phases propose concrete values in the PR body and
+  flag them for the maintainer; the packet deliberately does not freeze them.
+- Whether farming counting toward existing any-profession deeds is accepted (default
+  yes; it is automatic via the data-driven arm; flag in the Phase 1 PR body).
+- Seed-back roll rates for tier 3/4 seeds (economy-sensitive; propose in the content
+  phase with the market in mind).


### PR DESCRIPTION
## Summary

Planning packet for Farming, the fifth gathering profession: OSRS-style shared garden patches with per-player crops, offline wall-clock growth (nothing ever rots, no daily resets), front-loaded tending (two visits per cycle), skill-scaled survival and yield with an insurance economy (compost, farmer's watch paid in produce, growth tonic, withered husks), cooking and alchemy integration up to well-fed buff dishes and a placeable shared feast, the Harvest Journal timer window, and a procedural-first art pass with a swap-ready model handoff manifest.

Contents: six core docs (README, state.md with locked decisions D1 to D24, implementation plan with the review dispatch matrix, brainstorm and research digest, progress, whole-feature QA matrix) plus thirteen implementation phases, each with a QA twin. Phases 1 to 6 land dormant sim and content, 7 and 8 land visuals and the timer surface, 9 is the atomic go-live (Farmer Jessica, the intro quest, vendor stock, work orders), 10 to 13 add celebrations, buff food, the feast, and the integration polish plus handoff. The design was grounded in seam and blast-radius recon verified against release/v0.36.0 (fishing-shaped integration, no new GatherNodeType, the lockoutNowMs wall-clock seam, pre-rolled growth scripts for determinism).

The packet docs are cross-session scaffolding: the final QA phase offers teardown before the feature ships, and the asset handoff manifest deliberately lands in docs/design/ so it survives.

## Type of change

- [x] Documentation

## How was this tested?

- Commands: node scripts/gate_select.mjs (PASS, all 11 steps green on this branch)
- Manual steps: a structural scan (file index, one starter prompt per phase file, fence integrity, forbidden-character sweep) and an independent coverage review over the whole packet; all 5 blocking and 12 should-fix findings it raised were resolved before commit (cross-phase handoffs, vendor pricing sources, persistence plumbing, dispatch coverage).

---

## Checklist

### Quality

- [x] **The gate passes.** node scripts/gate_select.mjs is green. Docs-only change; no behavior or tests changed.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or .env committed, and ALLOW_DEV_COMMANDS is not enabled in any production path.
- [x] I didn't hand-edit generated files.