### PR TITLE
perf(malware-scan): skip the local Turborepo cache directory

### DIFF
--- a/scripts/malware_scan.mjs
+++ b/scripts/malware_scan.mjs
@@ -64,6 +64,8 @@ const SKIP_DIRS = new Set([
   // number of worktrees present and throwing the same self-matching false
   // positives the agent worktree dirs below are skipped for.
   '.worktrees',
+  // Turborepo local task-cache directory (gitignored, never source), same rationale as .venv.
+  '.turbo',
 ]);
 
 // Root-relative directory paths (POSIX-normalized) we never descend into, while

--- a/tests/malware_scan.test.ts
+++ b/tests/malware_scan.test.ts
@@ -502,6 +502,9 @@ describe('malware_scan: agent instructions and worktree copies', () => {
     );
     write('.worktrees/wt-z/server/auth.ts', 'const kp = Keypair.fromSecretKey(bytes);');
     write('nested/pkg/.worktrees/wt-n/server/auth.ts', 'const kp = Keypair.fromSecretKey(bytes);');
+    // Turborepo's local task-cache directory (gitignored, never source): same
+    // basename-at-any-depth SKIP_DIRS treatment as .worktrees above.
+    write('.turbo/cache/payload.mjs', 'await token.approve(spender, ethers.constants.MaxUint256);');
     return { root, cleanup: () => fs.rmSync(root, { recursive: true, force: true }) };
   }
 
@@ -516,6 +519,7 @@ describe('malware_scan: agent instructions and worktree copies', () => {
       expect(rels.some((r) => r.startsWith('.claude/worktrees/'))).toBe(false);
       expect(rels.some((r) => r.startsWith('.codex/worktrees/'))).toBe(false);
       expect(rels.some((r) => r.includes('.worktrees/'))).toBe(false);
+      expect(rels.some((r) => r.startsWith('.turbo/'))).toBe(false);
       expect(rels).toContain('.claude/agents/notes.md');
       expect(rels).toContain('.agents/skills/notes/SKILL.md');
       expect(rels).toContain('.agents/skills/notes/agents/openai.yaml');
@@ -536,6 +540,18 @@ describe('malware_scan: agent instructions and worktree copies', () => {
         /\/(\.claude|\.codex)\/worktrees\/|\/\.worktrees\//.test(posix(f.file)),
       );
       expect(fromWorktree).toEqual([]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('does not flag HIGH planted signatures inside the local Turborepo cache', () => {
+    const { root, cleanup } = buildFixture();
+    try {
+      const fromTurboCache = (scanTree(root) as Array<{ file: string }>).filter((f) =>
+        /\/\.turbo\//.test(posix(f.file)),
+      );
+      expect(fromTurboCache).toEqual([]);
     } finally {
       cleanup();
     }


### PR DESCRIPTION
## Summary

`scripts/malware_scan.mjs`'s `SKIP_DIRS` set (`scripts/malware_scan.mjs:41`) already
excludes other gitignored, local-only tooling directories that are never repository
source: `.vite`, `.cache`, `.venv`, `.chrome`, `.worktrees`. This worktree's own
`.turbo` directory (Turborepo's local task-cache dir, gitignored via `.gitignore`) was
missing from that list. It gets created by `gate_select.mjs`'s
`npx turbo run i18n:gen wiki:content sfx:check --ui=stream` step, and `turbo.json` wires
several more tasks (`build:bundle` -> `dist/**`, `build:server` -> `dist-server/**`,
`check:types` -> `node_modules/.cache/tsc/**`) to cache larger outputs under it as a
developer runs the gate or builds locally over time, so every malware scan was walking
that directory in full, same rationale as the existing `.vite`/`.cache` entries. Added
`.turbo` to `SKIP_DIRS` with the same basename-at-any-depth treatment as the other
entries, plus a fixture case in `tests/malware_scan.test.ts` mirroring the existing
`.worktrees`-skip test (`describe('malware_scan: agent instructions and worktree
copies')`), covering both `collectFiles` and `scanTree`.

## Related issues

N/A

## Type of change

- [x] Refactor or performance (no behavior change)
- [x] Build, CI, or tooling

## How was this tested?

- Commands:
  - `npx vitest run tests/malware_scan.test.ts` (82/82 passed, including the two new
    `.turbo` assertions).
  - `npm run security:gate` (the actual `node scripts/malware_scan.mjs --gate` command
    from `package.json`): `PASS (5778 files, 310 flags, 0 high after priors)`.
  - `npx tsc --noEmit`: clean.
  - `GATE_SELECT_BASE=2a10e0f621e5fad3fb002bdf296e0950a0c88266 node scripts/gate_select.mjs`:
    reached and passed the i18n/wiki/sfx step, the malware-scan step
    (`PASS (5778 files, 310 flags, 0 high after priors)`), and the changed-files biome
    step, then failed at the "vitest (always-run 1/4)" leg on ONE pre-existing,
    unrelated test: `tests/ci_shard_plan.test.ts > vitest honors exact-path --exclude
    flags additively`. I reproduced the identical failure on the pinned base commit
    itself (`2a10e0f621e5fad3fb002bdf296e0950a0c88266`, before any of my changes, via
    `git stash`), and root-caused it: that test spawns `npx vitest list --filesOnly
    --exclude=tests/battleground.test.ts` and merges stdout+stderr, but this machine's
    npm (`12.0.2`) prints an `npm notice run 'vitest' list --filesOnly
    --exclude=tests/battleground.test.ts` banner line into that same stream, which
    itself ends with the literal string `tests/battleground.test.ts`, tripping the
    test's `endsWith` assertion. Nothing in this change touches vitest invocation,
    npm's banner behavior, or `tests/ci_shard_plan.test.ts`. The pre-push hook's own
    QA floor (typecheck, `tests/architecture.test.ts` +
    `tests/localization_fixes.test.ts`, changed-file lint, copy rules) ran clean on
    push.
  - Local timing measurement (interleaved, warmed-up, `collectFiles` called directly,
    30 iterations each, on this worktree's actual `.turbo` directory, which currently
    holds 3 small log files from the gate's own turbo-wrapped steps): median 238.82ms
    with `.turbo` walked vs 237.56ms with it skipped, i.e. within noise on this small
    a cache. The fix pays off as `.turbo` accumulates more entries locally (cached
    `dist/**`, `dist-server/**`, `node_modules/.cache/tsc/**` outputs across repeated
    local `gate`/`build` runs), the same shape of problem the `.worktrees` entry
    predates this one for.

## Screenshots / recordings

N/A: non-visual infra/performance change (no player- or operator-facing UI).

```mermaid
flowchart LR
    subgraph before["Before"]
        A1["walk(root)"] --> A2{".turbo/ dir?"}
        A2 -->|"not in SKIP_DIRS"| A3["descend and stat every\nentry under .turbo/"]
        A3 --> A4["classify() drops non-source\nfiles (.log etc), but the\nreaddir/stat walk still ran"]
    end
    subgraph after["After"]
        B1["walk(root)"] --> B2{".turbo/ dir?"}
        B2 -->|"basename in SKIP_DIRS"| B3["skip: never descend,\nsame as .vite/.cache"]
    end
```

---

## Checklist

### Quality

- [x] **The gate passes.** `node scripts/gate_select.mjs` reached and passed the
      malware-scan and biome steps; the one vitest-step failure it hit is a
      pre-existing, unrelated npm-banner artifact reproduced identically on the base
      commit (see "How was this tested?" above). I added decisive tests for the new
      behavior.

### Cross-platform

~~Tested on desktop and mobile.~~ N/A, no UI.
~~Accessible.~~ N/A, no UI.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not
      enabled in any production path.
- [x] I didn't hand-edit generated files.
