### PR TITLE
refactor(net): extract account cosmetics wire decode into its own module

### DIFF
--- a/src/net/account_cosmetics_wire.ts
+++ b/src/net/account_cosmetics_wire.ts
@@ -1,0 +1,37 @@
+// Wire decode for the account cosmetics self-snapshot facet (the `cosmetics`
+// field on the `self` record). Kept as its own DOM-free, ClientWorld-free
+// module so the decode is unit-testable without standing up a socket, and so
+// online.ts stays a consumer rather than growing another decode block.
+//
+// Defensive by construction, the online.ts decode idiom: every field is
+// re-validated and a malformed entry is DROPPED rather than mirrored.
+
+import type { AccountCosmetics } from '../world_api';
+
+function stringList(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === 'string')
+    : [];
+}
+
+function stringRecord(value: unknown): Record<string, string> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {};
+  const out: Record<string, string> = {};
+  for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+    if (typeof entry === 'string' && entry.length > 0) out[key] = entry;
+  }
+  return out;
+}
+
+/** Decode a `self.cosmetics` payload into an `AccountCosmetics` mirror. Missing
+ *  or malformed input yields all-empty defaults rather than throwing, matching
+ *  the rest of the online decode idiom. */
+export function normalizeAccountCosmetics(value: unknown): AccountCosmetics {
+  const src = value && typeof value === 'object' ? (value as Record<string, unknown>) : {};
+  return {
+    completedQuestIds: stringList(src.completedQuestIds),
+    mechChromaIds: stringList(src.mechChromaIds),
+    weaponSkinIds: stringList(src.weaponSkinIds),
+    weaponSkinLoadout: stringRecord(src.weaponSkinLoadout),
+  };
+}

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -145,6 +145,7 @@ import type {
   MasterworkView,
   SalvageResultView,
 } from '../world_api/professions';
+import { normalizeAccountCosmetics } from './account_cosmetics_wire';
 import { computeBackoffDelay } from './backoff';
 import { decodeGuildBankLogFrame, GUILD_BANK_LOG_TTL_MS } from './guild_bank_log_wire';
 import { INPUT_SEND_TIMER_INTERVAL_MS, inputFlushGateOpen } from './input_send_cadence';
@@ -210,31 +211,6 @@ export interface CharacterSummary {
   /** The account's active Armory weapon skin for this character (server-resolved
    *  per class + mainhand). Optional for back-compat like the fields above. */
   weaponSkinId?: string | null;
-}
-
-function stringList(value: unknown): string[] {
-  return Array.isArray(value)
-    ? value.filter((item): item is string => typeof item === 'string')
-    : [];
-}
-
-function stringRecord(value: unknown): Record<string, string> {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) return {};
-  const out: Record<string, string> = {};
-  for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
-    if (typeof entry === 'string' && entry.length > 0) out[key] = entry;
-  }
-  return out;
-}
-
-function normalizeAccountCosmetics(value: unknown): AccountCosmetics {
-  const src = value && typeof value === 'object' ? (value as Record<string, unknown>) : {};
-  return {
-    completedQuestIds: stringList(src.completedQuestIds),
-    mechChromaIds: stringList(src.mechChromaIds),
-    weaponSkinIds: stringList(src.weaponSkinIds),
-    weaponSkinLoadout: stringRecord(src.weaponSkinLoadout),
-  };
 }
 
 export function buildWebSocketUrl(protocol: string, host: string): string {

--- a/tests/account_cosmetics_wire.test.ts
+++ b/tests/account_cosmetics_wire.test.ts
@@ -1,0 +1,53 @@
+// The account cosmetics self-snapshot decoder (src/net/account_cosmetics_wire.ts):
+// undefined/malformed input yields all-empty defaults, and a well-formed payload
+// passes real entries through while filtering out anything the wrong shape.
+import { describe, expect, it } from 'vitest';
+
+import { normalizeAccountCosmetics } from '../src/net/account_cosmetics_wire';
+
+describe('normalizeAccountCosmetics', () => {
+  it('returns all-empty defaults for undefined', () => {
+    expect(normalizeAccountCosmetics(undefined)).toEqual({
+      completedQuestIds: [],
+      mechChromaIds: [],
+      weaponSkinIds: [],
+      weaponSkinLoadout: {},
+    });
+  });
+
+  it('returns all-empty defaults for an empty object', () => {
+    expect(normalizeAccountCosmetics({})).toEqual({
+      completedQuestIds: [],
+      mechChromaIds: [],
+      weaponSkinIds: [],
+      weaponSkinLoadout: {},
+    });
+  });
+
+  it('passes through well-formed id arrays and filters non-string entries', () => {
+    const result = normalizeAccountCosmetics({
+      completedQuestIds: ['quest_a', 'quest_b', 7, null],
+      mechChromaIds: ['chroma_red', 42, 'chroma_blue'],
+      weaponSkinIds: ['skin_gold', false, 'skin_shadow'],
+    });
+    expect(result.completedQuestIds).toEqual(['quest_a', 'quest_b']);
+    expect(result.mechChromaIds).toEqual(['chroma_red', 'chroma_blue']);
+    expect(result.weaponSkinIds).toEqual(['skin_gold', 'skin_shadow']);
+  });
+
+  it('keeps only string, non-empty-string values in weaponSkinLoadout', () => {
+    const result = normalizeAccountCosmetics({
+      weaponSkinLoadout: {
+        sword: 'skin_gold',
+        axe: '',
+        mace: 12,
+        bow: null,
+        staff: 'skin_shadow',
+      },
+    });
+    expect(result.weaponSkinLoadout).toEqual({
+      sword: 'skin_gold',
+      staff: 'skin_shadow',
+    });
+  });
+});


### PR DESCRIPTION
<!--
Thanks for contributing to World of ClaudeCraft!

New here? The contributing guide is available in your language:
https://github.com/levy-street/world-of-claudecraft/blob/main/CONTRIBUTING.md

Filling this out helps reviewers understand and merge your work faster. Anything
that doesn't apply to your change, feel free to delete or mark as N/A.
-->

## Summary

Moves the three pure AccountCosmetics wire-decode helpers (`stringList`, `stringRecord`,
`normalizeAccountCosmetics`) out of `src/net/online.ts` into a new sibling module,
`src/net/account_cosmetics_wire.ts`, matching the existing `guild_bank_log_wire.ts` /
`snapshot_timer_wire.ts` naming pattern. `online.ts` now imports `normalizeAccountCosmetics`
for its single call site in `applySnapshot`. No behavior change: the decode logic is
verbatim, just relocated and now independently unit-tested.

```mermaid
graph LR
    subgraph before["before"]
        A["src/net/online.ts\n(stringList, stringRecord,\nnormalizeAccountCosmetics inline)"]
    end
    subgraph after["after"]
        B["src/net/online.ts\n(applySnapshot calls out)"]
        C["src/net/account_cosmetics_wire.ts\n(stringList, stringRecord,\nnormalizeAccountCosmetics)"]
        B --> C
    end
```

## Related issues

N/A

## Type of change

- [x] Refactor or performance (no behavior change)

## How was this tested?

- Commands:
  - `npx tsc --noEmit` (clean, exit 0)
  - `npx vitest run tests/account_cosmetics_wire.test.ts` (4 passed, new test file)
  - `npx vitest run tests/snapshots.test.ts tests/game_sessions.test.ts tests/architecture.test.ts tests/world_api_parity.test.ts` (577 passed; run because these are the net/cosmetics-adjacent suites that exercise `ClientWorld.applySnapshot` and the `IWorld` seam)
  - `npx @biomejs/biome check src/net/online.ts src/net/account_cosmetics_wire.ts tests/account_cosmetics_wire.test.ts` (0 errors, 2 pre-existing `noExplicitAny` warnings at online.ts:976/978, unrelated to this change and outside the touched lines)
  - `git push` (this repo's `.githooks/pre-push` QA floor: `tsc --noEmit`, the guard tests
    `tests/architecture.test.ts` + `tests/localization_fixes.test.ts`, and the biome
    changed-files check) ran for real on the actual commit and printed
    "pre-push QA floor: green."
  - `node scripts/gate_select.mjs`: started but did not finish within this session. This
    worktree's local environment was under extreme, unrelated resource contention while
    testing (dozens of concurrent sibling worktree agents each running full vitest/tsc/build
    passes; `free -h` showed under 200 MB free of 30 GB with 26+ GB of swap in use, and one
    interim `tsc --noEmit` invocation was OOM-killed rather than failing on real type errors,
    confirmed by immediately re-running it standalone to a clean exit 0). Separately,
    `gate_select.mjs`'s own diff-base detection picked a stale integration base
    (`origin/release/v0.33.0`, this fork's `origin` remote lagging the real
    `upstream/release/v0.36.0` tip by hundreds of commits) and fell back to full-suite mode
    over an unrelated 6334-path diff. Both are pre-existing environment/worktree issues, not
    caused by this change, worth fixing once (point `origin` at the real upstream release
    tip, or teach the diff-base step to prefer `upstream/release/**`) rather than every
    worktree agent hitting it independently.
- Manual steps:
  - Confirmed the diff is scoped to exactly the three files above:
    `git diff --stat upstream/release/v0.36.0` shows only `src/net/online.ts` modified plus
    the two new files.
