### PR TITLE
refactor(editor): consolidate the CustomMap-to-MapDoc bridge cast

### DIFF
--- a/src/editor/custom_map.ts
+++ b/src/editor/custom_map.ts
@@ -30,6 +30,17 @@ export type CustomMapMeta = MapDocMeta;
 // here; serialization casts back to the mutable MapDoc shape.
 export type CustomMap = Omit<MapDoc, 'content'> & { content: ZoneContent };
 
+// CustomMap and MapDoc describe the SAME on-wire document: only the static
+// type of `content` differs (CustomMap's ZoneContent is readonly so the
+// editor can share live table references with the marker model; MapDoc's
+// MapDocContent is mutable, the shape the shared sanitizer/serializer and the
+// server expect). The unsafe cast that bridges the two lives here, ONCE, so
+// every save/serialize call site asks for the shared shape by name instead of
+// re-deriving `map as unknown as MapDoc` inline.
+export function toMapDoc(map: CustomMap): MapDoc {
+  return map as unknown as MapDoc;
+}
+
 // The shipped world seed; a fresh map defaults to it so its built-in derived
 // terrain matches what the editor previews (mirrors DEFAULT_PLAYTEST_SEED).
 const DEFAULT_SEED = WORLD_SEED;

--- a/src/editor/map_io.ts
+++ b/src/editor/map_io.ts
@@ -10,8 +10,7 @@
 // resolve: a stale tab keeps its own optimistic version and gets the server
 // 409 instead of silently overwriting another tab's save.
 
-import type { MapDoc } from '../sim/map_doc';
-import type { CustomMap } from './custom_map';
+import { type CustomMap, toMapDoc } from './custom_map';
 import * as net from './net';
 import {
   type KeyValueStore,
@@ -105,7 +104,7 @@ export class MapIO {
    * version_conflict the app resolves via Save As Copy).
    */
   async saveServer(map: CustomMap): Promise<ServerLink> {
-    const doc = map as unknown as MapDoc;
+    const doc = toMapDoc(map);
     const link = this.linkFor(map.meta.id);
     if (!link) {
       const created = await net.createMap(map.meta.name, doc);
@@ -121,7 +120,7 @@ export class MapIO {
 
   /** Create a NEW server map from this document (Save As Copy after a 409). */
   async saveServerAsCopy(map: CustomMap): Promise<ServerLink> {
-    const created = await net.createMap(map.meta.name, map as unknown as MapDoc);
+    const created = await net.createMap(map.meta.name, toMapDoc(map));
     const next = { serverId: created.id, version: created.version };
     this.setLink(map.meta.id, next);
     return next;

--- a/src/editor/persist.ts
+++ b/src/editor/persist.ts
@@ -12,11 +12,11 @@
 // key (woc_editor_maps) migrates lazily on first access.
 
 import { sanitizeMapDoc, serializeMapDoc } from '../sim/map_doc';
-import type { CustomMap, CustomMapMeta } from './custom_map';
+import { type CustomMap, type CustomMapMeta, toMapDoc } from './custom_map';
 
 /** Pretty-printed serialization, for the human-readable file export ONLY. */
 export function serializeMap(map: CustomMap): string {
-  return serializeMapDoc(map as unknown as Parameters<typeof serializeMapDoc>[0]);
+  return serializeMapDoc(toMapDoc(map));
 }
 
 /**

--- a/tests/editor_to_map_doc.test.ts
+++ b/tests/editor_to_map_doc.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { newCustomMap, toMapDoc } from '../src/editor/custom_map';
+import { sanitizeMapDoc, serializeMapDoc } from '../src/sim/map_doc';
+
+// toMapDoc bridges CustomMap's readonly-content editor view to the mutable
+// MapDoc shape the shared sim sanitizer/serializer (and the server) expect.
+// It is a pure type-level bridge with no runtime transformation, so the
+// contract to pin is: same object identity in and out, and the shared
+// serializer/sanitizer round-trip the document exactly as before the
+// extraction (map_io.ts and persist.ts previously re-derived this cast
+// inline at three call sites; this is the ONE place it now lives).
+describe('toMapDoc', () => {
+  it('returns the same underlying object (no runtime copy)', () => {
+    const map = newCustomMap('Bridge', 'id1', 1000);
+    const doc = toMapDoc(map);
+    expect(doc).toBe(map as unknown as typeof doc);
+  });
+
+  it('produces a document the shared serializer/sanitizer round-trip exactly', () => {
+    const map = newCustomMap('Round', 'rid', 42);
+    map.terrainEdits.push({ x: 1, z: 2, radius: 8, delta: -3, falloff: 'flat' });
+    map.placements.push({ assetId: 'props/well', x: 5, z: 6, rotY: 1, scale: 2, collide: true });
+
+    const doc = toMapDoc(map);
+    expect(doc.meta).toEqual(map.meta);
+    expect(doc.content.zones).toEqual(map.content.zones);
+    expect(doc.terrainEdits).toEqual(map.terrainEdits);
+    expect(doc.placements).toEqual(map.placements);
+
+    const parsed = sanitizeMapDoc(JSON.parse(serializeMapDoc(doc)));
+    expect(parsed).not.toBeNull();
+    expect(parsed?.meta.id).toBe(map.meta.id);
+    expect(parsed?.terrainEdits).toEqual(map.terrainEdits);
+    expect(parsed?.placements).toEqual(map.placements);
+    expect(parsed?.content.zones.length).toBe(map.content.zones.length);
+  });
+});


### PR DESCRIPTION
## Summary

Consolidates the `map as unknown as MapDoc` cast that was repeated verbatim at three
call sites (`map_io.ts` saveServer, `map_io.ts` saveServerAsCopy, and `persist.ts`
serializeMap) into one named, documented `toMapDoc(map: CustomMap): MapDoc` helper
exported from `custom_map.ts`, next to the `CustomMap` type and the comment that
already explains the readonly/mutable split. The three call sites now ask for the
shared shape by name instead of re-deriving the unsafe cast inline.

```mermaid
graph LR
    subgraph before["before"]
        A["src/editor/map_io.ts\n(saveServer, saveServerAsCopy:\nmap as unknown as MapDoc)"]
        D["src/editor/persist.ts\n(serializeMap:\nmap as unknown as Parameters<...>[0])"]
    end
    subgraph after["after"]
        B["src/editor/map_io.ts\n(thin, calls toMapDoc)"]
        E["src/editor/persist.ts\n(thin, calls toMapDoc)"]
        C["src/editor/custom_map.ts\n(new exported toMapDoc function\nnear the CustomMap type)"]
        B --> C
        E --> C
    end
```

## Related issues

N/A

## Type of change

- [x] Refactor or performance (no behavior change)

## How was this tested?

- Commands run (all passed):
  - `npx tsc --noEmit` (clean)
  - `npx vitest run tests/editor_to_map_doc.test.ts tests/editor_persist.test.ts tests/editor_map_io_drafts.test.ts` (20 passed)
  - `npx @biomejs/biome check src/editor/custom_map.ts src/editor/map_io.ts src/editor/persist.ts tests/editor_to_map_doc.test.ts` (clean)
  - `node scripts/gate_select.mjs` (see note below)
- New test: `tests/editor_to_map_doc.test.ts` imports `toMapDoc` directly and asserts (a)
  it returns the same underlying object (the cast is a pure type-level bridge, no runtime
  copy) and (b) the shared `serializeMapDoc`/`sanitizeMapDoc` round-trip a document built
  through `toMapDoc` exactly, matching the previous inline-cast behavior. The existing
  `tests/editor_persist.test.ts` (serializeMap round-trip) and
  `tests/editor_map_io_drafts.test.ts` (MapIO draft/link behavior) continue to pass
  unchanged, confirming the extraction preserved identical runtime output.
- Manual note: this worktree's local `origin` remote (a personal fork) has a stale
  `main` ref (`biome.json`'s `defaultBranch: "origin/main"` resolves to a commit many
  releases behind `upstream/release/v0.36.0`, the real PR base), so a plain
  `npm run ci:changed` reports pre-existing diagnostics across roughly 548 files that
  differ only because of that ref staleness (confirmed none of them are files this PR
  touches, and they are warnings, not errors, so the same run inside the pre-push hook
  passed green). Ran `npx @biomejs/biome check` directly against the four files this PR
  changes as an extra spot check, which is clean.
- `node scripts/gate_select.mjs` (run with `GATE_SELECT_BASE=upstream/release/v0.36.0`
  so the diff base matches the real PR base instead of the same stale fork ref): the
  i18n/wiki/sfx artifact generation, the i18n freshness diff, the malware scan, and
  `ci:changed` all passed. The gate then failed inside the "vitest (always-run 1/4, 173
  files)" chunk on 5 test files unrelated to this change: `tests/asset_pipeline.test.ts`,
  `tests/battleground.test.ts`, `tests/ci_shard_partition.test.ts`,
  `tests/ci_shard_plan.test.ts` (several cases, including the
  "vitest honors exact-path --exclude flags additively" case named as a known-flaky
  case under this gate's CPU contention), and `tests/defer_launcher_preloads.test.ts`.
  Re-running just those 5 files directly still failed, with the same tests timing out
  (20000ms) or taking 100+ seconds each, consistent with the heavy CPU contention from
  running this batch's many parallel worktree agents rather than a real regression:
  none of the 5 files import or reference `src/editor/custom_map.ts`, `map_io.ts`,
  `persist.ts`, or `src/sim/map_doc.ts` (confirmed by grep), and this PR's own targeted
  tests plus `tsc` and biome all stayed clean throughout. Proceeding per the documented
  fallback for a pre-existing, unrelated gate failure; worth a maintainer re-run on a
  quieter machine to fix once, separately, if it reproduces outside this batch.
