### PR TITLE
refactor(ui): consolidate the duplicated clamp01 helper into src/ui/clamp.ts

### DIFF
--- a/src/ui/absorb_bar.ts
+++ b/src/ui/absorb_bar.ts
@@ -9,6 +9,7 @@
 // math can be snapshot tested directly (mirrors xp_bar.ts).
 
 import type { Aura } from '../sim/types';
+import { clamp01 } from './clamp';
 
 export interface AbsorbBarInput {
   hp: number;
@@ -66,8 +67,4 @@ export function absorbBarViewInto(out: AbsorbBarView, input: AbsorbBarInput): Ab
   out.sizeFrac = sizeFrac;
   out.overshield = overshield;
   return out;
-}
-
-function clamp01(v: number): number {
-  return Math.max(0, Math.min(1, v));
 }

--- a/src/ui/clamp.ts
+++ b/src/ui/clamp.ts
@@ -1,0 +1,8 @@
+// Tiny shared numeric helper. Clamps a value to the 0..1 range, used by every
+// HUD bar/vignette that derives a fill or opacity fraction from raw game state
+// (low_health, absorb_bar, low_resource, swing_timer, xp_bar). Pulled out of
+// those five modules, which each redefined the identical private helper.
+
+export function clamp01(v: number): number {
+  return Math.max(0, Math.min(1, v));
+}

--- a/src/ui/low_health.ts
+++ b/src/ui/low_health.ts
@@ -3,6 +3,8 @@
 // Kept DOM-free so the intensity curve can be unit-tested directly; the HUD just
 // applies the returned values to a fixed overlay element each frame.
 
+import { clamp01 } from './clamp';
+
 // Below this HP fraction the vignette begins to show; at full HP it is hidden.
 export const LOW_HEALTH_THRESHOLD = 0.35;
 // Peak opacity reached as HP approaches 0 (kept < 1 so the world stays readable).
@@ -31,8 +33,4 @@ export function lowHealthVignette(hp: number, maxHp: number): LowHealthVignette 
   const opacity = t ** 0.8 * MAX_OPACITY;
   const pulseHz = PULSE_HZ_MIN + (PULSE_HZ_MAX - PULSE_HZ_MIN) * t;
   return { active: true, opacity, pulseSeconds: 1 / pulseHz };
-}
-
-function clamp01(v: number): number {
-  return Math.max(0, Math.min(1, v));
 }

--- a/src/ui/low_resource.ts
+++ b/src/ui/low_resource.ts
@@ -7,6 +7,7 @@
 // tested directly, mirroring xp_bar.ts. All display strings route through t().
 
 import type { ResourceType } from '../sim/types';
+import { clamp01 } from './clamp';
 import { t } from './i18n';
 
 export interface LowResourceInput {
@@ -70,8 +71,4 @@ export function lowResourceViewInto(
   out.pulseSeconds = pulseSeconds;
   out.label = label;
   return out;
-}
-
-function clamp01(v: number): number {
-  return Math.max(0, Math.min(1, v));
 }

--- a/src/ui/swing_timer.ts
+++ b/src/ui/swing_timer.ts
@@ -12,6 +12,8 @@
 // back next frame, so the core stays allocation-light (a single returned object,
 // or the shared HIDDEN constant when the bar is off).
 
+import { clamp01 } from './clamp';
+
 // Epsilon for detecting the swing reset edge: the timer jumping UP past the last
 // value means a fresh swing began, so the full interval is recovered.
 const SWING_EDGE_EPSILON = 1e-4;
@@ -79,8 +81,4 @@ export function swingTimerState(
     nextPeriod: period,
     nextTimer: swingTimer,
   };
-}
-
-function clamp01(v: number): number {
-  return Math.max(0, Math.min(1, v));
 }

--- a/src/ui/xp_bar.ts
+++ b/src/ui/xp_bar.ts
@@ -3,6 +3,7 @@
 // tested directly. All display strings route through i18n's t().
 
 import { MAX_LEVEL, virtualLevelProgress, xpForLevel } from '../sim/types';
+import { clamp01 } from './clamp';
 import { formatNumber, t } from './i18n';
 
 export interface XpBarInput {
@@ -76,8 +77,4 @@ export function xpBarView(input: XpBarInput): XpBarView {
     `${formatXp(lifetimeXp)} ${t('game.xp.totalXp')}  ·  ` +
     `${formatPercent(prog.into / prog.span)} ${t('game.xp.toNext')}`;
   return { fillFrac: clamp01(prog.into / prog.span), restedFrac: 0, label, postCap: true };
-}
-
-function clamp01(v: number): number {
-  return Math.max(0, Math.min(1, v));
 }

--- a/tests/clamp.test.ts
+++ b/tests/clamp.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { clamp01 } from '../src/ui/clamp';
+
+describe('clamp01', () => {
+  it('clamps values below 0 up to 0', () => {
+    expect(clamp01(-1)).toBe(0);
+    expect(clamp01(-0.0001)).toBe(0);
+    expect(clamp01(-Infinity)).toBe(0);
+  });
+
+  it('clamps values above 1 down to 1', () => {
+    expect(clamp01(1.0001)).toBe(1);
+    expect(clamp01(2)).toBe(1);
+    expect(clamp01(Infinity)).toBe(1);
+  });
+
+  it('passes mid-range values through unchanged', () => {
+    expect(clamp01(0)).toBe(0);
+    expect(clamp01(1)).toBe(1);
+    expect(clamp01(0.5)).toBe(0.5);
+    expect(clamp01(0.123)).toBe(0.123);
+  });
+
+  it('matches the original Math.max(0, Math.min(1, v)) NaN passthrough', () => {
+    // Math.min/Math.max both propagate NaN, so the original inline helper
+    // returned NaN for a NaN input rather than clamping it; the shared
+    // helper must preserve that behavior exactly, not silently start
+    // coercing NaN to 0 or 1.
+    expect(clamp01(NaN)).toBeNaN();
+  });
+});


### PR DESCRIPTION
## Summary

The private `clamp01` helper was copy-pasted identically into five `src/ui/` pure-core
modules (`low_health.ts`, `absorb_bar.ts`, `low_resource.ts`, `swing_timer.ts`,
`xp_bar.ts`). This consolidates it into one shared, exported `clamp01` in a new
`src/ui/clamp.ts` module and has all five import it instead of redefining it. No
behavior changes: each call site produces the exact same output as before.

```mermaid
graph LR
    subgraph before["before"]
        A1["src/ui/low_health.ts\n(own clamp01)"]
        A2["src/ui/absorb_bar.ts\n(own clamp01)"]
        A3["src/ui/low_resource.ts\n(own clamp01)"]
        A4["src/ui/swing_timer.ts\n(own clamp01)"]
        A5["src/ui/xp_bar.ts\n(own clamp01)"]
    end
    subgraph after["after"]
        B1["src/ui/low_health.ts"]
        B2["src/ui/absorb_bar.ts"]
        B3["src/ui/low_resource.ts"]
        B4["src/ui/swing_timer.ts"]
        B5["src/ui/xp_bar.ts"]
        C["src/ui/clamp.ts\n(shared clamp01)"]
        B1 --> C
        B2 --> C
        B3 --> C
        B4 --> C
        B5 --> C
    end
```

## Related issues

N/A

## Type of change

- [x] Refactor or performance (no behavior change)

## How was this tested?

- Commands:
  - `npx tsc --noEmit` (clean)
  - `npx vitest run tests/clamp.test.ts tests/low_health.test.ts tests/absorb_bar.test.ts
    tests/low_resource.test.ts tests/swing_timer.test.ts tests/swing_timer_painter.test.ts
    tests/xp_bar_painter.test.ts tests/architecture.test.ts` (85 tests passed)
  - `npm run ci:changed` (exit 0; no findings on any of the changed files)
  - `npx vite build` (client bundle builds cleanly)
  - `GATE_SELECT_BASE=HEAD node scripts/gate_select.mjs` (see manual steps below for why
    the base override and the outcome)
  - `.githooks/pre-push` floor (tsc, guard tests, lint, copy rules) ran automatically on
    `git push` and reported green
- Manual steps:
  - This worktree's default `GATE_SELECT_BASE` resolution picks the newest
    `origin/release/*` branch, and this fork's `origin` remote is stale relative to
    `upstream/release/v0.36.0` (which had also moved 36 commits ahead of this branch's
    fork point by the time the gate ran, since `upstream` refs are shared across this
    batch's many concurrent worktree agents). That produced a 6337-path diff and forced
    `gate_select.mjs` into its full-suite fallback. Re-ran with
    `GATE_SELECT_BASE=HEAD` (the correct fork point, since nothing here is committed
    beyond the merge base) to get the intended selective plan: `mode=selective (6
    changed source file(s), 1 changed test file(s))`.
  - That selective run's first always-run leg (174 files, includes `architecture.test.ts`
    and the new `tests/clamp.test.ts`) failed on 5 files unrelated to this change:
    `tests/battleground.test.ts`, `tests/asset_pipeline.test.ts`,
    `tests/ci_shard_plan.test.ts` (9 sub-tests, including the documented flaky
    "vitest honors exact-path --exclude flags additively" case),
    `tests/defer_launcher_preloads.test.ts`, and `tests/ci_shard_partition.test.ts`.
    None touch `src/ui/`. Re-ran just those 5 files twice: with my changes and, after
    `git stash`, against the clean base with zero changes. Both runs reproduced the
    same failures (the exact sub-test count varied run to run: 13, 14, then 13 again),
    and every affected test either scans "the REAL collected suite" or spawns a
    subprocess with a fixed timeout, consistent with the severe CPU contention in this
    batch (observed `uptime` load average 127 to 149 while roughly a dozen sibling
    worktree agents were also running full vitest suites). Confirmed pre-existing and
    unrelated to this change, not something a full gate re-run was likely to resolve
    given the multi-hour cost of each full cycle under this contention; proceeding per
    the documented pre-existing-failure protocol. Worth fixing once, separately: either
    the CPU-bound timeouts in `ci_shard_plan.test.ts`/`ci_shard_partition.test.ts`/
    `asset_pipeline.test.ts`/`battleground.test.ts`/`defer_launcher_preloads.test.ts`
    under contention, or (independently) `gate_select.mjs`'s default base resolution
    when `origin/release/*` is behind the `upstream` release branch actually being
    worked from.
  - No visual change to verify (pure logic extraction, same inputs produce the same
    outputs at every call site).

## Screenshots / recordings

N/A: non-visual refactor (no behavior change)
