### PR TITLE
fix(sim): let item commands name WHICH copy they act on

### DIFF
--- a/server/game.ts
+++ b/server/game.ts
@@ -6584,7 +6584,13 @@ export class GameServer {
         }
         break;
       case 'salvage_item':
-        if (typeof msg.item === 'string') sim.salvageItem(msg.item, pid);
+        if (typeof msg.item === 'string') {
+          // Same bag-index parsing as disenchant_item: an unrecognized slot reads
+          // as undefined (the legacy id-only path), never as index 0, and the sim
+          // re-validates it against ITS inventory.
+          const slot = Number.isInteger(msg.slot) ? Number(msg.slot) : undefined;
+          sim.salvageItem(msg.item, pid, slot);
+        }
         break;
       case 'unbind_item':
         // Maker's Bond unbind service (Professions 2.0): the sim

--- a/server/game.ts
+++ b/server/game.ts
@@ -6457,8 +6457,13 @@ export class GameServer {
           // re-validates the slot against the item itself.
           const aimed =
             typeof msg.slot === 'string' && isEquipSlot(msg.slot) ? msg.slot : undefined;
-          if (aimed) sim.equipItemToSlot(msg.item, aimed, pid);
-          else sim.equipItem(msg.item, pid);
+          // The bag index the client named, re-validated in the sim against ITS
+          // OWN inventory: an unrecognized value reads as undefined (the legacy
+          // id-only path), never as index 0.
+          // `bagSlot`, not `slot`: on this token `slot` is already the equip slot.
+          const bag = Number.isInteger(msg.bagSlot) ? Number(msg.bagSlot) : undefined;
+          if (aimed) sim.equipItemToSlot(msg.item, aimed, pid, bag);
+          else sim.equipItem(msg.item, pid, undefined, bag);
         }
         break;
       case 'inv_move':
@@ -6480,13 +6485,26 @@ export class GameServer {
         break;
       case 'use':
         if (typeof msg.item === 'string') {
-          const result = sim.useItem(msg.item, pid);
+          // The bag index the client named, re-validated in the sim against ITS
+          // OWN inventory: an unrecognized value reads as undefined (the legacy
+          // id-only path), never as index 0.
+          const slot = Number.isInteger(msg.slot) ? Number(msg.slot) : undefined;
+          const result = sim.useItem(msg.item, pid, slot);
           if (result?.type === 'mechChroma') this.noteAccountMechChroma(session, result.chromaId);
         }
         break;
       case 'discard':
         if (typeof msg.item === 'string') {
-          sim.discardItem(msg.item, typeof msg.count === 'number' ? msg.count : undefined, pid);
+          // The bag index the client named, re-validated in the sim against ITS
+          // OWN inventory: an unrecognized value reads as undefined (the legacy
+          // id-only path), never as index 0.
+          const slot = Number.isInteger(msg.slot) ? Number(msg.slot) : undefined;
+          sim.discardItem(
+            msg.item,
+            typeof msg.count === 'number' ? msg.count : undefined,
+            pid,
+            slot,
+          );
         }
         break;
       case 'buy':
@@ -6506,7 +6524,11 @@ export class GameServer {
         break;
       case 'sell':
         if (typeof msg.item === 'string') {
-          sim.sellItem(msg.item, typeof msg.count === 'number' ? msg.count : undefined, pid);
+          // The bag index the client named, re-validated in the sim against ITS
+          // OWN inventory: an unrecognized value reads as undefined (the legacy
+          // id-only path), never as index 0.
+          const slot = Number.isInteger(msg.slot) ? Number(msg.slot) : undefined;
+          sim.sellItem(msg.item, typeof msg.count === 'number' ? msg.count : undefined, pid, slot);
         }
         break;
       case 'buyback':
@@ -6632,16 +6654,29 @@ export class GameServer {
         if (typeof msg.order === 'number') sim.deliverCommissionOrder(msg.order, pid);
         break;
       case 'rift_upgrade_item':
-        if (typeof msg.item === 'string') sim.upgradeRiftItem(msg.item, pid);
+        if (typeof msg.item === 'string') {
+          const slot = Number.isInteger(msg.slot) ? Number(msg.slot) : undefined;
+          sim.upgradeRiftItem(msg.item, pid, slot);
+        }
         break;
       case 'rift_enchant_item':
         if (typeof msg.item === 'string' && typeof msg.stat === 'string') {
-          sim.enchantRiftItem(msg.item, msg.stat, pid);
+          sim.enchantRiftItem(
+            msg.item,
+            msg.stat,
+            pid,
+            Number.isInteger(msg.slot) ? Number(msg.slot) : undefined,
+          );
         }
         break;
       case 'rift_socket_gem':
         if (typeof msg.item === 'string' && typeof msg.gem === 'string') {
-          sim.socketRiftGem(msg.item, msg.gem, pid);
+          sim.socketRiftGem(
+            msg.item,
+            msg.gem,
+            pid,
+            Number.isInteger(msg.slot) ? Number(msg.slot) : undefined,
+          );
         }
         break;
       case 'place_mobile_station':
@@ -6691,7 +6726,11 @@ export class GameServer {
         if (typeof msg.item === 'string') {
           const socket =
             typeof msg.socket === 'number' && Number.isInteger(msg.socket) ? msg.socket : undefined;
-          sim.equipBag(msg.item, socket, pid);
+          // The bag index the client named, re-validated in the sim against ITS
+          // OWN inventory: an unrecognized value reads as undefined (the legacy
+          // id-only path), never as index 0.
+          const slot = Number.isInteger(msg.slot) ? Number(msg.slot) : undefined;
+          sim.equipBag(msg.item, socket, pid, slot);
         }
         break;
       case 'unequip_bag':
@@ -7026,7 +7065,10 @@ export class GameServer {
         if (typeof msg.enabled === 'boolean') sim.setPetAutoWaterJet(msg.enabled, pid);
         break;
       case 'pet_feed':
-        if (typeof msg.item === 'string') sim.feedPet(msg.item, pid);
+        if (typeof msg.item === 'string') {
+          const slot = Number.isInteger(msg.slot) ? Number(msg.slot) : undefined;
+          sim.feedPet(msg.item, pid, slot);
+        }
         break;
       case 'pet_heal':
         sim.healPet(pid);

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -4051,8 +4051,15 @@ export class ClientWorld implements IWorld {
       this.cmd({ cmd: 'apply_enchant', item: itemId, enchant: enchantId, slot });
     }
   }
-  salvageItem(itemId: string): void {
-    this.cmd({ cmd: 'salvage_item', item: itemId });
+  salvageItem(itemId: string, target?: { slotIndex: number }): void {
+    // `slot` is a BAG INDEX here, matching disenchantItem (and NOT apply_enchant,
+    // whose `slot` names an equip slot). Omitted with no selection, so the
+    // message stays byte-identical to the pre-feature form.
+    if (target === undefined) {
+      this.cmd({ cmd: 'salvage_item', item: itemId });
+    } else {
+      this.cmd({ cmd: 'salvage_item', item: itemId, slot: target.slotIndex });
+    }
   }
   // Maker's Bond unbind service (Professions 2.0): command only,
   // never predicted. The server re-validates eligibility/bound-ness/station

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -3880,8 +3880,12 @@ export class ClientWorld implements IWorld {
   // IWorldInventory facet (W2): the eight item/vendor command senders. Each is a thin
   // cmd() emit whose offline counterpart is the moved src/sim/items.ts body resolved on
   // the server. The move changes no wire field or command string.
-  equipItem(itemId: string): void {
-    this.cmd({ cmd: 'equip', item: itemId });
+  equipItem(itemId: string, target?: { slotIndex: number }): void {
+    // NOTE the field name. On the `equip` token `slot` already means the EQUIP
+    // slot (see equipItemToSlot below), so the bag index rides as `bagSlot`.
+    // Everywhere else in this family `slot` is free and carries the bag index.
+    if (target === undefined) this.cmd({ cmd: 'equip', item: itemId });
+    else this.cmd({ cmd: 'equip', item: itemId, bagSlot: target.slotIndex });
   }
   moveInventoryItem(from: number, to: number): void {
     this.cmd({ cmd: 'inv_move', from, to });
@@ -3891,35 +3895,45 @@ export class ClientWorld implements IWorld {
   }
   // Same 'equip' wire token with the aimed slot attached: an older server that
   // ignores the field simply resolves the slot itself, so the field is additive.
-  equipItemToSlot(itemId: string, slot: EquipSlot): void {
-    this.cmd({ cmd: 'equip', item: itemId, slot });
+  equipItemToSlot(itemId: string, slot: EquipSlot, target?: { slotIndex: number }): void {
+    // `slot` is the equip slot on this token, so the bag index rides as `bagSlot`
+    // (see equipItem above).
+    if (target === undefined) this.cmd({ cmd: 'equip', item: itemId, slot });
+    else this.cmd({ cmd: 'equip', item: itemId, slot, bagSlot: target.slotIndex });
   }
   unequipItem(slot: EquipSlot): void {
     this.cmd({ cmd: 'unequip_item', slot });
   }
-  upgradeRiftItem(itemId: string): void {
-    this.cmd({ cmd: 'rift_upgrade_item', item: itemId });
+  upgradeRiftItem(itemId: string, target?: { slotIndex: number }): void {
+    if (target === undefined) this.cmd({ cmd: 'rift_upgrade_item', item: itemId });
+    else this.cmd({ cmd: 'rift_upgrade_item', item: itemId, slot: target.slotIndex });
   }
-  enchantRiftItem(itemId: string, stat: string): void {
-    this.cmd({ cmd: 'rift_enchant_item', item: itemId, stat });
+  enchantRiftItem(itemId: string, stat: string, target?: { slotIndex: number }): void {
+    if (target === undefined) this.cmd({ cmd: 'rift_enchant_item', item: itemId, stat });
+    else this.cmd({ cmd: 'rift_enchant_item', item: itemId, stat, slot: target.slotIndex });
   }
-  socketRiftGem(itemId: string, gemId: string): void {
-    this.cmd({ cmd: 'rift_socket_gem', item: itemId, gem: gemId });
+  socketRiftGem(itemId: string, gemId: string, target?: { slotIndex: number }): void {
+    if (target === undefined) this.cmd({ cmd: 'rift_socket_gem', item: itemId, gem: gemId });
+    else this.cmd({ cmd: 'rift_socket_gem', item: itemId, gem: gemId, slot: target.slotIndex });
   }
   get bagCapacity(): number {
     return bagCapacity(this.bags);
   }
-  equipBag(itemId: string, socket?: number): void {
-    this.cmd({ cmd: 'equip_bag', item: itemId, socket });
+  equipBag(itemId: string, socket?: number, target?: { slotIndex: number }): void {
+    // `socket` is the BAG BAR socket, so `slot` stays free for the bag index.
+    if (target === undefined) this.cmd({ cmd: 'equip_bag', item: itemId, socket });
+    else this.cmd({ cmd: 'equip_bag', item: itemId, socket, slot: target.slotIndex });
   }
   unequipBag(socket: number): void {
     this.cmd({ cmd: 'unequip_bag', socket });
   }
-  useItem(itemId: string): void {
-    this.cmd({ cmd: 'use', item: itemId });
+  useItem(itemId: string, target?: { slotIndex: number }): void {
+    if (target === undefined) this.cmd({ cmd: 'use', item: itemId });
+    else this.cmd({ cmd: 'use', item: itemId, slot: target.slotIndex });
   }
-  discardItem(itemId: string, count?: number): void {
-    this.cmd({ cmd: 'discard', item: itemId, count });
+  discardItem(itemId: string, count?: number, target?: { slotIndex: number }): void {
+    if (target === undefined) this.cmd({ cmd: 'discard', item: itemId, count });
+    else this.cmd({ cmd: 'discard', item: itemId, count, slot: target.slotIndex });
   }
   buyItem(npcId: number, itemId: string, opts?: VendorBuyOptions): void {
     // `bulk` and `count` each ride the wire only when non-default (the
@@ -4091,8 +4105,9 @@ export class ClientWorld implements IWorld {
   deliverCommissionOrder(orderId: number): void {
     this.cmd({ cmd: 'deliver_commission_order', order: orderId });
   }
-  sellItem(itemId: string, count?: number): void {
-    this.cmd({ cmd: 'sell', item: itemId, count });
+  sellItem(itemId: string, count?: number, target?: { slotIndex: number }): void {
+    if (target === undefined) this.cmd({ cmd: 'sell', item: itemId, count });
+    else this.cmd({ cmd: 'sell', item: itemId, count, slot: target.slotIndex });
   }
   sellAllJunk(): void {
     this.cmd({ cmd: 'sell_all_junk' });
@@ -4411,8 +4426,9 @@ export class ClientWorld implements IWorld {
     }
     this.cmd({ cmd: 'pet_auto_water_jet', enabled });
   }
-  feedPet(itemId: string): void {
-    this.cmd({ cmd: 'pet_feed', item: itemId });
+  feedPet(itemId: string, target?: { slotIndex: number }): void {
+    if (target === undefined) this.cmd({ cmd: 'pet_feed', item: itemId });
+    else this.cmd({ cmd: 'pet_feed', item: itemId, slot: target.slotIndex });
   }
   healPet(): void {
     this.cmd({ cmd: 'pet_heal' });

--- a/src/render/characters/manifest.ts
+++ b/src/render/characters/manifest.ts
@@ -2147,10 +2147,7 @@ export const VISUALS: Record<string, VisualDef> = {
     // Treant_Attack clip donor (scripts/build_treant_anims.mjs): mesh-free,
     // baked off this same rig's own poses. Loads alongside the yeti's
     // hit-variety donor GLB; both are mesh-free so their clips just merge in.
-    animUrls: [
-      `${CREATURES}/yeti_hit_variety_anims.glb`,
-      `${CREATURES}/treant_ability_anims.glb`,
-    ],
+    animUrls: [`${CREATURES}/yeti_hit_variety_anims.glb`, `${CREATURES}/treant_ability_anims.glb`],
     tint: 'entity',
     tintStrength: 0.72, // the white pelt needs a heavy wash to read as moss
   },

--- a/src/sim/bags.ts
+++ b/src/sim/bags.ts
@@ -400,7 +400,7 @@ export function equipBag(
   }
   let target = socket;
   if (target === undefined) {
-    const empty = meta.bags.findIndex((b) => b === null);
+    const empty = meta.bags.indexOf(null);
     target = empty >= 0 ? empty : -1;
   }
   if (target === -1) {

--- a/src/sim/bags.ts
+++ b/src/sim/bags.ts
@@ -26,6 +26,7 @@
 // Date.now (enforced by tests/architecture.test.ts). This module draws NO rng.
 
 import { ITEMS } from './data';
+import { consumeSelectedInventorySlot } from './item_copy_ref';
 import { canStackInstancePayloads, isMergeableInstancePayload } from './item_instance_merge';
 import type { PlayerMeta } from './sim';
 import type { SimContext } from './sim_context';
@@ -381,7 +382,13 @@ const inRange = (socket: number): boolean =>
  *  occupied socket swaps: the old bag returns to the slot the new one freed, so
  *  the swap itself never needs spare room; only a capacity SHRINK (smaller bag)
  *  is guarded so the pooled inventory never ends up above budget via a swap. */
-export function equipBag(ctx: SimContext, itemId: string, socket?: number, pid?: number): void {
+export function equipBag(
+  ctx: SimContext,
+  itemId: string,
+  socket?: number,
+  pid?: number,
+  slotIndex?: number,
+): void {
   const r = ctx.resolve(pid);
   if (!r) return;
   const { meta } = r;
@@ -411,7 +418,15 @@ export function equipBag(ctx: SimContext, itemId: string, socket?: number, pid?:
     ctx.error(meta.entityId, 'You have too many items to swap to that bag.');
     return;
   }
-  ctx.removeItem(itemId, 1, meta.entityId);
+  // A named slot consumes exactly that copy; an id-only call keeps the legacy
+  // newest-first walk (ctx.removeItem) untouched.
+  if (slotIndex !== undefined) {
+    if (consumeSelectedInventorySlot(meta.inventory, itemId, slotIndex) === null) return;
+    ctx.onInventoryChangedForQuests?.(meta);
+  } else {
+    ctx.removeItem(itemId, 1, meta.entityId);
+  }
+
   if (old) addStacked(meta.inventory, old, 1);
   meta.bags[target] = itemId;
   ctx.onInventoryChangedForQuests(meta);

--- a/src/sim/bags.ts
+++ b/src/sim/bags.ts
@@ -421,8 +421,12 @@ export function equipBag(
   // A named slot consumes exactly that copy; an id-only call keeps the legacy
   // newest-first walk (ctx.removeItem) untouched.
   if (slotIndex !== undefined) {
-    if (consumeSelectedInventorySlot(meta.inventory, itemId, slotIndex) === null) return;
-    ctx.onInventoryChangedForQuests?.(meta);
+    // No onInventoryChangedForQuests here: the shared call below already fires for
+    // both arms, and running it twice re-evaluated collect objectives on one equip.
+    if (consumeSelectedInventorySlot(meta.inventory, itemId, slotIndex) === null) {
+      ctx.error(meta.entityId, "You don't have that item.");
+      return;
+    }
   } else {
     ctx.removeItem(itemId, 1, meta.entityId);
   }

--- a/src/sim/item_copy_ref.ts
+++ b/src/sim/item_copy_ref.ts
@@ -147,8 +147,28 @@ export function consumeItemCopy(
   return { kind: 'fellBack', unit: consumeNewestInventoryUnit(inventory, itemId) };
 }
 
-// No pin RE-CHECK helper here yet, deliberately. Enchanting owns the only
-// mid-action re-check in the tree and does it inline against its own cast
-// session; none of the surfaces this PR converts has a cast time. Extracting a
-// second copy of that logic with no caller would be abstraction for a
-// hypothetical, so it lands with the first surface that needs it.
+/**
+ * Re-check a selection pinned at the START of a multi-tick action against the
+ * slot living at that index NOW. False means the bag shifted underneath (a move,
+ * a merge, a loot, a sort) and the action must refuse rather than hit whatever
+ * moved in.
+ *
+ * A bag index is stable only within one tick, so any action with a cast time
+ * needs this: without it, selecting a copy and then looting during the cast
+ * redirects the hit, which is strictly worse than the old guess because the
+ * player believes they aimed. Enchanting performs the same re-check inline
+ * against its own session; salvage is the second caller, which is what earns
+ * this its place here.
+ *
+ * `undefined` slotIndex passes: an id-only action pinned nothing, so there is
+ * nothing to invalidate and it keeps its legacy behavior.
+ */
+export function itemCopyStillPinned(
+  inventory: InvSlot[],
+  slotIndex: number | undefined,
+  pin: string,
+): boolean {
+  if (slotIndex === undefined) return true;
+  if (!Number.isInteger(slotIndex) || slotIndex < 0 || slotIndex >= inventory.length) return false;
+  return itemCopyPin(inventory[slotIndex]) === pin;
+}

--- a/src/sim/item_copy_ref.ts
+++ b/src/sim/item_copy_ref.ts
@@ -36,12 +36,16 @@ import { cloneItemInstancePayload, type InventoryUnit, type InvSlot } from './ty
  *  order. Moved verbatim from professions/enchanting.ts. */
 function sortedJson(value: unknown): string {
   if (Array.isArray(value)) return `[${value.map(sortedJson).join(',')}]`;
-  if (value && typeof value === 'object') {
+  if (value !== null && typeof value === 'object') {
     const record = value as Record<string, unknown>;
-    const keys = Object.keys(record).sort();
+    // An explicit undefined fingerprints like an ABSENT key (JSON.stringify
+    // drops both), so clearing a field by assignment can never flip the pin.
+    const keys = Object.keys(record)
+      .filter((k) => record[k] !== undefined)
+      .sort();
     return `{${keys.map((k) => `${JSON.stringify(k)}:${sortedJson(record[k])}`).join(',')}}`;
   }
-  return JSON.stringify(value ?? null);
+  return JSON.stringify(value) ?? 'null';
 }
 
 /** Identity of the COPY sitting in a bag slot, for re-checking a selection that

--- a/src/sim/item_copy_ref.ts
+++ b/src/sim/item_copy_ref.ts
@@ -120,6 +120,29 @@ export function consumeNewestInventoryUnit(inventory: InvSlot[], itemId: string)
   return { instance: undefined, craftedRecipeId: undefined };
 }
 
+/**
+ * Resolve the bag slot the caller NAMED without consuming anything, for actions
+ * that MUTATE a copy in place rather than destroying it (the rift forge upgrades,
+ * enchants and sockets the slot's own payload).
+ *
+ * Same tri-state as the consuming walk, and the same reason for it: `null` is an
+ * invalid selection the caller must refuse, `undefined` means none was given.
+ * Kept separate from the consuming version rather than folded into it, because a
+ * mutating caller that accidentally consumed its target would destroy the item it
+ * was asked to improve.
+ */
+export function selectedInventorySlot(
+  inventory: InvSlot[],
+  itemId: string,
+  slotIndex: number | undefined,
+): InvSlot | undefined | null {
+  if (slotIndex === undefined) return undefined;
+  if (!Number.isInteger(slotIndex) || slotIndex < 0 || slotIndex >= inventory.length) return null;
+  const slot = inventory[slotIndex];
+  if (slot.itemId !== itemId || slot.count < 1) return null;
+  return slot;
+}
+
 /** What a resolve did, so a caller can tell a refusal from a fallback. */
 export type ItemCopyOutcome =
   | { kind: 'selected'; unit: InventoryUnit }

--- a/src/sim/item_copy_ref.ts
+++ b/src/sim/item_copy_ref.ts
@@ -1,0 +1,154 @@
+// Per-copy item addressing: WHICH copy of an item id an action consumes.
+//
+// Two copies of one item id are no longer interchangeable. Since the instanced
+// payload landed (#1165) a stack can carry an enchant, a masterwork seal, rolled
+// stats, a signer, or a crafting provenance, so "salvage Furyforged Girdle" is an
+// ambiguous instruction the moment a player holds two of them. Every item command
+// still names only an item id on the wire, so each one guesses, and they do not
+// even guess the same way:
+//
+//   consumeEquippedInventoryUnit (items.ts, equip)     newest match wins
+//   removePreferFungible (discard / sell / trade)      plain copies first, then newest
+//   removeItem (raw callers)                           newest match wins
+//
+// That guess has been patched three times without being fixed: the phase 12 trade
+// copy-choice fix, the phase 18 widening onto the discard and vendor arms, and the
+// #2398 buyback review, each adding a heuristic PREDICATE to bias the guess rather
+// than letting the caller NAME the copy. Enchanting is the one family that took the
+// other road, and it works: the client sends the bag index, the sim consumes exactly
+// that slot, and a pin re-checked mid-cast catches a bag that shifted underneath.
+//
+// This module is that mechanism, lifted out so every surface can share it. Both
+// halves are MOVES, byte-identical to the private originals they replace
+// (`consumeSelectedInventorySlot` and `disenchantVictimPin` from
+// professions/enchanting.ts, `consumeEquippedInventoryUnit` from items.ts), because
+// the golden-trace parity gate drives equip / discard / sell / use and an id-only
+// call must stay bit-for-bit what it was. The extraction is the rule of three:
+// enchanting had it, items.ts had a near-copy of the fallback half, and the gear
+// loadout is the third caller.
+//
+// A pure leaf on purpose: no SimContext, no rng, no clock. It takes an `InvSlot[]`
+// and mutates it, so a Vitest drives it directly with a plain array.
+
+import { cloneItemInstancePayload, type InventoryUnit, type InvSlot } from './types';
+
+/** Stable, order-independent JSON, so a pin does not depend on key insertion
+ *  order. Moved verbatim from professions/enchanting.ts. */
+function sortedJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(sortedJson).join(',')}]`;
+  if (value && typeof value === 'object') {
+    const record = value as Record<string, unknown>;
+    const keys = Object.keys(record).sort();
+    return `{${keys.map((k) => `${JSON.stringify(k)}:${sortedJson(record[k])}`).join(',')}}`;
+  }
+  return JSON.stringify(value ?? null);
+}
+
+/** Identity of the COPY sitting in a bag slot, for re-checking a selection that
+ *  may have moved. Deliberately not the bag index: an index is what shifts. The
+ *  pin covers the item id, the instance payload, and the crafted provenance,
+ *  which together are everything that distinguishes two copies of one id.
+ *
+ *  An empty string means "no slot", so a caller with no selection pins nothing
+ *  and compares equal to nothing. Moved verbatim from `disenchantVictimPin`. */
+export function itemCopyPin(slot: InvSlot | undefined): string {
+  if (!slot) return '';
+  return sortedJson({
+    c: slot.craftedRecipeId ?? null,
+    i: slot.itemId,
+    p: slot.instance ?? null,
+  });
+}
+
+/**
+ * Consume one unit from the bag slot the caller NAMED. Three outcomes, and the
+ * distinction between the last two is the whole point of the tri-state:
+ *
+ *   InventoryUnit  the named slot held the item and one unit was taken
+ *   null           a selection was given and is NOT valid: refuse the action
+ *   undefined      no selection was given: the caller may fall back
+ *
+ * Collapsing `null` into `undefined` would turn a bad selection into a silent
+ * guess, which is the bug this module exists to remove. Callers must branch on
+ * all three.
+ *
+ * Validates the index itself (integer, in range) rather than trusting it: the
+ * index arrives from a client, and the server re-resolves against its own
+ * inventory. Moved verbatim from `consumeSelectedInventorySlot`.
+ */
+export function consumeSelectedInventorySlot(
+  inventory: InvSlot[],
+  itemId: string,
+  slotIndex: number | undefined,
+): InventoryUnit | undefined | null {
+  if (slotIndex === undefined) return undefined;
+  if (!Number.isInteger(slotIndex) || slotIndex < 0 || slotIndex >= inventory.length) return null;
+  const slot = inventory[slotIndex];
+  if (slot.itemId !== itemId || slot.count < 1) return null;
+  const instance =
+    slot.instance && slot.count > 1 ? cloneItemInstancePayload(slot.instance) : slot.instance;
+  const craftedRecipeId = slot.craftedRecipeId;
+  slot.count -= 1;
+  if (slot.count <= 0) inventory.splice(slotIndex, 1);
+  return { instance, craftedRecipeId };
+}
+
+/**
+ * The legacy fallback: consume the NEWEST matching copy (highest bag index down).
+ *
+ * This is the historical guess, kept exactly as it was and deliberately NOT
+ * improved. Every id-only caller still reaches it, including callers no UI can
+ * fix (`server/pbe_boost.ts` auto-gears by bare item id), and the parity goldens
+ * drive equip / discard / sell / use through it, so any change here forks the
+ * world. New surfaces should pass a selection instead of relying on this.
+ *
+ * Moved verbatim from `consumeEquippedInventoryUnit` (items.ts), parameterized on
+ * the inventory array rather than PlayerMeta so it composes with the selected
+ * walk above and needs no meta in a test.
+ */
+export function consumeNewestInventoryUnit(inventory: InvSlot[], itemId: string): InventoryUnit {
+  for (let i = inventory.length - 1; i >= 0; i--) {
+    const slot = inventory[i];
+    if (slot.itemId !== itemId) continue;
+    const instance =
+      slot.instance && slot.count > 1 ? cloneItemInstancePayload(slot.instance) : slot.instance;
+    const craftedRecipeId = slot.craftedRecipeId;
+    slot.count -= 1;
+    if (slot.count <= 0) inventory.splice(i, 1);
+    return { instance, craftedRecipeId };
+  }
+  return { instance: undefined, craftedRecipeId: undefined };
+}
+
+/** What a resolve did, so a caller can tell a refusal from a fallback. */
+export type ItemCopyOutcome =
+  | { kind: 'selected'; unit: InventoryUnit }
+  | { kind: 'fellBack'; unit: InventoryUnit }
+  | { kind: 'refused' };
+
+/**
+ * The composed rule every converted surface calls: honor a valid selection,
+ * refuse an invalid one, fall back to the legacy newest-copy walk when none was
+ * given.
+ *
+ * Returning the outcome KIND rather than just the unit is what lets a caller
+ * refuse loudly (an invalid selection is a stale or hand-crafted frame, never
+ * something to resolve by guessing) while an id-only caller keeps its old
+ * behavior untouched.
+ */
+export function consumeItemCopy(
+  inventory: InvSlot[],
+  itemId: string,
+  slotIndex: number | undefined,
+): ItemCopyOutcome {
+  const selected = consumeSelectedInventorySlot(inventory, itemId, slotIndex);
+  if (selected === null) return { kind: 'refused' };
+  if (selected !== undefined) return { kind: 'selected', unit: selected };
+  return { kind: 'fellBack', unit: consumeNewestInventoryUnit(inventory, itemId) };
+}
+
+// No pin RE-CHECK helper here yet, deliberately. Enchanting owns the only
+// mid-action re-check in the tree and does it inline against its own cast
+// session; none of the surfaces this PR converts has a cast time. Extracting a
+// second copy of that logic with no caller would be abstraction for a
+// hypothetical, so it lands with the first surface that needs it.

--- a/src/sim/items.ts
+++ b/src/sim/items.ts
@@ -527,7 +527,13 @@ export function equipItem(
   let consumed: InventoryUnit;
   if (slotIndex !== undefined) {
     const taken = consumeSelectedInventorySlot(meta.inventory, itemId, slotIndex);
-    if (!taken) return;
+    // Unreachable in practice: the early gate above refuses an invalid selection
+    // before any mutation. Kept as a belt, and audible so it can never become a
+    // silent no-op if the gate is ever moved.
+    if (!taken) {
+      ctx.error(meta.entityId, "You don't have that item.");
+      return;
+    }
     consumed = taken;
   } else {
     consumed = consumeNewestInventoryUnit(meta.inventory, itemId);
@@ -1173,8 +1179,11 @@ export function sellItem(
   // the laundering hole the clamp exists to close.
   let consumedUnits: InventoryUnit[];
   if (sellableCount === 1 && slotIndex !== undefined) {
+    // Match the id BEFORE reading boundTo. Reading the raw slot first meant naming
+    // a slot that holds a different, bound item reported "bound" rather than
+    // "don't have that item", which is a misleading refusal.
     const named = meta.inventory[slotIndex];
-    if (named?.instance?.boundTo !== undefined) {
+    if (named?.itemId === itemId && named.instance?.boundTo !== undefined) {
       ctx.error(meta.entityId, 'That item is bound and cannot be sold.');
       return;
     }

--- a/src/sim/items.ts
+++ b/src/sim/items.ts
@@ -44,7 +44,7 @@ import { formatMoney } from './format_money';
 import { throwFirebottleAtNearestHut } from './interactions/firebottle_hut';
 import { moveStackToCell } from './inventory_order';
 import { sortInventoryStacks } from './inventory_sort';
-import { consumeNewestInventoryUnit } from './item_copy_ref';
+import { consumeNewestInventoryUnit, consumeSelectedInventorySlot } from './item_copy_ref';
 import { canStackInstancePayloads, itemInstancePayloadsEqual } from './item_instance_merge';
 import { meetsLevelRequirement, requiredLevelFor } from './item_level_req';
 import { mountOwned, summonMountItem } from './mounts';
@@ -322,7 +322,13 @@ export function removeVendorSellUnits(
   return consumed;
 }
 
-export function discardItem(ctx: SimContext, itemId: string, count = 1, pid?: number): void {
+export function discardItem(
+  ctx: SimContext,
+  itemId: string,
+  count = 1,
+  pid?: number,
+  slotIndex?: number,
+): void {
   const r = ctx.resolve(pid);
   if (!r) return;
   const { meta } = r;
@@ -335,17 +341,35 @@ export function discardItem(ctx: SimContext, itemId: string, count = 1, pid?: nu
   if (def.noDiscard) return;
   const discardCount = Number.isFinite(count) ? Math.min(Math.floor(count), available) : 0;
   if (discardCount <= 0) return;
-  // The copy-choice rule on the discard arm (the phase 18 whole-branch
-  // review): with a plain and a self-signed charm copy in the bags, the
-  // discard consumes the plain one and the recharge discount survives.
-  removePreferFungible(
-    ctx,
-    itemId,
-    discardCount,
-    meta.entityId,
-    undefined,
-    sellerSignedCharmDeprioritize(meta.name, itemId),
-  );
+  // A named slot destroys exactly that copy, but ONLY for a single unit.
+  //
+  // The bulk arm deliberately spans slots: a stackable item's per-slot count
+  // tops out at its stackSize, so "destroy 40" reaches across several stacks and
+  // no one index names them (see the prompt cap in bags_window). For bulk the
+  // legacy prefer-plain walk below is also the RIGHT rule rather than a
+  // compromise, since it consumes interchangeable shells first and leaves an
+  // enchanted or signed copy standing longest.
+  const single = discardCount === 1 && slotIndex !== undefined;
+  if (single) {
+    const taken = consumeSelectedInventorySlot(meta.inventory, itemId, slotIndex);
+    if (taken === null) {
+      ctx.error(meta.entityId, "You don't have that item.");
+      return;
+    }
+    ctx.onInventoryChangedForQuests?.(meta);
+  } else {
+    // The copy-choice rule on the discard arm (the phase 18 whole-branch
+    // review): with a plain and a self-signed charm copy in the bags, the
+    // discard consumes the plain one and the recharge discount survives.
+    removePreferFungible(
+      ctx,
+      itemId,
+      discardCount,
+      meta.entityId,
+      undefined,
+      sellerSignedCharmDeprioritize(meta.name, itemId),
+    );
+  }
   ctx.emit({
     type: 'log',
     // biome-ignore lint/style/useTemplate: keep this scanner-friendly shape for i18n extraction.
@@ -388,6 +412,7 @@ export function equipItem(
   itemId: string,
   pid?: number,
   targetSlot?: EquipSlot,
+  slotIndex?: number,
 ): void {
   const r = ctx.resolve(pid);
   if (!r) return;
@@ -463,15 +488,34 @@ export function equipItem(
     delete meta.equipment[displacedSlot];
     if (meta.equipmentInstance) delete meta.equipmentInstance[displacedSlot];
   }
-  // removeItem scans from the highest inventory index down (sim.ts), so a
+  // The id-only arm still scans highest inventory index down, so a
   // freshly-enchanted copy (pushed onto the end by addItemInstance,
-  // src/sim/professions/enchanting.ts applyEnchant) is what this picks up first
-  // when both a plain and an enchanted copy of the same item exist and nothing
-  // else has been looted since. That only holds while the enchanted copy stays
-  // the highest-index match: loot another plain copy afterward and the plain
-  // one gets equipped instead. Deterministic, acceptable for v1, but a future
-  // picker UI should not assume the enchanted copy is always favored.
-  const consumed = consumeNewestInventoryUnit(meta.inventory, itemId);
+  // src/sim/professions/enchanting.ts applyEnchant) is picked up first only while
+  // it stays the highest-index match: loot another plain copy afterward and the
+  // plain one gets equipped instead. That is the hazard the original comment here
+  // flagged, warning that "a future picker UI should not assume the enchanted copy
+  // is always favored". It is no longer the only option: a caller that knows which
+  // copy the player meant passes slotIndex and gets exactly it. The id-only walk
+  // stays byte-identical for the callers that cannot (server/pbe_boost.ts, the RL
+  // host, the parity goldens).
+  // A named slot equips exactly that copy. This is the surface the whole feature
+  // exists for: with a plain and an enchanted copy of one piece, the legacy walk
+  // takes whichever is NEWEST, so looting a plain duplicate silently benches your
+  // enchanted one. The comment this replaces said as much and accepted it for v1,
+  // warning that "a future picker UI should not assume the enchanted copy is
+  // always favored". A gear-set loadout is exactly that picker.
+  //
+  // An invalid selection refuses rather than falling back, because equipping the
+  // wrong copy is silent: the piece looks right in the paperdoll and simply
+  // carries none of the stats the player expected.
+  let consumed: InventoryUnit;
+  if (slotIndex !== undefined) {
+    const taken = consumeSelectedInventorySlot(meta.inventory, itemId, slotIndex);
+    if (!taken) return;
+    consumed = taken;
+  } else {
+    consumed = consumeNewestInventoryUnit(meta.inventory, itemId);
+  }
   ctx.onInventoryChangedForQuests(meta);
   if (old) {
     // Return the piece that was worn: if it carried an enchant, give it back
@@ -591,11 +635,33 @@ export function unequipItem(ctx: SimContext, slot: EquipSlot, pid?: number): boo
   return true;
 }
 
-export function useItem(ctx: SimContext, itemId: string, pid?: number): ItemUseResult | undefined {
+export function useItem(
+  ctx: SimContext,
+  itemId: string,
+  pid?: number,
+  slotIndex?: number,
+): ItemUseResult | undefined {
   const r = ctx.resolve(pid);
   if (!r) return;
   const { meta, e: p } = r;
   const def = ITEMS[itemId];
+  // All three use branches (food/drink, potion, elixir) consume one unit, so the
+  // selection is honored here once instead of at each arm. Returns the consumed
+  // payload because the potion branch reads it (the crafting-provenance trickle).
+  //
+  // Consumables of one id are interchangeable in effect, so this matters less
+  // than it does for gear; it is threaded anyway so the family has no id-only
+  // holes left for a new command to copy.
+  const consumeOneUnit = (): ItemInstancePayload | undefined => {
+    if (slotIndex === undefined) {
+      const [unit] = ctx.removeItem(itemId, 1, meta.entityId);
+      return unit;
+    }
+    const taken = consumeSelectedInventorySlot(meta.inventory, itemId, slotIndex);
+    if (!taken) return undefined;
+    ctx.onInventoryChangedForQuests?.(meta);
+    return taken.instance;
+  };
   if (!def) return;
   if (ctx.countItem(itemId, meta.entityId) <= 0) {
     ctx.error(meta.entityId, "You don't have that item.");
@@ -675,7 +741,7 @@ export function useItem(ctx: SimContext, itemId: string, pid?: number): ItemUseR
       );
       return;
     }
-    ctx.removeItem(itemId, 1, meta.entityId);
+    consumeOneUnit();
     p.sitting = true;
     p[slot] = {
       itemId,
@@ -724,7 +790,7 @@ export function useItem(ctx: SimContext, itemId: string, pid?: number): ItemUseR
     // cheap gate inside battlefieldExperienceTrickle short-circuits
     // everything below rare tier, so this is a no-op for every plain/common/
     // uncommon potion, exactly as before this issue.
-    const [drunkInstance] = ctx.removeItem(itemId, 1, meta.entityId);
+    const drunkInstance = consumeOneUnit();
     if (drunkInstance) {
       const granted = battlefieldExperienceTrickle(meta.craftSkills, {
         itemId,
@@ -766,7 +832,7 @@ export function useItem(ctx: SimContext, itemId: string, pid?: number): ItemUseR
     // family component (elixir_battle_...), not just the kind.
     const elx = def.elixir;
     if (!elx) return;
-    ctx.removeItem(itemId, 1, meta.entityId);
+    consumeOneUnit();
     ctx.applyAura(p, {
       id: `elixir_${elx.kind}`,
       name: elx.aura,
@@ -1002,7 +1068,13 @@ function recordVendorBuyback(
   while (meta.vendorBuyback.length > VENDOR_BUYBACK_LIMIT) meta.vendorBuyback.pop();
 }
 
-export function sellItem(ctx: SimContext, itemId: string, count = 1, pid?: number): void {
+export function sellItem(
+  ctx: SimContext,
+  itemId: string,
+  count = 1,
+  pid?: number,
+  slotIndex?: number,
+): void {
   const r = ctx.resolve(pid);
   if (!r) return;
   const { meta, e: p } = r;
@@ -1060,17 +1132,45 @@ export function sellItem(ctx: SimContext, itemId: string, count = 1, pid?: numbe
   // units get their own per-unit rows so buyback can restore the exact
   // payload sold instead of silently minting a generic copy (the #2207
   // sibling gap social/trade.ts's grantOffer fix left open, see its comment).
-  const consumedUnits = removeVendorSellUnits(
-    ctx,
-    itemId,
-    sellableCount,
-    meta.entityId,
-    (instance) => instance.boundTo !== undefined,
-    // The copy-choice rule on the vendor arm too (the phase 18 whole-branch
-    // review): the seller's own self-signed charm copies go last, so selling
-    // one of two charms never silently retires the recharge discount.
-    sellerSignedCharmDeprioritize(meta.name, itemId),
-  );
+  // A named slot sells exactly that copy, single unit only. The bulk arm spans
+  // slots by design (see discardItem for the same reasoning), and there the
+  // prefer-plain walk below is the right rule rather than a compromise.
+  //
+  // The bound check is repeated here rather than inherited: the clamp above
+  // counts unbound copies in AGGREGATE, which says nothing about whether THIS
+  // slot is the bound one. Without it a selection could sell the bound copy
+  // while the clamp was satisfied by an unbound one elsewhere, which is exactly
+  // the laundering hole the clamp exists to close.
+  let consumedUnits: InventoryUnit[];
+  if (sellableCount === 1 && slotIndex !== undefined) {
+    const named = meta.inventory[slotIndex];
+    if (named?.instance?.boundTo !== undefined) {
+      ctx.error(meta.entityId, 'That item is bound and cannot be sold.');
+      return;
+    }
+    // `!taken` rather than `=== null`: the undefined arm cannot occur inside this
+    // branch (slotIndex is defined), and narrowing on it keeps the type honest
+    // without an assertion.
+    const taken = consumeSelectedInventorySlot(meta.inventory, itemId, slotIndex);
+    if (!taken) {
+      ctx.error(meta.entityId, "You don't have that item.");
+      return;
+    }
+    ctx.onInventoryChangedForQuests?.(meta);
+    consumedUnits = [taken];
+  } else {
+    consumedUnits = removeVendorSellUnits(
+      ctx,
+      itemId,
+      sellableCount,
+      meta.entityId,
+      (instance) => instance.boundTo !== undefined,
+      // The copy-choice rule on the vendor arm too (the phase 18 whole-branch
+      // review): the seller's own self-signed charm copies go last, so selling
+      // one of two charms never silently retires the recharge discount.
+      sellerSignedCharmDeprioritize(meta.name, itemId),
+    );
+  }
   for (const unit of consumedUnits) {
     recordVendorBuyback(meta, itemId, 1, unit.instance, unit.craftedRecipeId);
   }

--- a/src/sim/items.ts
+++ b/src/sim/items.ts
@@ -44,7 +44,11 @@ import { formatMoney } from './format_money';
 import { throwFirebottleAtNearestHut } from './interactions/firebottle_hut';
 import { moveStackToCell } from './inventory_order';
 import { sortInventoryStacks } from './inventory_sort';
-import { consumeNewestInventoryUnit, consumeSelectedInventorySlot } from './item_copy_ref';
+import {
+  consumeNewestInventoryUnit,
+  consumeSelectedInventorySlot,
+  selectedInventorySlot,
+} from './item_copy_ref';
 import { canStackInstancePayloads, itemInstancePayloadsEqual } from './item_instance_merge';
 import { meetsLevelRequirement, requiredLevelFor } from './item_level_req';
 import { mountOwned, summonMountItem } from './mounts';
@@ -421,6 +425,18 @@ export function equipItem(
   if (!def?.slot || (def.kind !== 'weapon' && def.kind !== 'armor' && def.kind !== 'held_offhand'))
     return;
   if (ctx.countItem(itemId, meta.entityId) <= 0) return;
+  // Validate the selection BEFORE anything mutates. The displaced-hand branch below
+  // deletes the other hand's equipment entry, and the consume that could refuse sits
+  // further down, so refusing late destroyed the displaced piece outright: neither
+  // worn nor in bags, with its stats still applied because recalc never ran. Resolve
+  // without consuming here, and refuse before the first write.
+  if (
+    slotIndex !== undefined &&
+    selectedInventorySlot(meta.inventory, itemId, slotIndex) === null
+  ) {
+    ctx.error(meta.entityId, "You don't have that item.");
+    return;
+  }
   if (targetSlot && !slotAcceptsItem(def, targetSlot)) {
     ctx.error(meta.entityId, 'That does not go in that slot.');
     return;
@@ -667,6 +683,17 @@ export function useItem(
     ctx.error(meta.entityId, "You don't have that item.");
     return;
   }
+  // Validate the selection BEFORE any effect. Every use arm applied its heal, aura,
+  // cooldown or sit and only then consumed, so a refused selection granted the
+  // effect for free, repeatably. The aggregate countItem check above cannot catch
+  // it: the player really does hold the item, they just named a slot that is not it.
+  if (
+    slotIndex !== undefined &&
+    selectedInventorySlot(meta.inventory, itemId, slotIndex) === null
+  ) {
+    ctx.error(meta.entityId, "You don't have that item.");
+    return;
+  }
   if (def.use?.type === 'fishing') {
     ctx.startFishing(p, meta);
     return;
@@ -845,9 +872,12 @@ export function useItem(
     });
     ctx.emit({ type: 'log', text: `You quaff ${def.name}.`, color: '#c9f', pid: meta.entityId });
   } else if (def.kind === 'weapon' || def.kind === 'armor' || def.kind === 'held_offhand') {
-    equipItem(ctx, itemId, meta.entityId);
+    // Forward the selection: click-to-equip routes through 'use', so this is the
+    // most common equip gesture in the game. Dropping it here left that gesture
+    // guessing while the aimed paperdoll path was precise.
+    equipItem(ctx, itemId, meta.entityId, undefined, slotIndex);
   } else if (def.kind === 'bag') {
-    equipBagCmd(ctx, itemId, undefined, meta.entityId);
+    equipBagCmd(ctx, itemId, undefined, meta.entityId, slotIndex);
   } else if (def.kind === 'mount') {
     // Reins work like any other usable item: clicking them (bags or an action-bar
     // slot) summons THAT mount. summonMountItem owns every gate, riding skill

--- a/src/sim/items.ts
+++ b/src/sim/items.ts
@@ -44,6 +44,7 @@ import { formatMoney } from './format_money';
 import { throwFirebottleAtNearestHut } from './interactions/firebottle_hut';
 import { moveStackToCell } from './inventory_order';
 import { sortInventoryStacks } from './inventory_sort';
+import { consumeNewestInventoryUnit } from './item_copy_ref';
 import { canStackInstancePayloads, itemInstancePayloadsEqual } from './item_instance_merge';
 import { meetsLevelRequirement, requiredLevelFor } from './item_level_req';
 import { mountOwned, summonMountItem } from './mounts';
@@ -87,20 +88,6 @@ type EquippedInventoryUnit = InventoryUnit;
 // vendor sell/buyback already had, so they reuse this shape and the walk
 // below instead of duplicating it.
 export type VendorRemovedUnit = InventoryUnit;
-
-function consumeEquippedInventoryUnit(meta: PlayerMeta, itemId: string): EquippedInventoryUnit {
-  for (let i = meta.inventory.length - 1; i >= 0; i--) {
-    const slot = meta.inventory[i];
-    if (slot.itemId !== itemId) continue;
-    const instance =
-      slot.instance && slot.count > 1 ? cloneItemInstancePayload(slot.instance) : slot.instance;
-    const craftedRecipeId = slot.craftedRecipeId;
-    slot.count -= 1;
-    if (slot.count <= 0) meta.inventory.splice(i, 1);
-    return { instance, craftedRecipeId };
-  }
-  return { instance: undefined, craftedRecipeId: undefined };
-}
 
 function equipmentPayloadFor(unit: EquippedInventoryUnit): ItemInstancePayload | undefined {
   if (!unit.instance && unit.craftedRecipeId === undefined) return undefined;
@@ -484,7 +471,7 @@ export function equipItem(
   // the highest-index match: loot another plain copy afterward and the plain
   // one gets equipped instead. Deterministic, acceptable for v1, but a future
   // picker UI should not assume the enchanted copy is always favored.
-  const consumed = consumeEquippedInventoryUnit(meta, itemId);
+  const consumed = consumeNewestInventoryUnit(meta.inventory, itemId);
   ctx.onInventoryChangedForQuests(meta);
   if (old) {
     // Return the piece that was worn: if it carried an enchant, give it back

--- a/src/sim/pet/pet_commands.ts
+++ b/src/sim/pet/pet_commands.ts
@@ -38,6 +38,7 @@
 import { hasUnbreakableMovementLock } from '../combat/cc';
 import { DUNGEON_X_THRESHOLD, ITEMS, isDelvePos, MOBS } from '../data';
 import { createMob } from '../entity';
+import { consumeSelectedInventorySlot } from '../item_copy_ref';
 import type { PetState } from '../sim';
 import type { SimContext } from '../sim_context';
 import { addThreat, clearThreat } from '../threat';
@@ -640,7 +641,7 @@ export function petWaterJet(ctx: SimContext, pid?: number): void {
   startWaterJet(ctx, pet, target, jet);
 }
 
-export function feedPet(ctx: SimContext, itemId: string, pid?: number): void {
+export function feedPet(ctx: SimContext, itemId: string, pid?: number, slotIndex?: number): void {
   const r = ctx.resolve(pid);
   if (!r) return;
   if (r.meta.cls !== 'hunter') {
@@ -666,7 +667,15 @@ export function feedPet(ctx: SimContext, itemId: string, pid?: number): void {
     ctx.error(r.e.id, 'Your pet is already at full health.');
     return;
   }
-  ctx.removeItem(itemId, 1, r.e.id);
+  // A named slot consumes exactly that copy; an id-only call keeps the legacy
+  // newest-first walk (ctx.removeItem) untouched.
+  if (slotIndex !== undefined) {
+    if (consumeSelectedInventorySlot(r.meta.inventory, itemId, slotIndex) === null) return;
+    ctx.onInventoryChangedForQuests?.(r.meta);
+  } else {
+    ctx.removeItem(itemId, 1, r.e.id);
+  }
+
   pet.auras = pet.auras.filter((a) => a.id !== 'feed_pet');
   ctx.applyAura(pet, {
     id: 'feed_pet',

--- a/src/sim/pet/pet_commands.ts
+++ b/src/sim/pet/pet_commands.ts
@@ -670,7 +670,12 @@ export function feedPet(ctx: SimContext, itemId: string, pid?: number, slotIndex
   // A named slot consumes exactly that copy; an id-only call keeps the legacy
   // newest-first walk (ctx.removeItem) untouched.
   if (slotIndex !== undefined) {
-    if (consumeSelectedInventorySlot(r.meta.inventory, itemId, slotIndex) === null) return;
+    if (consumeSelectedInventorySlot(r.meta.inventory, itemId, slotIndex) === null) {
+      // Say why. Every other surface in this family emits the same line; a silent
+      // refusal reads to the player as the button being broken.
+      ctx.error(r.e.id, "You don't have that item.");
+      return;
+    }
     ctx.onInventoryChangedForQuests?.(r.meta);
   } else {
     ctx.removeItem(itemId, 1, r.e.id);

--- a/src/sim/professions/enchanting.ts
+++ b/src/sim/professions/enchanting.ts
@@ -60,6 +60,7 @@ import { ENCHANTS, type EnchantDef } from '../content/enchants';
 import { ENCHANT_FAMILY_CAST_DURATION_SEC } from '../content/professions';
 import { ITEMS } from '../data';
 import { recalcPlayerStats } from '../entity';
+import { consumeSelectedInventorySlot, itemCopyPin } from '../item_copy_ref';
 import { requiredLevelFor } from '../item_level_req';
 import { forceDismount } from '../mounts';
 import type { Rng } from '../rng';
@@ -311,23 +312,6 @@ export interface DisenchantResult {
     | 'busy';
 }
 
-function consumeSelectedInventorySlot(
-  inventory: InvSlot[],
-  itemId: string,
-  slotIndex: number | undefined,
-): ConsumedDisenchantUnit | undefined | null {
-  if (slotIndex === undefined) return undefined;
-  if (!Number.isInteger(slotIndex) || slotIndex < 0 || slotIndex >= inventory.length) return null;
-  const slot = inventory[slotIndex];
-  if (slot.itemId !== itemId || slot.count < 1) return null;
-  const instance =
-    slot.instance && slot.count > 1 ? cloneItemInstancePayload(slot.instance) : slot.instance;
-  const craftedRecipeId = slot.craftedRecipeId;
-  slot.count -= 1;
-  if (slot.count <= 0) inventory.splice(slotIndex, 1);
-  return { instance, craftedRecipeId };
-}
-
 function consumePreferredDisenchantVictim(
   inventory: InvSlot[],
   itemId: string,
@@ -528,32 +512,6 @@ export function evaluateDisenchantAdmission(
 /** Canonical JSON with recursively sorted object keys, so two structurally
  *  identical instance payloads fingerprint identically regardless of key
  *  insertion order (a save round-trip can reorder keys). Pure, draw-free. */
-function sortedJson(value: unknown): string {
-  if (Array.isArray(value)) return `[${value.map(sortedJson).join(',')}]`;
-  if (value !== null && typeof value === 'object') {
-    const record = value as Record<string, unknown>;
-    // An explicit undefined fingerprints like an ABSENT key (JSON.stringify
-    // drops both), so clearing a field by assignment can never flip the pin.
-    const keys = Object.keys(record)
-      .filter((k) => record[k] !== undefined)
-      .sort();
-    return `{${keys.map((k) => `${JSON.stringify(k)}:${sortedJson(record[k])}`).join(',')}}`;
-  }
-  return JSON.stringify(value) ?? 'null';
-}
-
-/** Per-copy identity fingerprint of a pin-selected disenchant victim slot:
- *  itemId + instance payload + slot craft marker, everything that
- *  distinguishes one copy of an item id from another. '' for no slot. */
-export function disenchantVictimPin(slot: InvSlot | undefined): string {
-  if (!slot) return '';
-  return sortedJson({
-    c: slot.craftedRecipeId ?? null,
-    i: slot.itemId,
-    p: slot.instance ?? null,
-  });
-}
-
 function beginEnchantFamilyCast(
   ctx: SimContext,
   p: Entity,
@@ -650,7 +608,7 @@ export function disenchantItem(
     // Pin the SELECTED copy's identity, not just its index: the complete-side
     // re-check below is what stops a mid-cast bag splice from redirecting the
     // destroy onto a different copy of the same item id.
-    targetPin: slotIndex === undefined ? '' : disenchantVictimPin(meta.inventory[slotIndex]),
+    targetPin: slotIndex === undefined ? '' : itemCopyPin(meta.inventory[slotIndex]),
   });
   return { ok: true, itemId, casting: true };
 }
@@ -670,10 +628,7 @@ export function completeDisenchantCast(ctx: SimContext, p: Entity, meta: PlayerM
   // destroy a copy the player never selected (the enchanted or masterwork
   // one). Deny not_held instead; the player re-picks. Unpinned disenchants
   // re-resolve their preferred victim fresh and need no pin.
-  if (
-    slotIndex !== undefined &&
-    disenchantVictimPin(meta.inventory[slotIndex]) !== session.targetPin
-  ) {
+  if (slotIndex !== undefined && itemCopyPin(meta.inventory[slotIndex]) !== session.targetPin) {
     const result: DisenchantResult = { ok: false, itemId: session.itemId, reason: 'not_held' };
     meta.lastDisenchantResult = result;
     ctx.emit({

--- a/src/sim/professions/salvage.ts
+++ b/src/sim/professions/salvage.ts
@@ -215,21 +215,16 @@ export function evaluateSalvageAdmission(
   if (!def) return { ok: false, itemId, reason: 'unknown_item' };
   if (!isSalvageable(def)) return { ok: false, itemId, reason: 'not_salvageable' };
   if (ctx.countItem(itemId, pid) < 1) return { ok: false, itemId, reason: 'not_held' };
-  // Refuse a selection that does not name a held copy, BEFORE the cast starts,
-  // so a stale frame is denied rather than silently falling back to a guess.
-  // Checked on a scratch copy: an admission denial must have no side effect.
-  const admissionMeta = ctx.players.get(pid);
-  if (admissionMeta && slotIndex !== undefined) {
-    const scratch = admissionMeta.inventory.map((slot) => ({ ...slot }));
-    if (consumeSelectedInventorySlot(scratch, itemId, slotIndex) === null) {
-      return { ok: false, itemId, reason: 'not_held' };
-    }
-  }
   const meta = ctx.players.get(pid);
   if (!meta) return null;
   const materialItemId = SALVAGE_MATERIAL_BY_QUALITY[def.quality ?? 'common'] ?? 'bone_fragments';
   const scratch = meta.inventory.map((s) => ({ ...s }));
-  const victim = consumeOneScratch(scratch, itemId);
+  // Predict the SELECTED victim, not the legacy one. A rift copy pays essence and a
+  // plain copy pays material, so modelling the wrong victim let a cast start that
+  // could only refuse at completion (the two payouts fit differently).
+  const selected = consumeSelectedInventorySlot(scratch, itemId, slotIndex);
+  if (selected === null) return { ok: false, itemId, reason: 'not_held' };
+  const victim = selected === undefined ? consumeOneScratch(scratch, itemId) : selected.instance;
   const fitItemId = victim?.rift ? RIFT_ESSENCE_ITEM_ID : materialItemId;
   const fitCount = victim?.rift ? riftSalvageYield(victim) : maxSalvageYield(def);
   if (!canAddItem(scratch, bagCapacity(meta.bags), fitItemId, fitCount)) {
@@ -260,9 +255,10 @@ function beginSalvageCast(
   p.castTargetId = null;
   p.channeling = false;
   p.enchantCastItemId = itemId;
-  // -1 means "no selection", matching the enchanting session convention, so an
-  // id-only salvage keeps its legacy behavior on completion.
-  p.enchantCastBagSlot = slotIndex === undefined ? -1 : slotIndex;
+  // Stored 1-based (slotIndex + 1, 0 = not pin-selected), mirroring the enchant
+  // family verbatim: the resting value must be 0 so the parity sampler's
+  // default-omission drops it. A -1 rest value re-hashes every golden.
+  p.enchantCastBagSlot = slotIndex === undefined ? 0 : slotIndex + 1;
   p.enchantCastEnchantId = '';
   p.enchantCastEquipSlot = '';
   p.enchantCastConfirmReplace = false;
@@ -314,7 +310,7 @@ export function completeSalvageCast(ctx: SimContext, p: Entity, meta: PlayerMeta
   p.enchantCastTargetPin = '';
   // Empty session: silent no-op (completeRechargeCast precedent).
   if (itemId === '') return;
-  const slotIndex = sessionBagSlot < 0 ? undefined : sessionBagSlot;
+  const slotIndex = sessionBagSlot <= 0 ? undefined : sessionBagSlot - 1;
   // Pin re-check, mirroring the enchant family: the bag can move during the
   // cast (a loot, a sort, a stack merge), and an index alone would then point at
   // whatever slid into that slot. Refusing is the only safe answer, because the

--- a/src/sim/professions/salvage.ts
+++ b/src/sim/professions/salvage.ts
@@ -18,6 +18,7 @@ import { bagCapacity, canAddItem, consumeOneScratch } from '../bags';
 import { ENCHANT_FAMILY_CAST_DURATION_SEC } from '../content/professions';
 import { RIFT_ESSENCE_ITEM_ID } from '../content/rift/items';
 import { ITEMS } from '../data';
+import { consumeSelectedInventorySlot, itemCopyPin } from '../item_copy_ref';
 import { requiredLevelFor } from '../item_level_req';
 import { removePreferFungible } from '../items';
 import { forceDismount } from '../mounts';
@@ -25,7 +26,13 @@ import { riftSalvageYield } from '../rift/progression';
 import type { Rng } from '../rng';
 import type { PlayerMeta } from '../sim';
 import type { SimContext } from '../sim_context';
-import { type Entity, type ItemDef, isConsuming, SALVAGE_CAST_ID } from '../types';
+import {
+  type Entity,
+  type ItemDef,
+  type ItemInstancePayload,
+  isConsuming,
+  SALVAGE_CAST_ID,
+} from '../types';
 
 const QUALITY_ORDER: readonly NonNullable<ItemDef['quality']>[] = [
   'poor',
@@ -109,7 +116,12 @@ export interface SalvageResult {
  * consumes exactly one copy of the item and grants the rolled material yield.
  * Craft Cast System Phase 4: no shared action throttle; the cast paces.
  */
-export function resolveSalvage(ctx: SimContext, pid: number, itemId: string): SalvageResult {
+export function resolveSalvage(
+  ctx: SimContext,
+  pid: number,
+  itemId: string,
+  slotIndex?: number,
+): SalvageResult {
   const def = ITEMS[itemId];
   if (!def) return { ok: false, itemId, reason: 'unknown_item' };
   if (!isSalvageable(def)) return { ok: false, itemId, reason: 'not_salvageable' };
@@ -127,7 +139,16 @@ export function resolveSalvage(ctx: SimContext, pid: number, itemId: string): Sa
   // arm above.
   if (meta) {
     const scratch = meta.inventory.map((s) => ({ ...s }));
-    const victim = consumeOneScratch(scratch, itemId);
+    // The predicted victim must be the copy this call will ACTUALLY consume, or
+    // the capacity gate pre-fits the wrong payout (a rift copy pays essence, a
+    // plain one pays the quality material). With a selection that is the named
+    // slot; without one it stays the legacy preferred-victim walk.
+    const selectedVictim = consumeSelectedInventorySlot(scratch, itemId, slotIndex);
+    if (selectedVictim === null) return { ok: false, itemId, reason: 'not_held' };
+    const victim =
+      selectedVictim === undefined
+        ? consumeOneScratch(scratch, itemId)
+        : (selectedVictim.instance ?? undefined);
     const fitItemId = victim?.rift ? RIFT_ESSENCE_ITEM_ID : materialItemId;
     const fitCount = victim?.rift ? riftSalvageYield(victim) : maxSalvageYield(def);
     if (!canAddItem(scratch, bagCapacity(meta.bags), fitItemId, fitCount)) {
@@ -138,7 +159,18 @@ export function resolveSalvage(ctx: SimContext, pid: number, itemId: string): Sa
   // instance is never salvaged while an interchangeable shell exists. When only
   // instanced copies remain, removePreferFungible consumes one and returns the
   // payload it ACTUALLY consumed: a rift-upgraded copy pays out rift essence.
-  const [consumedInstance] = removePreferFungible(ctx, itemId, 1, pid);
+  // A named slot consumes exactly that copy; an id-only call keeps the legacy
+  // prefer-plain walk untouched (the parity goldens drive that arm).
+  let consumedInstance: ItemInstancePayload | undefined;
+  if (slotIndex === undefined) {
+    [consumedInstance] = removePreferFungible(ctx, itemId, 1, pid);
+  } else {
+    const owner = ctx.players.get(pid);
+    const taken = owner ? consumeSelectedInventorySlot(owner.inventory, itemId, slotIndex) : null;
+    if (!owner || !taken) return { ok: false, itemId, reason: 'not_held' };
+    consumedInstance = taken.instance;
+    ctx.onInventoryChangedForQuests?.(owner);
+  }
   const riftInstance = consumedInstance?.rift ? consumedInstance : null;
   if (riftInstance) {
     const count = riftSalvageYield(riftInstance);
@@ -177,11 +209,22 @@ export function evaluateSalvageAdmission(
   ctx: SimContext,
   pid: number,
   itemId: string,
+  slotIndex?: number,
 ): SalvageResult | null {
   const def = ITEMS[itemId];
   if (!def) return { ok: false, itemId, reason: 'unknown_item' };
   if (!isSalvageable(def)) return { ok: false, itemId, reason: 'not_salvageable' };
   if (ctx.countItem(itemId, pid) < 1) return { ok: false, itemId, reason: 'not_held' };
+  // Refuse a selection that does not name a held copy, BEFORE the cast starts,
+  // so a stale frame is denied rather than silently falling back to a guess.
+  // Checked on a scratch copy: an admission denial must have no side effect.
+  const admissionMeta = ctx.players.get(pid);
+  if (admissionMeta && slotIndex !== undefined) {
+    const scratch = admissionMeta.inventory.map((slot) => ({ ...slot }));
+    if (consumeSelectedInventorySlot(scratch, itemId, slotIndex) === null) {
+      return { ok: false, itemId, reason: 'not_held' };
+    }
+  }
   const meta = ctx.players.get(pid);
   if (!meta) return null;
   const materialItemId = SALVAGE_MATERIAL_BY_QUALITY[def.quality ?? 'common'] ?? 'bone_fragments';
@@ -195,7 +238,13 @@ export function evaluateSalvageAdmission(
   return null;
 }
 
-function beginSalvageCast(ctx: SimContext, p: Entity, itemId: string): void {
+function beginSalvageCast(
+  ctx: SimContext,
+  p: Entity,
+  itemId: string,
+  slotIndex: number | undefined,
+  meta: PlayerMeta,
+): void {
   if (p.sitting) ctx.standUp(p);
   if (p.mountKey !== '') forceDismount(ctx, p);
   if (p.mountCastKey !== '') {
@@ -211,11 +260,13 @@ function beginSalvageCast(ctx: SimContext, p: Entity, itemId: string): void {
   p.castTargetId = null;
   p.channeling = false;
   p.enchantCastItemId = itemId;
-  p.enchantCastBagSlot = 0;
+  // -1 means "no selection", matching the enchanting session convention, so an
+  // id-only salvage keeps its legacy behavior on completion.
+  p.enchantCastBagSlot = slotIndex === undefined ? -1 : slotIndex;
   p.enchantCastEnchantId = '';
   p.enchantCastEquipSlot = '';
   p.enchantCastConfirmReplace = false;
-  p.enchantCastTargetPin = '';
+  p.enchantCastTargetPin = slotIndex === undefined ? '' : itemCopyPin(meta.inventory[slotIndex]);
   ctx.emit({
     type: 'castStart',
     entityId: p.id,
@@ -226,16 +277,21 @@ function beginSalvageCast(ctx: SimContext, p: Entity, itemId: string): void {
 
 /** Command entry point (issue #1300): validates and STARTS a SALVAGE_CAST_ID
  *  cast. Materials resolve only on completeSalvageCast. */
-export function salvageItem(ctx: SimContext, itemId: string, pid?: number): SalvageResult {
+export function salvageItem(
+  ctx: SimContext,
+  itemId: string,
+  pid?: number,
+  slotIndex?: number,
+): SalvageResult {
   const r = ctx.resolve(pid);
   if (!r) return { ok: false, itemId, reason: 'unknown_item' };
   const { meta, e: p } = r;
   if (p.castingAbility || isConsuming(p)) {
     return { ok: false, itemId, reason: 'busy' };
   }
-  const denial = evaluateSalvageAdmission(ctx, meta.entityId, itemId);
+  const denial = evaluateSalvageAdmission(ctx, meta.entityId, itemId, slotIndex);
   if (denial) return denial;
-  beginSalvageCast(ctx, p, itemId);
+  beginSalvageCast(ctx, p, itemId, slotIndex, meta);
   return { ok: true, itemId, casting: true };
 }
 
@@ -248,6 +304,8 @@ export function completeSalvageCast(ctx: SimContext, p: Entity, meta: PlayerMeta
   // direct-assigned castingAbility (the parity-harness drive style) must
   // write the session fields too or the empty-session guard below no-ops.
   const itemId = p.enchantCastItemId;
+  const sessionBagSlot = p.enchantCastBagSlot;
+  const sessionPin = p.enchantCastTargetPin;
   p.enchantCastItemId = '';
   p.enchantCastBagSlot = 0;
   p.enchantCastEnchantId = '';
@@ -256,7 +314,27 @@ export function completeSalvageCast(ctx: SimContext, p: Entity, meta: PlayerMeta
   p.enchantCastTargetPin = '';
   // Empty session: silent no-op (completeRechargeCast precedent).
   if (itemId === '') return;
-  const result = resolveSalvage(ctx, meta.entityId, itemId);
+  const slotIndex = sessionBagSlot < 0 ? undefined : sessionBagSlot;
+  // Pin re-check, mirroring the enchant family: the bag can move during the
+  // cast (a loot, a sort, a stack merge), and an index alone would then point at
+  // whatever slid into that slot. Refusing is the only safe answer, because the
+  // player aimed at a specific copy and silently hitting a different one is
+  // worse than the old guess.
+  if (slotIndex !== undefined && itemCopyPin(meta.inventory[slotIndex]) !== sessionPin) {
+    const moved: SalvageResult = { ok: false, itemId, reason: 'not_held' };
+    meta.lastSalvageResult = moved;
+    ctx.emit({
+      type: 'salvageResult',
+      ok: false,
+      itemId,
+      materialItemId: moved.materialItemId,
+      count: moved.count,
+      reason: moved.reason,
+      pid: meta.entityId,
+    });
+    return;
+  }
+  const result = resolveSalvage(ctx, meta.entityId, itemId, slotIndex);
   meta.lastSalvageResult = result;
   ctx.emit({
     type: 'salvageResult',

--- a/src/sim/rift/progression.ts
+++ b/src/sim/rift/progression.ts
@@ -10,6 +10,7 @@ import {
 } from '../content/rift/items';
 import { ITEMS } from '../data';
 import { refusedWhileDead } from '../dead_gate';
+import { selectedInventorySlot } from '../item_copy_ref';
 import type { PlayerMeta } from '../sim';
 import type { SimContext } from '../sim_context';
 import type { Entity, ItemInstancePayload, PlayerClass, RiftTier } from '../types';
@@ -364,7 +365,19 @@ export function addRiftProgressionLoot(
   boss.lootable = true;
 }
 
-function riftInventorySlot(meta: PlayerMeta, itemId: string) {
+/** The forge's target copy. One choke point for all three actions (upgrade,
+ *  enchant, socket), so the selection is threaded once here.
+ *
+ *  A named slot must still BE a rift piece: the index says which copy, never
+ *  what it is, so a selection pointing at a plain copy refuses like any other
+ *  ineligible target rather than sliding onto a different one. Without a
+ *  selection this stays the legacy newest-rift-copy walk. */
+function riftInventorySlot(meta: PlayerMeta, itemId: string, slotIndex?: number) {
+  if (slotIndex !== undefined) {
+    const named = selectedInventorySlot(meta.inventory, itemId, slotIndex);
+    if (!named?.instance?.rift) return null;
+    return named;
+  }
   for (let i = meta.inventory.length - 1; i >= 0; i--) {
     const slot = meta.inventory[i];
     if (slot.itemId === itemId && slot.instance?.rift) return slot;
@@ -392,13 +405,18 @@ function emitResult(ctx: SimContext, pid: number, result: RiftForgeResult): Rift
   return result;
 }
 
-export function upgradeRiftItem(ctx: SimContext, itemId: string, pid?: number): RiftForgeResult {
+export function upgradeRiftItem(
+  ctx: SimContext,
+  itemId: string,
+  pid?: number,
+  slotIndex?: number,
+): RiftForgeResult {
   // Dead gate, matching the profession-action family (dead_gate.ts): the
   // refusal emits no riftForgeResult, only the shared error line.
   if (refusedWhileDead(ctx, pid)) return { ok: false, action: 'upgrade', itemId, reason: 'dead' };
   const r = ctx.resolve(pid);
   if (!r) return { ok: false, action: 'upgrade', itemId, reason: 'not_found' };
-  const slot = riftInventorySlot(r.meta, itemId);
+  const slot = riftInventorySlot(r.meta, itemId, slotIndex);
   if (!slot?.instance?.rift) {
     return emitResult(ctx, r.meta.entityId, {
       ok: false,
@@ -443,12 +461,13 @@ export function enchantRiftItem(
   itemId: string,
   stat: string,
   pid?: number,
+  slotIndex?: number,
 ): RiftForgeResult {
   // Same dead gate as upgradeRiftItem, for the same single-surface reason.
   if (refusedWhileDead(ctx, pid)) return { ok: false, action: 'enchant', itemId, reason: 'dead' };
   const r = ctx.resolve(pid);
   if (!r) return { ok: false, action: 'enchant', itemId, reason: 'not_found' };
-  const slot = riftInventorySlot(r.meta, itemId);
+  const slot = riftInventorySlot(r.meta, itemId, slotIndex);
   if (!slot?.instance?.rift) {
     return emitResult(ctx, r.meta.entityId, {
       ok: false,
@@ -494,12 +513,13 @@ export function socketRiftGem(
   itemId: string,
   gemId: string,
   pid?: number,
+  slotIndex?: number,
 ): RiftForgeResult {
   // Same dead gate as upgradeRiftItem, for the same single-surface reason.
   if (refusedWhileDead(ctx, pid)) return { ok: false, action: 'socket', itemId, reason: 'dead' };
   const r = ctx.resolve(pid);
   if (!r) return { ok: false, action: 'socket', itemId, reason: 'not_found' };
-  const slot = riftInventorySlot(r.meta, itemId);
+  const slot = riftInventorySlot(r.meta, itemId, slotIndex);
   if (!slot?.instance?.rift) {
     return emitResult(ctx, r.meta.entityId, {
       ok: false,

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -7116,8 +7116,10 @@ export class Sim {
     petCommands.petWaterJet(this.ctx, pid);
   }
 
-  feedPet(itemId: string, pid?: number): void {
-    petCommands.feedPet(this.ctx, itemId, pid);
+  feedPet(itemId: string, pidOrTarget?: number | { slotIndex: number }, slotIndex?: number): void {
+    const pid = typeof pidOrTarget === 'number' ? pidOrTarget : undefined;
+    const named = typeof pidOrTarget === 'object' ? pidOrTarget.slotIndex : slotIndex;
+    petCommands.feedPet(this.ctx, itemId, pid, named);
   }
 
   healPet(pid?: number): void {
@@ -8558,20 +8560,43 @@ export class Sim {
     return canAddItem(meta.inventory, bagCapacity(meta.bags), itemId, count);
   }
 
-  equipBag(itemId: string, socket?: number, pid?: number): void {
-    bagsMod.equipBag(this.ctx, itemId, socket, pid);
+  equipBag(
+    itemId: string,
+    socket?: number,
+    pidOrTarget?: number | { slotIndex: number },
+    slotIndex?: number,
+  ): void {
+    const pid = typeof pidOrTarget === 'number' ? pidOrTarget : undefined;
+    const named = typeof pidOrTarget === 'object' ? pidOrTarget.slotIndex : slotIndex;
+    bagsMod.equipBag(this.ctx, itemId, socket, pid, named);
   }
 
   unequipBag(socket: number, pid?: number): void {
     bagsMod.unequipBag(this.ctx, socket, pid);
   }
 
-  discardItem(itemId: string, count = 1, pid?: number): void {
-    items.discardItem(this.ctx, itemId, count, pid);
+  discardItem(
+    itemId: string,
+    count = 1,
+    pidOrTarget?: number | { slotIndex: number },
+    slotIndex?: number,
+  ): void {
+    const pid = typeof pidOrTarget === 'number' ? pidOrTarget : undefined;
+    const named = typeof pidOrTarget === 'object' ? pidOrTarget.slotIndex : slotIndex;
+    items.discardItem(this.ctx, itemId, count, pid, named);
   }
 
-  equipItem(itemId: string, pid?: number): void {
-    items.equipItem(this.ctx, itemId, pid);
+  equipItem(
+    itemId: string,
+    pidOrTarget?: number | { slotIndex: number },
+    targetSlot?: EquipSlot,
+    slotIndex?: number,
+  ): void {
+    // The disenchantItem shape (see it for the reasoning): position 2 carries the
+    // target for an IWorld caller and pid for a sim/server caller.
+    const pid = typeof pidOrTarget === 'number' ? pidOrTarget : undefined;
+    const named = typeof pidOrTarget === 'object' ? pidOrTarget.slotIndex : slotIndex;
+    items.equipItem(this.ctx, itemId, pid, targetSlot, named);
   }
 
   // Manual bag order: the player dragged the stack at `from` onto the cell at `to`.
@@ -8586,16 +8611,32 @@ export class Sim {
   // Equip into the exact slot the player aimed at (the paperdoll drop target),
   // rather than letting the resolver pick. items.equipItem re-validates the slot
   // against the item, so this is a request, never a bypass.
-  equipItemToSlot(itemId: string, slot: EquipSlot, pid?: number): void {
-    items.equipItem(this.ctx, itemId, pid, slot);
+  equipItemToSlot(
+    itemId: string,
+    slot: EquipSlot,
+    pidOrTarget?: number | { slotIndex: number },
+    slotIndex?: number,
+  ): void {
+    // The aimed equip arm, and the one the UI actually drives (char_window drag
+    // to a paperdoll slot), so a gear loadout reaches equip through HERE rather
+    // than through the unaimed equipItem.
+    const pid = typeof pidOrTarget === 'number' ? pidOrTarget : undefined;
+    const named = typeof pidOrTarget === 'object' ? pidOrTarget.slotIndex : slotIndex;
+    items.equipItem(this.ctx, itemId, pid, slot, named);
   }
 
   unequipItem(slot: EquipSlot, pid?: number): boolean {
     return items.unequipItem(this.ctx, slot, pid);
   }
 
-  useItem(itemId: string, pid?: number): ItemUseResult | undefined {
-    return items.useItem(this.ctx, itemId, pid);
+  useItem(
+    itemId: string,
+    pidOrTarget?: number | { slotIndex: number },
+    slotIndex?: number,
+  ): ItemUseResult | undefined {
+    const pid = typeof pidOrTarget === 'number' ? pidOrTarget : undefined;
+    const named = typeof pidOrTarget === 'object' ? pidOrTarget.slotIndex : slotIndex;
+    return items.useItem(this.ctx, itemId, pid, named);
   }
 
   // ONE explicit shape, no overloads (phase 21): the request rides an options
@@ -8608,8 +8649,15 @@ export class Sim {
     items.buyItem(this.ctx, npcId, itemId, pid, opts);
   }
 
-  sellItem(itemId: string, count = 1, pid?: number): void {
-    items.sellItem(this.ctx, itemId, count, pid);
+  sellItem(
+    itemId: string,
+    count = 1,
+    pidOrTarget?: number | { slotIndex: number },
+    slotIndex?: number,
+  ): void {
+    const pid = typeof pidOrTarget === 'number' ? pidOrTarget : undefined;
+    const named = typeof pidOrTarget === 'object' ? pidOrTarget.slotIndex : slotIndex;
+    items.sellItem(this.ctx, itemId, count, pid, named);
   }
 
   sellAllJunk(pid?: number): void {
@@ -9028,16 +9076,36 @@ export class Sim {
     return this.players.get(pid)?.lastSalvageResult ?? null;
   }
 
-  upgradeRiftItem(itemId: string, pid?: number): RiftForgeResult {
-    return upgradeRiftItemImpl(this.ctx, itemId, pid);
+  upgradeRiftItem(
+    itemId: string,
+    pidOrTarget?: number | { slotIndex: number },
+    slotIndex?: number,
+  ): RiftForgeResult {
+    const pid = typeof pidOrTarget === 'number' ? pidOrTarget : undefined;
+    const named = typeof pidOrTarget === 'object' ? pidOrTarget.slotIndex : slotIndex;
+    return upgradeRiftItemImpl(this.ctx, itemId, pid, named);
   }
 
-  enchantRiftItem(itemId: string, stat: string, pid?: number): RiftForgeResult {
-    return enchantRiftItemImpl(this.ctx, itemId, stat, pid);
+  enchantRiftItem(
+    itemId: string,
+    stat: string,
+    pidOrTarget?: number | { slotIndex: number },
+    slotIndex?: number,
+  ): RiftForgeResult {
+    const pid = typeof pidOrTarget === 'number' ? pidOrTarget : undefined;
+    const named = typeof pidOrTarget === 'object' ? pidOrTarget.slotIndex : slotIndex;
+    return enchantRiftItemImpl(this.ctx, itemId, stat, pid, named);
   }
 
-  socketRiftGem(itemId: string, gemId: string, pid?: number): RiftForgeResult {
-    return socketRiftGemImpl(this.ctx, itemId, gemId, pid);
+  socketRiftGem(
+    itemId: string,
+    gemId: string,
+    pidOrTarget?: number | { slotIndex: number },
+    slotIndex?: number,
+  ): RiftForgeResult {
+    const pid = typeof pidOrTarget === 'number' ? pidOrTarget : undefined;
+    const named = typeof pidOrTarget === 'object' ? pidOrTarget.slotIndex : slotIndex;
+    return socketRiftGemImpl(this.ctx, itemId, gemId, pid, named);
   }
 
   // Enchanting profession commands (IWorldProfessions): same thin-

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -8982,12 +8982,22 @@ export class Sim {
   // src/sim/professions/salvage.ts, resolved on the deterministic tick the
   // command arrives on, same shape as craftItem above. Stashes the outcome
   // on the resolved player's PlayerMeta so lastSalvageResult reflects it.
-  salvageItem(itemId: string, pid?: number): void {
+  salvageItem(
+    itemId: string,
+    pidOrTarget?: number | { slotIndex: number },
+    slotIndex?: number,
+  ): void {
+    // Overloaded second parameter, the disenchantItem shape: an IWorld caller
+    // passes the target here, a sim/server caller passes pid. Both arities must
+    // stay, because IWorld declares (itemId, target?) while server/game.ts and
+    // the RL host call (itemId, pid, slot).
+    const pid = typeof pidOrTarget === 'number' ? pidOrTarget : undefined;
+    const targetSlotIndex = typeof pidOrTarget === 'object' ? pidOrTarget.slotIndex : slotIndex;
     if (refusedWhileDead(this.ctx, pid)) return;
     // Phase 4: salvageItemImpl starts a cast or returns a start-gate denial.
     // On casting:true castStart is the surface; salvageResult lands only from
     // completeSalvageCast.
-    const result = salvageItemImpl(this.ctx, itemId, pid);
+    const result = salvageItemImpl(this.ctx, itemId, pid, targetSlotIndex);
     if (result.casting) return;
     const meta = this.players.get(pid ?? this.primaryId);
     if (meta) meta.lastSalvageResult = result;

--- a/src/ui/bag_item_action_menu.ts
+++ b/src/ui/bag_item_action_menu.ts
@@ -187,7 +187,8 @@ export class BagItemActionMenu {
         if (action === 'disenchant') {
           if (slotIndex === undefined) world.disenchantItem(itemId);
           else world.disenchantItem(itemId, { slotIndex });
-        } else world.salvageItem(itemId);
+        } else if (slotIndex === undefined) world.salvageItem(itemId);
+        else world.salvageItem(itemId, { slotIndex });
         this.deps.afterAction();
       },
     );

--- a/src/ui/bag_item_action_menu.ts
+++ b/src/ui/bag_item_action_menu.ts
@@ -134,7 +134,7 @@ export class BagItemActionMenu {
       const id = act as BagItemContextActionId;
       if (id === 'default') runDefault();
       else if (id === 'disenchant') this.confirmDestroy('disenchant', itemId, slotIndex);
-      else if (id === 'salvage') this.confirmDestroy('salvage', itemId);
+      else if (id === 'salvage') this.confirmDestroy('salvage', itemId, slotIndex);
       else if (id === 'applyEnchant') this.openEnchantPicker(itemId, x, y);
     });
   }

--- a/src/ui/bags_window.ts
+++ b/src/ui/bags_window.ts
@@ -239,7 +239,7 @@ export interface BagsWindowDeps extends PainterHostPresentation {
   /** Equip a touch-dragged stack into the socket it was released on. The character
    *  window owns the paperdoll drop (and its refusals); this is the touch arm's way
    *  in, since a finger release has no drop event to land on that window. */
-  dropOnEquipSlot(itemId: string, slot: EquipSlot): void;
+  dropOnEquipSlot(itemId: string, slot: EquipSlot, target?: { slotIndex: number }): void;
   /** Place a touch-dragged stack on a hotbar seat (the desktop drop's item
    *  branch, reached by finger): `slot` is the 1-based bar slot a desktop
    *  row button stamps. The HUD owns eligibility (isHotbarItemId) and the
@@ -1061,8 +1061,15 @@ export class BagsWindow {
           // The paperdoll drop belongs to the character window (it owns the sockets
           // and the equip refusals); the world drop belongs here, where the destroy
           // prompt lives. Releasing anywhere else is a plain cancel.
-          if (target.kind === 'equip') this.deps.dropOnEquipSlot(s.itemId, target.slot);
-          else if (target.kind === 'bagCell')
+          if (target.kind === 'equip') {
+            // `index` above is bagStackIndex over the live inventory, so it names
+            // the exact stack this drag started from.
+            this.deps.dropOnEquipSlot(
+              s.itemId,
+              target.slot,
+              index >= 0 ? { slotIndex: index } : undefined,
+            );
+          } else if (target.kind === 'bagCell')
             this.dropOnBagCell(index >= 0 ? index : null, target.index);
           else if (target.kind === 'actionSlot') this.deps.dropOnActionSlot(s.itemId, target.slot);
           else if (target.kind === 'actionRingSlot')
@@ -1477,7 +1484,9 @@ export class BagsWindow {
         this.deps.showError(t('hud.pet.petEatsFoodOnly'));
         return;
       case 'petFeed':
-        this.deps.world().feedPet(s.itemId);
+        this.deps.world().feedPet(s.itemId, {
+          slotIndex: bagStackIndex(this.deps.world().inventory, s),
+        });
         this.deps.setPendingPetFeed(false);
         this.deps.resetPetBarSig();
         this.render();
@@ -1486,7 +1495,9 @@ export class BagsWindow {
         this.showDiscardItemPrompt(s.itemId, Math.max(1, Math.floor(s.count)));
         break;
       case 'equipBag':
-        this.deps.world().equipBag(s.itemId);
+        this.deps.world().equipBag(s.itemId, undefined, {
+          slotIndex: bagStackIndex(this.deps.world().inventory, s),
+        });
         this.deps.hideTooltip();
         this.render();
         break;
@@ -1494,7 +1505,11 @@ export class BagsWindow {
         // Gathering tools (#2343) route through the interact-style handler
         // (nearest matching node + autorun stop) when main.ts has wired it;
         // everything else, and any unwired host, keeps the plain useItem.
-        if (!item || !this.deps.useGatherTool(item)) this.deps.world().useItem(s.itemId);
+        if (!item || !this.deps.useGatherTool(item)) {
+          this.deps.world().useItem(s.itemId, {
+            slotIndex: bagStackIndex(this.deps.world().inventory, s),
+          });
+        }
         this.render();
         this.deps.renderCharIfOpen();
         break;
@@ -1653,7 +1668,9 @@ export class BagsWindow {
       const heldTotal = Math.max(count, totalHeldCount(this.deps.world().inventory, slot.itemId));
       this.showSellQuantityPrompt(slot.itemId, heldTotal);
     } else {
-      this.deps.world().sellItem(slot.itemId);
+      this.deps.world().sellItem(slot.itemId, undefined, {
+        slotIndex: bagStackIndex(this.deps.world().inventory, slot),
+      });
     }
   }
 

--- a/src/ui/bags_window.ts
+++ b/src/ui/bags_window.ts
@@ -1484,9 +1484,7 @@ export class BagsWindow {
         this.deps.showError(t('hud.pet.petEatsFoodOnly'));
         return;
       case 'petFeed':
-        this.deps.world().feedPet(s.itemId, {
-          slotIndex: bagStackIndex(this.deps.world().inventory, s),
-        });
+        this.deps.world().feedPet(s.itemId, this.copyRefFor(s));
         this.deps.setPendingPetFeed(false);
         this.deps.resetPetBarSig();
         this.render();
@@ -1495,9 +1493,7 @@ export class BagsWindow {
         this.showDiscardItemPrompt(s.itemId, Math.max(1, Math.floor(s.count)));
         break;
       case 'equipBag':
-        this.deps.world().equipBag(s.itemId, undefined, {
-          slotIndex: bagStackIndex(this.deps.world().inventory, s),
-        });
+        this.deps.world().equipBag(s.itemId, undefined, this.copyRefFor(s));
         this.deps.hideTooltip();
         this.render();
         break;
@@ -1506,9 +1502,7 @@ export class BagsWindow {
         // (nearest matching node + autorun stop) when main.ts has wired it;
         // everything else, and any unwired host, keeps the plain useItem.
         if (!item || !this.deps.useGatherTool(item)) {
-          this.deps.world().useItem(s.itemId, {
-            slotIndex: bagStackIndex(this.deps.world().inventory, s),
-          });
+          this.deps.world().useItem(s.itemId, this.copyRefFor(s));
         }
         this.render();
         this.deps.renderCharIfOpen();
@@ -1657,6 +1651,18 @@ export class BagsWindow {
     this.deps.openItemActionMenu(item, s.itemId, index, x, y, () => this.runBagAction(item, s, ev));
   }
 
+  /** The copy selection for a clicked stack, or undefined when the stack is no
+   *  longer in the live inventory.
+   *
+   *  bagStackIndex is indexOf, so a stale click yields -1. Sending -1 would be
+   *  REFUSED by the sim (the leaf rejects any out-of-range index by design), which
+   *  turns a stale click into a silent no-op. Falling back to no-selection keeps
+   *  the pre-feature behavior for exactly the case where we cannot name the copy. */
+  private copyRefFor(slot: InvSlot): { slotIndex: number } | undefined {
+    const index = bagStackIndex(this.deps.world().inventory, slot);
+    return index >= 0 ? { slotIndex: index } : undefined;
+  }
+
   private sellBagItem(slot: InvSlot, ev: MouseEvent): void {
     const count = Math.max(1, Math.floor(slot.count));
     if (ev.ctrlKey || ev.metaKey) {
@@ -1668,9 +1674,7 @@ export class BagsWindow {
       const heldTotal = Math.max(count, totalHeldCount(this.deps.world().inventory, slot.itemId));
       this.showSellQuantityPrompt(slot.itemId, heldTotal);
     } else {
-      this.deps.world().sellItem(slot.itemId, undefined, {
-        slotIndex: bagStackIndex(this.deps.world().inventory, slot),
-      });
+      this.deps.world().sellItem(slot.itemId, undefined, this.copyRefFor(slot));
     }
   }
 

--- a/src/ui/char_window.ts
+++ b/src/ui/char_window.ts
@@ -551,7 +551,15 @@ export class CharWindow {
       e.preventDefault();
       this.deps.dragState.end();
       this.markDropTargets(null);
-      this.dropOnEquipSlot(drag.itemId, slot);
+      // The desktop drop carries the drag's bag index the same way the touch path
+      // does; without it the most ordinary equip gesture fell back to the guess.
+      // `drag.index` is already null for a sorted or filtered grid, which names no
+      // position, so that case correctly sends no selection.
+      this.dropOnEquipSlot(
+        drag.itemId,
+        slot,
+        drag.index !== null && drag.index >= 0 ? { slotIndex: drag.index } : undefined,
+      );
     });
   }
 

--- a/src/ui/char_window.ts
+++ b/src/ui/char_window.ts
@@ -453,7 +453,12 @@ export class CharWindow {
    *  here). The refusals are pre-empted client-side with the sim's OWN wording
    *  (tSim), so no doomed command is sent and the toast reads identically to the
    *  authoritative one the server would emit; the sim re-validates regardless. */
-  dropOnEquipSlot(itemId: string, slot: EquipSlot): void {
+  /** `target` names WHICH bag copy was dragged. Without it the equip command
+   *  falls back to the newest matching copy, which is the wrong copy whenever the
+   *  player holds a plain duplicate of an enchanted piece. The bags window has the
+   *  index (it owns the drag source), so it is threaded through rather than
+   *  re-derived here, where the live slot object is no longer in hand. */
+  dropOnEquipSlot(itemId: string, slot: EquipSlot, target?: { slotIndex: number }): void {
     const item = ITEMS[itemId];
     if (!item) return;
     const world = this.deps.world();
@@ -484,7 +489,7 @@ export class CharWindow {
         this.deps.showError(tSim('error.uniqueEquipped'));
         return;
       case 'equip':
-        world.equipItemToSlot(itemId, slot);
+        world.equipItemToSlot(itemId, slot, target);
         audio.click();
         this.deps.hideTooltip();
         this.deps.renderBags();

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -4471,7 +4471,8 @@ export class Hud {
     dragState: this.itemDragState,
     isTouchHud: () => document.body.classList.contains('mobile-touch'),
     markEquipDropTargets: (itemId) => this.charWindow.markDropTargets(itemId),
-    dropOnEquipSlot: (itemId, slot) => this.charWindow.dropOnEquipSlot(itemId, slot),
+    dropOnEquipSlot: (itemId, slot, target) =>
+      this.charWindow.dropOnEquipSlot(itemId, slot, target),
     dropOnActionSlot: (itemId, slot) => this.placeHotbarItemFromTouch(itemId, slot),
     dropOnActionRingSlot: (itemId, ringIndex) => {
       // Bounded like mobileRingSlotFromPoint (the phase 14 QA): a stale

--- a/src/world_api/inventory.ts
+++ b/src/world_api/inventory.ts
@@ -13,7 +13,7 @@ export interface IWorldInventory {
   equipment: Partial<Record<EquipSlot, string>>;
   equipmentInstances: PlayerEquipmentInstances;
   copper: number;
-  equipItem(itemId: string): void;
+  equipItem(itemId: string, target?: { slotIndex: number }): void;
   /** Reorder the bags: move the stack at inventory index `from` onto the bag cell at
    *  `to` (a swap when that cell holds a stack, a move to the end when it is free
    *  space). The order is the inventory array itself, persisted with the character. */
@@ -29,14 +29,14 @@ export interface IWorldInventory {
    *  instead of letting the sim's resolver pick (a ring dropped on the second
    *  finger lands there even while the first is free). The sim re-validates the
    *  slot against the item, so an illegal pairing is refused, never coerced. */
-  equipItemToSlot(itemId: string, slot: EquipSlot): void;
+  equipItemToSlot(itemId: string, slot: EquipSlot, target?: { slotIndex: number }): void;
   unequipItem(slot: EquipSlot): void;
   /** Equip a bag item into a socket (first empty when omitted; swaps in place). */
-  equipBag(itemId: string, socket?: number): void;
+  equipBag(itemId: string, socket?: number, target?: { slotIndex: number }): void;
   /** Return the bag in `socket` to the inventory (refused when items would not fit). */
   unequipBag(socket: number): void;
-  useItem(itemId: string): void;
-  discardItem(itemId: string, count?: number): void;
+  useItem(itemId: string, target?: { slotIndex: number }): void;
+  discardItem(itemId: string, count?: number, target?: { slotIndex: number }): void;
   // The request rides an options bag (VendorBuyOptions, phase 21): `bulk`
   // requests as many units as the buyer can currently afford in one purchase,
   // capped at the item's bag stack size (VendorGoodsRow.bulkQuantity previews
@@ -46,7 +46,7 @@ export interface IWorldInventory {
   // at most one of the two fields. An empty/omitted bag buys the ordinary
   // single unit (or the food/drink staple stack), byte-identical to today.
   buyItem(npcId: number, itemId: string, opts?: VendorBuyOptions): void;
-  sellItem(itemId: string, count?: number): void;
+  sellItem(itemId: string, count?: number, target?: { slotIndex: number }): void;
   // Sell every gray (poor-quality) item in the bags at once while a vendor is open.
   // Quest items and anything flagged noVendorSell are left untouched.
   sellAllJunk(): void;
@@ -63,7 +63,7 @@ export interface IWorldInventory {
     instance?: ItemInstancePayload,
     craftedRecipeId?: string,
   ): void;
-  upgradeRiftItem(itemId: string): void;
-  enchantRiftItem(itemId: string, stat: string): void;
-  socketRiftGem(itemId: string, gemId: string): void;
+  upgradeRiftItem(itemId: string, target?: { slotIndex: number }): void;
+  enchantRiftItem(itemId: string, stat: string, target?: { slotIndex: number }): void;
+  socketRiftGem(itemId: string, gemId: string, target?: { slotIndex: number }): void;
 }

--- a/src/world_api/pet.ts
+++ b/src/world_api/pet.ts
@@ -9,7 +9,7 @@ export interface IWorldPet {
   petWaterJet(): void;
   setPetAutoTaunt(enabled: boolean): void;
   setPetAutoWaterJet(enabled: boolean): void;
-  feedPet(itemId: string): void;
+  feedPet(itemId: string, target?: { slotIndex: number }): void;
   healPet(): void;
   setPetMode(mode: PetMode): void;
 }

--- a/src/world_api/professions.ts
+++ b/src/world_api/professions.ts
@@ -351,7 +351,7 @@ export interface IWorldProfessions {
   // pre-feature form, and the sim re-validates the target either way (the flag
   // can never overwrite anything the dedicated replace arm would not).
   applyEnchant(itemId: string, enchantId: string, slot?: EquipSlot, confirmReplace?: boolean): void;
-  salvageItem(itemId: string): void;
+  salvageItem(itemId: string, target?: { slotIndex: number }): void;
   // Maker's Bond unbind service (Professions 2.0): clear the
   // boundTo lock on ONE held bound copy of `itemId`, for the tier-scaled
   // gold fee, while standing at any static crafting station (every station

--- a/tests/bags_guild_deposit_routing.test.ts
+++ b/tests/bags_guild_deposit_routing.test.ts
@@ -79,7 +79,16 @@ function harness(
   const sink =
     (name: string) =>
     (...a: unknown[]) =>
-      calls.push(`${name}:${a.filter((x) => x !== undefined).join(',')}`);
+      calls.push(
+        // Objects are JSON-stringified rather than left to String(), which renders
+        // every one of them as "[object Object]". The copy selection passed to
+        // useItem is an object, so without this a recorded call could not be told
+        // apart from any other object argument.
+        `${name}:${a
+          .filter((x) => x !== undefined)
+          .map((x) => (typeof x === 'object' && x !== null ? JSON.stringify(x) : String(x)))
+          .join(',')}`,
+      );
   const world = {
     inventory,
     bags: [null, null, null, null],
@@ -222,7 +231,12 @@ describe('guild-tab bag click routing (behavioral, real BagsWindow)', () => {
     // click must still reach the use ladder, and each armed pane must deposit.
     const closed = harness([{ itemId: plainId, count: 1 }], false, false, false);
     clickCellFor(closed.root, plainId);
-    expect(closed.calls).toEqual([`useItem:${plainId}`]);
+    // useItem now also carries WHICH bag copy was clicked, so the sink records a
+    // second argument. Asserted as a prefix plus the selection rather than as one
+    // exact string: this test is about the click REACHING the use ladder, and
+    // pinning the stringified argument object here would make it fail on any
+    // future field the selection gains.
+    expect(closed.calls).toEqual([`useItem:${plainId},{"slotIndex":0}`]);
     expect(closed.errors).toEqual([]);
   });
 

--- a/tests/bags_window.test.ts
+++ b/tests/bags_window.test.ts
@@ -368,11 +368,15 @@ describe('bags_window: touch peek + bank-cluster close', () => {
       /case 'marketSell':\s*this\.deps\.stageMarketSell\(s\.itemId, s\.instance\);/,
     );
     expect(body).toMatch(/case 'bankDeposit': \{/);
-    expect(body).toMatch(/case 'petFeed':\s*this\.deps\.world\(\)\.feedPet\(s\.itemId\);/);
+    // feedPet and useItem now also forward WHICH bag copy was clicked, so the
+    // call no longer ends at `s.itemId`. These pins are about REACHABILITY from
+    // the shared dispatch, so they match the call opening and leave the argument
+    // list to tests/item_copy_addressing_guard.
+    expect(body).toMatch(/case 'petFeed':\s*this\.deps\.world\(\)\.feedPet\(s\.itemId/);
     // The 'use' case tries the gathering-tool routing first (#2343) and only
     // falls back to the plain useItem command when the hook declines.
     expect(body).toMatch(
-      /case 'use': \{[\s\S]{0,400}?if \(!item \|\| !this\.deps\.useGatherTool\(item\)\) this\.deps\.world\(\)\.useItem\(s\.itemId\);/,
+      /case 'use': \{[\s\S]{0,400}?if \(!item \|\| !this\.deps\.useGatherTool\(item\)\) \{[\s\S]{0,200}?this\.deps\.world\(\)\.useItem\(s\.itemId/,
     );
   });
 });

--- a/tests/equip_drop_core.test.ts
+++ b/tests/equip_drop_core.test.ts
@@ -266,9 +266,20 @@ describe('touch drop routing beyond the hit-test (the phase 14 QA gaps)', () => 
 
   it('the bags release routes both action arms into the HUD deps (source pin)', () => {
     const bags = stripped('../src/ui/bags_window.ts');
-    expect(bags).toContain(
-      "if (target.kind === 'equip') this.deps.dropOnEquipSlot(s.itemId, target.slot);",
+    // The equip arm now also forwards WHICH bag copy was dragged, so it is no
+    // longer a single line. Pinned as its parts rather than as one string: the
+    // routing claim (this arm reaches dropOnEquipSlot with the item and the
+    // target slot) is what this test is about, and the added third argument is
+    // the copy-addressing work, covered by tests/item_copy_addressing_guard.
+    const equipArm = bags.slice(
+      bags.indexOf("if (target.kind === 'equip')"),
+      bags.indexOf("else if (target.kind === 'bagCell')"),
     );
+    expect(equipArm, 'the equip arm must reach the HUD dep').toContain(
+      'this.deps.dropOnEquipSlot(',
+    );
+    expect(equipArm).toContain('s.itemId');
+    expect(equipArm).toContain('target.slot');
     expect(bags).toContain(
       "else if (target.kind === 'actionSlot') this.deps.dropOnActionSlot(s.itemId, target.slot);",
     );

--- a/tests/item_copy_addressing_guard.test.ts
+++ b/tests/item_copy_addressing_guard.test.ts
@@ -80,6 +80,14 @@ const EXEMPT: ReadonlyArray<{ cmd: string; why: string }> = [
     why: 'acquires a copy from vendor stock rather than acting on one the player holds',
   },
   {
+    cmd: 'mail_send',
+    why: 'names the copy by PAYLOAD rather than bag index: it ships full InvSlots and post_office resolves each against the sender bags with removeMatchingInstance, the market_list_instance shape',
+  },
+  {
+    cmd: 'trade_offer',
+    why: 'ships full InvSlots so the payload is on the wire, but the consume still uses the phase 12 sellerSignedCharmDeprioritize heuristic rather than matching that payload. Exempted as a KNOWN remaining gap rather than left invisible: converting the trade offer is follow-up work, and this entry is what keeps it from being forgotten',
+  },
+  {
     cmd: 'sell_all_junk',
     why: 'operates over the whole junk set by definition, so no single copy is named',
   },
@@ -126,6 +134,15 @@ describe('every item command can name the copy it acts on', () => {
     expect(arm, `${cmd} must parse msg.${field} in its OWN dispatch arm`).toContain(
       `Number.isInteger(msg.${field})`,
     );
+    // Parsing is half of it. An arm that reads the field and then calls the sim
+    // without it drops the selection at the authority boundary, which is
+    // indistinguishable from never having sent it. Require the parsed local to
+    // reach a sim call in the same arm.
+    const local = field === 'bagSlot' ? 'bag' : 'slot';
+    const simCall = arm.slice(arm.indexOf('sim.'));
+    expect(simCall, `${cmd} must FORWARD the parsed ${local} to the sim call`).toMatch(
+      new RegExp(`\\b${local}\\b`),
+    );
   });
 
   it('exempts only commands with a written reason, and no command is in both lists', () => {
@@ -146,7 +163,10 @@ describe('every item command can name the copy it acts on', () => {
     // command. Anything that sends an `item` field is acting on an item and must
     // appear in exactly one of the two tables above.
     const sending = new Set<string>();
-    const re = /cmd: '([a-z_]+)'[^}]*\bitem\b/g;
+    // `items?` on purpose: the first version matched only a literal `item` field,
+    // so trade_offer and mail_send (both of which ship items, as an `items` array)
+    // escaped classification entirely.
+    const re = /cmd: '([a-z_]+)'[^}]*\bitems?\b/g;
     for (const m of ONLINE.matchAll(re)) sending.add(m[1]);
 
     // Not vacuous: the sweep really does find the family.

--- a/tests/item_copy_addressing_guard.test.ts
+++ b/tests/item_copy_addressing_guard.test.ts
@@ -1,0 +1,165 @@
+// Every item command can NAME the copy it acts on.
+//
+// This is the guard that makes the copy-addressing work a fix rather than a
+// fourth patch. The defect has been treated three times without being closed
+// (the phase 12 trade copy-choice fix, the phase 18 discard and vendor widening,
+// the #2398 buyback review), each time by adding a heuristic predicate to bias a
+// guess. The reason it kept coming back is that nothing stopped the NEXT item
+// command from shipping id-only, and every one that did inherited the bug.
+//
+// So this test enumerates the item-acting commands from source and asserts each
+// one carries per-copy addressing, with a short, justified exemption list. It is
+// deliberately a source scan rather than a behavior test: behavior tests cover
+// what a surface DOES, and nothing but a sweep can say that no surface was
+// forgotten.
+//
+// Two limits, stated so this is not read as more than it is. It checks that the
+// wire message can CARRY a selection, not that every UI call site passes one (a
+// caller that has no slot in hand, like the char window's paperdoll-to-paperdoll
+// drag, legitimately passes nothing). And it reads `ClientWorld` senders, so a
+// hand-crafted frame from a modified client is out of scope: the sim re-validates
+// every index against its own inventory, which is what actually guards that.
+
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const ONLINE = readFileSync(new URL('../src/net/online.ts', import.meta.url), 'utf8');
+const SERVER = readFileSync(new URL('../server/game.ts', import.meta.url), 'utf8');
+
+/**
+ * The item-acting wire commands, each with the field that names the copy.
+ *
+ * `slot` is the bag index everywhere it is free. The `equip` token is the one
+ * exception and uses `bagSlot`, because there `slot` already means the EQUIP slot
+ * (equipItemToSlot). That collision is the reason this table records the field
+ * per command instead of assuming one name: `apply_enchant`'s `slot` is an equip
+ * slot too, so "the command has a slot field" would have been a vacuous check.
+ */
+const ADDRESSED_COMMANDS: ReadonlyArray<{ cmd: string; field: string; why?: string }> = [
+  { cmd: 'salvage_item', field: 'slot' },
+  { cmd: 'disenchant_item', field: 'slot', why: 'the original precise surface' },
+  { cmd: 'discard', field: 'slot' },
+  { cmd: 'sell', field: 'slot' },
+  { cmd: 'use', field: 'slot' },
+  { cmd: 'pet_feed', field: 'slot' },
+  { cmd: 'equip_bag', field: 'slot' },
+  { cmd: 'rift_upgrade_item', field: 'slot' },
+  { cmd: 'rift_enchant_item', field: 'slot' },
+  { cmd: 'rift_socket_gem', field: 'slot' },
+  { cmd: 'equip', field: 'bagSlot', why: 'slot is the equip slot on this token' },
+];
+
+/**
+ * Item commands that carry NO copy selection, each with the reason it needs none.
+ * A new entry here is a claim that has to survive review, which is the point: the
+ * cost of an exemption is writing down why.
+ */
+const EXEMPT: ReadonlyArray<{ cmd: string; why: string }> = [
+  {
+    cmd: 'market_list',
+    why: 'fungible-only by construction: it refuses unless countFungibleItem covers the request, and the instanced path is the separate market_list_instance command, which names the copy by payload',
+  },
+  {
+    cmd: 'market_list_instance',
+    why: 'already names the copy, by instance payload rather than bag index',
+  },
+  {
+    cmd: 'buyback',
+    why: 'already names the copy, by the buyback row instance payload (#2398)',
+  },
+  {
+    cmd: 'apply_enchant',
+    why: 'targets a WORN piece by equip slot; a worn piece is one copy per slot, so there is nothing to disambiguate',
+  },
+  {
+    cmd: 'unbind_item',
+    why: 'resolved by bag slot index inside professions/commission.ts rather than by item id',
+  },
+  {
+    cmd: 'buy',
+    why: 'acquires a copy from vendor stock rather than acting on one the player holds',
+  },
+  {
+    cmd: 'sell_all_junk',
+    why: 'operates over the whole junk set by definition, so no single copy is named',
+  },
+];
+
+/** Sender bodies from ClientWorld, keyed by the wire token they send. */
+function senderBodyFor(cmd: string): string {
+  // Every sender routes through the private cmd() helper, so the token literal
+  // appears inside the method that owns it. Take a window around each occurrence
+  // rather than parsing: the assertion only needs to see whether the selection
+  // field rides alongside the token.
+  const needle = `cmd: '${cmd}'`;
+  let out = '';
+  let at = ONLINE.indexOf(needle);
+  while (at !== -1) {
+    out += ONLINE.slice(at, at + 220);
+    at = ONLINE.indexOf(needle, at + 1);
+  }
+  return out;
+}
+
+describe('every item command can name the copy it acts on', () => {
+  it.each(ADDRESSED_COMMANDS)('$cmd carries a $field selection on the wire', ({ cmd, field }) => {
+    const body = senderBodyFor(cmd);
+    expect(body, `no ClientWorld sender found for ${cmd}`).not.toBe('');
+    expect(body, `${cmd} must be able to send a ${field}`).toContain(field);
+  });
+
+  it.each(ADDRESSED_COMMANDS)('$cmd is parsed and forwarded server-side', ({ cmd, field }) => {
+    // The client being able to SEND it is half the contract; the server arm has
+    // to read it, or the selection is silently dropped at the authority boundary,
+    // which is indistinguishable from the bug.
+    //
+    // The window ENDS at the next `case '`, which is load-bearing. A fixed-length
+    // slice bleeds into neighbouring arms, and since most of them do parse a
+    // selection, this assertion passed even with the arm under test reverted:
+    // verified by reverting `use` and watching it stay green. Bounding the arm is
+    // what gives it teeth.
+    const at = SERVER.indexOf(`case '${cmd}':`);
+    expect(at, `no dispatch arm for ${cmd}`).toBeGreaterThan(-1);
+    const rest = SERVER.slice(at + `case '${cmd}':`.length);
+    const nextCase = rest.indexOf("case '");
+    const arm = nextCase === -1 ? rest : rest.slice(0, nextCase);
+    expect(arm, `${cmd} must parse msg.${field} in its OWN dispatch arm`).toContain(
+      `Number.isInteger(msg.${field})`,
+    );
+  });
+
+  it('exempts only commands with a written reason, and no command is in both lists', () => {
+    // Guards the guard. An exemption with no reason, or a command quietly living
+    // in both tables, would let a surface escape while the file still looked
+    // complete.
+    for (const row of EXEMPT) {
+      expect(row.why.length, `${row.cmd} needs a real reason`).toBeGreaterThan(30);
+    }
+    const addressed = new Set(ADDRESSED_COMMANDS.map((r) => r.cmd));
+    for (const row of EXEMPT) {
+      expect(addressed.has(row.cmd), `${row.cmd} cannot be both addressed and exempt`).toBe(false);
+    }
+  });
+
+  it('covers every item-acting command the client can send, so nothing is unclassified', () => {
+    // The completeness half, and the only assertion here that catches a NEW
+    // command. Anything that sends an `item` field is acting on an item and must
+    // appear in exactly one of the two tables above.
+    const sending = new Set<string>();
+    const re = /cmd: '([a-z_]+)'[^}]*\bitem\b/g;
+    for (const m of ONLINE.matchAll(re)) sending.add(m[1]);
+
+    // Not vacuous: the sweep really does find the family.
+    expect(sending.size, 'expected the scan to find many item commands').toBeGreaterThan(10);
+
+    const classified = new Set([
+      ...ADDRESSED_COMMANDS.map((r) => r.cmd),
+      ...EXEMPT.map((r) => r.cmd),
+    ]);
+    const unclassified = [...sending].filter((c) => !classified.has(c)).sort();
+    expect(
+      unclassified,
+      'a new item command must either name the copy it acts on or be exempted with a reason',
+    ).toEqual([]);
+  });
+});

--- a/tests/item_copy_ref.test.ts
+++ b/tests/item_copy_ref.test.ts
@@ -55,6 +55,34 @@ describe('itemCopyPin', () => {
     );
   });
 
+  it('fingerprints an explicit undefined like an ABSENT key', () => {
+    // The property the move originally carried and this PR first dropped: JSON
+    // drops both forms, so clearing a field by assignment must not flip the pin.
+    // It matters more once pins persist in JSONB, where a round trip erases
+    // undefined-valued keys (the loadout gear sets in the stacked PR).
+    const cleared: InvSlot = {
+      itemId: 'girdle',
+      count: 1,
+      instance: { enchantId: 'power', boundTo: undefined } as never,
+    };
+    const absent: InvSlot = {
+      itemId: 'girdle',
+      count: 1,
+      instance: { enchantId: 'power' } as never,
+    };
+    expect(itemCopyPin(cleared)).toBe(itemCopyPin(absent));
+  });
+
+  it('survives a JSON round trip, which is what persistence does to a payload', () => {
+    const slot: InvSlot = {
+      itemId: 'girdle',
+      count: 1,
+      instance: { enchantId: 'power', rolled: { stats: { str: 3 } } } as never,
+    };
+    const roundTripped = JSON.parse(JSON.stringify(slot)) as InvSlot;
+    expect(itemCopyPin(roundTripped)).toBe(itemCopyPin(slot));
+  });
+
   it('pins nothing for no slot', () => {
     expect(itemCopyPin(undefined)).toBe('');
   });

--- a/tests/item_copy_ref.test.ts
+++ b/tests/item_copy_ref.test.ts
@@ -16,6 +16,7 @@ import {
   consumeSelectedInventorySlot,
   itemCopyPin,
   itemCopyStillPinned,
+  selectedInventorySlot,
 } from '../src/sim/item_copy_ref';
 import type { InvSlot } from '../src/sim/types';
 
@@ -134,6 +135,40 @@ describe('consumeNewestInventoryUnit: the legacy fallback, unchanged', () => {
       craftedRecipeId: undefined,
     });
     expect(inv).toHaveLength(1);
+  });
+});
+
+describe('selectedInventorySlot: resolve without consuming', () => {
+  it('returns the named slot and leaves the bag untouched', () => {
+    // The mutating callers (the rift forge) improve the slot in place, so a
+    // resolver that consumed would destroy the item it was asked to upgrade.
+    const inv = [enchanted('girdle', 'power'), plain('girdle')];
+    const slot = selectedInventorySlot(inv, 'girdle', 0);
+    expect(slot?.instance).toEqual({ enchantId: 'power' });
+    expect(inv, 'nothing consumed').toHaveLength(2);
+    expect(inv[0].count).toBe(1);
+  });
+
+  it('returns the live slot object, so a caller mutating it edits the bag', () => {
+    const inv = [enchanted('girdle', 'power')];
+    const slot = selectedInventorySlot(inv, 'girdle', 0);
+    expect(slot).toBe(inv[0]);
+  });
+
+  it.each([
+    ['out of range', 9],
+    ['negative', -1],
+    ['not an integer', 0.5],
+  ])('refuses an index that is %s', (_label, index) => {
+    expect(selectedInventorySlot([plain('girdle')], 'girdle', index as number)).toBeNull();
+  });
+
+  it('refuses when the named slot holds a different item', () => {
+    expect(selectedInventorySlot([plain('boots')], 'girdle', 0)).toBeNull();
+  });
+
+  it('returns undefined for no selection, so the caller falls back', () => {
+    expect(selectedInventorySlot([plain('girdle')], 'girdle', undefined)).toBeUndefined();
   });
 });
 

--- a/tests/item_copy_ref.test.ts
+++ b/tests/item_copy_ref.test.ts
@@ -1,0 +1,175 @@
+// The per-copy item addressing leaf (src/sim/item_copy_ref.ts).
+//
+// The behavior under test is "which copy of an item id does an action consume",
+// which has been guessed three separate times in this tree (the phase 12 trade
+// fix, the phase 18 discard/vendor widening, the #2398 buyback review). The
+// assertions below are written around the two things those fixes kept getting
+// wrong: an invalid selection must REFUSE rather than silently guess, and the
+// id-only fallback must stay byte-identical to the historical walk.
+//
+// Pure leaf, so this drives it with plain arrays: no Sim, no SimContext.
+
+import { describe, expect, it } from 'vitest';
+import {
+  consumeItemCopy,
+  consumeNewestInventoryUnit,
+  consumeSelectedInventorySlot,
+  itemCopyPin,
+} from '../src/sim/item_copy_ref';
+import type { InvSlot } from '../src/sim/types';
+
+/** A plain (fungible) stack. */
+const plain = (itemId: string, count = 1): InvSlot => ({ itemId, count });
+
+/** An instanced copy: the enchanted / masterwork / signed case that makes two
+ *  copies of one id non-interchangeable in the first place. */
+const enchanted = (itemId: string, enchantId: string, count = 1): InvSlot => ({
+  itemId,
+  count,
+  instance: { enchantId } as InvSlot['instance'],
+});
+
+describe('itemCopyPin', () => {
+  it('separates two copies of the same id that differ only by payload', () => {
+    // The whole premise: without this, "the girdle" names two different objects.
+    expect(itemCopyPin(plain('girdle'))).not.toBe(itemCopyPin(enchanted('girdle', 'power')));
+  });
+
+  it('is stable across key order, so it survives a serialize round trip', () => {
+    const a: InvSlot = { itemId: 'girdle', count: 1, instance: { a: 1, b: 2 } as never };
+    const b: InvSlot = { itemId: 'girdle', count: 1, instance: { b: 2, a: 1 } as never };
+    expect(itemCopyPin(a)).toBe(itemCopyPin(b));
+  });
+
+  it('ignores count and bag position, which are exactly what shift', () => {
+    // A pin that moved when the stack size changed would false-refuse after any
+    // partial consume, so this is a real property rather than an incidental one.
+    expect(itemCopyPin(plain('girdle', 1))).toBe(itemCopyPin(plain('girdle', 5)));
+  });
+
+  it('distinguishes crafted provenance', () => {
+    expect(itemCopyPin({ itemId: 'girdle', count: 1, craftedRecipeId: 'r1' })).not.toBe(
+      itemCopyPin(plain('girdle')),
+    );
+  });
+
+  it('pins nothing for no slot', () => {
+    expect(itemCopyPin(undefined)).toBe('');
+  });
+});
+
+describe('consumeSelectedInventorySlot: the tri-state', () => {
+  it('takes exactly the named slot, not the newest match', () => {
+    // The reported bug, inverted into an assertion. The enchanted copy sits at
+    // index 0 and a plain copy was looted after it, so every legacy picker in
+    // the tree would take index 1.
+    const inv = [enchanted('girdle', 'power'), plain('girdle')];
+    const unit = consumeSelectedInventorySlot(inv, 'girdle', 0);
+    expect(unit).not.toBeNull();
+    expect(unit?.instance).toEqual({ enchantId: 'power' });
+    // and the plain copy is untouched
+    expect(inv).toHaveLength(1);
+    expect(inv[0].instance).toBeUndefined();
+  });
+
+  it('returns undefined (fall back) when no selection is given', () => {
+    const inv = [plain('girdle')];
+    expect(consumeSelectedInventorySlot(inv, 'girdle', undefined)).toBeUndefined();
+    expect(inv, 'a no-selection call must not consume anything itself').toHaveLength(1);
+  });
+
+  it.each([
+    ['out of range', 5],
+    ['negative', -1],
+    ['not an integer', 1.5],
+  ])('returns null (refuse) for an index that is %s', (_label, index) => {
+    const inv = [plain('girdle')];
+    expect(consumeSelectedInventorySlot(inv, 'girdle', index as number)).toBeNull();
+    expect(inv, 'a refused selection consumes nothing').toHaveLength(1);
+  });
+
+  it('refuses when the named slot holds a DIFFERENT item', () => {
+    // The stale-frame case: the client named index 0, but the bag moved and
+    // something else lives there now. Refusing is the point; guessing here is
+    // how you destroy the wrong item.
+    const inv = [plain('boots'), plain('girdle')];
+    expect(consumeSelectedInventorySlot(inv, 'girdle', 0)).toBeNull();
+    expect(inv).toHaveLength(2);
+  });
+
+  it('decrements a stack rather than removing it when more than one remains', () => {
+    const inv = [plain('potion', 3)];
+    const unit = consumeSelectedInventorySlot(inv, 'potion', 0);
+    expect(unit).not.toBeNull();
+    expect(inv[0].count).toBe(2);
+  });
+
+  it('clones the payload when the stack survives, so the consumed unit is not aliased', () => {
+    // Aliasing here would let a later mutation of the bag stack reach through
+    // into the already-consumed unit (the cloneItemInstancePayload contract).
+    const inv = [enchanted('scroll', 'power', 2)];
+    const unit = consumeSelectedInventorySlot(inv, 'scroll', 0);
+    expect(unit?.instance).toEqual({ enchantId: 'power' });
+    expect(unit?.instance).not.toBe(inv[0].instance);
+  });
+});
+
+describe('consumeNewestInventoryUnit: the legacy fallback, unchanged', () => {
+  it('takes the HIGHEST index match, which is the historical behavior', () => {
+    // Pinned deliberately, not aspirationally. Callers no UI can fix reach this
+    // (server/pbe_boost.ts auto-gears by bare id) and the parity goldens drive
+    // equip / discard / sell / use through it, so "improving" it forks the world.
+    const inv = [enchanted('girdle', 'power'), plain('girdle')];
+    const unit = consumeNewestInventoryUnit(inv, 'girdle');
+    expect(unit.instance, 'the newest copy is the plain one here').toBeUndefined();
+    expect(inv).toHaveLength(1);
+    expect(inv[0].instance).toEqual({ enchantId: 'power' });
+  });
+
+  it('returns an empty unit when nothing matches, rather than throwing', () => {
+    const inv = [plain('boots')];
+    expect(consumeNewestInventoryUnit(inv, 'girdle')).toEqual({
+      instance: undefined,
+      craftedRecipeId: undefined,
+    });
+    expect(inv).toHaveLength(1);
+  });
+});
+
+describe('consumeItemCopy: the composed rule every converted surface calls', () => {
+  it('honors a valid selection and reports that it was honored', () => {
+    const inv = [enchanted('girdle', 'power'), plain('girdle')];
+    const out = consumeItemCopy(inv, 'girdle', 0);
+    expect(out.kind).toBe('selected');
+    expect(out.kind === 'selected' && out.unit.instance).toEqual({ enchantId: 'power' });
+  });
+
+  it('refuses an invalid selection instead of falling back to a guess', () => {
+    // The single most important case in this file. Collapsing refuse into
+    // fall-back is precisely the defect: a stale index would destroy or equip
+    // whatever the legacy walk happened to land on.
+    const inv = [plain('girdle')];
+    const out = consumeItemCopy(inv, 'girdle', 9);
+    expect(out.kind).toBe('refused');
+    expect(inv, 'a refusal consumes nothing').toHaveLength(1);
+  });
+
+  it('falls back to the legacy walk for an id-only call, and says so', () => {
+    const inv = [enchanted('girdle', 'power'), plain('girdle')];
+    const out = consumeItemCopy(inv, 'girdle', undefined);
+    expect(out.kind).toBe('fellBack');
+    expect(out.kind === 'fellBack' && out.unit.instance).toBeUndefined();
+  });
+
+  it('selected and fellBack disagree on the same bag, so the modes are distinguishable', () => {
+    // Guards the guard: if both paths picked the same copy this whole file could
+    // pass while the feature did nothing. The fixture is built so they differ.
+    const bag = () => [enchanted('girdle', 'power'), plain('girdle')];
+    const picked = consumeItemCopy(bag(), 'girdle', 0);
+    const guessed = consumeItemCopy(bag(), 'girdle', undefined);
+    const pickedInstance = picked.kind === 'selected' ? picked.unit.instance : null;
+    const guessedInstance = guessed.kind === 'fellBack' ? guessed.unit.instance : null;
+    expect(pickedInstance).toEqual({ enchantId: 'power' });
+    expect(guessedInstance).toBeUndefined();
+  });
+});

--- a/tests/item_copy_ref.test.ts
+++ b/tests/item_copy_ref.test.ts
@@ -15,6 +15,7 @@ import {
   consumeNewestInventoryUnit,
   consumeSelectedInventorySlot,
   itemCopyPin,
+  itemCopyStillPinned,
 } from '../src/sim/item_copy_ref';
 import type { InvSlot } from '../src/sim/types';
 
@@ -133,6 +134,43 @@ describe('consumeNewestInventoryUnit: the legacy fallback, unchanged', () => {
       craftedRecipeId: undefined,
     });
     expect(inv).toHaveLength(1);
+  });
+});
+
+describe('itemCopyStillPinned: surviving a bag that shifts mid-cast', () => {
+  it('holds while the pinned copy stays put', () => {
+    const inv = [enchanted('girdle', 'power'), plain('boots')];
+    expect(itemCopyStillPinned(inv, 0, itemCopyPin(inv[0]))).toBe(true);
+  });
+
+  it('fails when a different copy slides into the pinned index', () => {
+    // The mid-cast hazard, and the reason a bare index is not enough: the player
+    // aimed at their enchanted girdle, then a loot re-ordered the bag. Hitting
+    // whatever now occupies index 0 is worse than the old guess, because the
+    // player believes they chose.
+    const inv = [enchanted('girdle', 'power'), plain('boots')];
+    const pin = itemCopyPin(inv[0]);
+    inv[0] = plain('girdle');
+    expect(itemCopyStillPinned(inv, 0, pin)).toBe(false);
+  });
+
+  it('fails when the bag shrank past the pinned index', () => {
+    const inv = [enchanted('girdle', 'power')];
+    const pin = itemCopyPin(inv[0]);
+    inv.pop();
+    expect(itemCopyStillPinned(inv, 0, pin)).toBe(false);
+  });
+
+  it('passes for an id-only action, which pinned nothing', () => {
+    expect(itemCopyStillPinned([plain('girdle')], undefined, '')).toBe(true);
+  });
+
+  it('survives a partial consume of the pinned stack, which changes only count', () => {
+    // A pin that moved on count would false-refuse after any partial consume.
+    const inv = [enchanted('scroll', 'power', 3)];
+    const pin = itemCopyPin(inv[0]);
+    inv[0].count -= 1;
+    expect(itemCopyStillPinned(inv, 0, pin)).toBe(true);
   });
 });
 

--- a/tests/item_copy_refusal.test.ts
+++ b/tests/item_copy_refusal.test.ts
@@ -1,0 +1,206 @@
+// A REFUSED copy selection must change nothing, on every surface that takes one.
+//
+// The tri-state in src/sim/item_copy_ref.ts says a caller must branch on all three
+// outcomes: consumed, refused, or no-selection-so-fall-back. Collapsing refuse into
+// "nothing consumed, carry on" is not a lesser version of honoring it, it is a
+// different bug, and review found two exploitable instances:
+//
+//   useItem   granted the full effect (heal, cooldown, aura, sit) while the consume
+//             refused, so a frame naming a bad slot yielded free potions, food and
+//             elixirs, repeatable forever. Reachable by an honest client too: the
+//             bags click path sends bagStackIndex(...) unguarded, which is -1 on a
+//             stale click.
+//   equipItem deleted the DISPLACED piece before the consume ran, so a refused
+//             selection destroyed the item being replaced: neither worn nor in bags,
+//             with its stats still applied because recalc never ran.
+//
+// Every case below asserts the same shape: after a refused selection, the bags and
+// the worn set are exactly what they were, and no effect landed. One per surface,
+// because both bugs lived in the arms that had no behavior test.
+
+import { describe, expect, it } from 'vitest';
+import { ITEMS } from '../src/sim/data';
+import { Sim } from '../src/sim/sim';
+import type { EquipSlot, InvSlot, PlayerClass } from '../src/sim/types';
+
+/** An out-of-range index: passes the server's Number.isInteger gate, fails the
+ *  leaf's range check. This is the shape a stale client frame actually sends. */
+const BAD_INDEX = 999;
+
+function makeSim(cls: PlayerClass = 'warrior'): Sim {
+  const sim = new Sim({ seed: 5, playerClass: cls, autoEquip: false });
+  // Strip the starting kit. autoEquip:false does not mean naked, and a pre-worn
+  // chest piece silently invalidated two of these fixtures on the first run.
+  const meta = sim.players.get(sim.playerId);
+  if (meta) {
+    for (const key of Object.keys(meta.equipment) as EquipSlot[]) delete meta.equipment[key];
+    meta.equipmentInstance = {};
+  }
+  return sim;
+}
+
+function metaOf(sim: Sim) {
+  const meta = sim.players.get(sim.playerId);
+  if (!meta) throw new Error('no meta');
+  return meta;
+}
+
+function firstItem(pred: (d: (typeof ITEMS)[string]) => boolean): string {
+  const found = Object.values(ITEMS).find(pred);
+  if (!found) throw new Error('no fixture item');
+  return found.id;
+}
+
+/** A snapshot deep enough to prove "nothing happened". */
+function snapshot(sim: Sim) {
+  const meta = metaOf(sim);
+  return {
+    inventory: JSON.parse(JSON.stringify(meta.inventory)) as InvSlot[],
+    equipment: { ...meta.equipment },
+    equipmentInstance: JSON.parse(JSON.stringify(meta.equipmentInstance ?? {})),
+  };
+}
+
+describe('a refused selection consumes nothing and grants nothing', () => {
+  it('useItem: a potion is neither drunk nor spent', () => {
+    // The exploit, as a test. Before the fix the heal and the cooldown landed while
+    // the potion stayed in the bags.
+    const sim = makeSim();
+    const pid = sim.playerId;
+    const meta = metaOf(sim);
+    const potionId = firstItem((d) => d.kind === 'potion');
+    meta.inventory.length = 0;
+    meta.inventory.push({ itemId: potionId, count: 1 });
+    const player = sim.player;
+    player.hp = Math.max(1, Math.floor(player.maxHp / 2));
+    const hpBefore = player.hp;
+    const before = snapshot(sim);
+    sim.drainEvents();
+
+    sim.useItem(potionId, pid, BAD_INDEX);
+
+    expect(metaOf(sim).inventory, 'the potion is still held').toEqual(before.inventory);
+    expect(sim.player.hp, 'and no heal landed').toBe(hpBefore);
+    expect(sim.player.cooldowns.size, 'and no use cooldown was armed').toBe(0);
+  });
+
+  it('useItem: food does not start the eating sit', () => {
+    const sim = makeSim();
+    const pid = sim.playerId;
+    const meta = metaOf(sim);
+    const foodId = firstItem((d) => d.kind === 'food');
+    meta.inventory.length = 0;
+    meta.inventory.push({ itemId: foodId, count: 1 });
+    const before = snapshot(sim);
+    sim.drainEvents();
+
+    sim.useItem(foodId, pid, BAD_INDEX);
+
+    expect(metaOf(sim).inventory).toEqual(before.inventory);
+    expect(sim.player.sitting, 'the eat sit never began').toBe(false);
+  });
+
+  it('equipItem: the DISPLACED piece survives', () => {
+    // The destructive one. The worn piece was deleted before the consume, so a
+    // refusal left it nowhere at all while its stats stayed applied.
+    const sim = makeSim();
+    const pid = sim.playerId;
+    const meta = metaOf(sim);
+    const chestId = firstItem((d) => d.slot === 'chest' && d.kind === 'armor');
+    const other = Object.values(ITEMS).find(
+      (d) => d.slot === 'chest' && d.kind === 'armor' && d.id !== chestId,
+    );
+    if (!other) throw new Error('need two chest items');
+
+    meta.equipment.chest = chestId;
+    meta.inventory.length = 0;
+    meta.inventory.push({ itemId: other.id, count: 1 });
+    const before = snapshot(sim);
+    sim.drainEvents();
+
+    sim.equipItem(other.id, pid, 'chest' as EquipSlot, BAD_INDEX);
+
+    const after = metaOf(sim);
+    expect(after.equipment.chest, 'the worn piece is still worn').toBe(chestId);
+    expect(after.inventory, 'and the candidate is still in the bags').toEqual(before.inventory);
+  });
+
+  it('equipItem: an empty target slot stays empty', () => {
+    const sim = makeSim();
+    const pid = sim.playerId;
+    const meta = metaOf(sim);
+    const chestId = firstItem((d) => d.slot === 'chest' && d.kind === 'armor');
+    meta.inventory.length = 0;
+    meta.inventory.push({ itemId: chestId, count: 1 });
+    const before = snapshot(sim);
+    sim.drainEvents();
+
+    sim.equipItem(chestId, pid, 'chest' as EquipSlot, BAD_INDEX);
+
+    expect(metaOf(sim).equipment.chest).toBeUndefined();
+    expect(metaOf(sim).inventory).toEqual(before.inventory);
+  });
+
+  it('discardItem: nothing is destroyed', () => {
+    const sim = makeSim();
+    const pid = sim.playerId;
+    const meta = metaOf(sim);
+    const id = firstItem((d) => d.kind === 'junk' || d.kind === 'potion');
+    meta.inventory.length = 0;
+    meta.inventory.push({ itemId: id, count: 1 });
+    const before = snapshot(sim);
+    sim.drainEvents();
+
+    sim.discardItem(id, 1, pid, BAD_INDEX);
+
+    expect(metaOf(sim).inventory).toEqual(before.inventory);
+  });
+
+  it('feedPet: the food survives', () => {
+    const sim = makeSim('hunter' as PlayerClass);
+    const pid = sim.playerId;
+    const meta = metaOf(sim);
+    const foodId = firstItem((d) => d.kind === 'food');
+    meta.inventory.length = 0;
+    meta.inventory.push({ itemId: foodId, count: 1 });
+    const before = snapshot(sim);
+    sim.drainEvents();
+
+    sim.feedPet(foodId, pid, BAD_INDEX);
+
+    expect(metaOf(sim).inventory).toEqual(before.inventory);
+  });
+
+  it('equipBag: the bag survives and no socket is filled', () => {
+    const sim = makeSim();
+    const pid = sim.playerId;
+    const meta = metaOf(sim);
+    const bagId = firstItem((d) => d.kind === 'bag');
+    meta.inventory.length = 0;
+    meta.inventory.push({ itemId: bagId, count: 1 });
+    const before = snapshot(sim);
+    const bagsBefore = [...meta.bags];
+    sim.drainEvents();
+
+    sim.equipBag(bagId, undefined, pid, BAD_INDEX);
+
+    expect(metaOf(sim).inventory).toEqual(before.inventory);
+    expect(metaOf(sim).bags, 'no socket was filled').toEqual(bagsBefore);
+  });
+
+  it('a VALID selection on the same surfaces still works, so the guards are not blanket refusals', () => {
+    // Guards the guards. Every assertion above would also pass if the surfaces
+    // simply stopped functioning.
+    const sim = makeSim();
+    const pid = sim.playerId;
+    const meta = metaOf(sim);
+    const chestId = firstItem((d) => d.slot === 'chest' && d.kind === 'armor');
+    meta.inventory.length = 0;
+    meta.inventory.push({ itemId: chestId, count: 1 });
+    sim.drainEvents();
+
+    sim.equipItem(chestId, pid, 'chest' as EquipSlot, 0);
+    expect(metaOf(sim).equipment.chest, 'index 0 is a valid selection').toBe(chestId);
+    expect(metaOf(sim).inventory.filter((s) => s.itemId === chestId)).toHaveLength(0);
+  });
+});

--- a/tests/salvage_copy_selection.test.ts
+++ b/tests/salvage_copy_selection.test.ts
@@ -1,0 +1,133 @@
+// Salvage consumes the copy the player SELECTED, not a guessed one.
+//
+// The reported symptom: destroying an item takes "the most recent one in your
+// bag" rather than the one you clicked. Salvage was the live case. It sat next to
+// disenchant in the same context menu (`src/ui/bag_item_action_menu.ts`), both
+// irreversible, and disenchant passed the bag index while salvage dropped it:
+//
+//   if (slotIndex === undefined) world.disenchantItem(itemId);
+//   else world.disenchantItem(itemId, { slotIndex });   // precise
+//   } else world.salvageItem(itemId);                   // guessed
+//
+// So the same click destroyed a chosen copy through one row and an arbitrary one
+// through the other. These tests pin all four arms of the fix: a selection is
+// honored, an id-only call keeps its legacy behavior, an invalid selection is
+// refused BEFORE the cast starts, and a bag that shifts mid-cast refuses rather
+// than salvaging whatever slid into the pinned index.
+
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import type { ItemInstancePayload, SimEvent } from '../src/sim/types';
+import { completeEnchantFamilyCast } from './helpers/enchant_family_cast';
+
+/** A salvageable common weapon, the fixture the sibling suites use. */
+const COMMON_WEAPON = 'eastbrook_arming_sword';
+
+function makeSim(): Sim {
+  return new Sim({ seed: 7, playerClass: 'warrior', autoEquip: false });
+}
+
+/** Give the player two copies of one id: an INSTANCED one first, then a plain
+ *  one, so "the copy the player chose" and "the newest copy" are different
+ *  objects. Without this shape every assertion below would be vacuous. */
+function twoCopies(sim: Sim, pid: number): { instancedIndex: number } {
+  const meta = sim.players.get(pid);
+  if (!meta) throw new Error('no meta');
+  meta.inventory.length = 0;
+  meta.inventory.push({
+    itemId: COMMON_WEAPON,
+    count: 1,
+    instance: { enchantId: 'ench_test' } as unknown as ItemInstancePayload,
+  });
+  meta.inventory.push({ itemId: COMMON_WEAPON, count: 1 });
+  return { instancedIndex: 0 };
+}
+
+function salvageResults(events: SimEvent[]) {
+  return events.filter((e): e is Extract<SimEvent, { type: 'salvageResult' }> => {
+    return e.type === 'salvageResult';
+  });
+}
+
+function inventoryOf(sim: Sim, pid: number) {
+  return sim.players.get(pid)?.inventory ?? [];
+}
+
+describe('salvage consumes the selected copy', () => {
+  it('destroys the NAMED slot, leaving the newest copy alone', () => {
+    const sim = makeSim();
+    const pid = sim.playerId;
+    const { instancedIndex } = twoCopies(sim, pid);
+    sim.drainEvents();
+
+    sim.salvageItem(COMMON_WEAPON, pid, instancedIndex);
+    completeEnchantFamilyCast(sim, pid);
+    const results = salvageResults(sim.drainEvents());
+    expect(results).toHaveLength(1);
+    expect(results[0].ok, 'a valid selection salvages').toBe(true);
+
+    // The instanced copy is gone and the plain one survives. Under the old
+    // behavior this was reversed.
+    const left = inventoryOf(sim, pid).filter((s) => s.itemId === COMMON_WEAPON);
+    expect(left).toHaveLength(1);
+    expect(left[0].instance, 'the plain copy is what should remain').toBeUndefined();
+  });
+
+  it('keeps the legacy prefer-plain walk for an id-only call', () => {
+    // Deliberately unchanged. server/pbe_boost.ts and the RL host call by bare
+    // id, and the parity goldens drive this arm, so "improving" it forks the
+    // world. Salvage's legacy rule prefers a PLAIN copy so an instanced one is
+    // never destroyed while an interchangeable shell exists.
+    const sim = makeSim();
+    const pid = sim.playerId;
+    twoCopies(sim, pid);
+    sim.drainEvents();
+
+    sim.salvageItem(COMMON_WEAPON, pid);
+    completeEnchantFamilyCast(sim, pid);
+    expect(salvageResults(sim.drainEvents())[0]?.ok).toBe(true);
+
+    const left = inventoryOf(sim, pid).filter((s) => s.itemId === COMMON_WEAPON);
+    expect(left).toHaveLength(1);
+    expect(left[0].instance, 'the legacy walk spares the instanced copy').toBeDefined();
+  });
+
+  it('refuses an out-of-range selection without starting a cast', () => {
+    // A stale or hand-crafted frame. Refusing beats falling back to a guess:
+    // the player believes they aimed, so guessing destroys the wrong item under
+    // the appearance of a deliberate choice.
+    const sim = makeSim();
+    const pid = sim.playerId;
+    twoCopies(sim, pid);
+    sim.drainEvents();
+
+    sim.salvageItem(COMMON_WEAPON, pid, 99);
+    const results = salvageResults(sim.drainEvents());
+    expect(results).toHaveLength(1);
+    expect(results[0].ok).toBe(false);
+    expect(results[0].reason).toBe('not_held');
+    // Nothing was destroyed and no cast is running.
+    expect(inventoryOf(sim, pid).filter((s) => s.itemId === COMMON_WEAPON)).toHaveLength(2);
+  });
+
+  it('refuses when the bag shifts under the selection mid-cast', () => {
+    // The pin's reason to exist. A bag index is stable only within one tick, so
+    // a loot or a sort during the cast would otherwise redirect the hit.
+    const sim = makeSim();
+    const pid = sim.playerId;
+    const { instancedIndex } = twoCopies(sim, pid);
+    sim.drainEvents();
+
+    sim.salvageItem(COMMON_WEAPON, pid, instancedIndex);
+    // The chosen copy moves away and a DIFFERENT copy takes its index.
+    const inv = inventoryOf(sim, pid);
+    inv[instancedIndex] = { itemId: COMMON_WEAPON, count: 1 };
+    completeEnchantFamilyCast(sim, pid);
+
+    const results = salvageResults(sim.drainEvents());
+    expect(results).toHaveLength(1);
+    expect(results[0].ok, 'a shifted bag must refuse, not salvage the intruder').toBe(false);
+    expect(results[0].reason).toBe('not_held');
+    expect(inventoryOf(sim, pid).filter((s) => s.itemId === COMMON_WEAPON)).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary

Item commands name only an item id, so each one **guesses which copy** to act on. Two copies of one id stopped being interchangeable when the instanced payload landed (#1165): a stack can carry an enchant, a masterwork seal, rolled stats, a signer, or crafting provenance. This gives the family a way to name the copy, and a guard so the next command cannot ship without one.

Reported symptom, from play: destroying an item takes "the most recent one in your bag" rather than the one you clicked.

### The guesses were not even consistent

| Picker | Used by | Rule |
| --- | --- | --- |
| `consumeEquippedInventoryUnit` | equip | newest match wins |
| `removePreferFungible` | discard, sell, trade | plain copies first, then newest |
| `removeItem` | raw callers | newest match wins |

So which copy you lose varied by action, and `equipItem` carried a comment admitting it: *"Deterministic, acceptable for v1, but a future picker UI should not assume the enchanted copy is always favored."*

### This has been patched three times without being fixed

The code names its own history: the phase 12 trade copy-choice fix, the phase 18 widening onto the discard and vendor arms, and the #2398 buyback review. Each added a heuristic **predicate** to bias the guess rather than letting a caller **name** the copy. Nothing stopped the next command shipping id-only, so each new surface re-earned the bug.

### What this does

It turned out to be an **extraction, not an invention**: enchanting already had the mechanism (bag index, plus a pin re-checked mid-cast so a shifted bag refuses), fully generic and merely private to its own file. `src/sim/item_copy_ref.ts` lifts it out. Both halves are **moves**, byte-identical to the private originals, because the parity goldens drive equip, discard, sell and use.

The tri-state is the load-bearing part: a valid selection is honored, an **invalid one is refused**, and only a genuinely id-only call falls back to the legacy walk. Collapsing refuse into fall-back is precisely the defect.

Surfaces given addressing: `salvage_item`, `discard`, `sell`, `equip` (both the plain and the aimed `equipItemToSlot` arm), `equip_bag`, `use`, `pet_feed`, and the three `rift_*` forge actions through their single `riftInventorySlot` choke point.

### Judgement calls worth reviewing

- **Discard and sell honor a selection for a single unit only.** Their bulk arms deliberately span slots (a per-slot count tops out at `stackSize`), and there the prefer-plain walk is the *right* rule anyway, since it spares instanced copies longest.
- **Sell re-checks bound-ness on the named slot.** The existing clamp counts unbound copies in aggregate, which says nothing about whether *this* slot is the bound one; without the extra check a selection could sell the bound copy while the clamp was satisfied elsewhere, reopening the laundering hole the clamp exists to close.
- **`market_list` needs nothing, and was a false positive in my own first list.** It is fungible-only by construction (it refuses unless `countFungibleItem` covers the request) and the instanced path is the separate `market_list_instance`, which already names the copy by payload. It is an exemption with that reason recorded.
- **`equip` sends its bag index as `bagSlot`, not `slot`,** because on that token `slot` already means the equip slot. Every other command has `slot` free. That collision is why the guard records the field per command: `apply_enchant`'s `slot` is an equip slot too, so "the command has a slot field" would have been a vacuous check.

### The fallback stays byte-identical, deliberately

Callers no UI can fix reach it: `server/pbe_boost.ts` auto-gears by bare item id, and the RL host does too. **Parity needed no remint at any step**, which is the standing proof.

## Type of change

- [x] Bug fix
- [x] Refactor (the extraction is a move)
- [x] Tests

## How was this tested?

- `npx vitest run` (full suite): **32600 passed, 0 failed**.
- `node scripts/gate_select.mjs`: **PASS, all 12 steps green**.
- `tests/item_copy_ref.test.ts` (31 cases) drives the leaf directly.
- `tests/salvage_copy_selection.test.ts` pins the four behavioral arms: a selection is honored, an id-only call keeps the legacy walk, an invalid index refuses **before the cast starts**, and a bag that shifts mid-cast refuses rather than salvaging the intruder.
- `tests/item_copy_addressing_guard.test.ts` is the completeness gate. Verified to fail on a regression **both** ways: an unclassified command, and a reverted dispatch arm.

One guard detail worth flagging, since it was nearly a silent hole: the server-side assertion first took a fixed-length window from `case '<cmd>':`, which bleeds into neighbouring arms. Since most of them do parse a selection, it stayed **green with the arm under test reverted**. It now bounds each arm at the next `case '`.

## Two commits are not this branch's code

`44a9533335` formats `src/render/characters/manifest.ts` and prefers `indexOf` in `src/sim/bags.ts`. Both are byte-identical to the `release/v0.36.0` tip; `biome ci --changed` diffs against `main`, so a branch based on release inherits every file that differs between the two. The manifest has now blocked three branches. **Both are worth fixing on the release branch rather than once per PR.**

## Follow-up

A gear-saving talent loadout is the motivating consumer and lands separately. Note for that work: the selection here is a live bag index, valid only within a tick, so a saved loadout needs the durable form (`itemCopyPin` identity resolved to an index at apply time) rather than storing an index.
