### PR TITLE
refactor(game-audio): extract MusicDirector's mix-audibility policy

### DIFF
--- a/src/game/music.ts
+++ b/src/game/music.ts
@@ -11,6 +11,8 @@
 
 import type { BiomeId } from '../sim/types';
 import { resumeWhenAllowed } from './audio_unlock';
+import type { MusicMixState } from './music_mix_policy';
+import { isMusicMixAudible, musicMixMasterTarget } from './music_mix_policy';
 import { MUSIC_OVERRIDES } from './music_overrides.generated';
 import { COMBAT_STREAM_URLS, pickCombatTrackIndex, ZONE_STREAM_URLS } from './music_tracks';
 
@@ -4825,12 +4827,23 @@ export class MusicDirector {
     return this._enabled;
   }
 
+  // Maps this director's private mix-relevant fields into the shared, pure
+  // MusicMixState shape so masterTarget()/streamsAudible() can delegate to
+  // music_mix_policy.ts.
+  private mixState(): MusicMixState {
+    return {
+      enabled: this._enabled,
+      menuPaused: this._menuPaused,
+      bossActive: this.bossActive,
+      sowfieldActive: this.sowfieldTrack !== null,
+      vol: this._vol,
+    };
+  }
+
   // master gain target given the enabled flag and volume (base STREAM_LEVEL).
   // The dedicated Nythraxis track owns the mix while active.
   private masterTarget(): number {
-    if (!this._enabled || this._menuPaused || this.bossActive || this.sowfieldTrack !== null)
-      return 0;
-    return STREAM_LEVEL * this._vol;
+    return musicMixMasterTarget(this.mixState(), STREAM_LEVEL);
   }
 
   /** Engage/disengage the dedicated boss-fight loop. Idempotent; called every
@@ -5117,13 +5130,7 @@ export class MusicDirector {
   // Sowfield file tracks (which own the mix while active). While inaudible,
   // streams pause instead of decoding silence.
   private streamsAudible(): boolean {
-    return (
-      this._enabled &&
-      !this._menuPaused &&
-      this._vol > 0 &&
-      !this.bossActive &&
-      this.sowfieldTrack === null
-    );
+    return isMusicMixAudible(this.mixState());
   }
 
   private setStreamTarget(stream: StreamTrack, target: number, fadeSeconds: number): void {

--- a/src/game/music_mix_policy.ts
+++ b/src/game/music_mix_policy.ts
@@ -1,0 +1,34 @@
+// Pure decision logic for whether the procedural soundtrack mix should be
+// audible, and at what level. Extracted from MusicDirector (music.ts) so the
+// five-flag policy (enabled, menuPaused, bossActive, sowfieldActive, vol) is
+// unit-testable without any AudioContext or other WebAudio wiring.
+
+export interface MusicMixState {
+  enabled: boolean;
+  menuPaused: boolean;
+  bossActive: boolean;
+  sowfieldActive: boolean;
+  vol: number;
+}
+
+// master gain target given the mix state and a base stream level. The
+// dedicated boss/Sowfield file tracks own the mix while active, and the
+// toggle, menu fade, and volume slider each duck the procedural score to 0.
+export function musicMixMasterTarget(state: MusicMixState, streamLevel: number): number {
+  if (!state.enabled || state.menuPaused || state.bossActive || state.sowfieldActive) return 0;
+  return streamLevel * state.vol;
+}
+
+// Streams are audible only when nothing has the master ducked to zero: the
+// toggle, the menu fade, the volume slider, and the dedicated boss and
+// Sowfield file tracks (which own the mix while active). While inaudible,
+// streams pause instead of decoding silence.
+export function isMusicMixAudible(state: MusicMixState): boolean {
+  return (
+    state.enabled &&
+    !state.menuPaused &&
+    state.vol > 0 &&
+    !state.bossActive &&
+    !state.sowfieldActive
+  );
+}

--- a/tests/music_mix_policy.test.ts
+++ b/tests/music_mix_policy.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isMusicMixAudible,
+  type MusicMixState,
+  musicMixMasterTarget,
+} from '../src/game/music_mix_policy';
+
+const baseState: MusicMixState = {
+  enabled: true,
+  menuPaused: false,
+  bossActive: false,
+  sowfieldActive: false,
+  vol: 0.5,
+};
+
+describe('musicMixMasterTarget', () => {
+  it('returns 0 when disabled', () => {
+    expect(musicMixMasterTarget({ ...baseState, enabled: false }, 0.5)).toBe(0);
+  });
+
+  it('returns 0 while the menu is paused', () => {
+    expect(musicMixMasterTarget({ ...baseState, menuPaused: true }, 0.5)).toBe(0);
+  });
+
+  it('returns 0 while a boss track owns the mix', () => {
+    expect(musicMixMasterTarget({ ...baseState, bossActive: true }, 0.5)).toBe(0);
+  });
+
+  it('returns 0 while a Sowfield track owns the mix', () => {
+    expect(musicMixMasterTarget({ ...baseState, sowfieldActive: true }, 0.5)).toBe(0);
+  });
+
+  it('returns streamLevel * vol otherwise', () => {
+    expect(musicMixMasterTarget(baseState, 0.5)).toBeCloseTo(0.25);
+  });
+});
+
+describe('isMusicMixAudible', () => {
+  it('mirrors the four duck conditions', () => {
+    expect(isMusicMixAudible({ ...baseState, enabled: false })).toBe(false);
+    expect(isMusicMixAudible({ ...baseState, menuPaused: true })).toBe(false);
+    expect(isMusicMixAudible({ ...baseState, bossActive: true })).toBe(false);
+    expect(isMusicMixAudible({ ...baseState, sowfieldActive: true })).toBe(false);
+  });
+
+  it('is false at vol 0', () => {
+    expect(isMusicMixAudible({ ...baseState, vol: 0 })).toBe(false);
+  });
+
+  it('is true only when no duck flag is set and vol > 0', () => {
+    expect(isMusicMixAudible(baseState)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

`MusicDirector.masterTarget()` and `streamsAudible()` were pure boolean/numeric
logic over five simple flags (`enabled`, `menuPaused`, `bossActive`,
`sowfieldTrack !== null`, `vol`) with no dependency on `AudioContext` or any
other `MusicDirector`-private mutable state. This PR extracts that logic
verbatim into a new pure module, `src/game/music_mix_policy.ts`
(`musicMixMasterTarget`/`isMusicMixAudible`), and has `MusicDirector` call it
through a small `mixState()` helper that maps its private fields into the
shared `MusicMixState` shape. All WebAudio wiring and observable behavior are
unchanged.

```mermaid
graph LR
    subgraph before["before"]
        A["src/game/music.ts\nmasterTarget()\nstreamsAudible()\n(inline boolean logic)"]
    end
    subgraph after["after"]
        B["src/game/music.ts\nmixState()\nmasterTarget() -> delegates\nstreamsAudible() -> delegates"]
        C["src/game/music_mix_policy.ts\nmusicMixMasterTarget()\nisMusicMixAudible()"]
        B --> C
    end
```

## Related issues

N/A

## Type of change

- [x] Refactor or performance (no behavior change)

## How was this tested?

- Commands:
  - `npx tsc --noEmit` (clean)
  - `npx vitest run tests/music_mix_policy.test.ts tests/music.test.ts tests/music_tracks.test.ts tests/architecture.test.ts` (4 files, 97 tests passed)
  - `npm run ci:changed` (clean: 0 errors, only pre-existing whole-repo warnings, exit 0)
  - `node scripts/gate_select.mjs` and the `.githooks/pre-push` QA floor (typecheck, guard tests
    `tests/architecture.test.ts` + `tests/localization_fixes.test.ts`, changed-files biome) all
    ran green on this diff.
- Manual steps: this batch run shared the machine with roughly two dozen other
  agents each running their own full `gate_select.mjs`/`tsc`/`vitest` concurrently, which drove
  the box into heavy CPU/memory contention (system RAM and swap both saturated). Under that
  contention a background full-suite `gate_select.mjs` run and a couple of `git push` attempts
  had their `tsc` subprocess OOM-killed (process `Killed`, not a real type error), and
  `tests/corpse_harvest_sim.test.ts` showed transient multi-minute timeouts on an unrelated
  worktree run. None of these touch `src/game/music.ts`, `music_mix_policy.ts`, or the new
  test; `npx tsc --noEmit` and the targeted Vitest run above were independently confirmed clean
  once contention eased, and the push that finally went through reports "pre-push QA floor:
  green." with `tsc`, the guard tests, and biome all passing on this exact diff.

## Screenshots / recordings

N/A: non-visual refactor (no behavior change)
