### PR TITLE
refactor(net): drop unused stable timer wire version guard

### DIFF
--- a/src/net/snapshot_timer_wire.ts
+++ b/src/net/snapshot_timer_wire.ts
@@ -17,10 +17,6 @@ export function snapshotTimerWireMode(value: unknown): SnapshotTimerWireMode {
   return 'unsupported';
 }
 
-export function isStableTimerWireVersion(value: unknown): value is StableTimerWireVersion {
-  return value === STABLE_TIMER_WIRE_VERSION;
-}
-
 export function stableDeadlineRemaining(value: unknown, now: number): number | null {
   if (
     typeof value !== 'number' ||


### PR DESCRIPTION
## Summary

Removes the unused `isStableTimerWireVersion` type-guard from `src/net/snapshot_timer_wire.ts`: it had no callers anywhere in the repo (`online.ts` only uses the sibling `snapshotTimerWireMode`, and the existing test suite never referenced it either). The `StableTimerWireVersion` type export it used is untouched, so nothing downstream changes.

```mermaid
graph LR
    subgraph before["before"]
        A["src/net/snapshot_timer_wire.ts\n(exports isStableTimerWireVersion, unused)"]
    end
    subgraph after["after"]
        B["src/net/snapshot_timer_wire.ts\n(dead export removed, rest unchanged)"]
    end
```

## Related issues

N/A

## Type of change

- [x] Refactor or performance (no behavior change)

## How was this tested?

- Commands (all run directly against this worktree/branch):
  - `npx tsc --noEmit`: passed, clean.
  - `npx vitest run tests/client_snapshot_timer_wire.test.ts`: passed, 6/6 tests.
  - `npm run ci:changed`: passed, exit 0 (2306 pre-existing repo-wide warnings, zero errors; consistent with the repo's documented warnings-are-not-blocking convention).
  - `node scripts/gate_select.mjs`: this environment is running roughly 40 parallel agents concurrently, each executing this same gate, so the machine was under severe resource contention during this change (observed at one point: 28-30Gi/30Gi RAM and swap in use, load average 130+). My first `gate_select.mjs` run was killed outright by the environment before completing. A retry made real progress (through i18n/sfx checks and into the full vitest suite) but I could not get a clean, uncontaminated final verdict from it: the shared scratch log I was tailing was later overwritten by a different parallel agent's run (its tail showed a worktree path that was not mine), so I am not citing its result either way.
  - In place of a contaminated `gate_select.mjs` verdict, the actual `git push` ran the repo's `.githooks/pre-push` QA floor directly against this worktree/branch (not shared scratch state), and it went green: `tsc --noEmit` clean, `tests/architecture.test.ts` + `tests/localization_fixes.test.ts` both passed (80 passed, 3 skipped, unaffected by this change), `npm run ci:changed` clean, and the em/en dash and emoji copy-scan over the push diff was clean. Push succeeded with "pre-push QA floor: green."
- Manual steps: confirmed via `grep -rn "isStableTimerWireVersion"` across the repo that the only match was the definition itself before removal, so no caller was left dangling.
- Given the change is a single, zero-caller dead-code deletion with no behavior change, and every check that ran cleanly against this actual branch (tsc, the targeted unit test, the two guard suites, and the changed-files lint) passed, I'm confident in this change despite not getting an uncontaminated full `gate_select.mjs` run in this heavily-loaded shared environment.

## Screenshots / recordings

N/A: non-visual refactor (no behavior change)
