### PR TITLE
refactor(server): drop dead guild bank log reader test seam

### DIFF
--- a/server/guild_bank_log.ts
+++ b/server/guild_bank_log.ts
@@ -165,10 +165,11 @@ export function projectGuildBankLogRows(
 }
 
 // ---------------------------------------------------------------------------
-// The process cache. The database reader is INJECTED (the
-// configure<Domain>Runtime idiom) so tests can drive the cache mechanics with a
-// counting fake and no Postgres, and so the cache builds lazily: no clock and
-// no bound is bound before a test can replace it.
+// The process cache. The database reader is INJECTED, swappable only via the
+// `reader` override on resetGuildBankLogCacheForTests below, so tests can
+// drive the cache mechanics with a counting fake and no Postgres, and so the
+// cache builds lazily: no clock and no bound is bound before a test can
+// replace it.
 // ---------------------------------------------------------------------------
 
 export type GuildBankLogReader = (guildId: number) => Promise<readonly GuildBankLogEntry[]>;
@@ -309,12 +310,6 @@ export function guildBankLogCacheStats(): KeyedCachedReadStats & { dirtyGuilds: 
     entries: 0,
   };
   return { ...stats, dirtyGuilds: dirtyUntil.size };
-}
-
-/** Test seam: swap the database reader and rebuild the cache. */
-export function configureGuildBankLogReader(read: GuildBankLogReader): void {
-  reader = read;
-  active = null;
 }
 
 /** Test seam: reset to the production reader (or keep an injected one) and


### PR DESCRIPTION
## Summary

Removes `configureGuildBankLogReader` from `server/guild_bank_log.ts`: a "test seam: swap the
database reader" helper that has zero call sites anywhere in the repo. Its job is already fully
covered by `resetGuildBankLogCacheForTests`'s optional `reader` override, which every existing
test already uses. The doc comment above the injected-reader block was also updated to point at
that real seam instead of the deleted function.

```mermaid
graph LR
    subgraph before["before"]
        A["server/guild_bank_log.ts\nconfigureGuildBankLogReader (dead, 0 call sites)\nresetGuildBankLogCacheForTests (reader override)"]
    end
    subgraph after["after"]
        B["server/guild_bank_log.ts\nresetGuildBankLogCacheForTests (reader override)\n(the ONLY test seam for the reader)"]
    end
    A -.->|deleted, no behavior change| B
```

## Related issues

N/A

## Type of change

- [x] Refactor or performance (no behavior change)

## How was this tested?

- Commands run in this order, all passing:
  - `npx tsc --noEmit` (clean, confirms nothing imports the removed export)
  - `npx vitest run tests/server/guild_bank_log.test.ts tests/guild_bank_log_server.test.ts tests/guild_bank_log_view.test.ts tests/guild_bank_log_wire.test.ts` (4 files, 80 tests passed)
  - `npm run ci:changed` (exit 0; the only findings are pre-existing whole-repo warnings unrelated
    to this change, per the repo's documented "whole-repo biome is intentionally red" policy; the
    changed file itself is clean under a direct `biome check server/guild_bank_log.ts`)
  - `node scripts/gate_select.mjs` (full mode; see note below)
- Manual steps: none needed beyond the above; this is a pure dead-code deletion with no behavior
  change, so no manual verification was applicable.
