### PR TITLE
refactor(ui-i18n): narrow the resident locale table type

### DIFF
--- a/src/ui/i18n.ts
+++ b/src/ui/i18n.ts
@@ -193,7 +193,9 @@ export function setLanguage(lang: SupportedLanguage): void {
 // statically available (only `en` is), so the bootstrap await (src/main.ts startGame,
 // behind the loading screen) is a REAL per-locale fetch that populates resident before the
 // HUD's first localized paint.
-const resident: Partial<Record<SupportedLanguage, EnTranslations>> = { en };
+const resident: Partial<Record<SupportedLanguage, EnTranslations>> & { en: EnTranslations } = {
+  en,
+};
 // One in-flight load promise per locale so concurrent callers coalesce onto a single
 // import instead of racing N of them.
 const inflight = new Map<SupportedLanguage, Promise<void>>();
@@ -343,7 +345,7 @@ function tableFor(lang: SupportedLanguage): EnTranslations {
   // resident.en is the universal English fallback for a locale not yet loaded (or one whose
   // chunk failed to fetch): the synchronous read never blocks and never throws. Callers that
   // need the localized table await ensureLocaleLoaded(lang) first (bootstrap / picker).
-  return resident[lang] ?? resident.en!;
+  return resident[lang] ?? resident.en;
 }
 
 export function t(key: TranslationKey, values?: InterpolationValues): string {


### PR DESCRIPTION
## Summary

`resident` (the lazy locale table in `src/ui/i18n.ts`) is always initialized with `en` and that
key is never removed, so `tableFor`'s English fallback read had to use a non-null assertion
(`resident.en!`). Narrowing the declared type to intersect with `{ en: EnTranslations }` lets
`tsc` know `resident.en` is always present, so the assertion can be dropped. No behavior change:
the value stored under `en` and every other read/write path is identical.

```mermaid
graph LR
    subgraph before["before"]
        A["src/ui/i18n.ts\nresident: Partial<Record<...>>\ntableFor() uses resident.en!"]
    end
    subgraph after["after"]
        B["src/ui/i18n.ts\nresident: Partial<Record<...>> & { en: EnTranslations }\ntableFor() uses resident.en (no assertion)"]
    end
    A -->|type narrowed, assertion dropped| B
```

## Related issues

N/A

## Type of change

- [x] Refactor or performance (no behavior change)

## How was this tested?

- Commands run:
  - `npx tsc --noEmit` (clean; confirms the narrowed type still satisfies both the `{ en }`
    initializer and the `resident[lang] = ...` assignment)
  - `npx vitest run tests/i18n*.test.ts` (16 files, 184 passed, 2 skipped)
  - `npx vitest run tests/architecture.test.ts` (40 passed; `src/ui/` touched)
  - `npm run ci:changed` (clean on the changed file, no format diff, no errors; pre-existing
    whole-repo lint warnings only, unrelated to this change)
  - `node scripts/gate_select.mjs` (exited 0; the diff base it picked resolved to a broad/
    unclassified mode that ran the full suite, which passed end to end)
- Manual steps: read the surrounding module and the assignment at `resident[lang] = ...` to
  confirm the intersection type still accepts a `SupportedLanguage`-keyed write; no
  known-flaky retries were needed and no unrelated pre-existing gate failure was observed.

## Screenshots / recordings

N/A: non-visual refactor (no behavior change)
