### PR TITLE
perf(ci): resolve vitest binary directly in the CI shard planner

### DIFF
--- a/scripts/lib/ci_shard_plan.d.mts
+++ b/scripts/lib/ci_shard_plan.d.mts
@@ -16,6 +16,8 @@ export function buildFloor(opts: {
   changedTestFiles: string[];
 }): { floor: string[]; missingGuards: string[] };
 
+export function resolveLocalBin(name: string): string;
+
 export interface ShardLeg {
   name: string;
   cmd: string;

--- a/scripts/lib/ci_shard_plan.mjs
+++ b/scripts/lib/ci_shard_plan.mjs
@@ -42,6 +42,7 @@
 // set 8 ways. The two legs may overlap on partial tests; that re-runs a few
 // files and is wasted time, never a correctness gap.
 
+import path from 'node:path';
 import { isRelayablePath } from './ci_test_select.mjs';
 import { classifySelectPaths } from './gate_select_plan.mjs';
 
@@ -154,6 +155,25 @@ export function buildFloor({ alwaysRun, testFiles, changedTestFiles }) {
   }
   for (const t of changedTestFiles ?? []) floor.add(t);
   return { floor: [...floor].sort(), missingGuards };
+}
+
+/**
+ * Resolve a locally installed CLI binary from node_modules/.bin so the
+ * `vitest related` leg spawns the exact vitest binary `npm test` already
+ * resolves, instead of paying npx's extra registry-aware resolution path for
+ * a binary this monorepo always has installed. This planner always runs from
+ * the repo root (CI invokes it there, and so does the local gate), so the
+ * binary is resolved against process.cwd() rather than adding a repoRoot
+ * input every caller would have to start threading through. win32-aware:
+ * pnpm links a .cmd shim there; every other platform ships the bare POSIX
+ * script npm/pnpm links.
+ *
+ * @param {string} name
+ * @returns {string}
+ */
+export function resolveLocalBin(name) {
+  const bin = process.platform === 'win32' ? `${name}.cmd` : name;
+  return path.join(process.cwd(), 'node_modules', '.bin', bin);
 }
 
 /**
@@ -320,17 +340,8 @@ export function buildShardPlan({
       // changed sources and fed-through generated i18n artifacts; the mode
       // reason carries the split counts.
       name: `vitest related (${liveSources.length} path(s), shard ${shard.index}/${shard.total})`,
-      cmd: 'npx',
-      args: [
-        '--no-install',
-        'vitest',
-        'related',
-        ...liveSources,
-        '--run',
-        '--passWithNoTests',
-        shardArg,
-        workersArg,
-      ],
+      cmd: resolveLocalBin('vitest'),
+      args: ['related', ...liveSources, '--run', '--passWithNoTests', shardArg, workersArg],
     });
   }
   return {

--- a/tests/ci_shard_plan.test.ts
+++ b/tests/ci_shard_plan.test.ts
@@ -1,5 +1,5 @@
 import { spawn } from 'node:child_process';
-import { readdirSync, readFileSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -14,6 +14,7 @@ import {
   collectedLaneFiles,
   FLOOR_SANITY_MIN,
   parseShardArg,
+  resolveLocalBin,
 } from '../scripts/lib/ci_shard_plan.mjs';
 import { collectSuiteVisibility } from '../scripts/lib/gate_discovery.mjs';
 
@@ -50,6 +51,28 @@ describe('parseShardArg', () => {
     [[], null],
   ])('%j -> %j', (argv, expected) => {
     expect(parseShardArg(argv as string[])).toEqual(expected);
+  });
+});
+
+describe('resolveLocalBin', () => {
+  it('resolves the binary under node_modules/.bin, win32-aware', () => {
+    // Independently computed, not by calling the function under test: the
+    // shard plan's own comparison (below) reuses resolveLocalBin to build its
+    // expectation, which only pins internal consistency, not the resolved
+    // shape.
+    const expected = path.join(
+      process.cwd(),
+      'node_modules',
+      '.bin',
+      process.platform === 'win32' ? 'vitest.cmd' : 'vitest',
+    );
+    expect(resolveLocalBin('vitest')).toBe(expected);
+  });
+
+  it('resolves to a binary that actually exists in this tree', () => {
+    // A wrong suffix or directory would otherwise only surface as an ENOENT
+    // deep inside a real CI spawn, far from this test.
+    expect(existsSync(resolveLocalBin('vitest'))).toBe(true);
   });
 });
 
@@ -158,10 +181,10 @@ describe('buildShardPlan: selective mode', () => {
     expect(floorLeg.args).toContain('--shard=3/8');
     expect(floorLeg.args).toContain('--maxWorkers=2');
     expect(floorLeg.args).not.toContain('--passWithNoTests');
-    expect(relatedLeg.cmd).toBe('npx');
+    // Resolved directly, not through npx: the same binary `npm test` already
+    // uses, without paying npx's extra registry-aware resolution path.
+    expect(relatedLeg.cmd).toBe(resolveLocalBin('vitest'));
     expect(relatedLeg.args).toEqual([
-      '--no-install',
-      'vitest',
       'related',
       'src/ui/unit_portrait.ts',
       '--run',


### PR DESCRIPTION
## Summary

`scripts/lib/ci_shard_plan.mjs` is the pure planner behind each CI shard's PR-tier
vitest step (`tests/ci_shard_plan.test.ts`, no spawning). In selective mode its
`vitest related` leg previously built its argv as `cmd: 'npx', args: ['--no-install',
'vitest', 'related', ...]`. That pays npx's own resolution path (spawn npx, then npx
locates and re-execs the local `vitest` binary) for a binary this monorepo always has
installed at `node_modules/.bin/vitest`, since `npm test` (the floor leg right next to
it) already runs through the local binary directly via npm's own bin resolution.

This change adds `resolveLocalBin(name)`, a small win32-aware helper that resolves
`node_modules/.bin/<name>` (`.cmd` suffix on Windows, matching the same convention
`scripts/electron-dev.mjs` already uses for `npm.cmd`/`electron.cmd`), and spawns that
path directly for the `vitest related` leg instead of going through `npx`. The module
stays a pure planner: `resolveLocalBin` reads only `process.platform` and
`process.cwd()`, no filesystem or subprocess I/O, so `tests/ci_shard_plan.test.ts`
still exercises `buildShardPlan` without spawning a real process.

## Related issues

N/A.

## Type of change

- [x] Refactor or performance (no behavior change)
- [x] Build, CI, or tooling

## How was this tested?

- Commands:
  - `npx vitest run tests/ci_shard_plan.test.ts` : 54 passed, 1 failed. The one failure
    (`vitest honors exact-path --exclude flags additively (the one external
    assumption)`) is an already-documented, unrelated environmental flake in this test
    file (a real `npx vitest list` subprocess whose merged output happens to include an
    npm notice line that ends with a `tests/battleground.test.ts`-like substring). I
    reproduced it identically on the clean, unmodified base commit
    (`2a10e0f621e5fad3fb002bdf296e0950a0c88266`) before and after my change, with the
    exact same assertion and line number shift, confirming it is pre-existing and
    unrelated to this diff.
  - `npx tsc --noEmit` : clean (also updated the hand-written
    `scripts/lib/ci_shard_plan.d.mts` companion, since a type-checked Vitest suite
    imports this module and the new export needed a declaration).
  - `npx @biomejs/biome check --write scripts/lib/ci_shard_plan.mjs
    scripts/lib/ci_shard_plan.d.mts tests/ci_shard_plan.test.ts` : clean, no diffs left.
  - `git push` (through the repo's pre-push QA floor: `tsc --noEmit`, the
    architecture/localization guard tests, and `biome ci --changed --since=<branch
    base>`) : green.
- Manual steps: none (planner-only change, no runtime behavior to click through).

## Screenshots / recordings

N/A: non-visual infra/performance change (no player- or operator-facing UI).

```mermaid
sequenceDiagram
    participant Shard as pr-gate shard job
    participant Plan as buildShardPlan (ci_shard_plan.mjs)
    participant OS as child_process.spawn

    Note over Plan: Before
    Shard->>Plan: selective mode, live changed sources
    Plan-->>Shard: leg = { cmd: "npx", args: ["--no-install", "vitest", "related", ...] }
    Shard->>OS: spawn("npx", [...])
    OS->>OS: npx resolves and re-execs the local vitest binary

    Note over Plan: After
    Shard->>Plan: selective mode, live changed sources
    Plan-->>Shard: leg = { cmd: resolveLocalBin("vitest"), args: ["related", ...] }
    Shard->>OS: spawn(".../node_modules/.bin/vitest", [...])
    OS->>OS: vitest runs directly, no npx resolution hop
```

---

## Checklist

### Quality

- [x] **The gate passes.** `node scripts/gate_select.mjs` is green (or `npm run gate` for
      the full suite). I added or updated decisive
      tests for changed behavior and recorded any manual checks above.

      Note: on this local fork, `node scripts/gate_select.mjs`'s own "biome (changed
      files)" step calls `npm run ci:changed` directly (no `--since`), which falls back
      to `biome.json`'s static `vcs.defaultBranch: "origin/main"`. This fork's `origin/main`
      trails `release/v0.36.0` by 476 commits (an existing, out-of-scope fork-staleness
      fact), so that local step flags 433 files as "changed" and surfaces 3 pre-existing
      formatting diffs in files this PR never touches (`src/sim/progression/talents.ts`,
      `tests/loadout_gear.test.ts`, `tests/loadout_gear_swap.test.ts`). I reproduced that
      identically on the clean base commit before making any change, confirming it is
      unrelated. The real enforcement gate, the repo's pre-push hook, resolves its lint
      diff base from the branch's `@{upstream}` tracking ref and ran clean on push (see
      "How was this tested?" above); CI's own lint job similarly passes an explicit
      `--since=` computed from the real PR base, so it is unaffected.

### Cross-platform

- ~Tested on desktop and mobile.~ N/A, no UI.
- ~Accessible.~ N/A, no UI.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.
