### PR TITLE
feat(render): make a wedged background GPU queue unit observable

### DIFF
--- a/scripts/border_crossing_bench.mjs
+++ b/scripts/border_crossing_bench.mjs
@@ -191,6 +191,12 @@ async function measureCrossing(page) {
       gpuQueueSlowest: (stats.gpuQueue?.slowest ?? [])
         .slice(0, 10)
         .map((u) => ({ label: u.label, syncMs: u.syncMs, wallMs: u.wallMs })),
+      gpuQueueActive: stats.gpuQueue?.active ?? null,
+      gpuQueueStalls: (stats.gpuQueue?.stalls ?? []).map((s) => ({
+        label: s.label,
+        ageMs: s.ageMs,
+        settled: s.settled,
+      })),
       topStalls: (s.devTrace?.frames ?? [])
         .filter((f) => f.stallAttribution)
         .slice(0, 3)

--- a/server/perf_report.ts
+++ b/server/perf_report.ts
@@ -257,6 +257,64 @@ function sanitizeBrowserSummary(value: unknown): Record<string, unknown> | undef
   };
 }
 
+// rendererGpuQueue (issue #3167): the background GPU queue is serial, so the
+// running unit and the units it stalled behind it are the only evidence a
+// never-settling unit leaves. Same JSONB-not-DDL treatment as the longtask
+// block above, with the same kind of numeric bound. A completed unit's slice
+// is a single piece of GPU work; an active unit's age is time SINCE it started
+// and can span whole reporting intervals, hence the two different ceilings.
+const GPU_QUEUE_RAW_MS_MAX = 60_000;
+const GPU_QUEUE_RAW_AGE_MS_MAX = 30 * 60_000;
+const GPU_QUEUE_RAW_STALLS_MAX = 8;
+const GPU_QUEUE_RAW_SLOWEST_MAX = 8;
+
+function gpuQueueUnitLabel(value: unknown): string {
+  return textIn(value, 80, 'unlabeled');
+}
+
+function gpuQueuePriority(value: unknown): number {
+  return intIn(value, -1000, 1000, 0);
+}
+
+function sanitizeGpuQueueSummary(value: unknown): Record<string, unknown> | undefined {
+  if (!isRecord(value)) return undefined;
+  const active = isRecord(value.active)
+    ? {
+        label: gpuQueueUnitLabel(value.active.label),
+        priority: gpuQueuePriority(value.active.priority),
+        ageMs: numberIn(value.active.ageMs, 0, GPU_QUEUE_RAW_AGE_MS_MAX, 0),
+      }
+    : null;
+  const stalls = Array.isArray(value.stalls) ? value.stalls : [];
+  const slowest = Array.isArray(value.slowest) ? value.slowest : [];
+  return {
+    units: intIn(value.units, 0, 10_000_000, 0),
+    totalSyncMs: numberIn(value.totalSyncMs, 0, GPU_QUEUE_RAW_AGE_MS_MAX, 0),
+    worstSyncMs: numberIn(value.worstSyncMs, 0, GPU_QUEUE_RAW_MS_MAX, 0),
+    pending: intIn(value.pending, 0, 1_000_000, 0),
+    stallCount: intIn(value.stallCount, 0, 1_000_000, 0),
+    active,
+    stalls: stalls
+      .slice(0, GPU_QUEUE_RAW_STALLS_MAX)
+      .filter(isRecord)
+      .map((stall) => ({
+        label: gpuQueueUnitLabel(stall.label),
+        priority: gpuQueuePriority(stall.priority),
+        ageMs: numberIn(stall.ageMs, 0, GPU_QUEUE_RAW_AGE_MS_MAX, 0),
+        settled: Boolean(stall.settled),
+      })),
+    slowest: slowest
+      .slice(0, GPU_QUEUE_RAW_SLOWEST_MAX)
+      .filter(isRecord)
+      .map((unit) => ({
+        label: gpuQueueUnitLabel(unit.label),
+        priority: gpuQueuePriority(unit.priority),
+        syncMs: numberIn(unit.syncMs, 0, GPU_QUEUE_RAW_MS_MAX, 0),
+        wallMs: numberIn(unit.wallMs, 0, GPU_QUEUE_RAW_AGE_MS_MAX, 0),
+      })),
+  };
+}
+
 function compactPrewarmSummary(value: unknown): Record<string, unknown> | null {
   if (!isRecord(value)) return null;
   const out: Record<string, unknown> = {};
@@ -323,6 +381,9 @@ function compactRawSummary(value: Record<string, unknown>): Record<string, unkno
     'netPipeline',
     'heapSawtooth',
     'browser',
+    // A wedged GPU queue is exactly what a truncated report must still carry:
+    // the block is small and bounded, and it is the whole signal.
+    'rendererGpuQueue',
   ]) {
     if (value[key] !== undefined) out[key] = value[key];
   }
@@ -340,6 +401,9 @@ function rawSummary(value: unknown, devTraceAllowed = false): Record<string, unk
     const browser = sanitizeBrowserSummary(parsed.browser);
     if (browser) parsed.browser = browser;
     else delete parsed.browser;
+    const gpuQueue = sanitizeGpuQueueSummary(parsed.rendererGpuQueue);
+    if (gpuQueue) parsed.rendererGpuQueue = gpuQueue;
+    else delete parsed.rendererGpuQueue;
     const boundedText = JSON.stringify(parsed);
     const maxBytes = devTraceAllowed ? RAW_SUMMARY_DEV_TRACE_MAX_BYTES : RAW_SUMMARY_MAX_BYTES;
     if (Buffer.byteLength(boundedText) > maxBytes) {
@@ -478,4 +542,7 @@ export const perfReportInternalsForTest = {
   PERF_REPORT_SCHEMA_VERSION,
   LONG_TASK_RAW_MS_MAX,
   LONG_TASK_RAW_AGE_MS_MAX,
+  GPU_QUEUE_RAW_MS_MAX,
+  GPU_QUEUE_RAW_AGE_MS_MAX,
+  GPU_QUEUE_RAW_STALLS_MAX,
 };

--- a/src/game/perf.ts
+++ b/src/game/perf.ts
@@ -690,6 +690,10 @@ export class PerfMonitor {
       state.views = r.views;
       state.gpuQueueUnits = r.gpuQueue.units;
       state.gpuQueueSyncMs = Math.round(r.gpuQueue.totalSyncMs);
+      // Monotonic on purpose: a unit that never settles moves neither of the
+      // two above, so a hitch bracketing a new stall reads as the queue
+      // wedging rather than as an empty diff.
+      state.gpuQueueStalls = r.gpuQueue.stallCount;
       state.effectiveRenderScale = r.effectiveRenderScale;
       state.budgetMode = r.renderBudget.mode;
       // Day/night dimension: a hitch cluster that only appears with

--- a/src/game/perf_reporter.ts
+++ b/src/game/perf_reporter.ts
@@ -235,6 +235,46 @@ function rendererPrewarmSummary(
   };
 }
 
+type RendererGpuQueueSnapshot = NonNullable<PerfSnapshot['renderer']>['gpuQueue'];
+
+// The GPU queue is serial, so one unit that never settles blocks every later
+// unit in every lane while contributing nothing to the completed-unit ring.
+// The running unit and the recorded stalls ride the beacon beside the slowest
+// completed units, so a wedge is a fleet signal instead of local console noise
+// (issue #3167). Bounded like every other raw-summary block; atMs is dropped
+// because a page-relative timestamp carries no fleet meaning.
+const GPU_QUEUE_REPORT_STALLS = 6;
+const GPU_QUEUE_REPORT_SLOWEST = 5;
+
+function rendererGpuQueueSummary(gpuQueue: RendererGpuQueueSnapshot): Record<string, unknown> {
+  return {
+    units: gpuQueue.units,
+    totalSyncMs: gpuQueue.totalSyncMs,
+    worstSyncMs: gpuQueue.worstSyncMs,
+    pending: gpuQueue.pending,
+    stallCount: gpuQueue.stallCount,
+    active: gpuQueue.active
+      ? {
+          label: gpuQueue.active.label,
+          priority: gpuQueue.active.priority,
+          ageMs: gpuQueue.active.ageMs,
+        }
+      : null,
+    stalls: gpuQueue.stalls.slice(-GPU_QUEUE_REPORT_STALLS).map((stall) => ({
+      label: stall.label,
+      priority: stall.priority,
+      ageMs: stall.ageMs,
+      settled: stall.settled,
+    })),
+    slowest: gpuQueue.slowest.slice(0, GPU_QUEUE_REPORT_SLOWEST).map((unit) => ({
+      label: unit.label,
+      priority: unit.priority,
+      syncMs: unit.syncMs,
+      wallMs: unit.wallMs,
+    })),
+  };
+}
+
 function payloadFromSnapshot(
   snapshot: PerfSnapshot,
   settings: Settings,
@@ -327,6 +367,7 @@ function payloadFromSnapshot(
       rendererDiagnostics: renderer.renderDiagnostics,
       rendererPrewarmSummary: rendererPrewarmSummary(renderer.prewarm),
       rendererPrewarm: renderer.prewarm,
+      rendererGpuQueue: rendererGpuQueueSummary(renderer.gpuQueue),
       assets: {
         preload: snapshot.assets.preload,
         byType: snapshot.assets.byType,

--- a/src/render/background_gpu_queue.ts
+++ b/src/render/background_gpu_queue.ts
@@ -30,35 +30,90 @@ export interface GpuWorkUnitStat {
   atMs: number;
 }
 
+/** The unit the drain loop is awaiting right now. The queue is serial, so this
+ *  one unit is what every pending unit in every lane is waiting on. */
+export interface GpuWorkActiveUnit {
+  label: string;
+  priority: number;
+  /** Wall time since the unit started, i.e. how long it has been running. */
+  ageMs: number;
+  atMs: number;
+}
+
+/** A unit observed past the stall threshold. `settled: false` is the case a
+ *  completed-unit ring can never show: it had still not finished when the
+ *  stats were read. */
+export interface GpuWorkStallStat {
+  label: string;
+  priority: number;
+  /** Longest unsettled age observed, or the final wall time once it settled. */
+  ageMs: number;
+  atMs: number;
+  settled: boolean;
+}
+
 export interface BackgroundGpuQueueStats {
   units: number;
   totalSyncMs: number;
   worstSyncMs: number;
   /** Slowest units by sync slice, worst first, bounded. */
   slowest: GpuWorkUnitStat[];
+  /** Units queued behind the running one: the backlog a wedge accumulates. */
+  pending: number;
+  /** The running unit, or null when the queue is idle. */
+  active: GpuWorkActiveUnit | null;
+  /** Every unit seen past the stall threshold, including evicted records. A
+   *  non-zero count is not by itself a wedged queue: a long hold that ended
+   *  counts too. A wedge is an unsettled stall plus an `active` naming it. */
+  stallCount: number;
+  /** Most recent stalls, bounded. */
+  stalls: GpuWorkStallStat[];
 }
 
 export interface BackgroundGpuQueue {
   run<T>(work: () => T | Promise<T>, priority?: number, label?: string): Promise<T>;
-  /** Per-unit timing: names which lane's units block the main thread. */
+  /** Per-unit timing plus the running unit: names which lane's units block the
+   *  main thread, and which one is currently blocking the whole queue. */
   stats(): BackgroundGpuQueueStats;
   /** Reject queued work, stop accepting more, and await the active unit. */
   shutdown(reason?: Error): Promise<void>;
 }
 
 const DEFAULT_SLOWEST_LIMIT = 20;
+// Low on purpose, because a hold this long is worth seeing whether or not it
+// ends. A live compile gate waiting out a non-cancellable driver link really
+// does occupy the serial queue for seconds (a local run measured 7.5 s on a
+// unit that cost 2.5 ms of main-thread time), and every other lane waits behind
+// it. Those records settle; a wedge is the record that never does.
+const DEFAULT_STALL_MS = 4000;
+const DEFAULT_STALL_LIMIT = 8;
+
+interface RunningGpuWork {
+  entry: PendingGpuWork<unknown>;
+  startedAt: number;
+  stall: GpuWorkStallStat | null;
+}
+
+const round1 = (value: number): number => Math.round(value * 10) / 10;
 
 export function createBackgroundGpuQueue(opts?: {
   now?: () => number;
   slowestLimit?: number;
+  stallMs?: number;
+  stallLimit?: number;
 }): BackgroundGpuQueue {
   const now = opts?.now ?? ((): number => performance.now());
   const slowestLimit = Math.max(1, opts?.slowestLimit ?? DEFAULT_SLOWEST_LIMIT);
+  const stallMs = Math.max(1, opts?.stallMs ?? DEFAULT_STALL_MS);
+  const stallLimit = Math.max(1, opts?.stallLimit ?? DEFAULT_STALL_LIMIT);
   const pending: PendingGpuWork<unknown>[] = [];
   const slowest: GpuWorkUnitStat[] = [];
+  const stalls: GpuWorkStallStat[] = [];
   let units = 0;
   let totalSyncMs = 0;
   let worstSyncMs = 0;
+  let stallCount = 0;
+  let running: RunningGpuWork | null = null;
   let active = false;
   let accepting = true;
   let nextOrder = 0;
@@ -66,16 +121,40 @@ export function createBackgroundGpuQueue(opts?: {
   let shutdownPromise: Promise<void> | null = null;
   let resolveShutdown: (() => void) | null = null;
 
-  const recordUnit = (entry: PendingGpuWork<unknown>, startedAt: number, syncMs: number): void => {
+  // A unit that never settles has no completion callback to record it, so the
+  // threshold is evaluated wherever the queue is observed instead: at every
+  // stats() read while the unit is still running, and once more if it settles.
+  const noteStall = (unit: RunningGpuWork, ageMs: number): void => {
+    if (ageMs < stallMs) return;
+    if (unit.stall) {
+      if (ageMs > unit.stall.ageMs) unit.stall.ageMs = ageMs;
+      return;
+    }
+    stallCount++;
+    unit.stall = {
+      label: unit.entry.label,
+      priority: unit.entry.priority,
+      ageMs,
+      atMs: unit.startedAt,
+      settled: false,
+    };
+    stalls.push(unit.stall);
+    if (stalls.length > stallLimit) stalls.shift();
+  };
+
+  const recordUnit = (unit: RunningGpuWork, syncMs: number): void => {
     units++;
     totalSyncMs += syncMs;
     if (syncMs > worstSyncMs) worstSyncMs = syncMs;
+    const wallMs = now() - unit.startedAt;
+    noteStall(unit, wallMs);
+    if (unit.stall) unit.stall.settled = true;
     const stat: GpuWorkUnitStat = {
-      label: entry.label,
-      priority: entry.priority,
+      label: unit.entry.label,
+      priority: unit.entry.priority,
       syncMs,
-      wallMs: now() - startedAt,
-      atMs: startedAt,
+      wallMs,
+      atMs: unit.startedAt,
     };
     let index = slowest.length;
     while (index > 0 && slowest[index - 1].syncMs < stat.syncMs) index--;
@@ -103,17 +182,19 @@ export function createBackgroundGpuQueue(opts?: {
         }
       }
       const [next] = pending.splice(selectedIndex, 1);
-      const startedAt = now();
+      const unit: RunningGpuWork = { entry: next, startedAt: now(), stall: null };
+      running = unit;
       let syncMs = 0;
       try {
         const returned = next.work();
-        syncMs = now() - startedAt;
+        syncMs = now() - unit.startedAt;
         next.resolve(await returned);
       } catch (error) {
-        if (syncMs === 0) syncMs = now() - startedAt;
+        if (syncMs === 0) syncMs = now() - unit.startedAt;
         next.reject(error);
       } finally {
-        recordUnit(next, startedAt, syncMs);
+        running = null;
+        recordUnit(unit, syncMs);
       }
     }
     active = false;
@@ -152,15 +233,34 @@ export function createBackgroundGpuQueue(opts?: {
       return result;
     },
     stats(): BackgroundGpuQueueStats {
+      let activeUnit: GpuWorkActiveUnit | null = null;
+      if (running) {
+        const ageMs = now() - running.startedAt;
+        noteStall(running, ageMs);
+        activeUnit = {
+          label: running.entry.label,
+          priority: running.entry.priority,
+          ageMs: round1(ageMs),
+          atMs: Math.round(running.startedAt),
+        };
+      }
       return {
         units,
-        totalSyncMs: Math.round(totalSyncMs * 10) / 10,
-        worstSyncMs: Math.round(worstSyncMs * 10) / 10,
+        totalSyncMs: round1(totalSyncMs),
+        worstSyncMs: round1(worstSyncMs),
         slowest: slowest.map((stat) => ({
           ...stat,
-          syncMs: Math.round(stat.syncMs * 10) / 10,
-          wallMs: Math.round(stat.wallMs * 10) / 10,
+          syncMs: round1(stat.syncMs),
+          wallMs: round1(stat.wallMs),
           atMs: Math.round(stat.atMs),
+        })),
+        pending: pending.length,
+        active: activeUnit,
+        stallCount,
+        stalls: stalls.map((stall) => ({
+          ...stall,
+          ageMs: round1(stall.ageMs),
+          atMs: Math.round(stall.atMs),
         })),
       };
     },

--- a/tests/background_gpu_queue.test.ts
+++ b/tests/background_gpu_queue.test.ts
@@ -183,6 +183,137 @@ describe('createBackgroundGpuQueue', () => {
     expect(stats.worstSyncMs).toBe(30);
   });
 
+  it('exposes the running unit with its age and reports none while idle', async () => {
+    let clock = 0;
+    const queue = createBackgroundGpuQueue({ now: () => clock });
+    expect(queue.stats().active).toBeNull();
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => (release = resolve));
+    const running = queue.run(() => gate, GPU_WORK_PRIORITY.LIVE_VIEW, 'live-view-compile');
+    const behind = queue.run(async () => {}, GPU_WORK_PRIORITY.BACKGROUND, 'texture-chunk');
+    await Promise.resolve();
+    clock += 250;
+
+    const busy = queue.stats();
+    expect(busy.active).toEqual({
+      label: 'live-view-compile',
+      priority: GPU_WORK_PRIORITY.LIVE_VIEW,
+      ageMs: 250,
+      atMs: 0,
+    });
+    expect(busy.pending).toBe(1);
+    expect(busy.units).toBe(0);
+
+    release();
+    await Promise.all([running, behind]);
+    const idle = queue.stats();
+    expect(idle.active).toBeNull();
+    expect(idle.pending).toBe(0);
+    expect(idle.units).toBe(2);
+  });
+
+  it('records a never-settling unit past the threshold without counting it as completed', async () => {
+    let clock = 0;
+    const queue = createBackgroundGpuQueue({ now: () => clock, stallMs: 4000 });
+    // The shape of the r165 compileAsync deadlock: the unit's promise never
+    // settles, so no completion callback ever runs for it.
+    void queue.run(
+      () => new Promise<void>(() => {}),
+      GPU_WORK_PRIORITY.ACTIONABLE_VIEW,
+      'wedged-compile',
+    );
+    void queue.run(async () => {}, GPU_WORK_PRIORITY.BACKGROUND, 'texture-chunk');
+    await Promise.resolve();
+
+    clock += 3999;
+    expect(queue.stats().stalls).toEqual([]);
+    clock += 1;
+    const stalled = queue.stats();
+    expect(stalled.stallCount).toBe(1);
+    expect(stalled.stalls).toEqual([
+      {
+        label: 'wedged-compile',
+        priority: GPU_WORK_PRIORITY.ACTIONABLE_VIEW,
+        ageMs: 4000,
+        atMs: 0,
+        settled: false,
+      },
+    ]);
+    expect(stalled.active?.label).toBe('wedged-compile');
+    expect(stalled.pending).toBe(1);
+    // It is a stall, not a completed unit: nothing lands in the completed-unit
+    // reporting, which is exactly why it used to be invisible.
+    expect(stalled.units).toBe(0);
+    expect(stalled.totalSyncMs).toBe(0);
+    expect(stalled.worstSyncMs).toBe(0);
+    expect(stalled.slowest).toEqual([]);
+
+    clock += 10_000;
+    const later = queue.stats();
+    expect(later.stallCount).toBe(1);
+    expect(later.stalls[0].ageMs).toBe(14_000);
+    expect(later.stalls[0].settled).toBe(false);
+    expect(later.active?.ageMs).toBe(14_000);
+  });
+
+  it('settles a stall when the unit finishes and leaves the slowest ring on sync time', async () => {
+    let clock = 0;
+    const queue = createBackgroundGpuQueue({ now: () => clock, stallMs: 1000 });
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => (release = resolve));
+    const slow = queue.run(
+      () => {
+        clock += 8;
+        return gate;
+      },
+      GPU_WORK_PRIORITY.VISIBLE_PREWARM,
+      'zone-prewarm',
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+    clock += 5000;
+    release();
+    await slow;
+
+    const stats = queue.stats();
+    expect(stats.active).toBeNull();
+    expect(stats.stallCount).toBe(1);
+    expect(stats.stalls).toEqual([
+      {
+        label: 'zone-prewarm',
+        priority: GPU_WORK_PRIORITY.VISIBLE_PREWARM,
+        ageMs: 5008,
+        atMs: 0,
+        settled: true,
+      },
+    ]);
+    // Completed-unit reporting is unchanged: the sync slice, not the wall time,
+    // still drives worstSyncMs and the slowest ring.
+    expect(stats.units).toBe(1);
+    expect(stats.worstSyncMs).toBe(8);
+    expect(stats.slowest[0].syncMs).toBe(8);
+    expect(stats.slowest[0].wallMs).toBe(5008);
+  });
+
+  it('bounds the retained stalls while counting every one of them', async () => {
+    let clock = 0;
+    const queue = createBackgroundGpuQueue({ now: () => clock, stallMs: 100, stallLimit: 2 });
+    for (const label of ['first', 'second', 'third']) {
+      await queue.run(
+        () => {
+          clock += 500;
+        },
+        GPU_WORK_PRIORITY.BACKGROUND,
+        label,
+      );
+    }
+    const stats = queue.stats();
+    expect(stats.stallCount).toBe(3);
+    expect(stats.stalls.map((stall) => stall.label)).toEqual(['second', 'third']);
+    expect(stats.stalls.every((stall) => stall.settled)).toBe(true);
+    expect(stats.units).toBe(3);
+  });
+
   it('wires sky, feature, archetype, and boot-resume units through one renderer queue', () => {
     const source = readFileSync(new URL('../src/render/renderer.ts', import.meta.url), 'utf8');
     const method = (startText: string, endText: string): string => {

--- a/tests/perf_diagnosis.test.ts
+++ b/tests/perf_diagnosis.test.ts
@@ -115,7 +115,16 @@ function baseSnapshot(): PerfSnapshot {
       renderDiagnostics: {} as never,
       nightAmount: 0,
       prewarm: null,
-      gpuQueue: { units: 0, totalSyncMs: 0, worstSyncMs: 0, slowest: [] },
+      gpuQueue: {
+        units: 0,
+        totalSyncMs: 0,
+        worstSyncMs: 0,
+        slowest: [],
+        pending: 0,
+        active: null,
+        stallCount: 0,
+        stalls: [],
+      },
     },
     hud: { hotDomWrites: 10, hotDomSkippedWrites: 90, hotDomSkipRate: 0.9 },
     assets: {

--- a/tests/perf_monitor_report_dimensions.test.ts
+++ b/tests/perf_monitor_report_dimensions.test.ts
@@ -181,7 +181,7 @@ describe('perf monitor forensics state assembly', () => {
       calls: 1200,
       triangles: 9_000_000,
       views: 40,
-      gpuQueue: { units: 3, totalSyncMs: 12.6 },
+      gpuQueue: { units: 3, totalSyncMs: 12.6, stallCount: 2 },
       effectiveRenderScale: 1,
       renderBudget: { mode: 'steady' },
       nightAmount: 0.85,
@@ -196,6 +196,9 @@ describe('perf monitor forensics state assembly', () => {
     expect(state.activePointLights).toBe(6);
     expect(state.programs).toBe(700);
     expect(state.gpuQueueSyncMs).toBe(13);
+    // A wedged unit moves neither units nor sync time, so the stall counter is
+    // the dimension that can bracket a hitch with a queue that stopped draining.
+    expect(state.gpuQueueStalls).toBe(2);
     expect(state.biome).toBe('marsh');
     expect(state.px).toBe(123);
     expect(state.pz).toBe(-56);

--- a/tests/perf_report.test.ts
+++ b/tests/perf_report.test.ts
@@ -695,6 +695,112 @@ describe('perf report ingestion', () => {
     expect((stored.rawSummary as Record<string, unknown>).oversized).toBeUndefined();
   });
 
+  it('stores the GPU queue block bounded, and keeps it when raw summaries are truncated (#3167)', async () => {
+    const { GPU_QUEUE_RAW_MS_MAX, GPU_QUEUE_RAW_AGE_MS_MAX, GPU_QUEUE_RAW_STALLS_MAX } =
+      perfReportInternalsForTest;
+    const wedged = {
+      units: 12,
+      totalSyncMs: 240.5,
+      worstSyncMs: 88.2,
+      pending: 6,
+      stallCount: 1,
+      active: { label: 'wedged-compile', priority: 40, ageMs: 91_000 },
+      stalls: [{ label: 'wedged-compile', priority: 40, ageMs: 91_000, settled: false }],
+      slowest: [{ label: 'live-view-compile', priority: 30, syncMs: 88.2, wallMs: 120.4 }],
+    };
+    const stored = fakeRes();
+
+    await handlePerfReport(
+      fakeReq({
+        sessionId: 'gpu-queue-wedge',
+        rawSummary: { seconds: 30, rendererGpuQueue: wedged },
+      }),
+      stored,
+    );
+
+    expect(stored.statusCode).toBe(200);
+    expect(insertClientPerfReport).toHaveBeenCalledWith(
+      expect.objectContaining({ rawSummary: { seconds: 30, rendererGpuQueue: wedged } }),
+    );
+
+    // A hostile payload cannot inject an absurd age, an unbounded stall list,
+    // or a novel-length label into the admin raw-report reader.
+    vi.mocked(insertClientPerfReport).mockClear();
+    const hostile = fakeRes();
+    await handlePerfReport(
+      fakeReq({
+        sessionId: 'gpu-queue-hostile',
+        rawSummary: {
+          rendererGpuQueue: {
+            units: -5,
+            totalSyncMs: 'nope',
+            worstSyncMs: 9e12,
+            pending: 1e12,
+            stallCount: 3,
+            active: { label: 'x'.repeat(400), priority: 9e9, ageMs: 9e12 },
+            stalls: Array.from({ length: 40 }, () => ({
+              label: 'wedged',
+              priority: 40,
+              ageMs: 9e12,
+              settled: 'yes',
+            })),
+            slowest: 'not-an-array',
+          },
+        },
+      }),
+      hostile,
+    );
+    expect(hostile.statusCode).toBe(200);
+    const hostileRow = vi.mocked(insertClientPerfReport).mock.calls.at(-1)![0];
+    const hostileQueue = (hostileRow.rawSummary as Record<string, Record<string, unknown>>)
+      .rendererGpuQueue;
+    expect(hostileQueue).toMatchObject({
+      units: 0,
+      totalSyncMs: 0,
+      worstSyncMs: GPU_QUEUE_RAW_MS_MAX,
+      stallCount: 3,
+      active: { label: 'x'.repeat(80), priority: 1000, ageMs: GPU_QUEUE_RAW_AGE_MS_MAX },
+      slowest: [],
+    });
+    expect(hostileQueue.stalls).toHaveLength(GPU_QUEUE_RAW_STALLS_MAX);
+    expect((hostileQueue.stalls as Record<string, unknown>[])[0].ageMs).toBe(
+      GPU_QUEUE_RAW_AGE_MS_MAX,
+    );
+
+    // A malformed block is dropped rather than stored half-shaped.
+    vi.mocked(insertClientPerfReport).mockClear();
+    const malformed = fakeRes();
+    await handlePerfReport(
+      fakeReq({
+        sessionId: 'gpu-queue-malformed',
+        rawSummary: { seconds: 12, rendererGpuQueue: 'not-an-object' },
+      }),
+      malformed,
+    );
+    expect(malformed.statusCode).toBe(200);
+    expect(insertClientPerfReport).toHaveBeenCalledWith(
+      expect.objectContaining({ rawSummary: { seconds: 12 } }),
+    );
+
+    // The compact path keeps it: a wedge is exactly what an oversized report
+    // must still carry.
+    vi.mocked(insertClientPerfReport).mockClear();
+    const truncated = fakeRes();
+    await handlePerfReport(
+      fakeReq({
+        sessionId: 'gpu-queue-truncated',
+        rawSummary: { seconds: 30, rendererGpuQueue: wedged, oversized: 'x'.repeat(40_000) },
+      }),
+      truncated,
+    );
+    expect(truncated.statusCode).toBe(200);
+    expect(insertClientPerfReport).toHaveBeenCalledWith(
+      expect.objectContaining({
+        rawSummary: expect.objectContaining({ truncated: true, rendererGpuQueue: wedged }),
+      }),
+    );
+  });
+
   it('preserves the net pipeline and heap sawtooth blocks when raw summaries are truncated', async () => {
     const res = fakeRes();
     const netPipeline = {

--- a/tests/perf_reporter.test.ts
+++ b/tests/perf_reporter.test.ts
@@ -223,7 +223,19 @@ function snapshot(): PerfSnapshot {
       graphicsConfigVersion: 16,
       tier: 'high',
       qualityBuckets: qualityBuckets(),
-      gpuQueue: { units: 0, totalSyncMs: 0, worstSyncMs: 0, slowest: [] },
+      gpuQueue: {
+        units: 2,
+        totalSyncMs: 18.4,
+        worstSyncMs: 12.1,
+        slowest: [
+          { label: 'live-view-compile', priority: 30, syncMs: 12.1, wallMs: 40.2, atMs: 5000 },
+          { label: 'texture-chunk', priority: 10, syncMs: 6.3, wallMs: 6.3, atMs: 5200 },
+        ],
+        pending: 0,
+        active: null,
+        stallCount: 0,
+        stalls: [],
+      },
       nightAmount: 0,
       autoGovernor: true,
       budget: {
@@ -428,6 +440,59 @@ describe('perf reporter payload', () => {
     expect(
       (body.rawSummary as { browser?: { longTasks?: Record<string, number> } }).browser?.longTasks,
     ).toEqual({ totalMs: 120, avg: 60, max: 80, lastAge: 1000 });
+  });
+
+  it('carries the GPU queue block, active unit included, into raw summary (#3167)', () => {
+    // A settled queue: only completed units, no running one. This is the arm
+    // that used to be the ONLY arm, since a never-settling unit records nothing.
+    const settings = new Settings();
+    const settled = perfReporterInternalsForTest.payloadFromSnapshot(
+      snapshot(),
+      settings,
+      'sess1',
+      42,
+    )!;
+    const settledQueue = (settled.rawSummary as { rendererGpuQueue?: Record<string, unknown> })
+      .rendererGpuQueue;
+    expect(settledQueue).toMatchObject({
+      units: 2,
+      totalSyncMs: 18.4,
+      worstSyncMs: 12.1,
+      pending: 0,
+      stallCount: 0,
+      active: null,
+      stalls: [],
+    });
+    expect(settledQueue?.slowest).toEqual([
+      { label: 'live-view-compile', priority: 30, syncMs: 12.1, wallMs: 40.2 },
+      { label: 'texture-chunk', priority: 10, syncMs: 6.3, wallMs: 6.3 },
+    ]);
+
+    const snap = snapshot();
+    snap.renderer!.gpuQueue = {
+      units: 2,
+      totalSyncMs: 18.4,
+      worstSyncMs: 12.1,
+      slowest: [],
+      pending: 7,
+      active: { label: 'wedged-compile', priority: 40, ageMs: 91_000, atMs: 12_000 },
+      stallCount: 1,
+      stalls: [
+        { label: 'wedged-compile', priority: 40, ageMs: 91_000, atMs: 12_000, settled: false },
+      ],
+    };
+    const wedged = perfReporterInternalsForTest.payloadFromSnapshot(snap, settings, 'sess1', 42)!;
+    const wedgedQueue = (wedged.rawSummary as { rendererGpuQueue?: Record<string, unknown> })
+      .rendererGpuQueue;
+    // The wedge is the whole point: units stayed at 2, so only the active unit
+    // and the stall say the queue has been blocked for a minute and a half.
+    expect(wedgedQueue).toMatchObject({
+      units: 2,
+      pending: 7,
+      stallCount: 1,
+      active: { label: 'wedged-compile', priority: 40, ageMs: 91_000 },
+      stalls: [{ label: 'wedged-compile', priority: 40, ageMs: 91_000, settled: false }],
+    });
   });
 
   it('carries the always-on net pipeline and heap sawtooth blocks into raw summary', () => {


### PR DESCRIPTION
## Summary

A background GPU queue unit that never settles was invisible to telemetry. `recordUnit`
runs in the settled unit's `finally` block and `stats()` reported completed units only, so
the worst possible outcome, a unit that never finishes, contributed nothing to
`worstSyncMs` or the slowest ring. The drain loop is strictly serial, so one wedged unit
silently blocks every later unit in every lane (live view compile gates, texture chunk
uploads, visible-zone prewarm, boot resume) while the perf report and fleet telemetry show
a perfectly healthy queue.

This makes the running unit and the stalled ones observable. Diagnostics only: scheduling,
ordering, and failure handling are untouched.

- `src/render/background_gpu_queue.ts`: the queue tracks the unit the drain loop is
  awaiting. `stats()` now reports `active` (label, priority, age, start), `pending` (the
  backlog a wedge accumulates), `stallCount`, and a bounded `stalls` list. A unit past the
  stall threshold (4 s by default, injectable) is recorded with `settled: false`; if it
  eventually finishes, the record flips to `settled: true` with its final wall time. There
  is no timer: a never-settling unit has no completion callback, so the threshold is
  evaluated wherever the queue is observed, at each `stats()` read and once more on settle.
- `src/game/perf_reporter.ts`: a bounded `rendererGpuQueue` block rides the beacon's raw
  summary beside the prewarm summary, carrying the running unit and the recorded stalls
  next to the slowest completed units.
- `server/perf_report.ts`: the block is numerically bounded on ingest like the browser
  longtask block (#2479), and is preserved on the compact path, since a wedge is exactly
  what an oversized report must still carry.
- `src/game/perf.ts`: `gpuQueueStalls` joins the hitch-forensics state vector. A wedged
  unit moves neither `gpuQueueUnits` nor `gpuQueueSyncMs`, so the stall counter is the only
  dimension that can bracket a hitch with a queue that stopped draining.
- `scripts/border_crossing_bench.mjs`: the crossing bench prints the active unit and the
  stalls next to `gpuQueueSlowest`.

Completed-unit reporting is unchanged: `worstSyncMs` and the slowest ring still rank on the
sync slice, and a settled unit's numbers are byte-identical to before.

## Related issues

Closes #3167

## Type of change

- [x] Feature: new functionality
- [ ] Bug fix
- [x] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change

## How was this tested?

- Commands:
  - `node scripts/gate_select.mjs` (green)
  - `npx vitest run tests/background_gpu_queue.test.ts tests/perf_report.test.ts tests/perf_reporter.test.ts tests/perf_monitor_report_dimensions.test.ts tests/perf_diagnosis.test.ts`
  - `npx vitest related --run src/render/background_gpu_queue.ts src/game/perf.ts src/game/perf_reporter.ts server/perf_report.ts`
  - `npx tsc --noEmit`
- Manual run (local dev client, one session of about two minutes): normal play reported
  `active: null` when idle, the running unit with its age while a gate ran, and two settled
  stalls. A synthetic never-settling unit injected into the live queue showed up as
  `active` with a growing age at 1 s and as an unsettled stall at 5 s, while `units`,
  `totalSyncMs`, `worstSyncMs` and the slowest ring stayed byte-identical across both reads.
  The same run surfaced a live compile gate holding the serial queue for 7.5 s on 2.5 ms of
  main-thread time, which is pre-existing behavior and is being filed separately.
- New coverage:
  - a synthetic never-settling unit becomes visible in `stats()` after the threshold, with
    `units`, `totalSyncMs`, `worstSyncMs` and the slowest ring all still empty
  - the active unit is exposed with its age while running and is null when idle
  - a stall that eventually settles is marked settled and leaves the slowest ring on sync time
  - the stall list stays bounded while `stallCount` counts every one
  - the beacon carries the wedge (active unit plus stall) and the server bounds a hostile
    block, drops a malformed one, and keeps the block when the raw summary is truncated

## Screenshots / recordings

N/A, no player-visible or operator-visible surface changes.

---

## Checklist

### Quality

- [x] **The gate passes.** `node scripts/gate_select.mjs` is green, with decisive tests for
      the new behavior.

### Cross-platform

- ~Tested on desktop and mobile~ Game launched on desktop only, because no UI change.
- ~Accessible~ N/A, no UI.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings (the perf report and the bench script are
      dev diagnostics under the existing perf-overlay English carve-out).

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled
      in any production path.
- [x] No generated files were hand-edited.