### PR TITLE
perf(gate): resolve turbo's binary directly instead of npx

### DIFF
--- a/docs/qa-gate.md
+++ b/docs/qa-gate.md
@@ -104,8 +104,10 @@ bounds Vitest workers to avoid load flakes on shared machines. It resolves FFmpe
 falling back to PATH, and refuses to run when neither source yields a working binary.
 
 **Task cache (Turborepo):** pure artifact steps (`i18n:gen`, `wiki:content`, `sfx:check`,
-`check:types`, `build:env`, `build:server`, `build:bot`, `build:bundle`) run through `npx turbo run`
-with inputs/outputs in root `turbo.json`. A warm second gate on an unchanged tree
+`check:types`, `build:env`, `build:server`, `build:bot`, `build:bundle`) run through the
+resolved `node_modules/.bin/turbo` binary directly (`resolveTurboBin` in
+`scripts/lib/gate_task_cache.mjs`, skipping `npx`'s own dispatch overhead) with
+inputs/outputs in root `turbo.json`. A warm second gate on an unchanged tree
 replays those steps from `.turbo/` (often under a second). Full vitest, browser tests,
 malware, changed-file Biome, and the i18n freshness `git diff` always run (they are not
 cached as "passed"). Catalog edits under `src/ui/i18n.catalog/**` invalidate `i18n:gen`.

--- a/scripts/gate.mjs
+++ b/scripts/gate.mjs
@@ -21,10 +21,18 @@
 // changed-file biome are never treated as cacheable "green forever".
 import { spawnSync } from 'node:child_process';
 import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { resolveAvailableMemoryBytes } from './lib/gate_memory.mjs';
 import { runGatePreflights } from './lib/gate_preflight.mjs';
 import { buildFullGateSteps } from './lib/gate_steps.mjs';
 import { computeGateWorkers, resolveGateWorkerTierCap } from './lib/gate_workers.mjs';
+
+// Same fileURLToPath-based resolution gate_select.mjs already uses: correct
+// regardless of the invoking process's cwd, unlike process.cwd(). Threaded
+// into buildFullGateSteps so its turbo steps resolve node_modules/.bin/turbo
+// directly instead of paying npx's dispatch overhead on every cacheable step.
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 
 // Halving the core count only protects a gate run from ITSELF; it does nothing when a
 // second `npm run gate` (or any other heavy vitest run) is happening in a sibling
@@ -78,7 +86,7 @@ const baseEnv = { ...process.env };
 // Shared step list (Phase 2 generate-once + Phase 8 turbo cacheable pure steps).
 // The bot build rides inside buildFullGateSteps (scripts/lib/gate_steps.mjs), so
 // the packet's R7 step stays in every consumer of the shared list.
-const steps = buildFullGateSteps(workers, { releaseTier });
+const steps = buildFullGateSteps(workers, { releaseTier, repoRoot });
 
 if (releaseTier) {
   console.log(

--- a/scripts/gate_profile.mjs
+++ b/scripts/gate_profile.mjs
@@ -150,6 +150,7 @@ if (args.steps) {
     skipBuilds: args.skipBuilds,
     skipVitest: args.skipVitest,
     skipTypes: args.skipTypes,
+    repoRoot: ROOT,
   });
 
   if (args.dryRun) {

--- a/scripts/gate_select.mjs
+++ b/scripts/gate_select.mjs
@@ -143,7 +143,7 @@ console.log(`[gate:select] workers=${workers}`);
 
 const branch = git('git', ['branch', '--show-current']).stdout?.trim() ?? '';
 const releaseTier = branch.startsWith('release/');
-const steps = buildFullGateSteps(workers, { releaseTier, skipVitest: true });
+const steps = buildFullGateSteps(workers, { releaseTier, skipVitest: true, repoRoot });
 
 /** @type {Array<{ name: string, cmd: string, args: string[], hint?: string, env?: Record<string, string> }>} */
 const vitestSteps = [];

--- a/scripts/lib/gate_profile.d.mts
+++ b/scripts/lib/gate_profile.d.mts
@@ -94,6 +94,8 @@ export declare function buildGateProfileSteps(
     skipBuilds?: boolean;
     skipVitest?: boolean;
     skipTypes?: boolean;
+    /** Forwarded to buildFullGateSteps: resolveTurboBin's cmd for turbo steps. */
+    repoRoot?: string;
   },
 ): GateProfileStep[];
 

--- a/scripts/lib/gate_profile.mjs
+++ b/scripts/lib/gate_profile.mjs
@@ -229,6 +229,7 @@ export function parseGateProfileArgs(argv) {
  *   skipBuilds?: boolean,
  *   skipVitest?: boolean,
  *   skipTypes?: boolean,
+ *   repoRoot?: string,
  * }} [opts]
  * @returns {Array<{ name: string, cmd: string, args: string[], env?: Record<string, string> }>}
  */

--- a/scripts/lib/gate_steps.d.mts
+++ b/scripts/lib/gate_steps.d.mts
@@ -18,5 +18,7 @@ export function buildFullGateSteps(
     skipBuilds?: boolean;
     skipVitest?: boolean;
     skipTypes?: boolean;
+    /** Passed to resolveTurboBin for the turbo steps' cmd; defaults to process.cwd(). */
+    repoRoot?: string;
   },
 ): FullGateStep[];

--- a/scripts/lib/gate_steps.mjs
+++ b/scripts/lib/gate_steps.mjs
@@ -3,7 +3,7 @@
 // never-cache vitest semantics in one place so profile timings match the real
 // merge bar.
 import { gateVitestSkipPretestEnv } from './gate_artifact_skip.mjs';
-import { turboRunArgs } from './gate_task_cache.mjs';
+import { resolveTurboBin, turboRunArgs } from './gate_task_cache.mjs';
 
 // The suites whose ASSERTIONS change under I18N_RELEASE_TIER=1 (they read the flag
 // and tighten from "key is registered" to "every locale is filled"). They are the
@@ -43,7 +43,8 @@ export const I18N_ARTIFACTS = Object.freeze([
 /**
  * Full local gate steps (after dep-sync and ffmpeg preflights in gate.mjs).
  *
- * Cacheable pure artifacts go through `npx turbo run ...` (inputs/outputs in
+ * Cacheable pure artifacts go through the resolved turbo binary directly
+ * (`resolveTurboBin`, no `npx` dispatch overhead; inputs/outputs in
  * turbo.json). Malware, biome, and tests always run via npm (no "passed"
  * cache). i18n:gen, wiki:content, and sfx:check are independent leaf tasks in
  * turbo.json (none dependsOn another), so they share one turbo multi-task step
@@ -57,6 +58,7 @@ export const I18N_ARTIFACTS = Object.freeze([
  *   skipBuilds?: boolean,
  *   skipVitest?: boolean,
  *   skipTypes?: boolean,
+ *   repoRoot?: string,
  * }} [opts]
  * @returns {Array<{
  *   name: string,
@@ -67,11 +69,17 @@ export const I18N_ARTIFACTS = Object.freeze([
  * }>}
  */
 export function buildFullGateSteps(workers, opts = {}) {
+  // Callers that already resolve their own repoRoot from the module's own
+  // location (gate.mjs, gate_select.mjs; see resolveTurboBin) pass it through
+  // rather than relying on process.cwd(), which is only correct when the gate
+  // is invoked FROM the repo root.
+  const repoRoot = opts.repoRoot ?? process.cwd();
+  const turboBin = resolveTurboBin(repoRoot);
   /** @type {Array<{ name: string, cmd: string, args: string[], hint?: string, env?: Record<string, string> }>} */
   const steps = [
     {
       name: 'i18n + wiki + sfx artifacts',
-      cmd: 'npx',
+      cmd: turboBin,
       args: turboRunArgs(['i18n:gen', 'wiki:content', 'sfx:check']),
     },
     {
@@ -128,19 +136,19 @@ export function buildFullGateSteps(workers, opts = {}) {
   if (!opts.skipTypes && !opts.skipBuilds) {
     steps.push({
       name: 'typecheck + env/server/bot builds',
-      cmd: 'npx',
+      cmd: turboBin,
       args: turboRunArgs(['check:types', 'build:env', 'build:server', 'build:bot']),
     });
     steps.push({
       name: 'client build',
-      cmd: 'npx',
+      cmd: turboBin,
       args: turboRunArgs(['build:bundle']),
     });
   } else {
     if (!opts.skipTypes) {
       steps.push({
         name: 'typecheck',
-        cmd: 'npx',
+        cmd: turboBin,
         args: turboRunArgs(['check:types']),
       });
     }
@@ -148,22 +156,22 @@ export function buildFullGateSteps(workers, opts = {}) {
       steps.push(
         {
           name: 'env build',
-          cmd: 'npx',
+          cmd: turboBin,
           args: turboRunArgs(['build:env']),
         },
         {
           name: 'server build',
-          cmd: 'npx',
+          cmd: turboBin,
           args: turboRunArgs(['build:server']),
         },
         {
           name: 'bot build',
-          cmd: 'npx',
+          cmd: turboBin,
           args: turboRunArgs(['build:bot']),
         },
         {
           name: 'client build',
-          cmd: 'npx',
+          cmd: turboBin,
           args: turboRunArgs(['build:bundle']),
         },
       );

--- a/scripts/lib/gate_task_cache.d.mts
+++ b/scripts/lib/gate_task_cache.d.mts
@@ -10,6 +10,8 @@ export const GATE_CACHE_TASK_INVENTORY: Readonly<Record<string, CacheTaskInvento
 
 export const GATE_TURBO_UI_ARGS: readonly string[];
 
+export function resolveTurboBin(repoRoot: string): string;
+
 export function turboRunArgs(tasks: readonly string[]): string[];
 
 export function isTurboGateStep(cmd: string, args: readonly string[]): boolean;

--- a/scripts/lib/gate_task_cache.mjs
+++ b/scripts/lib/gate_task_cache.mjs
@@ -15,6 +15,13 @@
 //   cannot hide drift from committed artifacts.
 // - Standalone `npm test` / `npm run build` still regenerate via pretest/build
 //   (Phase 2 generate-once only applies inside gate.mjs).
+//
+// Turbo invocation: gate steps resolve the pnpm-hoisted node_modules/.bin/turbo
+// binary directly (resolveTurboBin) rather than spawning `npx turbo`, so every
+// cacheable step skips npx's own package-resolution and version-check overhead
+// on top of an install `pnpm install --frozen-lockfile` already guarantees.
+
+import path from 'node:path';
 
 /** Tasks the full gate runs through turbo for local disk cache. */
 export const GATE_CACHEABLE_TASKS = Object.freeze([
@@ -136,7 +143,26 @@ export const GATE_CACHE_TASK_INVENTORY = Object.freeze({
 export const GATE_TURBO_UI_ARGS = Object.freeze(['--ui=stream']);
 
 /**
- * Args for `npx turbo run <tasks...>`.
+ * Absolute path to the pnpm-hoisted turbo binary for a gate step's `cmd`. Gate
+ * steps spawn this directly instead of `npx turbo`, matching how gate.mjs and
+ * gate_select.mjs already resolve their own repoRoot (fileURLToPath, not cwd,
+ * so the path is correct regardless of the invoking process's working directory).
+ * @param {string} repoRoot
+ * @returns {string}
+ */
+export function resolveTurboBin(repoRoot) {
+  return path.join(
+    repoRoot,
+    'node_modules',
+    '.bin',
+    `turbo${process.platform === 'win32' ? '.cmd' : ''}`,
+  );
+}
+
+/**
+ * Args for the resolved turbo binary's `run <tasks...>` (see resolveTurboBin).
+ * No leading `turbo` token: the binary itself, not npx's dispatch argv, already
+ * names the tool, so `cmd` carries that identity and `args` starts at `run`.
  * @param {ReadonlyArray<string>} tasks package.json script names
  * @returns {string[]}
  */
@@ -149,14 +175,21 @@ export function turboRunArgs(tasks) {
       throw new Error(`turboRunArgs: invalid task ${JSON.stringify(t)}`);
     }
   }
-  return ['turbo', 'run', ...tasks, ...GATE_TURBO_UI_ARGS];
+  return ['run', ...tasks, ...GATE_TURBO_UI_ARGS];
 }
 
 /**
- * True when a gate step is invoked through turbo (cacheable pure artifacts).
+ * True when a gate step invokes the resolved turbo binary directly (cacheable
+ * pure artifacts). `cmd` is an absolute path from resolveTurboBin, so this
+ * matches the binary's basename rather than an exact `npx` command string.
  * @param {string} cmd
  * @param {ReadonlyArray<string>} args
  */
 export function isTurboGateStep(cmd, args) {
-  return cmd === 'npx' && Array.isArray(args) && args[0] === 'turbo' && args[1] === 'run';
+  return (
+    typeof cmd === 'string' &&
+    /(?:^|[\\/])turbo(?:\.cmd)?$/.test(cmd) &&
+    Array.isArray(args) &&
+    args[0] === 'run'
+  );
 }

--- a/tests/ci_workflow.test.ts
+++ b/tests/ci_workflow.test.ts
@@ -243,9 +243,11 @@ describe('CI workflow parity', () => {
     // of the shared list builds the bot beside the server).
     expect(gate).toContain('buildFullGateSteps');
     expect(gateSteps.some((s) => s.name === 'typecheck + env/server/bot builds')).toBe(true);
-    expect(gateSteps.find((s) => s.name === 'typecheck + env/server/bot builds')?.args).toEqual(
-      expect.arrayContaining(['turbo', 'run', 'check:types', 'build:bot']),
-    );
+    const typesBuilds = gateSteps.find((s) => s.name === 'typecheck + env/server/bot builds');
+    // The local gate resolves turbo's own binary directly (no npx dispatch);
+    // cmd carries the "turbo" identity, args starts at "run" (gate_task_cache.mjs).
+    expect(typesBuilds?.cmd).toMatch(/(?:^|[\\/])turbo(?:\.cmd)?$/);
+    expect(typesBuilds?.args).toEqual(expect.arrayContaining(['run', 'check:types', 'build:bot']));
   });
 
   it('provisions FFmpeg from the static npm packages instead of apt', () => {
@@ -987,7 +989,7 @@ describe('CI workflow parity', () => {
     expect(vitest?.args).toEqual(['test', '--', '--maxWorkers=8']);
     expect(vitest?.env).toEqual({ WOC_SKIP_PRETEST: '1' });
     // gate.mjs still binds workers into the shared step builder.
-    expect(gate).toContain('buildFullGateSteps(workers, { releaseTier })');
+    expect(gate).toContain('buildFullGateSteps(workers, { releaseTier, repoRoot })');
     expect(gate).toContain('computeGateWorkers');
     // Both check jobs stay single unsharded jobs: serialized checks run once.
     for (const job of [prChecks, releaseChecks]) {
@@ -1125,21 +1127,19 @@ describe('CI workflow parity', () => {
     // bundles still run before the slow client build.
     const combined = gateSteps.find((s) => s.name === 'typecheck + env/server/bot builds');
     expect(combined?.args).toEqual(
-      expect.arrayContaining(['turbo', 'run', 'build:env', 'build:server', 'build:bot']),
+      expect.arrayContaining(['run', 'build:env', 'build:server', 'build:bot']),
     );
     const combinedIdx = gateSteps.findIndex((s) => s.name === 'typecheck + env/server/bot builds');
     const clientIdx = gateSteps.findIndex((s) => s.name === 'client build');
     expect(combinedIdx).toBeGreaterThanOrEqual(0);
     expect(clientIdx).toBeGreaterThan(combinedIdx);
-    expect(gateSteps[clientIdx]?.args).toEqual(
-      expect.arrayContaining(['turbo', 'run', 'build:bundle']),
-    );
+    expect(gateSteps[clientIdx]?.args).toEqual(expect.arrayContaining(['run', 'build:bundle']));
     // The profile fallback arm (types-only or builds-only runs) must carry the
     // bot build as its own step too, or --skip-types would silently drop it.
     const fallback = buildFullGateSteps(8, { skipTypes: true });
     expect(fallback.some((s) => s.name === 'bot build')).toBe(true);
     expect(fallback.find((s) => s.name === 'bot build')?.args).toEqual(
-      expect.arrayContaining(['turbo', 'run', 'build:bot']),
+      expect.arrayContaining(['run', 'build:bot']),
     );
   });
 

--- a/tests/gate_profile.test.ts
+++ b/tests/gate_profile.test.ts
@@ -11,8 +11,13 @@ import {
   parseGateProfileArgs,
   rankSlowestFiles,
 } from '../scripts/lib/gate_profile.mjs';
+import { resolveTurboBin } from '../scripts/lib/gate_task_cache.mjs';
 
 const GIB = 1024 * 1024 * 1024;
+// buildGateProfileSteps(workers) with no explicit opts.repoRoot falls back to
+// process.cwd() (gate_steps.mjs's buildFullGateSteps), which vitest always
+// runs from the repo root.
+const EXPECTED_TURBO_BIN = resolveTurboBin(process.cwd());
 
 describe('classifyMachineTier', () => {
   it('labels high when both CPU and RAM clear the high bar', () => {
@@ -250,13 +255,13 @@ describe('buildGateProfileSteps', () => {
     // Generate-once: skip pretest after i18n + wiki; client build is turbo build:bundle.
     expect(vitest?.env).toEqual({ WOC_SKIP_PRETEST: '1' });
     const i18n = steps.find((s) => s.name === 'i18n + wiki + sfx artifacts');
-    expect(i18n?.cmd).toBe('npx');
+    expect(i18n?.cmd).toBe(EXPECTED_TURBO_BIN);
     expect(i18n?.args).toEqual(
-      expect.arrayContaining(['turbo', 'run', 'i18n:gen', 'wiki:content', 'sfx:check']),
+      expect.arrayContaining(['run', 'i18n:gen', 'wiki:content', 'sfx:check']),
     );
     const client = steps.find((s) => s.name === 'client build');
-    expect(client?.cmd).toBe('npx');
-    expect(client?.args).toEqual(expect.arrayContaining(['turbo', 'run', 'build:bundle']));
+    expect(client?.cmd).toBe(EXPECTED_TURBO_BIN);
+    expect(client?.args).toEqual(expect.arrayContaining(['run', 'build:bundle']));
   });
 
   it('honors skip flags without dropping unskipped steps', () => {

--- a/tests/gate_task_cache.test.ts
+++ b/tests/gate_task_cache.test.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from 'node:fs';
+import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { buildFullGateSteps, I18N_ARTIFACTS } from '../scripts/lib/gate_steps.mjs';
 import {
@@ -6,8 +7,13 @@ import {
   GATE_CACHEABLE_TASKS,
   GATE_NON_CACHEABLE_TASKS,
   isTurboGateStep,
+  resolveTurboBin,
   turboRunArgs,
 } from '../scripts/lib/gate_task_cache.mjs';
+
+// buildFullGateSteps(workers) with no explicit opts.repoRoot falls back to
+// process.cwd(), which vitest always runs from the repo root.
+const EXPECTED_TURBO_BIN = resolveTurboBin(process.cwd());
 
 const turboJson = JSON.parse(readFileSync(new URL('../turbo.json', import.meta.url), 'utf8')) as {
   cacheDir?: string;
@@ -23,10 +29,9 @@ const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url),
 };
 
 describe('turboRunArgs', () => {
-  it('builds npx-ready turbo run argv with stream UI', () => {
-    expect(turboRunArgs(['i18n:gen'])).toEqual(['turbo', 'run', 'i18n:gen', '--ui=stream']);
+  it('builds argv for the resolved turbo binary with stream UI, no leading "turbo" token', () => {
+    expect(turboRunArgs(['i18n:gen'])).toEqual(['run', 'i18n:gen', '--ui=stream']);
     expect(turboRunArgs(['check:types', 'build:env', 'build:server'])).toEqual([
-      'turbo',
       'run',
       'check:types',
       'build:env',
@@ -38,6 +43,15 @@ describe('turboRunArgs', () => {
   it('rejects empty or invalid task lists', () => {
     expect(() => turboRunArgs([])).toThrow(/at least one/);
     expect(() => turboRunArgs([''])).toThrow(/invalid task/);
+  });
+});
+
+describe('resolveTurboBin', () => {
+  it('resolves the pnpm-hoisted binary under the given repoRoot with a platform-appropriate suffix', () => {
+    const suffix = process.platform === 'win32' ? '.cmd' : '';
+    expect(resolveTurboBin('/repo')).toBe(
+      path.join('/repo', 'node_modules', '.bin', `turbo${suffix}`),
+    );
   });
 });
 
@@ -116,8 +130,9 @@ describe('buildFullGateSteps orchestration', () => {
 
     const artifacts = byName['i18n + wiki + sfx artifacts'];
     expect(isTurboGateStep(artifacts.cmd, artifacts.args)).toBe(true);
+    expect(artifacts.cmd).toBe(EXPECTED_TURBO_BIN);
     expect(artifacts.args).toEqual(
-      expect.arrayContaining(['turbo', 'run', 'i18n:gen', 'wiki:content', 'sfx:check']),
+      expect.arrayContaining(['run', 'i18n:gen', 'wiki:content', 'sfx:check']),
     );
     expect(byName['i18n freshness'].cmd).toBe('git');
     expect(byName['i18n freshness'].args).toEqual(
@@ -133,16 +148,9 @@ describe('buildFullGateSteps orchestration', () => {
     expect(byName['browser regressions'].cmd).toBe('npm');
 
     const typesBuilds = byName['typecheck + env/server/bot builds'];
-    expect(typesBuilds.cmd).toBe('npx');
+    expect(typesBuilds.cmd).toBe(EXPECTED_TURBO_BIN);
     expect(typesBuilds.args).toEqual(
-      expect.arrayContaining([
-        'turbo',
-        'run',
-        'check:types',
-        'build:env',
-        'build:server',
-        'build:bot',
-      ]),
+      expect.arrayContaining(['run', 'check:types', 'build:env', 'build:server', 'build:bot']),
     );
     expect(isTurboGateStep(byName['client build'].cmd, byName['client build'].args)).toBe(true);
     expect(byName['client build'].args).toContain('build:bundle');
@@ -202,5 +210,12 @@ describe('gate.mjs wiring pins', () => {
     expect(pkg.scripts.build).toContain('i18n:gen');
     expect(pkg.scripts.build).toContain('wiki:content');
     expect(pkg.scripts['build:bundle']).not.toContain('i18n:gen');
+  });
+
+  it('resolves its own repoRoot and threads it into buildFullGateSteps', () => {
+    // Same fileURLToPath pattern gate_select.mjs already used, not process.cwd():
+    // correct regardless of the invoking process's working directory.
+    expect(gateSrc).toContain('fileURLToPath(import.meta.url)');
+    expect(gateSrc).toContain('buildFullGateSteps(workers, { releaseTier, repoRoot })');
   });
 });


### PR DESCRIPTION
## Summary

The gate scripts spawned turbo via `npx turbo run ...` at 8 call sites, paying `npx`'s per-invocation resolution overhead every time (measured about 1-2s across a full `gate.mjs`/`gate_select.mjs` run). Added `resolveTurboBin(repoRoot)`, resolving `node_modules/.bin/turbo` (`.cmd` on win32) directly, and pointed every call site at the resolved binary instead of `npx`. `turboRunArgs()` no longer needs the leading `'turbo'` token since the binary identity now comes from `cmd`. `repoRoot` is threaded into `buildFullGateSteps` and `buildGateProfileSteps` the same way `gate_select.mjs` already computes it.

## Related issues

N/A

## Type of change

- [x] Refactor or performance (no behavior change)
- [x] Build, CI, or tooling

## How was this tested

- Commands: `npx tsc --noEmit`; `npx vitest run tests/gate_task_cache.test.ts tests/ci_workflow.test.ts tests/gate_profile.test.ts tests/gate_artifact_skip.test.ts tests/release_i18n_tier_coverage.test.ts tests/gate_select_plan.test.ts tests/architecture.test.ts tests/localization_fixes.test.ts` (all green); `npx @biomejs/biome check` on the 12 touched files (clean).
- Manual steps: drove `buildFullGateSteps` end to end through every real step object (i18n/wiki/sfx artifacts, i18n freshness, malware scan, typecheck+env/server/bot builds, client build) via the resolved turbo binary; several hit a warm turbo cache ("FULL TURBO") and all exited 0.

## Screenshots / recordings

N/A: non-visual infra/performance change (no player- or operator-facing UI).

```mermaid
flowchart LR
    A[gate step needs turbo] -->|before| B["cmd: npx, args: turbo run ..."]
    B --> C[npx resolves/checks the binary every call]
    A -->|after| D["cmd: node_modules/.bin/turbo, args: run ..."]
    D --> E[binary resolved once, no npx overhead]
```

---

## Checklist

### Quality

- [x] **The gate passes.** `node scripts/gate_select.mjs` is green (or `npm run gate` for the full suite). I added or updated decisive tests for changed behavior and recorded any manual checks above.

### Cross-platform

- ~~Tested on desktop and mobile.~~
- ~~Accessible.~~

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files.
