### PR TITLE
refactor(server): remove dead discordEnabled wrapper from discord.ts

### DIFF
--- a/server/discord.ts
+++ b/server/discord.ts
@@ -161,11 +161,6 @@ export function autoJoinEnabled(cfg: DiscordConfig): boolean {
   return cfg.botToken !== '' && isDiscordSnowflake(cfg.guildId);
 }
 
-/** Whether the feature is configured. Read by the route table + client UI gate. */
-export function discordEnabled(): boolean {
-  return discordConfig() !== null;
-}
-
 export function discordInviteUrl(): string {
   return process.env.DISCORD_GUILD_INVITE || DEFAULT_INVITE;
 }


### PR DESCRIPTION
## Summary

Removes `discordEnabled()` from `server/discord.ts`. It was exported with a doc comment
claiming it is "read by the route table + client UI gate," but nothing in the repo calls
it: every real call site checks `discordConfig() !== null` directly instead, so the
wrapper (and its stale comment) was dead code.

```mermaid
graph LR
    subgraph before["before"]
        A["server/discord.ts\nexport function discordEnabled()\nreturn discordConfig() !== null\n(unused wrapper, stale doc comment)"]
    end
    subgraph after["after"]
        B["server/discord.ts\ndiscordConfig() only\n(callers already checked !== null directly)"]
    end
    A -. "deleted, no replacement needed" .-> B
```

## Related issues

N/A

## Type of change

- [x] Refactor or performance (no behavior change)

## How was this tested?

- Commands run (all passed):
  - `npx tsc --noEmit` (clean, no references to the removed export)
  - `npx vitest run tests/server/discord.test.ts` (38 passed)
  - `npx vitest run tests/discord_server.test.ts` (73 passed)
  - `npx vitest run tests/architecture.test.ts tests/localization_fixes.test.ts` (40 passed,
    3 skipped; ran `npm run i18n:gen` first since a fresh worktree has no generated
    `src/ui/i18n.status.json`)
  - `npm run ci:changed` (exit 0; biome warnings only, none on `server/discord.ts`)
  - `GATE_SELECT_BASE=upstream/release/v0.36.0 node scripts/gate_select.mjs` (the correct
    scoping flag: the fork's `origin` remote lags the real integration base, so without it
    the planner falls back to a full-suite run against a stale diff base). This machine was
    under heavy multi-agent batch load for the whole run (dozens of concurrent
    `gate_select.mjs`/`vitest` processes visible system-wide, RAM/swap both saturated), which
    surfaced timeout-driven flakes in files unrelated to this change: `tests/ci_shard_plan.test.ts`
    (including the documented flaky case, "vitest honors exact-path --exclude flags
    additively"), `tests/ci_shard_partition.test.ts`, `tests/asset_pipeline.test.ts` (an
    `ECONNREFUSED` to a local service on port 3000, unrelated to Discord), and
    `tests/character_tpose_repair.test.ts`. To confirm these are pre-existing and unrelated
    to this diff, `server/discord.ts` was reverted to the clean `upstream/release/v0.36.0`
    state (via `git diff` + `git checkout` + `git apply`, not `git stash`, since stash refs
    are shared across the batch's sibling worktrees) and `tests/ci_shard_plan.test.ts` was
    run alone against that clean tree: it failed identically (10 timeouts), proving the
    flakiness is pre-existing CPU-contention noise, not caused by this change. The patch was
    then reapplied and `tsc --noEmit` plus the two discord test files were re-run clean.
    `npm run ci:changed` and the `.githooks/pre-push` floor (`tsc`, the same two guard test
    files, biome, the copy scan) both passed green at push time.
- Manual steps: grepped the whole repo (excluding `node_modules`) for `discordEnabled` to
  confirm the only remaining reference was the removed definition itself, and confirmed
  every real gate on Discord being configured already calls `discordConfig() !== null`
  directly (e.g. the `enabled` field in `discordStatusPayload`).

## Screenshots / recordings

N/A: non-visual refactor (no behavior change)
