### PR TITLE
perf(build): run build_server.mjs's two esbuild calls concurrently

### DIFF
--- a/scripts/build_server.mjs
+++ b/scripts/build_server.mjs
@@ -10,24 +10,25 @@ const privateImpl = fileURLToPath(new URL('../private/bot_detector/src/index.ts'
 const stubImpl = fileURLToPath(new URL('../server/bot_detector/stub.ts', import.meta.url));
 const usePrivate = existsSync(privateImpl);
 
-await esbuild.build({
-  entryPoints: ['server/main.ts'],
-  bundle: true,
-  platform: 'node',
-  format: 'cjs',
-  external: ['pg-native', 'bufferutil', 'utf-8-validate'],
-  outfile: 'dist-server/server.cjs',
-  alias: { '#bot-detector': usePrivate ? privateImpl : stubImpl },
-});
-
-await esbuild.build({
-  entryPoints: ['scripts/migrate_old_cragmaw_pelt.ts'],
-  bundle: true,
-  platform: 'node',
-  format: 'cjs',
-  external: ['pg-native'],
-  outfile: 'dist-server/migrate_old_cragmaw_pelt.cjs',
-  alias: { '#bot-detector': usePrivate ? privateImpl : stubImpl },
-});
+await Promise.all([
+  esbuild.build({
+    entryPoints: ['server/main.ts'],
+    bundle: true,
+    platform: 'node',
+    format: 'cjs',
+    external: ['pg-native', 'bufferutil', 'utf-8-validate'],
+    outfile: 'dist-server/server.cjs',
+    alias: { '#bot-detector': usePrivate ? privateImpl : stubImpl },
+  }),
+  esbuild.build({
+    entryPoints: ['scripts/migrate_old_cragmaw_pelt.ts'],
+    bundle: true,
+    platform: 'node',
+    format: 'cjs',
+    external: ['pg-native'],
+    outfile: 'dist-server/migrate_old_cragmaw_pelt.cjs',
+    alias: { '#bot-detector': usePrivate ? privateImpl : stubImpl },
+  }),
+]);
 
 console.log(`[build:server] bot detector: ${usePrivate ? 'private' : 'stub (no-op)'}`);


### PR DESCRIPTION
## Summary

`scripts/build_server.mjs` ran two independent `esbuild.build()` calls sequentially (the server bundle to `dist-server/server.cjs`, a migration script to `dist-server/migrate_old_cragmaw_pelt.cjs`). They write to different outfiles and share no state beyond already-resolved, read-only alias values computed before both calls. Replaced the two sequential `await`s with `await Promise.all([...])`, preserving every existing option unchanged.

## Related issues

N/A

## Type of change

- [x] Refactor or performance (no behavior change)
- [x] Build, CI, or tooling

## How was this tested

- Commands: `node scripts/build_server.mjs` (confirmed both `dist-server/server.cjs` and `dist-server/migrate_old_cragmaw_pelt.cjs` still emit correctly), `npx tsc --noEmit`, `npx @biomejs/biome check --write scripts/build_server.mjs` (no changes needed).
- Manual steps: verified the two esbuild configs write to distinct outfiles with no shared mutable state before parallelizing.

## Screenshots / recordings

N/A: non-visual infra/performance change (no player- or operator-facing UI).

```mermaid
sequenceDiagram
    participant S as build_server.mjs
    participant E1 as esbuild (server bundle)
    participant E2 as esbuild (migration bundle)
    Note over S,E2: Before
    S->>E1: await build()
    E1-->>S: done
    S->>E2: await build()
    E2-->>S: done
    Note over S,E2: After
    S->>E1: build() (no await)
    S->>E2: build() (no await)
    par
        E1-->>S: done
    and
        E2-->>S: done
    end
```

---

## Checklist

### Quality

- [x] **The gate passes.** `node scripts/gate_select.mjs` is green (or `npm run gate` for the full suite). I added or updated decisive tests for changed behavior and recorded any manual checks above.

### Cross-platform

- ~~Tested on desktop and mobile.~~
- ~~Accessible.~~

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files.
