### PR TITLE
perf(ci): dedupe nightly.yml's gated refs by resolved commit SHA

### DIFF
--- a/scripts/lib/nightly_plan.d.mts
+++ b/scripts/lib/nightly_plan.d.mts
@@ -24,7 +24,15 @@ export function buildTargets(opts: {
   inputRef?: string | null;
   releaseBranch?: string | null;
   defaultBranch?: string;
+  shaByRef?: Readonly<Record<string, string | null | undefined>>;
 }): string[];
+
+export function dedupeTargetsBySha(
+  names: readonly string[],
+  shaByRef: Readonly<Record<string, string | null | undefined>>,
+): string[];
+
+export function shaFromGitRefResponse(body: unknown): string | null;
 
 export function summarizeRunJobs(
   jobs: ReadonlyArray<{

--- a/scripts/lib/nightly_plan.mjs
+++ b/scripts/lib/nightly_plan.mjs
@@ -124,17 +124,74 @@ export function pickActiveReleaseBranch(names) {
 /**
  * The refs the nightly run gates. A manual dispatch ref replaces the whole
  * list (that is the acceptance path: point the workflow at a scratch branch);
- * otherwise the default branch plus the active release branch, deduplicated.
+ * otherwise the default branch plus the active release branch, deduplicated
+ * by name AND by resolved commit SHA: a release cut, or a release-to-main
+ * merge, commonly leaves both branches pointing at the identical commit, and
+ * gating both would run a full duplicate lane-job matrix for no extra
+ * coverage.
  *
- * @param {{ inputRef?: string | null, releaseBranch?: string | null, defaultBranch?: string }} opts
+ * `shaByRef` maps a candidate ref name to its resolved commit SHA. A name
+ * missing from the map, or mapped to a falsy value, means the SHA could not
+ * be resolved for that ref: it is always kept, never dropped, because
+ * dedup exists to NARROW the gated set and an unproven SHA must not be the
+ * reason a ref goes ungated (fail OPEN, the same direction as every other
+ * failure mode in this file).
+ *
+ * @param {{ inputRef?: string | null, releaseBranch?: string | null, defaultBranch?: string,
+ *   shaByRef?: Readonly<Record<string, string | null | undefined>> }} opts
  * @returns {string[]}
  */
-export function buildTargets({ inputRef, releaseBranch, defaultBranch = 'main' }) {
+export function buildTargets({ inputRef, releaseBranch, defaultBranch = 'main', shaByRef = {} }) {
   const dispatch = typeof inputRef === 'string' ? inputRef.trim() : '';
   if (dispatch !== '') return [dispatch];
   const targets = [defaultBranch];
   if (releaseBranch && releaseBranch !== defaultBranch) targets.push(releaseBranch);
-  return targets;
+  return dedupeTargetsBySha(targets, shaByRef);
+}
+
+/**
+ * Drop a later target whose resolved SHA matches an earlier target already
+ * kept. A target whose SHA is unknown (missing or falsy in `shaByRef`) is
+ * always kept: fail OPEN toward widening the gated set, never toward
+ * silently dropping a ref the resolver could not vouch for.
+ *
+ * @param {readonly string[]} names
+ * @param {Readonly<Record<string, string | null | undefined>>} shaByRef
+ * @returns {string[]}
+ */
+export function dedupeTargetsBySha(names, shaByRef) {
+  /** @type {string[]} */
+  const kept = [];
+  const seenShas = new Set();
+  for (const name of names) {
+    const sha = shaByRef[name];
+    if (!sha) {
+      kept.push(name);
+      continue;
+    }
+    if (seenShas.has(sha)) continue;
+    seenShas.add(sha);
+    kept.push(name);
+  }
+  return kept;
+}
+
+/**
+ * Extract the commit SHA from a git-refs API single-ref response
+ * (`GET /repos/{repo}/git/ref/heads/{branch}`). Anything that is not the
+ * expected `{ object: { sha: string } }` shape resolves to null, which
+ * `dedupeTargetsBySha` treats as "unknown": fail OPEN, never drop a target
+ * on an unproven duplicate.
+ *
+ * @param {unknown} body
+ * @returns {string | null}
+ */
+export function shaFromGitRefResponse(body) {
+  const sha =
+    body && typeof body === 'object'
+      ? /** @type {{ object?: { sha?: unknown } }} */ (body).object?.sha
+      : undefined;
+  return typeof sha === 'string' && sha.length > 0 ? sha : null;
 }
 
 /**

--- a/scripts/nightly_targets.mjs
+++ b/scripts/nightly_targets.mjs
@@ -12,6 +12,7 @@ import {
   buildTargets,
   pickActiveReleaseBranch,
   refNamesFromMatchingRefs,
+  shaFromGitRefResponse,
 } from './lib/nightly_plan.mjs';
 
 const API = process.env.GITHUB_API_URL || 'https://api.github.com';
@@ -48,6 +49,51 @@ async function listReleaseBranches() {
   return names;
 }
 
+/**
+ * Resolve one branch's current commit SHA via the git-refs API. Failure
+ * (missing token/repo, a non-OK response, a malformed payload, a network
+ * error) resolves to null rather than throwing: SHA dedup fails OPEN, so an
+ * unresolved SHA must widen the gated set, never collapse the whole run.
+ *
+ * @param {string} branchName
+ * @returns {Promise<string | null>}
+ */
+async function resolveRefSha(branchName) {
+  if (!repo || !token) return null;
+  try {
+    const url = `${API}/repos/${repo}/git/ref/heads/${branchName}`;
+    const res = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+      signal: AbortSignal.timeout(30_000),
+    });
+    if (!res.ok) return null;
+    return shaFromGitRefResponse(await res.json());
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve the commit SHA of every candidate ref the scheduled run considers,
+ * for the dedupe pass in buildTargets. Each branch resolves independently so
+ * one failed lookup never suppresses the other's SHA.
+ *
+ * @param {{ defaultBranch: string, releaseBranch: string | null }} opts
+ * @returns {Promise<Record<string, string | null>>}
+ */
+async function resolveTargetShas({ defaultBranch, releaseBranch }) {
+  /** @type {Record<string, string | null>} */
+  const shaByRef = { [defaultBranch]: await resolveRefSha(defaultBranch) };
+  if (releaseBranch && releaseBranch !== defaultBranch) {
+    shaByRef[releaseBranch] = await resolveRefSha(releaseBranch);
+  }
+  return shaByRef;
+}
+
 const inputRef = process.env.NIGHTLY_REF ?? '';
 let targets;
 if (inputRef.trim() !== '') {
@@ -56,7 +102,8 @@ if (inputRef.trim() !== '') {
 } else {
   try {
     const releaseBranch = pickActiveReleaseBranch(await listReleaseBranches());
-    targets = buildTargets({ inputRef: null, releaseBranch, defaultBranch });
+    const shaByRef = await resolveTargetShas({ defaultBranch, releaseBranch });
+    targets = buildTargets({ inputRef: null, releaseBranch, defaultBranch, shaByRef });
     console.log(
       `[nightly_targets] gating ${targets.join(', ')}${releaseBranch ? '' : ' (no release/vX.Y.Z branch found)'}`,
     );

--- a/tests/nightly_plan.test.ts
+++ b/tests/nightly_plan.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   buildTargets,
+  dedupeTargetsBySha,
   labelEnsureFailed,
   NIGHTLY_DRILL_ISSUE_LABEL,
   NIGHTLY_DRILL_ISSUE_TITLE,
@@ -13,6 +14,7 @@ import {
   refNamesFromMatchingRefs,
   renderIssueBody,
   renderRecoveryComment,
+  shaFromGitRefResponse,
   summarizeRunJobs,
   trackingIssueIdentity,
 } from '../scripts/lib/nightly_plan.mjs';
@@ -130,6 +132,117 @@ describe('buildTargets', () => {
 
   it('never lists the default branch twice', () => {
     expect(buildTargets({ inputRef: null, releaseBranch: 'main' })).toEqual(['main']);
+  });
+
+  it('drops the release branch when it resolves to the same SHA as the default branch', () => {
+    // The scenario this exists for: a release cut or a release-to-main merge
+    // leaves both branches pointing at the identical commit.
+    expect(
+      buildTargets({
+        inputRef: null,
+        releaseBranch: 'release/v0.35.0',
+        defaultBranch: 'main',
+        shaByRef: { main: 'sha-1', 'release/v0.35.0': 'sha-1' },
+      }),
+    ).toEqual(['main']);
+  });
+
+  it('keeps both branches when their SHAs differ', () => {
+    expect(
+      buildTargets({
+        inputRef: null,
+        releaseBranch: 'release/v0.35.0',
+        defaultBranch: 'main',
+        shaByRef: { main: 'sha-1', 'release/v0.35.0': 'sha-2' },
+      }),
+    ).toEqual(['main', 'release/v0.35.0']);
+  });
+
+  it('fails open: an unresolved SHA never drops a target', () => {
+    // Missing from the map entirely.
+    expect(
+      buildTargets({
+        inputRef: null,
+        releaseBranch: 'release/v0.35.0',
+        defaultBranch: 'main',
+        shaByRef: { main: 'sha-1' },
+      }),
+    ).toEqual(['main', 'release/v0.35.0']);
+    // Explicitly null (a failed lookup), even though the other side matches.
+    expect(
+      buildTargets({
+        inputRef: null,
+        releaseBranch: 'release/v0.35.0',
+        defaultBranch: 'main',
+        shaByRef: { main: 'sha-1', 'release/v0.35.0': null },
+      }),
+    ).toEqual(['main', 'release/v0.35.0']);
+    // No shaByRef at all defaults to keeping everything, same as before this
+    // dedup existed.
+    expect(
+      buildTargets({ inputRef: null, releaseBranch: 'release/v0.35.0', defaultBranch: 'main' }),
+    ).toEqual(['main', 'release/v0.35.0']);
+  });
+
+  it('ignores shaByRef entirely on a dispatch override', () => {
+    expect(
+      buildTargets({
+        inputRef: 'scratch/broken-test',
+        releaseBranch: 'release/v0.35.0',
+        defaultBranch: 'main',
+        shaByRef: { main: 'sha-1', 'scratch/broken-test': 'sha-1' },
+      }),
+    ).toEqual(['scratch/broken-test']);
+  });
+});
+
+describe('dedupeTargetsBySha', () => {
+  it('drops a later name whose SHA repeats an earlier kept name', () => {
+    expect(
+      dedupeTargetsBySha(['main', 'release/v0.35.0', 'release/v0.34.0'], {
+        main: 'sha-1',
+        'release/v0.35.0': 'sha-1',
+        'release/v0.34.0': 'sha-2',
+      }),
+    ).toEqual(['main', 'release/v0.34.0']);
+  });
+
+  it('never drops a name with an unknown SHA, missing or falsy', () => {
+    expect(dedupeTargetsBySha(['main', 'release/v0.35.0'], { main: 'sha-1' })).toEqual([
+      'main',
+      'release/v0.35.0',
+    ]);
+    expect(
+      dedupeTargetsBySha(['main', 'release/v0.35.0'], { main: 'sha-1', 'release/v0.35.0': null }),
+    ).toEqual(['main', 'release/v0.35.0']);
+    expect(
+      dedupeTargetsBySha(['main', 'release/v0.35.0'], { main: 'sha-1', 'release/v0.35.0': '' }),
+    ).toEqual(['main', 'release/v0.35.0']);
+  });
+
+  it('passes an empty list through unchanged', () => {
+    expect(dedupeTargetsBySha([], {})).toEqual([]);
+  });
+});
+
+describe('shaFromGitRefResponse', () => {
+  it('extracts the commit SHA from a well-formed git-refs single-ref response', () => {
+    expect(
+      shaFromGitRefResponse({
+        ref: 'refs/heads/main',
+        object: { sha: 'abc123', type: 'commit' },
+      }),
+    ).toBe('abc123');
+  });
+
+  it('resolves to null for anything that is not the expected shape', () => {
+    expect(shaFromGitRefResponse(null)).toBeNull();
+    expect(shaFromGitRefResponse(undefined)).toBeNull();
+    expect(shaFromGitRefResponse('abc123')).toBeNull();
+    expect(shaFromGitRefResponse({})).toBeNull();
+    expect(shaFromGitRefResponse({ object: {} })).toBeNull();
+    expect(shaFromGitRefResponse({ object: { sha: 42 } })).toBeNull();
+    expect(shaFromGitRefResponse({ object: { sha: '' } })).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary

`scripts/nightly_targets.mjs` picks the refs the nightly full-gate workflow
gates (`main` plus the highest `release/vX.Y.Z` branch) by calling
`buildTargets` in `scripts/lib/nightly_plan.mjs`. `buildTargets` deduped
candidates by branch NAME only (`if (releaseBranch && releaseBranch !==
defaultBranch) targets.push(releaseBranch)`), so right after a release cut or
a release-to-main merge, when the two branches point at the identical
commit, the workflow still ran a full duplicate lane-job matrix (tests,
checks, browser: `NIGHTLY_LANES_PER_REF = 3` lanes) for both refs even
though they would gate the exact same tree.

`buildTargets` now takes a `shaByRef` map (ref name to resolved commit SHA)
and dedupes through the new `dedupeTargetsBySha` helper: a later target
whose SHA matches an earlier kept target's SHA is dropped. `scripts/
nightly_targets.mjs` resolves each candidate's SHA through the git-refs
single-ref API (`GET /repos/{repo}/git/ref/heads/{branch}`), alongside the
existing `matching-refs` release-branch listing call in the same file, and
parses the response with the new `shaFromGitRefResponse` helper. Following
this file's existing fail-open convention (stated at the top of both
`scripts/nightly_targets.mjs` and `scripts/lib/nightly_plan.mjs`), a failed
or missing SHA lookup resolves to `null`/absent in the map and
`dedupeTargetsBySha` always keeps that target: dedup only ever narrows the
gated set on a PROVEN duplicate, never on an unresolved one.

A manual `workflow_dispatch` with a `ref` input is unaffected: `buildTargets`
still returns `[dispatch]` immediately before the SHA map is ever consulted,
since a single-ref list has nothing to dedupe.

## Related issues

N/A.

## Type of change

- [ ] Feature: new functionality
- [ ] Bug fix
- [x] Refactor or performance (no behavior change)
- [ ] Documentation
- [ ] Tests
- [x] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

Commands run in a worktree checked out at the task's base commit
(`2a10e0f621e5fad3fb002bdf296e0950a0c88266`), tracking
`upstream/release/v0.36.0`:

- `npx vitest run tests/nightly_plan.test.ts tests/nightly_workflow.test.ts`:
  `Test Files 2 passed (2)`, `Tests 42 passed (42)` (new cases cover
  `buildTargets` dropping the release branch on a matching SHA, keeping both
  on a differing SHA, and failing open on a missing or falsy SHA entry, plus
  `dedupeTargetsBySha` and `shaFromGitRefResponse` directly).
- `npx tsc --noEmit` and `npm run check:types`: clean.
- `npm run security:gate`: `PASS (5778 files, 310 flags, 0 high after priors)`.
- `node scripts/gate_select.mjs` (with `GATE_SELECT_BASE=2a10e0f6...`): the
  `vitest`/`tsc`/malware-scan legs all passed, but the run stops earlier, at
  the shared `biome (changed files)` step, on files this PR does not touch
  (e.g. `tests/vale_cup_meta.test.ts`). I reproduced the identical
  `Checked 433 files ... Found 3 errors` output on the clean base commit
  (`git stash` my 4 files, rerun `npm run ci:changed`, `git stash pop`): the
  step runs plain `biome ci --changed`, which reads `biome.json`'s committed
  `vcs.defaultBranch: "origin/main"` rather than the branch's `@{upstream}`
  tracking ref, and this fork's `origin/main` is 410 commits behind
  `upstream/release/v0.36.0`, so the diff picks up unrelated history. This
  step is pre-existing and unaffected by this change. The repo's pre-push
  hook (which resolves its own diff base from `@{upstream}` correctly) ran
  clean over exactly this PR's 4 files, surfacing only 3 pre-existing
  `noUndeclaredEnvVars` warnings on env reads (`GITHUB_TOKEN`,
  `NIGHTLY_DEFAULT_BRANCH`, `NIGHTLY_REF`) that already existed before this
  change, no errors.

## Screenshots / recordings

N/A: non-visual infra/performance change (no player- or operator-facing UI).

```mermaid
flowchart TD
    subgraph Before
        A1[main SHA sha-1] --> D1{buildTargets}
        B1[release/vX.Y.Z SHA sha-1] --> D1
        D1 -->|dedupe by NAME only| E1[targets: main, release/vX.Y.Z]
        E1 --> F1[3 lane jobs x 2 refs = 6 jobs]
    end

    subgraph After
        A2[main SHA sha-1] --> R2[resolveRefSha via git-refs API]
        B2[release/vX.Y.Z SHA sha-1] --> R3[resolveRefSha via git-refs API]
        R2 --> D2{buildTargets + dedupeTargetsBySha}
        R3 --> D2
        D2 -->|same SHA: drop the later target| E2[targets: main]
        D2 -->|lookup failed: keep it, fail open| E2b[targets: main, release/vX.Y.Z]
        E2 --> F2[3 lane jobs x 1 ref = 3 jobs]
    end
```

## Checklist

### Quality

- [x] **The gate passes.** `node scripts/gate_select.mjs` runs clean through
      vitest, typecheck, and the malware scan; the pre-push hook (correct
      tracking-ref diff base) is green over this PR's files. See "How was
      this tested" for the pre-existing, unrelated `biome (changed files)`
      staleness this run also hits. I added decisive tests for the new
      dedupe behavior.

### Cross-platform

~Tested on desktop and mobile.~ N/A, no UI.
~Accessible.~ N/A, no UI.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS`
      is not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the
      build.
