### PR TITLE
perf(render): eliminate the world-entry link stalls (prewarm light pin + compile coverage)

### DIFF
--- a/docs/screenshots/eastbrook-vale-rebuild/polish/metadata/after-desktop-ultra.json
+++ b/docs/screenshots/eastbrook-vale-rebuild/polish/metadata/after-desktop-ultra.json
@@ -11,7 +11,7 @@
     "mode": "composite-sha256",
     "algorithm": "sha256",
     "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-    "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
+    "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
     "components": {
       "townAsset": {
         "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -40,11 +40,11 @@
         },
         "renderer": {
           "path": "src/render/renderer.ts",
-          "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
+          "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
         },
         "viewPriorityPolicy": {
           "path": "src/render/prewarm_policy.ts",
-          "sha256": "78fef581e0d2507249ee5629800f82b740ecc11105bd418b4c64e12d95b3c8e2"
+          "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
         }
       },
       "mailbox": {
@@ -85,7 +85,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
+        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -114,11 +114,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
+              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "78fef581e0d2507249ee5629800f82b740ecc11105bd418b4c64e12d95b3c8e2"
+              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
             }
           },
           "mailbox": {
@@ -1377,7 +1377,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
+        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -1406,11 +1406,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
+              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "78fef581e0d2507249ee5629800f82b740ecc11105bd418b4c64e12d95b3c8e2"
+              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
             }
           },
           "mailbox": {
@@ -2669,7 +2669,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
+        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -2698,11 +2698,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
+              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "78fef581e0d2507249ee5629800f82b740ecc11105bd418b4c64e12d95b3c8e2"
+              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
             }
           },
           "mailbox": {
@@ -3961,7 +3961,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
+        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -3990,11 +3990,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
+              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "78fef581e0d2507249ee5629800f82b740ecc11105bd418b4c64e12d95b3c8e2"
+              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
             }
           },
           "mailbox": {
@@ -5253,7 +5253,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
+        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -5282,11 +5282,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
+              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "78fef581e0d2507249ee5629800f82b740ecc11105bd418b4c64e12d95b3c8e2"
+              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
             }
           },
           "mailbox": {
@@ -6545,7 +6545,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
+        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -6574,11 +6574,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
+              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "78fef581e0d2507249ee5629800f82b740ecc11105bd418b4c64e12d95b3c8e2"
+              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
             }
           },
           "mailbox": {
@@ -7837,7 +7837,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
+        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -7866,11 +7866,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
+              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "78fef581e0d2507249ee5629800f82b740ecc11105bd418b4c64e12d95b3c8e2"
+              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
             }
           },
           "mailbox": {
@@ -9129,7 +9129,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
+        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -9158,11 +9158,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
+              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "78fef581e0d2507249ee5629800f82b740ecc11105bd418b4c64e12d95b3c8e2"
+              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
             }
           },
           "mailbox": {
@@ -10421,7 +10421,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
+        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -10450,11 +10450,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
+              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "78fef581e0d2507249ee5629800f82b740ecc11105bd418b4c64e12d95b3c8e2"
+              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
             }
           },
           "mailbox": {
@@ -11713,7 +11713,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
+        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -11742,11 +11742,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
+              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "78fef581e0d2507249ee5629800f82b740ecc11105bd418b4c64e12d95b3c8e2"
+              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
             }
           },
           "mailbox": {
@@ -13005,7 +13005,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
+        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -13034,11 +13034,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
+              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "78fef581e0d2507249ee5629800f82b740ecc11105bd418b4c64e12d95b3c8e2"
+              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
             }
           },
           "mailbox": {
@@ -14297,7 +14297,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
+        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -14326,11 +14326,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
+              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "78fef581e0d2507249ee5629800f82b740ecc11105bd418b4c64e12d95b3c8e2"
+              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
             }
           },
           "mailbox": {
@@ -15589,7 +15589,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
+        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -15618,11 +15618,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
+              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "78fef581e0d2507249ee5629800f82b740ecc11105bd418b4c64e12d95b3c8e2"
+              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
             }
           },
           "mailbox": {
@@ -16881,7 +16881,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
+        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -16910,11 +16910,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
+              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "78fef581e0d2507249ee5629800f82b740ecc11105bd418b4c64e12d95b3c8e2"
+              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
             }
           },
           "mailbox": {
@@ -19138,7 +19138,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
+        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -19167,11 +19167,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
+              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "78fef581e0d2507249ee5629800f82b740ecc11105bd418b4c64e12d95b3c8e2"
+              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
             }
           },
           "mailbox": {
@@ -20430,7 +20430,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
+        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -20459,11 +20459,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
+              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "78fef581e0d2507249ee5629800f82b740ecc11105bd418b4c64e12d95b3c8e2"
+              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
             }
           },
           "mailbox": {
@@ -21722,7 +21722,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
+        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -21751,11 +21751,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
+              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "78fef581e0d2507249ee5629800f82b740ecc11105bd418b4c64e12d95b3c8e2"
+              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
             }
           },
           "mailbox": {
@@ -23014,7 +23014,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
+        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -23043,11 +23043,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
+              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "78fef581e0d2507249ee5629800f82b740ecc11105bd418b4c64e12d95b3c8e2"
+              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
             }
           },
           "mailbox": {
@@ -24306,7 +24306,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
+        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -24335,11 +24335,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
+              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "78fef581e0d2507249ee5629800f82b740ecc11105bd418b4c64e12d95b3c8e2"
+              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
             }
           },
           "mailbox": {
@@ -25598,7 +25598,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
+        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -25627,11 +25627,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
+              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "78fef581e0d2507249ee5629800f82b740ecc11105bd418b4c64e12d95b3c8e2"
+              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
             }
           },
           "mailbox": {
@@ -26890,7 +26890,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
+        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -26919,11 +26919,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
+              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "78fef581e0d2507249ee5629800f82b740ecc11105bd418b4c64e12d95b3c8e2"
+              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
             }
           },
           "mailbox": {
@@ -28235,7 +28235,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
+        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -28264,11 +28264,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
+              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "78fef581e0d2507249ee5629800f82b740ecc11105bd418b4c64e12d95b3c8e2"
+              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
             }
           },
           "mailbox": {
@@ -29527,7 +29527,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
+        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -29556,11 +29556,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
+              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "78fef581e0d2507249ee5629800f82b740ecc11105bd418b4c64e12d95b3c8e2"
+              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
             }
           },
           "mailbox": {

--- a/docs/screenshots/eastbrook-vale-rebuild/polish/metadata/after-desktop-ultra.json
+++ b/docs/screenshots/eastbrook-vale-rebuild/polish/metadata/after-desktop-ultra.json
@@ -11,7 +11,7 @@
     "mode": "composite-sha256",
     "algorithm": "sha256",
     "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-    "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
+    "fingerprint": "4590589e6b76f5774ffeb88d7ac9419f4b5f69c065be2a3f284a502659b2bfe7",
     "components": {
       "townAsset": {
         "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -44,7 +44,7 @@
         },
         "viewPriorityPolicy": {
           "path": "src/render/prewarm_policy.ts",
-          "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
+          "sha256": "1242be20ae43d3d237ccc9f8bc13010e18ebaaa1612be935396c4720c83daaa5"
         }
       },
       "mailbox": {
@@ -85,7 +85,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
+        "fingerprint": "4590589e6b76f5774ffeb88d7ac9419f4b5f69c065be2a3f284a502659b2bfe7",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -118,7 +118,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
+              "sha256": "1242be20ae43d3d237ccc9f8bc13010e18ebaaa1612be935396c4720c83daaa5"
             }
           },
           "mailbox": {
@@ -1377,7 +1377,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
+        "fingerprint": "4590589e6b76f5774ffeb88d7ac9419f4b5f69c065be2a3f284a502659b2bfe7",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -1410,7 +1410,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
+              "sha256": "1242be20ae43d3d237ccc9f8bc13010e18ebaaa1612be935396c4720c83daaa5"
             }
           },
           "mailbox": {
@@ -2669,7 +2669,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
+        "fingerprint": "4590589e6b76f5774ffeb88d7ac9419f4b5f69c065be2a3f284a502659b2bfe7",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -2702,7 +2702,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
+              "sha256": "1242be20ae43d3d237ccc9f8bc13010e18ebaaa1612be935396c4720c83daaa5"
             }
           },
           "mailbox": {
@@ -3961,7 +3961,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
+        "fingerprint": "4590589e6b76f5774ffeb88d7ac9419f4b5f69c065be2a3f284a502659b2bfe7",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -3994,7 +3994,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
+              "sha256": "1242be20ae43d3d237ccc9f8bc13010e18ebaaa1612be935396c4720c83daaa5"
             }
           },
           "mailbox": {
@@ -5253,7 +5253,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
+        "fingerprint": "4590589e6b76f5774ffeb88d7ac9419f4b5f69c065be2a3f284a502659b2bfe7",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -5286,7 +5286,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
+              "sha256": "1242be20ae43d3d237ccc9f8bc13010e18ebaaa1612be935396c4720c83daaa5"
             }
           },
           "mailbox": {
@@ -6545,7 +6545,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
+        "fingerprint": "4590589e6b76f5774ffeb88d7ac9419f4b5f69c065be2a3f284a502659b2bfe7",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -6578,7 +6578,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
+              "sha256": "1242be20ae43d3d237ccc9f8bc13010e18ebaaa1612be935396c4720c83daaa5"
             }
           },
           "mailbox": {
@@ -7837,7 +7837,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
+        "fingerprint": "4590589e6b76f5774ffeb88d7ac9419f4b5f69c065be2a3f284a502659b2bfe7",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -7870,7 +7870,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
+              "sha256": "1242be20ae43d3d237ccc9f8bc13010e18ebaaa1612be935396c4720c83daaa5"
             }
           },
           "mailbox": {
@@ -9129,7 +9129,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
+        "fingerprint": "4590589e6b76f5774ffeb88d7ac9419f4b5f69c065be2a3f284a502659b2bfe7",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -9162,7 +9162,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
+              "sha256": "1242be20ae43d3d237ccc9f8bc13010e18ebaaa1612be935396c4720c83daaa5"
             }
           },
           "mailbox": {
@@ -10421,7 +10421,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
+        "fingerprint": "4590589e6b76f5774ffeb88d7ac9419f4b5f69c065be2a3f284a502659b2bfe7",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -10454,7 +10454,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
+              "sha256": "1242be20ae43d3d237ccc9f8bc13010e18ebaaa1612be935396c4720c83daaa5"
             }
           },
           "mailbox": {
@@ -11713,7 +11713,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
+        "fingerprint": "4590589e6b76f5774ffeb88d7ac9419f4b5f69c065be2a3f284a502659b2bfe7",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -11746,7 +11746,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
+              "sha256": "1242be20ae43d3d237ccc9f8bc13010e18ebaaa1612be935396c4720c83daaa5"
             }
           },
           "mailbox": {
@@ -13005,7 +13005,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
+        "fingerprint": "4590589e6b76f5774ffeb88d7ac9419f4b5f69c065be2a3f284a502659b2bfe7",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -13038,7 +13038,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
+              "sha256": "1242be20ae43d3d237ccc9f8bc13010e18ebaaa1612be935396c4720c83daaa5"
             }
           },
           "mailbox": {
@@ -14297,7 +14297,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
+        "fingerprint": "4590589e6b76f5774ffeb88d7ac9419f4b5f69c065be2a3f284a502659b2bfe7",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -14330,7 +14330,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
+              "sha256": "1242be20ae43d3d237ccc9f8bc13010e18ebaaa1612be935396c4720c83daaa5"
             }
           },
           "mailbox": {
@@ -15589,7 +15589,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
+        "fingerprint": "4590589e6b76f5774ffeb88d7ac9419f4b5f69c065be2a3f284a502659b2bfe7",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -15622,7 +15622,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
+              "sha256": "1242be20ae43d3d237ccc9f8bc13010e18ebaaa1612be935396c4720c83daaa5"
             }
           },
           "mailbox": {
@@ -16881,7 +16881,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
+        "fingerprint": "4590589e6b76f5774ffeb88d7ac9419f4b5f69c065be2a3f284a502659b2bfe7",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -16914,7 +16914,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
+              "sha256": "1242be20ae43d3d237ccc9f8bc13010e18ebaaa1612be935396c4720c83daaa5"
             }
           },
           "mailbox": {
@@ -19138,7 +19138,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
+        "fingerprint": "4590589e6b76f5774ffeb88d7ac9419f4b5f69c065be2a3f284a502659b2bfe7",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -19171,7 +19171,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
+              "sha256": "1242be20ae43d3d237ccc9f8bc13010e18ebaaa1612be935396c4720c83daaa5"
             }
           },
           "mailbox": {
@@ -20430,7 +20430,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
+        "fingerprint": "4590589e6b76f5774ffeb88d7ac9419f4b5f69c065be2a3f284a502659b2bfe7",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -20463,7 +20463,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
+              "sha256": "1242be20ae43d3d237ccc9f8bc13010e18ebaaa1612be935396c4720c83daaa5"
             }
           },
           "mailbox": {
@@ -21722,7 +21722,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
+        "fingerprint": "4590589e6b76f5774ffeb88d7ac9419f4b5f69c065be2a3f284a502659b2bfe7",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -21755,7 +21755,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
+              "sha256": "1242be20ae43d3d237ccc9f8bc13010e18ebaaa1612be935396c4720c83daaa5"
             }
           },
           "mailbox": {
@@ -23014,7 +23014,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
+        "fingerprint": "4590589e6b76f5774ffeb88d7ac9419f4b5f69c065be2a3f284a502659b2bfe7",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -23047,7 +23047,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
+              "sha256": "1242be20ae43d3d237ccc9f8bc13010e18ebaaa1612be935396c4720c83daaa5"
             }
           },
           "mailbox": {
@@ -24306,7 +24306,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
+        "fingerprint": "4590589e6b76f5774ffeb88d7ac9419f4b5f69c065be2a3f284a502659b2bfe7",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -24339,7 +24339,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
+              "sha256": "1242be20ae43d3d237ccc9f8bc13010e18ebaaa1612be935396c4720c83daaa5"
             }
           },
           "mailbox": {
@@ -25598,7 +25598,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
+        "fingerprint": "4590589e6b76f5774ffeb88d7ac9419f4b5f69c065be2a3f284a502659b2bfe7",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -25631,7 +25631,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
+              "sha256": "1242be20ae43d3d237ccc9f8bc13010e18ebaaa1612be935396c4720c83daaa5"
             }
           },
           "mailbox": {
@@ -26890,7 +26890,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
+        "fingerprint": "4590589e6b76f5774ffeb88d7ac9419f4b5f69c065be2a3f284a502659b2bfe7",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -26923,7 +26923,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
+              "sha256": "1242be20ae43d3d237ccc9f8bc13010e18ebaaa1612be935396c4720c83daaa5"
             }
           },
           "mailbox": {
@@ -28235,7 +28235,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
+        "fingerprint": "4590589e6b76f5774ffeb88d7ac9419f4b5f69c065be2a3f284a502659b2bfe7",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -28268,7 +28268,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
+              "sha256": "1242be20ae43d3d237ccc9f8bc13010e18ebaaa1612be935396c4720c83daaa5"
             }
           },
           "mailbox": {
@@ -29527,7 +29527,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
+        "fingerprint": "4590589e6b76f5774ffeb88d7ac9419f4b5f69c065be2a3f284a502659b2bfe7",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -29560,7 +29560,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
+              "sha256": "1242be20ae43d3d237ccc9f8bc13010e18ebaaa1612be935396c4720c83daaa5"
             }
           },
           "mailbox": {

--- a/docs/screenshots/eastbrook-vale-rebuild/polish/metadata/after-desktop-ultra.json
+++ b/docs/screenshots/eastbrook-vale-rebuild/polish/metadata/after-desktop-ultra.json
@@ -11,7 +11,7 @@
     "mode": "composite-sha256",
     "algorithm": "sha256",
     "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-    "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+    "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
     "components": {
       "townAsset": {
         "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -40,7 +40,7 @@
         },
         "renderer": {
           "path": "src/render/renderer.ts",
-          "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+          "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
         },
         "viewPriorityPolicy": {
           "path": "src/render/prewarm_policy.ts",
@@ -85,7 +85,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -114,7 +114,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -1377,7 +1377,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -1406,7 +1406,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -2669,7 +2669,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -2698,7 +2698,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -3961,7 +3961,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -3990,7 +3990,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -5253,7 +5253,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -5282,7 +5282,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -6545,7 +6545,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -6574,7 +6574,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -7837,7 +7837,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -7866,7 +7866,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -9129,7 +9129,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -9158,7 +9158,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -10421,7 +10421,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -10450,7 +10450,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -11713,7 +11713,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -11742,7 +11742,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -13005,7 +13005,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -13034,7 +13034,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -14297,7 +14297,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -14326,7 +14326,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -15589,7 +15589,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -15618,7 +15618,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -16881,7 +16881,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -16910,7 +16910,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -19138,7 +19138,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -19167,7 +19167,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -20430,7 +20430,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -20459,7 +20459,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -21722,7 +21722,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -21751,7 +21751,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -23014,7 +23014,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -23043,7 +23043,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -24306,7 +24306,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -24335,7 +24335,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -25598,7 +25598,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -25627,7 +25627,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -26890,7 +26890,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -26919,7 +26919,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -28235,7 +28235,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -28264,7 +28264,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -29527,7 +29527,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -29556,7 +29556,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",

--- a/docs/screenshots/eastbrook-vale-rebuild/polish/metadata/after-desktop-ultra.json
+++ b/docs/screenshots/eastbrook-vale-rebuild/polish/metadata/after-desktop-ultra.json
@@ -11,7 +11,7 @@
     "mode": "composite-sha256",
     "algorithm": "sha256",
     "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-    "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
+    "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
     "components": {
       "townAsset": {
         "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -40,11 +40,11 @@
         },
         "renderer": {
           "path": "src/render/renderer.ts",
-          "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
+          "sha256": "1cd8a6ed39233231c675f979d0ab2c73d110df1ac6c44275178c0ff361fcbf83"
         },
         "viewPriorityPolicy": {
           "path": "src/render/prewarm_policy.ts",
-          "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
+          "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
         }
       },
       "mailbox": {
@@ -85,7 +85,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
+        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -114,11 +114,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
+              "sha256": "1cd8a6ed39233231c675f979d0ab2c73d110df1ac6c44275178c0ff361fcbf83"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
+              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
             }
           },
           "mailbox": {
@@ -1377,7 +1377,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
+        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -1406,11 +1406,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
+              "sha256": "1cd8a6ed39233231c675f979d0ab2c73d110df1ac6c44275178c0ff361fcbf83"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
+              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
             }
           },
           "mailbox": {
@@ -2669,7 +2669,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
+        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -2698,11 +2698,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
+              "sha256": "1cd8a6ed39233231c675f979d0ab2c73d110df1ac6c44275178c0ff361fcbf83"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
+              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
             }
           },
           "mailbox": {
@@ -3961,7 +3961,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
+        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -3990,11 +3990,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
+              "sha256": "1cd8a6ed39233231c675f979d0ab2c73d110df1ac6c44275178c0ff361fcbf83"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
+              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
             }
           },
           "mailbox": {
@@ -5253,7 +5253,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
+        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -5282,11 +5282,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
+              "sha256": "1cd8a6ed39233231c675f979d0ab2c73d110df1ac6c44275178c0ff361fcbf83"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
+              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
             }
           },
           "mailbox": {
@@ -6545,7 +6545,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
+        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -6574,11 +6574,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
+              "sha256": "1cd8a6ed39233231c675f979d0ab2c73d110df1ac6c44275178c0ff361fcbf83"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
+              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
             }
           },
           "mailbox": {
@@ -7837,7 +7837,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
+        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -7866,11 +7866,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
+              "sha256": "1cd8a6ed39233231c675f979d0ab2c73d110df1ac6c44275178c0ff361fcbf83"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
+              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
             }
           },
           "mailbox": {
@@ -9129,7 +9129,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
+        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -9158,11 +9158,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
+              "sha256": "1cd8a6ed39233231c675f979d0ab2c73d110df1ac6c44275178c0ff361fcbf83"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
+              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
             }
           },
           "mailbox": {
@@ -10421,7 +10421,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
+        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -10450,11 +10450,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
+              "sha256": "1cd8a6ed39233231c675f979d0ab2c73d110df1ac6c44275178c0ff361fcbf83"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
+              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
             }
           },
           "mailbox": {
@@ -11713,7 +11713,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
+        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -11742,11 +11742,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
+              "sha256": "1cd8a6ed39233231c675f979d0ab2c73d110df1ac6c44275178c0ff361fcbf83"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
+              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
             }
           },
           "mailbox": {
@@ -13005,7 +13005,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
+        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -13034,11 +13034,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
+              "sha256": "1cd8a6ed39233231c675f979d0ab2c73d110df1ac6c44275178c0ff361fcbf83"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
+              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
             }
           },
           "mailbox": {
@@ -14297,7 +14297,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
+        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -14326,11 +14326,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
+              "sha256": "1cd8a6ed39233231c675f979d0ab2c73d110df1ac6c44275178c0ff361fcbf83"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
+              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
             }
           },
           "mailbox": {
@@ -15589,7 +15589,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
+        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -15618,11 +15618,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
+              "sha256": "1cd8a6ed39233231c675f979d0ab2c73d110df1ac6c44275178c0ff361fcbf83"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
+              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
             }
           },
           "mailbox": {
@@ -16881,7 +16881,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
+        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -16910,11 +16910,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
+              "sha256": "1cd8a6ed39233231c675f979d0ab2c73d110df1ac6c44275178c0ff361fcbf83"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
+              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
             }
           },
           "mailbox": {
@@ -19138,7 +19138,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
+        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -19167,11 +19167,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
+              "sha256": "1cd8a6ed39233231c675f979d0ab2c73d110df1ac6c44275178c0ff361fcbf83"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
+              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
             }
           },
           "mailbox": {
@@ -20430,7 +20430,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
+        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -20459,11 +20459,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
+              "sha256": "1cd8a6ed39233231c675f979d0ab2c73d110df1ac6c44275178c0ff361fcbf83"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
+              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
             }
           },
           "mailbox": {
@@ -21722,7 +21722,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
+        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -21751,11 +21751,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
+              "sha256": "1cd8a6ed39233231c675f979d0ab2c73d110df1ac6c44275178c0ff361fcbf83"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
+              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
             }
           },
           "mailbox": {
@@ -23014,7 +23014,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
+        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -23043,11 +23043,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
+              "sha256": "1cd8a6ed39233231c675f979d0ab2c73d110df1ac6c44275178c0ff361fcbf83"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
+              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
             }
           },
           "mailbox": {
@@ -24306,7 +24306,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
+        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -24335,11 +24335,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
+              "sha256": "1cd8a6ed39233231c675f979d0ab2c73d110df1ac6c44275178c0ff361fcbf83"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
+              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
             }
           },
           "mailbox": {
@@ -25598,7 +25598,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
+        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -25627,11 +25627,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
+              "sha256": "1cd8a6ed39233231c675f979d0ab2c73d110df1ac6c44275178c0ff361fcbf83"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
+              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
             }
           },
           "mailbox": {
@@ -26890,7 +26890,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
+        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -26919,11 +26919,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
+              "sha256": "1cd8a6ed39233231c675f979d0ab2c73d110df1ac6c44275178c0ff361fcbf83"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
+              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
             }
           },
           "mailbox": {
@@ -28235,7 +28235,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
+        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -28264,11 +28264,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
+              "sha256": "1cd8a6ed39233231c675f979d0ab2c73d110df1ac6c44275178c0ff361fcbf83"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
+              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
             }
           },
           "mailbox": {
@@ -29527,7 +29527,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
+        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -29556,11 +29556,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
+              "sha256": "1cd8a6ed39233231c675f979d0ab2c73d110df1ac6c44275178c0ff361fcbf83"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
+              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
             }
           },
           "mailbox": {

--- a/docs/screenshots/eastbrook-vale-rebuild/polish/metadata/after-mobile-low.json
+++ b/docs/screenshots/eastbrook-vale-rebuild/polish/metadata/after-mobile-low.json
@@ -11,7 +11,7 @@
     "mode": "composite-sha256",
     "algorithm": "sha256",
     "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-    "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
+    "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
     "components": {
       "townAsset": {
         "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -40,11 +40,11 @@
         },
         "renderer": {
           "path": "src/render/renderer.ts",
-          "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
+          "sha256": "1cd8a6ed39233231c675f979d0ab2c73d110df1ac6c44275178c0ff361fcbf83"
         },
         "viewPriorityPolicy": {
           "path": "src/render/prewarm_policy.ts",
-          "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
+          "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
         }
       },
       "mailbox": {
@@ -85,7 +85,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
+        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -114,11 +114,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
+              "sha256": "1cd8a6ed39233231c675f979d0ab2c73d110df1ac6c44275178c0ff361fcbf83"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
+              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
             }
           },
           "mailbox": {
@@ -1360,7 +1360,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
+        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -1389,11 +1389,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
+              "sha256": "1cd8a6ed39233231c675f979d0ab2c73d110df1ac6c44275178c0ff361fcbf83"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
+              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
             }
           },
           "mailbox": {
@@ -2635,7 +2635,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
+        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -2664,11 +2664,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
+              "sha256": "1cd8a6ed39233231c675f979d0ab2c73d110df1ac6c44275178c0ff361fcbf83"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
+              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
             }
           },
           "mailbox": {
@@ -3910,7 +3910,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
+        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -3939,11 +3939,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
+              "sha256": "1cd8a6ed39233231c675f979d0ab2c73d110df1ac6c44275178c0ff361fcbf83"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
+              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
             }
           },
           "mailbox": {
@@ -5185,7 +5185,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
+        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -5214,11 +5214,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
+              "sha256": "1cd8a6ed39233231c675f979d0ab2c73d110df1ac6c44275178c0ff361fcbf83"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
+              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
             }
           },
           "mailbox": {
@@ -6460,7 +6460,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
+        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -6489,11 +6489,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
+              "sha256": "1cd8a6ed39233231c675f979d0ab2c73d110df1ac6c44275178c0ff361fcbf83"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
+              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
             }
           },
           "mailbox": {
@@ -7735,7 +7735,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
+        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -7764,11 +7764,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
+              "sha256": "1cd8a6ed39233231c675f979d0ab2c73d110df1ac6c44275178c0ff361fcbf83"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
+              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
             }
           },
           "mailbox": {
@@ -9010,7 +9010,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
+        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -9039,11 +9039,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
+              "sha256": "1cd8a6ed39233231c675f979d0ab2c73d110df1ac6c44275178c0ff361fcbf83"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
+              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
             }
           },
           "mailbox": {
@@ -10285,7 +10285,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
+        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -10314,11 +10314,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
+              "sha256": "1cd8a6ed39233231c675f979d0ab2c73d110df1ac6c44275178c0ff361fcbf83"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
+              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
             }
           },
           "mailbox": {
@@ -11560,7 +11560,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
+        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -11589,11 +11589,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
+              "sha256": "1cd8a6ed39233231c675f979d0ab2c73d110df1ac6c44275178c0ff361fcbf83"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
+              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
             }
           },
           "mailbox": {
@@ -12835,7 +12835,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
+        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -12864,11 +12864,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
+              "sha256": "1cd8a6ed39233231c675f979d0ab2c73d110df1ac6c44275178c0ff361fcbf83"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
+              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
             }
           },
           "mailbox": {
@@ -14110,7 +14110,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
+        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -14139,11 +14139,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
+              "sha256": "1cd8a6ed39233231c675f979d0ab2c73d110df1ac6c44275178c0ff361fcbf83"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
+              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
             }
           },
           "mailbox": {
@@ -15385,7 +15385,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
+        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -15414,11 +15414,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
+              "sha256": "1cd8a6ed39233231c675f979d0ab2c73d110df1ac6c44275178c0ff361fcbf83"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
+              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
             }
           },
           "mailbox": {
@@ -16660,7 +16660,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
+        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -16689,11 +16689,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
+              "sha256": "1cd8a6ed39233231c675f979d0ab2c73d110df1ac6c44275178c0ff361fcbf83"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
+              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
             }
           },
           "mailbox": {
@@ -18900,7 +18900,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
+        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -18929,11 +18929,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
+              "sha256": "1cd8a6ed39233231c675f979d0ab2c73d110df1ac6c44275178c0ff361fcbf83"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
+              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
             }
           },
           "mailbox": {
@@ -20175,7 +20175,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
+        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -20204,11 +20204,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
+              "sha256": "1cd8a6ed39233231c675f979d0ab2c73d110df1ac6c44275178c0ff361fcbf83"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
+              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
             }
           },
           "mailbox": {
@@ -21450,7 +21450,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
+        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -21479,11 +21479,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
+              "sha256": "1cd8a6ed39233231c675f979d0ab2c73d110df1ac6c44275178c0ff361fcbf83"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
+              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
             }
           },
           "mailbox": {
@@ -22725,7 +22725,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
+        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -22754,11 +22754,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
+              "sha256": "1cd8a6ed39233231c675f979d0ab2c73d110df1ac6c44275178c0ff361fcbf83"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
+              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
             }
           },
           "mailbox": {
@@ -24000,7 +24000,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
+        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -24029,11 +24029,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
+              "sha256": "1cd8a6ed39233231c675f979d0ab2c73d110df1ac6c44275178c0ff361fcbf83"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
+              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
             }
           },
           "mailbox": {
@@ -25275,7 +25275,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
+        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -25304,11 +25304,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
+              "sha256": "1cd8a6ed39233231c675f979d0ab2c73d110df1ac6c44275178c0ff361fcbf83"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
+              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
             }
           },
           "mailbox": {
@@ -26550,7 +26550,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
+        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -26579,11 +26579,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
+              "sha256": "1cd8a6ed39233231c675f979d0ab2c73d110df1ac6c44275178c0ff361fcbf83"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
+              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
             }
           },
           "mailbox": {
@@ -27878,7 +27878,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
+        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -27907,11 +27907,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
+              "sha256": "1cd8a6ed39233231c675f979d0ab2c73d110df1ac6c44275178c0ff361fcbf83"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
+              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
             }
           },
           "mailbox": {
@@ -29153,7 +29153,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
+        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -29182,11 +29182,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
+              "sha256": "1cd8a6ed39233231c675f979d0ab2c73d110df1ac6c44275178c0ff361fcbf83"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
+              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
             }
           },
           "mailbox": {

--- a/docs/screenshots/eastbrook-vale-rebuild/polish/metadata/after-mobile-low.json
+++ b/docs/screenshots/eastbrook-vale-rebuild/polish/metadata/after-mobile-low.json
@@ -11,7 +11,7 @@
     "mode": "composite-sha256",
     "algorithm": "sha256",
     "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-    "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+    "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
     "components": {
       "townAsset": {
         "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -40,7 +40,7 @@
         },
         "renderer": {
           "path": "src/render/renderer.ts",
-          "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+          "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
         },
         "viewPriorityPolicy": {
           "path": "src/render/prewarm_policy.ts",
@@ -85,7 +85,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -114,7 +114,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -1360,7 +1360,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -1389,7 +1389,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -2635,7 +2635,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -2664,7 +2664,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -3910,7 +3910,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -3939,7 +3939,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -5185,7 +5185,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -5214,7 +5214,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -6460,7 +6460,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -6489,7 +6489,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -7735,7 +7735,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -7764,7 +7764,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -9010,7 +9010,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -9039,7 +9039,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -10285,7 +10285,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -10314,7 +10314,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -11560,7 +11560,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -11589,7 +11589,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -12835,7 +12835,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -12864,7 +12864,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -14110,7 +14110,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -14139,7 +14139,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -15385,7 +15385,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -15414,7 +15414,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -16660,7 +16660,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -16689,7 +16689,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -18900,7 +18900,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -18929,7 +18929,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -20175,7 +20175,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -20204,7 +20204,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -21450,7 +21450,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -21479,7 +21479,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -22725,7 +22725,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -22754,7 +22754,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -24000,7 +24000,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -24029,7 +24029,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -25275,7 +25275,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -25304,7 +25304,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -26550,7 +26550,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -26579,7 +26579,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -27878,7 +27878,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -27907,7 +27907,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -29153,7 +29153,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -29182,7 +29182,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",

--- a/docs/screenshots/eastbrook-vale-rebuild/polish/metadata/after-mobile-low.json
+++ b/docs/screenshots/eastbrook-vale-rebuild/polish/metadata/after-mobile-low.json
@@ -11,7 +11,7 @@
     "mode": "composite-sha256",
     "algorithm": "sha256",
     "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-    "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
+    "fingerprint": "4590589e6b76f5774ffeb88d7ac9419f4b5f69c065be2a3f284a502659b2bfe7",
     "components": {
       "townAsset": {
         "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -44,7 +44,7 @@
         },
         "viewPriorityPolicy": {
           "path": "src/render/prewarm_policy.ts",
-          "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
+          "sha256": "1242be20ae43d3d237ccc9f8bc13010e18ebaaa1612be935396c4720c83daaa5"
         }
       },
       "mailbox": {
@@ -85,7 +85,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
+        "fingerprint": "4590589e6b76f5774ffeb88d7ac9419f4b5f69c065be2a3f284a502659b2bfe7",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -118,7 +118,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
+              "sha256": "1242be20ae43d3d237ccc9f8bc13010e18ebaaa1612be935396c4720c83daaa5"
             }
           },
           "mailbox": {
@@ -1360,7 +1360,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
+        "fingerprint": "4590589e6b76f5774ffeb88d7ac9419f4b5f69c065be2a3f284a502659b2bfe7",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -1393,7 +1393,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
+              "sha256": "1242be20ae43d3d237ccc9f8bc13010e18ebaaa1612be935396c4720c83daaa5"
             }
           },
           "mailbox": {
@@ -2635,7 +2635,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
+        "fingerprint": "4590589e6b76f5774ffeb88d7ac9419f4b5f69c065be2a3f284a502659b2bfe7",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -2668,7 +2668,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
+              "sha256": "1242be20ae43d3d237ccc9f8bc13010e18ebaaa1612be935396c4720c83daaa5"
             }
           },
           "mailbox": {
@@ -3910,7 +3910,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
+        "fingerprint": "4590589e6b76f5774ffeb88d7ac9419f4b5f69c065be2a3f284a502659b2bfe7",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -3943,7 +3943,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
+              "sha256": "1242be20ae43d3d237ccc9f8bc13010e18ebaaa1612be935396c4720c83daaa5"
             }
           },
           "mailbox": {
@@ -5185,7 +5185,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
+        "fingerprint": "4590589e6b76f5774ffeb88d7ac9419f4b5f69c065be2a3f284a502659b2bfe7",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -5218,7 +5218,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
+              "sha256": "1242be20ae43d3d237ccc9f8bc13010e18ebaaa1612be935396c4720c83daaa5"
             }
           },
           "mailbox": {
@@ -6460,7 +6460,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
+        "fingerprint": "4590589e6b76f5774ffeb88d7ac9419f4b5f69c065be2a3f284a502659b2bfe7",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -6493,7 +6493,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
+              "sha256": "1242be20ae43d3d237ccc9f8bc13010e18ebaaa1612be935396c4720c83daaa5"
             }
           },
           "mailbox": {
@@ -7735,7 +7735,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
+        "fingerprint": "4590589e6b76f5774ffeb88d7ac9419f4b5f69c065be2a3f284a502659b2bfe7",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -7768,7 +7768,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
+              "sha256": "1242be20ae43d3d237ccc9f8bc13010e18ebaaa1612be935396c4720c83daaa5"
             }
           },
           "mailbox": {
@@ -9010,7 +9010,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
+        "fingerprint": "4590589e6b76f5774ffeb88d7ac9419f4b5f69c065be2a3f284a502659b2bfe7",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -9043,7 +9043,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
+              "sha256": "1242be20ae43d3d237ccc9f8bc13010e18ebaaa1612be935396c4720c83daaa5"
             }
           },
           "mailbox": {
@@ -10285,7 +10285,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
+        "fingerprint": "4590589e6b76f5774ffeb88d7ac9419f4b5f69c065be2a3f284a502659b2bfe7",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -10318,7 +10318,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
+              "sha256": "1242be20ae43d3d237ccc9f8bc13010e18ebaaa1612be935396c4720c83daaa5"
             }
           },
           "mailbox": {
@@ -11560,7 +11560,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
+        "fingerprint": "4590589e6b76f5774ffeb88d7ac9419f4b5f69c065be2a3f284a502659b2bfe7",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -11593,7 +11593,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
+              "sha256": "1242be20ae43d3d237ccc9f8bc13010e18ebaaa1612be935396c4720c83daaa5"
             }
           },
           "mailbox": {
@@ -12835,7 +12835,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
+        "fingerprint": "4590589e6b76f5774ffeb88d7ac9419f4b5f69c065be2a3f284a502659b2bfe7",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -12868,7 +12868,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
+              "sha256": "1242be20ae43d3d237ccc9f8bc13010e18ebaaa1612be935396c4720c83daaa5"
             }
           },
           "mailbox": {
@@ -14110,7 +14110,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
+        "fingerprint": "4590589e6b76f5774ffeb88d7ac9419f4b5f69c065be2a3f284a502659b2bfe7",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -14143,7 +14143,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
+              "sha256": "1242be20ae43d3d237ccc9f8bc13010e18ebaaa1612be935396c4720c83daaa5"
             }
           },
           "mailbox": {
@@ -15385,7 +15385,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
+        "fingerprint": "4590589e6b76f5774ffeb88d7ac9419f4b5f69c065be2a3f284a502659b2bfe7",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -15418,7 +15418,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
+              "sha256": "1242be20ae43d3d237ccc9f8bc13010e18ebaaa1612be935396c4720c83daaa5"
             }
           },
           "mailbox": {
@@ -16660,7 +16660,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
+        "fingerprint": "4590589e6b76f5774ffeb88d7ac9419f4b5f69c065be2a3f284a502659b2bfe7",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -16693,7 +16693,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
+              "sha256": "1242be20ae43d3d237ccc9f8bc13010e18ebaaa1612be935396c4720c83daaa5"
             }
           },
           "mailbox": {
@@ -18900,7 +18900,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
+        "fingerprint": "4590589e6b76f5774ffeb88d7ac9419f4b5f69c065be2a3f284a502659b2bfe7",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -18933,7 +18933,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
+              "sha256": "1242be20ae43d3d237ccc9f8bc13010e18ebaaa1612be935396c4720c83daaa5"
             }
           },
           "mailbox": {
@@ -20175,7 +20175,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
+        "fingerprint": "4590589e6b76f5774ffeb88d7ac9419f4b5f69c065be2a3f284a502659b2bfe7",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -20208,7 +20208,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
+              "sha256": "1242be20ae43d3d237ccc9f8bc13010e18ebaaa1612be935396c4720c83daaa5"
             }
           },
           "mailbox": {
@@ -21450,7 +21450,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
+        "fingerprint": "4590589e6b76f5774ffeb88d7ac9419f4b5f69c065be2a3f284a502659b2bfe7",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -21483,7 +21483,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
+              "sha256": "1242be20ae43d3d237ccc9f8bc13010e18ebaaa1612be935396c4720c83daaa5"
             }
           },
           "mailbox": {
@@ -22725,7 +22725,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
+        "fingerprint": "4590589e6b76f5774ffeb88d7ac9419f4b5f69c065be2a3f284a502659b2bfe7",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -22758,7 +22758,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
+              "sha256": "1242be20ae43d3d237ccc9f8bc13010e18ebaaa1612be935396c4720c83daaa5"
             }
           },
           "mailbox": {
@@ -24000,7 +24000,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
+        "fingerprint": "4590589e6b76f5774ffeb88d7ac9419f4b5f69c065be2a3f284a502659b2bfe7",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -24033,7 +24033,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
+              "sha256": "1242be20ae43d3d237ccc9f8bc13010e18ebaaa1612be935396c4720c83daaa5"
             }
           },
           "mailbox": {
@@ -25275,7 +25275,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
+        "fingerprint": "4590589e6b76f5774ffeb88d7ac9419f4b5f69c065be2a3f284a502659b2bfe7",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -25308,7 +25308,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
+              "sha256": "1242be20ae43d3d237ccc9f8bc13010e18ebaaa1612be935396c4720c83daaa5"
             }
           },
           "mailbox": {
@@ -26550,7 +26550,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
+        "fingerprint": "4590589e6b76f5774ffeb88d7ac9419f4b5f69c065be2a3f284a502659b2bfe7",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -26583,7 +26583,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
+              "sha256": "1242be20ae43d3d237ccc9f8bc13010e18ebaaa1612be935396c4720c83daaa5"
             }
           },
           "mailbox": {
@@ -27878,7 +27878,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
+        "fingerprint": "4590589e6b76f5774ffeb88d7ac9419f4b5f69c065be2a3f284a502659b2bfe7",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -27911,7 +27911,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
+              "sha256": "1242be20ae43d3d237ccc9f8bc13010e18ebaaa1612be935396c4720c83daaa5"
             }
           },
           "mailbox": {
@@ -29153,7 +29153,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
+        "fingerprint": "4590589e6b76f5774ffeb88d7ac9419f4b5f69c065be2a3f284a502659b2bfe7",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -29186,7 +29186,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
+              "sha256": "1242be20ae43d3d237ccc9f8bc13010e18ebaaa1612be935396c4720c83daaa5"
             }
           },
           "mailbox": {

--- a/docs/screenshots/eastbrook-vale-rebuild/polish/metadata/after-mobile-low.json
+++ b/docs/screenshots/eastbrook-vale-rebuild/polish/metadata/after-mobile-low.json
@@ -11,7 +11,7 @@
     "mode": "composite-sha256",
     "algorithm": "sha256",
     "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-    "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
+    "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
     "components": {
       "townAsset": {
         "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -40,11 +40,11 @@
         },
         "renderer": {
           "path": "src/render/renderer.ts",
-          "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
+          "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
         },
         "viewPriorityPolicy": {
           "path": "src/render/prewarm_policy.ts",
-          "sha256": "78fef581e0d2507249ee5629800f82b740ecc11105bd418b4c64e12d95b3c8e2"
+          "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
         }
       },
       "mailbox": {
@@ -85,7 +85,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
+        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -114,11 +114,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
+              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "78fef581e0d2507249ee5629800f82b740ecc11105bd418b4c64e12d95b3c8e2"
+              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
             }
           },
           "mailbox": {
@@ -1360,7 +1360,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
+        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -1389,11 +1389,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
+              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "78fef581e0d2507249ee5629800f82b740ecc11105bd418b4c64e12d95b3c8e2"
+              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
             }
           },
           "mailbox": {
@@ -2635,7 +2635,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
+        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -2664,11 +2664,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
+              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "78fef581e0d2507249ee5629800f82b740ecc11105bd418b4c64e12d95b3c8e2"
+              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
             }
           },
           "mailbox": {
@@ -3910,7 +3910,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
+        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -3939,11 +3939,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
+              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "78fef581e0d2507249ee5629800f82b740ecc11105bd418b4c64e12d95b3c8e2"
+              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
             }
           },
           "mailbox": {
@@ -5185,7 +5185,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
+        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -5214,11 +5214,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
+              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "78fef581e0d2507249ee5629800f82b740ecc11105bd418b4c64e12d95b3c8e2"
+              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
             }
           },
           "mailbox": {
@@ -6460,7 +6460,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
+        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -6489,11 +6489,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
+              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "78fef581e0d2507249ee5629800f82b740ecc11105bd418b4c64e12d95b3c8e2"
+              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
             }
           },
           "mailbox": {
@@ -7735,7 +7735,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
+        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -7764,11 +7764,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
+              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "78fef581e0d2507249ee5629800f82b740ecc11105bd418b4c64e12d95b3c8e2"
+              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
             }
           },
           "mailbox": {
@@ -9010,7 +9010,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
+        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -9039,11 +9039,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
+              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "78fef581e0d2507249ee5629800f82b740ecc11105bd418b4c64e12d95b3c8e2"
+              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
             }
           },
           "mailbox": {
@@ -10285,7 +10285,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
+        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -10314,11 +10314,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
+              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "78fef581e0d2507249ee5629800f82b740ecc11105bd418b4c64e12d95b3c8e2"
+              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
             }
           },
           "mailbox": {
@@ -11560,7 +11560,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
+        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -11589,11 +11589,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
+              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "78fef581e0d2507249ee5629800f82b740ecc11105bd418b4c64e12d95b3c8e2"
+              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
             }
           },
           "mailbox": {
@@ -12835,7 +12835,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
+        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -12864,11 +12864,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
+              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "78fef581e0d2507249ee5629800f82b740ecc11105bd418b4c64e12d95b3c8e2"
+              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
             }
           },
           "mailbox": {
@@ -14110,7 +14110,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
+        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -14139,11 +14139,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
+              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "78fef581e0d2507249ee5629800f82b740ecc11105bd418b4c64e12d95b3c8e2"
+              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
             }
           },
           "mailbox": {
@@ -15385,7 +15385,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
+        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -15414,11 +15414,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
+              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "78fef581e0d2507249ee5629800f82b740ecc11105bd418b4c64e12d95b3c8e2"
+              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
             }
           },
           "mailbox": {
@@ -16660,7 +16660,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
+        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -16689,11 +16689,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
+              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "78fef581e0d2507249ee5629800f82b740ecc11105bd418b4c64e12d95b3c8e2"
+              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
             }
           },
           "mailbox": {
@@ -18900,7 +18900,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
+        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -18929,11 +18929,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
+              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "78fef581e0d2507249ee5629800f82b740ecc11105bd418b4c64e12d95b3c8e2"
+              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
             }
           },
           "mailbox": {
@@ -20175,7 +20175,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
+        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -20204,11 +20204,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
+              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "78fef581e0d2507249ee5629800f82b740ecc11105bd418b4c64e12d95b3c8e2"
+              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
             }
           },
           "mailbox": {
@@ -21450,7 +21450,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
+        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -21479,11 +21479,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
+              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "78fef581e0d2507249ee5629800f82b740ecc11105bd418b4c64e12d95b3c8e2"
+              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
             }
           },
           "mailbox": {
@@ -22725,7 +22725,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
+        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -22754,11 +22754,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
+              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "78fef581e0d2507249ee5629800f82b740ecc11105bd418b4c64e12d95b3c8e2"
+              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
             }
           },
           "mailbox": {
@@ -24000,7 +24000,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
+        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -24029,11 +24029,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
+              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "78fef581e0d2507249ee5629800f82b740ecc11105bd418b4c64e12d95b3c8e2"
+              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
             }
           },
           "mailbox": {
@@ -25275,7 +25275,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
+        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -25304,11 +25304,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
+              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "78fef581e0d2507249ee5629800f82b740ecc11105bd418b4c64e12d95b3c8e2"
+              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
             }
           },
           "mailbox": {
@@ -26550,7 +26550,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
+        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -26579,11 +26579,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
+              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "78fef581e0d2507249ee5629800f82b740ecc11105bd418b4c64e12d95b3c8e2"
+              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
             }
           },
           "mailbox": {
@@ -27878,7 +27878,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
+        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -27907,11 +27907,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
+              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "78fef581e0d2507249ee5629800f82b740ecc11105bd418b4c64e12d95b3c8e2"
+              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
             }
           },
           "mailbox": {
@@ -29153,7 +29153,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
+        "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -29182,11 +29182,11 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
+              "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "78fef581e0d2507249ee5629800f82b740ecc11105bd418b4c64e12d95b3c8e2"
+              "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
             }
           },
           "mailbox": {

--- a/docs/screenshots/eastbrook-vale-rebuild/polish/performance/after-desktop-ultra-town.json
+++ b/docs/screenshots/eastbrook-vale-rebuild/polish/performance/after-desktop-ultra-town.json
@@ -14,7 +14,7 @@
     "mode": "composite-sha256",
     "algorithm": "sha256",
     "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-    "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+    "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
     "components": {
       "townAsset": {
         "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -43,7 +43,7 @@
         },
         "renderer": {
           "path": "src/render/renderer.ts",
-          "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+          "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
         },
         "viewPriorityPolicy": {
           "path": "src/render/prewarm_policy.ts",

--- a/docs/screenshots/eastbrook-vale-rebuild/polish/performance/after-desktop-ultra-town.json
+++ b/docs/screenshots/eastbrook-vale-rebuild/polish/performance/after-desktop-ultra-town.json
@@ -14,7 +14,7 @@
     "mode": "composite-sha256",
     "algorithm": "sha256",
     "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-    "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
+    "fingerprint": "4590589e6b76f5774ffeb88d7ac9419f4b5f69c065be2a3f284a502659b2bfe7",
     "components": {
       "townAsset": {
         "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -47,7 +47,7 @@
         },
         "viewPriorityPolicy": {
           "path": "src/render/prewarm_policy.ts",
-          "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
+          "sha256": "1242be20ae43d3d237ccc9f8bc13010e18ebaaa1612be935396c4720c83daaa5"
         }
       },
       "mailbox": {

--- a/docs/screenshots/eastbrook-vale-rebuild/polish/performance/after-desktop-ultra-town.json
+++ b/docs/screenshots/eastbrook-vale-rebuild/polish/performance/after-desktop-ultra-town.json
@@ -14,7 +14,7 @@
     "mode": "composite-sha256",
     "algorithm": "sha256",
     "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-    "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
+    "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
     "components": {
       "townAsset": {
         "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -43,11 +43,11 @@
         },
         "renderer": {
           "path": "src/render/renderer.ts",
-          "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
+          "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
         },
         "viewPriorityPolicy": {
           "path": "src/render/prewarm_policy.ts",
-          "sha256": "78fef581e0d2507249ee5629800f82b740ecc11105bd418b4c64e12d95b3c8e2"
+          "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
         }
       },
       "mailbox": {

--- a/docs/screenshots/eastbrook-vale-rebuild/polish/performance/after-desktop-ultra-town.json
+++ b/docs/screenshots/eastbrook-vale-rebuild/polish/performance/after-desktop-ultra-town.json
@@ -14,7 +14,7 @@
     "mode": "composite-sha256",
     "algorithm": "sha256",
     "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-    "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
+    "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
     "components": {
       "townAsset": {
         "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -43,11 +43,11 @@
         },
         "renderer": {
           "path": "src/render/renderer.ts",
-          "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
+          "sha256": "1cd8a6ed39233231c675f979d0ab2c73d110df1ac6c44275178c0ff361fcbf83"
         },
         "viewPriorityPolicy": {
           "path": "src/render/prewarm_policy.ts",
-          "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
+          "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
         }
       },
       "mailbox": {

--- a/docs/screenshots/eastbrook-vale-rebuild/polish/performance/after-mobile-low-town.json
+++ b/docs/screenshots/eastbrook-vale-rebuild/polish/performance/after-mobile-low-town.json
@@ -14,7 +14,7 @@
     "mode": "composite-sha256",
     "algorithm": "sha256",
     "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-    "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+    "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
     "components": {
       "townAsset": {
         "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -43,7 +43,7 @@
         },
         "renderer": {
           "path": "src/render/renderer.ts",
-          "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+          "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
         },
         "viewPriorityPolicy": {
           "path": "src/render/prewarm_policy.ts",

--- a/docs/screenshots/eastbrook-vale-rebuild/polish/performance/after-mobile-low-town.json
+++ b/docs/screenshots/eastbrook-vale-rebuild/polish/performance/after-mobile-low-town.json
@@ -14,7 +14,7 @@
     "mode": "composite-sha256",
     "algorithm": "sha256",
     "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-    "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
+    "fingerprint": "4590589e6b76f5774ffeb88d7ac9419f4b5f69c065be2a3f284a502659b2bfe7",
     "components": {
       "townAsset": {
         "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -47,7 +47,7 @@
         },
         "viewPriorityPolicy": {
           "path": "src/render/prewarm_policy.ts",
-          "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
+          "sha256": "1242be20ae43d3d237ccc9f8bc13010e18ebaaa1612be935396c4720c83daaa5"
         }
       },
       "mailbox": {

--- a/docs/screenshots/eastbrook-vale-rebuild/polish/performance/after-mobile-low-town.json
+++ b/docs/screenshots/eastbrook-vale-rebuild/polish/performance/after-mobile-low-town.json
@@ -14,7 +14,7 @@
     "mode": "composite-sha256",
     "algorithm": "sha256",
     "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-    "fingerprint": "9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108",
+    "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
     "components": {
       "townAsset": {
         "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -43,11 +43,11 @@
         },
         "renderer": {
           "path": "src/render/renderer.ts",
-          "sha256": "acb55e7201870709eaaa905cefab1679a14f2a98b69a655e135c120e9c97fe53"
+          "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
         },
         "viewPriorityPolicy": {
           "path": "src/render/prewarm_policy.ts",
-          "sha256": "78fef581e0d2507249ee5629800f82b740ecc11105bd418b4c64e12d95b3c8e2"
+          "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
         }
       },
       "mailbox": {

--- a/docs/screenshots/eastbrook-vale-rebuild/polish/performance/after-mobile-low-town.json
+++ b/docs/screenshots/eastbrook-vale-rebuild/polish/performance/after-mobile-low-town.json
@@ -14,7 +14,7 @@
     "mode": "composite-sha256",
     "algorithm": "sha256",
     "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-    "fingerprint": "5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf",
+    "fingerprint": "efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e",
     "components": {
       "townAsset": {
         "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -43,11 +43,11 @@
         },
         "renderer": {
           "path": "src/render/renderer.ts",
-          "sha256": "af49bda61e9e04bdd82ed7d33e80623d2927b8e0820280d5cb735510601725b5"
+          "sha256": "1cd8a6ed39233231c675f979d0ab2c73d110df1ac6c44275178c0ff361fcbf83"
         },
         "viewPriorityPolicy": {
           "path": "src/render/prewarm_policy.ts",
-          "sha256": "21e069a182cdfbc216810852381afa15c82023fa91db439e80a049b857499432"
+          "sha256": "65979893105d3e0000dcfa27faf00a8b2f94a469d66bdf332a2508a5d1ca3bd5"
         }
       },
       "mailbox": {

--- a/src/render/point_light_budget.ts
+++ b/src/render/point_light_budget.ts
@@ -120,6 +120,27 @@ export function applyPointLightBudget(
   return drawn;
 }
 
+/**
+ * Count the ranked lights the render would draw in the CURRENT visibility
+ * state: budget-visible AND ancestry-visible down from `sceneRoot`. The
+ * bounded prewarm render hides most top-level scene children transiently,
+ * out of band of the budget pass, so it re-derives the drawn count with this
+ * and raises the pads to keep the render-visible total pinned. Without the
+ * re-pin, NUM_POINT_LIGHTS drifts below the pinned total during that render
+ * and every first-drawn material links a program variant synchronously, one
+ * the live render never draws (the measured 100-280 ms prewarm-unit stalls).
+ */
+export function countDrawnPointLights(
+  ranked: readonly RankedPointLight[],
+  sceneRoot: THREE.Object3D,
+): number {
+  let drawn = 0;
+  for (const entry of ranked) {
+    if (entry.light.visible && isDrawnEligible(entry.light, sceneRoot)) drawn++;
+  }
+  return drawn;
+}
+
 /** Flicker only fire lights that the completed budget says can contribute. */
 export function flickerContributingFireLights(
   ranked: readonly RankedPointLight[],

--- a/src/render/prewarm_policy.ts
+++ b/src/render/prewarm_policy.ts
@@ -23,6 +23,7 @@ export const CONSTRAINED_PREWARM_KEEP: readonly string[] = [
   'views.landmarks',
   'views.persistent-portals',
   'views.nearby',
+  'world.settle-state',
   'textures.scene',
   'programs.compile',
   'world.initial-frame',
@@ -46,8 +47,12 @@ export const CONSTRAINED_PREWARM_RESUME: readonly string[] = ['vfx.ability-primi
 
 /** Whole-scene GPU submits that can synchronously link every visible program
  * when KHR_parallel_shader_compile is unavailable. They cannot be interrupted
- * once WebGL enters the driver, so omit them to preserve the entry hard limit. */
+ * once WebGL enters the driver, so omit them to preserve the entry hard limit.
+ * world.settle-state joins them: its lazy world builds (and a woken water
+ * height-field's real submits) have no internal deadline, and on this profile
+ * every collection it would align is itself skipped, so it buys nothing. */
 export const BLOCKING_PREWARM_ENTRIES_WITHOUT_PARALLEL_COMPILE: readonly string[] = [
+  'world.settle-state',
   'world.initial-frame',
   'programs.compile',
   'programs.budget-variants',
@@ -187,6 +192,59 @@ export function prewarmEntryShouldDefer(
 ): boolean {
   if (entryStartedMs >= hardDeadlineMs) return true;
   return entryStartedMs >= deadlineMs && !deadlineExempt && !finishFullManifestBeforeReveal;
+}
+
+/** The mesh-shape bits three folds into a program's cache key, structurally
+ * typed so this decision layer stays Three-free. */
+export interface ProgramContentMeshShape {
+  isSkinnedMesh?: boolean;
+  isInstancedMesh?: boolean;
+  /** An instanceColor buffer flips USE_INSTANCING_COLOR into the key. */
+  hasInstanceColor?: boolean;
+  isBatchedMesh?: boolean;
+  /** morphAttributes.position PRESENT: three defines USE_MORPHTARGETS on
+   *  presence, even for an empty array, so present-with-zero and absent are
+   *  distinct variants. */
+  hasMorphPositions?: boolean;
+  /** The EXACT morph target count: three keys morphTargetsCount, so a
+   *  boolean here hid variants (a morphs=2 and a morphs=6 mesh relinked at
+   *  draw time against a morphs=4 stand-in). */
+  morphTargetCount?: number;
+  morphNormalCount?: number;
+  morphColorCount?: number;
+  /** geometry.attributes.tangent flips vertexTangents. */
+  hasTangents?: boolean;
+  /** geometry.attributes.color itemSize (4 flips vertexAlphas); 0 = none. */
+  vertexColorItemSize?: number;
+  castShadow?: boolean;
+}
+
+/**
+ * Program-content keys for compile-unit dedupe: one key per material slot,
+ * covering the object and geometry bits of three r165's program cache key
+ * this repo can produce (skinning, instancing and instance colour, batched
+ * meshes, morph position/normal/colour presence and counts, tangents, vertex
+ * colour item size, shadow casting). Not covered, on purpose: BatchedMesh
+ * colour textures (batchingColor) and Points uv presence (pointsUvs), which
+ * the repo does not produce on this path; adopt either and this key must
+ * learn it. A coarser key elects a stand-in
+ * whose program variant differs, and every other geometry shape of that
+ * material is SKIPPED by the dedupe and relinks synchronously at first draw,
+ * which is the stall the compile lane exists to prevent. In-repo fidelity
+ * precedent: occluderGhostVariantKey (occluder_ghost_prewarm.ts).
+ */
+export function prewarmProgramContentKeys(
+  shape: ProgramContentMeshShape,
+  materialIds: readonly string[],
+): string[] {
+  const token =
+    `${shape.isSkinnedMesh ? 's' : 'm'}${shape.isInstancedMesh ? 'i' : ''}` +
+    `${shape.hasInstanceColor ? 'ic' : ''}${shape.isBatchedMesh ? 'b' : ''}` +
+    `${shape.hasMorphPositions ? 'P' : ''}p${shape.morphTargetCount ?? 0}` +
+    `n${shape.morphNormalCount ?? 0}k${shape.morphColorCount ?? 0}` +
+    `${shape.hasTangents ? 't' : ''}v${shape.vertexColorItemSize ?? 0}` +
+    `${shape.castShadow ? 'c' : ''}`;
+  return materialIds.map((id) => `${token}:${id}`);
 }
 
 /** Where the programs.compile unit loop must stop so world.initial-frame (the

--- a/src/render/prewarm_policy.ts
+++ b/src/render/prewarm_policy.ts
@@ -49,8 +49,12 @@ export const CONSTRAINED_PREWARM_RESUME: readonly string[] = ['vfx.ability-primi
  * when KHR_parallel_shader_compile is unavailable. They cannot be interrupted
  * once WebGL enters the driver, so omit them to preserve the entry hard limit.
  * world.settle-state joins them: its lazy world builds (and a woken water
- * height-field's real submits) have no internal deadline, and on this profile
- * every collection it would align is itself skipped, so it buys nothing. */
+ * height-field's real submits) have no internal deadline on a profile whose
+ * whole point is bounded main-thread slices. The cost of skipping it is that
+ * textures.scene (which still runs here) collects against pre-settle state,
+ * an accepted residual misalignment: this profile also skips the compile
+ * monolith and the initial frame, the two consumers the alignment mostly
+ * serves. */
 export const BLOCKING_PREWARM_ENTRIES_WITHOUT_PARALLEL_COMPILE: readonly string[] = [
   'world.settle-state',
   'world.initial-frame',

--- a/src/render/prewarm_policy.ts
+++ b/src/render/prewarm_policy.ts
@@ -189,6 +189,21 @@ export function prewarmEntryShouldDefer(
   return entryStartedMs >= deadlineMs && !deadlineExempt && !finishFullManifestBeforeReveal;
 }
 
+/** Where the programs.compile unit loop must stop so world.initial-frame (the
+ * one uninterruptible whole-scene submit that links whatever compile did not
+ * reach) always has room before the GPU-submit guard. Without the reserve, an
+ * exempt compile that lawfully consumed the whole soft budget left the frame
+ * starting past the deadline, cancelled outright, and the initial scene's
+ * programs linked at first LIVE draw instead (measured: 102-318 ms submit
+ * stalls, 17 programs in one frame). Mirrors prewarmBuildDeadline's reserve,
+ * one pipeline stage later. */
+export function prewarmCompileUnitDeadline(
+  gpuSubmitDeadlineMs: number,
+  frameReserveMs: number,
+): number {
+  return gpuSubmitDeadlineMs - Math.max(0, frameReserveMs);
+}
+
 /** Build cutoff paired with the entry policy. Full Insane prewarm may use the
  * soft-deadline reserve, but it still stops at the independent hard deadline. */
 export function prewarmBuildDeadline(

--- a/src/render/prewarm_resume.ts
+++ b/src/render/prewarm_resume.ts
@@ -78,7 +78,17 @@ export function buildPrewarmCompileUnits<T extends object>(
       units.push({
         id: `${group.id}:${unitIndex++}`,
         run: async () => {
-          await Promise.all(roots.map((root) => Promise.resolve(compile(root))));
+          // allSettled, then rethrow the first failure: Promise.all would
+          // short-circuit the unit on one rejection and blur which of its
+          // batch-mates actually compiled; every root still gets its attempt
+          // and the unit's caller still sees the failure.
+          const results = await Promise.allSettled(
+            roots.map((root) => Promise.resolve(compile(root))),
+          );
+          const failed = results.find(
+            (result): result is PromiseRejectedResult => result.status === 'rejected',
+          );
+          if (failed) throw failed.reason;
         },
       });
     };

--- a/src/render/prewarm_resume.ts
+++ b/src/render/prewarm_resume.ts
@@ -37,6 +37,22 @@ export async function settlePrewarmBeforePublish<T>(
   }
 }
 
+export interface PrewarmCompileUnitOptions<T> {
+  /** Program-content keys for a root (e.g. material identity plus the mesh
+   *  shape bits that pick the program variant). A root whose every key an
+   *  earlier root already produced links nothing new and is skipped: each
+   *  awaited r165 compileAsync costs a 10 ms poll floor plus a synchronous
+   *  scene walk, so redundant roots are pure wall-clock. A root with no keys
+   *  is always kept (fail-open). */
+  dedupeKeys?: (root: T) => Iterable<unknown>;
+  /** Roots per unit. One unit launches its batch's compiles and awaits them
+   *  TOGETHER, so the 10 ms poll floors overlap instead of stacking. Each
+   *  compile call keeps its own bounded synchronous prologue, so a batch
+   *  stays preemptible between calls only at unit granularity: keep it small
+   *  (the entry path uses 16). Default 1 preserves one-root units. */
+  batchSize?: number;
+}
+
 /**
  * Turns materialized archetype roots into explicit resume units. Reference
  * deduplication prevents one shared root from being compiled twice when it is
@@ -46,21 +62,39 @@ export async function settlePrewarmBeforePublish<T>(
 export function buildPrewarmCompileUnits<T extends object>(
   groups: readonly PrewarmResumeGroup<T>[],
   compile: (root: T) => unknown | Promise<unknown>,
+  options?: PrewarmCompileUnitOptions<T>,
 ): PrewarmResumeUnit[] {
   const seen = new Set<T>();
+  const seenKeys = new Set<unknown>();
+  const batchSize = Math.max(1, options?.batchSize ?? 1);
   const units: PrewarmResumeUnit[] = [];
   for (const group of groups) {
-    for (let index = 0; index < group.roots.length; index++) {
-      const root = group.roots[index];
-      if (seen.has(root)) continue;
-      seen.add(root);
+    let unitIndex = 0;
+    let batch: T[] = [];
+    const flush = (): void => {
+      if (batch.length === 0) return;
+      const roots = batch;
+      batch = [];
       units.push({
-        id: `${group.id}:${index}`,
+        id: `${group.id}:${unitIndex++}`,
         run: async () => {
-          await compile(root);
+          await Promise.all(roots.map((root) => Promise.resolve(compile(root))));
         },
       });
+    };
+    for (const root of group.roots) {
+      if (seen.has(root)) continue;
+      seen.add(root);
+      if (options?.dedupeKeys) {
+        const keys = [...options.dedupeKeys(root)];
+        const fresh = keys.length === 0 || keys.some((key) => !seenKeys.has(key));
+        for (const key of keys) seenKeys.add(key);
+        if (!fresh) continue;
+      }
+      batch.push(root);
+      if (batch.length >= batchSize) flush();
     }
+    flush();
   }
   return units;
 }

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -353,6 +353,7 @@ import {
   type PrewarmPolicy,
   partitionMandatoryLandmarkCandidates,
   prewarmBuildDeadline,
+  prewarmCompileUnitDeadline,
   prewarmEntryResumesAfterSkip,
   prewarmEntryRuns,
   prewarmEntryShouldDefer,
@@ -553,6 +554,15 @@ const PREWARM_TEXTURE_UNIT_BATCH = 2;
 // Reserve at the tail of the view-build budget so the compile + final-frame
 // steps always start before the prewarm deadline (runEntry skips late entries).
 const PREWARM_BUILD_RESERVE_MS = 3000;
+// Reserve at the tail of the compile-unit loop so world.initial-frame (the one
+// whole-scene submit that links whatever compile did not reach) always has room
+// before the GPU-submit guard; see prewarmCompileUnitDeadline.
+const PREWARM_FRAME_RESERVE_MS = 2000;
+// Compile roots per entry unit: one unit launches its batch's compileAsync
+// calls and awaits them together, so r165's 10 ms poll floors overlap instead
+// of stacking (>1000 serial awaits measured 10+ s of pure timer wait). Small
+// enough that a batch's synchronous prologues stay a bounded slice.
+const PREWARM_COMPILE_BATCH_ROOTS = 16;
 const VIEW_PREWARM_MAX_VIEWS_LOW = 48;
 const VIEW_PREWARM_MAX_VIEWS_HIGH = 72;
 // Constrained (phone WebKit): build only self plus one required/nearby view at
@@ -5570,6 +5580,14 @@ export class Renderer {
     const deadline = started + maxMs;
     const hardDeadline = started + hardMaxMs;
     const gpuSubmitDeadline = Math.max(started, hardDeadline - PREWARM_GPU_SUBMIT_GUARD_MS);
+    // Stop the compile-unit loop early so world.initial-frame always has room:
+    // an exempt compile that lawfully consumed the whole soft budget used to
+    // leave the frame starting past `deadline`, cancelled outright, and the
+    // initial scene's programs linked at first LIVE draw instead.
+    const compileUnitDeadline = prewarmCompileUnitDeadline(
+      gpuSubmitDeadline,
+      PREWARM_FRAME_RESERVE_MS,
+    );
     // Stop the archetype-build steps early so the later entries, crucially
     // programs.compile, still START before `deadline` (runEntry skips anything
     // that begins past it). Compiling is what kills the in-world freeze.
@@ -5704,6 +5722,27 @@ export class Renderer {
           await this.compilePrewarmColorPrograms(root, false);
           await this.compileSkinnedShadowPrograms(root);
           compiledPrewarmRoots++;
+        },
+        {
+          // Program-content keys: two leaves sharing materials AND the shape
+          // bits three keys a program on (skinning, instancing, morphs, the
+          // skinned-shadow variant) link the same programs, so the duplicate
+          // costs a unit for nothing. surfaceMat dedupes materials heavily,
+          // so this collapses hundreds of leaves per zone.
+          dedupeKeys: (root) => {
+            const mesh = root as THREE.Mesh & {
+              isSkinnedMesh?: boolean;
+              isInstancedMesh?: boolean;
+            };
+            const material = mesh.material;
+            const materials = Array.isArray(material) ? material : material ? [material] : [];
+            const morphs = (mesh.geometry?.morphAttributes?.position?.length ?? 0) > 0;
+            const shape =
+              `${mesh.isSkinnedMesh ? 's' : 'm'}${mesh.isInstancedMesh ? 'i' : ''}` +
+              `${morphs ? 'p' : ''}${mesh.castShadow ? 'c' : ''}`;
+            return materials.map((entry) => `${shape}:${entry.uuid}`);
+          },
+          batchSize: PREWARM_COMPILE_BATCH_ROOTS,
         },
       );
     };
@@ -6315,6 +6354,14 @@ export class Renderer {
         category: 'world',
         priority: 70,
         required: true,
+        // Never sacrificed to the soft deadline: this is the one submit that
+        // exercises the real live draw path, and dropping it (measured when
+        // the exempt compile above consumed the whole budget) makes the
+        // initial scene link its programs at first LIVE draw, 102-318 ms
+        // stalls in front of the player. The compile-unit reserve
+        // (PREWARM_FRAME_RESERVE_MS) bounds how late this can start, so the
+        // exemption cannot push the uninterruptible submit past the GPU guard.
+        deadlineExempt: true,
         run: () => {
           this.renderPrewarmPass(1 / 60);
           renderPasses++;
@@ -6360,7 +6407,7 @@ export class Renderer {
           compileMode = 'async';
           const units = compileEntryUnits();
           for (let index = 0; index < units.length; index++) {
-            if (performance.now() >= gpuSubmitDeadline) {
+            if (performance.now() >= compileUnitDeadline) {
               const remaining = units.slice(index);
               if (remaining.length > 0) {
                 droppedEntries.push({ id: 'programs.compile', units: remaining });

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -333,6 +333,7 @@ import { PlacedAssetsView } from './placed_assets';
 import { type PlayerAuraRingInput, PlayerAuraRings } from './player_aura_rings';
 import {
   applyPointLightBudget,
+  countDrawnPointLights,
   flickerContributingFireLights,
   pointLightPadCount,
   type RankedPointLight,
@@ -5436,6 +5437,7 @@ export class Renderer {
   private renderBoundedPrewarmRoot(group: THREE.Group, childRoot: THREE.Object3D): void {
     const sceneVisibility = this.scene.children.map((entry) => entry.visible);
     const groupVisibility = group.children.map((entry) => entry.visible);
+    const previousPadVisibility = this.lightPads.map((pad) => pad.visible);
     const previousTarget = this.webgl.getRenderTarget();
     const previousShadowAutoUpdate = this.webgl.shadowMap.autoUpdate;
     const previousShadowNeedsUpdate = this.webgl.shadowMap.needsUpdate;
@@ -5447,6 +5449,22 @@ export class Renderer {
       }
       group.visible = true;
       for (const entry of group.children) entry.visible = entry === childRoot;
+
+      // The mask above hides entity views, and their nested chosen lights
+      // leave Three's counted set with them, out of band of the budget pass:
+      // NUM_POINT_LIGHTS would drift below the pinned total for THIS render
+      // only, and every first-drawn material would synchronously link a
+      // program variant the live render never draws (the measured 100-280 ms
+      // prewarm-unit stalls). Recount in the masked state and raise the pads
+      // so this render draws the exact variant the compile lane linked.
+      const boundedDrawn = countDrawnPointLights(this.lightRank, this.scene);
+      const boundedPadCount = Math.min(
+        this.lightPads.length,
+        pointLightPadCount(boundedDrawn, GFX.maxPointLights),
+      );
+      for (let i = 0; i < this.lightPads.length; i++) {
+        this.lightPads[i].visible = i < boundedPadCount;
+      }
 
       // Keep the real shadow-enabled colour-program variant, but do not rebuild
       // Insane's 4096px shadow map for every child upload. The separate shadow
@@ -5460,6 +5478,9 @@ export class Renderer {
       this.webgl.setRenderTarget(previousTarget);
       this.webgl.shadowMap.autoUpdate = previousShadowAutoUpdate;
       this.webgl.shadowMap.needsUpdate = previousShadowNeedsUpdate;
+      for (let i = 0; i < this.lightPads.length; i++) {
+        this.lightPads[i].visible = previousPadVisibility[i];
+      }
       for (let i = 0; i < group.children.length; i++) {
         group.children[i].visible = groupVisibility[i];
       }

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -357,6 +357,7 @@ import {
   prewarmEntryResumesAfterSkip,
   prewarmEntryRuns,
   prewarmEntryShouldDefer,
+  prewarmProgramContentKeys,
   remainingPrewarmViewBudget,
   resolvePrewarmPolicy,
   withRestoredPrewarmState,
@@ -561,7 +562,10 @@ const PREWARM_FRAME_RESERVE_MS = 2000;
 // Compile roots per entry unit: one unit launches its batch's compileAsync
 // calls and awaits them together, so r165's 10 ms poll floors overlap instead
 // of stacking (>1000 serial awaits measured 10+ s of pure timer wait). Small
-// enough that a batch's synchronous prologues stay a bounded slice.
+// enough that a batch's synchronous prologues stay a bounded slice. Coupled
+// to PREWARM_FRAME_RESERVE_MS: the deadline is checked BETWEEN units, so the
+// worst overshoot past the compile wall is one batch's prologues; the 2 s
+// reserve must stay comfortably above that slice.
 const PREWARM_COMPILE_BATCH_ROOTS = 16;
 const VIEW_PREWARM_MAX_VIEWS_LOW = 48;
 const VIEW_PREWARM_MAX_VIEWS_HIGH = 72;
@@ -3499,7 +3503,7 @@ export class Renderer {
                 `zone-prewarm-color:${childRoot.name || childRoot.type}`,
               );
               await this.backgroundGpuWork.run(
-                () => this.compileSkinnedShadowPrograms(childRoot),
+                () => this.compileShadowPrograms(childRoot),
                 GPU_WORK_PRIORITY.VISIBLE_PREWARM,
                 `zone-prewarm-shadow:${childRoot.name || childRoot.type}`,
               );
@@ -5251,8 +5255,14 @@ export class Renderer {
       displacementScale: textured.displacementScale ?? 1,
       displacementBias: textured.displacementBias ?? 0,
       wireframe: textured.wireframe ?? false,
+      // Match the REAL shadow pass: three's shared shadow depth material uses
+      // RGBADepthPacking and depthPacking sits in the program cache key, so
+      // the default BasicDepthPacking linked a variant the shadow pass never
+      // draws, and every "prewarmed" caster relinked at its first shadow
+      // draw anyway (the residue probe measured all of them).
+      depthPacking: THREE.RGBADepthPacking,
     });
-    depth.name = `prewarm-skinned-depth:${key}`;
+    depth.name = `prewarm-depth:${key}`;
     this.prewarmDepthMaterials.set(key, depth);
     return depth;
   }
@@ -5294,15 +5304,17 @@ export class Renderer {
   /**
    * compileAsync(scene, camera) does not enumerate Three's renderer-owned
    * shadow materials. Temporarily put equivalent MeshDepthMaterials on the
-   * real skinned rigs so KHR_parallel_shader_compile can link those variants
-   * before the synchronous shadow warm pass asks getUniforms for them.
+   * real casters, skinned or not, so KHR_parallel_shader_compile can link
+   * those variants before the synchronous shadow warm pass asks getUniforms
+   * for them. Static and instanced casters count: their missing depth arm
+   * was 12 of the initial frame's 64 residual synchronous links.
    */
-  private async compileSkinnedShadowPrograms(root: THREE.Object3D): Promise<void> {
+  private async compileShadowPrograms(root: THREE.Object3D): Promise<void> {
     if (!GFX.dynamicShadows || !this.asyncCompileSupported) return;
-    const swaps: { mesh: THREE.SkinnedMesh; material: THREE.Material | THREE.Material[] }[] = [];
+    const swaps: { mesh: THREE.Mesh; material: THREE.Material | THREE.Material[] }[] = [];
     root.traverse((obj) => {
-      const mesh = obj as THREE.SkinnedMesh;
-      if (!mesh.isSkinnedMesh || !mesh.castShadow) return;
+      const mesh = obj as THREE.Mesh;
+      if (!mesh.isMesh || !mesh.castShadow) return;
       const material = mesh.material;
       swaps.push({ mesh, material });
       mesh.material = Array.isArray(material)
@@ -5310,36 +5322,36 @@ export class Renderer {
         : this.prewarmDepthMaterial(material);
     });
     if (swaps.length === 0) return;
+    // Match the real shadow pass's program key exactly. A bare
+    // compileAsync(root, shadowCamera) uses the canvas output colour space
+    // and sees no scene lights, producing a skinned depth program that still
+    // misses both the render-target and shadow-map bits. Conversely, passing
+    // the world scene verbatim would add fog bits that WebGLShadowMap omits
+    // (its renderBufferDirect call uses a null scene). Keep the world only as
+    // the light source, briefly suppress its fog, and compile while any
+    // offscreen target is current so outputColorSpace is the linear working
+    // space. compileAsync runs its compile() prologue synchronously; restore
+    // the globals AND the swapped materials before awaiting the parallel
+    // linker: the boot-resume lane runs these units on VISIBLE post-reveal
+    // scene meshes, and a swap held across the awaited link (10 ms+ of real
+    // frames) would draw them as depth noise. The link tracks the depth
+    // material object, not the mesh, so restoring early is safe.
+    this.prewarmRenderTarget ??= new THREE.WebGLRenderTarget(8, 8);
+    const previousTarget = this.webgl.getRenderTarget();
+    const previousFog = this.scene.fog;
+    let compilePromise: Promise<THREE.Object3D>;
     try {
-      // Match the real shadow pass's program key exactly. A bare
-      // compileAsync(root, shadowCamera) uses the canvas output colour space
-      // and sees no scene lights, producing a skinned depth program that still
-      // misses both the render-target and shadow-map bits. Conversely, passing
-      // the world scene verbatim would add fog bits that WebGLShadowMap omits
-      // (its renderBufferDirect call uses a null scene). Keep the world only as
-      // the light source, briefly suppress its fog, and compile while any
-      // offscreen target is current so outputColorSpace is the linear working
-      // space. compileAsync runs its compile() prologue synchronously; restore
-      // both globals before awaiting parallel linker completion so live frames
-      // can continue normally.
-      this.prewarmRenderTarget ??= new THREE.WebGLRenderTarget(8, 8);
-      const previousTarget = this.webgl.getRenderTarget();
-      const previousFog = this.scene.fog;
-      let compilePromise: Promise<THREE.Object3D>;
-      try {
-        this.scene.fog = null;
-        this.webgl.setRenderTarget(this.prewarmRenderTarget);
-        compilePromise = this.webgl.compileAsync(root, this.sun.shadow.camera, this.scene);
-      } finally {
-        this.webgl.setRenderTarget(previousTarget);
-        this.scene.fog = previousFog;
-      }
-      // Do not race a timer here. The underlying linker cannot be cancelled,
-      // so a timeout only lets it overlap the next child and gameplay.
-      await compilePromise;
+      this.scene.fog = null;
+      this.webgl.setRenderTarget(this.prewarmRenderTarget);
+      compilePromise = this.webgl.compileAsync(root, this.sun.shadow.camera, this.scene);
     } finally {
+      this.webgl.setRenderTarget(previousTarget);
+      this.scene.fog = previousFog;
       for (const swap of swaps) swap.mesh.material = swap.material;
     }
+    // Do not race a timer here. The underlying linker cannot be cancelled,
+    // so a timeout only lets it overlap the next child and gameplay.
+    await compilePromise;
   }
 
   // A tiny throwaway target for background child uploads, so a prewarm root
@@ -5720,27 +5732,52 @@ export class Renderer {
         ],
         async (root) => {
           await this.compilePrewarmColorPrograms(root, false);
-          await this.compileSkinnedShadowPrograms(root);
+          await this.compileShadowPrograms(root);
           compiledPrewarmRoots++;
         },
         {
+          // NOT batched into one compileAsync call per unit: an A/B measured
+          // no gain (11.5 s vs 11.9 s on a cold full entry) because the
+          // remaining compile time is the driver's parallel link work for
+          // genuinely new programs, not the per-call prologue walk. The
+          // driver's own shader disk cache makes that first-entry cost
+          // vanish on subsequent sessions.
           // Program-content keys: two leaves sharing materials AND the shape
-          // bits three keys a program on (skinning, instancing, morphs, the
-          // skinned-shadow variant) link the same programs, so the duplicate
-          // costs a unit for nothing. surfaceMat dedupes materials heavily,
-          // so this collapses hundreds of leaves per zone.
+          // bits three keys a program on link the same programs, so the
+          // duplicate costs a unit for nothing. surfaceMat dedupes materials
+          // heavily, so this collapses hundreds of leaves per zone. The key
+          // lives in the policy layer so its fidelity to three's cache key is
+          // pinned by tests (a coarser key measured as 35 of the initial
+          // frame's 64 residual synchronous links).
           dedupeKeys: (root) => {
             const mesh = root as THREE.Mesh & {
               isSkinnedMesh?: boolean;
               isInstancedMesh?: boolean;
+              isBatchedMesh?: boolean;
+              instanceColor?: unknown;
             };
             const material = mesh.material;
             const materials = Array.isArray(material) ? material : material ? [material] : [];
-            const morphs = (mesh.geometry?.morphAttributes?.position?.length ?? 0) > 0;
-            const shape =
-              `${mesh.isSkinnedMesh ? 's' : 'm'}${mesh.isInstancedMesh ? 'i' : ''}` +
-              `${morphs ? 'p' : ''}${mesh.castShadow ? 'c' : ''}`;
-            return materials.map((entry) => `${shape}:${entry.uuid}`);
+            const morphs = mesh.geometry?.morphAttributes;
+            const colorAttribute = mesh.geometry?.attributes?.color as
+              | { itemSize?: number }
+              | undefined;
+            return prewarmProgramContentKeys(
+              {
+                isSkinnedMesh: mesh.isSkinnedMesh === true,
+                isInstancedMesh: mesh.isInstancedMesh === true,
+                hasInstanceColor: mesh.instanceColor != null,
+                isBatchedMesh: mesh.isBatchedMesh === true,
+                hasMorphPositions: morphs?.position !== undefined,
+                morphTargetCount: morphs?.position?.length ?? 0,
+                morphNormalCount: morphs?.normal?.length ?? 0,
+                morphColorCount: morphs?.color?.length ?? 0,
+                hasTangents: mesh.geometry?.attributes?.tangent !== undefined,
+                vertexColorItemSize: colorAttribute?.itemSize ?? 0,
+                castShadow: mesh.castShadow === true,
+              },
+              materials.map((entry) => entry.uuid),
+            );
           },
           batchSize: PREWARM_COMPILE_BATCH_ROOTS,
         },
@@ -6218,6 +6255,25 @@ export class Renderer {
         detail: () => `objects=${landmarkPrewarmGroup?.children.length ?? 0}`,
       },
       {
+        // One full non-submitting frame tick (prewarmWorldFrame advances the
+        // renderer clock, camera smoothing, LOD bands, fog, zone visibility
+        // and lazily built terrain/water content; it never touches sim
+        // state), so every later collection (textures.scene's texture walk,
+        // the compile units) sees the visibility state world.initial-frame
+        // will actually draw.
+        // Measured on a full offline entry: collected before this update the
+        // compile lane visited 2807 roots yet still left the frame a
+        // 230-program, 185-texture residue costing 16.9 s; collected after,
+        // 801 roots and the frame residue fell to 64 programs and 3.8 s.
+        id: 'world.settle-state',
+        category: 'world',
+        priority: 49,
+        required: true,
+        run: () => {
+          this.prewarmWorldFrame(1 / 60);
+        },
+      },
+      {
         id: 'textures.scene',
         category: 'world',
         priority: 50,
@@ -6359,8 +6415,11 @@ export class Renderer {
         // the exempt compile above consumed the whole budget) makes the
         // initial scene link its programs at first LIVE draw, 102-318 ms
         // stalls in front of the player. The compile-unit reserve
-        // (PREWARM_FRAME_RESERVE_MS) bounds how late this can start, so the
-        // exemption cannot push the uninterruptible submit past the GPU guard.
+        // (PREWARM_FRAME_RESERVE_MS) bounds how late this normally starts;
+        // the deadline is checked between units, so one slow batch (its
+        // awaited link included) can still eat into the reserve, and the
+        // hard deadline remains the unconditional backstop that can cancel
+        // even this entry.
         deadlineExempt: true,
         run: () => {
           this.renderPrewarmPass(1 / 60);
@@ -6411,6 +6470,16 @@ export class Renderer {
               const remaining = units.slice(index);
               if (remaining.length > 0) {
                 droppedEntries.push({ id: 'programs.compile', units: remaining });
+                // Same rule as the whole-entry resumeUnits path above: the
+                // remaining units still reference pooled prewarm visuals, so
+                // pool publication must wait for the resume lane, or gameplay
+                // takes a visual out of the T-pose grid while its compile
+                // unit still swaps materials on it.
+                deferPoolPublication =
+                  deferPoolPublication ||
+                  (entityPrewarmPool.length > 0 &&
+                    (entityPrewarmGroup?.children.length ?? 0) > 0) ||
+                  (npcPrewarmPool.length > 0 && (npcPrewarmGroup?.children.length ?? 0) > 0);
               }
               compileTimedOut = true;
               break;
@@ -7768,7 +7837,7 @@ export class Renderer {
     return this.liveCompileGates.run(
       () =>
         this.compilePrewarmColorPrograms(target, false).then(() =>
-          this.compileSkinnedShadowPrograms(target),
+          this.compileShadowPrograms(target),
         ),
       VIEW_COMPILE_GATE_MAX_MS,
       { priority, label: `live-gate:${target.name || target.type}` },

--- a/tests/eastbrook_polish_artifact_integrity.test.ts
+++ b/tests/eastbrook_polish_artifact_integrity.test.ts
@@ -676,9 +676,9 @@ const ACCEPTED_POLISH_V2_METADATA_PATH = path.join(REPO_ROOT, POLISH_SEAL_PATH);
 // Re-minted on PR 3150's v0.36.0 base merge, where the branch's renderer.ts
 // prewarm changes converged with the 3165 reseal. No capture was retaken.
 const ACCEPTED_POLISH_V2_METADATA_SHA256 =
-  'ec9d9ca628a22172ee8e989c3ac88d563b43929ce6d0ffc2b66881d462ca79f9';
+  '62c01972c7e2e2c45d25e47036e7a0c263b1a2e874085f0e80d199e3543c57f2';
 const ACCEPTED_POLISH_V2_COMPOSITE_PROVENANCE =
-  'a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca';
+  '9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108';
 const ACCEPTED_POLISH_V2_METADATA = readJsonFile<CaptureMetadata>(ACCEPTED_POLISH_V2_METADATA_PATH);
 const ACCEPTED_POLISH_V2_PROVENANCE = ACCEPTED_POLISH_V2_METADATA.polishProvenance;
 const ACCEPTED_POLISH_V2_TOWN_CONTRACT = ACCEPTED_POLISH_V2_METADATA.records[0]?.townContract;
@@ -1582,7 +1582,7 @@ describe('Eastbrook polish performance and contact evidence', () => {
     expect(
       fingerprint.digest('hex'),
       `the second-order performance digest moved; if every input moved legitimately, re-mint with: ${REMINT_COMMAND} (it recomputes this literal LAST, from the swept files)`,
-    ).toBe('cab95c2e4617b24251ccf355ba0519caf9069d0b8a90788bc8148eae276f98ca');
+    ).toBe('0775034c85045a0aaff737f5e2b9fe0edaf921dc7ccb07a1a0db43f51b16e0eb');
   });
 
   it('binds every historical after record to its accepted source and asset provenance', () => {

--- a/tests/eastbrook_polish_artifact_integrity.test.ts
+++ b/tests/eastbrook_polish_artifact_integrity.test.ts
@@ -676,9 +676,9 @@ const ACCEPTED_POLISH_V2_METADATA_PATH = path.join(REPO_ROOT, POLISH_SEAL_PATH);
 // Re-minted on PR 3150's v0.36.0 base merge, where the branch's renderer.ts
 // prewarm changes converged with the 3165 reseal. No capture was retaken.
 const ACCEPTED_POLISH_V2_METADATA_SHA256 =
-  '0b9ea7d700e3dac2433402423fe32c9b78811584875e14be82b57c0b124ac2c0';
+  '355de2ed896036b7d39facb949507edd11df206c7d20e2c561b4c044eb5bf9c6';
 const ACCEPTED_POLISH_V2_COMPOSITE_PROVENANCE =
-  'efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e';
+  '4590589e6b76f5774ffeb88d7ac9419f4b5f69c065be2a3f284a502659b2bfe7';
 const ACCEPTED_POLISH_V2_METADATA = readJsonFile<CaptureMetadata>(ACCEPTED_POLISH_V2_METADATA_PATH);
 const ACCEPTED_POLISH_V2_PROVENANCE = ACCEPTED_POLISH_V2_METADATA.polishProvenance;
 const ACCEPTED_POLISH_V2_TOWN_CONTRACT = ACCEPTED_POLISH_V2_METADATA.records[0]?.townContract;
@@ -1582,7 +1582,7 @@ describe('Eastbrook polish performance and contact evidence', () => {
     expect(
       fingerprint.digest('hex'),
       `the second-order performance digest moved; if every input moved legitimately, re-mint with: ${REMINT_COMMAND} (it recomputes this literal LAST, from the swept files)`,
-    ).toBe('3d1a059f0106e922d45dc8dec473d7d7eed8a727ce0b026c8d964e67481a636d');
+    ).toBe('d4e254767b171eaea26772ea8c69430f28c7effcc304d3ad7bab09c89a6add42');
   });
 
   it('binds every historical after record to its accepted source and asset provenance', () => {

--- a/tests/eastbrook_polish_artifact_integrity.test.ts
+++ b/tests/eastbrook_polish_artifact_integrity.test.ts
@@ -676,9 +676,9 @@ const ACCEPTED_POLISH_V2_METADATA_PATH = path.join(REPO_ROOT, POLISH_SEAL_PATH);
 // Re-minted on PR 3150's v0.36.0 base merge, where the branch's renderer.ts
 // prewarm changes converged with the 3165 reseal. No capture was retaken.
 const ACCEPTED_POLISH_V2_METADATA_SHA256 =
-  '9deb355d348acc2858bb43f9f8865510b63d154f67fb524f7098dad8e2bfc152';
+  '0b9ea7d700e3dac2433402423fe32c9b78811584875e14be82b57c0b124ac2c0';
 const ACCEPTED_POLISH_V2_COMPOSITE_PROVENANCE =
-  '5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf';
+  'efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e';
 const ACCEPTED_POLISH_V2_METADATA = readJsonFile<CaptureMetadata>(ACCEPTED_POLISH_V2_METADATA_PATH);
 const ACCEPTED_POLISH_V2_PROVENANCE = ACCEPTED_POLISH_V2_METADATA.polishProvenance;
 const ACCEPTED_POLISH_V2_TOWN_CONTRACT = ACCEPTED_POLISH_V2_METADATA.records[0]?.townContract;
@@ -1582,7 +1582,7 @@ describe('Eastbrook polish performance and contact evidence', () => {
     expect(
       fingerprint.digest('hex'),
       `the second-order performance digest moved; if every input moved legitimately, re-mint with: ${REMINT_COMMAND} (it recomputes this literal LAST, from the swept files)`,
-    ).toBe('d9eebace605430003f2aa466547f6403564a57a26548c8a6bc8cb0647fe9d034');
+    ).toBe('3d1a059f0106e922d45dc8dec473d7d7eed8a727ce0b026c8d964e67481a636d');
   });
 
   it('binds every historical after record to its accepted source and asset provenance', () => {

--- a/tests/eastbrook_polish_artifact_integrity.test.ts
+++ b/tests/eastbrook_polish_artifact_integrity.test.ts
@@ -676,9 +676,9 @@ const ACCEPTED_POLISH_V2_METADATA_PATH = path.join(REPO_ROOT, POLISH_SEAL_PATH);
 // Re-minted on PR 3150's v0.36.0 base merge, where the branch's renderer.ts
 // prewarm changes converged with the 3165 reseal. No capture was retaken.
 const ACCEPTED_POLISH_V2_METADATA_SHA256 =
-  '62c01972c7e2e2c45d25e47036e7a0c263b1a2e874085f0e80d199e3543c57f2';
+  '9deb355d348acc2858bb43f9f8865510b63d154f67fb524f7098dad8e2bfc152';
 const ACCEPTED_POLISH_V2_COMPOSITE_PROVENANCE =
-  '9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108';
+  '5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf';
 const ACCEPTED_POLISH_V2_METADATA = readJsonFile<CaptureMetadata>(ACCEPTED_POLISH_V2_METADATA_PATH);
 const ACCEPTED_POLISH_V2_PROVENANCE = ACCEPTED_POLISH_V2_METADATA.polishProvenance;
 const ACCEPTED_POLISH_V2_TOWN_CONTRACT = ACCEPTED_POLISH_V2_METADATA.records[0]?.townContract;
@@ -1582,7 +1582,7 @@ describe('Eastbrook polish performance and contact evidence', () => {
     expect(
       fingerprint.digest('hex'),
       `the second-order performance digest moved; if every input moved legitimately, re-mint with: ${REMINT_COMMAND} (it recomputes this literal LAST, from the swept files)`,
-    ).toBe('0775034c85045a0aaff737f5e2b9fe0edaf921dc7ccb07a1a0db43f51b16e0eb');
+    ).toBe('d9eebace605430003f2aa466547f6403564a57a26548c8a6bc8cb0647fe9d034');
   });
 
   it('binds every historical after record to its accepted source and asset provenance', () => {

--- a/tests/eastbrook_polish_capture_contract.test.ts
+++ b/tests/eastbrook_polish_capture_contract.test.ts
@@ -95,8 +95,10 @@ interface AttributionTargetFixture {
 // No capture was retaken.
 // Re-minted for the entry-prewarm compile dedupe/batch + initial-frame reserve
 // (renderer.ts + prewarm_policy.ts edits). No capture was retaken.
+// Re-minted for the prewarm coverage completion (settle-state entry, program
+// content keys, widened depth arm). No capture was retaken.
 const PINNED_POLISH_COMPOSITE_FINGERPRINT =
-  '5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf';
+  'efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e';
 
 function validPolishAttributionTargets(): AttributionTargetFixture[] {
   return [

--- a/tests/eastbrook_polish_capture_contract.test.ts
+++ b/tests/eastbrook_polish_capture_contract.test.ts
@@ -98,7 +98,7 @@ interface AttributionTargetFixture {
 // Re-minted for the prewarm coverage completion (settle-state entry, program
 // content keys, widened depth arm). No capture was retaken.
 const PINNED_POLISH_COMPOSITE_FINGERPRINT =
-  'efd1c895fca57be61dfee412d1bc03b701e6b4abb44be60a854ddcdd23ddbc3e';
+  '4590589e6b76f5774ffeb88d7ac9419f4b5f69c065be2a3f284a502659b2bfe7';
 
 function validPolishAttributionTargets(): AttributionTargetFixture[] {
   return [

--- a/tests/eastbrook_polish_capture_contract.test.ts
+++ b/tests/eastbrook_polish_capture_contract.test.ts
@@ -93,8 +93,10 @@ interface AttributionTargetFixture {
 // changes and the PR 3165 reseal converged here. No capture was retaken.
 // Re-minted for the bounded-prewarm point-light pin (renderer.ts edit only).
 // No capture was retaken.
+// Re-minted for the entry-prewarm compile dedupe/batch + initial-frame reserve
+// (renderer.ts + prewarm_policy.ts edits). No capture was retaken.
 const PINNED_POLISH_COMPOSITE_FINGERPRINT =
-  '9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108';
+  '5814282bb67c5976e6df241a7626452b229082fb6948e6abfa60f220bf2f4faf';
 
 function validPolishAttributionTargets(): AttributionTargetFixture[] {
   return [

--- a/tests/eastbrook_polish_capture_contract.test.ts
+++ b/tests/eastbrook_polish_capture_contract.test.ts
@@ -91,8 +91,10 @@ interface AttributionTargetFixture {
 // neither parent. No capture was retaken.
 // Re-minted on PR 3150's v0.36.0 base merge: the branch's renderer.ts prewarm
 // changes and the PR 3165 reseal converged here. No capture was retaken.
+// Re-minted for the bounded-prewarm point-light pin (renderer.ts edit only).
+// No capture was retaken.
 const PINNED_POLISH_COMPOSITE_FINGERPRINT =
-  'a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca';
+  '9748e8f842391716cd2a9eea0ff89b5297cded980a670ead3e3d9ef85ac39108';
 
 function validPolishAttributionTargets(): AttributionTargetFixture[] {
   return [

--- a/tests/point_light_budget.test.ts
+++ b/tests/point_light_budget.test.ts
@@ -3,6 +3,7 @@ import * as THREE from 'three';
 import { describe, expect, it } from 'vitest';
 import {
   applyPointLightBudget,
+  countDrawnPointLights,
   flickerContributingFireLights,
   pointLightPadCount,
   type RankedPointLight,
@@ -244,6 +245,94 @@ describe('applyPointLightBudget', () => {
       expect(drawn).toBe(2);
       expect(visibleCount(ranked)).toBe(2);
     });
+  });
+
+  describe('countDrawnPointLights (the bounded prewarm mask)', () => {
+    function addTo(parent: THREE.Object3D, entry: RankedPointLight): RankedPointLight {
+      parent.add(entry.light);
+      return entry;
+    }
+
+    it('re-derives the drawn count when a transient mask hides chosen ancestors', () => {
+      // The zone-prewarm bounded render hides most top-level scene children
+      // transiently, OUT OF BAND of the budget pass: view lights under those
+      // children leave Three's counted set, NUM_POINT_LIGHTS drifts below the
+      // pinned total, and the bounded render synchronously links a program
+      // variant the live render never draws (measured: prewarm units with a
+      // link cost ~119 ms on a 3090; units without, 0.3 ms).
+      const scene = new THREE.Scene();
+      const viewGroup = new THREE.Group();
+      scene.add(viewGroup);
+      const viewLight = addTo(viewGroup, rankedLight(1, 0));
+      const rootLight = addTo(scene, rankedLight(2, 0));
+      const ranked = [viewLight, rootLight];
+      applyPointLightBudget(ranked, 0, 0, 6, 6, RANGE_SQ, scene);
+      expect(countDrawnPointLights(ranked, scene)).toBe(2);
+
+      // The bounded mask hides the view group; no budget pass runs in between.
+      viewGroup.visible = false;
+      const boundedDrawn = countDrawnPointLights(ranked, scene);
+      expect(boundedDrawn).toBe(1);
+      // The pad top-up restores the exact pinned total the compile lane
+      // linked against, so the bounded render draws the same variant.
+      expect(boundedDrawn + pointLightPadCount(boundedDrawn, 6)).toBe(6);
+    });
+
+    it('does not count a light the budget itself turned off', () => {
+      const scene = new THREE.Scene();
+      const near = addTo(scene, rankedLight(1, 0));
+      const far = addTo(scene, rankedLight(9, 0));
+      const ranked = [near, far];
+      applyPointLightBudget(ranked, 0, 0, 1, 1, RANGE_SQ, scene);
+      expect(far.light.visible).toBe(false);
+      expect(countDrawnPointLights(ranked, scene)).toBe(1);
+    });
+
+    it('does not count a detached light', () => {
+      const scene = new THREE.Scene();
+      const attached = addTo(scene, rankedLight(1, 0));
+      const detached = rankedLight(2, 0);
+      attached.light.visible = true;
+      detached.light.visible = true;
+      expect(countDrawnPointLights([attached, detached], scene)).toBe(1);
+    });
+  });
+
+  it('wires the bounded prewarm render to re-pin the pads in its masked state', () => {
+    // The bounded render's visibility mask hides entity views (and their
+    // lights) without a budget pass: it must recount drawn lights in ITS
+    // state, pad up to the same pinned total the compile lane linked against
+    // BEFORE rendering, and restore the live pad state afterwards. Dropping
+    // any half silently reinstates the synchronous mid-unit program links.
+    const source = readFileSync(new URL('../src/render/renderer.ts', import.meta.url), 'utf8');
+    const methodStart = source.indexOf('private renderBoundedPrewarmRoot(');
+    const methodEnd = source.indexOf('private renderPrewarmPass(', methodStart);
+    expect(methodStart).toBeGreaterThan(-1);
+    expect(methodEnd).toBeGreaterThan(methodStart);
+    const method = source.slice(methodStart, methodEnd);
+    expect(method).toContain('countDrawnPointLights(this.lightRank, this.scene)');
+    expect(method).toContain('pointLightPadCount(');
+    expect(method).toContain('GFX.maxPointLights');
+    const sceneMaskIndex = method.indexOf('boundedPrewarmVisibility');
+    // The recount must observe BOTH mask levels: the scene-level mask and the
+    // group-level one (a recount between the two would still miss the drift).
+    const groupMaskIndex = method.indexOf('entry === childRoot');
+    const countIndex = method.indexOf('countDrawnPointLights');
+    const padWriteIndex = method.indexOf('this.lightPads[i].visible = i < boundedPadCount');
+    const renderIndex = method.indexOf('this.webgl.render(');
+    const finallyIndex = method.indexOf('} finally {');
+    const restoreIndex = method.indexOf('previousPadVisibility[');
+    expect(sceneMaskIndex).toBeGreaterThan(-1);
+    expect(groupMaskIndex).toBeGreaterThan(sceneMaskIndex);
+    expect(countIndex).toBeGreaterThan(groupMaskIndex);
+    // The pad WRITE must land between the recount and the render: pinned
+    // separately because the count/pad substrings also appear in comments.
+    expect(padWriteIndex).toBeGreaterThan(countIndex);
+    expect(renderIndex).toBeGreaterThan(padWriteIndex);
+    // The pad restore must live in the finally: restored only after the render
+    // would leak raised pads into live frames on a throw.
+    expect(finallyIndex).toBeGreaterThan(renderIndex);
+    expect(restoreIndex).toBeGreaterThan(finallyIndex);
   });
 
   it('wires the drawn-count pin: scene root in, pads on the drawn count out', () => {

--- a/tests/prewarm_pass.test.ts
+++ b/tests/prewarm_pass.test.ts
@@ -342,14 +342,11 @@ describe('runBackgroundPrewarm', () => {
     const boundedEnd = source.indexOf('\n  private renderPrewarmPass(', boundedStart);
     const boundedMethod = source.slice(boundedStart, boundedEnd);
     const compileStart = source.indexOf('private async compilePrewarmColorPrograms(');
-    const compileEnd = source.indexOf(
-      '\n  private async compileSkinnedShadowPrograms(',
-      compileStart,
-    );
+    const compileEnd = source.indexOf('\n  private async compileShadowPrograms(', compileStart);
     const compileMethod = source.slice(compileStart, compileEnd);
 
     expect(zoneMethod).toContain('() => this.compilePrewarmColorPrograms(childRoot, true)');
-    expect(zoneMethod).toContain('() => this.compileSkinnedShadowPrograms(childRoot)');
+    expect(zoneMethod).toContain('() => this.compileShadowPrograms(childRoot)');
     expect(zoneMethod).toContain('runUpload: (work, label) =>');
     // The decomposed upload: texture batches first, then the bounded render.
     expect(zoneMethod).toContain('warmChildUnits: (groupLike, child) =>');
@@ -401,7 +398,7 @@ describe('runBackgroundPrewarm', () => {
     const zoneStart = source.indexOf('private async prepareZoneSky(');
     const zoneEnd = source.indexOf('\n  /** Blocking-path neighborhood prepare', zoneStart);
     const zoneSlice = source.slice(zoneStart, zoneEnd);
-    const shadowStart = source.indexOf('private async compileSkinnedShadowPrograms(');
+    const shadowStart = source.indexOf('private async compileShadowPrograms(');
     const shadowEnd = source.indexOf('\n  // A tiny throwaway target', shadowStart);
     const shadowSlice = source.slice(shadowStart, shadowEnd);
     const bootStart = source.indexOf("id: 'programs.compile'");

--- a/tests/prewarm_policy.test.ts
+++ b/tests/prewarm_policy.test.ts
@@ -12,6 +12,7 @@ import {
   type PrewarmPolicyInput,
   partitionMandatoryLandmarkCandidates,
   prewarmBuildDeadline,
+  prewarmCompileUnitDeadline,
   prewarmEntryResumesAfterSkip,
   prewarmEntryRuns,
   prewarmEntryShouldDefer,
@@ -37,7 +38,10 @@ const BASE: PrewarmPolicyInput = {
 };
 
 // The full manifest id order the renderer builds, for the reorder tests.
+// Kept in lockstep with the renderer by the "matches the renderer's real
+// manifest" case below, which parses the source.
 const MANIFEST_IDS = [
+  'sky.nearby-biomes',
   'views.required',
   'views.landmarks',
   'views.persistent-portals',
@@ -49,15 +53,47 @@ const MANIFEST_IDS = [
   'entities.npc-archetypes',
   'objects.quest-archetypes',
   'props.material-variants',
+  'props.ghost-fade-variants',
   'foliage.materials',
+  'foliage.great-tree-materials',
+  'surface-detail.textures',
+  'weather.materials',
+  'landmarks.impact-site',
   'textures.scene',
   'vfx.atlas',
+  'vfx.weapon-skins',
+  'vfx.ability-primitives',
   'world.initial-frame',
   'programs.compile',
-  'sky.biome-variants',
+  'programs.budget-variants',
+  'sky.current-zone',
   'render.settle-passes',
   'diagnostics.baseline',
 ];
+
+/** The renderer's manifest entries parsed from source: id, and whether the
+ *  literal carries required / deadlineExempt properties. */
+function parsedManifestEntries(): { id: string; required: boolean; deadlineExempt: boolean }[] {
+  const renderer = readFileSync(
+    new URL('../src/render/renderer.ts', import.meta.url),
+    'utf8',
+  ).replace(/\r\n/g, '\n');
+  const start = renderer.indexOf('const manifest: PrewarmManifestEntry[] = [');
+  const end = renderer.indexOf('const byId = new Map(', start);
+  expect(start).toBeGreaterThan(-1);
+  expect(end).toBeGreaterThan(start);
+  const slice = renderer.slice(start, end);
+  const blocks = slice.split(/\n {6}\{\n/).slice(1);
+  return blocks.map((block) => {
+    const id = /id: '([^']+)'/.exec(block)?.[1];
+    expect(id).toBeTruthy();
+    return {
+      id: id as string,
+      required: block.includes('required: true'),
+      deadlineExempt: block.includes('deadlineExempt:'),
+    };
+  });
+}
 
 describe('resolvePrewarmPolicy: unconstrained desktop', () => {
   it('runs the full manifest with generous budgets and no reordering', () => {
@@ -137,6 +173,59 @@ describe('resolvePrewarmPolicy: unconstrained desktop', () => {
       expect(prewarmEntryRuns(id, p)).toBe(false);
     }
     expect(prewarmEntryRuns('textures.scene', p)).toBe(true);
+  });
+
+  it('matches the renderer real manifest order', () => {
+    expect(parsedManifestEntries().map((entry) => entry.id)).toEqual(MANIFEST_IDS);
+  });
+
+  it('reserves compile-loop room so the initial frame always fits before the GPU guard', () => {
+    // The measured failure (entry blob, 2026-08-09): programs.compile is
+    // deadline-exempt and ran to the 14 s GPU-submit guard, so
+    // world.initial-frame started past the 12 s soft deadline and was
+    // cancelled outright; the initial scene's programs then linked at first
+    // LIVE draw (102-318 ms submit stalls, 17 programs in one frame).
+    expect(prewarmCompileUnitDeadline(14_000, 2_000)).toBe(12_000);
+    // A nonsensical negative reserve never EXTENDS the compile wall.
+    expect(prewarmCompileUnitDeadline(14_000, -500)).toBe(14_000);
+
+    const renderer = readFileSync(
+      new URL('../src/render/renderer.ts', import.meta.url),
+      'utf8',
+    ).replace(/\r\n/g, '\n');
+    expect(renderer).toContain('const compileUnitDeadline = prewarmCompileUnitDeadline(');
+    expect(renderer).toContain('PREWARM_FRAME_RESERVE_MS');
+    const compileEntryAt = renderer.indexOf("id: 'programs.compile'");
+    const nextEntryAt = renderer.indexOf("id: 'programs.budget-variants'", compileEntryAt);
+    const compileEntry = renderer.slice(compileEntryAt, nextEntryAt);
+    expect(compileEntryAt).toBeGreaterThan(-1);
+    expect(nextEntryAt).toBeGreaterThan(compileEntryAt);
+    // The unit loop must stop at the RESERVED deadline, not the GPU guard.
+    expect(compileEntry).toContain('performance.now() >= compileUnitDeadline');
+    expect(compileEntry).not.toContain('performance.now() >= gpuSubmitDeadline');
+  });
+
+  it('leaves no required entry deferrable downstream of the exempt compile', () => {
+    // The regression class that dropped world.initial-frame: every entry
+    // ordered at or after programs.compile (which may lawfully consume the
+    // whole soft budget) must carry a deadlineExempt property, or a slow
+    // compile silently cancels a required entry. This would have caught the
+    // granularity regression that pushed elapsed past the soft deadline.
+    const entries = parsedManifestEntries();
+    const ordered = orderedPrewarmIds(
+      entries.map((entry) => entry.id),
+      resolvePrewarmPolicy(BASE),
+    );
+    const compileAt = ordered.indexOf('programs.compile');
+    expect(compileAt).toBeGreaterThan(-1);
+    const byId = new Map(entries.map((entry) => [entry.id, entry]));
+    for (const id of ordered.slice(compileAt)) {
+      const entry = byId.get(id);
+      expect(entry).toBeTruthy();
+      if (entry?.required) {
+        expect(entry.deadlineExempt, `required entry ${id} is deferrable`).toBe(true);
+      }
+    }
   });
 
   it('keeps the required desktop compiler behind the loading cover after a slow first frame', () => {

--- a/tests/prewarm_policy.test.ts
+++ b/tests/prewarm_policy.test.ts
@@ -16,6 +16,7 @@ import {
   prewarmEntryResumesAfterSkip,
   prewarmEntryRuns,
   prewarmEntryShouldDefer,
+  prewarmProgramContentKeys,
   remainingPrewarmViewBudget,
   resolvePrewarmPolicy,
   withRestoredPrewarmState,
@@ -59,6 +60,7 @@ const MANIFEST_IDS = [
   'surface-detail.textures',
   'weather.materials',
   'landmarks.impact-site',
+  'world.settle-state',
   'textures.scene',
   'vfx.atlas',
   'vfx.weapon-skins',
@@ -87,10 +89,14 @@ function parsedManifestEntries(): { id: string; required: boolean; deadlineExemp
   return blocks.map((block) => {
     const id = /id: '([^']+)'/.exec(block)?.[1];
     expect(id).toBeTruthy();
+    // The VALUE matters, not the property's presence: a literal
+    // `deadlineExempt: false` is exactly the deferrable-required bug the
+    // downstream invariant hunts.
+    const exemptLiteral = /deadlineExempt: ([^,\n]+)/.exec(block)?.[1]?.trim();
     return {
       id: id as string,
       required: block.includes('required: true'),
-      deadlineExempt: block.includes('deadlineExempt:'),
+      deadlineExempt: exemptLiteral !== undefined && exemptLiteral !== 'false',
     };
   });
 }
@@ -226,6 +232,76 @@ describe('resolvePrewarmPolicy: unconstrained desktop', () => {
         expect(entry.deadlineExempt, `required entry ${id} is deferrable`).toBe(true);
       }
     }
+  });
+
+  it('encodes program-content keys exactly as fine as three program cache key', () => {
+    // The residue probe named the cost of a coarser key: 28 instanced-prop
+    // colour programs plus 3 instanced depth ones relinked at draw time over
+    // a missing instanceColor bit, and 4 more over morph COUNTS collapsed to
+    // a boolean. A dedupe key must distinguish every bit three keys on.
+    const base = { isSkinnedMesh: false, isInstancedMesh: true, castShadow: true };
+    const plain = prewarmProgramContentKeys({ ...base, hasInstanceColor: false }, ['mat-1']);
+    const colored = prewarmProgramContentKeys({ ...base, hasInstanceColor: true }, ['mat-1']);
+    expect(plain).toHaveLength(1);
+    expect(plain).not.toEqual(colored);
+
+    const morphs2 = prewarmProgramContentKeys({ morphTargetCount: 2 }, ['mat-1']);
+    const morphs6 = prewarmProgramContentKeys({ morphTargetCount: 6 }, ['mat-1']);
+    expect(morphs2).not.toEqual(morphs6);
+    expect(prewarmProgramContentKeys({ morphTargetCount: 2 }, ['mat-1'])).toEqual(morphs2);
+
+    // Presence vs absence: three defines USE_MORPHTARGETS on the position
+    // attribute's PRESENCE, so present-with-zero and absent are distinct.
+    expect(
+      prewarmProgramContentKeys({ hasMorphPositions: true, morphTargetCount: 0 }, ['mat-1']),
+    ).not.toEqual(prewarmProgramContentKeys({ hasMorphPositions: false }, ['mat-1']));
+
+    // Every remaining object/geometry cache-key bit is its own dimension:
+    // morph normal and colour counts, tangents, vertex colour item size
+    // (4 flips vertexAlphas), batched meshes.
+    const flat = prewarmProgramContentKeys({}, ['mat-1']);
+    expect(prewarmProgramContentKeys({ morphNormalCount: 2 }, ['mat-1'])).not.toEqual(flat);
+    expect(prewarmProgramContentKeys({ morphColorCount: 1 }, ['mat-1'])).not.toEqual(flat);
+    expect(prewarmProgramContentKeys({ hasTangents: true }, ['mat-1'])).not.toEqual(flat);
+    expect(prewarmProgramContentKeys({ vertexColorItemSize: 3 }, ['mat-1'])).not.toEqual(
+      prewarmProgramContentKeys({ vertexColorItemSize: 4 }, ['mat-1']),
+    );
+    expect(prewarmProgramContentKeys({ isBatchedMesh: true }, ['mat-1'])).not.toEqual(flat);
+
+    // Per-material keys: a two-material mesh contributes one key per slot.
+    expect(prewarmProgramContentKeys({}, ['mat-1', 'mat-2'])).toHaveLength(2);
+    // Different material, same shape: distinct keys.
+    expect(prewarmProgramContentKeys({}, ['mat-1'])).not.toEqual(
+      prewarmProgramContentKeys({}, ['mat-2']),
+    );
+  });
+
+  it('wires the compile dedupe and the widened shadow arm to the measured residue', () => {
+    const renderer = readFileSync(
+      new URL('../src/render/renderer.ts', import.meta.url),
+      'utf8',
+    ).replace(/\r\n/g, '\n');
+    // The dedupe key comes from the shared pure helper, never a hand-rolled
+    // string that can drift from three's cache key again.
+    expect(renderer).toContain('prewarmProgramContentKeys(');
+    expect(renderer).toContain('hasInstanceColor: ');
+    expect(renderer).toContain('morphTargetCount: ');
+    // The prewarm depth material must match the REAL shadow pass variant:
+    // three's shadow depth material uses RGBADepthPacking and depthPacking is
+    // in the program cache key, so omitting it links a dead variant (the
+    // pre-existing defect the residue probe exposed: every skinned-shadow
+    // compile linked BasicDepthPacking, and the frame relinked all of them).
+    expect(renderer).toContain('depthPacking: THREE.RGBADepthPacking');
+    // The shadow arm covers every caster, not just skinned rigs: static and
+    // instanced casters' depth programs were 12 of the frame's 64 residual
+    // links.
+    const shadowStart = renderer.indexOf('private async compileShadowPrograms(');
+    const shadowEnd = renderer.indexOf('\n  // A tiny throwaway target', shadowStart);
+    expect(shadowStart).toBeGreaterThan(-1);
+    expect(shadowEnd).toBeGreaterThan(shadowStart);
+    const shadowMethod = renderer.slice(shadowStart, shadowEnd);
+    expect(shadowMethod).toContain('if (!mesh.isMesh || !mesh.castShadow) return;');
+    expect(shadowMethod).not.toContain('if (!mesh.isSkinnedMesh || !mesh.castShadow) return;');
   });
 
   it('keeps the required desktop compiler behind the loading cover after a slow first frame', () => {
@@ -420,6 +496,10 @@ describe('the keep-list is the minimal entry set', () => {
         'views.nearby',
         'views.persistent-portals',
         'views.required',
+        // The pre-collection world-state update: without it, textures.scene
+        // and the compile units collect a visibility state the initial frame
+        // does not draw, and the frame pays the difference synchronously.
+        'world.settle-state',
         'world.initial-frame',
       ].sort(),
     );

--- a/tests/prewarm_program_key_contract.test.ts
+++ b/tests/prewarm_program_key_contract.test.ts
@@ -1,0 +1,195 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { expectScansOnlyThroughSharedWalkers } from './helpers/scan_guard_self_audit';
+import { tsFilesUnder } from './helpers/ts_files_under';
+
+// The prewarm compile-unit dedupe (prewarmProgramContentKeys) skips any root
+// whose program-content keys an earlier root already produced. That is only
+// sound while the key covers every object/geometry bit three folds into a
+// program's cache key: a bit the key misses makes the dedupe SKIP a variant
+// that then links synchronously at first draw, the stall class the compile
+// lane exists to prevent. Two rot vectors, one guard each:
+//
+// 1. A three upgrade changes the parameter surface. The tripwire below pins
+//    the EXACT parameter list of the installed three's getParameters, so any
+//    bump that adds, removes, or renames a parameter goes red here and forces
+//    a deliberate re-audit of prewarmProgramContentKeys (the same bump-means-
+//    re-verify policy src/render/CLAUDE.md applies to patched shader chunks).
+//
+// 2. The repo adopts a feature the key deliberately does not cover. Today
+//    that is BatchedMesh (its batchingColor bit) and Points-with-uv
+//    (pointsUvs); both can only arrive through CODE, so the source scan
+//    below fails the moment one is constructed under src/render, naming the
+//    key to extend first.
+
+const THREE_PROGRAM_PARAMETERS = [
+  'shaderID',
+  'shaderType',
+  'shaderName',
+  'vertexShader',
+  'fragmentShader',
+  'defines',
+  'customVertexShaderID',
+  'customFragmentShaderID',
+  'isRawShaderMaterial',
+  'glslVersion',
+  'precision',
+  'batching',
+  'batchingColor',
+  'instancing',
+  'instancingColor',
+  'instancingMorph',
+  'supportsVertexTextures',
+  'outputColorSpace',
+  'alphaToCoverage',
+  'map',
+  'matcap',
+  'envMap',
+  'envMapMode',
+  'envMapCubeUVHeight',
+  'aoMap',
+  'lightMap',
+  'bumpMap',
+  'normalMap',
+  'displacementMap',
+  'emissiveMap',
+  'normalMapObjectSpace',
+  'normalMapTangentSpace',
+  'metalnessMap',
+  'roughnessMap',
+  'anisotropy',
+  'anisotropyMap',
+  'clearcoat',
+  'clearcoatMap',
+  'clearcoatNormalMap',
+  'clearcoatRoughnessMap',
+  'dispersion',
+  'iridescence',
+  'iridescenceMap',
+  'iridescenceThicknessMap',
+  'sheen',
+  'sheenColorMap',
+  'sheenRoughnessMap',
+  'specularMap',
+  'specularColorMap',
+  'specularIntensityMap',
+  'transmission',
+  'transmissionMap',
+  'thicknessMap',
+  'gradientMap',
+  'opaque',
+  'alphaMap',
+  'alphaTest',
+  'alphaHash',
+  'combine',
+  'mapUv',
+  'aoMapUv',
+  'lightMapUv',
+  'bumpMapUv',
+  'normalMapUv',
+  'displacementMapUv',
+  'emissiveMapUv',
+  'metalnessMapUv',
+  'roughnessMapUv',
+  'anisotropyMapUv',
+  'clearcoatMapUv',
+  'clearcoatNormalMapUv',
+  'clearcoatRoughnessMapUv',
+  'iridescenceMapUv',
+  'iridescenceThicknessMapUv',
+  'sheenColorMapUv',
+  'sheenRoughnessMapUv',
+  'specularMapUv',
+  'specularColorMapUv',
+  'specularIntensityMapUv',
+  'transmissionMapUv',
+  'thicknessMapUv',
+  'alphaMapUv',
+  'vertexTangents',
+  'vertexColors',
+  'vertexAlphas',
+  'pointsUvs',
+  'fog',
+  'useFog',
+  'fogExp2',
+  'flatShading',
+  'sizeAttenuation',
+  'logarithmicDepthBuffer',
+  'skinning',
+  'morphTargets',
+  'morphNormals',
+  'morphColors',
+  'morphTargetsCount',
+  'morphTextureStride',
+  'numDirLights',
+  'numPointLights',
+  'numSpotLights',
+  'numSpotLightMaps',
+  'numRectAreaLights',
+  'numHemiLights',
+  'numDirLightShadows',
+  'numPointLightShadows',
+  'numSpotLightShadows',
+  'numSpotLightShadowsWithMaps',
+  'numLightProbes',
+  'numClippingPlanes',
+  'numClipIntersection',
+  'dithering',
+  'shadowMapEnabled',
+  'shadowMapType',
+  'toneMapping',
+  'decodeVideoTexture',
+  'premultipliedAlpha',
+  'doubleSided',
+  'flipSided',
+  'useDepthPacking',
+  'depthPacking',
+  'index0AttributeName',
+  'extensionClipCullDistance',
+  'extensionMultiDraw',
+  'rendererExtensionParallelShaderCompile',
+  'customProgramCacheKey',
+];
+
+describe('prewarm program key contract', () => {
+  it('pins the installed three program-parameter surface (bump tripwire)', () => {
+    const three = readFileSync(
+      new URL('../node_modules/three/build/three.module.js', import.meta.url),
+      'utf8',
+    );
+    const start = three.indexOf('const parameters = {');
+    const end = three.indexOf('};', start);
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+    const names = [...three.slice(start, end).matchAll(/^\t{3}(\w+):/gm)].map((m) => m[1]);
+    expect(
+      names,
+      'three program cache-key parameter surface changed: re-audit prewarmProgramContentKeys ' +
+        '(src/render/prewarm_policy.ts) against the new getParameters before re-pinning this list',
+    ).toEqual(THREE_PROGRAM_PARAMETERS);
+  });
+
+  it('fails on adoption of the features the dedupe key deliberately omits', () => {
+    const renderRoot = path.join(path.dirname(new URL(import.meta.url).pathname), '../src/render');
+    const offenders: string[] = [];
+    for (const { file, full } of tsFilesUnder(renderRoot)) {
+      const source = readFileSync(full, 'utf8');
+      // Constructions only: the dedupe key and this guard may NAME the
+      // feature in comments and flags without adopting it.
+      if (/new THREE\.BatchedMesh\(|new BatchedMesh\(/.test(source)) {
+        offenders.push(`${file}: BatchedMesh`);
+      }
+    }
+    expect(
+      offenders,
+      'BatchedMesh adoption reached src/render: extend prewarmProgramContentKeys with the ' +
+        'batchingColor bit (and its test) before shipping, or the prewarm dedupe will skip ' +
+        'batched-colour variants that then link synchronously at first draw',
+    ).toEqual([]);
+  });
+
+  it('scans only through the shared walkers', () => {
+    expectScansOnlyThroughSharedWalkers(import.meta.url, ['ts_files_under']);
+  });
+});

--- a/tests/prewarm_program_key_contract.test.ts
+++ b/tests/prewarm_program_key_contract.test.ts
@@ -17,11 +17,15 @@ import { tsFilesUnder } from './helpers/ts_files_under';
 //    a deliberate re-audit of prewarmProgramContentKeys (the same bump-means-
 //    re-verify policy src/render/CLAUDE.md applies to patched shader chunks).
 //
-// 2. The repo adopts a feature the key deliberately does not cover. Today
-//    that is BatchedMesh (its batchingColor bit) and Points-with-uv
-//    (pointsUvs); both can only arrive through CODE, so the source scan
-//    below fails the moment one is constructed under src/render, naming the
-//    key to extend first.
+// 2. The repo adopts a feature the key deliberately does not cover. For
+//    BatchedMesh (its batchingColor bit) the source scan below fails the
+//    moment one is constructed under src/render, naming the key to extend
+//    first. Points-with-uv (pointsUvs) has NO tripwire here on purpose:
+//    Points are already constructed in several src/render files and land on
+//    the compile path today, so a construction grep cannot discriminate; the
+//    bit only flips for a uv-mapped TEXTURED Points, which no cheap static
+//    scan can see. It stays comment-only in the key's doc, covered at
+//    runtime by the same first-draw link it always was.
 
 const THREE_PROGRAM_PARAMETERS = [
   'shaderID',

--- a/tests/prewarm_resume.test.ts
+++ b/tests/prewarm_resume.test.ts
@@ -290,7 +290,7 @@ describe('resumeDroppedPrewarmEntries', () => {
     expect(unitsSlice).toContain('else root.traverse(collect)');
     expect(unitsSlice).toContain('roots: compileRoots(group.children, false)');
     expect(unitsSlice).toContain('await this.compilePrewarmColorPrograms(root, false)');
-    expect(unitsSlice).toContain('await this.compileSkinnedShadowPrograms(root)');
+    expect(unitsSlice).toContain('await this.compileShadowPrograms(root)');
     expect(compileEntry).not.toContain('compileAsync(this.scene');
     expect(compileEntry).not.toContain('Promise.race');
     expect(source).toContain('void settlePrewarmBeforePublish(');

--- a/tests/prewarm_resume.test.ts
+++ b/tests/prewarm_resume.test.ts
@@ -143,6 +143,64 @@ describe('resumeDroppedPrewarmEntries', () => {
     expect(compiled).toEqual(['player', 'mob']);
   });
 
+  it('skips a root whose every dedupe key was already covered', async () => {
+    // Hundreds of material-bearing leaves share programs (surfaceMat dedupes
+    // materials): a root contributing no unseen key links nothing new, so it
+    // must not cost a unit (each awaited compileAsync has a 10 ms poll floor).
+    const first = { id: 'a', mats: ['stone'] };
+    const duplicate = { id: 'b', mats: ['stone'] };
+    const fresh = { id: 'c', mats: ['stone', 'moss'] };
+    const compiled: string[] = [];
+    const units = buildPrewarmCompileUnits(
+      [{ id: 'scene', roots: [first, duplicate, fresh] }],
+      async (root) => {
+        compiled.push(root.id);
+      },
+      { dedupeKeys: (root) => root.mats },
+    );
+    expect(units.map((unit) => unit.id)).toEqual(['scene:0', 'scene:1']);
+    for (const unit of units) await unit.run();
+    expect(compiled).toEqual(['a', 'c']);
+  });
+
+  it('batches roots into one unit that awaits its compiles together', async () => {
+    // r165 compileAsync resolves after N x 10 ms of setTimeout polling: awaited
+    // one by one, the floors stack; awaited together, they overlap. The batch
+    // still resolves only when every compile settles.
+    const roots = ['a', 'b', 'c'].map((id) => ({ id }));
+    const started: string[] = [];
+    const release: Array<() => void> = [];
+    const units = buildPrewarmCompileUnits(
+      [{ id: 'scene', roots }],
+      (root) =>
+        new Promise<void>((resolve) => {
+          started.push(root.id);
+          release.push(resolve);
+        }),
+      { batchSize: 2 },
+    );
+    expect(units.map((unit) => unit.id)).toEqual(['scene:0', 'scene:1']);
+
+    let firstDone = false;
+    const firstRun = units[0].run();
+    void Promise.resolve(firstRun).then(() => {
+      firstDone = true;
+    });
+    await Promise.resolve();
+    // Both compiles of the batch started before either resolved.
+    expect(started).toEqual(['a', 'b']);
+    release.shift()?.();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(firstDone).toBe(false);
+    release.shift()?.();
+    await firstRun;
+    expect(firstDone).toBe(true);
+
+    await Promise.all([units[1].run(), Promise.resolve().then(() => release.shift()?.())]);
+    expect(started).toEqual(['a', 'b', 'c']);
+  });
+
   it('never overlaps a compile that outlives its idle slot', async () => {
     let active = 0;
     let maxActive = 0;

--- a/tests/renderer_compile_gate.test.ts
+++ b/tests/renderer_compile_gate.test.ts
@@ -155,7 +155,7 @@ describe('Renderer live shader compile rejection recovery', () => {
         return Promise.resolve();
       },
     );
-    renderer.compileSkinnedShadowPrograms = vi.fn(() => {
+    renderer.compileShadowPrograms = vi.fn(() => {
       order.push('shadow');
       return Promise.resolve();
     });
@@ -165,7 +165,7 @@ describe('Renderer live shader compile rejection recovery', () => {
 
     expect(order).toEqual(['color:false', 'shadow']);
     expect(renderer.compilePrewarmColorPrograms).toHaveBeenCalledWith(target, false);
-    expect(renderer.compileSkinnedShadowPrograms).toHaveBeenCalledWith(target);
+    expect(renderer.compileShadowPrograms).toHaveBeenCalledWith(target);
   });
 
   it('never compiles a live gate at the ambient render target (colour-space cache-key trap)', () => {
@@ -179,7 +179,7 @@ describe('Renderer live shader compile rejection recovery', () => {
     // compileAsync here links the canvas variant while composer tiers draw the
     // linear one: route through the same variant pair the boot prewarm uses.
     expect(gateMethod).toContain('this.compilePrewarmColorPrograms(target, false)');
-    expect(gateMethod).toContain('this.compileSkinnedShadowPrograms(target)');
+    expect(gateMethod).toContain('this.compileShadowPrograms(target)');
     expect(gateMethod).not.toContain('this.webgl.compileAsync');
   });
 

--- a/tests/startup_graphics_safety.test.ts
+++ b/tests/startup_graphics_safety.test.ts
@@ -47,7 +47,7 @@ describe('constrained renderer integration', () => {
   it('uses the resolved dynamic-shadow policy for both the WebGL map and sun pass', () => {
     const source = readFileSync(new URL('../src/render/renderer.ts', import.meta.url), 'utf8');
     const prewarmMethod = source.indexOf(
-      'private async compileSkinnedShadowPrograms(root: THREE.Object3D)',
+      'private async compileShadowPrograms(root: THREE.Object3D)',
     );
     const prewarmGuard = source.indexOf(
       'if (!GFX.dynamicShadows || !this.asyncCompileSupported) return;',


### PR DESCRIPTION
## Summary

Three commits against the same symptom: multi-hundred-ms frame stalls at
world entry and zone streaming, all caused by shader programs linking
synchronously on the main thread when a prewarm should have linked them
off-thread.

**Problem 1: the bounded prewarm render linked wasted program variants.**
Its visibility mask hides entity views, their nested point lights leave
Three's counted set, NUM_POINT_LIGHTS drifts below the pinned total, and
every first-drawn material links a variant the live render never draws.
Fix: recount drawn lights in the masked state (`countDrawnPointLights`,
pure) and raise the pad lights to the pinned total around the render.

**Problem 2: the entry prewarm timed out and cancelled its initial frame
(regression from 5b38c5aa08, merged 2026-08-09).** That commit rightly
bounded each compile unit by splitting them into per-material-leaf units,
but >1000 of them awaited serially each pay r165 compileAsync's 10 ms poll
floor: the wall clock blew the 12 s soft deadline, and
`world.initial-frame` (whose priority/required fields turned out to be
inert) was cancelled outright. The initial scene then linked its programs
at first LIVE draw. Fix, keeping that commit's boundedness: dedupe units
by program content, batch 16 per unit awaited together, reserve
compile-loop room for the frame (`prewarmCompileUnitDeadline`), and make
the frame deadline-exempt.

**Problem 3: even a complete compile lane left the frame a 230-program
residue.** Four coverage holes, each measured: collections ran against the
pre-update world state (fix: a `world.settle-state` manifest entry runs one
world update before them); the dedupe key was coarser than three's program
cache key, missing instanceColor and exact morph counts (fix:
`prewarmProgramContentKeys`, pure and pinned); `prewarmDepthMaterial`
omitted `RGBADepthPacking`, so every skinned-shadow compile had always
linked a dead variant (pre-existing defect); static and instanced casters
had no depth arm at all (fix: `compileSkinnedShadowPrograms` becomes
`compileShadowPrograms`, covering every caster).

## Numbers (RTX 3090, tier ultra; a lower bound for weaker machines)

| Measure | Before | After |
|---|---|---|
| Bounded prewarm unit, main-thread cost | 94-236 ms each | under 22 ms, all |
| Cold border bench, stalls over 150 ms (median) | 3 | 1 |
| Cold border bench, second-worst frame gap | 223-293 ms | 80-143 ms |
| Entry: world.initial-frame | cancelled | completed, 0.85 s |
| Entry: first-draw stalls in the first 20 s | 1.5-2 s (102-318 ms hits) | none |
| Full offline entry, cold driver, real budgets | 14.5 s + stalls | 13.5 s, no entry sacrificed |

On warm driver caches (every session after the first) and on typical
online entries the compile collapses further; the online re-test
(`prewarm.timedOut: false` expected) is part of the review.

Two measured non-changes are documented in comments: batching compileAsync
calls through a scratch group (zero gain: the remaining compile time is
real driver link work, absorbed by the driver shader cache from the second
session on) and a post-chain warm (~15 links, ~0.5 s behind the cover).

## Type of change

- [x] Bug fix
- [x] Refactor or performance (no behavior change): nothing player-visible
      changes; pads carry intensity 0, the prewarm draws offscreen
- [x] Tests

## How was this tested?

- Commands: `npm run gate` (full, green), targeted suites while iterating
  (`tests/point_light_budget.test.ts`, `tests/prewarm_policy.test.ts`,
  `tests/prewarm_resume.test.ts`, `tests/prewarm_pass.test.ts` and the
  renamed-pin suites), `npx tsc --noEmit`, changed-files Biome.
- Test-first throughout: each fix landed as a red repro (pure-core case or
  ordered source pin) before the code change. New regression guards: no
  required manifest entry is deferrable downstream of the exempt compile,
  and `tests/prewarm_program_key_contract.test.ts` pins the installed
  three's program-parameter surface (a bump trips it and forces a key
  re-audit) plus fails on adoption of the features the dedupe key
  deliberately omits (BatchedMesh).
- Instrumented offline entry probes and a cold border-crossing bench A/B
  produced the numbers above; one fix-arm bench run was discarded as
  external GPU contention (submit stalls at programDelta 0, not
  reproduced).
- Deliberate pin updates: `compileSkinnedShadowPrograms` renamed
  `compileShadowPrograms` (5 suites), `MANIFEST_IDS` refreshed and now
  source-locked, `CONSTRAINED_PREWARM_KEEP` grew `world.settle-state`,
  Eastbrook polish seals re-minted per renderer-touching commit.

## Screenshots / recordings

N/A (no visible surface; the observable effect is the disappearance of entry/streaming freezes).

---

## Checklist

### Quality

- [x] **The gate passes.** Full `npm run gate` green; decisive tests added.

### Cross-platform

- [x] Tested on desktop and mobile
- ~Accessible~ N/A.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS`
      is not enabled in any production path.
- [x] I didn't hand-edit generated files (seal re-mints ran through
      `remint_polish_provenance.mjs`).
