### PR TITLE
fix(render): merge mob_yeti's duplicate animUrls key

### DIFF
--- a/src/render/characters/manifest.ts
+++ b/src/render/characters/manifest.ts
@@ -1631,12 +1631,12 @@ export const VISUALS: Record<string, VisualDef> = {
   // the same rig worn honestly: an ice-white yeti for the Frostveil
   mob_yeti: {
     url: `${CREATURES}/yetialt.glb`,
-    animUrls: [`${CREATURES}/yetialt_hit_variety_anims.glb`],
     height: 2.5,
     clips: YETI_BIPED14,
     // Yeti_Attack clip donor (scripts/build_yeti_anims.mjs): mesh-free,
-    // baked off this same rig's own poses.
-    animUrls: [`${CREATURES}/yeti_ability_anims.glb`],
+    // baked off this same rig's own poses. Loads alongside the hit-variety
+    // donor GLB below; both are mesh-free so their clips just merge in.
+    animUrls: [`${CREATURES}/yetialt_hit_variety_anims.glb`, `${CREATURES}/yeti_ability_anims.glb`],
     tint: 'entity',
     tintStrength: 0.55,
   },

--- a/tests/anim_pipeline_biped14_hit_variety.test.ts
+++ b/tests/anim_pipeline_biped14_hit_variety.test.ts
@@ -70,13 +70,16 @@ describe('BIPED14 hit-reaction stagger (issue #2889 round 2)', () => {
       expect(idx, key).toBeGreaterThanOrEqual(0);
       const end = MANIFEST_SRC.indexOf('\n  },', idx);
       const block = MANIFEST_SRC.slice(idx, end);
-      // mob_troll wires TROLL_BIPED14 (`{ ...BIPED14, attack: ['Troll_Smash'] }`,
-      // issue #2889): it inherits BIPED14's hit array unchanged, so it still
-      // qualifies as a BIPED14 consumer for HitReact_Heavy.
+      // mob_troll wires TROLL_BIPED14 and mob_yeti wires YETI_BIPED14 (both
+      // `{ ...BIPED14, attack: [...] }`, issue #2889): each inherits BIPED14's
+      // hit array unchanged, so they still qualify as BIPED14 consumers for
+      // HitReact_Heavy.
       const clipsOk =
         key === 'mob_troll'
           ? block.includes('clips: TROLL_BIPED14')
-          : block.includes('clips: BIPED14');
+          : key === 'mob_yeti'
+            ? block.includes('clips: YETI_BIPED14')
+            : block.includes('clips: BIPED14');
       expect(clipsOk, key).toBe(true);
       expect(block, `${key} animUrls`).toContain(file);
     }


### PR DESCRIPTION
## Summary
- `mob_yeti` in `src/render/characters/manifest.ts` had two `animUrls` properties in the same object literal (a real `tsc` TS1117 error: object literal cannot have multiple properties with the same name). The second silently wins at runtime, so `yetialt_hit_variety_anims.glb` was never actually loaded.
- Merged both GLB URLs into one `animUrls` array.
- `tests/anim_pipeline_biped14_hit_variety.test.ts` also failed to account for `mob_yeti` wiring `YETI_BIPED14` (BIPED14 plus its own attack override) instead of plain `BIPED14`, the same pattern already carved out for `mob_troll`/`TROLL_BIPED14`. Added the same carve-out for `mob_yeti`.
- This was blocking `tsc --noEmit` (and therefore the release-tier typecheck gate) repo-wide on `release/v0.36.0`.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run tests/anim_pipeline_biped14_hit_variety.test.ts tests/anim_pipeline_yeti.test.ts tests/anim_pipeline_rogue_troll.test.ts` passes (14/14)
- [x] guard tests (architecture, i18n) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)