### PR TITLE
fix(combat): stop re-scaling white auto-attack damage by weapon speed

### DIFF
--- a/docs/design/frost-fury-rebalance.md
+++ b/docs/design/frost-fury-rebalance.md
@@ -219,6 +219,39 @@ Do not add a Fury-only offhand stat suppression or reduce the generic offhand wh
 after this hotfix. Those approaches duplicate the game-wide item correction and the explicit
 Titan's Grip tradeoff.
 
+### The v0.30.0 white-damage regression, and why the probe is the guard
+
+The hotfix above left `scripts/fury_dps_probe.ts` behind so later changes could be measured
+against its balance point. Nothing ran it for three releases. Re-run on the same fixture, the
+v0.27.1 tree reports 147.2 sustained DPS and the tree three releases later reports 186.3, with
+no warrior content change in between. White damage carried the whole gap.
+
+The cause was a contract mismatch rather than a tuning decision. Item content authors
+`weapon.min/max` as RAW per-swing damage at the weapon's real speed, with the two-hand premium
+already folded in: `item_budget.ts` (`weaponDpsBudget`, `scaleWeaponDamage`) writes it that way
+and `tests/twohand_rebudget.test.ts` pins every two-hander to `avg / speed`. The v0.30.0 swing
+path treated the same numbers as a speed-normalized figure and multiplied the roll again by
+`speed / 2` and `TWOHAND_DPS_MULT`, counting both terms twice.
+
+The decisive measurement is budget neutrality, and it needs no view about intent. Four weapons
+authored at an identical 15.0 dps delivered 12.9 / 15.0 / 22.7 / 25.6 dps at speeds
+1.7 / 2.0 / 3.0 / 3.4. Only the 2.0 baseline came out right, which is what a conversion applied
+to already-converted data looks like. Fast-weapon classes were quietly under budget for the same
+reason two-handers were over it.
+
+Two consequences worth carrying forward:
+
+- A weapon-damage change is a CROSS-CLASS change even when it presents as a warrior problem.
+  This one moved every melee auto-attacker, in both directions, sorted only by weapon speed.
+- Restoring the contract also restored the Titan's Grip tradeoff. While the double-count stood,
+  dual-2H beat dual-1H on white despite carrying the explicit 12 percent physical penalty, so
+  the penalty this document treats as the dual-wield cost was not actually being paid.
+
+The lasting guard is the contract, not the number: `tests/combat_auto_attack.test.ts` now pins
+that equal authored dps delivers equal white dps at any speed, and that the swing path re-applies
+neither the speed term nor `TWOHAND_DPS_MULT`. Run the probe on both trees for any later
+coefficient round, per the change protocol in `docs/design/spell-balance-framework.md`.
+
 ### Fury complexity follow-up
 
 Balance correction and action-bar correction are separate phases. The recurring damage loop can

--- a/docs/design/frost-fury-rebalance.md
+++ b/docs/design/frost-fury-rebalance.md
@@ -224,7 +224,9 @@ Titan's Grip tradeoff.
 The hotfix above left `scripts/fury_dps_probe.ts` behind so later changes could be measured
 against its balance point. Nothing ran it for three releases. Re-run on the same fixture, the
 v0.27.1 tree reports 147.2 sustained DPS and the tree three releases later reports 186.3, with
-no warrior content change in between. White damage carried the whole gap.
+no warrior content change in between. White damage carried the whole gap, and it kept widening
+after that: the same probe on the v0.36.0 tree reports 192.9. Those figures are dated on
+purpose. The drift, not any one of them, is the finding.
 
 The cause was a contract mismatch rather than a tuning decision. Item content authors
 `weapon.min/max` as RAW per-swing damage at the weapon's real speed, with the two-hand premium

--- a/src/sim/combat/auto_attack.ts
+++ b/src/sim/combat/auto_attack.ts
@@ -27,9 +27,7 @@
 // `src/sim`-pure: no DOM/Three, no Math.random/Date.now; all randomness is the shared
 // `ctx.rng` stream, drawn in the exact pre-move positions.
 
-import { CLASSES, ITEMS, isArenaPos, MOBS } from '../data';
-import { weaponHand } from '../equipment_rules';
-import { TWOHAND_DPS_MULT } from '../item_budget';
+import { CLASSES, isArenaPos, MOBS } from '../data';
 import { forceDismount } from '../mounts';
 import { scheduleProjectile } from '../projectile_travel';
 import type { PlayerMeta } from '../sim';
@@ -49,7 +47,6 @@ import {
   normAngle,
   STANCE_MASTERY_BERSERKER_HASTE,
   swingMissChance,
-  type WeaponHand,
   type WeaponInfo,
 } from '../types';
 import { drawWeapon } from '../weapon_stow';
@@ -74,22 +71,27 @@ const RANGED_WEAPON_COEFF = 0.6;
 const DUAL_WIELD_WHITE_MISS_PENALTY = 0.1;
 const SUDDEN_DEATH_CHANCE = 0.1;
 const SUDDEN_DEATH_DURATION = 10;
-const ONE_HAND_AUTO_ATTACK_BASE_SPEED = 2;
 const OFFHAND_AUTO_ATTACK_DMG_MULT = 0.5;
 
-type AutoAttackHand = Extract<WeaponHand, 'onehand' | 'twohand'> | 'offhand';
+// WEAPON DAMAGE CONTRACT: `weapon.min/max` is RAW per-swing damage at the weapon's
+// real speed, with the two-hand premium already folded in by itemization. A weapon's
+// power level is `avg / speed`, which is exactly how `item_budget.ts`
+// (`weaponDpsBudget`, `scaleWeaponDamage`) authors it and how
+// `tests/twohand_rebudget.test.ts` pins every two-hander to the curve. A slow weapon
+// therefore ALREADY hits harder per swing, because the author wrote a bigger number.
+//
+// So the swing path must NOT re-derive that. v0.30.0 briefly multiplied the roll by
+// `speed / 2 * TWOHAND_DPS_MULT`, treating min/max as a speed-normalized figure. That
+// double-counted both terms: four weapons authored at an identical 15.0 dps delivered
+// 12.9 / 15.0 / 22.7 / 25.6 dps at speeds 1.7 / 2.0 / 3.0 / 3.4 (only the 2.0 baseline
+// came out right, the signature of a conversion applied to already-converted data), and
+// it silently moved sustained Fury from 147.2 to 186.3 on `scripts/fury_dps_probe.ts`
+// with no warrior change in between. The offhand's classic 50% penalty is the one
+// genuine swing-time adjustment and stays here.
+type AutoAttackHand = 'mainhand' | 'offhand';
 
-function autoAttackWeaponDamageMult(hand: AutoAttackHand, speed: number): number {
-  const speedMult = Math.max(0.1, speed) / ONE_HAND_AUTO_ATTACK_BASE_SPEED;
-  const handMult = hand === 'twohand' ? TWOHAND_DPS_MULT : 1;
-  const offhandMult = hand === 'offhand' ? OFFHAND_AUTO_ATTACK_DMG_MULT : 1;
-  return speedMult * handMult * offhandMult;
-}
-
-function mainhandAutoAttackHand(attacker: Entity): AutoAttackHand {
-  const item = attacker.mainhandItemId ? ITEMS[attacker.mainhandItemId] : undefined;
-  if (item?.kind !== 'weapon') return 'onehand';
-  return weaponHand(item) === 'twohand' ? 'twohand' : 'onehand';
+function autoAttackWeaponDamageMult(hand: AutoAttackHand): number {
+  return hand === 'offhand' ? OFFHAND_AUTO_ATTACK_DMG_MULT : 1;
 }
 
 export function startAutoAttack(ctx: SimContext, pid?: number): void {
@@ -422,7 +424,7 @@ export function meleeSwing(
     cannotBeDodged?: boolean;
     weapon?: WeaponInfo;
     weaponMult?: number;
-    autoAttackHand?: AutoAttackHand | 'mainhand';
+    autoAttackHand?: AutoAttackHand;
     apSwingSpeed?: number;
     threatFlat?: number;
     threatMult?: number;
@@ -499,10 +501,8 @@ export function meleeSwing(
   }
   const mult = opts.weaponMult ?? 1;
   const weapon = opts.weapon ?? attacker.weapon;
-  const autoAttackHand =
-    opts.autoAttackHand === 'mainhand' ? mainhandAutoAttackHand(attacker) : opts.autoAttackHand;
   const weaponRollMult =
-    autoAttackHand === undefined ? 1 : autoAttackWeaponDamageMult(autoAttackHand, weapon.speed);
+    opts.autoAttackHand === undefined ? 1 : autoAttackWeaponDamageMult(opts.autoAttackHand);
   const apSwingSpeed = opts.apSwingSpeed ?? baseSwingSpeed(attacker);
   // weapon imbues (seals, rockbiter) add flat damage to every swing
   let imbueBonus = 0;

--- a/tests/combat_auto_attack.test.ts
+++ b/tests/combat_auto_attack.test.ts
@@ -125,64 +125,78 @@ describe('auto_attack meleeSwing: the white-hit table', () => {
     );
   });
 
-  it('slow one-hand auto attacks hit harder per swing than fast one-hand attacks at the same weapon damage budget', () => {
-    const hitWithSpeed = (speed: number): number => {
-      const { sim, p } = makeSim('warrior', 12);
-      const mob = spawnDummy(sim, p, 1);
-      p.attackPower = 0;
-      p.critChance = 0;
-      mob.stats = { ...mob.stats, armor: 0 };
-      sim.rng.next = () => 0.9; // clears miss/dodge/parry/block and crit; fixed weapon roll
-      const events = capture(sim);
+  // WEAPON DAMAGE CONTRACT (see the header comment on autoAttackWeaponDamageMult).
+  // `weapon.min/max` is RAW per-swing damage at the weapon's real speed, with the
+  // two-hand premium already folded in by itemization, so a weapon's power level is
+  // `avg / speed`. The swing path must pass that roll through untouched: re-deriving
+  // it from speed (or re-applying TWOHAND_DPS_MULT) double-counts what the item author
+  // already wrote and silently rebudgets every slow weapon in the game.
+  const swingRoll = (
+    weapon: { min: number; max: number; speed: number },
+    autoAttackHand?: 'mainhand' | 'offhand',
+  ): number => {
+    const { sim, p } = makeSim('warrior', 12);
+    const mob = spawnDummy(sim, p, 1);
+    p.attackPower = 0; // isolate the WEAPON term; AP is a separate, speed-normalized term
+    p.critChance = 0;
+    mob.stats = { ...mob.stats, armor: 0 };
+    sim.rng.next = () => 0.9; // clears miss/dodge/parry/block and crit; fixed weapon roll
+    const events = capture(sim);
 
-      const connected = meleeSwing(sim.ctx, p, mob, 0, null, {
-        cannotBeDodged: true,
-        weapon: { min: 20, max: 20, speed },
-        autoAttackHand: 'onehand',
-      });
+    const connected = meleeSwing(sim.ctx, p, mob, 0, null, {
+      cannotBeDodged: true,
+      weapon,
+      autoAttackHand,
+    });
 
-      expect(connected).toBe(true);
-      const hit = events.find(
-        (e): e is DamageEvent => isDamageEvent(e) && e.kind === 'hit' && e.sourceId === p.id,
-      );
-      expect(hit?.amount).toBeGreaterThan(0);
-      return hit?.amount ?? 0;
-    };
+    expect(connected).toBe(true);
+    const hit = events.find(
+      (e): e is DamageEvent => isDamageEvent(e) && e.kind === 'hit' && e.sourceId === p.id,
+    );
+    expect(hit?.amount).toBeGreaterThan(0);
+    return hit?.amount ?? 0;
+  };
 
-    const fast = hitWithSpeed(1);
-    const slow = hitWithSpeed(3);
-    expect(slow).toBeGreaterThan(fast);
-    expect({ fast, slow }).toEqual({ fast: 10, slow: 30 });
+  it('an auto attack deals the weapon roll as authored, never re-scaled by swing speed', () => {
+    // Same authored roll at three speeds: the per-swing damage must not move, because
+    // the slow weapon's bigger hit is expressed by the author writing a bigger min/max.
+    const fast = swingRoll({ min: 20, max: 20, speed: 1.7 }, 'mainhand');
+    const base = swingRoll({ min: 20, max: 20, speed: 2 }, 'mainhand');
+    const slow = swingRoll({ min: 20, max: 20, speed: 3.4 }, 'mainhand');
+    expect({ fast, base, slow }).toEqual({ fast: 20, base: 20, slow: 20 });
   });
 
-  it('a comparable two-hand auto attack hits harder per swing than a one-hand auto attack', () => {
-    const hitWithHand = (autoAttackHand: 'onehand' | 'twohand'): number => {
-      const { sim, p } = makeSim('warrior', 12);
-      const mob = spawnDummy(sim, p, 1);
-      p.attackPower = 0;
-      p.critChance = 0;
-      mob.stats = { ...mob.stats, armor: 0 };
-      sim.rng.next = () => 0.9; // clears miss/dodge/parry/block and crit; fixed weapon roll
-      const events = capture(sim);
+  it('two weapons authored at the same dps deliver the same white dps at any speed', () => {
+    // The decisive budget-neutrality check. Three weapons all authored at 20.0 dps
+    // (avg / speed; the rolls are whole numbers at every speed so swing rounding
+    // cannot mask a regression). Per-swing damage differs, but damage-per-second must
+    // not: before this fix the same three delivered 17.0 / 20.0 / 34.0 dps.
+    const dpsOf = (min: number, max: number, speed: number): number =>
+      swingRoll({ min, max, speed }, 'mainhand') / speed;
+    expect(dpsOf(34, 34, 1.7)).toBeCloseTo(20, 5);
+    expect(dpsOf(40, 40, 2)).toBeCloseTo(20, 5);
+    expect(dpsOf(68, 68, 3.4)).toBeCloseTo(20, 5);
+  });
 
-      const connected = meleeSwing(sim.ctx, p, mob, 0, null, {
-        cannotBeDodged: true,
-        weapon: { min: 20, max: 20, speed: 2 },
-        autoAttackHand,
-      });
+  it('a two-hander does not re-apply the itemization two-hand premium at swing time', () => {
+    // TWOHAND_DPS_MULT is an ITEMIZATION constant: heroic_loot.ts already bakes it into
+    // the authored min/max (weaponDpsBudget(33) = 16.6 x TWOHAND_DPS_MULT -> 19.1 dps).
+    // Importing it into the swing path applied it a second time.
+    const twoHanderRoll = swingRoll({ min: 52, max: 78, speed: 3.4 }, 'mainhand');
+    // rng 0.9 over [52, 78] lands at 75; a re-applied 1.15 premium would read 86.
+    expect(twoHanderRoll).toBe(75);
+  });
 
-      expect(connected).toBe(true);
-      const hit = events.find(
-        (e): e is DamageEvent => isDamageEvent(e) && e.kind === 'hit' && e.sourceId === p.id,
-      );
-      expect(hit?.amount).toBeGreaterThan(0);
-      return hit?.amount ?? 0;
-    };
+  it('an offhand auto attack deals half the weapon roll, the one real swing-time cut', () => {
+    const main = swingRoll({ min: 20, max: 20, speed: 2 }, 'mainhand');
+    const off = swingRoll({ min: 20, max: 20, speed: 2 }, 'offhand');
+    expect({ main, off }).toEqual({ main: 20, off: 10 });
+  });
 
-    const oneHand = hitWithHand('onehand');
-    const twoHand = hitWithHand('twohand');
-    expect(twoHand).toBeGreaterThan(oneHand);
-    expect({ oneHand, twoHand }).toEqual({ oneHand: 20, twoHand: 23 });
+  it('an ability weaponStrike (no autoAttackHand) is untouched by the offhand cut', () => {
+    // Abilities resolve through the same shell but pass no hand, so they must read the
+    // raw roll: the fix is scoped to white auto-attacks only.
+    expect(swingRoll({ min: 20, max: 20, speed: 3.4 })).toBe(20);
   });
 
   it('a 100% blind forces a miss: returns false, emits a miss, deals no damage', () => {

--- a/tests/parity/golden/c5_auto_attack.json
+++ b/tests/parity/golden/c5_auto_attack.json
@@ -35,8 +35,8 @@
       "tick": 5,
       "time": 0.25,
       "nextId": 973,
-      "state": "985c1ba7",
-      "events": "d5461ac8",
+      "state": "9d88e5f3",
+      "events": "a2b8adf5",
       "rng": {
         "draws": 22,
         "digest": "8306128b"
@@ -46,7 +46,7 @@
       "tick": 10,
       "time": 0.5,
       "nextId": 973,
-      "state": "801c629a",
+      "state": "0aa885d0",
       "events": "741638a5",
       "rng": {
         "draws": 22,
@@ -57,7 +57,7 @@
       "tick": 15,
       "time": 0.75,
       "nextId": 973,
-      "state": "34e70efe",
+      "state": "6a0acb82",
       "events": "0ad26cee",
       "rng": {
         "draws": 25,
@@ -68,7 +68,7 @@
       "tick": 20,
       "time": 1,
       "nextId": 973,
-      "state": "94fa92d7",
+      "state": "f5cdc229",
       "events": "78c49920",
       "rng": {
         "draws": 28,
@@ -79,7 +79,7 @@
       "tick": 25,
       "time": 1.25,
       "nextId": 973,
-      "state": "e33d6e01",
+      "state": "9ade06bd",
       "events": "229958b6",
       "rng": {
         "draws": 28,
@@ -90,7 +90,7 @@
       "tick": 30,
       "time": 1.5,
       "nextId": 973,
-      "state": "416f9334",
+      "state": "d77bd6d2",
       "events": "741638a5",
       "rng": {
         "draws": 28,
@@ -101,7 +101,7 @@
       "tick": 35,
       "time": 1.75,
       "nextId": 973,
-      "state": "ddd4d81c",
+      "state": "c8c1e3e4",
       "events": "229958b6",
       "rng": {
         "draws": 28,
@@ -112,7 +112,7 @@
       "tick": 40,
       "time": 2,
       "nextId": 973,
-      "state": "c01bb095",
+      "state": "46de0a6b",
       "events": "8611d25f",
       "rng": {
         "draws": 32,
@@ -123,8 +123,8 @@
       "tick": 45,
       "time": 2.25,
       "nextId": 973,
-      "state": "dc51f439",
-      "events": "761869de",
+      "state": "68caaacb",
+      "events": "03b288e3",
       "rng": {
         "draws": 81,
         "digest": "b91e3b38"
@@ -134,7 +134,7 @@
       "tick": 50,
       "time": 2.5,
       "nextId": 973,
-      "state": "199b89a8",
+      "state": "9e1acdd2",
       "events": "0ed959a7",
       "rng": {
         "draws": 124,
@@ -145,7 +145,7 @@
       "tick": 55,
       "time": 2.75,
       "nextId": 973,
-      "state": "e59797ce",
+      "state": "3693d518",
       "events": "229958b6",
       "rng": {
         "draws": 154,
@@ -156,7 +156,7 @@
       "tick": 60,
       "time": 3,
       "nextId": 973,
-      "state": "8b1acae1",
+      "state": "cb83484f",
       "events": "cb1bcb37",
       "rng": {
         "draws": 197,
@@ -167,7 +167,7 @@
       "tick": 65,
       "time": 3.25,
       "nextId": 973,
-      "state": "8875da28",
+      "state": "a9317ba6",
       "events": "229958b6",
       "rng": {
         "draws": 238,
@@ -178,7 +178,7 @@
       "tick": 70,
       "time": 3.5,
       "nextId": 973,
-      "state": "1ea77c7d",
+      "state": "e9be9027",
       "events": "741638a5",
       "rng": {
         "draws": 268,
@@ -189,7 +189,7 @@
       "tick": 75,
       "time": 3.75,
       "nextId": 973,
-      "state": "79c4b4e5",
+      "state": "46841053",
       "events": "9350396f",
       "rng": {
         "draws": 312,
@@ -200,7 +200,7 @@
       "tick": 80,
       "time": 4,
       "nextId": 973,
-      "state": "328f69d4",
+      "state": "249f9e5a",
       "events": "741638a5",
       "rng": {
         "draws": 356,
@@ -211,7 +211,7 @@
       "tick": 85,
       "time": 4.25,
       "nextId": 973,
-      "state": "e4de2434",
+      "state": "de91deb0",
       "events": "f7e38afc",
       "rng": {
         "draws": 414,
@@ -222,7 +222,7 @@
       "tick": 90,
       "time": 4.5,
       "nextId": 973,
-      "state": "fd77d6e9",
+      "state": "cf79c369",
       "events": "06dc01d0",
       "rng": {
         "draws": 466,
@@ -233,7 +233,7 @@
       "tick": 95,
       "time": 4.75,
       "nextId": 973,
-      "state": "090d9440",
+      "state": "7d45c914",
       "events": "dc891227",
       "rng": {
         "draws": 513,
@@ -244,7 +244,7 @@
       "tick": 100,
       "time": 5,
       "nextId": 973,
-      "state": "8652dfed",
+      "state": "78be6685",
       "events": "741638a5",
       "rng": {
         "draws": 559,
@@ -255,7 +255,7 @@
       "tick": 105,
       "time": 5.25,
       "nextId": 973,
-      "state": "5580d158",
+      "state": "cdc1ed88",
       "events": "4c508c28",
       "rng": {
         "draws": 619,
@@ -266,7 +266,7 @@
       "tick": 110,
       "time": 5.5,
       "nextId": 973,
-      "state": "9ddd0ced",
+      "state": "3fa16391",
       "events": "c995eea6",
       "rng": {
         "draws": 675,
@@ -277,7 +277,7 @@
       "tick": 115,
       "time": 5.75,
       "nextId": 973,
-      "state": "bf4d29b6",
+      "state": "9ba90b4a",
       "events": "229958b6",
       "rng": {
         "draws": 723,
@@ -288,7 +288,7 @@
       "tick": 120,
       "time": 6,
       "nextId": 973,
-      "state": "a9a7faa1",
+      "state": "aa5ae555",
       "events": "e8a71188",
       "rng": {
         "draws": 798,
@@ -299,7 +299,7 @@
       "tick": 120,
       "time": 6,
       "nextId": 973,
-      "state": "a9a7faa1",
+      "state": "aa5ae555",
       "events": "741638a5",
       "rng": {
         "draws": 798,
@@ -400,13 +400,13 @@
           "cls": "rogue",
           "companionUpgrades": {},
           "counters": {
-            "damageDealt": 71,
+            "damageDealt": 72,
             "damageTaken": 19
           },
           "craftSkills": {},
           "deedStats": {
             "counters": {
-              "damageDealt": 71
+              "damageDealt": 72
             },
             "dungeonClears": {},
             "itemsDiscovered": [
@@ -476,13 +476,13 @@
           "cls": "hunter",
           "companionUpgrades": {},
           "counters": {
-            "damageDealt": 74,
+            "damageDealt": 73,
             "damageTaken": 28
           },
           "craftSkills": {},
           "deedStats": {
             "counters": {
-              "damageDealt": 74
+              "damageDealt": 73
             },
             "dungeonClears": {},
             "itemsDiscovered": [
@@ -1075,7 +1075,7 @@
           "fallStartY": -2.998379,
           "fiveSecondRule": 99,
           "hostile": true,
-          "hp": 499929,
+          "hp": 499928,
           "id": 969,
           "inCombat": true,
           "kind": "mob",
@@ -1111,7 +1111,7 @@
           "threat": [
             [
               964,
-              73
+              74
             ]
           ],
           "weapon": {
@@ -1132,7 +1132,7 @@
           "fallStartY": -2.954371,
           "fiveSecondRule": 99,
           "hostile": true,
-          "hp": 499926,
+          "hp": 499927,
           "id": 970,
           "inCombat": true,
           "kind": "mob",
@@ -1165,7 +1165,7 @@
           "threat": [
             [
               965,
-              76
+              75
             ]
           ],
           "weapon": {
@@ -1304,7 +1304,7 @@
       "tick": 125,
       "time": 6.25,
       "nextId": 973,
-      "state": "3c1a7cb1",
+      "state": "af6ee001",
       "events": "f71fdd5e",
       "rng": {
         "draws": 852,
@@ -1315,7 +1315,7 @@
       "tick": 126,
       "time": 6.3,
       "nextId": 973,
-      "state": "bc341aab",
+      "state": "8a1055e3",
       "events": "741638a5",
       "rng": {
         "draws": 863,
@@ -1416,13 +1416,13 @@
           "cls": "rogue",
           "companionUpgrades": {},
           "counters": {
-            "damageDealt": 71,
+            "damageDealt": 72,
             "damageTaken": 19
           },
           "craftSkills": {},
           "deedStats": {
             "counters": {
-              "damageDealt": 71
+              "damageDealt": 72
             },
             "dungeonClears": {},
             "itemsDiscovered": [
@@ -1492,13 +1492,13 @@
           "cls": "hunter",
           "companionUpgrades": {},
           "counters": {
-            "damageDealt": 74,
+            "damageDealt": 73,
             "damageTaken": 28
           },
           "craftSkills": {},
           "deedStats": {
             "counters": {
-              "damageDealt": 74
+              "damageDealt": 73
             },
             "dungeonClears": {},
             "itemsDiscovered": [
@@ -2082,7 +2082,7 @@
           "fallStartY": -2.998379,
           "fiveSecondRule": 99,
           "hostile": true,
-          "hp": 499929,
+          "hp": 499928,
           "id": 969,
           "inCombat": true,
           "kind": "mob",
@@ -2118,7 +2118,7 @@
           "threat": [
             [
               964,
-              73
+              74
             ]
           ],
           "weapon": {
@@ -2139,7 +2139,7 @@
           "fallStartY": -2.954371,
           "fiveSecondRule": 99,
           "hostile": true,
-          "hp": 499926,
+          "hp": 499927,
           "id": 970,
           "inCombat": true,
           "kind": "mob",
@@ -2172,7 +2172,7 @@
           "threat": [
             [
               965,
-              76
+              75
             ]
           ],
           "weapon": {
@@ -2311,7 +2311,7 @@
       "tick": 126,
       "time": 6.3,
       "nextId": 973,
-      "state": "bc341aab",
+      "state": "8a1055e3",
       "events": "741638a5",
       "rng": {
         "draws": 863,
@@ -2412,13 +2412,13 @@
           "cls": "rogue",
           "companionUpgrades": {},
           "counters": {
-            "damageDealt": 71,
+            "damageDealt": 72,
             "damageTaken": 19
           },
           "craftSkills": {},
           "deedStats": {
             "counters": {
-              "damageDealt": 71
+              "damageDealt": 72
             },
             "dungeonClears": {},
             "itemsDiscovered": [
@@ -2488,13 +2488,13 @@
           "cls": "hunter",
           "companionUpgrades": {},
           "counters": {
-            "damageDealt": 74,
+            "damageDealt": 73,
             "damageTaken": 28
           },
           "craftSkills": {},
           "deedStats": {
             "counters": {
-              "damageDealt": 74
+              "damageDealt": 73
             },
             "dungeonClears": {},
             "itemsDiscovered": [
@@ -3078,7 +3078,7 @@
           "fallStartY": -2.998379,
           "fiveSecondRule": 99,
           "hostile": true,
-          "hp": 499929,
+          "hp": 499928,
           "id": 969,
           "inCombat": true,
           "kind": "mob",
@@ -3114,7 +3114,7 @@
           "threat": [
             [
               964,
-              73
+              74
             ]
           ],
           "weapon": {
@@ -3135,7 +3135,7 @@
           "fallStartY": -2.954371,
           "fiveSecondRule": 99,
           "hostile": true,
-          "hp": 499926,
+          "hp": 499927,
           "id": 970,
           "inCombat": true,
           "kind": "mob",
@@ -3168,7 +3168,7 @@
           "threat": [
             [
               965,
-              76
+              75
             ]
           ],
           "weapon": {

--- a/tests/parity/golden/solo_rogue.json
+++ b/tests/parity/golden/solo_rogue.json
@@ -142,8 +142,8 @@
       "tick": 20,
       "time": 1,
       "nextId": 965,
-      "state": "160c639a",
-      "events": "f4d55994",
+      "state": "a4c353da",
+      "events": "3fe6dc1f",
       "rng": {
         "draws": 12,
         "digest": "f30c489f"
@@ -153,8 +153,8 @@
       "tick": 40,
       "time": 2,
       "nextId": 965,
-      "state": "fe5faa25",
-      "events": "89d55a68",
+      "state": "65b83851",
+      "events": "5c406f5f",
       "rng": {
         "draws": 19,
         "digest": "d68c35cb"
@@ -164,7 +164,7 @@
       "tick": 60,
       "time": 3,
       "nextId": 965,
-      "state": "0eb126e2",
+      "state": "7347d08e",
       "events": "8c849a9d",
       "rng": {
         "draws": 162,
@@ -175,7 +175,7 @@
       "tick": 72,
       "time": 3.6,
       "nextId": 965,
-      "state": "058a63ba",
+      "state": "885addc6",
       "events": "741638a5",
       "rng": {
         "draws": 249,
@@ -200,14 +200,14 @@
           "cls": "rogue",
           "companionUpgrades": {},
           "counters": {
-            "damageDealt": 104,
+            "damageDealt": 106,
             "damageTaken": 8
           },
           "craftSkills": {},
           "deedStats": {
             "counters": {
               "crits": 1,
-              "damageDealt": 104
+              "damageDealt": 106
             },
             "dungeonClears": {},
             "itemsDiscovered": [
@@ -340,7 +340,7 @@
           "fallStartY": 1.5,
           "fiveSecondRule": 99,
           "hostile": true,
-          "hp": 8896,
+          "hp": 8894,
           "id": 964,
           "inCombat": true,
           "kind": "mob",
@@ -377,7 +377,7 @@
           "threat": [
             [
               959,
-              105
+              107
             ]
           ],
           "weapon": {


### PR DESCRIPTION
## Summary

White auto-attack damage is re-scaled by weapon speed at swing time, on top of item
content that already bakes speed into the numbers. The result is that a weapon's
authored dps is not the dps it delivers, and the error is proportional to how far the
weapon's speed sits from 2.0.

The codebase disagrees with itself about what `weapon.min/max` means. Item content
authors it as RAW per-swing damage at the weapon's real speed, with the two-hand
premium already folded in: `item_budget.ts` (`weaponDpsBudget`, `scaleWeaponDamage`)
writes it that way, `tests/twohand_rebudget.test.ts` pins every two-hander to
`avg / speed`, and the raid two-hander's own comment shows its math
(`weaponDpsBudget(33) = 16.6 x TWOHAND_DPS_MULT -> 19.1 dps`). The v0.30.0 swing path
treats the same numbers as a speed-normalized figure and multiplies the roll again by
`speed / 2` and `TWOHAND_DPS_MULT`, counting both terms twice.

The decisive check is budget neutrality, and it needs no view about intent. Four
weapons authored at an identical 15.0 dps delivered:

| Weapon speed | Authored dps | Delivered (before) |
|---|---|---|
| 1.7 | 15.0 | 12.9 |
| **2.0** | 15.0 | **15.0** |
| 3.0 | 15.0 | 22.7 |
| 3.4 | 15.0 | 25.6 |

Only the 2.0 baseline came out right, which is what a conversion applied to
already-converted data looks like.

This is framed as resolving the contract mismatch rather than reverting a change: if
the intended model is the normalized one, the fix is to re-author every weapon's
min/max and change `scaleWeaponDamage` and the itemization test, which is a much
larger change and still would not justify applying `TWOHAND_DPS_MULT` twice.

The offhand's classic 50% cut is the one genuine swing-time adjustment and stays,
applied to the weapon roll.

## Scope: this is a CROSS-CLASS change

It presents as a warrior problem and is not one. White dps by archetype:

| Setup | Before | After |
|---|---|---|
| Fury dual 2H (Titan's Grip) | 70.0 | 48.7 |
| Arms single 2H | 56.2 | 35.1 |
| Prot 1H + shield | 30.7 | 26.0 |
| Fury dual 1H | 50.1 | 43.2 |
| Rogue dual daggers (1.7) | 41.1 | **44.4** |
| Hunter melee 1H (1.8) | 28.2 | **30.0** |

Fast-weapon users were quietly UNDER budget for the same reason two-handers were over
it, and they gain here. Restoring the contract also restores the Titan's Grip
tradeoff, which the double-count had been paying off: while it stood, dual-2H beat
dual-1H on white despite carrying the explicit 12 percent physical penalty.

The fix touches melee white swings only. Ability `weaponStrike` damage, hunter Auto
Shot and caster wands all leave the multiplier at 1 and are untouched, pinned by a
test.

## Measured effect on Fury

`scripts/fury_dps_probe.ts`, same fixture both sides, measured on this PR's base:

| | `release/v0.36.0` | This branch |
|---|---|---|
| Sustained Fury DPS | 192.9 | **157.0** (-18.6%) |
| Red Harvests / min | 9.8 | **7.3** |

7.3/min is exactly the number the v0.27.1 hotfix landed on, so the white correction
alone reaches the cast-rate target without any ability coefficient change.

Where the drop comes from, by source:

| Source | Drop | As points of the whole kit |
|---|---|---|
| white (autos) | -30.2% | **13.0** |
| Red Harvest | -17.8% | 4.8 (fewer casts, not weaker) |
| Bloodletting | -9.4% | 0.8 |
| Twinstrike | -0.7% | 0.1 |

White is 42.9% of Fury's damage on base, the single largest source, which is why the
correction moves the total as much as it does. The Red Harvest drop is entirely cast
count through the rage economy, not a coefficient change.

## Related issues

Extracted from #3117, which is closed in favour of this PR and the warrior kit changes
that rode alongside it.

## Type of change

- [x] Bug fix
- [x] Tests
- [x] Documentation

## How was this tested?

- Commands: `npx vitest run tests/combat_auto_attack.test.ts`, `npx vitest run tests/parity`,
  `node scripts/gate_select.mjs`, `npx tsc --noEmit`, `npx tsx scripts/fury_dps_probe.ts`
  on both trees.
- **The lasting guard is the CONTRACT, not the numbers.** `tests/combat_auto_attack.test.ts`
  pins that equal authored dps delivers equal white dps at any speed, that a two-hander does
  not re-apply `TWOHAND_DPS_MULT` at swing time, that the offhand takes the one real cut,
  and that abilities are unaffected. A numbers-only test would have to be reminted by the
  next tuning round and would stop guarding anything.
- Parity: `solo_rogue` and `c5_auto_attack`, the two traces that carry melee white swings and the same two v0.30.0 reminted when it introduced the double-count. The other nine goldens are byte-identical, which is itself the scope check: no trace without a melee auto-attacker moves.

## Screenshots / recordings

N/A. No rendered surface changes; the effect is damage numbers, covered by the tables
above and by the pinned contract test.

---

## Checklist

### Quality

- [x] **The gate passes.** `node scripts/gate_select.mjs` is green, all 12 steps, on this branch. The one commit added after that run is documentation only.

### Cross-platform

- [x] N/A. Sim-only change, identical on all three hosts by construction.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not
      enabled in any production path.
- [x] I didn't hand-edit generated files. The parity goldens were reminted with
      `UPDATE_PARITY=1`, which is their owning build step.
