### PR TITLE
perf(render): observe, then release, compile-gate tails in the background GPU queue

### DIFF
--- a/scripts/border_crossing_bench.mjs
+++ b/scripts/border_crossing_bench.mjs
@@ -191,6 +191,12 @@ async function measureCrossing(page) {
       gpuQueueSlowest: (stats.gpuQueue?.slowest ?? [])
         .slice(0, 10)
         .map((u) => ({ label: u.label, syncMs: u.syncMs, wallMs: u.wallMs })),
+      gpuQueueActive: stats.gpuQueue?.active ?? null,
+      gpuQueueStalls: (stats.gpuQueue?.stalls ?? []).map((s) => ({
+        label: s.label,
+        ageMs: s.ageMs,
+        settled: s.settled,
+      })),
       topStalls: (s.devTrace?.frames ?? [])
         .filter((f) => f.stallAttribution)
         .slice(0, 3)

--- a/server/perf_report.ts
+++ b/server/perf_report.ts
@@ -257,8 +257,9 @@ function sanitizeBrowserSummary(value: unknown): Record<string, unknown> | undef
   };
 }
 
-// rendererGpuQueue (issue #3167): the background GPU queue is serial, so the
-// running unit and the units it stalled behind it are the only evidence a
+// rendererGpuQueue (issue #3167): the background GPU queue drains one unit at
+// a time (plus a small released-tail overlap), so the running unit, the
+// released tails, and the stalls they record are the only evidence a
 // never-settling unit leaves. Same JSONB-not-DDL treatment as the longtask
 // block above, with the same kind of numeric bound. A completed unit's slice
 // is a single piece of GPU work; an active unit's age is time SINCE it started
@@ -267,6 +268,9 @@ const GPU_QUEUE_RAW_MS_MAX = 60_000;
 const GPU_QUEUE_RAW_AGE_MS_MAX = 30 * 60_000;
 const GPU_QUEUE_RAW_STALLS_MAX = 8;
 const GPU_QUEUE_RAW_SLOWEST_MAX = 8;
+// Released compile-gate tails settling beside the active unit. The client caps
+// them at the queue's own tail limit; this bound only defends the ingest.
+const GPU_QUEUE_RAW_TAILS_MAX = 4;
 
 function gpuQueueUnitLabel(value: unknown): string {
   return textIn(value, 80, 'unlabeled');
@@ -287,6 +291,7 @@ function sanitizeGpuQueueSummary(value: unknown): Record<string, unknown> | unde
     : null;
   const stalls = Array.isArray(value.stalls) ? value.stalls : [];
   const slowest = Array.isArray(value.slowest) ? value.slowest : [];
+  const waitingTails = Array.isArray(value.waitingTails) ? value.waitingTails : [];
   return {
     units: intIn(value.units, 0, 10_000_000, 0),
     totalSyncMs: numberIn(value.totalSyncMs, 0, GPU_QUEUE_RAW_AGE_MS_MAX, 0),
@@ -294,6 +299,14 @@ function sanitizeGpuQueueSummary(value: unknown): Record<string, unknown> | unde
     pending: intIn(value.pending, 0, 1_000_000, 0),
     stallCount: intIn(value.stallCount, 0, 1_000_000, 0),
     active,
+    waitingTails: waitingTails
+      .slice(0, GPU_QUEUE_RAW_TAILS_MAX)
+      .filter(isRecord)
+      .map((tail) => ({
+        label: gpuQueueUnitLabel(tail.label),
+        priority: gpuQueuePriority(tail.priority),
+        ageMs: numberIn(tail.ageMs, 0, GPU_QUEUE_RAW_AGE_MS_MAX, 0),
+      })),
     stalls: stalls
       .slice(0, GPU_QUEUE_RAW_STALLS_MAX)
       .filter(isRecord)
@@ -545,4 +558,5 @@ export const perfReportInternalsForTest = {
   GPU_QUEUE_RAW_MS_MAX,
   GPU_QUEUE_RAW_AGE_MS_MAX,
   GPU_QUEUE_RAW_STALLS_MAX,
+  GPU_QUEUE_RAW_TAILS_MAX,
 };

--- a/server/perf_report.ts
+++ b/server/perf_report.ts
@@ -257,6 +257,64 @@ function sanitizeBrowserSummary(value: unknown): Record<string, unknown> | undef
   };
 }
 
+// rendererGpuQueue (issue #3167): the background GPU queue is serial, so the
+// running unit and the units it stalled behind it are the only evidence a
+// never-settling unit leaves. Same JSONB-not-DDL treatment as the longtask
+// block above, with the same kind of numeric bound. A completed unit's slice
+// is a single piece of GPU work; an active unit's age is time SINCE it started
+// and can span whole reporting intervals, hence the two different ceilings.
+const GPU_QUEUE_RAW_MS_MAX = 60_000;
+const GPU_QUEUE_RAW_AGE_MS_MAX = 30 * 60_000;
+const GPU_QUEUE_RAW_STALLS_MAX = 8;
+const GPU_QUEUE_RAW_SLOWEST_MAX = 8;
+
+function gpuQueueUnitLabel(value: unknown): string {
+  return textIn(value, 80, 'unlabeled');
+}
+
+function gpuQueuePriority(value: unknown): number {
+  return intIn(value, -1000, 1000, 0);
+}
+
+function sanitizeGpuQueueSummary(value: unknown): Record<string, unknown> | undefined {
+  if (!isRecord(value)) return undefined;
+  const active = isRecord(value.active)
+    ? {
+        label: gpuQueueUnitLabel(value.active.label),
+        priority: gpuQueuePriority(value.active.priority),
+        ageMs: numberIn(value.active.ageMs, 0, GPU_QUEUE_RAW_AGE_MS_MAX, 0),
+      }
+    : null;
+  const stalls = Array.isArray(value.stalls) ? value.stalls : [];
+  const slowest = Array.isArray(value.slowest) ? value.slowest : [];
+  return {
+    units: intIn(value.units, 0, 10_000_000, 0),
+    totalSyncMs: numberIn(value.totalSyncMs, 0, GPU_QUEUE_RAW_AGE_MS_MAX, 0),
+    worstSyncMs: numberIn(value.worstSyncMs, 0, GPU_QUEUE_RAW_MS_MAX, 0),
+    pending: intIn(value.pending, 0, 1_000_000, 0),
+    stallCount: intIn(value.stallCount, 0, 1_000_000, 0),
+    active,
+    stalls: stalls
+      .slice(0, GPU_QUEUE_RAW_STALLS_MAX)
+      .filter(isRecord)
+      .map((stall) => ({
+        label: gpuQueueUnitLabel(stall.label),
+        priority: gpuQueuePriority(stall.priority),
+        ageMs: numberIn(stall.ageMs, 0, GPU_QUEUE_RAW_AGE_MS_MAX, 0),
+        settled: Boolean(stall.settled),
+      })),
+    slowest: slowest
+      .slice(0, GPU_QUEUE_RAW_SLOWEST_MAX)
+      .filter(isRecord)
+      .map((unit) => ({
+        label: gpuQueueUnitLabel(unit.label),
+        priority: gpuQueuePriority(unit.priority),
+        syncMs: numberIn(unit.syncMs, 0, GPU_QUEUE_RAW_MS_MAX, 0),
+        wallMs: numberIn(unit.wallMs, 0, GPU_QUEUE_RAW_AGE_MS_MAX, 0),
+      })),
+  };
+}
+
 function compactPrewarmSummary(value: unknown): Record<string, unknown> | null {
   if (!isRecord(value)) return null;
   const out: Record<string, unknown> = {};
@@ -323,6 +381,9 @@ function compactRawSummary(value: Record<string, unknown>): Record<string, unkno
     'netPipeline',
     'heapSawtooth',
     'browser',
+    // A wedged GPU queue is exactly what a truncated report must still carry:
+    // the block is small and bounded, and it is the whole signal.
+    'rendererGpuQueue',
   ]) {
     if (value[key] !== undefined) out[key] = value[key];
   }
@@ -340,6 +401,9 @@ function rawSummary(value: unknown, devTraceAllowed = false): Record<string, unk
     const browser = sanitizeBrowserSummary(parsed.browser);
     if (browser) parsed.browser = browser;
     else delete parsed.browser;
+    const gpuQueue = sanitizeGpuQueueSummary(parsed.rendererGpuQueue);
+    if (gpuQueue) parsed.rendererGpuQueue = gpuQueue;
+    else delete parsed.rendererGpuQueue;
     const boundedText = JSON.stringify(parsed);
     const maxBytes = devTraceAllowed ? RAW_SUMMARY_DEV_TRACE_MAX_BYTES : RAW_SUMMARY_MAX_BYTES;
     if (Buffer.byteLength(boundedText) > maxBytes) {
@@ -478,4 +542,7 @@ export const perfReportInternalsForTest = {
   PERF_REPORT_SCHEMA_VERSION,
   LONG_TASK_RAW_MS_MAX,
   LONG_TASK_RAW_AGE_MS_MAX,
+  GPU_QUEUE_RAW_MS_MAX,
+  GPU_QUEUE_RAW_AGE_MS_MAX,
+  GPU_QUEUE_RAW_STALLS_MAX,
 };

--- a/src/game/perf.ts
+++ b/src/game/perf.ts
@@ -690,6 +690,10 @@ export class PerfMonitor {
       state.views = r.views;
       state.gpuQueueUnits = r.gpuQueue.units;
       state.gpuQueueSyncMs = Math.round(r.gpuQueue.totalSyncMs);
+      // Monotonic on purpose: a unit that never settles moves neither of the
+      // two above, so a hitch bracketing a new stall reads as the queue
+      // wedging rather than as an empty diff.
+      state.gpuQueueStalls = r.gpuQueue.stallCount;
       state.effectiveRenderScale = r.effectiveRenderScale;
       state.budgetMode = r.renderBudget.mode;
       // Day/night dimension: a hitch cluster that only appears with

--- a/src/game/perf_reporter.ts
+++ b/src/game/perf_reporter.ts
@@ -245,6 +245,9 @@ type RendererGpuQueueSnapshot = NonNullable<PerfSnapshot['renderer']>['gpuQueue'
 // because a page-relative timestamp carries no fleet meaning.
 const GPU_QUEUE_REPORT_STALLS = 6;
 const GPU_QUEUE_REPORT_SLOWEST = 5;
+// The queue's own tail cap keeps this list tiny; the slice only pins the
+// beacon size against a future cap raise, mirroring the two lists above.
+const GPU_QUEUE_REPORT_TAILS = 4;
 
 function rendererGpuQueueSummary(gpuQueue: RendererGpuQueueSnapshot): Record<string, unknown> {
   return {
@@ -260,6 +263,12 @@ function rendererGpuQueueSummary(gpuQueue: RendererGpuQueueSnapshot): Record<str
           ageMs: gpuQueue.active.ageMs,
         }
       : null,
+    // Released compile-gate tails settling off-thread.
+    waitingTails: gpuQueue.waitingTails.slice(0, GPU_QUEUE_REPORT_TAILS).map((tail) => ({
+      label: tail.label,
+      priority: tail.priority,
+      ageMs: tail.ageMs,
+    })),
     stalls: gpuQueue.stalls.slice(-GPU_QUEUE_REPORT_STALLS).map((stall) => ({
       label: stall.label,
       priority: stall.priority,

--- a/src/game/perf_reporter.ts
+++ b/src/game/perf_reporter.ts
@@ -235,6 +235,46 @@ function rendererPrewarmSummary(
   };
 }
 
+type RendererGpuQueueSnapshot = NonNullable<PerfSnapshot['renderer']>['gpuQueue'];
+
+// The GPU queue is serial, so one unit that never settles blocks every later
+// unit in every lane while contributing nothing to the completed-unit ring.
+// The running unit and the recorded stalls ride the beacon beside the slowest
+// completed units, so a wedge is a fleet signal instead of local console noise
+// (issue #3167). Bounded like every other raw-summary block; atMs is dropped
+// because a page-relative timestamp carries no fleet meaning.
+const GPU_QUEUE_REPORT_STALLS = 6;
+const GPU_QUEUE_REPORT_SLOWEST = 5;
+
+function rendererGpuQueueSummary(gpuQueue: RendererGpuQueueSnapshot): Record<string, unknown> {
+  return {
+    units: gpuQueue.units,
+    totalSyncMs: gpuQueue.totalSyncMs,
+    worstSyncMs: gpuQueue.worstSyncMs,
+    pending: gpuQueue.pending,
+    stallCount: gpuQueue.stallCount,
+    active: gpuQueue.active
+      ? {
+          label: gpuQueue.active.label,
+          priority: gpuQueue.active.priority,
+          ageMs: gpuQueue.active.ageMs,
+        }
+      : null,
+    stalls: gpuQueue.stalls.slice(-GPU_QUEUE_REPORT_STALLS).map((stall) => ({
+      label: stall.label,
+      priority: stall.priority,
+      ageMs: stall.ageMs,
+      settled: stall.settled,
+    })),
+    slowest: gpuQueue.slowest.slice(0, GPU_QUEUE_REPORT_SLOWEST).map((unit) => ({
+      label: unit.label,
+      priority: unit.priority,
+      syncMs: unit.syncMs,
+      wallMs: unit.wallMs,
+    })),
+  };
+}
+
 function payloadFromSnapshot(
   snapshot: PerfSnapshot,
   settings: Settings,
@@ -327,6 +367,7 @@ function payloadFromSnapshot(
       rendererDiagnostics: renderer.renderDiagnostics,
       rendererPrewarmSummary: rendererPrewarmSummary(renderer.prewarm),
       rendererPrewarm: renderer.prewarm,
+      rendererGpuQueue: rendererGpuQueueSummary(renderer.gpuQueue),
       assets: {
         preload: snapshot.assets.preload,
         byType: snapshot.assets.byType,

--- a/src/render/background_gpu_queue.ts
+++ b/src/render/background_gpu_queue.ts
@@ -1,6 +1,22 @@
 // Shared priority arbiter for work that reaches WebGL. A browser idle callback
 // only says when a unit may start; it does not prevent independent zone,
 // texture, PMREM, archetype, and live compile lanes from starting together.
+//
+// Tail policy (the seam decision this file owns): by DEFAULT a unit occupies
+// the queue from start until its promise settles, awaited tail included. A
+// caller whose tail is dominated by a non-cancellable off-thread wait (a
+// compile gate awaiting a KHR_parallel_shader_compile link, which three polls
+// with a 10 ms timer and costs the main thread nothing) opts in with
+// releaseTail: the queue then holds only for the synchronous prologue and the
+// tail keeps settling alongside other units, bounded by the released-tail cap.
+// Unconditional occupancy made one slow driver link hold every other lane for
+// seconds (measured locally: a 7.5 s hold on a 2.5 ms prologue, with
+// higher-priority actionable gates waiting behind it). The cap is what keeps
+// the original guarantee (#2753): driver link work stays bounded, never one
+// per streamed view during an online snapshot burst. Priority applies when a
+// unit STARTS: a higher-priority arrival can still wait on a full cap, but
+// that wait is bounded by the shortest in-flight tail instead of the whole
+// serial hold, so it is never longer than the pre-release policy's.
 
 export const GPU_WORK_PRIORITY = {
   BOOT_RESUME: 0,
@@ -10,10 +26,24 @@ export const GPU_WORK_PRIORITY = {
   ACTIONABLE_VIEW: 40,
 } as const;
 
+/** Per-unit scheduling options; see the tail policy in the header. */
+export interface GpuWorkRunOptions {
+  /** The caller declares that everything after work()'s synchronous return is
+   *  DOMINATED by an off-thread wait, so the queue may start other units while
+   *  the tail settles (bounded by the released-tail cap). Only for tails the
+   *  main thread is NOT doing the bulk of, e.g. a parallel shader link. A
+   *  short main-thread continuation inside the tail (the compile gate chains a
+   *  second compile prologue after the first link) is tolerated: it interleaves
+   *  with other units like any microtask work, but it books in no unit's
+   *  syncMs, so keep it small. */
+  releaseTail?: boolean;
+}
+
 interface PendingGpuWork<T> {
   order: number;
   priority: number;
   label: string;
+  releaseTail: boolean;
   work: () => T | Promise<T>;
   resolve: (value: T | PromiseLike<T>) => void;
   reject: (reason?: unknown) => void;
@@ -30,8 +60,9 @@ export interface GpuWorkUnitStat {
   atMs: number;
 }
 
-/** The unit the drain loop is awaiting right now. The queue is serial, so this
- *  one unit is what every pending unit in every lane is waiting on. */
+/** The unit the drain loop is awaiting right now. Every pending unit waits
+ *  either on this one or, when it is null with pending units and the released
+ *  tails at the cap, on a tail slot freeing (see waitingTails). */
 export interface GpuWorkActiveUnit {
   label: string;
   priority: number;
@@ -58,24 +89,36 @@ export interface BackgroundGpuQueueStats {
   worstSyncMs: number;
   /** Slowest units by sync slice, worst first, bounded. */
   slowest: GpuWorkUnitStat[];
-  /** Units queued behind the running one: the backlog a wedge accumulates. */
+  /** Units not started yet, waiting on the running unit or on the
+   *  released-tail cap: the backlog a wedge accumulates. */
   pending: number;
-  /** The running unit, or null when the queue is idle. */
+  /** The unit holding the drain loop, or null when nothing does. A released
+   *  tail is NOT active: it appears in waitingTails until it settles. */
   active: GpuWorkActiveUnit | null;
+  /** Released tails still settling. When pending grows with active null and
+   *  this list full, the released-tail cap is what the queue is waiting on. */
+  waitingTails: GpuWorkActiveUnit[];
   /** Every unit seen past the stall threshold, including evicted records. A
    *  non-zero count is not by itself a wedged queue: a long hold that ended
-   *  counts too. A wedge is an unsettled stall plus an `active` naming it. */
+   *  counts too. A wedge is an unsettled stall plus a live unit naming it:
+   *  either `active`, or a `waitingTails` entry for a released tail. */
   stallCount: number;
   /** Most recent stalls, bounded. */
   stalls: GpuWorkStallStat[];
 }
 
 export interface BackgroundGpuQueue {
-  run<T>(work: () => T | Promise<T>, priority?: number, label?: string): Promise<T>;
+  run<T>(
+    work: () => T | Promise<T>,
+    priority?: number,
+    label?: string,
+    options?: GpuWorkRunOptions,
+  ): Promise<T>;
   /** Per-unit timing plus the running unit: names which lane's units block the
    *  main thread, and which one is currently blocking the whole queue. */
   stats(): BackgroundGpuQueueStats;
-  /** Reject queued work, stop accepting more, and await the active unit. */
+  /** Reject queued work, stop accepting more, and await the active unit plus
+   *  any released tails still settling. */
   shutdown(reason?: Error): Promise<void>;
 }
 
@@ -87,6 +130,11 @@ const DEFAULT_SLOWEST_LIMIT = 20;
 // it. Those records settle; a wedge is the record that never does.
 const DEFAULT_STALL_MS = 4000;
 const DEFAULT_STALL_LIMIT = 8;
+// Concurrent released tails, i.e. driver links settling while the queue keeps
+// draining. 2 keeps a second gate flowing past one slow link while holding the
+// snapshot-burst bound: with the running unit's own prologue, at most 3 units'
+// driver work can be in flight at any instant, never one per streamed view.
+const DEFAULT_TAIL_LIMIT = 2;
 
 interface RunningGpuWork {
   entry: PendingGpuWork<unknown>;
@@ -101,14 +149,17 @@ export function createBackgroundGpuQueue(opts?: {
   slowestLimit?: number;
   stallMs?: number;
   stallLimit?: number;
+  tailLimit?: number;
 }): BackgroundGpuQueue {
   const now = opts?.now ?? ((): number => performance.now());
   const slowestLimit = Math.max(1, opts?.slowestLimit ?? DEFAULT_SLOWEST_LIMIT);
   const stallMs = Math.max(1, opts?.stallMs ?? DEFAULT_STALL_MS);
   const stallLimit = Math.max(1, opts?.stallLimit ?? DEFAULT_STALL_LIMIT);
+  const tailLimit = Math.max(1, opts?.tailLimit ?? DEFAULT_TAIL_LIMIT);
   const pending: PendingGpuWork<unknown>[] = [];
   const slowest: GpuWorkUnitStat[] = [];
   const stalls: GpuWorkStallStat[] = [];
+  const waitingTails = new Set<RunningGpuWork>();
   let units = 0;
   let totalSyncMs = 0;
   let worstSyncMs = 0;
@@ -117,6 +168,7 @@ export function createBackgroundGpuQueue(opts?: {
   let active = false;
   let accepting = true;
   let nextOrder = 0;
+  let tailNotify: (() => void) | null = null;
   let shutdownReason: Error | null = null;
   let shutdownPromise: Promise<void> | null = null;
   let resolveShutdown: (() => void) | null = null;
@@ -163,13 +215,55 @@ export function createBackgroundGpuQueue(opts?: {
   };
 
   const settleShutdownIfIdle = (): void => {
-    if (accepting || active || pending.length > 0) return;
+    if (accepting || active || pending.length > 0 || waitingTails.size > 0) return;
     resolveShutdown?.();
     resolveShutdown = null;
   };
 
+  // Moves a released unit's settling tail out of the drain loop's way. The
+  // unit's promise still resolves only when ITS tail settles (a gated view is
+  // revealed no earlier than before); only the queue occupancy changes.
+  const detachTail = (unit: RunningGpuWork, syncMs: number, tail: PromiseLike<unknown>): void => {
+    waitingTails.add(unit);
+    let settled = false;
+    const settle = (complete: () => void): void => {
+      if (settled) return;
+      settled = true;
+      waitingTails.delete(unit);
+      recordUnit(unit, syncMs);
+      complete();
+      const notify = tailNotify;
+      tailNotify = null;
+      notify?.();
+      // The drain loop may have exited while this tail was still settling.
+      settleShutdownIfIdle();
+    };
+    // A real Promise's then never throws, but the queue accepts any thenable:
+    // a synchronously-throwing then must not leak the unit's cap slot.
+    try {
+      void tail.then(
+        (value) => settle(() => unit.entry.resolve(value)),
+        (error) => settle(() => unit.entry.reject(error)),
+      );
+    } catch (error) {
+      settle(() => unit.entry.reject(error));
+    }
+  };
+
   const drain = async (): Promise<void> => {
     while (pending.length > 0) {
+      // The released-tail cap gates STARTING units, so the bound covers the
+      // running unit's own driver work too: at most tailLimit + 1 units'
+      // driver work can be in flight at any instant.
+      while (waitingTails.size >= tailLimit) {
+        await new Promise<void>((resolve) => {
+          tailNotify = resolve;
+        });
+      }
+      // shutdown() splices pending while the loop is parked on the cap wait
+      // above: re-check emptiness before selecting, or the resumed iteration
+      // dereferences a unit that no longer exists.
+      if (pending.length === 0) break;
       let selectedIndex = 0;
       for (let index = 1; index < pending.length; index++) {
         const candidate = pending[index];
@@ -185,16 +279,27 @@ export function createBackgroundGpuQueue(opts?: {
       const unit: RunningGpuWork = { entry: next, startedAt: now(), stall: null };
       running = unit;
       let syncMs = 0;
+      let released = false;
       try {
         const returned = next.work();
         syncMs = now() - unit.startedAt;
-        next.resolve(await returned);
+        if (
+          next.releaseTail &&
+          returned !== null &&
+          typeof returned === 'object' &&
+          typeof (returned as PromiseLike<unknown>).then === 'function'
+        ) {
+          released = true;
+          detachTail(unit, syncMs, returned as PromiseLike<unknown>);
+        } else {
+          next.resolve(await returned);
+        }
       } catch (error) {
         if (syncMs === 0) syncMs = now() - unit.startedAt;
         next.reject(error);
       } finally {
         running = null;
-        recordUnit(unit, syncMs);
+        if (!released) recordUnit(unit, syncMs);
       }
     }
     active = false;
@@ -215,6 +320,7 @@ export function createBackgroundGpuQueue(opts?: {
       work: () => T | Promise<T>,
       priority = GPU_WORK_PRIORITY.BACKGROUND,
       label = 'unlabeled',
+      options?: GpuWorkRunOptions,
     ): Promise<T> {
       if (!accepting) {
         return Promise.reject(shutdownReason ?? new Error('Background GPU queue is shut down'));
@@ -224,6 +330,7 @@ export function createBackgroundGpuQueue(opts?: {
           order: nextOrder++,
           priority,
           label,
+          releaseTail: options?.releaseTail === true,
           work,
           resolve,
           reject,
@@ -244,6 +351,17 @@ export function createBackgroundGpuQueue(opts?: {
           atMs: Math.round(running.startedAt),
         };
       }
+      const tailUnits: GpuWorkActiveUnit[] = [];
+      for (const tail of waitingTails) {
+        const ageMs = now() - tail.startedAt;
+        noteStall(tail, ageMs);
+        tailUnits.push({
+          label: tail.entry.label,
+          priority: tail.entry.priority,
+          ageMs: round1(ageMs),
+          atMs: Math.round(tail.startedAt),
+        });
+      }
       return {
         units,
         totalSyncMs: round1(totalSyncMs),
@@ -256,6 +374,7 @@ export function createBackgroundGpuQueue(opts?: {
         })),
         pending: pending.length,
         active: activeUnit,
+        waitingTails: tailUnits,
         stallCount,
         stalls: stalls.map((stall) => ({
           ...stall,

--- a/src/render/background_gpu_queue.ts
+++ b/src/render/background_gpu_queue.ts
@@ -30,35 +30,90 @@ export interface GpuWorkUnitStat {
   atMs: number;
 }
 
+/** The unit the drain loop is awaiting right now. The queue is serial, so this
+ *  one unit is what every pending unit in every lane is waiting on. */
+export interface GpuWorkActiveUnit {
+  label: string;
+  priority: number;
+  /** Wall time since the unit started, i.e. how long it has been running. */
+  ageMs: number;
+  atMs: number;
+}
+
+/** A unit observed past the stall threshold. `settled: false` is the case a
+ *  completed-unit ring can never show: it had still not finished when the
+ *  stats were read. */
+export interface GpuWorkStallStat {
+  label: string;
+  priority: number;
+  /** Longest unsettled age observed, or the final wall time once it settled. */
+  ageMs: number;
+  atMs: number;
+  settled: boolean;
+}
+
 export interface BackgroundGpuQueueStats {
   units: number;
   totalSyncMs: number;
   worstSyncMs: number;
   /** Slowest units by sync slice, worst first, bounded. */
   slowest: GpuWorkUnitStat[];
+  /** Units queued behind the running one: the backlog a wedge accumulates. */
+  pending: number;
+  /** The running unit, or null when the queue is idle. */
+  active: GpuWorkActiveUnit | null;
+  /** Every unit seen past the stall threshold, including evicted records. A
+   *  non-zero count is not by itself a wedged queue: a long hold that ended
+   *  counts too. A wedge is an unsettled stall plus an `active` naming it. */
+  stallCount: number;
+  /** Most recent stalls, bounded. */
+  stalls: GpuWorkStallStat[];
 }
 
 export interface BackgroundGpuQueue {
   run<T>(work: () => T | Promise<T>, priority?: number, label?: string): Promise<T>;
-  /** Per-unit timing: names which lane's units block the main thread. */
+  /** Per-unit timing plus the running unit: names which lane's units block the
+   *  main thread, and which one is currently blocking the whole queue. */
   stats(): BackgroundGpuQueueStats;
   /** Reject queued work, stop accepting more, and await the active unit. */
   shutdown(reason?: Error): Promise<void>;
 }
 
 const DEFAULT_SLOWEST_LIMIT = 20;
+// Low on purpose, because a hold this long is worth seeing whether or not it
+// ends. A live compile gate waiting out a non-cancellable driver link really
+// does occupy the serial queue for seconds (a local run measured 7.5 s on a
+// unit that cost 2.5 ms of main-thread time), and every other lane waits behind
+// it. Those records settle; a wedge is the record that never does.
+const DEFAULT_STALL_MS = 4000;
+const DEFAULT_STALL_LIMIT = 8;
+
+interface RunningGpuWork {
+  entry: PendingGpuWork<unknown>;
+  startedAt: number;
+  stall: GpuWorkStallStat | null;
+}
+
+const round1 = (value: number): number => Math.round(value * 10) / 10;
 
 export function createBackgroundGpuQueue(opts?: {
   now?: () => number;
   slowestLimit?: number;
+  stallMs?: number;
+  stallLimit?: number;
 }): BackgroundGpuQueue {
   const now = opts?.now ?? ((): number => performance.now());
   const slowestLimit = Math.max(1, opts?.slowestLimit ?? DEFAULT_SLOWEST_LIMIT);
+  const stallMs = Math.max(1, opts?.stallMs ?? DEFAULT_STALL_MS);
+  const stallLimit = Math.max(1, opts?.stallLimit ?? DEFAULT_STALL_LIMIT);
   const pending: PendingGpuWork<unknown>[] = [];
   const slowest: GpuWorkUnitStat[] = [];
+  const stalls: GpuWorkStallStat[] = [];
   let units = 0;
   let totalSyncMs = 0;
   let worstSyncMs = 0;
+  let stallCount = 0;
+  let running: RunningGpuWork | null = null;
   let active = false;
   let accepting = true;
   let nextOrder = 0;
@@ -66,16 +121,40 @@ export function createBackgroundGpuQueue(opts?: {
   let shutdownPromise: Promise<void> | null = null;
   let resolveShutdown: (() => void) | null = null;
 
-  const recordUnit = (entry: PendingGpuWork<unknown>, startedAt: number, syncMs: number): void => {
+  // A unit that never settles has no completion callback to record it, so the
+  // threshold is evaluated wherever the queue is observed instead: at every
+  // stats() read while the unit is still running, and once more if it settles.
+  const noteStall = (unit: RunningGpuWork, ageMs: number): void => {
+    if (ageMs < stallMs) return;
+    if (unit.stall) {
+      if (ageMs > unit.stall.ageMs) unit.stall.ageMs = ageMs;
+      return;
+    }
+    stallCount++;
+    unit.stall = {
+      label: unit.entry.label,
+      priority: unit.entry.priority,
+      ageMs,
+      atMs: unit.startedAt,
+      settled: false,
+    };
+    stalls.push(unit.stall);
+    if (stalls.length > stallLimit) stalls.shift();
+  };
+
+  const recordUnit = (unit: RunningGpuWork, syncMs: number): void => {
     units++;
     totalSyncMs += syncMs;
     if (syncMs > worstSyncMs) worstSyncMs = syncMs;
+    const wallMs = now() - unit.startedAt;
+    noteStall(unit, wallMs);
+    if (unit.stall) unit.stall.settled = true;
     const stat: GpuWorkUnitStat = {
-      label: entry.label,
-      priority: entry.priority,
+      label: unit.entry.label,
+      priority: unit.entry.priority,
       syncMs,
-      wallMs: now() - startedAt,
-      atMs: startedAt,
+      wallMs,
+      atMs: unit.startedAt,
     };
     let index = slowest.length;
     while (index > 0 && slowest[index - 1].syncMs < stat.syncMs) index--;
@@ -103,17 +182,19 @@ export function createBackgroundGpuQueue(opts?: {
         }
       }
       const [next] = pending.splice(selectedIndex, 1);
-      const startedAt = now();
+      const unit: RunningGpuWork = { entry: next, startedAt: now(), stall: null };
+      running = unit;
       let syncMs = 0;
       try {
         const returned = next.work();
-        syncMs = now() - startedAt;
+        syncMs = now() - unit.startedAt;
         next.resolve(await returned);
       } catch (error) {
-        if (syncMs === 0) syncMs = now() - startedAt;
+        if (syncMs === 0) syncMs = now() - unit.startedAt;
         next.reject(error);
       } finally {
-        recordUnit(next, startedAt, syncMs);
+        running = null;
+        recordUnit(unit, syncMs);
       }
     }
     active = false;
@@ -152,15 +233,34 @@ export function createBackgroundGpuQueue(opts?: {
       return result;
     },
     stats(): BackgroundGpuQueueStats {
+      let activeUnit: GpuWorkActiveUnit | null = null;
+      if (running) {
+        const ageMs = now() - running.startedAt;
+        noteStall(running, ageMs);
+        activeUnit = {
+          label: running.entry.label,
+          priority: running.entry.priority,
+          ageMs: round1(ageMs),
+          atMs: Math.round(running.startedAt),
+        };
+      }
       return {
         units,
-        totalSyncMs: Math.round(totalSyncMs * 10) / 10,
-        worstSyncMs: Math.round(worstSyncMs * 10) / 10,
+        totalSyncMs: round1(totalSyncMs),
+        worstSyncMs: round1(worstSyncMs),
         slowest: slowest.map((stat) => ({
           ...stat,
-          syncMs: Math.round(stat.syncMs * 10) / 10,
-          wallMs: Math.round(stat.wallMs * 10) / 10,
+          syncMs: round1(stat.syncMs),
+          wallMs: round1(stat.wallMs),
           atMs: Math.round(stat.atMs),
+        })),
+        pending: pending.length,
+        active: activeUnit,
+        stallCount,
+        stalls: stalls.map((stall) => ({
+          ...stall,
+          ageMs: round1(stall.ageMs),
+          atMs: Math.round(stall.atMs),
         })),
       };
     },

--- a/src/render/compile_gate.ts
+++ b/src/render/compile_gate.ts
@@ -4,8 +4,11 @@
 // program link off the main thread, but the returned work cannot be cancelled.
 // A timeout is therefore diagnostic only: revealing the target at that point
 // would make its first draw synchronously finish the same link while the async
-// compile remains active. The queue also keeps multiple streamed views from
-// starting overlapping driver work during an online snapshot burst.
+// compile remains active. The queue also BOUNDS how many streamed views can
+// have driver link work in flight during an online snapshot burst: the shared
+// queue's released-tail cap, or strict serialization on the local fallback.
+
+import type { GpuWorkRunOptions } from './background_gpu_queue';
 
 export interface CompileGateScheduler {
   setTimeout: (cb: () => void, ms: number) => number;
@@ -26,7 +29,12 @@ export interface CompileGateOptions {
 }
 
 export interface CompileGateWorkQueue {
-  run<T>(work: () => T | Promise<T>, priority?: number, label?: string): Promise<T>;
+  run<T>(
+    work: () => T | Promise<T>,
+    priority?: number,
+    label?: string,
+    options?: GpuWorkRunOptions,
+  ): Promise<T>;
 }
 
 const defaultScheduler: CompileGateScheduler = {
@@ -71,7 +79,15 @@ export function awaitCompileGate(
   });
 }
 
-/** Serializes live compile gates so online entity bursts cannot overlap them. */
+/** Bounds live compile gates so online entity bursts cannot pile up driver
+ *  work: strictly serial on the local fallback, cap-bounded on the shared
+ *  queue. There, a gate declares releaseTail: after the synchronous compile
+ *  prologue, the awaited remainder is the driver's off-thread link (three
+ *  polls KHR_parallel_shader_compile on a timer), so the queue keeps draining
+ *  other lanes while it settles, under the queue's released-tail cap. Gates
+ *  may therefore overlap and settle OUT OF ORDER. The gate's own contract is
+ *  unchanged: its result still resolves only when the link settles, so a
+ *  gated view is revealed no earlier than before. */
 export class CompileGateQueue {
   private tail: Promise<unknown> = Promise.resolve();
 
@@ -83,7 +99,9 @@ export class CompileGateQueue {
     options: CompileGateOptions = {},
   ): Promise<CompileGateResult> {
     const work = () => awaitCompileGate(compile, timeoutMs, options);
-    if (this.sharedQueue) return this.sharedQueue.run(work, options.priority, options.label);
+    if (this.sharedQueue) {
+      return this.sharedQueue.run(work, options.priority, options.label, { releaseTail: true });
+    }
     const result = this.tail.then(work);
     this.tail = result;
     return result;
@@ -96,9 +114,10 @@ export class CompileGateQueue {
  * across a family of mutually exclusive gated swaps instead of one pending flag
  * per swap target (e.g. shapeshift-form creation: sheep/bear/cat/travel share a
  * single formCompilePending token because at most one of them is ever active or
- * newly built per entity per frame). The shared CompileGateQueue runs gates one
- * at a time, but a NEWER swap can still be registered while an OLDER one is
- * still in flight (a fast form-to-form reswap before the first compile settles).
+ * newly built per entity per frame). The shared CompileGateQueue bounds gates
+ * to a small overlap (they can settle out of order), so a NEWER swap can be
+ * registered, or even settle, while an OLDER one is still in flight (a fast
+ * form-to-form reswap before the first compile settles).
  * Without this guard, the older gate's onSettled would clear the token as soon
  * as it resolves, revealing the newer target before its own compile is done:
  * exactly the freeze this gate exists to prevent. Passing the raw setter

--- a/tests/background_gpu_queue.test.ts
+++ b/tests/background_gpu_queue.test.ts
@@ -183,6 +183,137 @@ describe('createBackgroundGpuQueue', () => {
     expect(stats.worstSyncMs).toBe(30);
   });
 
+  it('exposes the running unit with its age and reports none while idle', async () => {
+    let clock = 0;
+    const queue = createBackgroundGpuQueue({ now: () => clock });
+    expect(queue.stats().active).toBeNull();
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => (release = resolve));
+    const running = queue.run(() => gate, GPU_WORK_PRIORITY.LIVE_VIEW, 'live-view-compile');
+    const behind = queue.run(async () => {}, GPU_WORK_PRIORITY.BACKGROUND, 'texture-chunk');
+    await Promise.resolve();
+    clock += 250;
+
+    const busy = queue.stats();
+    expect(busy.active).toEqual({
+      label: 'live-view-compile',
+      priority: GPU_WORK_PRIORITY.LIVE_VIEW,
+      ageMs: 250,
+      atMs: 0,
+    });
+    expect(busy.pending).toBe(1);
+    expect(busy.units).toBe(0);
+
+    release();
+    await Promise.all([running, behind]);
+    const idle = queue.stats();
+    expect(idle.active).toBeNull();
+    expect(idle.pending).toBe(0);
+    expect(idle.units).toBe(2);
+  });
+
+  it('records a never-settling unit past the threshold without counting it as completed', async () => {
+    let clock = 0;
+    const queue = createBackgroundGpuQueue({ now: () => clock, stallMs: 4000 });
+    // The shape of the r165 compileAsync deadlock: the unit's promise never
+    // settles, so no completion callback ever runs for it.
+    void queue.run(
+      () => new Promise<void>(() => {}),
+      GPU_WORK_PRIORITY.ACTIONABLE_VIEW,
+      'wedged-compile',
+    );
+    void queue.run(async () => {}, GPU_WORK_PRIORITY.BACKGROUND, 'texture-chunk');
+    await Promise.resolve();
+
+    clock += 3999;
+    expect(queue.stats().stalls).toEqual([]);
+    clock += 1;
+    const stalled = queue.stats();
+    expect(stalled.stallCount).toBe(1);
+    expect(stalled.stalls).toEqual([
+      {
+        label: 'wedged-compile',
+        priority: GPU_WORK_PRIORITY.ACTIONABLE_VIEW,
+        ageMs: 4000,
+        atMs: 0,
+        settled: false,
+      },
+    ]);
+    expect(stalled.active?.label).toBe('wedged-compile');
+    expect(stalled.pending).toBe(1);
+    // It is a stall, not a completed unit: nothing lands in the completed-unit
+    // reporting, which is exactly why it used to be invisible.
+    expect(stalled.units).toBe(0);
+    expect(stalled.totalSyncMs).toBe(0);
+    expect(stalled.worstSyncMs).toBe(0);
+    expect(stalled.slowest).toEqual([]);
+
+    clock += 10_000;
+    const later = queue.stats();
+    expect(later.stallCount).toBe(1);
+    expect(later.stalls[0].ageMs).toBe(14_000);
+    expect(later.stalls[0].settled).toBe(false);
+    expect(later.active?.ageMs).toBe(14_000);
+  });
+
+  it('settles a stall when the unit finishes and leaves the slowest ring on sync time', async () => {
+    let clock = 0;
+    const queue = createBackgroundGpuQueue({ now: () => clock, stallMs: 1000 });
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => (release = resolve));
+    const slow = queue.run(
+      () => {
+        clock += 8;
+        return gate;
+      },
+      GPU_WORK_PRIORITY.VISIBLE_PREWARM,
+      'zone-prewarm',
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+    clock += 5000;
+    release();
+    await slow;
+
+    const stats = queue.stats();
+    expect(stats.active).toBeNull();
+    expect(stats.stallCount).toBe(1);
+    expect(stats.stalls).toEqual([
+      {
+        label: 'zone-prewarm',
+        priority: GPU_WORK_PRIORITY.VISIBLE_PREWARM,
+        ageMs: 5008,
+        atMs: 0,
+        settled: true,
+      },
+    ]);
+    // Completed-unit reporting is unchanged: the sync slice, not the wall time,
+    // still drives worstSyncMs and the slowest ring.
+    expect(stats.units).toBe(1);
+    expect(stats.worstSyncMs).toBe(8);
+    expect(stats.slowest[0].syncMs).toBe(8);
+    expect(stats.slowest[0].wallMs).toBe(5008);
+  });
+
+  it('bounds the retained stalls while counting every one of them', async () => {
+    let clock = 0;
+    const queue = createBackgroundGpuQueue({ now: () => clock, stallMs: 100, stallLimit: 2 });
+    for (const label of ['first', 'second', 'third']) {
+      await queue.run(
+        () => {
+          clock += 500;
+        },
+        GPU_WORK_PRIORITY.BACKGROUND,
+        label,
+      );
+    }
+    const stats = queue.stats();
+    expect(stats.stallCount).toBe(3);
+    expect(stats.stalls.map((stall) => stall.label)).toEqual(['second', 'third']);
+    expect(stats.stalls.every((stall) => stall.settled)).toBe(true);
+    expect(stats.units).toBe(3);
+  });
+
   it('wires sky, feature, archetype, and boot-resume units through one renderer queue', () => {
     const source = readFileSync(new URL('../src/render/renderer.ts', import.meta.url), 'utf8');
     const method = (startText: string, endText: string): string => {

--- a/tests/background_gpu_queue.test.ts
+++ b/tests/background_gpu_queue.test.ts
@@ -314,6 +314,373 @@ describe('createBackgroundGpuQueue', () => {
     expect(stats.units).toBe(3);
   });
 
+  // The released-tail policy (see the tail policy header in the module): a
+  // unit that DECLARES its awaited tail as an off-thread wait releases the
+  // queue after its synchronous prologue, bounded by the tail cap.
+  const flush = async (rounds = 12): Promise<void> => {
+    for (let index = 0; index < rounds; index++) await Promise.resolve();
+  };
+
+  it('releases a declared wait-only tail so lower-priority lanes keep draining', async () => {
+    const queue = createBackgroundGpuQueue();
+    const events: string[] = [];
+    let settleLink!: () => void;
+    const gated = queue.run(
+      () => {
+        events.push('gate:prologue');
+        return new Promise<string>((resolve) => {
+          settleLink = () => resolve('linked');
+        });
+      },
+      GPU_WORK_PRIORITY.LIVE_VIEW,
+      'live-gate',
+      { releaseTail: true },
+    );
+    const upload = queue.run(
+      async () => {
+        events.push('upload');
+      },
+      GPU_WORK_PRIORITY.VISIBLE_PREWARM,
+      'texture-chunk-upload',
+    );
+
+    await flush();
+    // The upload no longer waits out the link; the gate itself is still pending.
+    expect(events).toEqual(['gate:prologue', 'upload']);
+    await upload;
+    settleLink();
+    await expect(gated).resolves.toBe('linked');
+  });
+
+  it('lets a higher-priority unit run to completion while a slow gate link settles', async () => {
+    const queue = createBackgroundGpuQueue();
+    const events: string[] = [];
+    let settleLink!: () => void;
+    let gateSettled = false;
+    const gated = queue
+      .run(
+        () =>
+          new Promise<void>((resolve) => {
+            settleLink = resolve;
+          }),
+        GPU_WORK_PRIORITY.LIVE_VIEW,
+        'slow-live-gate',
+        { releaseTail: true },
+      )
+      .then(() => {
+        gateSettled = true;
+      });
+    await flush();
+    const actionable = queue.run(
+      async () => {
+        events.push('actionable');
+      },
+      GPU_WORK_PRIORITY.ACTIONABLE_VIEW,
+      'actionable-gate',
+    );
+
+    await actionable;
+    expect(events).toEqual(['actionable']);
+    expect(gateSettled).toBe(false);
+    settleLink();
+    await gated;
+    expect(gateSettled).toBe(true);
+  });
+
+  it('caps concurrent released tails and resumes, by priority, when one settles', async () => {
+    const queue = createBackgroundGpuQueue({ tailLimit: 2 });
+    const events: string[] = [];
+    const links: Array<() => void> = [];
+    const gate = (name: string) =>
+      queue.run(
+        () => {
+          events.push(`${name}:prologue`);
+          return new Promise<void>((resolve) => {
+            links.push(resolve);
+          });
+        },
+        GPU_WORK_PRIORITY.LIVE_VIEW,
+        name,
+        { releaseTail: true },
+      );
+    const first = gate('first');
+    const second = gate('second');
+    await flush();
+    expect(events).toEqual(['first:prologue', 'second:prologue']);
+
+    const third = gate('third');
+    const actionable = queue.run(
+      async () => {
+        events.push('actionable');
+      },
+      GPU_WORK_PRIORITY.ACTIONABLE_VIEW,
+      'actionable-gate',
+    );
+    await flush();
+    // Two tails in flight fill the cap: NOTHING else starts, not even the
+    // higher-priority unit (the cap is what bounds concurrent driver work).
+    // The documented cap-limited readout is the triple: pending grows,
+    // active null, waitingTails full.
+    expect(events).toEqual(['first:prologue', 'second:prologue']);
+    const capped = queue.stats();
+    expect(capped.pending).toBe(2);
+    expect(capped.active).toBeNull();
+    expect(capped.waitingTails.map((tail) => tail.label)).toEqual(['first', 'second']);
+
+    links[0]();
+    await flush();
+    // One slot freed: the actionable unit outranks the older third gate.
+    expect(events).toEqual(['first:prologue', 'second:prologue', 'actionable', 'third:prologue']);
+
+    links[1]();
+    links[2]();
+    await Promise.all([first, second, third, actionable]);
+    expect(queue.stats().waitingTails).toEqual([]);
+  });
+
+  it('caps released tails at 2 by default: the snapshot-burst bound', async () => {
+    const queue = createBackgroundGpuQueue();
+    const events: string[] = [];
+    const links: Array<() => void> = [];
+    for (const name of ['first', 'second', 'third']) {
+      void queue.run(
+        () => {
+          events.push(`${name}:prologue`);
+          return new Promise<void>((resolve) => {
+            links.push(resolve);
+          });
+        },
+        GPU_WORK_PRIORITY.LIVE_VIEW,
+        name,
+        { releaseTail: true },
+      );
+    }
+    await flush();
+    // No tailLimit override: the DEFAULT cap must hold the third gate.
+    expect(events).toEqual(['first:prologue', 'second:prologue']);
+    links[0]();
+    await flush();
+    expect(events).toEqual(['first:prologue', 'second:prologue', 'third:prologue']);
+    links[1]();
+    links[2]();
+    await flush();
+    expect(queue.stats().waitingTails).toEqual([]);
+  });
+
+  it('runs a releaseTail unit returning a non-promise through the normal serial path', async () => {
+    const queue = createBackgroundGpuQueue();
+    const value = await queue.run(() => 42, GPU_WORK_PRIORITY.LIVE_VIEW, 'sync-gate', {
+      releaseTail: true,
+    });
+    expect(value).toBe(42);
+    const stats = queue.stats();
+    expect(stats.units).toBe(1);
+    expect(stats.waitingTails).toEqual([]);
+  });
+
+  it('rejects a hostile thenable whose then throws without leaking a cap slot', async () => {
+    const queue = createBackgroundGpuQueue();
+    const hostile = {
+      // biome-ignore lint/suspicious/noThenProperty: a deliberately broken thenable is the test subject
+      then() {
+        throw new Error('broken thenable');
+      },
+    };
+    const gated = queue.run(
+      () => hostile as unknown as Promise<void>,
+      GPU_WORK_PRIORITY.LIVE_VIEW,
+      'hostile-gate',
+      { releaseTail: true },
+    );
+    const later = queue.run(async () => 'later');
+    await expect(gated).rejects.toThrow('broken thenable');
+    await expect(later).resolves.toBe('later');
+    const stats = queue.stats();
+    expect(stats.waitingTails).toEqual([]);
+    expect(stats.units).toBe(2);
+  });
+
+  it('records a releaseTail unit that throws synchronously and keeps draining', async () => {
+    const queue = createBackgroundGpuQueue();
+    const failed = queue.run(
+      () => {
+        throw new Error('prologue failed');
+      },
+      GPU_WORK_PRIORITY.LIVE_VIEW,
+      'throwing-gate',
+      { releaseTail: true },
+    );
+    const later = queue.run(async () => 'later');
+    await expect(failed).rejects.toThrow('prologue failed');
+    await expect(later).resolves.toBe('later');
+    const stats = queue.stats();
+    expect(stats.units).toBe(2);
+    expect(stats.waitingTails).toEqual([]);
+  });
+
+  it('records a released unit on settle, keeping sync and wall time separate', async () => {
+    let clock = 0;
+    const queue = createBackgroundGpuQueue({ now: () => clock });
+    let settleLink!: () => void;
+    const gated = queue.run(
+      () => {
+        clock += 3;
+        return new Promise<void>((resolve) => {
+          settleLink = resolve;
+        });
+      },
+      GPU_WORK_PRIORITY.LIVE_VIEW,
+      'live-gate',
+      { releaseTail: true },
+    );
+    await flush();
+    const inFlight = queue.stats();
+    expect(inFlight.units).toBe(0);
+    expect(inFlight.active).toBeNull();
+    expect(inFlight.waitingTails).toEqual([
+      { label: 'live-gate', priority: GPU_WORK_PRIORITY.LIVE_VIEW, ageMs: 3, atMs: 0 },
+    ]);
+
+    clock += 7000;
+    settleLink();
+    await gated;
+    const stats = queue.stats();
+    expect(stats.units).toBe(1);
+    expect(stats.waitingTails).toEqual([]);
+    expect(stats.slowest[0]).toEqual({
+      label: 'live-gate',
+      priority: GPU_WORK_PRIORITY.LIVE_VIEW,
+      syncMs: 3,
+      wallMs: 7003,
+      atMs: 0,
+    });
+    // A multi-second link is still a recorded stall, settled: the release
+    // changes who waits behind it, not whether it is worth seeing.
+    expect(stats.stallCount).toBe(1);
+    expect(stats.stalls[0]).toMatchObject({ label: 'live-gate', settled: true, ageMs: 7003 });
+  });
+
+  it('propagates a released tail rejection and keeps draining', async () => {
+    const queue = createBackgroundGpuQueue();
+    let failLink!: (error: Error) => void;
+    const gated = queue.run(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          failLink = reject;
+        }),
+      GPU_WORK_PRIORITY.LIVE_VIEW,
+      'failing-gate',
+      { releaseTail: true },
+    );
+    const later = queue.run(async () => 'later');
+    await flush();
+    failLink(new Error('link failed'));
+    await expect(gated).rejects.toThrow('link failed');
+    await expect(later).resolves.toBe('later');
+    // The reject arm still runs the full settle bookkeeping: the failed unit
+    // is recorded and its cap slot is released, never leaked.
+    const stats = queue.stats();
+    expect(stats.waitingTails).toEqual([]);
+    expect(stats.units).toBe(2);
+  });
+
+  it('records an unsettled released tail as a stall while active stays null: the wedge readout', async () => {
+    let clock = 0;
+    const queue = createBackgroundGpuQueue({ now: () => clock, stallMs: 4000 });
+    // The r165 compileAsync deadlock shape, now on the RELEASED path (every
+    // compile gate declares releaseTail): the tail never settles, the drain
+    // loop is free, so active is null and the tail list plus the stall record
+    // are the only evidence.
+    void queue.run(
+      () => new Promise<void>(() => {}),
+      GPU_WORK_PRIORITY.LIVE_VIEW,
+      'wedged-released',
+      { releaseTail: true },
+    );
+    await flush();
+    clock += 10_000;
+    const stats = queue.stats();
+    expect(stats.active).toBeNull();
+    expect(stats.waitingTails).toEqual([
+      { label: 'wedged-released', priority: GPU_WORK_PRIORITY.LIVE_VIEW, ageMs: 10_000, atMs: 0 },
+    ]);
+    expect(stats.stallCount).toBe(1);
+    expect(stats.stalls).toEqual([
+      {
+        label: 'wedged-released',
+        priority: GPU_WORK_PRIORITY.LIVE_VIEW,
+        ageMs: 10_000,
+        atMs: 0,
+        settled: false,
+      },
+    ]);
+    expect(stats.units).toBe(0);
+  });
+
+  it('survives a shutdown that empties pending while the drain is parked on the tail cap', async () => {
+    const queue = createBackgroundGpuQueue({ tailLimit: 2 });
+    const links: Array<() => void> = [];
+    const gate = (name: string) =>
+      queue.run(
+        () =>
+          new Promise<void>((resolve) => {
+            links.push(resolve);
+          }),
+        GPU_WORK_PRIORITY.LIVE_VIEW,
+        name,
+        { releaseTail: true },
+      );
+    const first = gate('first');
+    const second = gate('second');
+    await flush();
+    // Cap saturated; this unit parks the drain loop on the tail-cap wait.
+    const parked = queue.run(async () => 'parked', GPU_WORK_PRIORITY.LIVE_VIEW, 'parked');
+    await flush();
+
+    const shutdownError = new Error('renderer generation ended');
+    const parkedRejected = expect(parked).rejects.toBe(shutdownError);
+    let shutdownDone = false;
+    const shutdown = queue.shutdown(shutdownError).then(() => {
+      shutdownDone = true;
+    });
+    await flush();
+    expect(shutdownDone).toBe(false);
+
+    // The tails settle AFTER shutdown spliced pending: the resumed drain must
+    // observe the emptied queue instead of dereferencing a missing unit, and
+    // shutdown must still resolve once both tails settle.
+    links[0]();
+    links[1]();
+    await Promise.all([first, second, parkedRejected, shutdown]);
+    expect(shutdownDone).toBe(true);
+    expect(queue.stats().waitingTails).toEqual([]);
+    expect(queue.stats().units).toBe(2);
+  });
+
+  it('shutdown resolves only after released tails settle', async () => {
+    const queue = createBackgroundGpuQueue();
+    let settleLink!: () => void;
+    const gated = queue.run(
+      () =>
+        new Promise<void>((resolve) => {
+          settleLink = resolve;
+        }),
+      GPU_WORK_PRIORITY.LIVE_VIEW,
+      'live-gate',
+      { releaseTail: true },
+    );
+    await flush();
+    let shutdownDone = false;
+    const shutdown = queue.shutdown().then(() => {
+      shutdownDone = true;
+    });
+    await flush();
+    expect(shutdownDone).toBe(false);
+    settleLink();
+    await Promise.all([gated, shutdown]);
+    expect(shutdownDone).toBe(true);
+  });
+
   it('wires sky, feature, archetype, and boot-resume units through one renderer queue', () => {
     const source = readFileSync(new URL('../src/render/renderer.ts', import.meta.url), 'utf8');
     const method = (startText: string, endText: string): string => {

--- a/tests/compile_gate.test.ts
+++ b/tests/compile_gate.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { createBackgroundGpuQueue } from '../src/render/background_gpu_queue';
 import {
   awaitCompileGate,
   CompileGateQueue,
@@ -138,11 +139,18 @@ describe('CompileGateQueue', () => {
     expect(secondCompile).toHaveBeenCalledTimes(1);
   });
 
-  it('uses a shared GPU arbiter and forwards live priority', async () => {
+  it('uses a shared GPU arbiter, forwards live priority, and declares its tail releasable', async () => {
     const priorities: Array<number | undefined> = [];
+    const tailOptions: Array<{ releaseTail?: boolean } | undefined> = [];
     const sharedQueue = {
-      run: async <T>(work: () => T | Promise<T>, priority?: number): Promise<T> => {
+      run: async <T>(
+        work: () => T | Promise<T>,
+        priority?: number,
+        _label?: string,
+        options?: { releaseTail?: boolean },
+      ): Promise<T> => {
         priorities.push(priority);
+        tailOptions.push(options);
         return work();
       },
     };
@@ -153,6 +161,33 @@ describe('CompileGateQueue', () => {
       timedOut: false,
     });
     expect(priorities).toEqual([40]);
+    // The gate's tail is the off-thread driver link: the shared queue may keep
+    // draining other lanes while it settles (the released-tail policy).
+    expect(tailOptions).toEqual([{ releaseTail: true }]);
+  });
+
+  it('overlaps gates up to the real shared queue cap and holds the next one', async () => {
+    // Composition over the REAL queue, not a fake: two gates start their
+    // compile prologues while neither link has settled, the third waits on
+    // the released-tail cap. This is the deliberate relaxation of the strict
+    // serialization the local fallback still provides.
+    const queue = new CompileGateQueue(createBackgroundGpuQueue());
+    const noopScheduler = { setTimeout: () => 0, clearTimeout: () => {} };
+    const started: string[] = [];
+    const gate = (name: string) =>
+      queue.run(
+        () => {
+          started.push(name);
+          return new Promise<void>(() => {});
+        },
+        1500,
+        { label: name, scheduler: noopScheduler },
+      );
+    void gate('one');
+    void gate('two');
+    void gate('three');
+    for (let index = 0; index < 12; index++) await Promise.resolve();
+    expect(started).toEqual(['one', 'two']);
   });
 });
 

--- a/tests/perf_diagnosis.test.ts
+++ b/tests/perf_diagnosis.test.ts
@@ -122,6 +122,7 @@ function baseSnapshot(): PerfSnapshot {
         slowest: [],
         pending: 0,
         active: null,
+        waitingTails: [],
         stallCount: 0,
         stalls: [],
       },

--- a/tests/perf_diagnosis.test.ts
+++ b/tests/perf_diagnosis.test.ts
@@ -115,7 +115,16 @@ function baseSnapshot(): PerfSnapshot {
       renderDiagnostics: {} as never,
       nightAmount: 0,
       prewarm: null,
-      gpuQueue: { units: 0, totalSyncMs: 0, worstSyncMs: 0, slowest: [] },
+      gpuQueue: {
+        units: 0,
+        totalSyncMs: 0,
+        worstSyncMs: 0,
+        slowest: [],
+        pending: 0,
+        active: null,
+        stallCount: 0,
+        stalls: [],
+      },
     },
     hud: { hotDomWrites: 10, hotDomSkippedWrites: 90, hotDomSkipRate: 0.9 },
     assets: {

--- a/tests/perf_monitor_report_dimensions.test.ts
+++ b/tests/perf_monitor_report_dimensions.test.ts
@@ -181,7 +181,7 @@ describe('perf monitor forensics state assembly', () => {
       calls: 1200,
       triangles: 9_000_000,
       views: 40,
-      gpuQueue: { units: 3, totalSyncMs: 12.6 },
+      gpuQueue: { units: 3, totalSyncMs: 12.6, stallCount: 2 },
       effectiveRenderScale: 1,
       renderBudget: { mode: 'steady' },
       nightAmount: 0.85,
@@ -196,6 +196,9 @@ describe('perf monitor forensics state assembly', () => {
     expect(state.activePointLights).toBe(6);
     expect(state.programs).toBe(700);
     expect(state.gpuQueueSyncMs).toBe(13);
+    // A wedged unit moves neither units nor sync time, so the stall counter is
+    // the dimension that can bracket a hitch with a queue that stopped draining.
+    expect(state.gpuQueueStalls).toBe(2);
     expect(state.biome).toBe('marsh');
     expect(state.px).toBe(123);
     expect(state.pz).toBe(-56);

--- a/tests/perf_report.test.ts
+++ b/tests/perf_report.test.ts
@@ -696,8 +696,12 @@ describe('perf report ingestion', () => {
   });
 
   it('stores the GPU queue block bounded, and keeps it when raw summaries are truncated (#3167)', async () => {
-    const { GPU_QUEUE_RAW_MS_MAX, GPU_QUEUE_RAW_AGE_MS_MAX, GPU_QUEUE_RAW_STALLS_MAX } =
-      perfReportInternalsForTest;
+    const {
+      GPU_QUEUE_RAW_MS_MAX,
+      GPU_QUEUE_RAW_AGE_MS_MAX,
+      GPU_QUEUE_RAW_STALLS_MAX,
+      GPU_QUEUE_RAW_TAILS_MAX,
+    } = perfReportInternalsForTest;
     const wedged = {
       units: 12,
       totalSyncMs: 240.5,
@@ -705,6 +709,7 @@ describe('perf report ingestion', () => {
       pending: 6,
       stallCount: 1,
       active: { label: 'wedged-compile', priority: 40, ageMs: 91_000 },
+      waitingTails: [{ label: 'released-gate', priority: 30, ageMs: 5000 }],
       stalls: [{ label: 'wedged-compile', priority: 40, ageMs: 91_000, settled: false }],
       slowest: [{ label: 'live-view-compile', priority: 30, syncMs: 88.2, wallMs: 120.4 }],
     };
@@ -738,6 +743,11 @@ describe('perf report ingestion', () => {
             pending: 1e12,
             stallCount: 3,
             active: { label: 'x'.repeat(400), priority: 9e9, ageMs: 9e12 },
+            waitingTails: Array.from({ length: 9 }, () => ({
+              label: 'y'.repeat(300),
+              priority: -9e9,
+              ageMs: -5,
+            })),
             stalls: Array.from({ length: 40 }, () => ({
               label: 'wedged',
               priority: 40,
@@ -766,6 +776,15 @@ describe('perf report ingestion', () => {
     expect((hostileQueue.stalls as Record<string, unknown>[])[0].ageMs).toBe(
       GPU_QUEUE_RAW_AGE_MS_MAX,
     );
+    // Pin the bound's VALUE too: comparing output length against the same
+    // constant the sanitizer slices with would pass at any value.
+    expect(GPU_QUEUE_RAW_TAILS_MAX).toBe(4);
+    expect(hostileQueue.waitingTails).toHaveLength(GPU_QUEUE_RAW_TAILS_MAX);
+    expect((hostileQueue.waitingTails as Record<string, unknown>[])[0]).toEqual({
+      label: 'y'.repeat(80),
+      priority: -1000,
+      ageMs: 0,
+    });
 
     // A malformed block is dropped rather than stored half-shaped.
     vi.mocked(insertClientPerfReport).mockClear();
@@ -799,6 +818,63 @@ describe('perf report ingestion', () => {
         rawSummary: expect.objectContaining({ truncated: true, rendererGpuQueue: wedged }),
       }),
     );
+
+    // Back-compat: an old client's block has no waitingTails key at all; it
+    // stores with an explicit empty list, everything else untouched.
+    vi.mocked(insertClientPerfReport).mockClear();
+    const legacy = fakeRes();
+    await handlePerfReport(
+      fakeReq({
+        sessionId: 'gpu-queue-legacy',
+        rawSummary: {
+          rendererGpuQueue: {
+            units: 3,
+            totalSyncMs: 12.5,
+            worstSyncMs: 8,
+            pending: 1,
+            stallCount: 0,
+            active: null,
+            stalls: [],
+            slowest: [],
+          },
+        },
+      }),
+      legacy,
+    );
+    expect(legacy.statusCode).toBe(200);
+    const legacyRow = vi.mocked(insertClientPerfReport).mock.calls.at(-1)![0];
+    const legacyQueue = (legacyRow.rawSummary as Record<string, Record<string, unknown>>)
+      .rendererGpuQueue;
+    expect(legacyQueue.waitingTails).toEqual([]);
+    expect(legacyQueue.units).toBe(3);
+
+    // Junk entries are dropped by the record filter, real ones kept.
+    vi.mocked(insertClientPerfReport).mockClear();
+    const junk = fakeRes();
+    await handlePerfReport(
+      fakeReq({
+        sessionId: 'gpu-queue-junk-tails',
+        rawSummary: {
+          rendererGpuQueue: {
+            units: 1,
+            totalSyncMs: 1,
+            worstSyncMs: 1,
+            pending: 0,
+            stallCount: 0,
+            active: null,
+            waitingTails: [null, 'junk', { label: 'real-gate', priority: 30, ageMs: 100 }],
+            stalls: [],
+            slowest: [],
+          },
+        },
+      }),
+      junk,
+    );
+    expect(junk.statusCode).toBe(200);
+    const junkRow = vi.mocked(insertClientPerfReport).mock.calls.at(-1)![0];
+    const junkQueue = (junkRow.rawSummary as Record<string, Record<string, unknown>>)
+      .rendererGpuQueue;
+    expect(junkQueue.waitingTails).toEqual([{ label: 'real-gate', priority: 30, ageMs: 100 }]);
   });
 
   it('preserves the net pipeline and heap sawtooth blocks when raw summaries are truncated', async () => {

--- a/tests/perf_report.test.ts
+++ b/tests/perf_report.test.ts
@@ -695,6 +695,112 @@ describe('perf report ingestion', () => {
     expect((stored.rawSummary as Record<string, unknown>).oversized).toBeUndefined();
   });
 
+  it('stores the GPU queue block bounded, and keeps it when raw summaries are truncated (#3167)', async () => {
+    const { GPU_QUEUE_RAW_MS_MAX, GPU_QUEUE_RAW_AGE_MS_MAX, GPU_QUEUE_RAW_STALLS_MAX } =
+      perfReportInternalsForTest;
+    const wedged = {
+      units: 12,
+      totalSyncMs: 240.5,
+      worstSyncMs: 88.2,
+      pending: 6,
+      stallCount: 1,
+      active: { label: 'wedged-compile', priority: 40, ageMs: 91_000 },
+      stalls: [{ label: 'wedged-compile', priority: 40, ageMs: 91_000, settled: false }],
+      slowest: [{ label: 'live-view-compile', priority: 30, syncMs: 88.2, wallMs: 120.4 }],
+    };
+    const stored = fakeRes();
+
+    await handlePerfReport(
+      fakeReq({
+        sessionId: 'gpu-queue-wedge',
+        rawSummary: { seconds: 30, rendererGpuQueue: wedged },
+      }),
+      stored,
+    );
+
+    expect(stored.statusCode).toBe(200);
+    expect(insertClientPerfReport).toHaveBeenCalledWith(
+      expect.objectContaining({ rawSummary: { seconds: 30, rendererGpuQueue: wedged } }),
+    );
+
+    // A hostile payload cannot inject an absurd age, an unbounded stall list,
+    // or a novel-length label into the admin raw-report reader.
+    vi.mocked(insertClientPerfReport).mockClear();
+    const hostile = fakeRes();
+    await handlePerfReport(
+      fakeReq({
+        sessionId: 'gpu-queue-hostile',
+        rawSummary: {
+          rendererGpuQueue: {
+            units: -5,
+            totalSyncMs: 'nope',
+            worstSyncMs: 9e12,
+            pending: 1e12,
+            stallCount: 3,
+            active: { label: 'x'.repeat(400), priority: 9e9, ageMs: 9e12 },
+            stalls: Array.from({ length: 40 }, () => ({
+              label: 'wedged',
+              priority: 40,
+              ageMs: 9e12,
+              settled: 'yes',
+            })),
+            slowest: 'not-an-array',
+          },
+        },
+      }),
+      hostile,
+    );
+    expect(hostile.statusCode).toBe(200);
+    const hostileRow = vi.mocked(insertClientPerfReport).mock.calls.at(-1)![0];
+    const hostileQueue = (hostileRow.rawSummary as Record<string, Record<string, unknown>>)
+      .rendererGpuQueue;
+    expect(hostileQueue).toMatchObject({
+      units: 0,
+      totalSyncMs: 0,
+      worstSyncMs: GPU_QUEUE_RAW_MS_MAX,
+      stallCount: 3,
+      active: { label: 'x'.repeat(80), priority: 1000, ageMs: GPU_QUEUE_RAW_AGE_MS_MAX },
+      slowest: [],
+    });
+    expect(hostileQueue.stalls).toHaveLength(GPU_QUEUE_RAW_STALLS_MAX);
+    expect((hostileQueue.stalls as Record<string, unknown>[])[0].ageMs).toBe(
+      GPU_QUEUE_RAW_AGE_MS_MAX,
+    );
+
+    // A malformed block is dropped rather than stored half-shaped.
+    vi.mocked(insertClientPerfReport).mockClear();
+    const malformed = fakeRes();
+    await handlePerfReport(
+      fakeReq({
+        sessionId: 'gpu-queue-malformed',
+        rawSummary: { seconds: 12, rendererGpuQueue: 'not-an-object' },
+      }),
+      malformed,
+    );
+    expect(malformed.statusCode).toBe(200);
+    expect(insertClientPerfReport).toHaveBeenCalledWith(
+      expect.objectContaining({ rawSummary: { seconds: 12 } }),
+    );
+
+    // The compact path keeps it: a wedge is exactly what an oversized report
+    // must still carry.
+    vi.mocked(insertClientPerfReport).mockClear();
+    const truncated = fakeRes();
+    await handlePerfReport(
+      fakeReq({
+        sessionId: 'gpu-queue-truncated',
+        rawSummary: { seconds: 30, rendererGpuQueue: wedged, oversized: 'x'.repeat(40_000) },
+      }),
+      truncated,
+    );
+    expect(truncated.statusCode).toBe(200);
+    expect(insertClientPerfReport).toHaveBeenCalledWith(
+      expect.objectContaining({
+        rawSummary: expect.objectContaining({ truncated: true, rendererGpuQueue: wedged }),
+      }),
+    );
+  });
+
   it('preserves the net pipeline and heap sawtooth blocks when raw summaries are truncated', async () => {
     const res = fakeRes();
     const netPipeline = {

--- a/tests/perf_reporter.test.ts
+++ b/tests/perf_reporter.test.ts
@@ -233,6 +233,7 @@ function snapshot(): PerfSnapshot {
         ],
         pending: 0,
         active: null,
+        waitingTails: [],
         stallCount: 0,
         stalls: [],
       },
@@ -476,6 +477,7 @@ describe('perf reporter payload', () => {
       slowest: [],
       pending: 7,
       active: { label: 'wedged-compile', priority: 40, ageMs: 91_000, atMs: 12_000 },
+      waitingTails: [{ label: 'released-gate', priority: 30, ageMs: 5000, atMs: 11_000 }],
       stallCount: 1,
       stalls: [
         { label: 'wedged-compile', priority: 40, ageMs: 91_000, atMs: 12_000, settled: false },
@@ -493,6 +495,12 @@ describe('perf reporter payload', () => {
       active: { label: 'wedged-compile', priority: 40, ageMs: 91_000 },
       stalls: [{ label: 'wedged-compile', priority: 40, ageMs: 91_000, settled: false }],
     });
+    // A released tail rides beside the active unit. Exact equality on purpose:
+    // toMatchObject's subset semantics would pass even if atMs leaked through,
+    // and dropping atMs (page-relative, fleet-meaningless) is the claim.
+    expect((wedgedQueue as { waitingTails?: unknown[] }).waitingTails).toEqual([
+      { label: 'released-gate', priority: 30, ageMs: 5000 },
+    ]);
   });
 
   it('carries the always-on net pipeline and heap sawtooth blocks into raw summary', () => {

--- a/tests/perf_reporter.test.ts
+++ b/tests/perf_reporter.test.ts
@@ -223,7 +223,19 @@ function snapshot(): PerfSnapshot {
       graphicsConfigVersion: 16,
       tier: 'high',
       qualityBuckets: qualityBuckets(),
-      gpuQueue: { units: 0, totalSyncMs: 0, worstSyncMs: 0, slowest: [] },
+      gpuQueue: {
+        units: 2,
+        totalSyncMs: 18.4,
+        worstSyncMs: 12.1,
+        slowest: [
+          { label: 'live-view-compile', priority: 30, syncMs: 12.1, wallMs: 40.2, atMs: 5000 },
+          { label: 'texture-chunk', priority: 10, syncMs: 6.3, wallMs: 6.3, atMs: 5200 },
+        ],
+        pending: 0,
+        active: null,
+        stallCount: 0,
+        stalls: [],
+      },
       nightAmount: 0,
       autoGovernor: true,
       budget: {
@@ -428,6 +440,59 @@ describe('perf reporter payload', () => {
     expect(
       (body.rawSummary as { browser?: { longTasks?: Record<string, number> } }).browser?.longTasks,
     ).toEqual({ totalMs: 120, avg: 60, max: 80, lastAge: 1000 });
+  });
+
+  it('carries the GPU queue block, active unit included, into raw summary (#3167)', () => {
+    // A settled queue: only completed units, no running one. This is the arm
+    // that used to be the ONLY arm, since a never-settling unit records nothing.
+    const settings = new Settings();
+    const settled = perfReporterInternalsForTest.payloadFromSnapshot(
+      snapshot(),
+      settings,
+      'sess1',
+      42,
+    )!;
+    const settledQueue = (settled.rawSummary as { rendererGpuQueue?: Record<string, unknown> })
+      .rendererGpuQueue;
+    expect(settledQueue).toMatchObject({
+      units: 2,
+      totalSyncMs: 18.4,
+      worstSyncMs: 12.1,
+      pending: 0,
+      stallCount: 0,
+      active: null,
+      stalls: [],
+    });
+    expect(settledQueue?.slowest).toEqual([
+      { label: 'live-view-compile', priority: 30, syncMs: 12.1, wallMs: 40.2 },
+      { label: 'texture-chunk', priority: 10, syncMs: 6.3, wallMs: 6.3 },
+    ]);
+
+    const snap = snapshot();
+    snap.renderer!.gpuQueue = {
+      units: 2,
+      totalSyncMs: 18.4,
+      worstSyncMs: 12.1,
+      slowest: [],
+      pending: 7,
+      active: { label: 'wedged-compile', priority: 40, ageMs: 91_000, atMs: 12_000 },
+      stallCount: 1,
+      stalls: [
+        { label: 'wedged-compile', priority: 40, ageMs: 91_000, atMs: 12_000, settled: false },
+      ],
+    };
+    const wedged = perfReporterInternalsForTest.payloadFromSnapshot(snap, settings, 'sess1', 42)!;
+    const wedgedQueue = (wedged.rawSummary as { rendererGpuQueue?: Record<string, unknown> })
+      .rendererGpuQueue;
+    // The wedge is the whole point: units stayed at 2, so only the active unit
+    // and the stall say the queue has been blocked for a minute and a half.
+    expect(wedgedQueue).toMatchObject({
+      units: 2,
+      pending: 7,
+      stallCount: 1,
+      active: { label: 'wedged-compile', priority: 40, ageMs: 91_000 },
+      stalls: [{ label: 'wedged-compile', priority: 40, ageMs: 91_000, settled: false }],
+    });
   });
 
   it('carries the always-on net pipeline and heap sawtooth blocks into raw summary', () => {

--- a/tests/prewarm_policy.test.ts
+++ b/tests/prewarm_policy.test.ts
@@ -538,7 +538,7 @@ describe('mandatory interaction-landmark prewarm', () => {
     expect(core).toContain('export class CompileGateQueue');
     expect(core).toContain('timedOut = true;');
     expect(core).toContain(
-      'if (this.sharedQueue) return this.sharedQueue.run(work, options.priority, options.label)',
+      'return this.sharedQueue.run(work, options.priority, options.label, { releaseTail: true })',
     );
     expect(core).toContain('this.tail.then(work)');
   });


### PR DESCRIPTION
## Summary

Two commits, one story: make the shared background GPU queue's holds visible,
then stop the wait-only ones from blocking every other lane.

Commit 1 (the issue #3167 telemetry, previously submitted as PR #3216 and
carried here unchanged; #3216 is superseded by this PR and will be closed): a
unit that never settles had no completion callback, so stats() reported
completed units only and a wedged or long-held queue looked healthy. stats()
now exposes the running unit with its age, the queued backlog, and a bounded
list of units seen past a wall-time stall threshold; the block rides the perf
beacon. Diagnostics only.

Commit 2 (what that telemetry revealed): the queue drains strictly serially,
a unit occupying it from start until its promise settles. A live compile
gate's promise settles only when the driver's parallel shader link finishes:
2 to 5 ms of main-thread prologue, then a pure off-thread wait that three
polls on a 10 ms timer. That wait held every other lane. Measured locally: a
7568 ms hold on a unit that cost 2.5 ms of main-thread time, with texture
uploads, zone prewarm, boot resume, and higher-priority actionable-view gates
all frozen behind it (reproduced at every world entry on a second machine:
5.3 s, 7.8 s, 8.9 s).

The fix makes the tail policy explicit at the seam and adds an opt-in:

- `run()` accepts `releaseTail`. The unit still holds the queue for its
  synchronous prologue; the awaited tail then moves to a bounded in-flight set
  and the queue keeps draining by priority. The cap (2) gates STARTING units,
  so at most `cap + 1` units' driver work is ever in flight: the snapshot-burst
  bound the serial queue was built for (#2753) is preserved in kind.
- `CompileGateQueue` declares `releaseTail` on the shared queue, covering new
  streamed views, live material swaps, and gated world-group attaches. The
  gate's contract is unchanged: a gated view is still revealed only when ITS
  link settles, so the 50 to 1700 ms first-draw stall does not come back. The
  local no-shared-queue fallback stays strictly serial.
- Telemetry follows the policy: `stats()` reports `waitingTails`, stall
  records cover released tails (a wedged tail is `active: null` plus an
  unsettled stall naming a tail), and the field rides the perf beacon through
  a bounded server-side sanitizer.

A higher-priority unit can still wait on a full cap, but that wait is bounded
by the shortest in-flight tail instead of the whole serial hold: never longer
than before, usually far shorter.

## Related issues

Closes #3167 (the wedged-queue observability issue; its telemetry is this
PR's first commit). Supersedes and replaces PR #3216, which carried that
commit alone and will be closed in favor of this PR. Investigation record:
the "live compile gate holds the shared GPU queue" issue text (local
capture; the appendix is deliberately not posted).

## Type of change

- [x] Refactor or performance (no behavior change): no gameplay change; the
      queue occupancy policy changes, the gate contract is preserved
- [x] Tests

## How was this tested?

- Commands:
  - `node scripts/gate_select.mjs` (green; its planner fell back to the FULL
    vitest suite, 2415 test files / 33k tests, so the coverage equals the
    full gate)
  - `npx vitest run tests/background_gpu_queue.test.ts tests/compile_gate.test.ts
    tests/perf_reporter.test.ts tests/perf_report.test.ts tests/perf_diagnosis.test.ts
    tests/prewarm_policy.test.ts` (137 tests)
  - `npx tsc --noEmit`, `npm run ci:changed`
  - A/B run of `scripts/border_crossing_bench.mjs` on the same machine (RTX
    3090), baseline = base without the patch, fixes = this patch, warm and
    cold scenarios, 3 runs each: warm medians 230.7 vs 230.6 ms (stalls>150:
    1 = 1), cold medians 334.7 vs 291.7 ms (stalls>150 per run [2,2,5] vs
    [4,3,1], overlapping within run-to-run noise). No regression in worstGaps
    or stallsOver150.
- Manual steps: online dev session, world entry, reading
  `window.__game.renderer.perfStats().gpuQueue` during a gate stall: the gate
  now sits in `waitingTails` while `active` keeps cycling and `units` keeps
  advancing (the queue is no longer blocked).

Notable test coverage (a full QA review pass ran over the diff: checklist,
correctness, test coverage, frontend seam, security):

- a slow gate can no longer starve a higher-priority unit;
- the default cap (2) is pinned behaviorally, with priority-ordered resume
  when a slot frees;
- shutdown awaits released tails, including the case where shutdown empties
  the pending list while the drain loop is parked on the cap (a real
  regression the review caught; reproduced test-first, then fixed);
- sync vs wall accounting recorded at settle, settled and unsettled stalls;
- rejection propagates without leaking a cap slot; a hostile thenable whose
  `then` throws does not leak a slot either;
- beacon: `atMs` dropped, server-side bounds pinned by value (4), old-client
  back-compat (absent field stores as an empty list), junk entries filtered.

## Screenshots / recordings

N/A (no visible surface; the observable behavior is shorter pop-in behind a
slow link).

---

## Checklist

### Quality

- [x] **The gate passes.** `node scripts/gate_select.mjs` is green (its vitest
      step ran the full suite); decisive tests added (see above).

### Cross-platform

- ~Tested on desktop and mobile~ N/A: no UI surface; an internal renderer
  queue policy, identical on every host.
- ~Accessible~ N/A.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings. (Telemetry labels are dev
      diagnostics under the perf-overlay carve-out.)

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files.

---

Reviewer notes:

- The header comment of `background_gpu_queue.ts` is the seam decision the
  investigation asked for (does a wait-only tail hold the queue, and why).
- Deliberate follow-ups left out of this PR: the boot-resume `scene:NNNN` and
  `zone-prewarm-*` units have the same compileAsync tail shape and keep full
  occupancy for now (a later one-line opt-in each, after verifying their
  compile op shape); the skinned-shadow / scene-wide compile interleaving
  window during a depth-material swap (no reachable consequence today,
  documented at `GpuWorkRunOptions`).
