### PR TITLE
fix(tests): correct manifest anchors in hunter/ghost anim pipeline test

### DIFF
--- a/tests/anim_pipeline_hunter_ghost.test.ts
+++ b/tests/anim_pipeline_hunter_ghost.test.ts
@@ -57,7 +57,7 @@ describe('hunter ability-specific attacks (issue #2889 follow-up batch)', () => 
   });
 
   it('wires both donor GLBs (the pre-existing bow_anims.glb and the new one) and an attackByAbility override for every mapped ability', () => {
-    const block = manifestBlock('player_hunter: {', 'player_rogue: {');
+    const block = manifestBlock('player_hunter: swims({', 'player_rogue: swims({');
     expect(block).toContain('bow_anims.glb');
     expect(block).toContain('hunter_ability_anims.glb');
     expect(block).toContain('attackByAbility');
@@ -65,7 +65,7 @@ describe('hunter ability-specific attacks (issue #2889 follow-up batch)', () => 
   });
 
   it('every mapped ability id is a real hunter ability, and every referenced clip is shipped or an existing rig clip', () => {
-    const hunterBlock = manifestBlock('player_hunter: {', 'player_rogue: {');
+    const hunterBlock = manifestBlock('player_hunter: swims({', 'player_rogue: swims({');
     const abilityStart = hunterBlock.indexOf('attackByAbility: {');
     expect(abilityStart).toBeGreaterThanOrEqual(0);
     const abilityEnd = hunterBlock.indexOf('\n      },', abilityStart);


### PR DESCRIPTION
## Summary
- `tests/anim_pipeline_hunter_ghost.test.ts` looked for `player_hunter: {` / `player_rogue: {` anchors in `src/render/characters/manifest.ts`, but both entries are wrapped in the `swims()` helper (`player_hunter: swims({`), so `manifestBlock()` threw on every run.
- This has been failing consistently on `release/v0.36.0` and blocking CI on every unrelated PR based off that branch.
- Fixed the two anchors to match the actual manifest source.

## Test plan
- [x] `npx vitest run tests/anim_pipeline_hunter_ghost.test.ts` passes (5/5)
- [x] guard tests (architecture, i18n) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)