### PR TITLE
perf(render): frame-budgeted grass builds and bounded character caches

### DIFF
--- a/docs/screenshots/eastbrook-vale-rebuild/polish/metadata/after-desktop-ultra.json
+++ b/docs/screenshots/eastbrook-vale-rebuild/polish/metadata/after-desktop-ultra.json
@@ -11,7 +11,7 @@
     "mode": "composite-sha256",
     "algorithm": "sha256",
     "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-    "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+    "fingerprint": "9345197315c6d496bf17b6e7c195a786a0d51ee5fb1742418d297803f256bdf1",
     "components": {
       "townAsset": {
         "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -40,7 +40,7 @@
         },
         "renderer": {
           "path": "src/render/renderer.ts",
-          "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+          "sha256": "d0331d8c9ced982c4f4f120ff9f89e016902a33baa0a36554bd3817ae93001e6"
         },
         "viewPriorityPolicy": {
           "path": "src/render/prewarm_policy.ts",
@@ -85,7 +85,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9345197315c6d496bf17b6e7c195a786a0d51ee5fb1742418d297803f256bdf1",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -114,7 +114,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "d0331d8c9ced982c4f4f120ff9f89e016902a33baa0a36554bd3817ae93001e6"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -1377,7 +1377,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9345197315c6d496bf17b6e7c195a786a0d51ee5fb1742418d297803f256bdf1",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -1406,7 +1406,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "d0331d8c9ced982c4f4f120ff9f89e016902a33baa0a36554bd3817ae93001e6"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -2669,7 +2669,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9345197315c6d496bf17b6e7c195a786a0d51ee5fb1742418d297803f256bdf1",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -2698,7 +2698,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "d0331d8c9ced982c4f4f120ff9f89e016902a33baa0a36554bd3817ae93001e6"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -3961,7 +3961,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9345197315c6d496bf17b6e7c195a786a0d51ee5fb1742418d297803f256bdf1",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -3990,7 +3990,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "d0331d8c9ced982c4f4f120ff9f89e016902a33baa0a36554bd3817ae93001e6"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -5253,7 +5253,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9345197315c6d496bf17b6e7c195a786a0d51ee5fb1742418d297803f256bdf1",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -5282,7 +5282,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "d0331d8c9ced982c4f4f120ff9f89e016902a33baa0a36554bd3817ae93001e6"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -6545,7 +6545,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9345197315c6d496bf17b6e7c195a786a0d51ee5fb1742418d297803f256bdf1",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -6574,7 +6574,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "d0331d8c9ced982c4f4f120ff9f89e016902a33baa0a36554bd3817ae93001e6"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -7837,7 +7837,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9345197315c6d496bf17b6e7c195a786a0d51ee5fb1742418d297803f256bdf1",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -7866,7 +7866,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "d0331d8c9ced982c4f4f120ff9f89e016902a33baa0a36554bd3817ae93001e6"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -9129,7 +9129,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9345197315c6d496bf17b6e7c195a786a0d51ee5fb1742418d297803f256bdf1",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -9158,7 +9158,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "d0331d8c9ced982c4f4f120ff9f89e016902a33baa0a36554bd3817ae93001e6"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -10421,7 +10421,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9345197315c6d496bf17b6e7c195a786a0d51ee5fb1742418d297803f256bdf1",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -10450,7 +10450,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "d0331d8c9ced982c4f4f120ff9f89e016902a33baa0a36554bd3817ae93001e6"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -11713,7 +11713,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9345197315c6d496bf17b6e7c195a786a0d51ee5fb1742418d297803f256bdf1",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -11742,7 +11742,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "d0331d8c9ced982c4f4f120ff9f89e016902a33baa0a36554bd3817ae93001e6"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -13005,7 +13005,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9345197315c6d496bf17b6e7c195a786a0d51ee5fb1742418d297803f256bdf1",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -13034,7 +13034,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "d0331d8c9ced982c4f4f120ff9f89e016902a33baa0a36554bd3817ae93001e6"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -14297,7 +14297,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9345197315c6d496bf17b6e7c195a786a0d51ee5fb1742418d297803f256bdf1",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -14326,7 +14326,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "d0331d8c9ced982c4f4f120ff9f89e016902a33baa0a36554bd3817ae93001e6"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -15589,7 +15589,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9345197315c6d496bf17b6e7c195a786a0d51ee5fb1742418d297803f256bdf1",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -15618,7 +15618,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "d0331d8c9ced982c4f4f120ff9f89e016902a33baa0a36554bd3817ae93001e6"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -16881,7 +16881,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9345197315c6d496bf17b6e7c195a786a0d51ee5fb1742418d297803f256bdf1",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -16910,7 +16910,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "d0331d8c9ced982c4f4f120ff9f89e016902a33baa0a36554bd3817ae93001e6"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -19138,7 +19138,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9345197315c6d496bf17b6e7c195a786a0d51ee5fb1742418d297803f256bdf1",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -19167,7 +19167,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "d0331d8c9ced982c4f4f120ff9f89e016902a33baa0a36554bd3817ae93001e6"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -20430,7 +20430,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9345197315c6d496bf17b6e7c195a786a0d51ee5fb1742418d297803f256bdf1",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -20459,7 +20459,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "d0331d8c9ced982c4f4f120ff9f89e016902a33baa0a36554bd3817ae93001e6"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -21722,7 +21722,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9345197315c6d496bf17b6e7c195a786a0d51ee5fb1742418d297803f256bdf1",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -21751,7 +21751,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "d0331d8c9ced982c4f4f120ff9f89e016902a33baa0a36554bd3817ae93001e6"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -23014,7 +23014,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9345197315c6d496bf17b6e7c195a786a0d51ee5fb1742418d297803f256bdf1",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -23043,7 +23043,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "d0331d8c9ced982c4f4f120ff9f89e016902a33baa0a36554bd3817ae93001e6"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -24306,7 +24306,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9345197315c6d496bf17b6e7c195a786a0d51ee5fb1742418d297803f256bdf1",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -24335,7 +24335,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "d0331d8c9ced982c4f4f120ff9f89e016902a33baa0a36554bd3817ae93001e6"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -25598,7 +25598,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9345197315c6d496bf17b6e7c195a786a0d51ee5fb1742418d297803f256bdf1",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -25627,7 +25627,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "d0331d8c9ced982c4f4f120ff9f89e016902a33baa0a36554bd3817ae93001e6"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -26890,7 +26890,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9345197315c6d496bf17b6e7c195a786a0d51ee5fb1742418d297803f256bdf1",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -26919,7 +26919,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "d0331d8c9ced982c4f4f120ff9f89e016902a33baa0a36554bd3817ae93001e6"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -28235,7 +28235,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9345197315c6d496bf17b6e7c195a786a0d51ee5fb1742418d297803f256bdf1",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -28264,7 +28264,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "d0331d8c9ced982c4f4f120ff9f89e016902a33baa0a36554bd3817ae93001e6"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -29527,7 +29527,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9345197315c6d496bf17b6e7c195a786a0d51ee5fb1742418d297803f256bdf1",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -29556,7 +29556,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "d0331d8c9ced982c4f4f120ff9f89e016902a33baa0a36554bd3817ae93001e6"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",

--- a/docs/screenshots/eastbrook-vale-rebuild/polish/metadata/after-mobile-low.json
+++ b/docs/screenshots/eastbrook-vale-rebuild/polish/metadata/after-mobile-low.json
@@ -11,7 +11,7 @@
     "mode": "composite-sha256",
     "algorithm": "sha256",
     "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-    "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+    "fingerprint": "9345197315c6d496bf17b6e7c195a786a0d51ee5fb1742418d297803f256bdf1",
     "components": {
       "townAsset": {
         "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -40,7 +40,7 @@
         },
         "renderer": {
           "path": "src/render/renderer.ts",
-          "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+          "sha256": "d0331d8c9ced982c4f4f120ff9f89e016902a33baa0a36554bd3817ae93001e6"
         },
         "viewPriorityPolicy": {
           "path": "src/render/prewarm_policy.ts",
@@ -85,7 +85,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9345197315c6d496bf17b6e7c195a786a0d51ee5fb1742418d297803f256bdf1",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -114,7 +114,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "d0331d8c9ced982c4f4f120ff9f89e016902a33baa0a36554bd3817ae93001e6"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -1360,7 +1360,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9345197315c6d496bf17b6e7c195a786a0d51ee5fb1742418d297803f256bdf1",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -1389,7 +1389,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "d0331d8c9ced982c4f4f120ff9f89e016902a33baa0a36554bd3817ae93001e6"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -2635,7 +2635,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9345197315c6d496bf17b6e7c195a786a0d51ee5fb1742418d297803f256bdf1",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -2664,7 +2664,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "d0331d8c9ced982c4f4f120ff9f89e016902a33baa0a36554bd3817ae93001e6"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -3910,7 +3910,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9345197315c6d496bf17b6e7c195a786a0d51ee5fb1742418d297803f256bdf1",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -3939,7 +3939,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "d0331d8c9ced982c4f4f120ff9f89e016902a33baa0a36554bd3817ae93001e6"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -5185,7 +5185,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9345197315c6d496bf17b6e7c195a786a0d51ee5fb1742418d297803f256bdf1",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -5214,7 +5214,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "d0331d8c9ced982c4f4f120ff9f89e016902a33baa0a36554bd3817ae93001e6"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -6460,7 +6460,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9345197315c6d496bf17b6e7c195a786a0d51ee5fb1742418d297803f256bdf1",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -6489,7 +6489,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "d0331d8c9ced982c4f4f120ff9f89e016902a33baa0a36554bd3817ae93001e6"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -7735,7 +7735,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9345197315c6d496bf17b6e7c195a786a0d51ee5fb1742418d297803f256bdf1",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -7764,7 +7764,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "d0331d8c9ced982c4f4f120ff9f89e016902a33baa0a36554bd3817ae93001e6"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -9010,7 +9010,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9345197315c6d496bf17b6e7c195a786a0d51ee5fb1742418d297803f256bdf1",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -9039,7 +9039,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "d0331d8c9ced982c4f4f120ff9f89e016902a33baa0a36554bd3817ae93001e6"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -10285,7 +10285,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9345197315c6d496bf17b6e7c195a786a0d51ee5fb1742418d297803f256bdf1",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -10314,7 +10314,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "d0331d8c9ced982c4f4f120ff9f89e016902a33baa0a36554bd3817ae93001e6"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -11560,7 +11560,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9345197315c6d496bf17b6e7c195a786a0d51ee5fb1742418d297803f256bdf1",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -11589,7 +11589,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "d0331d8c9ced982c4f4f120ff9f89e016902a33baa0a36554bd3817ae93001e6"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -12835,7 +12835,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9345197315c6d496bf17b6e7c195a786a0d51ee5fb1742418d297803f256bdf1",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -12864,7 +12864,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "d0331d8c9ced982c4f4f120ff9f89e016902a33baa0a36554bd3817ae93001e6"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -14110,7 +14110,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9345197315c6d496bf17b6e7c195a786a0d51ee5fb1742418d297803f256bdf1",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -14139,7 +14139,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "d0331d8c9ced982c4f4f120ff9f89e016902a33baa0a36554bd3817ae93001e6"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -15385,7 +15385,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9345197315c6d496bf17b6e7c195a786a0d51ee5fb1742418d297803f256bdf1",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -15414,7 +15414,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "d0331d8c9ced982c4f4f120ff9f89e016902a33baa0a36554bd3817ae93001e6"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -16660,7 +16660,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9345197315c6d496bf17b6e7c195a786a0d51ee5fb1742418d297803f256bdf1",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -16689,7 +16689,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "d0331d8c9ced982c4f4f120ff9f89e016902a33baa0a36554bd3817ae93001e6"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -18900,7 +18900,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9345197315c6d496bf17b6e7c195a786a0d51ee5fb1742418d297803f256bdf1",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -18929,7 +18929,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "d0331d8c9ced982c4f4f120ff9f89e016902a33baa0a36554bd3817ae93001e6"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -20175,7 +20175,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9345197315c6d496bf17b6e7c195a786a0d51ee5fb1742418d297803f256bdf1",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -20204,7 +20204,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "d0331d8c9ced982c4f4f120ff9f89e016902a33baa0a36554bd3817ae93001e6"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -21450,7 +21450,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9345197315c6d496bf17b6e7c195a786a0d51ee5fb1742418d297803f256bdf1",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -21479,7 +21479,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "d0331d8c9ced982c4f4f120ff9f89e016902a33baa0a36554bd3817ae93001e6"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -22725,7 +22725,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9345197315c6d496bf17b6e7c195a786a0d51ee5fb1742418d297803f256bdf1",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -22754,7 +22754,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "d0331d8c9ced982c4f4f120ff9f89e016902a33baa0a36554bd3817ae93001e6"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -24000,7 +24000,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9345197315c6d496bf17b6e7c195a786a0d51ee5fb1742418d297803f256bdf1",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -24029,7 +24029,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "d0331d8c9ced982c4f4f120ff9f89e016902a33baa0a36554bd3817ae93001e6"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -25275,7 +25275,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9345197315c6d496bf17b6e7c195a786a0d51ee5fb1742418d297803f256bdf1",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -25304,7 +25304,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "d0331d8c9ced982c4f4f120ff9f89e016902a33baa0a36554bd3817ae93001e6"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -26550,7 +26550,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9345197315c6d496bf17b6e7c195a786a0d51ee5fb1742418d297803f256bdf1",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -26579,7 +26579,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "d0331d8c9ced982c4f4f120ff9f89e016902a33baa0a36554bd3817ae93001e6"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -27878,7 +27878,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9345197315c6d496bf17b6e7c195a786a0d51ee5fb1742418d297803f256bdf1",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -27907,7 +27907,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "d0331d8c9ced982c4f4f120ff9f89e016902a33baa0a36554bd3817ae93001e6"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
@@ -29153,7 +29153,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+        "fingerprint": "9345197315c6d496bf17b6e7c195a786a0d51ee5fb1742418d297803f256bdf1",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -29182,7 +29182,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+              "sha256": "d0331d8c9ced982c4f4f120ff9f89e016902a33baa0a36554bd3817ae93001e6"
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",

--- a/docs/screenshots/eastbrook-vale-rebuild/polish/performance/after-desktop-ultra-town.json
+++ b/docs/screenshots/eastbrook-vale-rebuild/polish/performance/after-desktop-ultra-town.json
@@ -14,7 +14,7 @@
     "mode": "composite-sha256",
     "algorithm": "sha256",
     "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-    "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+    "fingerprint": "9345197315c6d496bf17b6e7c195a786a0d51ee5fb1742418d297803f256bdf1",
     "components": {
       "townAsset": {
         "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -43,7 +43,7 @@
         },
         "renderer": {
           "path": "src/render/renderer.ts",
-          "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+          "sha256": "d0331d8c9ced982c4f4f120ff9f89e016902a33baa0a36554bd3817ae93001e6"
         },
         "viewPriorityPolicy": {
           "path": "src/render/prewarm_policy.ts",

--- a/docs/screenshots/eastbrook-vale-rebuild/polish/performance/after-mobile-low-town.json
+++ b/docs/screenshots/eastbrook-vale-rebuild/polish/performance/after-mobile-low-town.json
@@ -14,7 +14,7 @@
     "mode": "composite-sha256",
     "algorithm": "sha256",
     "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-    "fingerprint": "a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca",
+    "fingerprint": "9345197315c6d496bf17b6e7c195a786a0d51ee5fb1742418d297803f256bdf1",
     "components": {
       "townAsset": {
         "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -43,7 +43,7 @@
         },
         "renderer": {
           "path": "src/render/renderer.ts",
-          "sha256": "de89fd6900632eb9f5b0e43f40fa68e5c52bf2db7eaa3e2b90c1f1e9616911ca"
+          "sha256": "d0331d8c9ced982c4f4f120ff9f89e016902a33baa0a36554bd3817ae93001e6"
         },
         "viewPriorityPolicy": {
           "path": "src/render/prewarm_policy.ts",

--- a/src/render/characters/CLAUDE.md
+++ b/src/render/characters/CLAUDE.md
@@ -283,8 +283,11 @@ painted with a generated RGBA map.
   of non-skinned node names to KEEP; omit it for creatures (keeps everything).
 - Bone names are sanitized by GLTFLoader (`handslot.r` to `handslotr`); `attach`
   resolution tries both. A missing bone ships the model without the prop.
-- Geometries/materials are **shared per-asset caches and never disposed**;
-  `dispose()` only releases this clone's mixer + Skeletons. YOU MUST call it on
-  despawn (online interest churn strands GPU bone textures otherwise).
+- Geometries are **shared per-asset caches and never disposed**. Shared tinted
+  materials are claim-counted (`tinted_material_cache_core.ts`): `dispose()`
+  releases this clone's mixer + Skeletons + its tinted-material claims, and the
+  bounded cache disposes a clone only once no visual mounts it. YOU MUST call
+  `dispose()` on despawn (online interest churn strands GPU bone textures and
+  pins tinted materials otherwise).
 - Never `Math.random` in *sim*, but here it's fine, this is presentation
   (bob phase, hit-clip pick). Never reach past `IWorld` into a concrete world.

--- a/src/render/characters/assets.ts
+++ b/src/render/characters/assets.ts
@@ -75,6 +75,7 @@ import { weaponSkinAttachBone, weaponSkinHandling } from './skin_attack';
 import { optimizeSkinGpuLayout } from './skin_gpu_layout';
 import { primeSkinnedSortSpheres } from './skinned_sort_spheres';
 import { buildStubbleDecal, headNodeName } from './stubble';
+import { TINTED_MATERIAL_IDLE_CACHE_MAX, TintedMaterialCache } from './tinted_material_cache_core';
 import { variantGripTransform, WEAPON_GRIP_OVERRIDES } from './weapon_grip';
 import { markOwnedWeaponSkinMaterials } from './weapon_skin_materials';
 
@@ -980,8 +981,10 @@ function modularVariant(url: string, names: readonly string[]): THREE.Object3D {
 
 // Bounded, because a colour WHEEL is a continuous input: dragging it emits a
 // new hex every pointermove, and each distinct hex would otherwise strand a
-// material here forever (and a second one in tintedMaterial's cache, which is
-// keyed off this material's uuid). An LRU keeps a drag's worth of shades warm,
+// material here forever. (Its downstream twin in tintedMaterial's cache, keyed
+// off this material's uuid, becomes a dead-source entry when the LRU evicts
+// here; the tinted cache reclaims those through its own idle bound, see
+// tinted_material_cache_core.ts.) An LRU keeps a drag's worth of shades warm,
 // re-picking a recent colour is still free, and disposes what falls out.
 const RECOLOR_CACHE_MAX = 48;
 const recolorCache = new Map<string, THREE.Material>();
@@ -1611,10 +1614,17 @@ export function setWeaponsStowed(
 }
 
 // ---------------------------------------------------------------------------
-// Tinted material cache (shared across all instances; never disposed)
+// Tinted material cache (shared across all instances; claim-counted and
+// bounded, see tinted_material_cache_core.ts). Two visuals asking for the
+// same (source, tint, tier, atlases, role) still share one clone; a clone is
+// disposed only once nothing claims it (idle LRU overflow, or a profile
+// reset's retire-on-last-release), so eviction can never touch a material a
+// live mesh still mounts.
 // ---------------------------------------------------------------------------
 
-const matCache = new Map<string, THREE.Material>();
+const matCache = new TintedMaterialCache<THREE.Material>(TINTED_MATERIAL_IDLE_CACHE_MAX, (mat) =>
+  mat.dispose(),
+);
 const sourceMaterials = new WeakMap<THREE.Mesh, THREE.Material | THREE.Material[]>();
 const tintScratch = new THREE.Color();
 const lowReadabilityWhite = new THREE.Color(0xffffff);
@@ -1667,6 +1677,27 @@ function applyWeaponMaterialPolish(
   }
 }
 
+/**
+ * A lease of shared tinted-material cache keys. A material sweep passes its
+ * visual's lease so every cache entry it mounts stays claimed (pinned against
+ * eviction) until the visual releases the lease via releaseTintedMaterials
+ * (on the next full re-apply sweep, and at dispose). The set also makes
+ * claims idempotent per lease: a sweep meeting the same source material on
+ * several meshes claims its key once.
+ *
+ * A caller that passes NO lease (tests, tools) still shares the memoized
+ * clone, but its entry stays evictable: never mount a leaseless result on a
+ * long-lived mesh.
+ */
+export type TintedMaterialClaims = Set<string>;
+
+/** Release one lease's claims (see TintedMaterialClaims). Keys the cache no
+ *  longer tracks are a refused no-op, so a double release cannot underflow
+ *  another visual's pin. */
+export function releaseTintedMaterials(claims: Iterable<string>): void {
+  for (const key of claims) matCache.release(key);
+}
+
 export function tintedMaterial(
   src: THREE.Material,
   tint: number | null,
@@ -1674,19 +1705,48 @@ export function tintedMaterial(
   skinTex: THREE.Texture | null = null,
   emisTex: THREE.Texture | null = null,
   role: MaterialRole = 'body',
+  claims: TintedMaterialClaims | null = null,
 ): THREE.Material {
-  const key = `${src.uuid}|${tint ?? 'n'}|${tint === null ? 0 : strength}|${GFX.standardMaterials ? 's' : 'l'}|${skinTex ? skinTex.uuid : 'n'}|${emisTex ? emisTex.uuid : 'n'}|${role}`;
-  const cached = matCache.get(key);
-  if (cached) return cached;
-
   // A source with no color property (the weapon-skin fresnel shell's
   // ShaderMaterial) has nothing this factory can tint, lift, or polish.
   // Return it unchanged: cloning would detach the rig's live uniform handles
   // (its per-frame uTime/uStr writes would land on a material nothing
   // renders), and caching that clone would strand it forever.
   if (!(src as THREE.MeshStandardMaterial).color) return src;
+  const key = `${src.uuid}|${tint ?? 'n'}|${tint === null ? 0 : strength}|${GFX.standardMaterials ? 's' : 'l'}|${skinTex ? skinTex.uuid : 'n'}|${emisTex ? emisTex.uuid : 'n'}|${role}`;
+  const build = () =>
+    buildTintedClone(src as THREE.MeshStandardMaterial, tint, strength, skinTex, emisTex, role);
+  if (claims) {
+    if (claims.has(key)) {
+      // This lease already claimed the key (the same source material on an
+      // earlier mesh of the sweep): serve the held clone without a second
+      // claim, keeping claims and releases exactly paired per lease.
+      const held = matCache.peek(key);
+      if (held) return held;
+    }
+    claims.add(key);
+    return matCache.claim(key, build);
+  }
+  // Leaseless: share the memo and stay warm, but hold no claim (claim then
+  // release parks the entry at the idle tail). Every production mount path
+  // leases; see TintedMaterialClaims.
+  const mat = matCache.claim(key, build);
+  matCache.release(key);
+  return mat;
+}
 
-  const s = src as THREE.MeshStandardMaterial;
+/** The tinted-clone derivation: a pure function of its arguments plus the
+ *  static graphics tier, which is why an evicted cache entry rebuilds
+ *  identically on the next request (see tinted_material_cache_core.ts). */
+function buildTintedClone(
+  s: THREE.MeshStandardMaterial,
+  tint: number | null,
+  strength: number,
+  skinTex: THREE.Texture | null,
+  emisTex: THREE.Texture | null,
+  role: MaterialRole,
+): THREE.Material {
+  const src: THREE.Material = s;
   let mat: THREE.MeshStandardMaterial | THREE.MeshLambertMaterial | THREE.MeshBasicMaterial;
   if (GFX.standardMaterials) {
     mat = s.clone();
@@ -1714,7 +1774,7 @@ export function tintedMaterial(
     if ((src as THREE.MeshBasicMaterial).isMeshBasicMaterial) {
       mat = (src as THREE.MeshBasicMaterial).clone();
     } else {
-      // low tier: Lambert with the same texture map — no PBR, no rim
+      // low tier: Lambert with the same texture map (no PBR, no rim)
       mat = new THREE.MeshLambertMaterial({
         map: s.map ?? null,
         color: s.color ? s.color.clone() : new THREE.Color(0xffffff),
@@ -1735,7 +1795,7 @@ export function tintedMaterial(
     }
   }
   if (tint !== null) {
-    // subtle pull toward the template color — hard multiplies turn the
+    // subtle pull toward the template color: hard multiplies turn the
     // hand-painted textures muddy
     mat.color.lerp(tintScratch.set(tint), strength);
   }
@@ -1760,7 +1820,6 @@ export function tintedMaterial(
     std.roughness = Math.min(Math.max(std.roughness, 0.55), 0.9);
   }
   if (!GFX.standardMaterials) applyLowReadabilityLift(mat, role);
-  matCache.set(key, mat);
   return mat;
 }
 
@@ -1770,13 +1829,17 @@ function tintFor(def: VisualDef, entityColor: number): number | null {
 }
 
 /** Swap every mesh material in an assembled clone for the shared tinted
- *  (and tier-appropriate) variant. Returns nothing — mutates the clone. */
+ *  (and tier-appropriate) variant. Returns nothing, mutates the clone. Pass
+ *  the owning visual's `claims` lease so every mounted cache entry stays
+ *  pinned against eviction until the visual releases it (see
+ *  TintedMaterialClaims). */
 export function applyMaterials(
   root: THREE.Object3D,
   def: VisualDef,
   entityColor: number,
   skinTex: THREE.Texture | null = null,
   emisTex: THREE.Texture | null = null,
+  claims: TintedMaterialClaims | null = null,
 ): void {
   const tint = tintFor(def, entityColor);
   const strength = def.tintStrength ?? DEFAULT_TINT_STRENGTH;
@@ -1804,9 +1867,11 @@ export function applyMaterials(
     const sk = skinTex && mesh.userData.bodyMesh ? skinTex : null;
     const em = emisTex && mesh.userData.bodyMesh ? emisTex : null;
     if (Array.isArray(source)) {
-      mesh.material = source.map((m) => tintedMaterial(m, materialTint, strength, sk, em, role));
+      mesh.material = source.map((m) =>
+        tintedMaterial(m, materialTint, strength, sk, em, role, claims),
+      );
     } else {
-      mesh.material = tintedMaterial(source, materialTint, strength, sk, em, role);
+      mesh.material = tintedMaterial(source, materialTint, strength, sk, em, role, claims);
     }
   });
 }
@@ -1824,11 +1889,20 @@ export function tintedFarMaterials(
   isBody: boolean[],
   skinTex: THREE.Texture | null = null,
   emisTex: THREE.Texture | null = null,
+  claims: TintedMaterialClaims | null = null,
 ): THREE.Material[] {
   const tint = tintFor(def, entityColor);
   const strength = def.tintStrength ?? DEFAULT_TINT_STRENGTH;
   return srcMats.map((m, i) =>
-    tintedMaterial(m, tint, strength, isBody[i] ? skinTex : null, isBody[i] ? emisTex : null),
+    tintedMaterial(
+      m,
+      tint,
+      strength,
+      isBody[i] ? skinTex : null,
+      isBody[i] ? emisTex : null,
+      'body',
+      claims,
+    ),
   );
 }
 
@@ -1860,12 +1934,24 @@ export interface PreparedVisual {
 
 const prepared = new Map<string, PreparedVisual>();
 
-/** Drop profile-derived character templates/materials while retaining loaded source assets. */
+/** Drop profile-derived character templates/materials while retaining loaded
+ *  source assets. The tinted-material cache resets rather than clears: idle
+ *  clones dispose now, and any clone a not-yet-torn-down visual still mounts
+ *  is retired to dispose on that visual's release instead of leaking (see
+ *  tinted_material_cache_core.ts). In the graphics-rebuild flow every visual
+ *  is already disposed before this runs, so normally everything disposes
+ *  here. */
 export function resetCharacterProfileCaches(): void {
   optimizedSceneCache.clear();
-  matCache.clear();
+  matCache.reset();
   prepared.clear();
 }
+
+/** Test-only observation window into the shared tinted-material cache. */
+export const tintedMaterialInternalsForTest = {
+  cacheSize: (): number => matCache.size,
+  cacheIdleSize: (): number => matCache.idleSize,
+};
 
 export function prepareVisual(key: string): PreparedVisual {
   const hit = prepared.get(key);

--- a/src/render/characters/tinted_material_cache_core.ts
+++ b/src/render/characters/tinted_material_cache_core.ts
@@ -1,0 +1,155 @@
+// The bounded, claim-counted store behind the shared tinted-material cache
+// (characters/assets.ts tintedMaterial). Pure bookkeeping: no Three, no DOM,
+// no clock; values are opaque to this core (the caller hands in material
+// clones and an onEvict that owns their disposal).
+//
+// Why bounded: the tinted-material memo used to retain every clone ever built
+// for the renderer's whole lifetime. Its keys embed the SOURCE material's
+// uuid, so an entry whose source is gone (the recolour LRU disposing a
+// colour-wheel shade, a profile reset dropping the optimized-scene cache) can
+// never be requested again and used to sit stranded until page unload (the C3
+// memory ratchet). C1's acquire-time retint added a second arm: every
+// distinct rift color mints one tinted-clone set per source material, so
+// colors cycling through the visual pool grew the cache without bound.
+//
+// The policy mirrors the C2 emissive-derivation core (weapon_vfx_emissive_
+// cache_core.ts): a mounted clone is pinned by its claims and is NEVER
+// evicted, so eviction cannot change what is on screen. When the last claim
+// releases, the entry joins the idle tail (warm for the next same-key
+// request) until more than `maxIdle` idle entries exist; the
+// least-recently-released idle entries then evict through `onEvict`. A
+// live-source key rebuilds identically on its next request (the tinted clone
+// is a pure function of source + tint + tier + atlases + role), so eviction
+// is invisible apart from the rebuild cost; a dead-source key is simply never
+// requested again, which is exactly what makes its idle eviction the
+// reclamation.
+//
+// Liveness argument, spelled out once: disposal happens only in `onEvict`,
+// `onEvict` runs only on entries with zero claims, and every mount of a
+// cached clone on a mesh holds a claim for as long as the mount can exist
+// (CharacterVisual's material sweeps claim into a lease before mounting and
+// release the previous lease only after the sweep replaced every mount; see
+// visual.ts). Zero claims therefore implies no live mesh mounts the value.
+//
+// Linear scans are fine at this scale: claim/release run on visual
+// build/re-tint/teardown (entity stream-in/out, skin/weapon swaps), never per
+// frame, and the entry count is bounded by live mounts plus the idle bound.
+
+/** Idle entries (no live claim) the tinted-material store keeps warm. Live
+ *  mounts are pinned on top of this. Each entry is one material clone (cheap
+ *  CPU-side, and its shader program is shared with the live tints of the same
+ *  source), so the bound is generous: it covers several full rigs' worth of
+ *  clones so despawn/respawn churn stays warm, and only has to make dead-key
+ *  and stale-rift-color residue finite, not tight. */
+export const TINTED_MATERIAL_IDLE_CACHE_MAX = 64;
+
+interface TintedEntry<V> {
+  value: V;
+  claims: number;
+  /** Set by reset(): the entry belongs to a retired generation (profile
+   *  reset), so it disposes on its last release instead of idling warm. A
+   *  fresh claim un-retires it (it is demonstrably live again). */
+  retired: boolean;
+}
+
+export class TintedMaterialCache<V> {
+  /** Insertion order doubles as the eviction order: an entry is re-inserted
+   *  the moment it becomes idle, so iteration meets idle entries
+   *  least-recently-released first. */
+  private entries = new Map<string, TintedEntry<V>>();
+  private readonly maxIdle: number;
+
+  constructor(
+    maxIdle: number,
+    private readonly onEvict: (value: V) => void,
+  ) {
+    // Fail closed: an invalid bound retains nothing idle rather than
+    // everything (the ratchet this cache exists to prevent).
+    this.maxIdle = Number.isFinite(maxIdle) ? Math.max(0, Math.floor(maxIdle)) : 0;
+  }
+
+  get size(): number {
+    return this.entries.size;
+  }
+
+  get idleSize(): number {
+    let idle = 0;
+    for (const entry of this.entries.values()) {
+      if (entry.claims === 0) idle++;
+    }
+    return idle;
+  }
+
+  /** The stored value for `key` without touching claims or recency, or
+   *  undefined. For lease-idempotent re-reads (a sweep meeting the same
+   *  source material on a second mesh). */
+  peek(key: string): V | undefined {
+    return this.entries.get(key)?.value;
+  }
+
+  /** The memoized value for `key`, building it cold on a miss; either way the
+   *  caller now holds one claim and owes exactly one `release`. */
+  claim(key: string, build: () => V): V {
+    const entry = this.entries.get(key);
+    if (entry) {
+      entry.claims++;
+      entry.retired = false;
+      return entry.value;
+    }
+    const value = build();
+    this.entries.set(key, { value, claims: 1, retired: false });
+    return value;
+  }
+
+  /**
+   * Drop one claim. Returns false (a refused no-op) for an unknown key or an
+   * entry with no live claims: a double-released lease must not underflow
+   * another mount's pin. When the last claim goes, a retired entry disposes
+   * immediately; a live-generation entry moves to the back of the eviction
+   * order and the idle overflow (if any) evicts oldest first through
+   * `onEvict`.
+   */
+  release(key: string): boolean {
+    const entry = this.entries.get(key);
+    if (!entry || entry.claims === 0) return false;
+    entry.claims--;
+    if (entry.claims > 0) return true;
+    this.entries.delete(key);
+    if (entry.retired) {
+      this.onEvict(entry.value);
+      return true;
+    }
+    this.entries.set(key, entry);
+    this.evictIdleOverflow();
+    return true;
+  }
+
+  /** Profile reset: dispose every idle entry now and retire the claimed ones,
+   *  so each disposes the moment its last mount releases (never while
+   *  mounted). Claimed entries stay servable in the meantime, and a re-claim
+   *  un-retires (see TintedEntry.retired). */
+  reset(): void {
+    for (const [key, entry] of this.entries) {
+      if (entry.claims === 0) {
+        this.entries.delete(key);
+        this.onEvict(entry.value);
+      } else {
+        entry.retired = true;
+      }
+    }
+  }
+
+  private evictIdleOverflow(): void {
+    let idle = 0;
+    for (const entry of this.entries.values()) {
+      if (entry.claims === 0) idle++;
+    }
+    for (const [key, entry] of this.entries) {
+      if (idle <= this.maxIdle) return;
+      if (entry.claims > 0) continue;
+      this.entries.delete(key);
+      this.onEvict(entry.value);
+      idle--;
+    }
+  }
+}

--- a/src/render/characters/visual.ts
+++ b/src/render/characters/visual.ts
@@ -1490,6 +1490,17 @@ export class CharacterVisual {
       this.tintedRigClaims,
     );
     releaseTintedMaterials(prevRigClaims);
+    // The per-effect clone maps (ghost/soul-rend/shadowform/moonkin/
+    // metamorph/rune-tint/aura-glow) key by SOURCE material, and this sweep
+    // just swapped every source (a new entity color or skin atlas), so
+    // clones derived from the old sources are unreachable from here on.
+    // Dispose them now, in the same synchronous pass that unmounts them (no
+    // render in between, the rune-chain precedent); the applyVisualMaterials
+    // call below re-derives any active overlay from the new sources, so a
+    // live effect survives the swap. Without this, a pooled visual
+    // accumulated one clone set per rift color worn (the maps only emptied
+    // in dispose()).
+    this.disposeEffectMaterials();
     // re-snapshot the material map ghost/restore relies on, then re-ghost if stealthed
     this.originalMaterials.clear();
     this.model.traverse((o) => {

--- a/src/render/characters/visual.ts
+++ b/src/render/characters/visual.ts
@@ -1,8 +1,10 @@
 // Per-entity character visual: a SkeletonUtils clone of a manifest asset with
 // its own AnimationMixer, a clip-driven state machine fed by renderer-derived
 // state, a baked static idle-pose far LOD, and a shadow-only proxy for the
-// mid-distance band. All geometry/materials are shared caches, dispose()
-// only releases mixer bindings.
+// mid-distance band. All geometry/materials are shared caches; dispose()
+// releases mixer bindings, this clone's Skeletons, and the visual's claims
+// on the shared tinted-material cache (which disposes a clone only once no
+// visual mounts it).
 import * as THREE from 'three';
 import { offhandMirrorsWeaponSkin } from '../../sim/content/weapon_skin_rules';
 import { WEAPON_SKINS } from '../../sim/content/weapon_skins';
@@ -37,11 +39,13 @@ import {
   assembleModel,
   ensureSkinTexture,
   prepareVisual,
+  releaseTintedMaterials,
   setHeldOffhand,
   setHeldWeapon,
   setWeaponsStowed,
   skinEmissiveTexture,
   skinTexture,
+  type TintedMaterialClaims,
   tintedFarMaterials,
 } from './assets';
 import { HairSwayDriver } from './hair_sway';
@@ -443,8 +447,19 @@ export class CharacterVisual {
   private metamorphMaterials = new Map<THREE.Material, THREE.Material>();
   // Thornhollow Fields rune buffs: a slight whole-body lean toward the rune's color
   // (weakest treatment: every form/death tint above wins). Keyed per source
-  // material AND color, since the wearer can chain different runes.
-  private runeTintMaterials = new Map<string, THREE.Material>();
+  // material, one clone each (the live rune color rides the clone's userData);
+  // chaining to a different rune replaces and disposes the old clone inside
+  // the same applyVisualMaterials sweep that unmounts it, and dispose()
+  // releases whatever remains, so rune wear can never strand materials.
+  private runeTintMaterials = new Map<THREE.Material, THREE.Material>();
+  // Leases over the shared tinted-material cache (assets.ts): every cache
+  // clone mounted on the rig (and, separately, on the far LOD) stays claimed
+  // through these sets so the cache can never dispose a mounted material. A
+  // full re-apply sweep claims into a fresh lease first and releases the old
+  // one after (shared keys never dip to zero claims mid-swap); dispose()
+  // releases both.
+  private tintedRigClaims: TintedMaterialClaims = new Set();
+  private tintedFarClaims: TintedMaterialClaims = new Set();
   // Ability VFX body glow (the gallery rim read): per-visual material clones
   // carrying an emissive tint while a spec'd cast or buff aura is live. Cloned
   // once per original because base materials are SHARED per-asset caches;
@@ -571,6 +586,7 @@ export class CharacterVisual {
       entityColor,
       skinTexture(key, skinIndex),
       skinEmissiveTexture(key, skinIndex),
+      this.tintedRigClaims,
     );
     // Class halo (the priest's Light): a glowing ring behind the head bone.
     // Added AFTER applyMaterials (its additive material must not be re-mapped)
@@ -622,6 +638,7 @@ export class CharacterVisual {
           prep.idleSrcIsBody,
           skinTexture(key, skinIndex),
           skinEmissiveTexture(key, skinIndex),
+          this.tintedFarClaims,
         ),
       );
       this.farMaterials = this.farMesh.material;
@@ -1416,6 +1433,22 @@ export class CharacterVisual {
     }
   }
 
+  /** Re-tint this visual for a new owner entity (pooled reuse across per-instance
+   *  colors: rift spawns jitter mob.color per instance, so the reuse-pool key is
+   *  per-template and color is applied at acquire time; see
+   *  characters/visual_pool.ts). Runs the same shared-material sweep setSkin
+   *  does, so the reused visual picks the exact tinted-material clones a fresh
+   *  construction with this color would, re-snapshots the ghost/restore map, and
+   *  re-applies any active overlay. No-op when the color already matches; a def
+   *  that ignores entity color (fixed or absent tint) only records the new
+   *  color, because no material reads it. */
+  setEntityColor(color: number): void {
+    if (color === this.entityColor) return;
+    this.entityColor = color;
+    if (this.def.tint !== 'entity') return;
+    this.applySkinMaterials(this.skinIndex);
+  }
+
   /** Swap the body skin (alternate texture atlas) at runtime; no-op if unchanged.
    *  Reuses the shared skin-keyed material cache, so this is a cheap reassign. */
   setSkin(skinIndex: number): void {
@@ -1441,13 +1474,22 @@ export class CharacterVisual {
   }
 
   private applySkinMaterials(skinIndex: number): void {
+    // Full-rig sweep: claim the new material set into a fresh lease BEFORE
+    // releasing the old one, so a key kept across the swap (same source, same
+    // tint) never dips to zero claims and can never be evicted mid-swap. Old
+    // keys nothing re-claimed (a previous entity color's tints, a previous
+    // skin's atlas variants) go idle and age out of the shared cache.
+    const prevRigClaims = this.tintedRigClaims;
+    this.tintedRigClaims = new Set();
     applyMaterials(
       this.model,
       this.def,
       this.entityColor,
       skinTexture(this.key, skinIndex),
       skinEmissiveTexture(this.key, skinIndex),
+      this.tintedRigClaims,
     );
+    releaseTintedMaterials(prevRigClaims);
     // re-snapshot the material map ghost/restore relies on, then re-ghost if stealthed
     this.originalMaterials.clear();
     this.model.traverse((o) => {
@@ -1466,6 +1508,8 @@ export class CharacterVisual {
     // pop reverts to the model's embedded default skin.
     if (this.farMesh) {
       const prep = prepareVisual(this.key);
+      const prevFarClaims = this.tintedFarClaims;
+      this.tintedFarClaims = new Set();
       this.farMaterials = tintedFarMaterials(
         this.def,
         this.entityColor,
@@ -1473,7 +1517,9 @@ export class CharacterVisual {
         prep.idleSrcIsBody,
         skinTexture(this.key, skinIndex),
         skinEmissiveTexture(this.key, skinIndex),
+        this.tintedFarClaims,
       );
+      releaseTintedMaterials(prevFarClaims);
     }
     this.applyVisualMaterials();
   }
@@ -1519,12 +1565,17 @@ export class CharacterVisual {
     );
     for (const payload of payloads) {
       configureTightBoneTextures(payload);
+      // Payload-subtree sweep: claim ADDITIVELY into the live rig lease (the
+      // rest of the rig keeps its mounts). Keys of the removed offhand's
+      // materials overstay in the lease until the next full sweep or dispose;
+      // an overstay only pins, it can never dispose a mounted material.
       applyMaterials(
         payload,
         this.def,
         this.entityColor,
         skinTexture(this.key, this.skinIndex),
         skinEmissiveTexture(this.key, this.skinIndex),
+        this.tintedRigClaims,
       );
     }
     this.originalMaterials.clear();
@@ -1614,13 +1665,20 @@ export class CharacterVisual {
           }))
         : [];
     }
+    // Full-rig sweep (the whole model graph, weapon meshes included): swap
+    // the rig lease like applySkinMaterials does, so the removed weapon's
+    // material claims release and can age out of the shared cache.
+    const prevRigClaims = this.tintedRigClaims;
+    this.tintedRigClaims = new Set();
     applyMaterials(
       this.model,
       this.def,
       this.entityColor,
       skinTexture(this.key, this.skinIndex),
       skinEmissiveTexture(this.key, this.skinIndex),
+      this.tintedRigClaims,
     );
+    releaseTintedMaterials(prevRigClaims);
     // A VFX-tier skin's emissive derive mutates its payload materials in place,
     // so give each payload exclusive clones BEFORE the caster snapshot: the
     // shared tinted-material cache must never carry derived state (two players
@@ -1859,6 +1917,7 @@ export class CharacterVisual {
       this.shadowformMaterials,
       this.moonkinMaterials,
       this.metamorphMaterials,
+      this.runeTintMaterials,
       this.auraGlowMaterials,
     ]);
   }
@@ -1870,6 +1929,7 @@ export class CharacterVisual {
       ...this.shadowformMaterials.values(),
       ...this.moonkinMaterials.values(),
       ...this.metamorphMaterials.values(),
+      ...this.runeTintMaterials.values(),
       ...this.auraGlowMaterials.values(),
     ]);
     for (const material of materials) material.dispose();
@@ -1878,6 +1938,7 @@ export class CharacterVisual {
     this.shadowformMaterials.clear();
     this.moonkinMaterials.clear();
     this.metamorphMaterials.clear();
+    this.runeTintMaterials.clear();
     this.auraGlowMaterials.clear();
   }
 
@@ -1969,14 +2030,24 @@ export class CharacterVisual {
     this.disposeWeaponVfx();
     this.disposeWeaponSkinMaterials();
     this.disposeEffectMaterials();
+    // Release the shared tinted-material leases (never disposing directly:
+    // another visual may still mount the same clones; the shared cache
+    // disposes an entry only once nothing claims it). Cleared so a double
+    // dispose cannot release another visual's claims.
+    releaseTintedMaterials(this.tintedRigClaims);
+    this.tintedRigClaims.clear();
+    releaseTintedMaterials(this.tintedFarClaims);
+    this.tintedFarClaims.clear();
     this.mixer.stopAllAction();
     this.mixer.uncacheRoot(this.model);
     this.skeletonUpdates.dispose();
     this.root.removeFromParent();
     // SkeletonUtils.clone gives each instance exclusive Skeletons whose GPU
     // bone textures the renderer allocates lazily, release them here or
-    // online interest churn strands one per despawned entity. Geometries and
-    // materials remain shared per-asset caches and are never disposed.
+    // online interest churn strands one per despawned entity. Geometries
+    // remain shared per-asset caches and are never disposed; shared tinted
+    // materials were claim-released above and dispose through the bounded
+    // cache once no visual mounts them.
     const skeletons = new Set<THREE.Skeleton>();
     this.model.traverse((o) => {
       const sm = o as THREE.SkinnedMesh;
@@ -2062,10 +2133,18 @@ export class CharacterVisual {
   }
 
   private runeTintMaterial(material: THREE.Material, tint: number): THREE.Material {
-    const key = `${tint}:${material.uuid}`;
-    const cached = this.runeTintMaterials.get(key);
-    if (cached) return cached;
+    const cached = this.runeTintMaterials.get(material);
+    if (cached && cached.userData.runeTintHex === tint) return cached;
+    // Chained to a different rune color: replace the clone and dispose the
+    // old one. Safe because every runeTintMaterial call happens inside an
+    // applyVisualMaterials sweep, and a tint change reaches here only while
+    // that sweep is rewriting every mount of the old clone (same synchronous
+    // pass, no render in between), so disposal lands exactly as the material
+    // is unmounted, and the map stays at one clone per source instead of one
+    // per (source, color) forever.
+    cached?.dispose();
     const marked = material.clone();
+    marked.userData.runeTintHex = tint;
     const withColor = marked as THREE.Material & {
       color?: THREE.Color;
       emissive?: THREE.Color;
@@ -2078,7 +2157,7 @@ export class CharacterVisual {
       withColor.emissive.setHex(tint);
       withColor.emissiveIntensity = 0.18;
     }
-    this.runeTintMaterials.set(key, marked);
+    this.runeTintMaterials.set(material, marked);
     return marked;
   }
 

--- a/src/render/characters/visual_pool.ts
+++ b/src/render/characters/visual_pool.ts
@@ -1,0 +1,111 @@
+// The character-visual reuse pool: the pure pool-key normalization plus a
+// bounded, release-ordered (LRU) store. Extracted from renderer.ts so a plain
+// Vitest drives the key rules, the bound, the eviction order, and the disposal
+// contract directly (tests/character_visual_pool.test.ts); the renderer stays
+// a thin consumer.
+import type { Entity } from '../../sim/types';
+import { shouldRetainPooledCharacterVisual } from './visual_pool_policy';
+
+/** The one surface the pool needs from a pooled visual. Kept minimal (and
+ *  Three-free) so tests exercise the pool with plain stubs. */
+export interface PoolableVisual {
+  dispose(): void;
+}
+
+/**
+ * The normalized reuse-pool key for an entity's character visual, or null for
+ * a kind that never pools. Players are deliberately excluded (their visual key
+ * varies with cosmetics/mech state; diagnosis item A6, not handled here).
+ *
+ * The key is the entity's TEMPLATE identity only. Per-instance presentation
+ * attributes stay OUT of the key on purpose:
+ * - `color` and `scale` are instance attributes. Rift spawns re-grade both per
+ *   instance (src/sim/rift/runs.ts: a deterministic sim-rng jitter stored on
+ *   the entity, so it reaches every host identically over the wire). A key
+ *   carrying them can never match a future request, so every despawned rift
+ *   mob minted a dead pool entry that sat retained until profile reset (the
+ *   C1 memory ratchet). Scale is applied at the view group
+ *   (group.scale.setScalar(e.scale)) and color at acquire time
+ *   (CharacterVisual.setEntityColor), so pooled reuse renders identically.
+ * - NPC `skin` STAYS in the key: it picks a texture atlas at construction and
+ *   the per-frame diff only reacts to live changes, so a cross-skin reuse
+ *   would keep the wrong atlas. The skin set is small and static, so keys
+ *   stay bounded.
+ */
+export function characterVisualPoolKey(
+  e: Pick<Entity, 'kind' | 'templateId' | 'skin'>,
+): string | null {
+  if (e.kind === 'mob') return `mob:${e.templateId}`;
+  if (e.kind === 'npc') return `npc:${e.templateId}:${e.skin}`;
+  return null;
+}
+
+interface PoolEntry<V> {
+  key: string;
+  visual: V;
+}
+
+/**
+ * Release-ordered bounded pool: entries[0] is the least-recently-released
+ * visual. `store` evicts (and DISPOSES) least-recently-released entries until
+ * the incoming visual fits, so the pool can never grow past the cap while the
+ * hottest working set stays resident. Eviction only ever touches detached,
+ * off-screen visuals (the renderer removes a visual from the scene before
+ * storing it), and an evicted key simply misses on its next request and
+ * rebuilds from the live entity: eviction is invisible on screen.
+ *
+ * Linear scans are fine at pool scale (the cap is
+ * GFX.maxPooledCharacterVisuals, low hundreds at most): take/store run on
+ * entity stream-in/out, not per frame per entity.
+ */
+export class CharacterVisualPool<V extends PoolableVisual> {
+  private entries: PoolEntry<V>[] = [];
+
+  get size(): number {
+    return this.entries.length;
+  }
+
+  /** The most-recently-released visual pooled under `key`, or null on a miss. */
+  take(key: string): V | null {
+    for (let i = this.entries.length - 1; i >= 0; i--) {
+      if (this.entries[i].key === key) {
+        const [entry] = this.entries.splice(i, 1);
+        return entry.visual;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Pool `visual` under `key`, evicting and disposing least-recently-released
+   * entries until the pool respects `maxEntries` (the live GFX cap, passed per
+   * call so a profile change applies immediately). An invalid or non-positive
+   * cap disposes the incoming visual instead of pooling it (fail closed,
+   * matching shouldRetainPooledCharacterVisual). Returns how many visuals were
+   * disposed.
+   */
+  store(key: string, visual: V, maxEntries: number): number {
+    if (!shouldRetainPooledCharacterVisual(0, maxEntries)) {
+      visual.dispose();
+      return 1;
+    }
+    let disposed = 0;
+    while (!shouldRetainPooledCharacterVisual(this.entries.length, maxEntries)) {
+      const oldest = this.entries.shift();
+      if (!oldest) break;
+      oldest.visual.dispose();
+      disposed++;
+    }
+    this.entries.push({ key, visual });
+    return disposed;
+  }
+
+  /** Empty the pool and hand every visual back (release order preserved).
+   *  Disposal stays with the caller: the renderer's terminal teardown wraps
+   *  each dispose in its best-effort guard. */
+  drain(): V[] {
+    const drained = this.entries.map((entry) => entry.visual);
+    this.entries = [];
+    return drained;
+  }
+}

--- a/src/render/characters/visual_pool_policy.ts
+++ b/src/render/characters/visual_pool_policy.ts
@@ -1,7 +1,10 @@
 /**
- * Inactive CharacterVisual instances retain a unique Skeleton and its GPU bone texture. Desktop
- * keeps the historical unbounded reuse pool to avoid travel hitches; a finite residency profile
- * disposes overflow so visiting new populations cannot grow GPU memory monotonically.
+ * Bounded-retention check shared by the render reuse pools: true while `currentCount` leaves
+ * room under `maxCount`. Inactive CharacterVisual instances retain a unique Skeleton and its
+ * GPU bone texture, so a finite cap disposes overflow and visiting new populations cannot grow
+ * GPU memory monotonically. Infinity means unbounded (the ground-object pool's desktop
+ * configuration); a non-finite or non-positive cap fails closed. The character-visual pool
+ * layers least-recently-released eviction on top of this predicate (visual_pool.ts).
  */
 export function shouldRetainPooledCharacterVisual(currentCount: number, maxCount: number): boolean {
   if (!Number.isFinite(currentCount) || currentCount < 0) return false;

--- a/src/render/foliage.ts
+++ b/src/render/foliage.ts
@@ -97,6 +97,7 @@ import {
   type GfxSettings,
   sharedUniforms,
 } from './gfx';
+import { runSlicedBuild } from './grass_build_slicer_core';
 import {
   type GrassCapCollapseBand,
   grassCapCollapseBand,
@@ -2353,6 +2354,8 @@ interface GrassChunk {
   centerZ: number;
   ready: boolean;
   queued: boolean;
+  /** True while a sliced build for this chunk is in flight across frames. */
+  building: boolean;
   lastSeen: number;
   lastUsed: number;
   prioritySq: number;
@@ -2362,6 +2365,14 @@ interface GrassChunk {
   flowerMesh?: THREE.InstancedMesh;
   flowerFullCount?: number;
   flowerTransitionCarry: number;
+}
+
+// The under-construction meshes of a sliced chunk build. They are parented
+// only in the finalize step, so a paused build never renders half-built; an
+// abandoned build releases them through this handle.
+interface GrassChunkPartialMeshes {
+  im: THREE.InstancedMesh | null;
+  fm: THREE.InstancedMesh | null;
 }
 
 // Tags every vertex of a tuft/flower card part with the aCap attribute the
@@ -2596,7 +2607,13 @@ function emptyGrassStats(
   return stats;
 }
 
-function buildGrassRing(parent: THREE.Group, seed: number): GrassRing {
+function buildGrassRing(
+  parent: THREE.Group,
+  seed: number,
+  // Injected so tests can drive the build budget with a fake clock; production
+  // always uses the real frame clock via the default.
+  now: () => number = () => performance.now(),
+): GrassRing {
   const baseRadius = GFX.grassRadius;
   const step = GFX.grassStep;
   const chunkCells = Math.ceil(GRASS_CHUNK_SIZE / step) + 3;
@@ -2806,6 +2823,7 @@ function buildGrassRing(parent: THREE.Group, seed: number): GrassRing {
       centerZ: chunkCenter(cz),
       ready: false,
       queued: false,
+      building: false,
       lastSeen: -1,
       lastUsed: -1,
       prioritySq: Infinity,
@@ -2817,13 +2835,24 @@ function buildGrassRing(parent: THREE.Group, seed: number): GrassRing {
   };
 
   const queueChunk = (chunk: GrassChunk): void => {
-    if (chunk.ready || chunk.queued) return;
+    if (chunk.ready || chunk.queued || chunk.building) return;
     chunk.queued = true;
     buildQueue.push(chunk);
   };
 
-  const buildChunk = (chunk: GrassChunk): void => {
-    const started = performance.now();
+  // A chunk build is a resumable generator: each yield marks a sub-unit
+  // boundary (setup, then one grid row per sub-unit, then finalize), and
+  // buildQueuedChunks below checks the frame budget BEFORE resuming each
+  // sub-unit. The rows a chunk produces depend only on chunk coordinates,
+  // seed, and the static tables (no clock reads between yields), so the
+  // finished geometry is byte-identical however the frames divide the work;
+  // only WHEN the rows run moves. `partial` exposes the under-construction
+  // meshes so an abandoned build can release them (they are parented only in
+  // the finalize step, so a paused chunk never renders half-built).
+  const buildChunk = function* (
+    chunk: GrassChunk,
+    partial: GrassChunkPartialMeshes,
+  ): Generator<undefined, void, undefined> {
     let n = 0;
     const chunkBiome = zoneBiomeAt(chunk.centerX, chunk.centerZ);
     // dense-grass biomes get a matching buffer so the extra tufts are never
@@ -2836,6 +2865,7 @@ function buildGrassRing(parent: THREE.Group, seed: number): GrassRing {
     im.frustumCulled = true;
     im.receiveShadow = true; // tufts must darken inside canopy shade, not glow through it
     im.count = 0;
+    partial.im = im;
     const fieldChunk = FIELD_BIOMES.has(chunkBiome);
     // a gale chunk that reaches the stable paddock's bloom band needs a
     // field-sized buffer, or the band's drifts hit the cap and vanish
@@ -2868,6 +2898,7 @@ function buildGrassRing(parent: THREE.Group, seed: number): GrassRing {
     fm.frustumCulled = true;
     fm.receiveShadow = true;
     fm.count = 0;
+    partial.fm = fm;
     let fn = 0;
 
     const minX = chunk.cx * GRASS_CHUNK_SIZE;
@@ -2895,6 +2926,7 @@ function buildGrassRing(parent: THREE.Group, seed: number): GrassRing {
             mw.x + mw.r > minX && mw.x - mw.r < maxX && mw.z + mw.r > minZ && mw.z - mw.r < maxZ,
         )
       : [];
+    yield; // setup (buffer allocation + chunk classification) is one sub-unit
 
     for (let i = i0; i <= i1 && n < chunkCap; i++) {
       for (let j = j0; j <= j1 && n < chunkCap; j++) {
@@ -3021,6 +3053,7 @@ function buildGrassRing(parent: THREE.Group, seed: number): GrassRing {
           }
         }
       }
+      yield; // one grid row per sub-unit: the budget gates between rows
     }
 
     // Authored meadows also bloom independent of grass anchors: the scrubby
@@ -3054,6 +3087,7 @@ function buildGrassRing(parent: THREE.Group, seed: number): GrassRing {
             fn++;
           }
         }
+        yield; // one meadow grid row per sub-unit
       }
     }
     // The Evergarden: no grass anchors exist (mown lawn), so the parterre
@@ -3084,6 +3118,7 @@ function buildGrassRing(parent: THREE.Group, seed: number): GrassRing {
             fn++;
           }
         }
+        yield; // one parterre grid row per sub-unit
       }
     }
     if (n > 0) {
@@ -3126,8 +3161,10 @@ function buildGrassRing(parent: THREE.Group, seed: number): GrassRing {
     }
     chunk.ready = true;
     builtChunks++;
-    lastBuildMs = Math.round((performance.now() - started) * 100) / 100;
-    buildMs = Math.round((buildMs + lastBuildMs) * 100) / 100;
+    // Ownership handed to the chunk (or dropped when a mesh stayed empty,
+    // exactly as before); the abandon path no longer needs to release them.
+    partial.im = null;
+    partial.fm = null;
   };
 
   const disposeChunk = (chunk: GrassChunk): void => {
@@ -3154,19 +3191,81 @@ function buildGrassRing(parent: THREE.Group, seed: number): GrassRing {
     }
   };
 
+  // The one in-flight sliced build. runSlicedBuild checks the budget BEFORE
+  // resuming each sub-unit (a grid row), so a frame never pays more than the
+  // budget plus one row, where the old check-after-build paid a whole chunk
+  // (18.6ms observed against the 2.2ms budget). An oversized chunk simply
+  // spans more frames; its pop-in when ready is the same pop-in the queue
+  // already implied, just a few frames later.
+  let activeBuild: {
+    chunk: GrassChunk;
+    job: { step(): boolean };
+    partial: GrassChunkPartialMeshes;
+    activeMs: number;
+  } | null = null;
+
+  const startChunkBuild = (chunk: GrassChunk): void => {
+    const partial: GrassChunkPartialMeshes = { im: null, fm: null };
+    const gen = buildChunk(chunk, partial);
+    chunk.building = true;
+    activeBuild = { chunk, job: { step: () => !gen.next().done }, partial, activeMs: 0 };
+  };
+
+  const abandonActiveBuild = (): void => {
+    if (!activeBuild) return;
+    // Partial meshes were never parented, so they never rendered: disposing
+    // releases their instance buffers without touching the shared geometry
+    // or material. The chunk rebuilds from scratch if it comes back into
+    // range, producing the same geometry (the build is a pure function of
+    // chunk coordinates and seed).
+    activeBuild.partial.im?.dispose();
+    activeBuild.partial.fm?.dispose();
+    activeBuild.chunk.building = false;
+    activeBuild = null;
+  };
+
   const buildQueuedChunks = (): void => {
-    if (buildQueue.length === 0) return;
-    buildQueue.sort((a, b) => a.prioritySq - b.prioritySq || a.key.localeCompare(b.key));
-    const deadline = performance.now() + buildBudgetMs;
-    let built = 0;
-    while (buildQueue.length > 0 && built < GRASS_CHUNK_MAX_BUILDS_PER_FRAME) {
-      const chunk = buildQueue.shift();
-      if (!chunk) break;
-      chunk.queued = false;
-      if (chunks.get(chunk.key) !== chunk || chunk.ready || chunk.lastSeen !== generation) continue;
-      buildChunk(chunk);
-      built++;
-      if (performance.now() >= deadline) break;
+    if (!activeBuild && buildQueue.length === 0) return;
+    const deadline = now() + buildBudgetMs;
+    let completed = 0;
+    let sorted = false;
+    while (completed < GRASS_CHUNK_MAX_BUILDS_PER_FRAME) {
+      if (activeBuild) {
+        const { chunk } = activeBuild;
+        // A mid-build chunk that left the streamed window (or was retired)
+        // is abandoned rather than finished into a hidden mesh.
+        if (chunks.get(chunk.key) !== chunk || chunk.lastSeen !== generation) {
+          abandonActiveBuild();
+          continue;
+        }
+      } else {
+        if (buildQueue.length === 0) return;
+        if (!sorted) {
+          buildQueue.sort((a, b) => a.prioritySq - b.prioritySq || a.key.localeCompare(b.key));
+          sorted = true;
+        }
+        const chunk = buildQueue.shift();
+        if (!chunk) return;
+        chunk.queued = false;
+        if (chunks.get(chunk.key) !== chunk || chunk.ready || chunk.building) continue;
+        if (chunk.lastSeen !== generation) continue;
+        // Starting a build costs nothing yet: the generator body only runs
+        // once runSlicedBuild passes its first pre-step budget check.
+        startChunkBuild(chunk);
+      }
+      const active = activeBuild;
+      if (!active) continue;
+      const sliceStart = now();
+      const outcome = runSlicedBuild(active.job, deadline, now);
+      active.activeMs += now() - sliceStart;
+      if (outcome === 'paused') return;
+      active.chunk.building = false;
+      activeBuild = null;
+      // grassLastBuildMs is the chunk's total active build time summed over
+      // its slices (inter-frame waiting excluded), same meaning as before.
+      lastBuildMs = Math.round(active.activeMs * 100) / 100;
+      buildMs = Math.round((buildMs + lastBuildMs) * 100) / 100;
+      completed++;
     }
   };
 
@@ -3346,7 +3445,8 @@ function buildGrassRing(parent: THREE.Group, seed: number): GrassRing {
       stats.grassQuality = Math.round(quality * 100) / 100;
       stats.grassActiveRadius = activeRadius();
       stats.grassChunks = chunks.size;
-      stats.grassQueuedChunks = buildQueue.length;
+      // The in-flight sliced build still counts as queued work until ready.
+      stats.grassQueuedChunks = buildQueue.length + (activeBuild ? 1 : 0);
       stats.grassBuiltChunks = builtChunks;
       stats.grassDisposedChunks = disposedChunks;
       stats.grassLastBuildMs = lastBuildMs;

--- a/src/render/foliage.ts
+++ b/src/render/foliage.ts
@@ -153,7 +153,6 @@ import { applySurfaceDetail, foliageWornFamilyFor } from './worn_stone';
 
 const GRASS_CHUNK_SIZE = 48;
 const GRASS_CHUNK_BUILD_BUDGET_MS = 2.2;
-const GRASS_CHUNK_MAX_BUILDS_PER_FRAME = 1;
 const GRASS_DENSITY_LOW = 0.38;
 const GRASS_DENSITY_HIGH = 0.5;
 // Per-biome grass density multipliers over the base above. The Reach is bare
@@ -3192,11 +3191,18 @@ function buildGrassRing(
   };
 
   // The one in-flight sliced build. runSlicedBuild checks the budget BEFORE
-  // resuming each sub-unit (a grid row), so a frame never pays more than the
-  // budget plus one row, where the old check-after-build paid a whole chunk
-  // (18.6ms observed against the 2.2ms budget). An oversized chunk simply
-  // spans more frames; its pop-in when ready is the same pop-in the queue
-  // already implied, just a few frames later.
+  // resuming each sub-unit, so a frame never pays more than the budget plus
+  // the one sub-unit that crossed the deadline, where the old
+  // check-after-build paid a whole chunk (18.6ms observed against the 2.2ms
+  // budget). Stated honestly, that bound is the budget plus FINALIZE: the
+  // grid-row sub-units are small, but the finalize sub-unit (stable-rank
+  // reorder over every instance, trim, bounding spheres, parenting, freeze)
+  // runs unsliced, so it is the largest single step a frame can absorb.
+  // Slicing finalize further is a possible follow-up; any new yield must
+  // land BEFORE the parenting writes, or abandonActiveBuild below would
+  // strand a parented partial mesh. An oversized chunk simply spans more
+  // frames; its pop-in when ready is the same pop-in the queue already
+  // implied, just a few frames later.
   let activeBuild: {
     chunk: GrassChunk;
     job: { step(): boolean };
@@ -3224,12 +3230,21 @@ function buildGrassRing(
     activeBuild = null;
   };
 
+  // Builds run until the frame budget is spent, however many chunks that
+  // completes: the pre-sub-unit deadline check inside runSlicedBuild is the
+  // worst-frame bound, so a cheap chunk finishing early hands its remaining
+  // budget to the next queued chunk instead of discarding it. (An older
+  // one-completion-per-frame cap predated slicing, when the deadline was only
+  // consulted AFTER a whole chunk built; kept after slicing it capped
+  // COMPLETIONS, starving ring fill while a many-frame chunk was in flight
+  // and dropping unspent budget after each finish. Per-frame parenting cost
+  // needs no cap of its own: finalize, the step that parents, is one
+  // sub-unit, so the budget already meters it.)
   const buildQueuedChunks = (): void => {
     if (!activeBuild && buildQueue.length === 0) return;
     const deadline = now() + buildBudgetMs;
-    let completed = 0;
     let sorted = false;
-    while (completed < GRASS_CHUNK_MAX_BUILDS_PER_FRAME) {
+    for (;;) {
       if (activeBuild) {
         const { chunk } = activeBuild;
         // A mid-build chunk that left the streamed window (or was retired)
@@ -3265,7 +3280,6 @@ function buildGrassRing(
       // its slices (inter-frame waiting excluded), same meaning as before.
       lastBuildMs = Math.round(active.activeMs * 100) / 100;
       buildMs = Math.round((buildMs + lastBuildMs) * 100) / 100;
-      completed++;
     }
   };
 
@@ -3391,7 +3405,13 @@ function buildGrassRing(
       uniforms.uPlayerPos.value.set(px, pz);
       uniforms.uFadeFar.value = activeRadius();
       if (px > DUNGEON_X_THRESHOLD) {
-        // dungeon instances live far outside the strip — no meadow indoors
+        // dungeon instances live far outside the strip: no meadow indoors.
+        // This branch returns before buildQueuedChunks, so a build paused
+        // mid-chunk would otherwise hold its two chunkCap instance buffers
+        // for the whole dungeon run; abandon it instead (the chunk rebuilds
+        // byte-identically on return, exactly like leaving the streamed
+        // window).
+        abandonActiveBuild();
         if (parent.visible) {
           parent.visible = false;
           for (const chunk of chunks.values()) {

--- a/src/render/gfx.ts
+++ b/src/render/gfx.ts
@@ -1072,24 +1072,30 @@ function settingsFor(tier: GfxTier, hints?: Partial<GfxRuntimeHints>): GfxSettin
     constrainedMemory,
     iosMemoryProfile,
     tightMemory: tightMemoryProfile,
-    // Every OTHER budget in this function falls back through constrainedMemory (the
-    // cross-platform touch/coarse-pointer/narrow-viewport/deviceMemory detector, see
-    // maxPointLights above) before reaching its desktop default; this one used to jump
-    // straight from the two narrow iOS profiles to POSITIVE_INFINITY, so any Android
-    // browser or native shell, and any iOS session that never stamped tightMemory, kept
-    // every despawned mob/NPC CharacterVisual (and its per-instance Skeleton + GPU
-    // bone-matrix DataTexture) forever: visualPool is keyed per template+color+scale, so
-    // roaming through a zone with any per-mob variance mints new keys continuously and
-    // never reuses, never shrinks. Bounded to a working set a bit above the crowd_lod
-    // "soft" articulated-rig band (CROWD_LOD_SOFT_RIGS) so ordinary reuse still avoids the
-    // GPU skeleton re-upload hitch pooling exists for, without growing without bound.
+    // Bounded on EVERY profile, desktop included. A pooled visual retains its
+    // per-instance Skeleton and GPU bone-matrix DataTexture so a re-entering
+    // mob/NPC skips the skeleton re-upload hitch pooling exists for, and the
+    // pool evicts least-recently-released first (characters/visual_pool.ts),
+    // so a finite cap trims the cold tail, never the hot working set: an
+    // evicted key transparently rebuilds on its next request. Desktop 128: the
+    // hitch referee's crowd/churn/soak calibration peaked at 57 to 72
+    // simultaneously pooled visuals (docs/perf/hitch), production crowds run
+    // larger, and pool keys are per template (per-instance rift color/scale
+    // jitter is applied at acquire time, no longer minting dead
+    // never-matching keys), so roughly 2x the observed peak keeps ordinary
+    // reuse intact while capping worst-case retention. The historical desktop
+    // POSITIVE_INFINITY retained every despawned character visual until
+    // profile reset, the C1 memory ratchet in crowded sessions. The
+    // constrained ladder sheds reuse for memory headroom: 24 on
+    // constrained-memory browsers, then 6/4 on the two iOS WebKit residency
+    // profiles, mirroring maxPooledObjects below.
     maxPooledCharacterVisuals: tightMemoryProfile
       ? 4
       : iosMemoryProfile
         ? 6
         : constrainedMemory
           ? 24
-          : Number.POSITIVE_INFINITY,
+          : 128,
     // The ground-object reuse pool (harvest nodes, loot piles, quest pickups) had NO cap at
     // all on any platform, not even the two narrow iOS memory profiles: every distinct item
     // template a player interacted with stayed retained (Group/Object3D graph, never GPU

--- a/src/render/grass_build_slicer_core.ts
+++ b/src/render/grass_build_slicer_core.ts
@@ -1,0 +1,47 @@
+// Budgeted resumable build slicing for the streamed grass ring (foliage.ts).
+//
+// The grass chunk builder used to run a whole chunk in one main-thread call
+// and only consulted its frame budget AFTER the build finished, so the budget
+// bounded how MANY builds ran per frame, never the worst single frame (one
+// build was measured at 18.6ms against a 2.2ms budget). This core owns the
+// fix: a chunk build is expressed as a sequence of small sub-units (grid rows
+// plus a finalize step) behind SlicedBuildJob, and runSlicedBuild checks the
+// deadline BEFORE every sub-unit, pausing the job so the remainder resumes on
+// a later frame. A call whose deadline has already passed performs zero
+// sub-units: the check always precedes the cost.
+//
+// Slicing moves only WHEN the work happens, never WHAT it produces: a job's
+// sub-unit sequence must be a pure function of its own cursor state (no clock
+// reads inside step()), so the finished output is byte-identical however the
+// frames divide the work. runSlicedBuild guarantees its half of that contract
+// by executing steps strictly in order, one at a time, with no skipping:
+// pinned by tests/grass_build_slicer_core.test.ts (order invariance) and
+// tests/grass_build_slicing.test.ts (vertex-data equality on the real ring).
+//
+// The clock is injected (never performance.now here): this core stays
+// deterministic and Node-testable per the RENDER_PURE_CORES contract.
+
+export interface SlicedBuildJob {
+  /** Runs the next sub-unit of work. Returns true while more sub-units remain. */
+  step(): boolean;
+}
+
+export type SlicedBuildOutcome = 'completed' | 'paused';
+
+/**
+ * Runs sub-units of `job` in order until it completes or `now()` reaches
+ * `deadlineMs`. The deadline check happens BEFORE each sub-unit, so once the
+ * elapsed time exceeds the budget no further work starts, and a call that
+ * arrives with its deadline already passed performs zero sub-units. A paused
+ * job resumes exactly where it left off on the next call.
+ */
+export function runSlicedBuild(
+  job: SlicedBuildJob,
+  deadlineMs: number,
+  now: () => number,
+): SlicedBuildOutcome {
+  while (now() < deadlineMs) {
+    if (!job.step()) return 'completed';
+  }
+  return 'paused';
+}

--- a/src/render/grass_build_slicer_core.ts
+++ b/src/render/grass_build_slicer_core.ts
@@ -4,11 +4,17 @@
 // and only consulted its frame budget AFTER the build finished, so the budget
 // bounded how MANY builds ran per frame, never the worst single frame (one
 // build was measured at 18.6ms against a 2.2ms budget). This core owns the
-// fix: a chunk build is expressed as a sequence of small sub-units (grid rows
-// plus a finalize step) behind SlicedBuildJob, and runSlicedBuild checks the
+// fix: a chunk build is expressed as a sequence of sub-units (grid rows plus
+// a finalize step) behind SlicedBuildJob, and runSlicedBuild checks the
 // deadline BEFORE every sub-unit, pausing the job so the remainder resumes on
 // a later frame. A call whose deadline has already passed performs zero
 // sub-units: the check always precedes the cost.
+//
+// The bound this buys is the budget plus the ONE sub-unit that crossed the
+// deadline, and sub-units are not uniformly small: the grass ring's finalize
+// step (stable-rank reorder over all instances, bounding spheres, trim,
+// freeze) runs unsliced, so the honest worst frame is the budget plus
+// finalize, not the budget plus one grid row.
 //
 // Slicing moves only WHEN the work happens, never WHAT it produces: a job's
 // sub-unit sequence must be a pure function of its own cursor state (no clock

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -141,6 +141,7 @@ import {
   playerRangedAttackAlreadyStarted,
   playerRangedAttackStartsAtLaunch,
 } from './characters/skin_attack';
+import { CharacterVisualPool, characterVisualPoolKey } from './characters/visual_pool';
 import { shouldRetainPooledCharacterVisual } from './characters/visual_pool_policy';
 import { attackAbilityId, isSpinAttackAbility } from './characters/weapon_attack_style_core';
 import { fogFarForBuiltGround, groundViewConeHalfAngle } from './chunk_residency_core';
@@ -1950,8 +1951,7 @@ export class Renderer {
   private renderDiagnosticsLastTextures = 0;
   private appliedBudgetLevels: RenderBudgetState['levels'] | null = null;
   private lastQualityChange: RendererQualityChangeStats | null = null;
-  private visualPool = new Map<string, CharacterVisual[]>();
-  private pooledVisualCount = 0;
+  private visualPool = new CharacterVisualPool<CharacterVisual>();
   private objectPool = new Map<string, PooledObjectView[]>();
   private pooledObjectCount = 0;
   private prewarmDepthMaterials = new Map<string, THREE.MeshDepthMaterial>();
@@ -3030,20 +3030,18 @@ export class Renderer {
     this.chatBubbles.clear();
     for (const id of [...this.views.keys()]) bestEffort(() => this.removeView(id, true));
     this.views.clear();
-    for (const pool of this.visualPool.values()) {
-      for (const visual of pool) bestEffort(() => visual.dispose());
-    }
-    this.visualPool.clear();
-    this.pooledVisualCount = 0;
+    for (const visual of this.visualPool.drain()) bestEffort(() => visual.dispose());
     this.objectPool.clear();
     this.pooledObjectCount = 0;
-    // The memoized weapon-skin emissive derivations are renderer-lifetime, not
-    // page-lifetime: they are shared across wearers, so no individual rig may
-    // release them, and a megabyte-class texture pair per skin would otherwise
-    // ride a WebGL context recycle into the next context. Safe here and only
-    // here, after every view (and every rig that borrowed them) is torn down
-    // above. Best-effort like its neighbours: nothing in terminal cleanup may
-    // abort the WebGL disposal below.
+    // The memoized weapon-skin emissive derivations are bounded, not
+    // page-lifetime: every rig releases its reference on dispose (never
+    // disposing the shared pair itself) and the cache evicts idle derivations
+    // past its idle cap as the session runs. This terminal drain releases
+    // whatever is still resident, or a megabyte-class texture pair per pinned
+    // skin would ride a WebGL context recycle into the next context. Safe here
+    // and only here, after every view (and every rig that borrowed them) is
+    // torn down above. Best-effort like its neighbours: nothing in terminal
+    // cleanup may abort the WebGL disposal below.
     bestEffort(() => this.weaponSkinApplies.clear());
     bestEffort(() => disposeWeaponEmissiveCache());
     this.clickTargets.length = 0;
@@ -4103,7 +4101,7 @@ export class Renderer {
       textures: info.memory.textures,
       programs: info.programs?.length ?? 0,
       views: this.views.size,
-      pooledVisuals: this.pooledVisualCount,
+      pooledVisuals: this.visualPool.size,
       foliage: this.foliage.perfStats(),
       glVendor: this.glVendor,
       glRenderer: this.glRenderer,
@@ -4865,22 +4863,22 @@ export class Renderer {
   }
 
   private visualPoolKeyFor(e: Entity): string | null {
-    if (e.kind === 'mob') return `mob:${e.templateId}:${e.color}:${e.scale}`;
-    // NPCs are skinned characters too: pool them like mobs so their Skeleton (and its
-    // bone-matrix DataTexture) survives interest churn instead of being disposed and
-    // re-uploaded every time one streams out and back into view - that dispose +
-    // re-upload cycle is the open-world "asset-upload" travel hitch (Skeleton.dispose
-    // via CharacterVisual.dispose in removeView, pinned by GPU-upload profiling).
-    if (e.kind === 'npc') return `npc:${e.templateId}:${e.skin}:${e.color}:${e.scale}`;
-    return null;
+    // Normalized per-TEMPLATE key (characters/visual_pool.ts): per-instance
+    // color/scale (rift spawns re-grade both per mob) is applied at acquire
+    // time instead of partitioning the key, so rift visuals pool and reuse
+    // like everything else instead of minting dead never-matching entries.
+    // NPCs are skinned characters too: pool them like mobs so their Skeleton
+    // (and its bone-matrix DataTexture) survives interest churn instead of
+    // being disposed and re-uploaded every time one streams out and back into
+    // view - that dispose + re-upload cycle is the open-world "asset-upload"
+    // travel hitch (Skeleton.dispose via CharacterVisual.dispose in
+    // removeView, pinned by GPU-upload profiling). Players never pool (A6).
+    return characterVisualPoolKey(e);
   }
 
-  private takePooledVisual(key: string): CharacterVisual | null {
-    const pool = this.visualPool.get(key);
-    const visual = pool?.pop() ?? null;
+  private takePooledVisual(key: string, entityColor: number): CharacterVisual | null {
+    const visual = this.visualPool.take(key);
     if (!visual) return null;
-    this.pooledVisualCount = Math.max(0, this.pooledVisualCount - 1);
-    if (pool?.length === 0) this.visualPool.delete(key);
     visual.root.removeFromParent();
     visual.root.visible = true;
     visual.root.position.set(0, 0, 0);
@@ -4888,26 +4886,27 @@ export class Renderer {
     visual.root.scale.set(1, 1, 1);
     visual.setFar(false);
     visual.setGhost(false);
+    // The pool key is per-template, so the pooled tint may belong to another
+    // instance (rift spawns jitter mob.color per mob): re-tint to THIS
+    // entity's color from the shared tinted-material cache. No-op when the
+    // color already matches; entity scale is applied at the view group by the
+    // caller, exactly as for a freshly built visual.
+    visual.setEntityColor(entityColor);
     return visual;
   }
 
   private storePooledVisual(key: string, visual: CharacterVisual): void {
     visual.root.removeFromParent();
-    if (!shouldRetainPooledCharacterVisual(this.pooledVisualCount, GFX.maxPooledCharacterVisuals)) {
-      visual.dispose();
-      return;
-    }
     visual.root.visible = false;
     visual.root.position.set(0, 0, 0);
     visual.root.rotation.set(0, 0, 0);
     visual.root.scale.set(1, 1, 1);
-    let pool = this.visualPool.get(key);
-    if (!pool) {
-      pool = [];
-      this.visualPool.set(key, pool);
-    }
-    pool.push(visual);
-    this.pooledVisualCount++;
+    // Bounded, least-recently-released-first: the pool disposes the coldest
+    // overflow (or the incoming visual when pooling is disabled) so eviction
+    // genuinely frees the per-instance Skeleton + GPU bone-matrix DataTexture
+    // while the hot working set keeps its reuse. An evicted key transparently
+    // rebuilds from the live entity on its next request.
+    this.visualPool.store(key, visual, GFX.maxPooledCharacterVisuals);
   }
 
   private objectPoolKeyFor(e: Entity): string | null {
@@ -7480,7 +7479,7 @@ export class Renderer {
         return;
       }
       visualPoolKey = this.visualPoolKeyFor(e);
-      visual = visualPoolKey ? this.takePooledVisual(visualPoolKey) : null;
+      visual = visualPoolKey ? this.takePooledVisual(visualPoolKey, e.color) : null;
       if (!visual) {
         // Pool MISS: build a fresh visual but KEEP its pool key so removeView returns
         // it to the pool (which self-sizes to demand) instead of disposing it. Disposing

--- a/src/render/weapon_vfx.ts
+++ b/src/render/weapon_vfx.ts
@@ -27,6 +27,10 @@
 import * as THREE from 'three';
 import { isSharedTexture, markSharedTexture } from './shared_resource';
 import {
+  WEAPON_EMISSIVE_IDLE_CACHE_MAX,
+  WeaponEmissiveDerivationCache,
+} from './weapon_vfx_emissive_cache_core';
+import {
   deriveEmissiveTexels,
   type WeaponEmissiveTint,
   weaponEmissiveCacheKey,
@@ -2151,6 +2155,9 @@ interface EmissiveEntry {
   prev: EmissiveRestore;
   tex: THREE.CanvasTexture | null;
   albedoTex: THREE.CanvasTexture | null;
+  /** The derivation-cache key this entry holds a reference on, or null on the
+   *  flat-tint fallback path (nothing cached, nothing to release). */
+  cacheKey: string | null;
 }
 
 interface DerivedEmissiveTextures {
@@ -2165,9 +2172,26 @@ interface DerivedEmissiveTextures {
 // readbacks, a per-texel HSL walk (262144 iterations at 512x512) and two fresh
 // texture uploads, all inside the frame a skinned player came into view. The
 // entries are marked shared, so an individual rig tearing down never disposes
-// the textures the next wearer is still drawing with; the ONE release path is
+// the textures the next wearer is still drawing with.
+//
+// BOUNDED, not renderer-lifetime: each rig holds a reference for as long as it
+// lives (deriveEmissive acquires, the rig's dispose releases), and the cache
+// evicts only IDLE derivations (every wearer gone) past
+// WEAPON_EMISSIVE_IDLE_CACHE_MAX, least-recently-released first, disposing
+// both textures. The boot prewarm never populates this cache (its host
+// material has no albedo map), so without the bound every cosmetic that ever
+// walked past retained a two-canvas, two-texture pair until teardown (the C2
+// memory ratchet). Eviction is invisible on screen: a live wearer's entry is
+// pinned by its reference count, and an evicted key re-derives byte-identically
+// (pure function of the key). The terminal release path remains
 // disposeWeaponEmissiveCache below, which the renderer calls at teardown.
-const derivedEmissiveCache = new Map<string, DerivedEmissiveTextures>();
+const derivedEmissiveCache = new WeaponEmissiveDerivationCache<DerivedEmissiveTextures>(
+  WEAPON_EMISSIVE_IDLE_CACHE_MAX,
+  ({ tex, albedoTex }) => {
+    tex.dispose();
+    albedoTex.dispose();
+  },
+);
 
 /**
  * Release every memoized derivation (one megabyte-class texture pair per skin).
@@ -2178,11 +2202,10 @@ const derivedEmissiveCache = new Map<string, DerivedEmissiveTextures>();
  * disposed textures.
  */
 export function disposeWeaponEmissiveCache(): void {
-  for (const { tex, albedoTex } of derivedEmissiveCache.values()) {
+  for (const { tex, albedoTex } of derivedEmissiveCache.drain()) {
     tex.dispose();
     albedoTex.dispose();
   }
-  derivedEmissiveCache.clear();
 }
 
 /** Test seam: drop the page-lifetime sprite/sky texture memo so a suite can
@@ -2193,17 +2216,16 @@ export function clearWeaponVfxTextureCacheForTest(): void {
   texCache.clear();
 }
 
-/** Derive (or reuse) the emissive + de-baked albedo pair for one source map.
- *  The canvas plumbing lives here; the per-texel math is the pure core. */
-function derivedEmissiveTextures(
+/** Cold-build the emissive + de-baked albedo pair for one source map: the
+ *  canvas plumbing around the pure per-texel core. Callers go through the
+ *  bounded derivedEmissiveCache (deriveEmissive acquires), never call this
+ *  directly, so one build serves every wearer. */
+function buildDerivedEmissiveTextures(
   source: THREE.Texture,
   img: HTMLImageElement | HTMLCanvasElement | ImageBitmap,
   e: WeaponVfxEmissiveSpec,
   tint: WeaponEmissiveTint,
 ): DerivedEmissiveTextures {
-  const key = weaponEmissiveCacheKey(source.uuid, e);
-  const cached = derivedEmissiveCache.get(key);
-  if (cached) return cached;
   const w = img.width;
   const h = img.height;
   const cv = document.createElement('canvas');
@@ -2233,9 +2255,7 @@ function derivedEmissiveTextures(
     t.wrapT = source.wrapT;
     return markSharedTexture(t);
   };
-  const derived: DerivedEmissiveTextures = { tex: mkTex(cv), albedoTex: mkTex(av) };
-  derivedEmissiveCache.set(key, derived);
-  return derived;
+  return { tex: mkTex(cv), albedoTex: mkTex(av) };
 }
 
 function deriveEmissive(mat: THREE.MeshStandardMaterial, e: WeaponVfxEmissiveSpec): EmissiveEntry {
@@ -2272,20 +2292,19 @@ function deriveEmissive(mat: THREE.MeshStandardMaterial, e: WeaponVfxEmissiveSpe
   if (!img?.width || !drawable) {
     mat.emissive = new THREE.Color(e.tint);
     mat.emissiveIntensity = 0.3;
-    return { prev, tex: null, albedoTex: null };
+    return { prev, tex: null, albedoTex: null, cacheKey: null };
   }
-  const { tex, albedoTex } = derivedEmissiveTextures(
-    mat.map as THREE.Texture,
-    img,
-    e,
-    new THREE.Color(e.tint),
+  const source = mat.map as THREE.Texture;
+  const cacheKey = weaponEmissiveCacheKey(source.uuid, e);
+  const { tex, albedoTex } = derivedEmissiveCache.acquire(cacheKey, () =>
+    buildDerivedEmissiveTextures(source, img, e, new THREE.Color(e.tint)),
   );
   mat.emissiveMap = tex;
   mat.emissive = new THREE.Color(0xffffff);
   mat.emissiveIntensity = e.intensity;
   mat.map = albedoTex;
   mat.needsUpdate = true;
-  return { prev, tex, albedoTex };
+  return { prev, tex, albedoTex, cacheKey };
 }
 
 // ---------------------------------------------------------------------------
@@ -2876,18 +2895,56 @@ export function createWeaponVfx(
   const emissives: EmissiveEntry[] = [];
   let time = 0;
 
+  // The single owner of the emissive unwind: restore every derived material to
+  // its captured state FIRST (after which no material of this rig references
+  // the shared pair), then drop this rig's cache reference, so a
+  // release-triggered eviction can never dispose a texture a material still
+  // points at. The derived pair is memoized and shared with every other wearer
+  // of this skin: dropping the reference leaves eviction to the bounded cache,
+  // which never touches an entry another wearer still pins (a disposed texture
+  // would leave that weapon unglowing). The unmarked-texture guard keeps a
+  // future rig-OWNED (non-shared) texture releasable. Clearing the array makes
+  // a second run a no-op.
+  const restoreAndReleaseEmissives = () => {
+    for (const { prev, tex, albedoTex, cacheKey } of emissives) {
+      prev.mat.emissiveMap = prev.emissiveMap;
+      prev.mat.map = prev.map;
+      prev.mat.metalness = prev.metalness;
+      prev.mat.roughness = prev.roughness;
+      prev.mat.metalnessMap = prev.metalnessMap;
+      prev.mat.roughnessMap = prev.roughnessMap;
+      prev.mat.envMapIntensity = prev.envMapIntensity;
+      if (prev.emissive) prev.mat.emissive.copy(prev.emissive);
+      prev.mat.emissiveIntensity = prev.emissiveIntensity;
+      prev.mat.needsUpdate = true;
+      if (cacheKey !== null) derivedEmissiveCache.release(cacheKey);
+      if (tex && !isSharedTexture(tex)) tex.dispose();
+      if (albedoTex && !isSharedTexture(albedoTex)) albedoTex.dispose();
+    }
+    emissives.length = 0;
+  };
+
   // 1. Emissive core derived from the painted texture (per unique material).
   const eSpec: WeaponVfxEmissiveSpec = { ...tier.emissive, ...(spec.emissive ?? {}) };
   const seen = new Set<THREE.Material>();
-  weaponRoot.traverse((o) => {
-    const mesh = o as THREE.Mesh;
-    if (!mesh.isMesh || !mesh.material || mesh.userData.__vfx) return;
-    for (const m of Array.isArray(mesh.material) ? mesh.material : [mesh.material]) {
-      if (seen.has(m)) continue;
-      seen.add(m);
-      emissives.push(deriveEmissive(m as THREE.MeshStandardMaterial, eSpec));
-    }
-  });
+  try {
+    weaponRoot.traverse((o) => {
+      const mesh = o as THREE.Mesh;
+      if (!mesh.isMesh || !mesh.material || mesh.userData.__vfx) return;
+      for (const m of Array.isArray(mesh.material) ? mesh.material : [mesh.material]) {
+        if (seen.has(m)) continue;
+        seen.add(m);
+        emissives.push(deriveEmissive(m as THREE.MeshStandardMaterial, eSpec));
+      }
+    });
+  } catch (error) {
+    // A derivation that throws mid-traverse (a detached ImageBitmap, a tainted
+    // or context-less canvas) must not leave the earlier materials' cache
+    // references pinned forever: a leaked reference silently reverts that skin
+    // to the unbounded ratchet. Unwind what was acquired and rethrow.
+    restoreAndReleaseEmissives();
+    throw error;
+  }
 
   // 2. Fresnel rim shell (the "living magic" silhouette glow).
   const shellSpec: WeaponVfxShellSpec = { ...tier.shell, ...(spec.shell ?? {}) };
@@ -2974,6 +3031,11 @@ export function createWeaponVfx(
     }
   };
 
+  // dispose() releases this rig's reference on each shared derivation, so it
+  // must run at most once: a second call would strip a reference another live
+  // wearer of the same skin still depends on.
+  let rigDisposed = false;
+
   return {
     group,
     sceneExtras,
@@ -3016,6 +3078,8 @@ export function createWeaponVfx(
       light.intensity = lightSpec.intensity * flick * tuning.light;
     },
     dispose() {
+      if (rigDisposed) return;
+      rigDisposed = true;
       weaponRoot.remove(group);
       sceneExtras.parent?.remove(sceneExtras);
       for (const p of parts) {
@@ -3027,26 +3091,7 @@ export function createWeaponVfx(
         }
       }
       for (const m of allMats) m.dispose();
-      for (const { prev, tex, albedoTex } of emissives) {
-        // The derived pair is memoized and shared with every other wearer of
-        // this skin, so tearing this rig down must not release it (a disposed
-        // texture would leave the next wearer's weapon unglowing, with no
-        // path back short of a page reload). The cache's own release path is
-        // disposeWeaponEmissiveCache at renderer teardown; the guard here
-        // keeps a future rig-OWNED (unmarked) texture releasable.
-        if (tex && !isSharedTexture(tex)) tex.dispose();
-        if (albedoTex && !isSharedTexture(albedoTex)) albedoTex.dispose();
-        prev.mat.emissiveMap = prev.emissiveMap;
-        prev.mat.map = prev.map;
-        prev.mat.metalness = prev.metalness;
-        prev.mat.roughness = prev.roughness;
-        prev.mat.metalnessMap = prev.metalnessMap;
-        prev.mat.roughnessMap = prev.roughnessMap;
-        prev.mat.envMapIntensity = prev.envMapIntensity;
-        if (prev.emissive) prev.mat.emissive.copy(prev.emissive);
-        prev.mat.emissiveIntensity = prev.emissiveIntensity;
-        prev.mat.needsUpdate = true;
-      }
+      restoreAndReleaseEmissives();
     },
   };
 }

--- a/src/render/weapon_vfx_emissive_cache_core.ts
+++ b/src/render/weapon_vfx_emissive_cache_core.ts
@@ -1,0 +1,111 @@
+// The bounded, reference-counted memo behind the weapon-skin emissive
+// derivation (weapon_vfx.ts). Pure bookkeeping: no Three, no DOM, no clock,
+// values are opaque to this core (the caller hands in derived texture pairs
+// and an onEvict that owns their disposal).
+//
+// Why bounded: the derivation memo used to retain every (source albedo map,
+// emissive spec) pair ever SEEN for the renderer's whole lifetime, about two
+// full-resolution canvases plus two GPU textures per weapon cosmetic that
+// ever walked past (the C2 memory ratchet). The boot prewarm deliberately
+// does not populate it (its host material carries no albedo map), so the set
+// grew with cosmetic traffic, never with the catalog.
+//
+// The policy: a live rig holds a reference, and a referenced entry is NEVER
+// evicted, so eviction can never change what is on screen. An entry whose
+// last wearer released it stays resident (warm for the next wearer of that
+// skin) until more than `maxIdle` idle entries exist; then the
+// least-recently-released idle entries evict through `onEvict`. An evicted
+// key simply derives again on its next acquire, byte-identically (the
+// derivation is a pure function of the memo key, see
+// weapon_vfx_emissive_core.ts), so eviction is invisible apart from the
+// rebuild cost.
+//
+// Linear scans are fine at this scale: acquire/release run on rig
+// build/teardown (entity stream-in/out and gear swaps), never per frame, and
+// the entry count is bounded by live wearers plus the idle bound.
+
+/** Idle entries (no live wearer) the derivation memo keeps warm. Live rigs
+ *  are pinned on top of this, so the resident set is live wearers + at most
+ *  this many recently-released derivations. */
+export const WEAPON_EMISSIVE_IDLE_CACHE_MAX = 8;
+
+interface DerivationEntry<V> {
+  value: V;
+  refs: number;
+}
+
+export class WeaponEmissiveDerivationCache<V> {
+  /** Insertion order doubles as the eviction order: an entry is re-inserted
+   *  the moment it becomes idle, so iteration meets idle entries
+   *  least-recently-released first. */
+  private entries = new Map<string, DerivationEntry<V>>();
+  private readonly maxIdle: number;
+
+  constructor(
+    maxIdle: number,
+    private readonly onEvict: (value: V) => void,
+  ) {
+    // Fail closed: an invalid bound retains nothing idle rather than
+    // everything (the ratchet this cache exists to prevent).
+    this.maxIdle = Number.isFinite(maxIdle) ? Math.max(0, Math.floor(maxIdle)) : 0;
+  }
+
+  get size(): number {
+    return this.entries.size;
+  }
+
+  /** The memoized value for `key`, deriving it cold on a miss; either way the
+   *  caller now holds one reference and owes exactly one `release`. */
+  acquire(key: string, derive: () => V): V {
+    const entry = this.entries.get(key);
+    if (entry) {
+      entry.refs++;
+      return entry.value;
+    }
+    const value = derive();
+    this.entries.set(key, { value, refs: 1 });
+    return value;
+  }
+
+  /**
+   * Drop one reference. Returns false (a refused no-op) for an unknown key or
+   * an entry with no live references: a double-released rig must not underflow
+   * another wearer's pin. When the last reference goes, the entry moves to the
+   * back of the eviction order and the idle overflow (if any) evicts oldest
+   * first through `onEvict`.
+   */
+  release(key: string): boolean {
+    const entry = this.entries.get(key);
+    if (!entry || entry.refs === 0) return false;
+    entry.refs--;
+    if (entry.refs > 0) return true;
+    this.entries.delete(key);
+    this.entries.set(key, entry);
+    this.evictIdleOverflow();
+    return true;
+  }
+
+  /** Empty the cache and hand every value back, live or idle. TERMINAL: the
+   *  renderer's teardown owns disposal (with its best-effort guard), so
+   *  `onEvict` is deliberately not invoked here. */
+  drain(): V[] {
+    const drained: V[] = [];
+    for (const entry of this.entries.values()) drained.push(entry.value);
+    this.entries.clear();
+    return drained;
+  }
+
+  private evictIdleOverflow(): void {
+    let idle = 0;
+    for (const entry of this.entries.values()) {
+      if (entry.refs === 0) idle++;
+    }
+    for (const [key, entry] of this.entries) {
+      if (idle <= this.maxIdle) return;
+      if (entry.refs > 0) continue;
+      this.entries.delete(key);
+      this.onEvict(entry.value);
+      idle--;
+    }
+  }
+}

--- a/tests/architecture.test.ts
+++ b/tests/architecture.test.ts
@@ -439,6 +439,7 @@ const RENDER_PURE_CORES = [
   'src/render/dashed_ring_core.ts',
   'src/render/detail_horizon_core.ts',
   'src/render/drape_lod_core.ts',
+  'src/render/weapon_vfx_emissive_cache_core.ts',
   'src/render/weapon_vfx_shed_core.ts',
   'src/render/draw_stats_core.ts',
   'src/render/fishing_bobber_core.ts',
@@ -455,6 +456,7 @@ const RENDER_PURE_CORES = [
   'src/render/env_prefilter_core.ts',
   'src/render/environment_transition_core.ts',
   'src/render/ground_tilt_core.ts',
+  'src/render/grass_build_slicer_core.ts',
   'src/render/grass_cap_collapse_core.ts',
   'src/render/step_smooth_core.ts',
   'src/render/eastbrook_town_visibility_core.ts',
@@ -507,6 +509,7 @@ const RENDER_PURE_CORES = [
   'src/render/weapon_vfx_emissive_core.ts',
   'src/render/zone_feature_visibility_core.ts',
   'src/render/characters/skeleton_update_core.ts',
+  'src/render/characters/tinted_material_cache_core.ts',
   'src/render/characters/weapon_attack_style_core.ts',
 ].map((rel) => join(repoRoot, rel));
 

--- a/tests/character_visual_material_release.test.ts
+++ b/tests/character_visual_material_release.test.ts
@@ -1,0 +1,187 @@
+// CharacterVisual's material lifecycle against the shared tinted-material
+// cache and the per-visual rune-tint clones: dispose() releases the visual's
+// cache claims (never disposing a clone another visual still mounts), pooled
+// retint (setEntityColor) releases the previous color's claims so cycling
+// rift colors stays bounded, and the Thornhollow rune-tint clones dispose
+// with the visual (and on a rune chain, exactly as they are unmounted).
+// Full-construction pins on the real CharacterVisual paths: the mocked loader
+// serves a minimal rig for every URL (the halo suite's pattern).
+import * as THREE from 'three';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { TINTED_MATERIAL_IDLE_CACHE_MAX } from '../src/render/characters/tinted_material_cache_core';
+
+type AssetsModule = typeof import('../src/render/characters/assets');
+type VisualModule = typeof import('../src/render/characters/visual');
+
+const stubGltf = () => {
+  const scene = new THREE.Group();
+  const mesh = new THREE.Mesh(new THREE.BoxGeometry(1, 2, 1), new THREE.MeshStandardMaterial());
+  mesh.name = 'body';
+  scene.add(mesh);
+  return { scene, animations: [new THREE.AnimationClip('Idle', 1, [])] };
+};
+
+async function loadModules(): Promise<{ assets: AssetsModule; visual: VisualModule }> {
+  vi.resetModules();
+  vi.doMock('../src/render/assets/loader', () => ({
+    loadGltf: vi.fn(() => Promise.resolve(stubGltf())),
+    loadHdr: vi.fn(() => new Promise(() => undefined)),
+    loadTexture: vi.fn(() => Promise.resolve(new THREE.Texture())),
+    loadKtx2Texture: vi.fn(() => Promise.resolve(new THREE.Texture())),
+    releaseGltf: vi.fn(),
+  }));
+  const assets = (await import('../src/render/characters/assets')) as AssetsModule;
+  await assets.charactersReady();
+  const visual = (await import('../src/render/characters/visual')) as VisualModule;
+  return { assets, visual };
+}
+
+afterEach(() => {
+  vi.doUnmock('../src/render/assets/loader');
+  vi.resetModules();
+});
+
+/** Every material mounted anywhere under root (arrays flattened). */
+function mountedMaterials(root: THREE.Object3D): Set<THREE.Material> {
+  const out = new Set<THREE.Material>();
+  root.traverse((o) => {
+    const mesh = o as THREE.Mesh;
+    if (!mesh.isMesh) return;
+    for (const mat of Array.isArray(mesh.material) ? mesh.material : [mesh.material]) {
+      out.add(mat);
+    }
+  });
+  return out;
+}
+
+/** Flood the shared cache's idle set well past its bound (leaseless calls
+ *  park at the idle tail), so anything unpinned must have evicted. */
+function floodIdle(assets: AssetsModule, salt: number): void {
+  for (let i = 0; i < TINTED_MATERIAL_IDLE_CACHE_MAX * 2; i++) {
+    assets.tintedMaterial(new THREE.MeshStandardMaterial({ color: 0xffffff }), salt + i, 0.4);
+  }
+}
+
+describe('CharacterVisual tinted-material release', () => {
+  it('two visuals share one cache clone; disposing one never disposes what the other still mounts', async () => {
+    const { assets, visual: visualModule } = await loadModules();
+    const a = new visualModule.CharacterVisual('mob_mushroom_pixie', 0x336699);
+    const b = new visualModule.CharacterVisual('mob_mushroom_pixie', 0x336699);
+    const bodyA = a.root.getObjectByName('body') as THREE.Mesh;
+    const bodyB = b.root.getObjectByName('body') as THREE.Mesh;
+    expect(bodyA).toBeDefined();
+    // Sharing pin: same (source, tint) resolves to the one shared clone.
+    expect(bodyB.material).toBe(bodyA.material);
+    const shared = bodyA.material as THREE.Material;
+    const spy = vi.spyOn(shared, 'dispose');
+
+    a.dispose();
+    floodIdle(assets, 0x10);
+    // The mutant that releases (or disposes) the shared clone on the FIRST
+    // visual's dispose goes red here: b still mounts it.
+    expect(spy).not.toHaveBeenCalled();
+    expect(bodyB.material).toBe(shared);
+
+    b.dispose();
+    floodIdle(assets, 0x2000);
+    // Last mount gone: the idle LRU genuinely reclaims and disposes.
+    expect(spy).toHaveBeenCalledTimes(1);
+  }, 20000);
+
+  it('setEntityColor cycling (the pooled rift retint path) keeps the shared cache bounded', async () => {
+    const { assets, visual: visualModule } = await loadModules();
+    // mob_mushroom_pixie carries tint: 'entity', the pooled-reuse case whose
+    // per-instance color used to mint a permanently retained clone set per
+    // distinct rift color (the C1 residual).
+    const v = new visualModule.CharacterVisual('mob_mushroom_pixie', 0x100000);
+    const body = v.root.getObjectByName('body') as THREE.Mesh;
+    const firstColorMaterial = body.material as THREE.Material;
+    const firstSpy = vi.spyOn(firstColorMaterial, 'dispose');
+
+    for (let i = 1; i <= TINTED_MATERIAL_IDLE_CACHE_MAX + 40; i++) {
+      v.setEntityColor(0x100000 + i * 37);
+    }
+    const lastColorMaterial = body.material as THREE.Material;
+    expect(lastColorMaterial).not.toBe(firstColorMaterial);
+
+    // Bounded: the live color plus at most the idle bound stays resident, and
+    // the first color's clone was genuinely disposed while the mounted one
+    // survives.
+    expect(assets.tintedMaterialInternalsForTest.cacheSize()).toBeLessThanOrEqual(
+      TINTED_MATERIAL_IDLE_CACHE_MAX + 2,
+    );
+    expect(firstSpy).toHaveBeenCalledTimes(1);
+    expect(mountedMaterials(v.root).has(lastColorMaterial)).toBe(true);
+
+    v.dispose();
+  }, 20000);
+
+  it('disposes the rune-tint clones with the visual', async () => {
+    const { visual: visualModule } = await loadModules();
+    const v = new visualModule.CharacterVisual('player_warrior', 0xffffff, 0);
+    v.setRuneTint(0xff2200);
+
+    const runeClones = [...mountedMaterials(v.root)].filter(
+      (mat) => mat.userData.runeTintHex === 0xff2200,
+    );
+    expect(runeClones.length).toBeGreaterThan(0);
+    const spies = runeClones.map((mat) => vi.spyOn(mat, 'dispose'));
+
+    v.dispose();
+    // The mutant that leaves runeTintMaterials out of disposeEffectMaterials
+    // goes red here: every rune clone must dispose with its owning visual.
+    for (const spy of spies) expect(spy).toHaveBeenCalledTimes(1);
+  }, 20000);
+
+  it('a rune chain replaces the clone per source, disposing the old tint exactly as it unmounts', async () => {
+    const { visual: visualModule } = await loadModules();
+    const v = new visualModule.CharacterVisual('player_warrior', 0xffffff, 0);
+    v.setRuneTint(0xff2200);
+    const oldClones = [...mountedMaterials(v.root)].filter(
+      (mat) => mat.userData.runeTintHex === 0xff2200,
+    );
+    expect(oldClones.length).toBeGreaterThan(0);
+    const oldSpies = oldClones.map((mat) => vi.spyOn(mat, 'dispose'));
+
+    v.setRuneTint(0x2266ff);
+    const mounted = mountedMaterials(v.root);
+    // Old tint fully unmounted and disposed; new tint mounted in its place.
+    for (const clone of oldClones) expect(mounted.has(clone)).toBe(false);
+    for (const spy of oldSpies) expect(spy).toHaveBeenCalledTimes(1);
+    expect(
+      [...mounted].filter((mat) => mat.userData.runeTintHex === 0x2266ff).length,
+    ).toBeGreaterThan(0);
+
+    // And the per-visual map holds ONE clone per source (the chain replaced,
+    // not accumulated) with no stale-tint residue.
+    const map = (v as unknown as { runeTintMaterials: Map<THREE.Material, THREE.Material> })
+      .runeTintMaterials;
+    for (const clone of map.values()) {
+      expect(clone.userData.runeTintHex).toBe(0x2266ff);
+    }
+
+    v.dispose();
+  }, 20000);
+
+  it('the currently mounted rune clone is never disposed while worn', async () => {
+    const { visual: visualModule } = await loadModules();
+    const v = new visualModule.CharacterVisual('player_warrior', 0xffffff, 0);
+    v.setRuneTint(0xff2200);
+    const clones = [...mountedMaterials(v.root)].filter(
+      (mat) => mat.userData.runeTintHex === 0xff2200,
+    );
+    const spies = clones.map((mat) => vi.spyOn(mat, 'dispose'));
+
+    // Re-asserting the same tint and toggling an unrelated overlay must not
+    // touch the live clones (the disposed-while-mounted mutant goes red).
+    v.setRuneTint(0xff2200);
+    v.setGhost(true);
+    v.setGhost(false);
+    for (const spy of spies) expect(spy).not.toHaveBeenCalled();
+    expect(
+      [...mountedMaterials(v.root)].filter((mat) => mat.userData.runeTintHex === 0xff2200).length,
+    ).toBeGreaterThan(0);
+
+    v.dispose();
+  }, 20000);
+});

--- a/tests/character_visual_material_release.test.ts
+++ b/tests/character_visual_material_release.test.ts
@@ -116,6 +116,40 @@ describe('CharacterVisual tinted-material release', () => {
     v.dispose();
   }, 20000);
 
+  it('color cycling with an active overlay holds one effect-clone set, not one per color', async () => {
+    const { visual: visualModule } = await loadModules();
+    // tint: 'entity', the pooled-reuse case: setEntityColor re-runs
+    // applySkinMaterials, swapping every SOURCE material the effect maps key
+    // by. The ratchet that only emptied those maps in dispose() accumulated
+    // one unreachable clone set per rift color worn.
+    const v = new visualModule.CharacterVisual('mob_mushroom_pixie', 0x100000);
+    v.setGhost(true);
+    const maps = v as unknown as { ghostMaterials: Map<THREE.Material, THREE.Material> };
+    const clonesPerSet = maps.ghostMaterials.size;
+    expect(clonesPerSet).toBeGreaterThan(0);
+    const firstClones = [...maps.ghostMaterials.values()];
+    const firstSpies = firstClones.map((mat) => vi.spyOn(mat, 'dispose'));
+
+    for (let i = 1; i <= 12; i++) v.setEntityColor(0x100000 + i * 37);
+
+    // One clone set for the CURRENT sources, not one per color worn, and the
+    // first color's clones were genuinely disposed as their sources swapped.
+    expect(maps.ghostMaterials.size).toBe(clonesPerSet);
+    for (const spy of firstSpies) expect(spy).toHaveBeenCalledTimes(1);
+
+    // The overlay survived the swaps visually: the mounted body material is
+    // a live ghost clone re-derived from the CURRENT source (transparent,
+    // faded), not the raw tint clone and not a stale disposed clone.
+    const body = v.root.getObjectByName('body') as THREE.Mesh;
+    const mounted = body.material as THREE.Material;
+    expect([...maps.ghostMaterials.values()]).toContain(mounted);
+    expect(firstClones).not.toContain(mounted);
+    expect(mounted.transparent).toBe(true);
+    expect(mounted.opacity).toBeLessThan(1);
+
+    v.dispose();
+  }, 20000);
+
   it('disposes the rune-tint clones with the visual', async () => {
     const { visual: visualModule } = await loadModules();
     const v = new visualModule.CharacterVisual('player_warrior', 0xffffff, 0);

--- a/tests/character_visual_pool.test.ts
+++ b/tests/character_visual_pool.test.ts
@@ -1,0 +1,308 @@
+// The character-visual reuse pool (src/render/characters/visual_pool.ts): the
+// normalized pool key (rift per-instance color/scale jitter must never
+// partition it), the bounded least-recently-released eviction with real
+// disposal, eviction transparency (an evicted key misses and rebuilds), and
+// the acquire-time re-tint seam (CharacterVisual.setEntityColor).
+import { readFileSync } from 'node:fs';
+import { describe, expect, it, vi } from 'vitest';
+import { CharacterVisualPool, characterVisualPoolKey } from '../src/render/characters/visual_pool';
+import { gfxInternalsForTest } from '../src/render/gfx';
+
+vi.mock('../src/render/assets/loader', () => ({
+  loadGltf: vi.fn(() => new Promise(() => undefined)),
+  loadKtx2Texture: vi.fn(() => new Promise(() => undefined)),
+  loadTexture: vi.fn(() => new Promise(() => undefined)),
+}));
+
+vi.mock('../src/render/assets/preload', () => ({
+  registerPreload: vi.fn(),
+  registerDeferredPreload: vi.fn((start: () => unknown) => start()),
+}));
+
+import { CharacterVisual } from '../src/render/characters/visual';
+
+interface StubVisual {
+  dispose: ReturnType<typeof vi.fn<() => void>>;
+}
+
+const stubVisual = (): StubVisual => ({ dispose: vi.fn<() => void>() });
+
+describe('characterVisualPoolKey normalization', () => {
+  it('gives two rift-jittered mobs of one template THE SAME per-template key', () => {
+    // Per-instance color/scale exactly as rift/runs.ts re-grades them:
+    // deterministic sim-rng jitter stored on the entity. The exact-literal
+    // assertions are the mutant proof: restoring `:${e.color}:${e.scale}` to
+    // the key re-introduces the dead-entry leak and turns this red.
+    const a = {
+      kind: 'mob' as const,
+      templateId: 'ashen_wolf',
+      skin: 0,
+      color: 0x8a3c2f,
+      scale: 1.0733,
+    };
+    const b = {
+      kind: 'mob' as const,
+      templateId: 'ashen_wolf',
+      skin: 0,
+      color: 0x93452a,
+      scale: 0.9481,
+    };
+    expect(characterVisualPoolKey(a)).toBe('mob:ashen_wolf');
+    expect(characterVisualPoolKey(b)).toBe('mob:ashen_wolf');
+    expect(characterVisualPoolKey(a)).toBe(characterVisualPoolKey(b));
+  });
+
+  it('keeps npc skin in the key (atlas identity) but drops color and scale', () => {
+    const npc = {
+      kind: 'npc' as const,
+      templateId: 'npc_innkeeper',
+      skin: 2,
+      color: 0x123456,
+      scale: 1.21,
+    };
+    expect(characterVisualPoolKey(npc)).toBe('npc:npc_innkeeper:2');
+    const otherSkin = { ...npc, skin: 3 };
+    expect(characterVisualPoolKey(otherSkin)).toBe('npc:npc_innkeeper:3');
+  });
+
+  it('never pools players (A6 exclusion) or non-character kinds', () => {
+    expect(
+      characterVisualPoolKey({ kind: 'player' as const, templateId: 'warrior', skin: 1 }),
+    ).toBeNull();
+    expect(
+      characterVisualPoolKey({ kind: 'object' as const, templateId: 'ore_node', skin: 0 }),
+    ).toBeNull();
+  });
+});
+
+describe('CharacterVisualPool bounded LRU', () => {
+  it('respects the bound: storing bound+1 evicts the least-recently-released and disposes it', () => {
+    const pool = new CharacterVisualPool<StubVisual>();
+    const visuals = [stubVisual(), stubVisual(), stubVisual(), stubVisual()];
+    pool.store('a', visuals[0], 3);
+    pool.store('b', visuals[1], 3);
+    pool.store('c', visuals[2], 3);
+    expect(pool.size).toBe(3);
+
+    const disposed = pool.store('d', visuals[3], 3);
+
+    expect(disposed).toBe(1);
+    expect(pool.size).toBe(3);
+    expect(visuals[0].dispose).toHaveBeenCalledTimes(1);
+    expect(visuals[1].dispose).not.toHaveBeenCalled();
+    expect(visuals[2].dispose).not.toHaveBeenCalled();
+    expect(visuals[3].dispose).not.toHaveBeenCalled();
+  });
+
+  it('evicts in RELEASE order across keys, not key insertion order', () => {
+    const pool = new CharacterVisualPool<StubVisual>();
+    const a1 = stubVisual();
+    const b1 = stubVisual();
+    const a2 = stubVisual();
+    pool.store('a', a1, 3);
+    pool.store('b', b1, 3);
+    pool.store('a', a2, 3);
+
+    pool.store('c', stubVisual(), 3);
+
+    // a1 was released first, so it goes first even though key 'a' also holds
+    // the most recent release.
+    expect(a1.dispose).toHaveBeenCalledTimes(1);
+    expect(b1.dispose).not.toHaveBeenCalled();
+    expect(a2.dispose).not.toHaveBeenCalled();
+    expect(pool.take('a')).toBe(a2);
+    expect(pool.take('b')).toBe(b1);
+  });
+
+  it('take returns the most-recently-released visual for the key and removes it', () => {
+    const pool = new CharacterVisualPool<StubVisual>();
+    const v1 = stubVisual();
+    const v2 = stubVisual();
+    pool.store('k', v1, 10);
+    pool.store('k', v2, 10);
+
+    expect(pool.take('k')).toBe(v2);
+    expect(pool.size).toBe(1);
+    expect(pool.take('k')).toBe(v1);
+    expect(pool.size).toBe(0);
+    expect(pool.take('k')).toBeNull();
+    expect(v1.dispose).not.toHaveBeenCalled();
+    expect(v2.dispose).not.toHaveBeenCalled();
+  });
+
+  it('an evicted key simply misses, so the caller transparently rebuilds and can re-pool', () => {
+    const pool = new CharacterVisualPool<StubVisual>();
+    const evicted = stubVisual();
+    pool.store('rift', evicted, 2);
+    pool.store('x', stubVisual(), 2);
+    pool.store('y', stubVisual(), 2); // evicts 'rift'
+    expect(evicted.dispose).toHaveBeenCalledTimes(1);
+
+    // Miss: the renderer falls through to a fresh createCharacterVisual from
+    // the live entity (identical construction inputs), then releases it back.
+    expect(pool.take('rift')).toBeNull();
+    const rebuilt = stubVisual();
+    pool.store('rift', rebuilt, 2);
+    expect(pool.take('rift')).toBe(rebuilt);
+  });
+
+  it('reads the cap live per store: a shrunken profile cap drains overflow immediately', () => {
+    const pool = new CharacterVisualPool<StubVisual>();
+    const visuals = [stubVisual(), stubVisual(), stubVisual(), stubVisual(), stubVisual()];
+    for (const v of visuals) pool.store('k', v, 8);
+    expect(pool.size).toBe(5);
+
+    const disposed = pool.store('k', stubVisual(), 3);
+
+    expect(disposed).toBe(3);
+    expect(pool.size).toBe(3);
+    expect(visuals[0].dispose).toHaveBeenCalledTimes(1);
+    expect(visuals[1].dispose).toHaveBeenCalledTimes(1);
+    expect(visuals[2].dispose).toHaveBeenCalledTimes(1);
+    expect(visuals[3].dispose).not.toHaveBeenCalled();
+  });
+
+  it('fails closed on a disabled or invalid cap: the incoming visual is disposed, never pooled', () => {
+    const pool = new CharacterVisualPool<StubVisual>();
+    const zero = stubVisual();
+    expect(pool.store('k', zero, 0)).toBe(1);
+    expect(zero.dispose).toHaveBeenCalledTimes(1);
+    const nan = stubVisual();
+    expect(pool.store('k', nan, Number.NaN)).toBe(1);
+    expect(nan.dispose).toHaveBeenCalledTimes(1);
+    expect(pool.size).toBe(0);
+  });
+
+  it('supports an unbounded cap without evicting (the Infinity arm stays valid)', () => {
+    const pool = new CharacterVisualPool<StubVisual>();
+    const visuals = Array.from({ length: 300 }, stubVisual);
+    for (const v of visuals) pool.store('k', v, Number.POSITIVE_INFINITY);
+    expect(pool.size).toBe(300);
+    for (const v of visuals) expect(v.dispose).not.toHaveBeenCalled();
+  });
+
+  it('drain empties the pool and hands visuals back UNdisposed (the caller owns teardown)', () => {
+    const pool = new CharacterVisualPool<StubVisual>();
+    const v1 = stubVisual();
+    const v2 = stubVisual();
+    pool.store('a', v1, 10);
+    pool.store('b', v2, 10);
+
+    const drained = pool.drain();
+
+    expect(drained).toEqual([v1, v2]);
+    expect(pool.size).toBe(0);
+    expect(pool.take('a')).toBeNull();
+    expect(v1.dispose).not.toHaveBeenCalled();
+    expect(v2.dispose).not.toHaveBeenCalled();
+  });
+});
+
+describe('per-profile pool bound (GFX.maxPooledCharacterVisuals)', () => {
+  it('bounds EVERY profile: desktop 128, constrained 24, iOS 6, tight-memory 4', () => {
+    const { settingsFor } = gfxInternalsForTest;
+    expect(settingsFor('high').maxPooledCharacterVisuals).toBe(128);
+    expect(settingsFor('ultra').maxPooledCharacterVisuals).toBe(128);
+    expect(settingsFor('medium', { deviceMemory: 4 }).maxPooledCharacterVisuals).toBe(24);
+    expect(settingsFor('medium', { platform: 'ios' }).maxPooledCharacterVisuals).toBe(6);
+    expect(
+      settingsFor('medium', { platform: 'ios', tightMemory: true }).maxPooledCharacterVisuals,
+    ).toBe(4);
+    // The C1 ratchet fix: no profile keeps the historical unbounded pool.
+    for (const tier of ['low', 'medium', 'high', 'ultra', 'insane'] as const) {
+      expect(Number.isFinite(settingsFor(tier).maxPooledCharacterVisuals)).toBe(true);
+    }
+  });
+});
+
+describe('renderer integration (source pins)', () => {
+  const renderer = readFileSync(new URL('../src/render/renderer.ts', import.meta.url), 'utf8');
+
+  it('keys the pool through the normalized helper, never a jittered inline key', () => {
+    const keyStart = renderer.indexOf('private visualPoolKeyFor(');
+    const keyEnd = renderer.indexOf('\n  private ', keyStart + 1);
+    expect(keyStart).toBeGreaterThan(-1);
+    const keyFor = renderer.slice(keyStart, keyEnd);
+    expect(keyFor).toContain('return characterVisualPoolKey(e);');
+    // Mutant proof at the renderer layer: re-inlining the per-instance
+    // color/scale key re-creates the dead-entry leak and turns this red.
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: a deliberate plain-string scan for template-literal SOURCE TEXT in renderer.ts
+    expect(renderer).not.toContain(':${e.color}:${e.scale}');
+  });
+
+  it('applies the per-instance jitter at acquire time and rebuilds on a miss from the live entity', () => {
+    const takeStart = renderer.indexOf('private takePooledVisual(');
+    const takeEnd = renderer.indexOf('\n  private ', takeStart + 1);
+    expect(takeStart).toBeGreaterThan(-1);
+    const take = renderer.slice(takeStart, takeEnd);
+    // color is an acquire-time instance attribute now that the key is
+    // per-template (rift mobs jitter it per instance)
+    expect(take).toContain('visual.setEntityColor(entityColor)');
+    // ... and the caller hands the live entity's color in
+    const acquire = 'this.takePooledVisual(visualPoolKey, e.color)';
+    const acquireIdx = renderer.indexOf(acquire);
+    expect(acquireIdx).toBeGreaterThan(-1);
+    // scale rides the view group for pooled and fresh visuals alike
+    expect(renderer).toContain('group.scale.setScalar(e.scale)');
+    // a pool miss falls through to a fresh build from the SAME entity the
+    // evicted visual was built from: eviction is invisible on screen
+    const missWindow = renderer.slice(acquireIdx, acquireIdx + 1200);
+    expect(missWindow).toContain("this.createCharacterVisualWithRetry(e, 'view')");
+  });
+});
+
+describe('CharacterVisual.setEntityColor', () => {
+  type RetintFake = {
+    entityColor: number;
+    def: { tint?: number | 'entity' };
+    skinIndex: number;
+    applySkinMaterials: ReturnType<typeof vi.fn>;
+  };
+  const callSetEntityColor = (fake: RetintFake, color: number): void => {
+    (
+      CharacterVisual.prototype.setEntityColor as unknown as (
+        this: RetintFake,
+        color: number,
+      ) => void
+    ).call(fake, color);
+  };
+
+  it('re-runs the shared material sweep only for an entity-tinted def with a new color', () => {
+    const fake: RetintFake = {
+      entityColor: 0x112233,
+      def: { tint: 'entity' },
+      skinIndex: 3,
+      applySkinMaterials: vi.fn(),
+    };
+    callSetEntityColor(fake, 0x112233);
+    expect(fake.applySkinMaterials).not.toHaveBeenCalled();
+
+    callSetEntityColor(fake, 0xaabbcc);
+    expect(fake.entityColor).toBe(0xaabbcc);
+    // the sweep runs against the CURRENT skin, exactly like setSkin's heal path
+    expect(fake.applySkinMaterials).toHaveBeenCalledTimes(1);
+    expect(fake.applySkinMaterials).toHaveBeenCalledWith(3);
+  });
+
+  it('records but never sweeps for a def that ignores entity color (fixed or absent tint)', () => {
+    const fixed: RetintFake = {
+      entityColor: 0x111111,
+      def: { tint: 0x336699 },
+      skinIndex: 0,
+      applySkinMaterials: vi.fn(),
+    };
+    callSetEntityColor(fixed, 0x222222);
+    expect(fixed.entityColor).toBe(0x222222);
+    expect(fixed.applySkinMaterials).not.toHaveBeenCalled();
+
+    const untinted: RetintFake = {
+      entityColor: 0x111111,
+      def: {},
+      skinIndex: 0,
+      applySkinMaterials: vi.fn(),
+    };
+    callSetEntityColor(untinted, 0x222222);
+    expect(untinted.entityColor).toBe(0x222222);
+    expect(untinted.applySkinMaterials).not.toHaveBeenCalled();
+  });
+});

--- a/tests/character_visual_pool_policy.test.ts
+++ b/tests/character_visual_pool_policy.test.ts
@@ -10,7 +10,7 @@ describe('character visual pool residency policy', () => {
     expect(shouldRetainPooledCharacterVisual(7, 6)).toBe(false);
   });
 
-  it('preserves the desktop unbounded-pool behavior', () => {
+  it('supports an unbounded cap (the ground-object pool desktop configuration)', () => {
     expect(shouldRetainPooledCharacterVisual(10_000, Number.POSITIVE_INFINITY)).toBe(true);
   });
 
@@ -19,7 +19,7 @@ describe('character visual pool residency policy', () => {
     expect(shouldRetainPooledCharacterVisual(0, Number.NaN)).toBe(false);
   });
 
-  it('is enforced by the renderer pool take and store paths', () => {
+  it('is enforced by the renderer pool take, store, and teardown paths', () => {
     const renderer = readFileSync(new URL('../src/render/renderer.ts', import.meta.url), 'utf8');
     const takeStart = renderer.indexOf('private takePooledVisual(');
     const storeStart = renderer.indexOf('private storePooledVisual(', takeStart);
@@ -29,14 +29,19 @@ describe('character visual pool residency policy', () => {
 
     expect(takeStart).toBeGreaterThan(-1);
     expect(storeStart).toBeGreaterThan(takeStart);
-    expect(store).toContain(
-      'shouldRetainPooledCharacterVisual(this.pooledVisualCount, GFX.maxPooledCharacterVisuals)',
+    // The character pool routes every release through the bounded LRU store
+    // (which evicts + disposes least-recently-released overflow under the
+    // live GFX cap; see tests/character_visual_pool.test.ts for its unit
+    // behavior), and every acquire through the pool take.
+    expect(store).toContain('this.visualPool.store(key, visual, GFX.maxPooledCharacterVisuals)');
+    expect(take).toContain('this.visualPool.take(key)');
+    // Terminal teardown drains the pool and really disposes every visual.
+    expect(renderer).toContain(
+      'for (const visual of this.visualPool.drain()) bestEffort(() => visual.dispose());',
     );
-    expect(take).toContain('this.pooledVisualCount = Math.max(0, this.pooledVisualCount - 1)');
-    expect(store).toContain('visual.dispose();');
-    expect(store).toContain('this.pooledVisualCount++;');
-    expect(store.indexOf('visual.dispose();')).toBeLessThan(
-      store.indexOf('this.pooledVisualCount++;'),
+    // The ground-object pool still gates retention on this policy predicate.
+    expect(renderer).toContain(
+      'shouldRetainPooledCharacterVisual(this.pooledObjectCount, GFX.maxPooledObjects)',
     );
   });
 });

--- a/tests/eastbrook_polish_artifact_integrity.test.ts
+++ b/tests/eastbrook_polish_artifact_integrity.test.ts
@@ -675,10 +675,13 @@ const ACCEPTED_POLISH_V2_METADATA_PATH = path.join(REPO_ROOT, POLISH_SEAL_PATH);
 // neither parent. No capture was retaken.
 // Re-minted on PR 3150's v0.36.0 base merge, where the branch's renderer.ts
 // prewarm changes converged with the 3165 reseal. No capture was retaken.
+// Re-minted for the render cache-lifecycle port: the rendererIntegration leaf
+// follows renderer.ts's bounded character-visual pool wiring and the emissive
+// cache teardown comment. No capture was retaken.
 const ACCEPTED_POLISH_V2_METADATA_SHA256 =
-  'ec9d9ca628a22172ee8e989c3ac88d563b43929ce6d0ffc2b66881d462ca79f9';
+  'ed55aa77beb548ff412761a710201011371b6eff23ea0deb9870345d7e5bc025';
 const ACCEPTED_POLISH_V2_COMPOSITE_PROVENANCE =
-  'a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca';
+  '9345197315c6d496bf17b6e7c195a786a0d51ee5fb1742418d297803f256bdf1';
 const ACCEPTED_POLISH_V2_METADATA = readJsonFile<CaptureMetadata>(ACCEPTED_POLISH_V2_METADATA_PATH);
 const ACCEPTED_POLISH_V2_PROVENANCE = ACCEPTED_POLISH_V2_METADATA.polishProvenance;
 const ACCEPTED_POLISH_V2_TOWN_CONTRACT = ACCEPTED_POLISH_V2_METADATA.records[0]?.townContract;
@@ -1579,10 +1582,14 @@ describe('Eastbrook polish performance and contact evidence', () => {
     // swept evidence bytes. No capture was retaken.
     // Re-minted after pinning the three specifier exact (PR 3165 review): only
     // the pnpm-lock.yaml specifier row moved. No capture was retaken.
+    // Re-minted for the render cache-lifecycle port: the first-order composite
+    // follows renderer.ts's bounded character-visual pool wiring and emissive
+    // cache teardown comment, then this second-order performance seal follows
+    // the swept evidence bytes. No capture was retaken.
     expect(
       fingerprint.digest('hex'),
       `the second-order performance digest moved; if every input moved legitimately, re-mint with: ${REMINT_COMMAND} (it recomputes this literal LAST, from the swept files)`,
-    ).toBe('cab95c2e4617b24251ccf355ba0519caf9069d0b8a90788bc8148eae276f98ca');
+    ).toBe('79eee8675f91a81bf644a5011968b0b8e5b132897ef49c3892003b2192513dc0');
   });
 
   it('binds every historical after record to its accepted source and asset provenance', () => {

--- a/tests/eastbrook_polish_capture_contract.test.ts
+++ b/tests/eastbrook_polish_capture_contract.test.ts
@@ -91,8 +91,11 @@ interface AttributionTargetFixture {
 // neither parent. No capture was retaken.
 // Re-minted on PR 3150's v0.36.0 base merge: the branch's renderer.ts prewarm
 // changes and the PR 3165 reseal converged here. No capture was retaken.
+// Re-minted for the render cache-lifecycle port: the rendererIntegration leaf
+// follows renderer.ts's bounded character-visual pool wiring and the emissive
+// cache teardown comment. No capture was retaken.
 const PINNED_POLISH_COMPOSITE_FINGERPRINT =
-  'a1ee3eaafc63148b46a8af7029cd990f82b4128ee7789e1a1a35e9126926fcca';
+  '9345197315c6d496bf17b6e7c195a786a0d51ee5fb1742418d297803f256bdf1';
 
 function validPolishAttributionTargets(): AttributionTargetFixture[] {
   return [

--- a/tests/foliage_perceptual_density.test.ts
+++ b/tests/foliage_perceptual_density.test.ts
@@ -38,9 +38,10 @@ describe('streamed grass perceptual density', () => {
     // tests/grass_build_slicing.test.ts): the sliced builder checks its frame
     // budget BEFORE every sub-unit on this clock, so on the real clock a slow
     // CI machine can leave the streamed window part-built after any fixed
-    // frame count. Freezing the clock makes every started chunk finish in its
-    // frame, restoring the deterministic one-whole-chunk-per-frame pacing
-    // this suite's full-window assertions were written against.
+    // frame count. Freezing the clock means the budget deadline never
+    // arrives, so the whole queued window builds deterministically in the
+    // first update (builds continue while budget remains), giving this
+    // suite the fully built window its assertions were written against.
     const grass = foliageGrassInternalsForTest.buildGrassRing(parent, 20_061, () => 0);
     const px = 15;
     const pz = 45;

--- a/tests/foliage_perceptual_density.test.ts
+++ b/tests/foliage_perceptual_density.test.ts
@@ -34,12 +34,22 @@ describe('streamed grass perceptual density', () => {
   it('keeps near chunks full and changes only existing immutable instance buffers', async () => {
     const { foliageGrassInternalsForTest } = await import('../src/render/foliage');
     const parent = new THREE.Group();
-    const grass = foliageGrassInternalsForTest.buildGrassRing(parent, 20_061);
+    // Frozen injected build clock (the unsliced reference pacing from
+    // tests/grass_build_slicing.test.ts): the sliced builder checks its frame
+    // budget BEFORE every sub-unit on this clock, so on the real clock a slow
+    // CI machine can leave the streamed window part-built after any fixed
+    // frame count. Freezing the clock makes every started chunk finish in its
+    // frame, restoring the deterministic one-whole-chunk-per-frame pacing
+    // this suite's full-window assertions were written against.
+    const grass = foliageGrassInternalsForTest.buildGrassRing(parent, 20_061, () => 0);
     const px = 15;
     const pz = 45;
     for (let frame = 0; frame < 64; frame++) {
       grass.update(px, pz, 8, 6, 40, 623.54, 1 / 60);
     }
+    // The density and immutability assertions below stand on a fully built
+    // streamed window: nothing may still be queued or mid-build here.
+    expect(grass.perfStats().grassQueuedChunks).toBe(0);
 
     const collectAllMeshes = (): THREE.InstancedMesh[] => {
       const result: THREE.InstancedMesh[] = [];

--- a/tests/gfx.test.ts
+++ b/tests/gfx.test.ts
@@ -534,7 +534,10 @@ describe('graphics tier resolution', () => {
     });
 
     expect(desktop.constrainedMemory).toBe(false);
-    expect(desktop.maxPooledCharacterVisuals).toBe(Number.POSITIVE_INFINITY);
+    // The character pool is bounded on EVERY profile since the C1 memory-ratchet
+    // fix (128 on desktop, LRU-evicted; see tests/character_visual_pool.test.ts);
+    // only the ground-object pool keeps the historical desktop Infinity.
+    expect(desktop.maxPooledCharacterVisuals).toBe(128);
     expect(desktop.maxPooledObjects).toBe(Number.POSITIVE_INFINITY);
 
     for (const constrained of [androidBrowser, androidNative]) {

--- a/tests/gfx_override_core.test.ts
+++ b/tests/gfx_override_core.test.ts
@@ -148,13 +148,18 @@ describe('gfx override application', () => {
     // Only the serialized KEY NAME moves for these desktop-default cases (none of them pass an
     // iOS platform hint, so the field's VALUE stays false throughout), but JSON.stringify bakes
     // the key name into the byte pin same as any other field.
+    // Regenerated again for the C1 memory-ratchet fix: the desktop
+    // maxPooledCharacterVisuals arm moved from POSITIVE_INFINITY (which
+    // JSON.stringify serializes as null) to the bounded 128 (see gfx.ts and
+    // tests/character_visual_pool.test.ts), so every desktop-default profile's
+    // serialized bytes moved by exactly that one value.
     expect(hashes).toEqual({
-      low: 'ffdec5a230db44fbb7ebfeaff1c7f70f41580ce717eed7fd9a25bc10c5ad21ec',
-      medium: '469d80e5a2f24e5d154e88f187bf35d03511549089c7a07ee0dd973771184d57',
-      high: 'be25f35848d170b70f25036ef8209df5ca0cdd6ced3660e53ded55ec6e65c45a',
-      ultra: '8ea3fcdd2c997953394b856aceeaf5036cfb638c0834401a39db349fea2cd3be',
-      insane: '5ce1944db03460cb8427df78b81503807405a5e26c25b5380f8b5d3557761de8',
-      advanced: '52c2de0c12c7897dd24bb600bec815f715c95aa2824eae895c8939f7d041414b',
+      low: '2b50e2f6a64cf6bc0540aea1138ba729db5ba29cd9e1ce7ae3630f9bb826f9bc',
+      medium: 'e38687c8392fe46ee6941e26374e11473f7208732e9aa251dde7239faa74504e',
+      high: '02a87653c70f90faeeeb22e918cd2bb79ad4fdd14b8115c6745a8e4f575f4547',
+      ultra: 'c7f51f9c5e62bb013db47cf42ad98d904b8f5a675aa072b7b2884f1903017cd2',
+      insane: '393167d184c3029be560b9601bc50a1d103fc2221204d85dae3c79be9dbdc3da',
+      advanced: 'e99d3a399f2a18903f9f31c80320f99e5b46f35af3e84f21a6220c02ca3475b8',
     });
   });
 

--- a/tests/grass_build_slicer_core.test.ts
+++ b/tests/grass_build_slicer_core.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import { runSlicedBuild } from '../src/render/grass_build_slicer_core';
+
+// A controllable clock plus a job whose every sub-unit costs a fixed amount of
+// simulated time. The job records the order its sub-units ran in, so the pins
+// below can assert exact counts (the budget check runs BEFORE each sub-unit)
+// and exact order (slicing is timing-only).
+const makeClock = (start = 0) => {
+  let t = start;
+  return {
+    now: () => t,
+    advance: (ms: number) => {
+      t += ms;
+    },
+  };
+};
+
+const makeJob = (totalSteps: number, costMs: number, clock: { advance: (ms: number) => void }) => {
+  const executed: number[] = [];
+  return {
+    executed,
+    job: {
+      step: () => {
+        executed.push(executed.length);
+        clock.advance(costMs);
+        return executed.length < totalSteps;
+      },
+    },
+  };
+};
+
+describe('grass build slicer core: the budget check precedes the cost', () => {
+  it('runs zero sub-units when the deadline has already passed (mutant: check-after runs one)', () => {
+    // Arrange: the clock sits at 10, past a deadline of 5.
+    const clock = makeClock(10);
+    const { job, executed } = makeJob(8, 2, clock);
+
+    // Act
+    const outcome = runSlicedBuild(job, 5, clock.now);
+
+    // Assert: not a single sub-unit of work started. Moving the deadline
+    // check after the step (the old check-after-build shape) executes one
+    // sub-unit here and turns this red.
+    expect(executed).toEqual([]);
+    expect(outcome).toBe('paused');
+  });
+
+  it('runs zero sub-units at the exact deadline boundary (now === deadline is exhausted)', () => {
+    const clock = makeClock(5);
+    const { job, executed } = makeJob(8, 2, clock);
+
+    expect(runSlicedBuild(job, 5, clock.now)).toBe('paused');
+    expect(executed).toEqual([]);
+  });
+
+  it('stops starting sub-units once the simulated work exhausts the budget (exact counts)', () => {
+    // Arrange: each sub-unit costs 2ms of simulated work against a 3ms budget.
+    const clock = makeClock(0);
+    const { job, executed } = makeJob(10, 2, clock);
+
+    // Act: checks run at t=0 (run, t->2) and t=2 (run, t->4); the t=4 check
+    // refuses a third sub-unit.
+    const outcome = runSlicedBuild(job, 3, clock.now);
+
+    // Assert
+    expect(executed).toEqual([0, 1]);
+    expect(outcome).toBe('paused');
+
+    // A resume whose budget is already exhausted continues NO work.
+    expect(runSlicedBuild(job, clock.now(), clock.now)).toBe('paused');
+    expect(executed).toEqual([0, 1]);
+
+    // A resume with fresh budget picks up exactly where the job paused.
+    expect(runSlicedBuild(job, clock.now() + 5, clock.now)).toBe('paused');
+    expect(executed).toEqual([0, 1, 2, 3, 4]);
+  });
+
+  it('completes a job that fits the budget and never calls step past completion', () => {
+    const clock = makeClock(0);
+    const { job, executed } = makeJob(3, 0.1, clock);
+
+    const outcome = runSlicedBuild(job, 100, clock.now);
+
+    expect(outcome).toBe('completed');
+    expect(executed).toEqual([0, 1, 2]);
+  });
+
+  it('executes the identical sub-unit sequence however the budget divides the work', () => {
+    // Arrange: the unsliced reference run (one generous budget).
+    const wholeClock = makeClock(0);
+    const whole = makeJob(25, 1, wholeClock);
+    expect(runSlicedBuild(whole.job, 1e9, wholeClock.now)).toBe('completed');
+
+    // Act: the same job resumed under a stingy 3ms budget per call.
+    const slicedClock = makeClock(0);
+    const sliced = makeJob(25, 1, slicedClock);
+    let calls = 0;
+    for (; calls < 100; calls++) {
+      if (runSlicedBuild(sliced.job, slicedClock.now() + 3, slicedClock.now) === 'completed') break;
+    }
+
+    // Assert: many resumes were needed (the slicing really happened), and the
+    // concatenated execution order is the unsliced order exactly.
+    expect(calls).toBeGreaterThan(5);
+    expect(calls).toBeLessThan(100);
+    expect(sliced.executed).toEqual(whole.executed);
+  });
+});

--- a/tests/grass_build_slicing.test.ts
+++ b/tests/grass_build_slicing.test.ts
@@ -42,8 +42,9 @@ const FRAME_CAP = 3000;
 
 // A fake clock whose every reading advances by a fixed amount, simulating
 // build sub-units that cost real main-thread time. advancePerReadMs 0 is the
-// unsliced reference: the budget deadline never arrives, so each queued chunk
-// builds whole in one frame, exactly the pre-slicing pacing.
+// unsliced reference: the budget deadline never arrives, so the whole queued
+// window builds in one frame (builds continue while budget remains; there is
+// no per-frame completions cap).
 const makeClock = (advancePerReadMs: number) => {
   let t = 0;
   return () => {
@@ -205,6 +206,77 @@ describe('sliced grass chunk builds', () => {
     // and every reference chunk, including the abandoned-and-rebuilt one,
     // matches the unsliced reference byte for byte. The far detour may cache
     // extra chunks; the reference keys are the ones under test.
+    const geometry = geometryByKey(parent);
+    for (const [key, expected] of reference.geometry) {
+      const actual = geometry.get(key);
+      expect(actual, key).toBeDefined();
+      if (!actual) continue;
+      expectSameBytes(actual.matrix, expected.matrix, `${key} matrix`);
+      expectSameBytes(actual.color, expected.color, `${key} color`);
+    }
+  }, 60_000);
+
+  it('a frame with budget left continues into the next queued chunk (ring fill beats one per frame)', async () => {
+    // Arrange: a cost profile where one whole chunk costs well under the
+    // 2.2ms frame budget, so only a per-frame completions cap could hold the
+    // fill rate down to the pre-slicing one chunk per frame.
+    const reference = await buildReference();
+    const buildGrassRing = await loadRingBuilder();
+    const parent = new THREE.Group();
+    const ring = buildGrassRing(parent, SEED, makeClock(0.005));
+
+    // Act
+    frameAt(ring, PX, PZ);
+    const firstFrameBuilt = ring.perfStats().grassBuiltChunks;
+    const frames = 1 + driveUntilIdle(ring, PX, PZ);
+
+    // Assert: the first frame completed a chunk AND kept building with its
+    // remaining budget (the completions cap that discarded unspent budget
+    // after one finish goes red here), so the whole ring fills in strictly
+    // fewer frames than the pre-slicing one-chunk-per-frame rate. The
+    // geometry stays byte-identical to the unsliced reference.
+    expect(firstFrameBuilt).toBeGreaterThan(1);
+    const stats = ring.perfStats();
+    expect(stats.grassReadyChunks).toBe(reference.readyChunks);
+    expect(frames).toBeLessThan(reference.readyChunks);
+    const geometry = geometryByKey(parent);
+    for (const [key, expected] of reference.geometry) {
+      const actual = geometry.get(key);
+      expect(actual, key).toBeDefined();
+      if (!actual) continue;
+      expectSameBytes(actual.matrix, expected.matrix, `${key} matrix`);
+      expectSameBytes(actual.color, expected.color, `${key} color`);
+    }
+  }, 60_000);
+
+  it('entering a dungeon abandons the in-flight build instead of stranding its buffers', async () => {
+    // Arrange: pause the first chunk mid-build (its two chunkCap instance
+    // buffers are allocated in the setup sub-unit).
+    const reference = await buildReference();
+    const buildGrassRing = await loadRingBuilder();
+    const parent = new THREE.Group();
+    const ring = buildGrassRing(parent, SEED, makeClock(0.35));
+    frameAt(ring, PX, PZ);
+    frameAt(ring, PX, PZ);
+    const statsBefore = ring.perfStats();
+    expect(statsBefore.grassReadyChunks).toBe(0);
+    expect(statsBefore.grassQueuedChunks).toBeGreaterThan(0);
+
+    // Act: cross the dungeon threshold. update() returns before
+    // buildQueuedChunks on that branch, so only the abandon path can release
+    // the paused build; without it the two InstancedMesh buffers stay held
+    // for the whole dungeon run.
+    const disposeSpy = vi.spyOn(THREE.InstancedMesh.prototype, 'dispose');
+    frameAt(ring, 200_000, PZ);
+    expect(disposeSpy).toHaveBeenCalledTimes(2);
+    disposeSpy.mockRestore();
+    // The abandoned build no longer counts as in-flight queued work.
+    expect(ring.perfStats().grassQueuedChunks).toBe(statsBefore.grassQueuedChunks - 1);
+
+    // Assert: back outside, the abandoned chunk rebuilds byte-identically
+    // (the pinned abandon contract) with no duplicate mesh per chunk+family.
+    const frames = driveUntilIdle(ring, PX, PZ);
+    expect(frames).toBeLessThan(FRAME_CAP);
     const geometry = geometryByKey(parent);
     for (const [key, expected] of reference.geometry) {
       const actual = geometry.get(key);

--- a/tests/grass_build_slicing.test.ts
+++ b/tests/grass_build_slicing.test.ts
@@ -1,0 +1,217 @@
+import * as THREE from 'three';
+import { describe, expect, it, vi } from 'vitest';
+
+// Sliced grass chunk builds (src/render/grass_build_slicer_core.ts wired into
+// foliage.ts buildGrassRing): the frame budget is enforced BEFORE each build
+// sub-unit, and slicing moves only WHEN the work happens, never WHAT it
+// produces. Mock set mirrors tests/foliage_perceptual_density.test.ts.
+
+vi.mock('../src/render/assets/loader', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/render/assets/loader')>();
+  return {
+    ...actual,
+    loadGltf: () => new Promise(() => {}),
+    loadTexture: () => new Promise(() => {}),
+    releaseGltf: () => {},
+  };
+});
+vi.mock('../src/render/assets/preload', () => ({
+  registerPreload: () => {},
+  registerDeferredPreload: () => {},
+}));
+vi.mock('../src/render/textures', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/render/textures')>();
+  return {
+    ...actual,
+    grassTuftTexture: () => new THREE.Texture(),
+    flowerTuftTexture: () => new THREE.Texture(),
+  };
+});
+vi.mock('../src/render/gfx', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/render/gfx')>();
+  return {
+    ...actual,
+    GFX: actual.gfxInternalsForTest.settingsFor('low'),
+  };
+});
+
+const SEED = 20_061;
+const PX = 15;
+const PZ = 45;
+const FRAME_CAP = 3000;
+
+// A fake clock whose every reading advances by a fixed amount, simulating
+// build sub-units that cost real main-thread time. advancePerReadMs 0 is the
+// unsliced reference: the budget deadline never arrives, so each queued chunk
+// builds whole in one frame, exactly the pre-slicing pacing.
+const makeClock = (advancePerReadMs: number) => {
+  let t = 0;
+  return () => {
+    const reading = t;
+    t += advancePerReadMs;
+    return reading;
+  };
+};
+
+const loadRingBuilder = async () => {
+  const { foliageGrassInternalsForTest } = await import('../src/render/foliage');
+  return foliageGrassInternalsForTest.buildGrassRing;
+};
+
+type GrassRingUnderTest = ReturnType<
+  typeof import('../src/render/foliage')['foliageGrassInternalsForTest']['buildGrassRing']
+>;
+
+const frameAt = (ring: GrassRingUnderTest, px: number, pz: number): void => {
+  ring.update(px, pz, 8, 6, 40, 623.54, 1 / 60);
+};
+
+const driveUntilIdle = (ring: GrassRingUnderTest, px: number, pz: number): number => {
+  let frames = 0;
+  while (frames < FRAME_CAP) {
+    frameAt(ring, px, pz);
+    frames++;
+    if (ring.perfStats().grassQueuedChunks === 0) return frames;
+  }
+  return frames;
+};
+
+interface ChunkGeometry {
+  matrix: Float32Array;
+  color: Float32Array | null;
+}
+
+// One immutable geometry record per chunk+family mesh; duplicate keys (a
+// double-built chunk) fail loudly instead of shadowing each other.
+const geometryByKey = (parent: THREE.Group): Map<string, ChunkGeometry> => {
+  const map = new Map<string, ChunkGeometry>();
+  parent.traverse((object) => {
+    const mesh = object as THREE.InstancedMesh;
+    if (!mesh.isInstancedMesh || !mesh.userData.instanceFamily) return;
+    const key = `${mesh.userData.grassChunkKey}:${mesh.userData.instanceFamily}`;
+    expect(map.has(key), `duplicate mesh for ${key}`).toBe(false);
+    map.set(key, {
+      matrix: mesh.instanceMatrix.array as Float32Array,
+      color: (mesh.instanceColor?.array as Float32Array | undefined) ?? null,
+    });
+  });
+  return map;
+};
+
+const expectSameBytes = (
+  actual: Float32Array | null,
+  expected: Float32Array | null,
+  label: string,
+): void => {
+  expect(actual === null, `${label}: presence`).toBe(expected === null);
+  if (!actual || !expected) return;
+  expect(actual.length, `${label}: length`).toBe(expected.length);
+  const actualBytes = Buffer.from(actual.buffer, actual.byteOffset, actual.byteLength);
+  const expectedBytes = Buffer.from(expected.buffer, expected.byteOffset, expected.byteLength);
+  expect(Buffer.compare(actualBytes, expectedBytes), `${label}: bytes`).toBe(0);
+};
+
+// The unsliced reference ring is built once and shared by the tests below
+// (building it means scanning every in-range chunk, the expensive part).
+let cachedReference: { readyChunks: number; geometry: Map<string, ChunkGeometry> } | null = null;
+const buildReference = async () => {
+  if (cachedReference) return cachedReference;
+  const buildGrassRing = await loadRingBuilder();
+  const parent = new THREE.Group();
+  const ring = buildGrassRing(parent, SEED, makeClock(0));
+  const frames = driveUntilIdle(ring, PX, PZ);
+  expect(frames).toBeLessThan(FRAME_CAP);
+  const stats = ring.perfStats();
+  expect(stats.grassReadyChunks).toBeGreaterThan(8);
+  expect(stats.grassReadyChunks).toBe(stats.grassBuiltChunks);
+  cachedReference = { readyChunks: stats.grassReadyChunks, geometry: geometryByKey(parent) };
+  return cachedReference;
+};
+
+describe('sliced grass chunk builds', () => {
+  it('sliced and unsliced builds produce byte-identical instance geometry', async () => {
+    // Arrange: the unsliced reference plus a ring whose clock advances 0.35ms
+    // per reading, so the 2.2ms budget pauses every chunk mid-build.
+    const reference = await buildReference();
+    const buildGrassRing = await loadRingBuilder();
+    const parent = new THREE.Group();
+    const ring = buildGrassRing(parent, SEED, makeClock(0.35));
+
+    // Act + slicing evidence: after one frame the unsliced reference had a
+    // finished chunk; the sliced ring is still mid-build with nothing ready.
+    frameAt(ring, PX, PZ);
+    expect(ring.perfStats().grassReadyChunks).toBe(0);
+    const frames = 1 + driveUntilIdle(ring, PX, PZ);
+    expect(frames).toBeLessThan(FRAME_CAP);
+
+    // Assert: same chunks, spread over strictly more frames than the old
+    // one-chunk-per-frame pacing, and every buffer byte-identical.
+    const stats = ring.perfStats();
+    expect(stats.grassReadyChunks).toBe(reference.readyChunks);
+    expect(frames).toBeGreaterThan(reference.readyChunks);
+    const geometry = geometryByKey(parent);
+    expect([...geometry.keys()].sort()).toEqual([...reference.geometry.keys()].sort());
+    for (const [key, expected] of reference.geometry) {
+      const actual = geometry.get(key);
+      expect(actual, key).toBeDefined();
+      if (!actual) continue;
+      expectSameBytes(actual.matrix, expected.matrix, `${key} matrix`);
+      expectSameBytes(actual.color, expected.color, `${key} color`);
+    }
+  }, 60_000);
+
+  it('a frame whose budget is already exhausted pays zero build cost (check precedes work)', async () => {
+    // Arrange: every clock reading jumps 100ms, so by the first pre-step
+    // check the 2.2ms deadline has always passed.
+    const buildGrassRing = await loadRingBuilder();
+    const parent = new THREE.Group();
+    const ring = buildGrassRing(parent, SEED, makeClock(100));
+
+    // Act
+    for (let frame = 0; frame < 5; frame++) frameAt(ring, PX, PZ);
+
+    // Assert: chunks are queued but not one build ran, and nothing was
+    // parented. The pre-slicing shape (build the chunk, then check the
+    // deadline) builds a whole chunk per frame here and turns this red.
+    const stats = ring.perfStats();
+    expect(stats.grassQueuedChunks).toBeGreaterThan(0);
+    expect(stats.grassBuiltChunks).toBe(0);
+    expect(stats.grassReadyChunks).toBe(0);
+    let meshes = 0;
+    parent.traverse((object) => {
+      if ((object as THREE.InstancedMesh).isInstancedMesh) meshes++;
+    });
+    expect(meshes).toBe(0);
+  }, 60_000);
+
+  it('an abandoned mid-build chunk rebuilds to the identical geometry', async () => {
+    // Arrange: pause the first chunk mid-build, then leave the area so the
+    // in-flight build is abandoned, then come back.
+    const reference = await buildReference();
+    const buildGrassRing = await loadRingBuilder();
+    const parent = new THREE.Group();
+    const ring = buildGrassRing(parent, SEED, makeClock(0.35));
+    frameAt(ring, PX, PZ);
+    frameAt(ring, PX, PZ);
+    expect(ring.perfStats().grassReadyChunks).toBe(0);
+
+    // Act: three frames far away (the streamed window moves off the chunk),
+    // then return and let the ring finish.
+    for (let frame = 0; frame < 3; frame++) frameAt(ring, -500, PZ);
+    const frames = driveUntilIdle(ring, PX, PZ);
+    expect(frames).toBeLessThan(FRAME_CAP);
+
+    // Assert: no duplicate mesh per chunk+family (geometryByKey pins that),
+    // and every reference chunk, including the abandoned-and-rebuilt one,
+    // matches the unsliced reference byte for byte. The far detour may cache
+    // extra chunks; the reference keys are the ones under test.
+    const geometry = geometryByKey(parent);
+    for (const [key, expected] of reference.geometry) {
+      const actual = geometry.get(key);
+      expect(actual, key).toBeDefined();
+      if (!actual) continue;
+      expectSameBytes(actual.matrix, expected.matrix, `${key} matrix`);
+      expectSameBytes(actual.color, expected.color, `${key} color`);
+    }
+  }, 60_000);
+});

--- a/tests/renderer_lifecycle.test.ts
+++ b/tests/renderer_lifecycle.test.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from 'node:fs';
 import { describe, expect, it, vi } from 'vitest';
+import { CharacterVisualPool } from '../src/render/characters/visual_pool';
 import { Renderer } from '../src/render/renderer';
 
 const source = readFileSync(new URL('../src/render/renderer.ts', import.meta.url), 'utf8');
@@ -64,7 +65,9 @@ describe('Renderer lifecycle wiring', () => {
     expect(disposal).toContain('this.post?.dispose()');
     expect(disposal).toContain('this.chatBubbles.clear()');
     expect(disposal).toContain('this.removeView(id, true)');
-    expect(disposal).toContain('for (const visual of pool) bestEffort(() => visual.dispose())');
+    expect(disposal).toContain(
+      'for (const visual of this.visualPool.drain()) bestEffort(() => visual.dispose())',
+    );
     expect(disposal).toContain('this.objectPool.clear()');
     expect(disposal).toContain('this.nameplatePainter?.dispose()');
     expect(disposal).toContain('this.nameplateLayer.replaceChildren()');
@@ -127,7 +130,9 @@ describe('Renderer lifecycle wiring', () => {
       events.push('view:dispose');
       throw new Error('injected view disposal failure');
     };
-    renderer.visualPool = new Map([['player', [{ dispose: () => events.push('pool:dispose') }]]]);
+    const visualPool = new CharacterVisualPool<{ dispose: () => void }>();
+    visualPool.store('player', { dispose: () => events.push('pool:dispose') }, 10);
+    renderer.visualPool = visualPool;
     renderer.objectPool = new Map();
     // The deferred weapon-skin apply queue is a teardown participant too: a
     // pending application must never survive into the next context.

--- a/tests/tinted_material_cache_core.test.ts
+++ b/tests/tinted_material_cache_core.test.ts
@@ -1,0 +1,179 @@
+// The bounded, claim-counted store policy behind the shared tinted-material
+// cache (characters/assets.ts tintedMaterial). A mounted clone is pinned by
+// its claims, so eviction can never touch a material a live mesh still draws
+// with; idle entries (every claim released) stay warm up to the idle bound and
+// then evict least-recently-released through the onEvict callback that owns
+// disposal. reset() (a graphics-profile change) disposes idle entries now and
+// retires claimed ones to dispose on their last release, never while mounted.
+// This is what turns the old grow-forever memo (dead-source keys stranded for
+// the page lifetime, one clone set per rift color ever seen) into a bounded
+// working set.
+import { describe, expect, it } from 'vitest';
+import {
+  TINTED_MATERIAL_IDLE_CACHE_MAX,
+  TintedMaterialCache,
+} from '../src/render/characters/tinted_material_cache_core';
+
+function makeCache(maxIdle: number) {
+  const evicted: string[] = [];
+  const cache = new TintedMaterialCache<string>(maxIdle, (value) => evicted.push(value));
+  return { cache, evicted };
+}
+
+/** A build callback that counts its cold runs and mints a distinct value. */
+function makeBuild(value: string) {
+  let calls = 0;
+  const build = () => {
+    calls++;
+    return `${value}#${calls}`;
+  };
+  return { build, calls: () => calls };
+}
+
+describe('TintedMaterialCache', () => {
+  it('builds once per key and shares the clone across later claims', () => {
+    const { cache, evicted } = makeCache(2);
+    const a = makeBuild('A');
+
+    const first = cache.claim('a', a.build);
+    const second = cache.claim('a', a.build);
+    expect(first).toBe(second);
+    expect(a.calls()).toBe(1);
+    expect(cache.size).toBe(1);
+    expect(evicted).toEqual([]);
+  });
+
+  it('never evicts an entry a live claim still pins, even at idle bound zero', () => {
+    const { cache, evicted } = makeCache(0);
+    const a = makeBuild('A');
+    const b = makeBuild('B');
+
+    cache.claim('a', a.build); // stays claimed for the whole case
+    cache.claim('b', b.build);
+    expect(cache.release('b')).toBe(true);
+
+    // b became idle over a zero idle bound: evicted immediately. a is pinned.
+    expect(evicted).toEqual(['B#1']);
+    expect(cache.claim('a', a.build)).toBe('A#1');
+    expect(a.calls()).toBe(1);
+  });
+
+  it('keeps a clone shared by two leases alive until BOTH release it', () => {
+    const { cache, evicted } = makeCache(0);
+    const a = makeBuild('A');
+
+    cache.claim('a', a.build); // lease 1 (visual 1's mount)
+    cache.claim('a', a.build); // lease 2 (visual 2's mount)
+    expect(cache.release('a')).toBe(true); // visual 1 disposed
+
+    // Still claimed by lease 2 over a zero idle bound: must not be evicted.
+    expect(evicted).toEqual([]);
+    expect(cache.peek('a')).toBe('A#1');
+
+    expect(cache.release('a')).toBe(true); // visual 2 disposed
+    expect(evicted).toEqual(['A#1']);
+  });
+
+  it('keeps idle entries warm up to the bound and evicts least-recently-released past it', () => {
+    const { cache, evicted } = makeCache(2);
+    for (const key of ['a', 'b', 'c']) {
+      cache.claim(key, makeBuild(key.toUpperCase()).build);
+    }
+    cache.release('a');
+    cache.release('b');
+    expect(evicted).toEqual([]); // two idle, at the bound
+
+    // Re-claiming and re-releasing a moves it to the eviction tail, so the
+    // third idle entry evicts b (oldest release), not a.
+    cache.claim('a', makeBuild('A2').build);
+    cache.release('a');
+    cache.release('c');
+    expect(evicted).toEqual(['B#1']);
+    expect(cache.peek('a')).toBe('A#1');
+    expect(cache.peek('c')).toBe('C#1');
+  });
+
+  it('serves an evicted key by rebuilding through the build callback', () => {
+    const { cache, evicted } = makeCache(0);
+    const a = makeBuild('A');
+
+    cache.claim('a', a.build);
+    cache.release('a');
+    expect(evicted).toEqual(['A#1']);
+
+    // The rebuild is a fresh value (the old clone was disposed).
+    expect(cache.claim('a', a.build)).toBe('A#2');
+    expect(a.calls()).toBe(2);
+  });
+
+  it('refuses an unknown-key or zero-claim release so a double release cannot underflow a pin', () => {
+    const { cache, evicted } = makeCache(1);
+    const a = makeBuild('A');
+
+    expect(cache.release('missing')).toBe(false);
+
+    cache.claim('a', a.build); // one live claim (another lease's mount)
+    cache.claim('a', a.build); // this lease
+    expect(cache.release('a')).toBe(true); // this lease releases
+    cache.release('a'); // the other lease releases: now idle
+    expect(cache.release('a')).toBe(false); // double release refused
+    // The refused release must not have evicted or double-disposed anything.
+    expect(evicted).toEqual([]);
+    expect(cache.peek('a')).toBe('A#1');
+  });
+
+  it('reset() disposes idle entries immediately and never a claimed one', () => {
+    const { cache, evicted } = makeCache(8);
+    cache.claim('idle', makeBuild('I').build);
+    cache.release('idle');
+    cache.claim('live', makeBuild('L').build);
+
+    cache.reset();
+    expect(evicted).toEqual(['I#1']);
+    expect(cache.peek('live')).toBe('L#1');
+    expect(cache.size).toBe(1);
+  });
+
+  it('reset() retires a claimed entry to dispose on its last release instead of idling warm', () => {
+    const { cache, evicted } = makeCache(8);
+    cache.claim('live', makeBuild('L').build);
+
+    cache.reset();
+    expect(evicted).toEqual([]);
+    expect(cache.release('live')).toBe(true);
+    // Disposed the moment its mount released, despite idle headroom.
+    expect(evicted).toEqual(['L#1']);
+    expect(cache.size).toBe(0);
+  });
+
+  it('a fresh claim un-retires a reset survivor (it is demonstrably live again)', () => {
+    const { cache, evicted } = makeCache(8);
+    const l = makeBuild('L');
+    cache.claim('live', l.build);
+    cache.reset();
+
+    cache.claim('live', l.build); // a new visual claims the same key
+    cache.release('live');
+    cache.release('live');
+    // Both claims released with idle headroom: the entry idles warm rather
+    // than disposing, because the post-reset claim proved it live.
+    expect(evicted).toEqual([]);
+    expect(cache.peek('live')).toBe('L#1');
+    expect(l.calls()).toBe(1);
+  });
+
+  it('fails closed on an invalid idle bound (retains nothing idle)', () => {
+    const { cache, evicted } = makeCache(Number.NaN);
+    cache.claim('a', makeBuild('A').build);
+    cache.release('a');
+    expect(evicted).toEqual(['A#1']);
+    expect(cache.size).toBe(0);
+  });
+
+  it('pins the shipped idle bound', () => {
+    // The bound only has to make dead-source keys and stale rift colors
+    // finite while keeping despawn/respawn churn warm; a change here is a
+    // deliberate retune, not drift.
+    expect(TINTED_MATERIAL_IDLE_CACHE_MAX).toBe(64);
+  });
+});

--- a/tests/tinted_material_lifecycle.test.ts
+++ b/tests/tinted_material_lifecycle.test.ts
@@ -1,0 +1,259 @@
+// Lifecycle of the shared tinted-material cache (characters/assets.ts): the
+// claims lease keeps every mounted clone pinned (eviction can never dispose a
+// material a live mesh draws with), released leases let dead-source keys and
+// stale rift colors age out through the bounded idle LRU, and an evicted key
+// rebuilds identically from a live source on its next request. Each test
+// imports the module fresh (vi.resetModules) so the module-level cache starts
+// empty every time.
+import * as THREE from 'three';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { VisualDef } from '../src/render/characters/manifest';
+import { TINTED_MATERIAL_IDLE_CACHE_MAX } from '../src/render/characters/tinted_material_cache_core';
+
+type AssetsModule = typeof import('../src/render/characters/assets');
+type GfxModule = typeof import('../src/render/gfx');
+
+async function loadAssets(): Promise<{
+  assets: AssetsModule;
+  restoreGfx: () => void;
+}> {
+  vi.resetModules();
+  vi.doMock('../src/render/assets/loader', () => ({
+    loadGltf: vi.fn(() => new Promise(() => undefined)),
+    loadKtx2Texture: vi.fn(() => new Promise(() => undefined)),
+    loadTexture: vi.fn(() => new Promise(() => undefined)),
+    releaseGltf: vi.fn(),
+  }));
+  vi.doMock('../src/render/assets/preload', () => ({
+    registerPreload: vi.fn(),
+    registerDeferredPreload: vi.fn((start: () => unknown) => start()),
+  }));
+  const gfx = (await import('../src/render/gfx')) as GfxModule;
+  const restoreGfx = gfx.gfxInternalsForTest.overrideSettings({ standardMaterials: true });
+  const assets = (await import('../src/render/characters/assets')) as AssetsModule;
+  return { assets, restoreGfx };
+}
+
+afterEach(() => {
+  vi.doUnmock('../src/render/assets/loader');
+  vi.doUnmock('../src/render/assets/preload');
+  vi.resetModules();
+});
+
+/** Track disposals without changing behavior. */
+function disposeSpy(mat: THREE.Material) {
+  return vi.spyOn(mat, 'dispose');
+}
+
+describe('tinted material cache lifecycle', () => {
+  it('shares one clone between two leases and keeps it alive until both release (a premature dispose goes red)', async () => {
+    const { assets, restoreGfx } = await loadAssets();
+    try {
+      const source = new THREE.MeshStandardMaterial({ color: 0xffffff });
+      const leaseA: Set<string> = new Set();
+      const leaseB: Set<string> = new Set();
+
+      const forA = assets.tintedMaterial(source, 0x336699, 0.4, null, null, 'body', leaseA);
+      const forB = assets.tintedMaterial(source, 0x336699, 0.4, null, null, 'body', leaseB);
+      // Sharing pin: two visuals with the same (source, tint) share one clone.
+      expect(forB).toBe(forA);
+      expect(leaseA).toEqual(leaseB);
+      const spy = disposeSpy(forA);
+
+      // Visual A goes away; B still mounts the clone. Flood the idle LRU far
+      // past its bound: the claimed entry must survive untouched.
+      assets.releaseTintedMaterials(leaseA);
+      for (let i = 0; i < TINTED_MATERIAL_IDLE_CACHE_MAX * 2; i++) {
+        assets.tintedMaterial(new THREE.MeshStandardMaterial({ color: 0xffffff }), i, 0.4);
+      }
+      expect(spy).not.toHaveBeenCalled();
+      // Still served shared for a third lease.
+      const leaseC: Set<string> = new Set();
+      expect(assets.tintedMaterial(source, 0x336699, 0.4, null, null, 'body', leaseC)).toBe(forA);
+
+      // Last mounts release: the entry idles, and idle pressure disposes it.
+      assets.releaseTintedMaterials(leaseB);
+      assets.releaseTintedMaterials(leaseC);
+      for (let i = 0; i < TINTED_MATERIAL_IDLE_CACHE_MAX * 2; i++) {
+        assets.tintedMaterial(new THREE.MeshStandardMaterial({ color: 0xffffff }), 0x1000 + i, 0.4);
+      }
+      expect(spy).toHaveBeenCalledTimes(1);
+    } finally {
+      restoreGfx();
+    }
+  }, 20000);
+
+  it('reclaims and disposes dead-source entries once released (the C3 leak pin)', async () => {
+    const { assets, restoreGfx } = await loadAssets();
+    try {
+      // A source that then "dies" (its owner disposes and drops it, as the
+      // recolour LRU does): its key can never be requested again, so the only
+      // way out is the idle LRU.
+      const dying = new THREE.MeshStandardMaterial({ color: 0xffffff });
+      const lease: Set<string> = new Set();
+      const clone = assets.tintedMaterial(dying, 0x883311, 0.4, null, null, 'body', lease);
+      const spy = disposeSpy(clone);
+      assets.releaseTintedMaterials(lease);
+      dying.dispose();
+
+      const before = assets.tintedMaterialInternalsForTest.cacheSize();
+      expect(before).toBe(1);
+      for (let i = 0; i < TINTED_MATERIAL_IDLE_CACHE_MAX * 2; i++) {
+        assets.tintedMaterial(new THREE.MeshStandardMaterial({ color: 0xffffff }), i, 0.4);
+      }
+      // The dead-source clone was disposed and the cache is bounded.
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(assets.tintedMaterialInternalsForTest.cacheSize()).toBeLessThanOrEqual(
+        TINTED_MATERIAL_IDLE_CACHE_MAX,
+      );
+    } finally {
+      restoreGfx();
+    }
+  }, 20000);
+
+  it('keeps the cache bounded while rift colors cycle through the acquire-time retint path', async () => {
+    const { assets, restoreGfx } = await loadAssets();
+    try {
+      // The C1 residual: pooled reuse re-tints per instance, so every distinct
+      // rift color used to mint a permanently retained clone set. Simulate the
+      // exact applySkinMaterials sequence: claim the new color's sweep into a
+      // fresh lease, then release the previous lease.
+      const body = new THREE.Mesh(
+        new THREE.BufferGeometry(),
+        new THREE.MeshStandardMaterial({ color: 0xffffff }),
+      );
+      const root = new THREE.Group();
+      root.add(body);
+      const def = { tint: 'entity', tintStrength: 0.35 } as VisualDef;
+
+      const colors = Array.from(
+        { length: TINTED_MATERIAL_IDLE_CACHE_MAX + 40 },
+        (_, i) => 0x100000 + i * 37,
+      );
+      const spies: ReturnType<typeof disposeSpy>[] = [];
+      let lease: Set<string> = new Set();
+      for (const color of colors) {
+        const next: Set<string> = new Set();
+        assets.applyMaterials(root, def, color, null, null, next);
+        spies.push(disposeSpy(body.material as THREE.Material));
+        assets.releaseTintedMaterials(lease);
+        lease = next;
+      }
+
+      // Bounded: one live color plus at most the idle bound stays resident.
+      expect(assets.tintedMaterialInternalsForTest.cacheSize()).toBeLessThanOrEqual(
+        TINTED_MATERIAL_IDLE_CACHE_MAX + 1,
+      );
+      // The oldest colors' clones were genuinely disposed...
+      expect(spies[0]).toHaveBeenCalledTimes(1);
+      expect(spies[1]).toHaveBeenCalledTimes(1);
+      // ...while the mounted (current color) clone was not.
+      expect(spies[spies.length - 1]).not.toHaveBeenCalled();
+    } finally {
+      restoreGfx();
+    }
+  }, 20000);
+
+  it('rebuilds an evicted entry identically when re-requested with a live source (transparency pin)', async () => {
+    const { assets, restoreGfx } = await loadAssets();
+    try {
+      const source = new THREE.MeshStandardMaterial({
+        color: 0xdddddd,
+        roughness: 0.2,
+        name: 'body_cloth',
+      });
+      const lease: Set<string> = new Set();
+      const first = assets.tintedMaterial(
+        source,
+        0x336699,
+        0.4,
+        null,
+        null,
+        'body',
+        lease,
+      ) as THREE.MeshStandardMaterial;
+      const firstHex = first.color.getHex();
+      const firstRoughness = first.roughness;
+      assets.releaseTintedMaterials(lease);
+      for (let i = 0; i < TINTED_MATERIAL_IDLE_CACHE_MAX * 2; i++) {
+        assets.tintedMaterial(new THREE.MeshStandardMaterial({ color: 0xffffff }), i, 0.4);
+      }
+
+      const rebuilt = assets.tintedMaterial(source, 0x336699, 0.4) as THREE.MeshStandardMaterial;
+      // A genuinely fresh clone (the old one was evicted and disposed)...
+      expect(rebuilt).not.toBe(first);
+      // ...that is derived identically: same tint lerp, same roughness clamp.
+      expect(rebuilt.color.getHex()).toBe(firstHex);
+      expect(rebuilt.roughness).toBe(firstRoughness);
+      expect(rebuilt.type).toBe(first.type);
+    } finally {
+      restoreGfx();
+    }
+  }, 20000);
+
+  it('claims idempotently per lease: one sweep meeting a source twice claims once and releases cleanly', async () => {
+    const { assets, restoreGfx } = await loadAssets();
+    try {
+      const source = new THREE.MeshStandardMaterial({ color: 0xffffff });
+      const lease: Set<string> = new Set();
+      const a = assets.tintedMaterial(source, 0x224466, 0.4, null, null, 'body', lease);
+      const b = assets.tintedMaterial(source, 0x224466, 0.4, null, null, 'body', lease);
+      expect(b).toBe(a);
+      expect(lease.size).toBe(1);
+      const spy = disposeSpy(a);
+
+      // One release balances the one claim: the entry idles (evictable), it
+      // was not left over-pinned by the duplicate call.
+      assets.releaseTintedMaterials(lease);
+      for (let i = 0; i < TINTED_MATERIAL_IDLE_CACHE_MAX * 2; i++) {
+        assets.tintedMaterial(new THREE.MeshStandardMaterial({ color: 0xffffff }), i, 0.4);
+      }
+      expect(spy).toHaveBeenCalledTimes(1);
+    } finally {
+      restoreGfx();
+    }
+  }, 20000);
+
+  it('resetCharacterProfileCaches disposes idle clones now and claimed clones only on release', async () => {
+    const { assets, restoreGfx } = await loadAssets();
+    try {
+      const idleSource = new THREE.MeshStandardMaterial({ color: 0xffffff });
+      const idleLease: Set<string> = new Set();
+      const idleClone = assets.tintedMaterial(
+        idleSource,
+        0x111111,
+        0.4,
+        null,
+        null,
+        'body',
+        idleLease,
+      );
+      const idleSpy = disposeSpy(idleClone);
+      assets.releaseTintedMaterials(idleLease);
+
+      const liveSource = new THREE.MeshStandardMaterial({ color: 0xffffff });
+      const liveLease: Set<string> = new Set();
+      const liveClone = assets.tintedMaterial(
+        liveSource,
+        0x222222,
+        0.4,
+        null,
+        null,
+        'body',
+        liveLease,
+      );
+      const liveSpy = disposeSpy(liveClone);
+
+      assets.resetCharacterProfileCaches();
+      // Idle disposed immediately; the mounted clone survives the reset...
+      expect(idleSpy).toHaveBeenCalledTimes(1);
+      expect(liveSpy).not.toHaveBeenCalled();
+      // ...and disposes the moment its visual releases, instead of idling.
+      assets.releaseTintedMaterials(liveLease);
+      expect(liveSpy).toHaveBeenCalledTimes(1);
+      expect(assets.tintedMaterialInternalsForTest.cacheSize()).toBe(0);
+    } finally {
+      restoreGfx();
+    }
+  }, 20000);
+});

--- a/tests/weapon_vfx_emissive_cache_core.test.ts
+++ b/tests/weapon_vfx_emissive_cache_core.test.ts
@@ -1,0 +1,154 @@
+// The bounded, reference-counted memo policy behind the weapon-skin emissive
+// derivation (weapon_vfx.ts). A live rig pins its derivation via a reference
+// count, so eviction can never touch a texture pair any wearer still draws
+// with; idle derivations (every wearer gone) stay warm up to the idle bound
+// and then evict least-recently-released, through the onEvict callback that
+// owns disposal. This is what turns the old grow-forever memo (one
+// megabyte-class texture pair retained per cosmetic ever seen) into a bounded
+// working set.
+import { describe, expect, it } from 'vitest';
+import {
+  WEAPON_EMISSIVE_IDLE_CACHE_MAX,
+  WeaponEmissiveDerivationCache,
+} from '../src/render/weapon_vfx_emissive_cache_core';
+
+function makeCache(maxIdle: number) {
+  const evicted: string[] = [];
+  const cache = new WeaponEmissiveDerivationCache<string>(maxIdle, (value) => evicted.push(value));
+  return { cache, evicted };
+}
+
+/** A derive callback that counts its cold runs and mints a distinct value. */
+function makeDerive(value: string) {
+  let calls = 0;
+  const derive = () => {
+    calls++;
+    return value;
+  };
+  return { derive, calls: () => calls };
+}
+
+describe('WeaponEmissiveDerivationCache', () => {
+  it('derives once per key and serves every later acquire from the memo', () => {
+    const { cache, evicted } = makeCache(2);
+    const a = makeDerive('A');
+
+    expect(cache.acquire('a', a.derive)).toBe('A');
+    expect(cache.acquire('a', a.derive)).toBe('A');
+    expect(a.calls()).toBe(1);
+    expect(cache.size).toBe(1);
+    expect(evicted).toEqual([]);
+  });
+
+  it('never evicts an entry a live reference still pins, even at idle bound zero', () => {
+    const { cache, evicted } = makeCache(0);
+    const a = makeDerive('A');
+    const b = makeDerive('B');
+
+    cache.acquire('a', a.derive); // stays live for the whole case
+    cache.acquire('b', b.derive);
+    expect(cache.release('b')).toBe(true);
+
+    // b became idle over a zero idle bound: evicted immediately. a is pinned.
+    expect(evicted).toEqual(['B']);
+    expect(cache.acquire('a', a.derive)).toBe('A');
+    expect(a.calls()).toBe(1);
+  });
+
+  it('keeps idle entries warm up to the bound and evicts least-recently-released past it', () => {
+    const { cache, evicted } = makeCache(2);
+    const derives = ['A', 'B', 'C', 'D'].map((value) => makeDerive(value));
+    for (const [i, key] of ['a', 'b', 'c', 'd'].entries()) {
+      cache.acquire(key, derives[i].derive);
+      cache.release(key);
+    }
+
+    // Release order a, b, c, d with two idle slots: a then b fall out.
+    expect(evicted).toEqual(['A', 'B']);
+    expect(cache.size).toBe(2);
+    // The survivors are served warm.
+    cache.acquire('c', derives[2].derive);
+    cache.acquire('d', derives[3].derive);
+    expect(derives[2].calls()).toBe(1);
+    expect(derives[3].calls()).toBe(1);
+  });
+
+  it('a revived then re-released entry moves to the back of the eviction order', () => {
+    const { cache, evicted } = makeCache(2);
+    const a = makeDerive('A');
+    const b = makeDerive('B');
+    const c = makeDerive('C');
+
+    cache.acquire('a', a.derive);
+    cache.release('a');
+    cache.acquire('b', b.derive);
+    cache.release('b');
+    // Revive a (a new wearer), then release again: a is now the most recently
+    // released idle entry, so b is the eviction candidate, not a.
+    cache.acquire('a', a.derive);
+    cache.release('a');
+
+    cache.acquire('c', c.derive);
+    cache.release('c');
+    expect(evicted).toEqual(['B']);
+    cache.acquire('a', a.derive);
+    expect(a.calls()).toBe(1);
+  });
+
+  it('release of an unknown key or an already idle entry is a refused no-op', () => {
+    const { cache, evicted } = makeCache(1);
+    const a = makeDerive('A');
+
+    expect(cache.release('missing')).toBe(false);
+    cache.acquire('a', a.derive);
+    expect(cache.release('a')).toBe(true);
+    // A double release (a double-disposed rig) must not underflow the count:
+    // the entry stays a single idle entry, evicted at most once, and a later
+    // flood cannot dispose it out from under a future wearer twice.
+    expect(cache.release('a')).toBe(false);
+    expect(cache.size).toBe(1);
+    expect(evicted).toEqual([]);
+  });
+
+  it('fails closed on an invalid idle bound: nothing idle is retained', () => {
+    // +Infinity is the load-bearing arm: an "unbounded" bound is exactly the
+    // ratchet this cache exists to prevent, so it must clamp to zero, not
+    // retain everything.
+    for (const bound of [Number.NaN, -3, Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY]) {
+      const { cache, evicted } = makeCache(bound);
+      const a = makeDerive('A');
+      cache.acquire('a', a.derive);
+      cache.release('a');
+      expect(evicted, `bound ${bound}`).toEqual(['A']);
+      expect(cache.size, `bound ${bound}`).toBe(0);
+    }
+  });
+
+  it('drain hands every value back, live or idle, without invoking onEvict', () => {
+    const { cache, evicted } = makeCache(4);
+    const a = makeDerive('A');
+    const b = makeDerive('B');
+    cache.acquire('a', a.derive); // still live: drain is the terminal path
+    cache.acquire('b', b.derive);
+    cache.release('b');
+
+    expect(cache.drain()).toEqual(['A', 'B']);
+    expect(cache.size).toBe(0);
+    // Disposal stays with the caller: the renderer teardown wraps each
+    // dispose in its own best-effort guard.
+    expect(evicted).toEqual([]);
+    // The map is empty, not merely detached: the next acquire derives cold.
+    cache.acquire('a', a.derive);
+    expect(a.calls()).toBe(2);
+  });
+
+  it('ships a real, finite idle bound (the ratchet fix cannot regress to unbounded)', () => {
+    expect(Number.isInteger(WEAPON_EMISSIVE_IDLE_CACHE_MAX)).toBe(true);
+    // Envelope, not an exact pin: at least one idle slot keeps the shared
+    // derivation warm across wearer churn of one skin (the pre-existing rig
+    // suite depends on that), and a two-digit ceiling keeps worst-case idle
+    // retention megabyte-class instead of the whole catalog.
+    expect(WEAPON_EMISSIVE_IDLE_CACHE_MAX).toBeGreaterThanOrEqual(1);
+    expect(WEAPON_EMISSIVE_IDLE_CACHE_MAX).toBeLessThanOrEqual(32);
+  });
+});

--- a/tests/weapon_vfx_rig_build.test.ts
+++ b/tests/weapon_vfx_rig_build.test.ts
@@ -1,12 +1,15 @@
 // What building a weapon-skin VFX rig is allowed to COST, driven against the
 // real createWeaponVfx over a stubbed 2d canvas (the module is otherwise plain
-// Three + math). Two regressions are pinned here:
+// Three + math). Three regressions are pinned here:
 //   1. the world path (grounded: false) must build no sky backdrop: its
 //      sceneExtras group is never added to any scene, so the 1024x1024 canvas
 //      of gradients and hundreds of stars was pure waste inside the frame a
 //      skinned player came into view;
 //   2. the memoized emissive derivation is SHARED, so the first wearer's rig
-//      tearing down must not dispose the textures the next wearer draws with.
+//      tearing down must not dispose the textures the next wearer draws with;
+//   3. the memo is BOUNDED (the C2 memory ratchet): idle derivations past the
+//      idle cap evict and dispose, live wearers pin theirs, and an evicted
+//      derivation rebuilds byte-identically on its next wearer.
 import * as THREE from 'three';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { isSharedTexture } from '../src/render/shared_resource';
@@ -19,6 +22,7 @@ import {
   WEAPON_VFX,
   type WeaponVfxSpec,
 } from '../src/render/weapon_vfx';
+import { WEAPON_EMISSIVE_IDLE_CACHE_MAX } from '../src/render/weapon_vfx_emissive_cache_core';
 
 interface StubCanvas {
   width: number;
@@ -27,8 +31,36 @@ interface StubCanvas {
 }
 
 const canvases: StubCanvas[] = [];
+const putImageDataWrites: Uint8ClampedArray[] = [];
 let getImageDataCalls = 0;
+/** When set, the Nth getImageData call throws (a tainted/detached source), for
+ *  the aborted-build reference-release pin. */
+let failGetImageDataAtCall: number | null = null;
 let priorDocument: unknown;
+
+// Deterministic 2d-context pixels: the derivation reads real bytes here, so
+// the bounded-cache suite below can compare a rebuilt derivation byte for
+// byte against the original. The palette cycles the texel classes the
+// emissive core distinguishes (in-window azure, out-of-window red, near-white
+// residual, dull reject), so a derivation writes real nonzero grades.
+const STUB_TEXELS = [
+  [51, 187, 255],
+  [255, 51, 51],
+  [250, 250, 250],
+  [110, 120, 128],
+] as const;
+
+function stubImageData(w: number, h: number) {
+  const data = new Uint8ClampedArray(w * h * 4);
+  for (let i = 0; i < w * h; i++) {
+    const [r, g, b] = STUB_TEXELS[i % STUB_TEXELS.length];
+    data[i * 4] = r;
+    data[i * 4 + 1] = g;
+    data[i * 4 + 2] = b;
+    data[i * 4 + 3] = 255;
+  }
+  return { data, width: w, height: h };
+}
 
 function stubContext() {
   const gradient = { addColorStop: () => {} };
@@ -52,9 +84,14 @@ function stubContext() {
     }),
     getImageData: (_x: number, _y: number, w: number, h: number) => {
       getImageDataCalls++;
-      return { data: new Uint8ClampedArray(w * h * 4), width: w, height: h };
+      if (getImageDataCalls === failGetImageDataAtCall) {
+        throw new Error('stub getImageData failure');
+      }
+      return stubImageData(w, h);
     },
-    putImageData: () => {},
+    putImageData: (image: { data: Uint8ClampedArray }) => {
+      putImageDataWrites.push(Uint8ClampedArray.from(image.data));
+    },
   };
 }
 
@@ -77,7 +114,9 @@ afterAll(() => {
 
 beforeEach(() => {
   canvases.length = 0;
+  putImageDataWrites.length = 0;
   getImageDataCalls = 0;
+  failGetImageDataAtCall = null;
   // Both module-level memos are reset per case, so no assertion here depends on
   // what an earlier case (or a shuffled run order) already cached.
   clearWeaponVfxTextureCacheForTest();
@@ -105,6 +144,14 @@ function weaponRoot(map: THREE.Texture | null = null): THREE.Mesh {
   const mesh = new THREE.Mesh(new THREE.BoxGeometry(0.1, 1, 0.1), material);
   mesh.userData.weaponMesh = true;
   return mesh;
+}
+
+/** A drawable source albedo, as a skin GLB's webp map arrives. Each call mints
+ *  a distinct texture uuid, i.e. a distinct skin as the cache sees it. */
+function sourceMap(): THREE.Texture {
+  const texture = new THREE.Texture();
+  texture.image = { width: 4, height: 4 };
+  return texture;
 }
 
 // Order-independent by construction: beforeEach drops the module-level
@@ -156,13 +203,6 @@ describe('createWeaponVfx backdrop construction', () => {
 });
 
 describe('weapon-skin emissive derivation sharing', () => {
-  /** A drawable source albedo, as a skin GLB's webp map arrives. */
-  function sourceMap(): THREE.Texture {
-    const texture = new THREE.Texture();
-    texture.image = { width: 4, height: 4 };
-    return texture;
-  }
-
   it('derives once per (source map, spec) and hands the same textures to every wearer', () => {
     const map = sourceMap();
     const first = weaponRoot(map);
@@ -267,6 +307,190 @@ describe('weapon-skin emissive derivation sharing', () => {
     createWeaponVfx(next, EPIC_SPEC, { grounded: false });
     expect(getImageDataCalls).toBe(4);
     expect((next.material as THREE.MeshStandardMaterial).emissiveMap).not.toBe(shared);
+  });
+});
+
+describe('bounded emissive derivation cache (the C2 ratchet fix)', () => {
+  /** Build a rig on a fresh wearer of `map` and immediately tear it down,
+   *  leaving the derivation idle in the cache. Returns the derived pair the
+   *  wearer drew with. */
+  function wearAndLeave(map: THREE.Texture) {
+    const root = weaponRoot(map);
+    const rig = createWeaponVfx(root, EPIC_SPEC, { grounded: false });
+    const material = root.material as THREE.MeshStandardMaterial;
+    const pair = {
+      tex: material.emissiveMap as THREE.CanvasTexture,
+      albedo: material.map as THREE.CanvasTexture,
+    };
+    rig.dispose();
+    return pair;
+  }
+
+  it('keeps an idle derivation warm for the next wearer of the same skin', () => {
+    const map = sourceMap();
+    wearAndLeave(map);
+    expect(getImageDataCalls).toBe(2);
+
+    // Every wearer left, but the derivation is within the idle bound: the
+    // next wearer pays no readback and no per-texel walk.
+    const rig = createWeaponVfx(weaponRoot(map), EPIC_SPEC, { grounded: false });
+    expect(getImageDataCalls).toBe(2);
+    rig.dispose();
+  });
+
+  it('bounds idle retention: past the cap the least-recently-released pairs are disposed', () => {
+    const maps = Array.from({ length: WEAPON_EMISSIVE_IDLE_CACHE_MAX + 2 }, () => sourceMap());
+    const disposals: number[] = maps.map(() => 0);
+    for (const [i, map] of maps.entries()) {
+      const { tex, albedo } = wearAndLeave(map);
+      tex.addEventListener('dispose', () => {
+        disposals[i]++;
+      });
+      albedo.addEventListener('dispose', () => {
+        disposals[i]++;
+      });
+    }
+
+    // Exactly the two oldest-released derivations fell out, both textures of
+    // each disposed exactly once; every resident survivor is untouched.
+    expect(disposals[0]).toBe(2);
+    expect(disposals[1]).toBe(2);
+    for (let i = 2; i < maps.length; i++) {
+      expect(disposals[i], `map ${i} must stay resident`).toBe(0);
+    }
+
+    // A survivor is served warm; an evicted skin re-derives cold.
+    const before = getImageDataCalls;
+    wearAndLeave(maps[maps.length - 1]);
+    expect(getImageDataCalls).toBe(before);
+    wearAndLeave(maps[0]);
+    expect(getImageDataCalls).toBe(before + 2);
+  });
+
+  it('never disposes a pair a live rig still draws with while idle churn evicts around it', () => {
+    const liveMap = sourceMap();
+    const liveRoot = weaponRoot(liveMap);
+    const liveRig = createWeaponVfx(liveRoot, EPIC_SPEC, { grounded: false });
+    const material = liveRoot.material as THREE.MeshStandardMaterial;
+    const liveTex = material.emissiveMap as THREE.Texture;
+    const liveAlbedo = material.map as THREE.Texture;
+    let disposals = 0;
+    const count = () => {
+      disposals++;
+    };
+    liveTex.addEventListener('dispose', count);
+    liveAlbedo.addEventListener('dispose', count);
+
+    for (let i = 0; i < WEAPON_EMISSIVE_IDLE_CACHE_MAX + 3; i++) wearAndLeave(sourceMap());
+
+    // Idle churn ran the cache well past its bound; the live wearer's pair
+    // was pinned through all of it, so nothing on screen changed.
+    expect(disposals).toBe(0);
+    expect(material.emissiveMap).toBe(liveTex);
+    expect(material.map).toBe(liveAlbedo);
+
+    // Once released it is the most recently released idle entry: still warm.
+    liveRig.dispose();
+    const before = getImageDataCalls;
+    wearAndLeave(liveMap);
+    expect(getImageDataCalls).toBe(before);
+    expect(disposals).toBe(0);
+  });
+
+  it('a double-disposed rig releases its pin only once (the other wearer stays pinned)', () => {
+    const map = sourceMap();
+    const rigA = createWeaponVfx(weaponRoot(map), EPIC_SPEC, { grounded: false });
+    const rootB = weaponRoot(map);
+    const rigB = createWeaponVfx(rootB, EPIC_SPEC, { grounded: false });
+    const material = rootB.material as THREE.MeshStandardMaterial;
+    const tex = material.emissiveMap as THREE.Texture;
+    let disposals = 0;
+    tex.addEventListener('dispose', () => {
+      disposals++;
+    });
+
+    rigA.dispose();
+    rigA.dispose(); // must not strip rigB's reference
+    for (let i = 0; i < WEAPON_EMISSIVE_IDLE_CACHE_MAX + 2; i++) wearAndLeave(sourceMap());
+
+    expect(disposals).toBe(0);
+    expect(material.emissiveMap).toBe(tex);
+    rigB.dispose();
+  });
+
+  it('an aborted build releases the references it already acquired', () => {
+    // Two meshes with two distinct maps: the first derives cleanly, the
+    // second derivation throws (a tainted/detached source mid-traverse).
+    const okMap = sourceMap();
+    const badMap = sourceMap();
+    const root = weaponRoot(okMap);
+    const second = weaponRoot(badMap);
+    root.add(second);
+
+    failGetImageDataAtCall = 3; // okMap reads twice; badMap's first read throws
+    expect(() => createWeaponVfx(root, EPIC_SPEC, { grounded: false })).toThrow(
+      'stub getImageData failure',
+    );
+
+    // The aborted build restored the first material ...
+    const material = root.material as THREE.MeshStandardMaterial;
+    expect(material.map).toBe(okMap);
+    expect(material.emissiveMap).toBeNull();
+
+    // ... and dropped its cache reference: the derivation is idle, so idle
+    // churn can evict it. A leaked reference would pin it forever, silently
+    // reverting this skin to the unbounded ratchet.
+    const pair = wearAndLeave(okMap);
+    let disposals = 0;
+    const count = () => {
+      disposals++;
+    };
+    pair.tex.addEventListener('dispose', count);
+    pair.albedo.addEventListener('dispose', count);
+    for (let i = 0; i < WEAPON_EMISSIVE_IDLE_CACHE_MAX + 1; i++) wearAndLeave(sourceMap());
+    expect(disposals).toBe(2);
+  });
+
+  it('rebuilds an evicted derivation byte-identically with identical texture parameters', () => {
+    const map = sourceMap();
+    const first = wearAndLeave(map);
+    const firstWrites = putImageDataWrites.slice(-2);
+    // Non-vacuous: the deterministic stub pattern includes in-window azure
+    // texels, so both derivation writes carry real color (alpha excluded).
+    expect(firstWrites[0].some((byte, i) => i % 4 !== 3 && byte > 0)).toBe(true);
+    expect(firstWrites[1].some((byte, i) => i % 4 !== 3 && byte > 0)).toBe(true);
+
+    // Flood the idle set until the pair is evicted.
+    for (let i = 0; i < WEAPON_EMISSIVE_IDLE_CACHE_MAX + 1; i++) wearAndLeave(sourceMap());
+
+    const before = getImageDataCalls;
+    const root = weaponRoot(map);
+    const rig = createWeaponVfx(root, EPIC_SPEC, { grounded: false });
+    // Truly re-derived, not served stale from a disposed entry.
+    expect(getImageDataCalls).toBe(before + 2);
+    const material = root.material as THREE.MeshStandardMaterial;
+    const rebuiltTex = material.emissiveMap as THREE.CanvasTexture;
+    const rebuiltAlbedo = material.map as THREE.CanvasTexture;
+    expect(rebuiltTex).not.toBe(first.tex);
+
+    // The rebuilt pair writes pixel-for-pixel the first derivation again ...
+    const rebuiltWrites = putImageDataWrites.slice(-2);
+    expect(rebuiltWrites[0]).toEqual(firstWrites[0]);
+    expect(rebuiltWrites[1]).toEqual(firstWrites[1]);
+    // ... under the same texture parameters, so an evicted-then-rebuilt
+    // derivation is indistinguishable on screen.
+    const pairs = [
+      [rebuiltTex, first.tex],
+      [rebuiltAlbedo, first.albedo],
+    ] as const;
+    for (const [rebuilt, original] of pairs) {
+      expect(rebuilt.flipY).toBe(original.flipY);
+      expect(rebuilt.colorSpace).toBe(original.colorSpace);
+      expect(rebuilt.wrapS).toBe(original.wrapS);
+      expect(rebuilt.wrapT).toBe(original.wrapT);
+      expect(isSharedTexture(rebuilt)).toBe(true);
+    }
+    rig.dispose();
   });
 });
 


### PR DESCRIPTION
## Summary

Four render-side fixes from the hitch elimination effort, attacking the GC-stutter and memory-ratchet halves of the production telemetry (a GC pause roughly every 4 seconds; roughly 500 MB retained heap growth per crowded session):

1. Grass chunk builds respected their 2.2ms frame budget only AFTER completing, so one build could hold the main thread 18.6ms. buildChunk is now a resumable generator (setup, per-grid-row, finalize sub-units) driven by a pure slicer core that checks the deadline BEFORE every sub-unit and resumes next frame. Sliced and unsliced builds are proven byte-identical at the buffer level, including an abandoned mid-build chunk rebuilt later; partial meshes never parent.
2. The desktop character-visual pool was unbounded (maxPooledCharacterVisuals infinity, overflow dropped the incoming visual), and rift mobs embedded their sim-authored color/scale jitter in pool keys, leaving a permanently unmatchable dead entry per despawn. Keys are normalized (the deterministic sim jitter is untouched; it re-applies at acquire time through the same shared tinted-material sweep a fresh construction uses, so reuse renders identically), and the pool is bounded at 128 (about 2x the referee's observed peak) with least-recently-released eviction that actually disposes GPU resources and transparently rebuilds on demand. Player exclusion from the pool is preserved and pinned.
3. The derived weapon-emissive cache retained two full-resolution canvas+texture pairs per cosmetic ever seen, released only at renderer teardown. Now a refcounted pure core: live rigs pin their entry (eviction can never touch what is on screen), idle entries evict past eight with real disposal, and an evicted key re-derives byte-identically.
4. The tinted-material cache retained every clone forever, including three dead-source leak arms (recolor-wheel disposals stranding tinted twins, profile resets clearing without disposing, and per-rift-color clone sets). Now claim-counted: per-visual leases pin mounted clones (every full-rig sweep claims the new set before releasing the old, so shared keys never dip to zero mid-swap), idle entries evict past 64 with disposal, resets retire claimed entries to dispose on last release. Rune tint materials join both dispose paths.

Evidence discipline: 27 mutant proofs across the four fixes (eviction order, disposal, liveness guards, key normalization, budget-check placement); rendering proven unchanged by differential fuzzing, buffer-level equality, and parity screenshots within same-build noise at every step. The macro MB/s effect is deliberately not claimed from single benchmark runs; fleet heapSawtooth telemetry is the designed judge post-release.

## Related issues

No overlap with open PRs 3219/3217: the renderer.ts hunks here are pool wiring and a teardown comment, outside their prewarm/queue regions. Whichever of this PR and 3219 merges second re-runs the polish provenance mint (both reseal it; one command).

## Type of change

- [x] Refactor or performance (no behavior change)
- [x] Tests

## How was this tested?

- Commands:
  - The 11 owned suites plus architecture and both polish suites in one run: 137 tests green.
  - npx vitest related --run over the changed sources: green modulo two known environment flakes (contention timeouts, pass in isolation) and the documented bare-vitest i18n-gen trap.
  - npx tsc --noEmit green; biome clean on changed files.
  - Polish provenance reminted last for the renderer edits; both polish suites green.
- Manual steps:
  - Verified on the hitch-elimination branch against the frozen hitch referee (PR 3220): soak settled heap 22.66 vs 24.57 baseline and allocation 3.65 vs 4.18 with the full set aboard; parity screenshots within the calibrated same-build noise floor at every step.

---

## Checklist

### Quality

- [x] Every changed behavior pinned with decisive tests; 27 mutants proven red.

### Cross-platform

- N/A: renderer-internal, no UI change; constrained-memory pool ladder unchanged.

### Localization (i18n)

- [x] N/A: no player-visible strings.

### Hygiene

- [x] No secrets; generated files touched only via their owning tools (polish mint).