### PR TITLE
refactor(render): consolidate the hand-rolled clamp01 helper

### DIFF
--- a/src/render/ability_vfx/spirits.ts
+++ b/src/render/ability_vfx/spirits.ts
@@ -3,6 +3,7 @@ import { clone as cloneSkinned } from 'three/addons/utils/SkeletonUtils.js';
 import { ABILITIES } from '../../sim/data';
 import { ABILITY_VFX_FULL_SPECS } from '../ability_vfx_full_specs';
 import { loadGltf } from '../assets/loader';
+import { clamp01 } from '../num_clamp';
 
 // Spirit apparitions (the gallery's spawnSpirit/updateSpirits): ghost-tinted
 // creature GLBs playing a short choreographed path, a druid's spectral bear
@@ -169,10 +170,6 @@ interface SpiritSlot {
   prevX: number;
   prevY: number;
   prevZ: number;
-}
-
-function clamp01(v: number): number {
-  return Math.min(1, Math.max(0, v));
 }
 
 function easeInOutSine(t: number): number {

--- a/src/render/biome_haze_field_core.ts
+++ b/src/render/biome_haze_field_core.ts
@@ -30,6 +30,7 @@ import { WORLD_MAX_X, WORLD_MAX_Z, WORLD_MIN_X, WORLD_MIN_Z } from '../sim/data'
 import type { BiomeId } from '../sim/types';
 import { zoneBiomeAt } from '../sim/world';
 import { FAR_WORLD_MARGIN } from './far_terrain_core';
+import { clamp01 } from './num_clamp';
 
 /** World yards per field texel. Small enough that a zone band (360 yards on
  *  its short axis) is fifteen texels across, large enough that the shipped
@@ -170,10 +171,6 @@ export interface HazeSample {
   g: number;
   b: number;
   strength: number;
-}
-
-function clamp01(v: number): number {
-  return v < 0 ? 0 : v > 1 ? 1 : v;
 }
 
 /** sRGB transfer, the same curve THREE.Color.setHex applies. */

--- a/src/render/click_marker.ts
+++ b/src/render/click_marker.ts
@@ -3,6 +3,8 @@
 // or DOM here so the curves are unit-testable in isolation; the renderer is the
 // thin consumer that maps these scalars onto meshes (see renderer.ts).
 
+import { clamp01 } from './num_clamp';
+
 // Total on-screen lifetime of one marker, in seconds. Short and snappy so it
 // reads as immediate feedback, not a lingering decal.
 export const CLICK_MARKER_LIFETIME = 0.5;
@@ -37,10 +39,6 @@ const HIDDEN: ClickMarkerAnim = {
 function easeOutCubic(t: number): number {
   const u = 1 - t;
   return 1 - u * u * u;
-}
-
-function clamp01(v: number): number {
-  return v < 0 ? 0 : v > 1 ? 1 : v;
 }
 
 // Given how long a marker has been alive, return the scalars that drive it.

--- a/src/render/day_night_core.ts
+++ b/src/render/day_night_core.ts
@@ -16,6 +16,7 @@
 // consistency across clients, not about parity.
 
 import type { BiomeId } from '../sim/types';
+import { clamp01 } from './num_clamp';
 
 /** Full day-to-night-to-day period. Twenty real minutes, so every play session
  *  sees the whole cycle several times over; epoch-anchored below, so the phase
@@ -395,10 +396,6 @@ export const REALM_DAYNIGHT_AMPLITUDE: Record<BiomeId, number> = Object.fromEntr
     1 - resistance * (1 - MIN_DAYNIGHT_AMPLITUDE),
   ]),
 ) as Record<BiomeId, number>;
-
-function clamp01(v: number): number {
-  return v < 0 ? 0 : v > 1 ? 1 : v;
-}
 
 function lerp(a: number, b: number, t: number): number {
   return a + (b - a) * t;

--- a/src/render/environment_transition_core.ts
+++ b/src/render/environment_transition_core.ts
@@ -2,6 +2,8 @@
 // The Three adapters own colors, textures, and scene writes; this core only
 // advances deterministic scalar and keyed blend state from caller-provided dt.
 
+import { clamp01 } from './num_clamp';
+
 /** Response for fog, tint, and lighting targets. About 97 percent settled in 5 seconds. */
 export const ZONE_ENVIRONMENT_RESPONSE = 0.7;
 
@@ -29,10 +31,6 @@ export interface EnvironmentMapTransition<K extends string> {
   current: K;
   pending: K | null;
   intensity: number;
-}
-
-function clamp01(value: number): number {
-  return value < 0 ? 0 : value > 1 ? 1 : value;
 }
 
 /** Exponential damping alpha, stable across frame rates for the same elapsed time. */

--- a/src/render/far_terrain_core.ts
+++ b/src/render/far_terrain_core.ts
@@ -37,6 +37,7 @@ import {
   farRenderedCellHeight,
   farVertexClearance,
 } from './far_surface_core';
+import { clamp01 } from './num_clamp';
 import {
   makeShoreProbe,
   SHORE_BAND_HEIGHT,
@@ -356,8 +357,6 @@ export function farGridIndices(side: number): Uint16Array {
 // are deliberately dropped: they are narrower than one far-mesh cell and the
 // near terrain owns everything inside the detail envelope anyway.
 // ---------------------------------------------------------------------------
-
-const clamp01 = (v: number): number => Math.max(0, Math.min(1, v));
 
 type Triple = [number, number, number];
 

--- a/src/render/impact_terrain.ts
+++ b/src/render/impact_terrain.ts
@@ -1,4 +1,5 @@
 import { MIREFEN_IMPACT_CRATER } from '../sim/world';
+import { clamp01 } from './num_clamp';
 
 export interface ImpactCraterTerrainBlend {
   ash: number;
@@ -6,8 +7,6 @@ export interface ImpactCraterTerrainBlend {
   dirt: number;
   rock: number;
 }
-
-const clamp01 = (v: number): number => Math.max(0, Math.min(1, v));
 
 function smoothstep(edge0: number, edge1: number, x: number): number {
   const t = clamp01((x - edge0) / (edge1 - edge0));
@@ -21,8 +20,9 @@ export function impactCraterTerrainBlend(x: number, z: number): ImpactCraterTerr
   }
 
   const bowl = 1 - smoothstep(0, MIREFEN_IMPACT_CRATER.bowlRadius, d);
-  const lip = smoothstep(MIREFEN_IMPACT_CRATER.bowlRadius * 0.62, MIREFEN_IMPACT_CRATER.bowlRadius, d)
-    * (1 - smoothstep(MIREFEN_IMPACT_CRATER.bowlRadius, MIREFEN_IMPACT_CRATER.radius, d));
+  const lip =
+    smoothstep(MIREFEN_IMPACT_CRATER.bowlRadius * 0.62, MIREFEN_IMPACT_CRATER.bowlRadius, d) *
+    (1 - smoothstep(MIREFEN_IMPACT_CRATER.bowlRadius, MIREFEN_IMPACT_CRATER.radius, d));
   const scorch = Math.max(bowl, lip * 0.55);
 
   return {

--- a/src/render/mage_barrier_visual.ts
+++ b/src/render/mage_barrier_visual.ts
@@ -1,4 +1,5 @@
 import * as THREE from 'three';
+import { clamp01 } from './num_clamp';
 
 const REFERENCE_CHARACTER_HEIGHT = 1.8;
 const REVEAL_SECONDS = 0.22;
@@ -30,10 +31,6 @@ const PALETTES: Record<MageBarrierTheme, BarrierPalette> = {
 const SHELL_GEOMETRY = new THREE.SphereGeometry(0.98, 24, 16);
 const RUNE_GEOMETRY = new THREE.TorusGeometry(0.9, 0.025, 5, 48);
 const MOTE_GEOMETRY = new THREE.OctahedronGeometry(0.055, 0);
-
-function clamp01(value: number): number {
-  return Math.max(0, Math.min(1, value));
-}
 
 function easeOutCubic(t: number): number {
   const u = 1 - t;

--- a/src/render/night_lighting_core.ts
+++ b/src/render/night_lighting_core.ts
@@ -23,9 +23,7 @@
 // is no per-tier scaling here, and nothing a player reacts to is hidden either
 // way (the lamp posts, mobs, and nameplates are drawn on every tier regardless).
 
-function clamp01(v: number): number {
-  return v < 0 ? 0 : v > 1 ? 1 : v;
-}
+import { clamp01 } from './num_clamp';
 
 /** Hermite ease, matching day_night_core's own smoothstep so the ramps agree. */
 function smoothstep(t: number): number {

--- a/src/render/num_clamp.ts
+++ b/src/render/num_clamp.ts
@@ -1,0 +1,14 @@
+// Tiny, dependency-free numeric helper shared across src/render. Deliberately
+// NOT named *_view.ts / *_core.ts, so it stays outside the RENDER_PURE_CORES
+// sweep in tests/architecture.test.ts (same pattern as gfx.ts / vfx_anchor.ts):
+// every consumer, including the pure cores, can import it without tripping
+// that allowlist.
+//
+// Extracted because the identical clamp01 one-liner had been hand-rolled in
+// close to a dozen separate render files; this is the single source of truth
+// they all import instead.
+
+/** Clamps v into the inclusive [0, 1] range. */
+export function clamp01(v: number): number {
+  return Math.max(0, Math.min(1, v));
+}

--- a/src/render/perceptual_lod_core.ts
+++ b/src/render/perceptual_lod_core.ts
@@ -2,6 +2,8 @@
 // size. Painters provide the live camera projection and keep all gameplay
 // visibility decisions outside this module.
 
+import { clamp01 } from './num_clamp';
+
 const GRASS_PROTECTED_RADIUS_FRACTION = 0.85;
 const GRASS_MIN_PROJECTED_PIXELS = 6;
 const GRASS_FULL_PROJECTED_PIXELS = 10;
@@ -24,10 +26,6 @@ export interface FarFieldDensityInput {
   projectedPixels: number;
   /** Preset floor for a still-partly-visible far chunk. */
   minKeepFraction: number;
-}
-
-function clamp01(value: number): number {
-  return Math.min(1, Math.max(0, value));
 }
 
 function smoothstep(edge0: number, edge1: number, value: number): number {

--- a/src/render/terrain_chunk_build.ts
+++ b/src/render/terrain_chunk_build.ts
@@ -35,6 +35,7 @@ import {
 import { fbm2 } from '../sim/rng';
 import { roadDistance, WATER_LEVEL, zoneBiomeAt } from '../sim/world';
 import { impactCraterTerrainBlend } from './impact_terrain';
+import { clamp01 } from './num_clamp';
 import { meshTerrainHeight } from './terrain_mesh_height';
 import { BIOME_PALETTE, ROCK_SLOPE_START, TERRAIN_TONES } from './terrain_palette';
 
@@ -45,8 +46,6 @@ const SKIRT_DROP = 0.3;
 const INDEX_TILE_QUADS = 3;
 // Ground palette + rock slope thresholds live in terrain_palette.ts (plain
 // data, no Three) so the far-vista mesh colors from the same source.
-
-const clamp01 = (v: number): number => Math.max(0, Math.min(1, v));
 
 interface VertexSample {
   height: number;

--- a/tests/num_clamp.test.ts
+++ b/tests/num_clamp.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { clamp01 } from '../src/render/num_clamp';
+
+describe('clamp01', () => {
+  it('passes values already inside [0, 1] through unchanged', () => {
+    expect(clamp01(0)).toBe(0);
+    expect(clamp01(1)).toBe(1);
+    expect(clamp01(0.5)).toBe(0.5);
+    expect(clamp01(0.0001)).toBeCloseTo(0.0001);
+  });
+
+  it('clamps values below 0 to 0', () => {
+    expect(clamp01(-0.5)).toBe(0);
+    expect(clamp01(-1000)).toBe(0);
+    expect(clamp01(-Infinity)).toBe(0);
+  });
+
+  it('clamps values above 1 to 1', () => {
+    expect(clamp01(1.5)).toBe(1);
+    expect(clamp01(1000)).toBe(1);
+    expect(clamp01(Infinity)).toBe(1);
+  });
+
+  it('is deterministic: the same input always yields the same output', () => {
+    const inputs = [-3, -0.001, 0, 0.25, 0.999, 1, 4.2];
+    const first = inputs.map(clamp01);
+    const second = inputs.map(clamp01);
+    expect(second).toEqual(first);
+  });
+});


### PR DESCRIPTION
## Summary

The `clamp01(v)` one-liner was hand-rolled independently in 11 `src/render/`
files. This moves it into one shared module, `src/render/num_clamp.ts`, and
has each file import it instead of redefining it. Pure code motion: every
call site keeps calling the same clamp semantics, so the generated terrain,
VFX, and lighting output is unchanged.

```mermaid
graph LR
    subgraph before["before"]
        A1["src/render/impact_terrain.ts\n(own clamp01)"]
        A2["src/render/terrain_chunk_build.ts\n(own clamp01)"]
        A3["src/render/far_terrain_core.ts\n(own clamp01)"]
        A4["src/render/environment_transition_core.ts\n(own clamp01)"]
        A5["src/render/mage_barrier_visual.ts\n(own clamp01)"]
        A6["src/render/perceptual_lod_core.ts\n(own clamp01)"]
        A7["src/render/biome_haze_field_core.ts\n(own clamp01)"]
        A8["src/render/night_lighting_core.ts\n(own clamp01)"]
        A9["src/render/click_marker.ts\n(own clamp01)"]
        A10["src/render/day_night_core.ts\n(own clamp01)"]
        A11["src/render/ability_vfx/spirits.ts\n(own clamp01)"]
    end
    subgraph after["after"]
        C["src/render/num_clamp.ts\n(exported clamp01, plain helper,\nnot *_view.ts/*_core.ts,\nsame pattern as gfx.ts/vfx_anchor.ts)"]
        B1["impact_terrain.ts"]
        B2["terrain_chunk_build.ts"]
        B3["far_terrain_core.ts"]
        B4["environment_transition_core.ts"]
        B5["mage_barrier_visual.ts"]
        B6["perceptual_lod_core.ts"]
        B7["biome_haze_field_core.ts"]
        B8["night_lighting_core.ts"]
        B9["click_marker.ts"]
        B10["day_night_core.ts"]
        B11["ability_vfx/spirits.ts"]
        B1 --> C
        B2 --> C
        B3 --> C
        B4 --> C
        B5 --> C
        B6 --> C
        B7 --> C
        B8 --> C
        B9 --> C
        B10 --> C
        B11 --> C
    end
```

## Related issues

N/A

## Type of change

- [x] Refactor or performance (no behavior change)

## How was this tested?

- Commands:
  - `npx tsc --noEmit` (clean, run standalone twice, and again as part of the
    pre-push hook on the final successful push)
  - `npx vitest run tests/num_clamp.test.ts tests/day_night.test.ts tests/terrain_chunk_geometry.test.ts tests/impact_site.test.ts tests/click_marker.test.ts tests/environment_transition_core.test.ts tests/mage_barrier_visual.test.ts tests/mage_barrier_scaling.test.ts tests/mage_barrier_tooltip.test.ts tests/perceptual_lod_core.test.ts tests/perceptual_lod_wiring.test.ts tests/biome_haze_field_core.test.ts tests/biome_haze_field.test.ts tests/night_lighting_core.test.ts tests/far_terrain_core.test.ts tests/far_terrain_detail.test.ts tests/far_terrain_night.test.ts tests/far_terrain_view.test.ts tests/spirit_models.test.ts tests/spirit_puppet_build.test.ts tests/foliage_impostor_core.test.ts tests/detail_horizon_core.test.ts tests/far_surface_core.test.ts tests/graphics_rebuild_core.test.ts tests/sky_zone_haze.test.ts tests/scenery_flame.test.ts tests/terrain_chunk_worker.test.ts tests/terrain_vertex_pipeline.test.ts` (every test file that imports one of the 11 touched files or the new module; 274/275 passed on the first run; the sole failure, `tests/terrain_chunk_geometry.test.ts`'s byte-for-byte geometry pin, was a 20s test-timeout under heavy host CPU contention from dozens of sibling batch agents running concurrently on the same host, confirmed by re-running it alone, which passed cleanly in 48.88s)
  - `npx vitest run tests/architecture.test.ts` (40/40 passed, confirms `num_clamp.ts` needs no `RENDER_PURE_CORES` registration since it is not named `*_view.ts`/`*_core.ts`, and that the 6 touched `*_core.ts` files still pass the pure-core import/DOM/determinism scans)
  - `npm run ci:changed` (clean; none of the touched files were flagged; run twice, standalone and as part of the pre-push hook)
  - `node scripts/gate_select.mjs`: this batch runs dozens of sibling agents concurrently on the shared host, which surfaced two environmental issues unrelated to this diff, both worth calling out separately from the actual result: (1) the planner's default base-branch resolution picked up this fork's stale `origin/release/v0.33.0` (three releases behind the `upstream/release/v0.36.0` this branch is actually based on), which made it treat thousands of unrelated pre-existing files as "changed" and fall back to a full-suite run; re-running with `GATE_SELECT_BASE=upstream/release/v0.36.0` fixed the selection (correctly down to the 13 files this change touches, mode=selective) and its i18n-freshness, malware-scan, and biome steps all passed cleanly; (2) under the resulting host contention, the always-run vitest legs hit scattered timeout failures in files this change never touches (`tests/delves.test.ts`, `tests/professions_fishing.test.ts` (a test already documented as known-flaky under this batch's contention), a gathering-professions test, `tests/battleground.test.ts`), each one exceeding the 20s default test timeout by 2 to 4x, the same signature as the confirmed-flaky `terrain_chunk_geometry` case above; none of the failures were in a file this PR touches. Given the exhaustive targeted verification above and the pre-push QA floor (`tsc`, `tests/architecture.test.ts`, `tests/localization_fixes.test.ts`, and biome, all scoped to this branch) running clean on the actual push, I judged continuing to babysit a full unsharded vitest pass through this batch's contention not worth the wait; flagging it here so the pattern (not a specific bug) gets noticed if it recurs.
- Manual steps: read every one of the 11 clamp01 definitions being replaced
  to confirm they were all functionally identical for every input, including
  NaN and +/-Infinity (`Math.max(0, Math.min(1, v))` and the ternary form
  `v < 0 ? 0 : v > 1 ? 1 : v` agree on every case). Added
  `tests/num_clamp.test.ts` exercising the shared helper directly (in-range
  passthrough, below/above clamping, +/-Infinity, determinism).

## Screenshots / recordings

N/A: non-visual refactor (no behavior change)
