### PR TITLE
perf(malware-scan): stop scanning docs/**, matching its own contract

### DIFF
--- a/scripts/malware_scan.mjs
+++ b/scripts/malware_scan.mjs
@@ -78,11 +78,18 @@ const SKIP_DIRS = new Set([
 // desktop build): the same node_modules rationale applies, and electron-updater
 // legitimately require()s child_process (it spawns installers), which would
 // bury real findings under HIGH noise on any tree that ran a desktop build.
+// docs/ is documented as out of scope entirely (docs/security/malware-scan-catalog.md:
+// "Prose docs (docs/**, README.md) ... not scanned: docs are not executed"), but before
+// this entry that was only true for the .md/.txt files inside it: the walker still
+// descended and classify() scanned every .json/.html/.js/.sh file it found there (over a
+// hundred, mostly design-doc JSON fixtures) as source. Root-anchored so only the top-level
+// docs/ tree is skipped; a nested <module>/docs/ directory (none exist today) stays in scope.
 const SKIP_PATHS = new Set([
   '.claude/worktrees',
   '.codex/worktrees',
   '.codex/cache',
   'electron/vendor',
+  'docs',
 ]);
 
 // Executable / config source extensions. Documentation prose (.md, .txt) is

--- a/tests/malware_scan.test.ts
+++ b/tests/malware_scan.test.ts
@@ -577,6 +577,60 @@ describe('malware_scan: agent instructions and worktree copies', () => {
   });
 });
 
+describe('malware_scan: docs/ is out of scope (root-anchored)', () => {
+  // docs/security/malware-scan-catalog.md documents the whole docs/** tree as
+  // "not scanned: docs are not executed". Before the SKIP_PATHS entry that backs
+  // this, that was only true for the .md/.txt files inside it: collectFiles still
+  // walked in and classified every .json/.html/.js/.sh file there as source.
+  function buildFixture(): { root: string; cleanup: () => void } {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'mwscan-docs-'));
+    const write = (rel: string, body: string) => {
+      const full = path.join(root, rel);
+      fs.mkdirSync(path.dirname(full), { recursive: true });
+      fs.writeFileSync(full, body);
+    };
+    // a planted HIGH signature in a JSON fixture under the top-level docs/ tree
+    write('docs/design/professions-system/fixture.json', '{"kp": "Keypair.fromSecretKey(bytes)"}');
+    // a same-named docs/ directory nested under a module: SKIP_PATHS matches by
+    // path (unlike SKIP_DIRS basename matching, see .worktrees above), so this
+    // one is NOT the root-relative "docs" entry and must stay in scope.
+    write('server/docs/fixture.json', '{"kp": "Keypair.fromSecretKey(bytes)"}');
+    write('src/app.ts', 'export const greet = () => "hi";');
+    return { root, cleanup: () => fs.rmSync(root, { recursive: true, force: true }) };
+  }
+
+  const posix = (p: string) => p.split(path.sep).join('/');
+
+  it('skips the whole top-level docs/ tree but keeps a nested <module>/docs/ in scope', () => {
+    const { root, cleanup } = buildFixture();
+    try {
+      const rels = (collectFiles(root) as unknown as Array<{ rel: string }>).map((f) =>
+        posix(f.rel),
+      );
+      expect(rels.some((r) => r.startsWith('docs/'))).toBe(false);
+      expect(rels).toContain('server/docs/fixture.json');
+      expect(rels).toContain('src/app.ts');
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('does not flag a planted HIGH signature inside docs/, but still flags one in a nested <module>/docs/', () => {
+    const { root, cleanup } = buildFixture();
+    try {
+      const hits = scanTree(root) as Array<{ file: string; category: string }>;
+      expect(hits.some((f) => posix(f.file).startsWith(`${posix(root)}/docs/`))).toBe(false);
+      expect(
+        hits.some(
+          (f) => posix(f.file).endsWith('server/docs/fixture.json') && f.category === 'key-exfil',
+        ),
+      ).toBe(true);
+    } finally {
+      cleanup();
+    }
+  });
+});
+
 describe('malware_scan: whole-tree gate', () => {
   it('the real working tree has zero HIGH-severity findings (the release gate)', () => {
     const findings = scanTree(repoRoot) as Array<{


### PR DESCRIPTION
## Summary

`docs/security/malware-scan-catalog.md` (line 35) already documents `docs/**`
as entirely out of scope for the release malware scanner: "Prose docs
(`docs/**`, `README.md`) ... not scanned: docs are not executed." But
`scripts/malware_scan.mjs`'s file walker only enforced that for `.md`/`.txt`
files (`classify()` returns `null` for those two extensions only). Every other
matched extension under `docs/` (`.json`, `.html`, `.js`, `.sh`, all in
`SOURCE_EXT`) was still walked into and scanned as source. A quick count on
this tree: `docs/` holds 104 `.json`, 24 `.html`, 1 `.sh`, and 1 `.js` file
(mostly design-doc JSON fixtures such as
`docs/design/professions-system/manifest`), all of which were read and
regex-scanned on every gate run despite the catalog already treating them as
out of scope.

This PR adds a root-anchored `docs` entry to the existing `SKIP_PATHS` Set (the
same mechanism `.claude/worktrees`, `.codex/worktrees`, `.codex/cache`, and
`electron/vendor` already use), so the walker never descends into the
top-level `docs/` tree at all. `SKIP_PATHS` is matched by root-relative path,
not basename (unlike `SKIP_DIRS`), so a future nested `<module>/docs/`
directory would stay in scope; none exist in the tree today (verified with
`find . -maxdepth 3 -type d -iname docs`, which returns only `./docs`).

`docs/security/malware-scan-catalog.md` needed no change: it already states
the contract this PR now actually enforces at the file-walk level rather than
only at the per-extension classify level.

## Related issues

N/A.

## Type of change

- [x] Refactor or performance (no behavior change)
- [x] Build, CI, or tooling

## How was this tested?

- Commands:
  - `npx vitest run tests/malware_scan.test.ts`
  - `node scripts/malware_scan.mjs --gate` before and after the change
  - `npx tsc --noEmit`
  - `npx @biomejs/biome check --write scripts/malware_scan.mjs tests/malware_scan.test.ts`
  - `npx --no-install biome ci --changed --since=2a10e0f621e5fad3fb002bdf296e0950a0c88266 --no-errors-on-unmatched`
    (the exact scoped check the shared `.githooks/pre-push` floor runs)
  - `npx vitest run tests/architecture.test.ts tests/localization_fixes.test.ts`
  - `git push` (the real pre-push hook, not bypassed)
- Observed:
  - `tests/malware_scan.test.ts`: 83 passed, including the two new fixture
    cases (`collectFiles`/`scanTree` skip a synthetic `docs/**/*.json` path,
    but still scan a same-named nested `server/docs/` directory).
  - `malware_scan --gate` file count scanned dropped from 5778 to 5647 (131
    fewer files, matching the 130 non-`.md`/`.txt` files under `docs/` counted
    above), `0 high after priors` unchanged on both runs, so the scanner's
    verdict is identical, only its scanned-file count shrank.
  - `tsc --noEmit`: clean.
  - Biome on the 2 changed files: "Checked 2 files ... No fixes applied",
    only 6 pre-existing `noNonNullAssertion` warnings at lines the diff does
    not touch, no errors.
  - `tests/architecture.test.ts` + `tests/localization_fixes.test.ts`: 80
    passed, 3 skipped (pre-existing skips, unrelated to this change).
  - The real push floor, `.githooks/pre-push` (its lint step resolves the
    diff base from this branch's `@{upstream}` tracking ref, set to
    `upstream/release/v0.36.0` per the setup step), ran clean end to end and
    the push succeeded with no bypass.

Note on `node scripts/gate_select.mjs`: its "biome (changed files)" step
calls `npm run ci:changed` = `biome ci --changed`, which reads `biome.json`'s
`vcs.defaultBranch: "origin/main"` rather than this branch's tracked release
base, and reports hundreds of pre-existing, unrelated findings across files
this PR never touches. `main` trails the active release branch by hundreds of
commits in this repo by design; I confirmed this is pre-existing by diffing
`origin/main` directly against this PR's unmodified base commit
(`2a10e0f621e5fad3fb002bdf296e0950a0c88266`), with zero involvement from this
change: 769 files, 410 commits of divergence, identical either way. The
scoped equivalent the pre-push hook actually enforces (shown above) passes
cleanly.

## Screenshots / recordings

N/A: non-visual infra/performance change (no player- or operator-facing UI).

```mermaid
flowchart TD
    subgraph before["Before"]
        A1["walk(dir)"] --> B1{"dir in SKIP_DIRS\nor SKIP_PATHS?"}
        B1 -- "no" --> C1["descend into docs/"]
        C1 --> D1["classify(file)"]
        D1 -- ".md/.txt" --> E1["skip"]
        D1 -- ".json/.html/.js/.sh" --> F1["scan as source\n(130+ files)"]
    end
    subgraph after["After"]
        A2["walk(dir)"] --> B2{"dir in SKIP_DIRS\nor SKIP_PATHS?"}
        B2 -- "docs matches\nroot-relative SKIP_PATHS" --> E2["skip whole docs/ tree,\nnever reaches classify()"]
        B2 -- "no" --> C2["descend normally"]
    end
```

## Checklist

### Quality

- [x] **The gate passes.** `node scripts/gate_select.mjs` is green apart from
      the pre-existing, unrelated `biome (changed files)` origin/main
      divergence documented above (present on the clean base commit with no
      involvement from this change); the actual push-blocking floor,
      `.githooks/pre-push`, which correctly scopes its lint step to this
      branch's tracked release base, is green end to end and this PR's push
      succeeded through it with no bypass. I added decisive tests for the
      changed behavior (see "How was this tested?").

### Cross-platform

- ~~Tested on desktop and mobile.~~ N/A, no UI.
- ~~Accessible.~~ N/A, no UI.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files.
