### PR TITLE
perf(ui): allocation-free hot paths for nameplates, elision, and i18n

### DIFF
--- a/src/render/nameplate_canvas.ts
+++ b/src/render/nameplate_canvas.ts
@@ -18,6 +18,11 @@ export interface NameplateCanvasState {
   level: string;
   levelColor: string;
   guild: string;
+  /** Memo of the drawn `<guild>` form, keyed on `guildLabelSource`, so the
+   *  per-frame draw path never rebuilds the string for an unchanged guild
+   *  (the resolve-diff idiom; drawBase maintains both fields). */
+  guildLabel: string;
+  guildLabelSource: string;
   title: string;
   marker: string;
   markerTone: NameplateMarkerTone;
@@ -53,6 +58,8 @@ export function createNameplateCanvasState(): NameplateCanvasState {
     level: '',
     levelColor: '#fff',
     guild: '',
+    guildLabel: '',
+    guildLabelSource: '',
     title: '',
     marker: '',
     markerTone: 'none',
@@ -351,9 +358,16 @@ export class NameplateCanvasSurface {
     if (state.guild) {
       y -= state.currentTarget ? 14 : 12;
       const guildStyle = state.currentTarget ? this.targetGuildStyle : this.guildStyle;
+      // Rebuild the `<guild>` wrapper only when the guild changes: this runs
+      // per plate per frame, and an unconditional template literal here was a
+      // steady per-frame allocation for every guilded plate on screen.
+      if (state.guildLabelSource !== state.guild) {
+        state.guildLabelSource = state.guild;
+        state.guildLabel = `<${state.guild}>`;
+      }
       this.text.draw(
         ctx,
-        `<${state.guild}>`,
+        state.guildLabel,
         screenX,
         y + (state.currentTarget ? 11 : 10),
         this.configureTextStyle(guildStyle, GUILD_STYLE.fill),

--- a/src/render/nameplate_canvas.ts
+++ b/src/render/nameplate_canvas.ts
@@ -18,11 +18,10 @@ export interface NameplateCanvasState {
   level: string;
   levelColor: string;
   guild: string;
-  /** Memo of the drawn `<guild>` form, keyed on `guildLabelSource`, so the
-   *  per-frame draw path never rebuilds the string for an unchanged guild
-   *  (the resolve-diff idiom; drawBase maintains both fields). */
+  /** The drawn `<guild>` form, prebuilt by the painter's resolveContent
+   *  alongside `guild` (its only writer), so the per-frame draw path never
+   *  allocates the wrapper; drawBase only consumes it. */
   guildLabel: string;
-  guildLabelSource: string;
   title: string;
   marker: string;
   markerTone: NameplateMarkerTone;
@@ -59,7 +58,6 @@ export function createNameplateCanvasState(): NameplateCanvasState {
     levelColor: '#fff',
     guild: '',
     guildLabel: '',
-    guildLabelSource: '',
     title: '',
     marker: '',
     markerTone: 'none',
@@ -358,13 +356,10 @@ export class NameplateCanvasSurface {
     if (state.guild) {
       y -= state.currentTarget ? 14 : 12;
       const guildStyle = state.currentTarget ? this.targetGuildStyle : this.guildStyle;
-      // Rebuild the `<guild>` wrapper only when the guild changes: this runs
-      // per plate per frame, and an unconditional template literal here was a
-      // steady per-frame allocation for every guilded plate on screen.
-      if (state.guildLabelSource !== state.guild) {
-        state.guildLabelSource = state.guild;
-        state.guildLabel = `<${state.guild}>`;
-      }
+      // The `<guild>` wrapper is prebuilt by resolveContent (guild's only
+      // writer): this runs per plate per frame, and an unconditional template
+      // literal here was a steady per-frame allocation for every guilded
+      // plate on screen.
       this.text.draw(
         ctx,
         state.guildLabel,

--- a/src/render/nameplate_painter.ts
+++ b/src/render/nameplate_painter.ts
@@ -302,6 +302,7 @@ export class NameplatePainter {
     state.level = '';
     state.levelColor = '#fff';
     state.guild = '';
+    state.guildLabel = '';
     state.title = '';
     state.marker = '';
     state.markerTone = 'none';
@@ -352,6 +353,11 @@ export class NameplatePainter {
       state.name = entity.afk ? `<${t('hudChrome.nameplate.afkTag')}> ${baseName}` : baseName;
       state.nameColor = roleColor ?? '#7fb8ff';
       state.guild = entity.guild;
+      // Build the drawn `<guild>` wrapper here, not in the per-frame drawBase:
+      // resolveContent is guild's only writer and runs strictly less often (the
+      // init / fullPass / urgent / languageChanged gate), so the label can
+      // never diverge from the guild it wraps.
+      if (entity.guild) state.guildLabel = `<${entity.guild}>`;
       state.hpVisible = !entity.dead;
       state.title = entity.title ? deedTitleText(entity.title) : '';
       state.aiLabel = entity.aiAccount === true ? t('hudChrome.playerMenu.aiTag') : '';

--- a/src/ui/CLAUDE.md
+++ b/src/ui/CLAUDE.md
@@ -79,7 +79,9 @@ Per-frame HUD code (anything reached from `Hud.update()`) holds these:
   (`setText`/`setDisplay`/`setTransform`/`setWidth` + the multi-slot `setStyleProp`/
   `toggleClass`/`setAttr`), bound over the private `hotWriteCache` field in `src/ui/hud.ts`
   and exposed to painters via `src/ui/painter_host.ts` (`PainterHostWriters` /
-  `makeWriterFacet`). The cache key is byte-identical so an unchanged value skips the DOM.
+  `makeWriterFacet`). Elision compares the cached (kind, value) components per element on the
+  painter-host seam (multi-slot writers per (element, slot)), never a composed key string, so
+  an unchanged value skips the DOM and an elided call allocates nothing.
   ALSO elide the expensive upstream RESOLVE, not just the write: diff a stable key and re-run
   the costly producer (icon data-URL, image decode, tooltip HTML) only when the key changes
   (`action_bar_painter` `lastIcon`, `auras_painter` `lastIconKey`, `unit_portrait_painter`

--- a/src/ui/entity_i18n.ts
+++ b/src/ui/entity_i18n.ts
@@ -376,6 +376,9 @@ export function entityTranslationKey(request: EntityTranslationRequest): string 
 // (the localized TEXT memo lives in i18n.ts behind the resolution revision).
 // The compound kinds (questObjective, zonePoi) carry an index and stay on the
 // direct builder: their surfaces (quest log, map POIs) are cold.
+// No eviction on purpose: the ids that arrive at runtime (loot and mail entity
+// ids, wire snapshots) all name entities shipped in src/sim/content, so the
+// memo stays bounded by the static content catalog.
 const entityKeyMemo = new Map<EntityTranslationKind, Map<string, Map<string, string>>>();
 
 function cachedEntityTranslationKey(request: EntityTranslationRequest): string {

--- a/src/ui/entity_i18n.ts
+++ b/src/ui/entity_i18n.ts
@@ -367,6 +367,39 @@ export function entityTranslationKey(request: EntityTranslationRequest): string 
   }
 }
 
+// tEntity sits on per-frame paths (nameplates, aura names, HUD frames), and
+// entityTranslationKey allocates a template literal plus runs the
+// entityPathSegment regex on EVERY call for ids that never change
+// (hitch-elimination B3). The nested memo serves a stable (kind, id, field)
+// triple with three Map reads and zero allocation. Keys derive only from
+// static content ids, never from the locale, so the memo never invalidates
+// (the localized TEXT memo lives in i18n.ts behind the resolution revision).
+// The compound kinds (questObjective, zonePoi) carry an index and stay on the
+// direct builder: their surfaces (quest log, map POIs) are cold.
+const entityKeyMemo = new Map<EntityTranslationKind, Map<string, Map<string, string>>>();
+
+function cachedEntityTranslationKey(request: EntityTranslationRequest): string {
+  if (request.kind === 'questObjective' || request.kind === 'zonePoi') {
+    return entityTranslationKey(request);
+  }
+  let byId = entityKeyMemo.get(request.kind);
+  if (!byId) {
+    byId = new Map();
+    entityKeyMemo.set(request.kind, byId);
+  }
+  let byField = byId.get(request.id);
+  if (!byField) {
+    byField = new Map();
+    byId.set(request.id, byField);
+  }
+  let key = byField.get(request.field);
+  if (key === undefined) {
+    key = entityTranslationKey(request);
+    byField.set(request.field, key);
+  }
+  return key;
+}
+
 function requestManifestEntry(request: EntityTranslationRequest): EntityTranslationManifestEntry {
   const id =
     request.kind === 'questObjective'
@@ -399,7 +432,7 @@ function recordFallback(request: EntityTranslationRequest, value: string): void 
 }
 
 export function tEntity(request: EntityTranslationRequest): string {
-  const key = entityTranslationKey(request);
+  const key = cachedEntityTranslationKey(request);
   const translated = tOptional(key, request.values);
   if (translated !== null) return translated;
   const fallback = interpolateSource(canonicalEntityText(request), request.values);

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -553,7 +553,12 @@ import { MountRaceStrip } from './mount_race_strip';
 import { MovableFrame } from './movable_frame';
 import { NPC_WINDOW_CLOSE_RANGE } from './npc_service_range';
 import { OptionsWindow } from './options_window';
-import { makeWriterFacet, type PainterHostPresentation } from './painter_host';
+import {
+  makeWriterFacet,
+  type PainterHostPresentation,
+  type SingleSlotCache,
+  shouldWriteSingleSlot,
+} from './painter_host';
 import { PartyBelowTargetPainter } from './party_below_target_painter';
 import { loadPartyCollapsed, savePartyCollapsed } from './party_collapse';
 import type { PartyRowAuraDeps } from './party_frame_row';
@@ -1498,7 +1503,7 @@ export class Hud {
   private resurrectHealerBtnEl = $('#resurrect-healer-btn');
   // Cached once (was re-queried every frame): the near-death screen-edge overlay.
   private lowHealthVignetteEl = document.getElementById('low-health-vignette');
-  private hotWriteCache = new Map<HTMLElement, string>();
+  private hotWriteCache: SingleSlotCache = new Map();
   // Multi-slot caches for the per-frame writers: one element holds many
   // custom properties / toggled classes, so these key per (element, prop) and
   // (element, class) instead of the single slot per element hotWriteCache uses.
@@ -2892,23 +2897,26 @@ export class Hud {
     this.log(t('hudChrome.tips.joinChannels'), '#7fd4ff');
   }
 
+  // The two Hud-direct single-slot writers. The elision DECISION is
+  // shouldWriteSingleSlot (painter_host.ts), shared verbatim with the painter
+  // facet over the SAME hotWriteCache: it compares (kind, value) components so
+  // an elided call composes no key string and allocates nothing (the old shape
+  // built a `display:` + value key BEFORE the skip check, allocating a discarded
+  // string on every elided write).
   private setText(el: HTMLElement, text: string): void {
-    if (this.hotWriteCache.get(el) === text) {
+    if (!shouldWriteSingleSlot(this.hotWriteCache, el, 'text', text)) {
       this.hotDomSkippedWrites++;
       return;
     }
-    this.hotWriteCache.set(el, text);
     this.hotDomWrites++;
     el.textContent = text;
   }
 
   private setDisplay(el: HTMLElement, display: string): void {
-    const key = `display:${display}`;
-    if (this.hotWriteCache.get(el) === key) {
+    if (!shouldWriteSingleSlot(this.hotWriteCache, el, 'display', display)) {
       this.hotDomSkippedWrites++;
       return;
     }
-    this.hotWriteCache.set(el, key);
     this.hotDomWrites++;
     el.style.display = display;
   }
@@ -2917,8 +2925,8 @@ export class Hud {
   // (makeWriterFacet's setTransform/setWidth, painter_host.ts). The target hp bar was
   // the last Hud-direct setTransform caller and the cast bars were the last
   // setWidth caller; with both on their painters, every transform/width write
-  // routes through the facet over the SAME hotWriteCache + `transform:`/`width:` keys,
-  // so the Hud no longer mirrors a private setTransform or setWidth.
+  // routes through the facet over the SAME hotWriteCache + the shared (kind, value)
+  // single-slot entries, so the Hud no longer mirrors a private setTransform or setWidth.
 
   // Write-elision extension. setStyleProp drives a custom
   // property (or any standard property) and toggleClass drives a class, each

--- a/src/ui/i18n.ts
+++ b/src/ui/i18n.ts
@@ -23,6 +23,7 @@ import { en } from './i18n.resolved.generated/en';
 import { en_XA } from './i18n.resolved.generated/en_XA';
 import { LOCALE_LOADERS, SUPPORTED_LANGUAGES } from './i18n.resolved.generated/loaders';
 import { pending } from './i18n.resolved.generated/pending';
+import { type InterpolationMemoEntry, interpolateWithMemo } from './i18n_interpolation';
 
 // Re-export the dense per-locale objects so const-importers of './i18n' keep an unchanged
 // surface: the S3 guard (tests/localization_fixes.test.ts) and the byte-equivalence
@@ -271,6 +272,10 @@ if (typeof window !== 'undefined') {
   prefetchLocale();
 }
 
+// Legacy single-pass interpolation, kept for the cold explicit-locale arm of
+// tOptional/translationValue only (a read of a NON-current locale, e.g. the
+// entity-translation manifest sweep). The current-language read paths go
+// through the memoized resolvedEntry pipeline below instead.
 function interpolate(template: string, values?: InterpolationValues): string {
   if (!values) return template;
   return template.replace(/\{([A-Za-z0-9_]+)\}/g, (match, name: string) => {
@@ -346,28 +351,28 @@ function tableFor(lang: SupportedLanguage): EnTranslations {
   return resident[lang] ?? resident.en!;
 }
 
-export function t(key: TranslationKey, values?: InterpolationValues): string {
-  const parts = key.split('.');
-  let current: unknown = tableFor(currentLanguage);
-  for (const part of parts) {
-    if (current && typeof current === 'object' && part in current) {
-      current = (current as Record<string, unknown>)[part];
-    } else {
-      return onUntrackedKey(key);
-    }
-  }
-  if (typeof current !== 'string') return onUntrackedKey(key);
-  if (PENDING_TOTAL > 0 && PENDING_SETS[currentLanguage]?.has(key) && isReleaseBuild()) {
-    throw new Error(
-      `i18n: key "${key}" is untranslated (pending) for locale "${currentLanguage}" on a release build; English must never ship to a translated player`,
-    );
-  }
-  return interpolate(current, values);
-}
+// --- the resolved-string memo (hitch-elimination B3) -----------------------
+//
+// Hot HUD/aura/nameplate paths call t()/tOptional with the SAME key (and often
+// the same params) every frame; re-splitting the dotted key, re-walking the
+// nested table, and re-running the {slot} regex per call was pure per-frame
+// garbage. resolvedEntry caches, per key, the leaf template PLUS the compiled
+// interpolation plan and a last-params memo (i18n_interpolation.ts), all for
+// the CURRENT resolution only. Invalidation is the existing resolution
+// revision: setLanguage bumps it on any language/pseudo change and
+// ensureLocaleLoaded bumps it when the active locale's chunk lands, so the
+// whole cache drops atomically and the next read re-resolves through the same
+// t() pipeline (never a bypass; a locale change invalidates everything).
+// Misses cache as null: a miss is stable for a revision, and the per-call
+// onUntrackedKey policy (dev throw / release raw-key degrade) stays live
+// because it runs on every call, cached or not. The release-build pending
+// hard-fail likewise runs per call in t(), never from the cache.
+const resolvedMemo = new Map<string, InterpolationMemoEntry | null>();
+let resolvedMemoRevision = -1;
 
-function translationValue(key: string, lang: SupportedLanguage): string | null {
+function leafValue(key: string, table: EnTranslations): string | null {
   const parts = key.split('.');
-  let current: unknown = tableFor(lang);
+  let current: unknown = table;
   for (const part of parts) {
     if (current && typeof current === 'object' && part in current) {
       current = (current as Record<string, unknown>)[part];
@@ -376,6 +381,39 @@ function translationValue(key: string, lang: SupportedLanguage): string | null {
     }
   }
   return typeof current === 'string' ? current : null;
+}
+
+function resolvedEntry(key: string): InterpolationMemoEntry | null {
+  if (resolvedMemoRevision !== resolutionRevision) {
+    resolvedMemo.clear();
+    resolvedMemoRevision = resolutionRevision;
+  }
+  const cached = resolvedMemo.get(key);
+  if (cached !== undefined) return cached;
+  const template = leafValue(key, tableFor(currentLanguage));
+  const entry = template === null ? null : { template };
+  resolvedMemo.set(key, entry);
+  return entry;
+}
+
+export function t(key: TranslationKey, values?: InterpolationValues): string {
+  const entry = resolvedEntry(key);
+  if (entry === null) return onUntrackedKey(key);
+  if (PENDING_TOTAL > 0 && PENDING_SETS[currentLanguage]?.has(key) && isReleaseBuild()) {
+    throw new Error(
+      `i18n: key "${key}" is untranslated (pending) for locale "${currentLanguage}" on a release build; English must never ship to a translated player`,
+    );
+  }
+  if (!values) return entry.template;
+  return interpolateWithMemo(entry, values);
+}
+
+function translationValue(key: string, lang: SupportedLanguage): string | null {
+  if (lang === currentLanguage) {
+    const entry = resolvedEntry(key);
+    return entry === null ? null : entry.template;
+  }
+  return leafValue(key, tableFor(lang));
 }
 
 export function hasTranslation(key: string, lang: SupportedLanguage = currentLanguage): boolean {
@@ -387,7 +425,13 @@ export function tOptional(
   values?: InterpolationValues,
   lang: SupportedLanguage = currentLanguage,
 ): string | null {
-  const value = translationValue(key, lang);
+  if (lang === currentLanguage) {
+    const entry = resolvedEntry(key);
+    if (entry === null) return null;
+    if (!values) return entry.template;
+    return interpolateWithMemo(entry, values);
+  }
+  const value = leafValue(key, tableFor(lang));
   return value === null ? null : interpolate(value, values);
 }
 

--- a/src/ui/i18n.ts
+++ b/src/ui/i18n.ts
@@ -367,6 +367,9 @@ function tableFor(lang: SupportedLanguage): EnTranslations {
 // onUntrackedKey policy (dev throw / release raw-key degrade) stays live
 // because it runs on every call, cached or not. The release-build pending
 // hard-fail likewise runs per call in t(), never from the cache.
+// No eviction within a revision on purpose: misses cache as null, so the memo
+// stays bounded by the shipped catalog plus any unknown wire ids, the same
+// growth class as entity_i18n's fallbackLog.
 const resolvedMemo = new Map<string, InterpolationMemoEntry | null>();
 let resolvedMemoRevision = -1;
 

--- a/src/ui/i18n_interpolation.ts
+++ b/src/ui/i18n_interpolation.ts
@@ -1,0 +1,108 @@
+// Per-key interpolation plans plus a last-call memo for the t() hot path
+// (hitch-elimination B3). Hot HUD, aura, and nameplate painters resolve the
+// SAME (key, params) every frame; the old shape re-split the dotted key,
+// re-ran the {slot} regex, and allocated a fresh replacer closure and result
+// string per call. This module holds the pure pieces:
+//   - compileInterpolationPlan splits a template into static chunks and slot
+//     names ONCE (the only regex work, paid once per key per locale epoch);
+//   - interpolateWithMemo serves a repeat of the same slot values from the
+//     entry's single-slot memo with zero allocation (the compare is === over
+//     the plan's own slot list; InterpolationValue is string | number, so
+//     === is exact), and otherwise rebuilds by plain concatenation, storing
+//     the values into a REUSED snapshot array (mutate-in-place is the cache
+//     idiom here, mirroring the painter-host elision entries).
+// Output is byte-identical to the legacy single-pass regex replace: an
+// undefined slot value keeps its literal `{name}` token, values never re-scan
+// (single left-to-right pass), and extra params are ignored.
+// The OWNING cache in i18n.ts is epoch-guarded by the resolution revision
+// (getI18nRevision), so a locale switch (setLanguage) or a late locale chunk
+// (ensureLocaleLoaded) drops every entry; nothing here outlives a revision.
+// This module is pure and host-agnostic: no DOM, no browser globals, no
+// clock, no randomness. Type-only import below, so nothing of the catalog
+// lands in the bundle through it.
+
+import type { InterpolationValue, InterpolationValues } from './i18n.catalog';
+
+export interface InterpolationPlan {
+  /** The n+1 static chunks around the n slots (may be empty strings). */
+  statics: string[];
+  /** The n slot names in template order; duplicates are kept as-is. */
+  names: string[];
+  /** The raw `{name}` token per slot (the undefined-value fallback text). */
+  tokens: string[];
+}
+
+export interface InterpolationMemoEntry {
+  /** The resolved leaf template this entry serves (fixed for the entry's lifetime). */
+  template: string;
+  /** undefined = not compiled yet (lazy); null = the template has no slots. */
+  plan?: InterpolationPlan | null;
+  /** Slot values of the last interpolation, aligned with plan.names (reused array). */
+  lastValues?: (InterpolationValue | undefined)[];
+  /** The interpolated result matching lastValues. */
+  lastResult?: string;
+}
+
+// Same slot grammar as the legacy interpolate() replace: {A-Za-z0-9_ runs}.
+const SLOT_RE = /\{([A-Za-z0-9_]+)\}/g;
+
+/** Split a template into its interpolation plan, or null when it has no slots. */
+export function compileInterpolationPlan(template: string): InterpolationPlan | null {
+  SLOT_RE.lastIndex = 0;
+  let match = SLOT_RE.exec(template);
+  if (!match) return null;
+  const statics: string[] = [];
+  const names: string[] = [];
+  const tokens: string[] = [];
+  let cursor = 0;
+  while (match) {
+    statics.push(template.slice(cursor, match.index));
+    names.push(match[1]);
+    tokens.push(match[0]);
+    cursor = match.index + match[0].length;
+    match = SLOT_RE.exec(template);
+  }
+  statics.push(template.slice(cursor));
+  return { statics, names, tokens };
+}
+
+/**
+ * Interpolate `values` into the entry's template, memoized on the last call.
+ * A repeat with the same slot values (shallow === over the plan's names, so
+ * params-object identity never matters) returns the stored result with zero
+ * allocation and zero string composition; a change rebuilds and re-latches.
+ */
+export function interpolateWithMemo(
+  entry: InterpolationMemoEntry,
+  values: InterpolationValues,
+): string {
+  if (entry.plan === undefined) entry.plan = compileInterpolationPlan(entry.template);
+  const plan = entry.plan;
+  if (plan === null) return entry.template;
+  const names = plan.names;
+  const last = entry.lastValues;
+  if (last !== undefined && entry.lastResult !== undefined) {
+    let unchanged = true;
+    for (let i = 0; i < names.length; i++) {
+      if (values[names[i]] !== last[i]) {
+        unchanged = false;
+        break;
+      }
+    }
+    if (unchanged) return entry.lastResult;
+  }
+  let snapshot = last;
+  if (snapshot === undefined) {
+    snapshot = new Array(names.length);
+    entry.lastValues = snapshot;
+  }
+  let out = plan.statics[0];
+  for (let i = 0; i < names.length; i++) {
+    const value = values[names[i]];
+    snapshot[i] = value;
+    out += value === undefined ? plan.tokens[i] : typeof value === 'string' ? value : String(value);
+    out += plan.statics[i + 1];
+  }
+  entry.lastResult = out;
+  return out;
+}

--- a/src/ui/painter_host.ts
+++ b/src/ui/painter_host.ts
@@ -69,10 +69,11 @@ export interface PainterHostPresentation {
  * Canvas painter touches the context directly and uses these writers only for the
  * DOM bits it owns (e.g. a `#zone-label` text node).
  *
- * setText/setDisplay/setTransform/setWidth are SINGLE-SLOT (one cached string per
- * element, since each owns one DOM facet). setStyleProp/toggleClass/setAttr are
- * MULTI-SLOT (keyed per (element, prop) / (element, class) / (element, attr)), since
- * one element holds many custom properties, toggled classes, and attributes.
+ * setText/setDisplay/setTransform/setWidth are SINGLE-SLOT (one cached
+ * (kind, value) entry per element, since each owns one DOM facet).
+ * setStyleProp/toggleClass/setAttr are MULTI-SLOT (keyed per (element, prop) /
+ * (element, class) / (element, attr)), since one element holds many custom
+ * properties, toggled classes, and attributes.
  */
 export interface PainterHostWriters {
   /** Set `el.textContent`, eliding a repeat of the same text. */
@@ -105,33 +106,81 @@ export interface PainterHostWriters {
 }
 
 /**
+ * Which of the four single-slot DOM facets last wrote an element. Compared as a
+ * component beside the raw value, so the elision check never composes a key
+ * string.
+ */
+export type SingleSlotKind = 'text' | 'display' | 'transform' | 'width';
+
+/**
+ * One single-slot cache entry: the writer kind plus the raw value it last
+ * wrote. A value change MUTATES the entry in place (this cache is a deliberate
+ * mutable hot-path structure), so after an element's first routed write both
+ * the skip path and the repeat-write path allocate nothing.
+ */
+export interface SingleSlotEntry {
+  kind: SingleSlotKind;
+  value: string;
+}
+
+/** The shared single-slot elision cache (Hud's private `hotWriteCache` field). */
+export type SingleSlotCache = Map<HTMLElement, SingleSlotEntry>;
+
+/**
+ * The single-slot elision decision, shared VERBATIM by Hud's private writers and
+ * the facet below over the SAME cache, so the two can never disagree on an
+ * element. Returns true when the caller must perform the DOM write (the cache is
+ * already updated), false when the write elides. Allocation-free after an
+ * element's first routed write BY CONTRACT: it compares the (kind, value)
+ * components directly and never composes a `display:` + value style key, which
+ * the old shape built BEFORE the skip check, allocating a discarded string on
+ * every ELIDED call. tests/painter_host.test.ts pins both the decision table and
+ * the allocation-free skip path.
+ */
+export function shouldWriteSingleSlot(
+  cache: SingleSlotCache,
+  el: HTMLElement,
+  kind: SingleSlotKind,
+  value: string,
+): boolean {
+  const entry = cache.get(el);
+  if (entry === undefined) {
+    cache.set(el, { kind, value });
+    return true;
+  }
+  if (entry.kind === kind && entry.value === value) return false;
+  entry.kind = kind;
+  entry.value = value;
+  return true;
+}
+
+/**
  * Build the write-elision facet over the supplied caches. The four single-slot
- * writers share `cache` (one string per element); setStyleProp/toggleClass/setAttr
- * use the multi-slot `stylePropCache` / `classCache` / `attrCache` (a per-element
- * inner map keyed by prop / class / attr). Every closure reports each real write via
- * `onWrite` and each elided write via `onSkip`, so a host that builds the facet from
- * its own caches + counters keeps a single skip-rate across its direct writes and
- * the painter writes. The key scheme matches Hud's private writers exactly (raw text
- * for setText; `display:`/`transform:`/`width:` prefixes for the style writers; the
- * raw value for setStyleProp; `on`/`off` for toggleClass; the raw value for setAttr)
- * so the two never disagree on the same element.
+ * writers share `cache` (one (kind, value) entry per element, decided by
+ * `shouldWriteSingleSlot` above, the same helper Hud's private writers call);
+ * setStyleProp/toggleClass/setAttr use the multi-slot `stylePropCache` /
+ * `classCache` / `attrCache` (a per-element inner map keyed by prop / class /
+ * attr, compared against the raw value). Every closure reports each real write
+ * via `onWrite` and each elided write via `onSkip`, so a host that builds the
+ * facet from its own caches + counters keeps a single skip-rate across its
+ * direct writes and the painter writes. No writer composes a key string on any
+ * path: an elided frame allocates nothing.
  */
 export function makeWriterFacet(
-  cache: Map<HTMLElement, string>,
+  cache: SingleSlotCache,
   stylePropCache: Map<HTMLElement, Map<string, string>>,
   classCache: Map<HTMLElement, Map<string, string>>,
   attrCache: Map<HTMLElement, Map<string, string>>,
   onWrite: () => void,
   onSkip: () => void,
 ): PainterHostWriters {
-  const shouldWrite = (el: HTMLElement, key: string): boolean => {
-    if (cache.get(el) === key) {
-      onSkip();
-      return false;
+  const shouldWrite = (el: HTMLElement, kind: SingleSlotKind, value: string): boolean => {
+    if (shouldWriteSingleSlot(cache, el, kind, value)) {
+      onWrite();
+      return true;
     }
-    cache.set(el, key);
-    onWrite();
-    return true;
+    onSkip();
+    return false;
   };
   // Multi-slot variant: resolves (or lazily creates) the per-element inner map and
   // elides per (element, slot). Used by setStyleProp/toggleClass so one element can
@@ -157,16 +206,16 @@ export function makeWriterFacet(
   };
   return {
     setText: (el, text) => {
-      if (shouldWrite(el, text)) el.textContent = text;
+      if (shouldWrite(el, 'text', text)) el.textContent = text;
     },
     setDisplay: (el, display) => {
-      if (shouldWrite(el, `display:${display}`)) el.style.display = display;
+      if (shouldWrite(el, 'display', display)) el.style.display = display;
     },
     setTransform: (el, transform) => {
-      if (shouldWrite(el, `transform:${transform}`)) el.style.transform = transform;
+      if (shouldWrite(el, 'transform', transform)) el.style.transform = transform;
     },
     setWidth: (el, width) => {
-      if (shouldWrite(el, `width:${width}`)) el.style.width = width;
+      if (shouldWrite(el, 'width', width)) el.style.width = width;
     },
     setStyleProp: (el, prop, value) => {
       if (shouldWriteSlot(stylePropCache, el, prop, value)) el.style.setProperty(prop, value);

--- a/src/ui/text_sprite_cache.ts
+++ b/src/ui/text_sprite_cache.ts
@@ -144,15 +144,56 @@ const FALLBACK_FONT_PX = 12;
 const SPRITE_ALIGN = 'center';
 const SPRITE_BASELINE = 'alphabetic';
 
+/** One cached sprite plus its recency-list links and the text-level bucket
+ *  that owns it, so a hit can move to the list tail and an eviction can unhook
+ *  itself from its own bucket without rebuilding any key. */
+interface SpriteEntry {
+  sprite: TextSprite;
+  text: string;
+  owner: SpriteBucket;
+  prev: SpriteEntry | null;
+  next: SpriteEntry | null;
+}
+
+// The cache key, STRUCTURAL rather than a joined string: one map level per
+// style field, font -> fill -> stroke -> drawn outline width -> text. The old
+// scheme built a key array plus a joined string of a couple hundred bytes on
+// every draw and measure call, HITS INCLUDED, which at tens of nameplates per
+// frame was the client's dominant allocation treadmill; walking the levels
+// with the caller's existing strings allocates nothing. Collision safety is
+// structural: there is no delimiter to inject (a player name carrying any
+// separator is just a longer key at the text level), adjacent fields can never
+// fuse (fill 'ab' + stroke 'c' and fill 'a' + stroke 'bc' part ways at the
+// fill level), and a fill-only label can never alias an outlined one whose
+// stroke token has not resolved yet (undefined and '' are distinct stroke
+// keys). The width level keys outlineWidth, the width actually drawn, so it
+// stays in lockstep with the padding rule below.
+type SpriteBucket = Map<string, SpriteEntry>;
+type WidthLevel = Map<number, SpriteBucket>;
+type StrokeLevel = Map<string | undefined, WidthLevel>;
+type FillLevel = Map<string, StrokeLevel>;
+type FontLevel = Map<string, FillLevel>;
+
 /**
  * A bounded per-(font, fill, outline, text) cache of rasterized labels. One
  * instance per painter; the painter calls `beginRedraw` once per redraw and
  * `draw` per label.
  */
 export class TextSpriteCache {
-  // Insertion order IS the LRU order: a cache hit re-inserts, so the oldest
-  // live key is always the front of the iteration.
-  private readonly sprites = new Map<string, TextSprite>();
+  // The structural key tree plus an intrusive doubly-linked recency list
+  // threaded through the entries. The list keeps EXACT least-recently-used
+  // order with the same bound and hit behavior as the insertion-ordered Map it
+  // replaced (head = oldest, a hit moves its entry to the tail, eviction pops
+  // the head), but a hit is a handful of pointer swaps instead of a per-hit
+  // map delete plus re-insert, so the steady-state hot path does no map churn
+  // and allocates nothing. Emptied text buckets stay in the tree: every fill
+  // and stroke a painter passes is a resolved theme token or a fixed style
+  // constant, so the tree's own footprint is bounded by that closed palette,
+  // never by player-supplied text, and clear() drops it wholesale.
+  private readonly fonts: FontLevel = new Map();
+  private lruHead: SpriteEntry | null = null;
+  private lruTail: SpriteEntry | null = null;
+  private spriteCount = 0;
   private pixelRatio = 1;
   private cachedBytes = 0;
   private readonly spriteLimit: number;
@@ -167,7 +208,7 @@ export class TextSpriteCache {
 
   /** Live sprite count. */
   get size(): number {
-    return this.sprites.size;
+    return this.spriteCount;
   }
 
   /** RGBA backing-store bytes retained by live sprites. */
@@ -179,7 +220,10 @@ export class TextSpriteCache {
    *  a language switch, where every label re-resolves to a new string and the old
    *  rasters would otherwise sit in the budget until LRU worked them out. */
   clear(): void {
-    this.sprites.clear();
+    this.fonts.clear();
+    this.lruHead = null;
+    this.lruTail = null;
+    this.spriteCount = 0;
     this.cachedBytes = 0;
   }
 
@@ -196,10 +240,7 @@ export class TextSpriteCache {
    *  redraw's draws so a label-heavy redraw can overshoot rather than thrash
    *  (see the header). */
   beginRedraw(): void {
-    for (const key of this.sprites.keys()) {
-      if (this.sprites.size <= this.spriteLimit) return;
-      this.deleteSprite(key);
-    }
+    while (this.spriteCount > this.spriteLimit && this.lruHead) this.evictOldest(this.lruHead);
   }
 
   /**
@@ -250,13 +291,10 @@ export class TextSpriteCache {
   }
 
   private sprite(text: string, style: TextSpriteStyle): TextSprite | null {
-    const key = spriteKey(text, style);
-    const cached = this.sprites.get(key);
+    const cached = this.lookup(text, style);
     if (cached) {
-      // Re-insert so the iteration order stays least-recently-used first.
-      this.sprites.delete(key);
-      this.sprites.set(key, cached);
-      return cached;
+      this.touch(cached);
+      return cached.sprite;
     }
     const sprite = rasterize(text, style, this.pixelRatio);
     // A transient 2D-context failure must not be cached: freezing a blank canvas
@@ -269,25 +307,93 @@ export class TextSpriteCache {
     // this redraw (exactly what the inline fillText did on that frame) but never
     // cache it.
     if (style.fill !== '' && style.stroke !== '') {
-      this.sprites.set(key, sprite);
+      const owner = this.bucketFor(style);
+      const entry: SpriteEntry = { sprite, text, owner, prev: this.lruTail, next: null };
+      owner.set(text, entry);
+      if (this.lruTail) this.lruTail.next = entry;
+      else this.lruHead = entry;
+      this.lruTail = entry;
+      this.spriteCount++;
       this.cachedBytes += sprite.bytes;
       if (Number.isFinite(this.hardByteLimit)) this.trimHardBudget();
     }
     return sprite;
   }
 
-  private trimHardBudget(): void {
-    for (const key of this.sprites.keys()) {
-      if (this.sprites.size <= this.spriteLimit && this.cachedBytes <= this.hardByteLimit) return;
-      this.deleteSprite(key);
-    }
+  /** The hit path. Allocation-free ON PURPOSE: this runs per label per frame
+   *  (nameplate names, levels, guilds and their measure calls all land here),
+   *  so it walks the key levels with the caller's existing strings and builds
+   *  nothing. Keep it that way. */
+  private lookup(text: string, style: TextSpriteStyle): SpriteEntry | undefined {
+    const fills = this.fonts.get(style.font);
+    if (!fills) return undefined;
+    const strokes = fills.get(style.fill);
+    if (!strokes) return undefined;
+    const widths = strokes.get(style.stroke);
+    if (!widths) return undefined;
+    return widths.get(outlineWidth(style))?.get(text);
   }
 
-  private deleteSprite(key: string): void {
-    const sprite = this.sprites.get(key);
-    if (!sprite) return;
-    this.cachedBytes -= sprite.bytes;
-    this.sprites.delete(key);
+  /** Resolve (creating on demand) the text bucket for a style. Miss path only:
+   *  a level created here is retained until clear(). */
+  private bucketFor(style: TextSpriteStyle): SpriteBucket {
+    let fills = this.fonts.get(style.font);
+    if (!fills) {
+      fills = new Map();
+      this.fonts.set(style.font, fills);
+    }
+    let strokes = fills.get(style.fill);
+    if (!strokes) {
+      strokes = new Map();
+      fills.set(style.fill, strokes);
+    }
+    let widths = strokes.get(style.stroke);
+    if (!widths) {
+      widths = new Map();
+      strokes.set(style.stroke, widths);
+    }
+    const width = outlineWidth(style);
+    let bucket = widths.get(width);
+    if (!bucket) {
+      bucket = new Map();
+      widths.set(width, bucket);
+    }
+    return bucket;
+  }
+
+  /** Move a hit to the most-recently-used end of the recency list. */
+  private touch(entry: SpriteEntry): void {
+    const tail = this.lruTail;
+    if (entry === tail || !tail) return;
+    if (entry.prev) entry.prev.next = entry.next;
+    else this.lruHead = entry.next;
+    if (entry.next) entry.next.prev = entry.prev;
+    entry.prev = tail;
+    entry.next = null;
+    tail.next = entry;
+    this.lruTail = entry;
+  }
+
+  /** Unhook the least-recently-used entry from the list and its bucket. */
+  private evictOldest(entry: SpriteEntry): void {
+    this.lruHead = entry.next;
+    if (entry.next) entry.next.prev = null;
+    else this.lruTail = null;
+    // Null the dead entry's links so any future stale touch no-ops rather than corrupting the list.
+    entry.prev = null;
+    entry.next = null;
+    entry.owner.delete(entry.text);
+    this.spriteCount--;
+    this.cachedBytes -= entry.sprite.bytes;
+  }
+
+  private trimHardBudget(): void {
+    while (
+      (this.spriteCount > this.spriteLimit || this.cachedBytes > this.hardByteLimit) &&
+      this.lruHead
+    ) {
+      this.evictOldest(this.lruHead);
+    }
   }
 }
 
@@ -297,17 +403,6 @@ export class TextSpriteCache {
 // width strokes at 1px and has to be padded and keyed for 1px, not for 0.
 function outlineWidth(style: TextSpriteStyle): number {
   return style.stroke === undefined ? 0 : (style.lineWidth ?? 1);
-}
-
-// The cache key. `text` goes LAST so no separator collision is possible whatever
-// the label says, and the separator is a newline because neither a font
-// shorthand nor a resolved CSS color can contain one (a space could:
-// `rgb(255 209 0)`). The outlined flag is its own field so a fill-only label can
-// never alias one whose outline token has not resolved yet ('').
-function spriteKey(text: string, style: TextSpriteStyle): string {
-  const outlined = style.stroke === undefined ? 'flat' : 'outlined';
-  const stroke = style.stroke ?? '';
-  return [style.font, style.fill, outlined, stroke, outlineWidth(style), text].join('\n');
 }
 
 // Rasterize one label into its own canvas, or null when the 2D context fails.

--- a/tests/browser/delve_map_painter.browser.test.ts
+++ b/tests/browser/delve_map_painter.browser.test.ts
@@ -104,7 +104,7 @@ function makeWorld(): IWorld {
 // DOM write, the #zone-label text, through setText).
 function realWriterFacet(): PainterHostWriters {
   return makeWriterFacet(
-    new Map<HTMLElement, string>(),
+    new Map(),
     new Map<HTMLElement, Map<string, string>>(),
     new Map<HTMLElement, Map<string, string>>(),
     new Map<HTMLElement, Map<string, string>>(),

--- a/tests/i18n_interpolation.test.ts
+++ b/tests/i18n_interpolation.test.ts
@@ -1,0 +1,174 @@
+// The pure interpolation-plan module behind the t() resolved-string memo
+// (hitch-elimination B3). Pins three things:
+//   1. compileInterpolationPlan decomposes a template exactly (statics, slot
+//      names, raw tokens) and returns null for a slotless template.
+//   2. interpolateWithMemo is BYTE-IDENTICAL to the legacy single-pass regex
+//      replace across a template x values matrix, including undefined slots,
+//      numbers, duplicates, and values containing brace text.
+//   3. The memo really is a memo: a repeat with the same slot values performs
+//      zero string composition over the values (composition-probe idiom from
+//      tests/painter_host.test.ts), any changed slot rebuilds correctly, and
+//      the snapshot array is reused rather than reallocated.
+
+import { describe, expect, it } from 'vitest';
+import type { InterpolationValues } from '../src/ui/i18n.catalog';
+import {
+  compileInterpolationPlan,
+  type InterpolationMemoEntry,
+  interpolateWithMemo,
+} from '../src/ui/i18n_interpolation';
+
+// The legacy interpolate() shape (the pre-B3 t() hot path), kept here as the
+// byte-identity reference. If the plan/concat pipeline ever diverges from this
+// on any input, the matrix below goes red.
+function legacyInterpolate(template: string, values?: InterpolationValues): string {
+  if (!values) return template;
+  return template.replace(/\{([A-Za-z0-9_]+)\}/g, (match, name: string) => {
+    const value = values[name];
+    return value === undefined ? match : String(value);
+  });
+}
+
+function compositionProbe(text: string): { value: string; compositions: () => number } {
+  let count = 0;
+  const probe = {
+    [Symbol.toPrimitive](): string {
+      count++;
+      return text;
+    },
+    toString(): string {
+      count++;
+      return text;
+    },
+    valueOf(): string {
+      count++;
+      return text;
+    },
+  };
+  return { value: probe as unknown as string, compositions: () => count };
+}
+
+describe('compileInterpolationPlan', () => {
+  it('returns null for a template with no slots', () => {
+    expect(compileInterpolationPlan('plain text, no slots')).toBeNull();
+    expect(compileInterpolationPlan('')).toBeNull();
+  });
+
+  it('does not treat malformed braces as slots (same grammar as the legacy regex)', () => {
+    expect(compileInterpolationPlan('{not-a-slot} and {} and {unclosed')).toBeNull();
+  });
+
+  it('decomposes statics, names, and raw tokens in template order', () => {
+    const plan = compileInterpolationPlan('{a}b{c_2}');
+    expect(plan).toEqual({
+      statics: ['', 'b', ''],
+      names: ['a', 'c_2'],
+      tokens: ['{a}', '{c_2}'],
+    });
+  });
+
+  it('keeps duplicate slot names as separate slots', () => {
+    const plan = compileInterpolationPlan('x {name} y {name} z');
+    expect(plan).toEqual({
+      statics: ['x ', ' y ', ' z'],
+      names: ['name', 'name'],
+      tokens: ['{name}', '{name}'],
+    });
+  });
+});
+
+describe('interpolateWithMemo is byte-identical to the legacy regex replace', () => {
+  const templates = [
+    'no slots at all',
+    '{a}',
+    'x{a}',
+    '{a}y',
+    '{a}{b}',
+    'a {name} b {name} c',
+    'start {a} mid {b_2} end',
+    'brace but not a slot {not-a-slot} and {} then {a}',
+    '{a} tail with {unclosed',
+    'unicode: {name} cadáver ({rank})',
+  ];
+  const valuesMatrix: InterpolationValues[] = [
+    {},
+    { a: 'x' },
+    { a: 0 },
+    { a: '', b: 'y' },
+    { a: '{b}', b: 'B' },
+    { a: 1.5, b_2: 'two', name: 'Web Weaver', rank: 'S' },
+    { c: 'extra param, never referenced' },
+  ];
+
+  it('matches on every template x values pair, and repeats match too', () => {
+    for (const template of templates) {
+      for (const values of valuesMatrix) {
+        const entry: InterpolationMemoEntry = { template };
+        const expected = legacyInterpolate(template, values);
+        expect(interpolateWithMemo(entry, values), `${template} :: ${JSON.stringify(values)}`).toBe(
+          expected,
+        );
+        // The memo-hit repeat must serve the same bytes.
+        expect(interpolateWithMemo(entry, values)).toBe(expected);
+      }
+    }
+  });
+
+  it('leaves an undefined slot as its literal {name} token', () => {
+    const entry: InterpolationMemoEntry = { template: 'hi {known} and {unknown}' };
+    expect(interpolateWithMemo(entry, { known: 'yes' })).toBe('hi yes and {unknown}');
+  });
+});
+
+describe('the last-call memo (the B3 allocation guarantee)', () => {
+  it('a repeat with the same slot values composes nothing over them (probe)', () => {
+    const entry: InterpolationMemoEntry = { template: 'corpse of {name}' };
+    const probe = compositionProbe('Web Weaver');
+    expect(interpolateWithMemo(entry, { name: probe.value })).toBe('corpse of Web Weaver');
+    const afterBuild = probe.compositions();
+    expect(afterBuild).toBeGreaterThan(0); // the establishing build converts the value
+    for (let i = 0; i < 50; i++) {
+      interpolateWithMemo(entry, { name: probe.value });
+    }
+    expect(probe.compositions()).toBe(afterBuild); // memo hits convert NOTHING
+  });
+
+  it('params-object identity never matters, only slot values (shallow ===)', () => {
+    const entry: InterpolationMemoEntry = { template: '{name} ({rank})' };
+    const first = interpolateWithMemo(entry, { name: 'Rift', rank: 'S' });
+    const probe = compositionProbe('never');
+    // A FRESH object per call carrying an extra never-referenced probe value:
+    // the memo must hit (same slot values) and never touch the extra param.
+    const second = interpolateWithMemo(entry, { name: 'Rift', rank: 'S', extra: probe.value });
+    expect(second).toBe(first);
+    expect(probe.compositions()).toBe(0);
+  });
+
+  it('any changed slot rebuilds correctly, including the LAST of several', () => {
+    const entry: InterpolationMemoEntry = { template: '{name} ({rank})' };
+    expect(interpolateWithMemo(entry, { name: 'Rift', rank: 'S' })).toBe('Rift (S)');
+    // Change only the second slot: a memo comparing fewer than all slots
+    // would wrongly serve the stale result (mutant guard).
+    expect(interpolateWithMemo(entry, { name: 'Rift', rank: 'A' })).toBe('Rift (A)');
+    // And only the first.
+    expect(interpolateWithMemo(entry, { name: 'Vale', rank: 'A' })).toBe('Vale (A)');
+    // Back to the original pair still rebuilds the correct bytes.
+    expect(interpolateWithMemo(entry, { name: 'Rift', rank: 'S' })).toBe('Rift (S)');
+  });
+
+  it('reuses the snapshot array across rebuilds (no per-change allocation)', () => {
+    const entry: InterpolationMemoEntry = { template: '{a}/{b}' };
+    interpolateWithMemo(entry, { a: 1, b: 2 });
+    const snapshot = entry.lastValues;
+    expect(snapshot).toBeDefined();
+    interpolateWithMemo(entry, { a: 3, b: 4 });
+    expect(entry.lastValues).toBe(snapshot); // same array object, mutated in place
+    expect(entry.lastResult).toBe('3/4');
+  });
+
+  it('a slotless template returns the template itself even with values present', () => {
+    const entry: InterpolationMemoEntry = { template: 'static text' };
+    expect(interpolateWithMemo(entry, { a: 'ignored' })).toBe('static text');
+    expect(entry.plan).toBeNull();
+  });
+});

--- a/tests/i18n_resolution_memo.test.ts
+++ b/tests/i18n_resolution_memo.test.ts
@@ -1,0 +1,181 @@
+// The t()/tOptional/tEntity resolved-string memo (hitch-elimination B3).
+//
+// Pins the four B3 guarantees at the REAL t() pipeline level:
+//   1. A repeated hot call with unchanged inputs performs no split / regex /
+//      replacer-closure work at all (String.prototype.split,
+//      String.prototype.replace and RegExp.prototype.exec are all spied at
+//      zero across hundreds of repeats), for t() with and without params and
+//      for tEntity.
+//   2. Same key + different params rebuilds the correct distinct output
+//      (the memo compares slot VALUES, never the params object identity).
+//   3. Locale-switch invalidation: BOTH revision arms (setLanguage and the
+//      late ensureLocaleLoaded chunk arrival) drop every memoized string, so
+//      the next read re-resolves through the same t() pipeline. Serving a
+//      stale cached string after either arm turns this suite red (the memo
+//      mutant guard).
+//   4. The per-call miss policy stays live across the cached miss: an
+//      untracked key throws on EVERY dev call, not just the first.
+//
+// No referee scenarios, no macro claims: unit-level evidence only.
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { MOBS } from '../src/sim/data';
+import { tEntity } from '../src/ui/entity_i18n';
+import { en, ensureLocaleLoaded, es, isLocaleResident, setLanguage, t } from '../src/ui/i18n';
+
+afterEach(() => setLanguage('en'));
+
+/** Count split/replace/exec calls performed by `run` (tight window, no expects inside). */
+function stringWorkDuring(run: () => void): { splits: number; replaces: number; execs: number } {
+  const splitSpy = vi.spyOn(String.prototype, 'split');
+  const replaceSpy = vi.spyOn(String.prototype, 'replace');
+  const execSpy = vi.spyOn(RegExp.prototype, 'exec');
+  try {
+    run();
+    return {
+      splits: splitSpy.mock.calls.length,
+      replaces: replaceSpy.mock.calls.length,
+      execs: execSpy.mock.calls.length,
+    };
+  } finally {
+    splitSpy.mockRestore();
+    replaceSpy.mockRestore();
+    execSpy.mockRestore();
+  }
+}
+
+function leaf(table: unknown, path: readonly string[]): unknown {
+  let current: unknown = table;
+  for (const part of path) {
+    if (!current || typeof current !== 'object') return undefined;
+    current = (current as Record<string, unknown>)[part];
+  }
+  return current;
+}
+
+const seg = (value: string) => value.replace(/[^A-Za-z0-9_]/g, '_');
+
+describe('t(): repeated hot calls with unchanged inputs do zero string work', () => {
+  it('a params-bearing key: no split, no replace, no regex exec after the warm call', () => {
+    setLanguage('en');
+    // Warm: resolves the leaf, compiles the plan, latches the memo.
+    expect(t('worldContent.corpseName', { name: 'Web Weaver' })).toBe('Web Weaver (corpse)');
+    let out = '';
+    const work = stringWorkDuring(() => {
+      // A FRESH params object every call: the memo must hit on shallow slot
+      // values, never on object identity (hot callers rebuild params per frame).
+      for (let i = 0; i < 200; i++) out = t('worldContent.corpseName', { name: 'Web Weaver' });
+    });
+    expect(out).toBe('Web Weaver (corpse)');
+    expect(work).toEqual({ splits: 0, replaces: 0, execs: 0 });
+  });
+
+  it('a no-params key (the per-frame aura duration units): zero string work on repeats', () => {
+    setLanguage('en');
+    const warm = t('hudChrome.unitFrame.durationUnitSeconds');
+    expect(warm).toBe(en.hudChrome.unitFrame.durationUnitSeconds);
+    let out = '';
+    const work = stringWorkDuring(() => {
+      for (let i = 0; i < 200; i++) out = t('hudChrome.unitFrame.durationUnitSeconds');
+    });
+    expect(out).toBe(warm);
+    expect(work).toEqual({ splits: 0, replaces: 0, execs: 0 });
+  });
+});
+
+describe('t(): params-change correctness (the memo never over-serves)', () => {
+  it('same key, different params, different (correct) output, both directions', () => {
+    setLanguage('en');
+    expect(t('hud.core.riftLabelRanked', { name: 'Rift', rank: 'S' })).toBe('Rift (S)');
+    // Change only the SECOND slot: a memo comparing fewer than all slots
+    // would serve the stale result here.
+    expect(t('hud.core.riftLabelRanked', { name: 'Rift', rank: 'A' })).toBe('Rift (A)');
+    expect(t('hud.core.riftLabelRanked', { name: 'Vale', rank: 'A' })).toBe('Vale (A)');
+    // Returning to earlier params rebuilds the correct bytes (single-entry memo).
+    expect(t('hud.core.riftLabelRanked', { name: 'Rift', rank: 'S' })).toBe('Rift (S)');
+  });
+});
+
+describe('tEntity: hot repeats do zero string work (key memo + leaf memo)', () => {
+  it('a repeated mob-name resolution runs no entityPathSegment regex and no split', () => {
+    setLanguage('en');
+    const mobId = Object.keys(MOBS)[0];
+    expect(mobId).toBeTruthy();
+    const warm = tEntity({ kind: 'mob', id: mobId, field: 'name' });
+    expect(warm).toBe(leaf(en, ['entities', 'mobs', seg(mobId), 'name']));
+    let out = '';
+    const work = stringWorkDuring(() => {
+      for (let i = 0; i < 200; i++) out = tEntity({ kind: 'mob', id: mobId, field: 'name' });
+    });
+    expect(out).toBe(warm);
+    expect(work).toEqual({ splits: 0, replaces: 0, execs: 0 });
+  });
+});
+
+describe('locale switch invalidates every memoized string (the memo mutant guard)', () => {
+  it('setLanguage AND the late chunk arrival both drop the memo; stale strings never survive', async () => {
+    setLanguage('en');
+    // Warm the memo under en, params memo included.
+    expect(t('nav.play')).toBe(en.nav.play);
+    expect(t('worldContent.corpseName', { name: 'Iron Boar' })).toBe('Iron Boar (corpse)');
+    // Non-vacuous floor: es genuinely differs from en on both keys, so a stale
+    // memo is distinguishable from a correct re-resolve.
+    expect(es.nav.play).not.toBe(en.nav.play);
+    expect(es.worldContent.corpseName).not.toBe(en.worldContent.corpseName);
+    expect(isLocaleResident('es')).toBe(false);
+
+    // Arm 1: setLanguage bumps the revision. The es chunk is NOT resident yet,
+    // so the pipeline's synchronous English fallback serves (never a throw).
+    setLanguage('es');
+    expect(t('nav.play')).toBe(en.nav.play);
+
+    // Arm 2: the late chunk arrival bumps the revision again. If that bump or
+    // the memo's epoch compare were broken, the warmed English strings above
+    // would be served stale here: red.
+    await ensureLocaleLoaded('es');
+    expect(t('nav.play')).toBe(es.nav.play);
+    expect(t('worldContent.corpseName', { name: 'Iron Boar' })).toBe(
+      es.worldContent.corpseName.replace('{name}', 'Iron Boar'),
+    );
+
+    // And back: switching to en again must re-resolve English (the es strings
+    // just memoized may not survive either).
+    setLanguage('en');
+    expect(t('nav.play')).toBe(en.nav.play);
+    expect(t('worldContent.corpseName', { name: 'Iron Boar' })).toBe('Iron Boar (corpse)');
+  });
+
+  it('tEntity re-resolves through the switched locale too', async () => {
+    const mobId = Object.keys(MOBS).find((id) => {
+      const path = ['entities', 'mobs', seg(id), 'name'];
+      const enName = leaf(en, path);
+      const esName = leaf(es, path);
+      return typeof enName === 'string' && typeof esName === 'string' && enName !== esName;
+    });
+    // Non-vacuous floor: at least one mob name is genuinely translated.
+    expect(mobId).toBeTruthy();
+    if (!mobId) return;
+    setLanguage('en');
+    const enName = tEntity({ kind: 'mob', id: mobId, field: 'name' });
+    expect(enName).toBe(leaf(en, ['entities', 'mobs', seg(mobId), 'name']));
+    await ensureLocaleLoaded('es');
+    setLanguage('es');
+    expect(tEntity({ kind: 'mob', id: mobId, field: 'name' })).toBe(
+      leaf(es, ['entities', 'mobs', seg(mobId), 'name']),
+    );
+    setLanguage('en');
+    expect(tEntity({ kind: 'mob', id: mobId, field: 'name' })).toBe(enName);
+  });
+});
+
+describe('the cached miss keeps the per-call policy live', () => {
+  it('an untracked key throws on EVERY dev call, not just the first', () => {
+    setLanguage('en');
+    const tRaw = t as unknown as (key: string) => string;
+    expect(() => tRaw('totally.bogus.b3.memo.key')).toThrow(/untracked key/);
+    // The second call hits the cached miss and must STILL throw.
+    expect(() => tRaw('totally.bogus.b3.memo.key')).toThrow(/untracked key/);
+    // A real key beside it still resolves (the miss cache never blankets).
+    expect(t('nav.home')).toBe(en.nav.home);
+  });
+});

--- a/tests/nameplate_ai_tag.test.ts
+++ b/tests/nameplate_ai_tag.test.ts
@@ -317,3 +317,24 @@ describe('batched canvas nameplate state', () => {
     expect((painter as unknown as PainterStateAccess).states.has(target.id)).toBe(false);
   });
 });
+
+describe('guild single-writer invariant', () => {
+  // The guildLabel memo is load-bearing on "resolveContent is state.guild's
+  // only writer": a second writer appearing anywhere would silently stop the
+  // guild line drawing rather than drawing something stale (the harder
+  // failure to notice). Pin the writer set so a new assignment site fails
+  // here instead.
+  it('state.guild is written only by resolveContent, and drawBase never writes it', async () => {
+    const { readFileSync } = await import('node:fs');
+    const painter = readFileSync('src/render/nameplate_painter.ts', 'utf8');
+    const canvas = readFileSync('src/render/nameplate_canvas.ts', 'utf8');
+    const painterWrites = painter.match(/state\.guild\s*=[^=]/g) ?? [];
+    expect(painterWrites).toHaveLength(2);
+    const resolveStart = painter.indexOf('resolveContent(');
+    expect(resolveStart).toBeGreaterThan(-1);
+    for (const write of painterWrites) {
+      expect(painter.indexOf(write)).toBeGreaterThan(resolveStart);
+    }
+    expect(canvas.match(/\.guild\s*=[^=]/g) ?? []).toHaveLength(0);
+  });
+});

--- a/tests/nameplate_ai_tag.test.ts
+++ b/tests/nameplate_ai_tag.test.ts
@@ -239,6 +239,10 @@ describe('batched canvas nameplate state', () => {
     const state = stateOf(painter, target.id);
 
     expect(state.guild).toBe('Canvas Raiders');
+    // The drawn `<...>` wrapper is prebuilt here in resolveContent (guild's
+    // only writer), so a guild change through the resolve gate rebuilds it
+    // and the per-frame draw path never allocates it.
+    expect(state.guildLabel).toBe('<Canvas Raiders>');
     expect(state.title).toBe('Veteran');
     expect(state.opacity).toBe(0.55);
     expect(state.badges).toHaveLength(3);
@@ -256,6 +260,16 @@ describe('batched canvas nameplate state', () => {
     expect(state.castFill).toBe(0.5);
     expect(state.castSource).toBe('fireball');
     expect(state.castLabel).not.toBe('fireball');
+
+    target.guild = 'New Banner';
+    painter.update(true);
+    expect(state.guild).toBe('New Banner');
+    expect(state.guildLabel).toBe('<New Banner>');
+
+    target.guild = '';
+    painter.update(true);
+    expect(state.guild).toBe('');
+    expect(state.guildLabel).toBe('');
   });
 
   it('maps object, quest NPC, boss, and lootable corpse presentation', () => {

--- a/tests/nameplate_ai_tag.test.ts
+++ b/tests/nameplate_ai_tag.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment happy-dom
 
+import { readFileSync } from 'node:fs';
 import * as THREE from 'three';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { NameplateCanvasState } from '../src/render/nameplate_canvas';
@@ -272,6 +273,48 @@ describe('batched canvas nameplate state', () => {
     expect(state.guildLabel).toBe('');
   });
 
+  it('keeps guild and guildLabel paired across the gated non-fullPass cadence', () => {
+    // 18 yd out: beyond NAMEPLATE_URGENT_RANGE (14), untargeted, and not
+    // casting, so a non-fullPass update takes the gated path and skips
+    // resolveContent (the default harness targets sit 3 yd away, inside the
+    // urgent range, and resolve every pass). The view group stays at the
+    // origin, so the plate itself remains on screen.
+    const target = entity({
+      id: 2,
+      guild: 'Far Banner',
+      pos: { x: 0, y: 0, z: -15 } as Entity['pos'],
+    });
+    const { painter } = harness([target]);
+    painter.update(true);
+    const state = stateOf(painter, target.id);
+    expect(state.guild).toBe('Far Banner');
+    expect(state.guildLabel).toBe('<Far Banner>');
+
+    // A guild change seen only by a throttled pass: the resolve gate has not
+    // run, so both fields legitimately hold the pre-change values. The
+    // invariant under test is the PAIRING, not freshness: a stray per-frame
+    // writer would split them (guild cleared, label still drawn stale).
+    target.guild = 'New Banner';
+    painter.update(false);
+    expect(state.guild).toBe('Far Banner');
+    expect(state.guildLabel).toBe(`<${state.guild}>`);
+
+    // The next full pass refreshes both together.
+    painter.update(true);
+    expect(state.guild).toBe('New Banner');
+    expect(state.guildLabel).toBe('<New Banner>');
+
+    // Guild removal through the same cadence: stale pair on the throttled
+    // pass, then both clear together on the full pass.
+    target.guild = '';
+    painter.update(false);
+    expect(state.guild).toBe('New Banner');
+    expect(state.guildLabel).toBe(`<${state.guild}>`);
+    painter.update(true);
+    expect(state.guild).toBe('');
+    expect(state.guildLabel).toBe('');
+  });
+
   it('maps object, quest NPC, boss, and lootable corpse presentation', () => {
     const questNpc = entity({
       id: 2,
@@ -324,16 +367,39 @@ describe('guild single-writer invariant', () => {
   // guild line drawing rather than drawing something stale (the harder
   // failure to notice). Pin the writer set so a new assignment site fails
   // here instead.
-  it('state.guild is written only by resolveContent, and drawBase never writes it', async () => {
-    const { readFileSync } = await import('node:fs');
-    const painter = readFileSync('src/render/nameplate_painter.ts', 'utf8');
-    const canvas = readFileSync('src/render/nameplate_canvas.ts', 'utf8');
-    const painterWrites = painter.match(/state\.guild\s*=[^=]/g) ?? [];
+  // The sibling source-pin idiom (tests/painter_host.test.ts). The rel arg
+  // must stay a VARIABLE: this file runs under happy-dom, whose web transform
+  // statically rewrites a literal `new URL('...', import.meta.url)` to a
+  // document-origin http URL that readFileSync then rejects.
+  const read = (rel: string): string => readFileSync(new URL(rel, import.meta.url), 'utf8');
+
+  it('state.guild is written only by resolveContent, and drawBase never writes it', () => {
+    const painter = read('../src/render/nameplate_painter.ts');
+    const canvas = read('../src/render/nameplate_canvas.ts');
+    // Anchor on the DEFINITION: a bare indexOf('resolveContent(') lands on the
+    // call site in update(), which sits above updateDynamicState and would
+    // admit that whole per-frame method into the window.
+    const definitionStart = painter.indexOf('private resolveContent(');
+    expect(definitionStart).toBeGreaterThan(-1);
+    const bodyStart = definitionStart + 'private resolveContent('.length;
+    // The window closes at the next class-member declaration after the
+    // definition (2-space indent, optional modifiers, then the member name and
+    // its open paren; today that is `private questMarker(`). Matching the
+    // declaration SHAPE rather than that name survives a rename or reorder,
+    // and method-body lines sit at 4+ spaces so they cannot match.
+    const memberDecl = /^ {2}(?:(?:private|public|protected|static) )*[A-Za-z_$][\w$]*\(/m;
+    const nextMember = painter.slice(bodyStart).match(memberDecl);
+    expect(nextMember).not.toBeNull();
+    const memberEnd = bodyStart + (nextMember?.index ?? painter.length);
+    // Both writes are the byte-identical `state.guild = `, so indexOf(match)
+    // cannot position the second one; matchAll carries each occurrence's own
+    // index instead, and every write must land inside [definitionStart,
+    // memberEnd).
+    const painterWrites = [...painter.matchAll(/state\.guild\s*=[^=]/g)];
     expect(painterWrites).toHaveLength(2);
-    const resolveStart = painter.indexOf('resolveContent(');
-    expect(resolveStart).toBeGreaterThan(-1);
     for (const write of painterWrites) {
-      expect(painter.indexOf(write)).toBeGreaterThan(resolveStart);
+      expect(write.index).toBeGreaterThanOrEqual(definitionStart);
+      expect(write.index).toBeLessThan(memberEnd);
     }
     expect(canvas.match(/\.guild\s*=[^=]/g) ?? []).toHaveLength(0);
   });

--- a/tests/nameplate_canvas.test.ts
+++ b/tests/nameplate_canvas.test.ts
@@ -168,6 +168,31 @@ describe('nameplate canvas surface', () => {
     expect(traces[0].drawImage).toHaveBeenCalledTimes(2);
   });
 
+  it('draws the byte-identical guild wrapper from the memo, rebuilt only on change', () => {
+    const parent = document.createElement('div');
+    const surface = new NameplateCanvasSurface(parent);
+    const state = createNameplateCanvasState();
+    state.initialized = true;
+    state.name = 'Guilded Hero';
+    state.guild = 'The Testers';
+
+    surface.beginFrame(320, 180, 1);
+    surface.drawBase(state, 160, 90);
+    surface.beginFrame(320, 180, 1);
+    surface.drawBase(state, 160, 90);
+
+    const drawnText = (): string[] =>
+      traces.flatMap((trace) => trace.fillText.mock.calls.map(([value]) => value as string));
+    // Same content as the old per-frame template build: the exact `<...>` form
+    // rasterized ONCE, then re-blitted from the sprite cache on later frames.
+    expect(drawnText().filter((text) => text === '<The Testers>')).toHaveLength(1);
+
+    state.guild = 'New Banner';
+    surface.beginFrame(320, 180, 1);
+    surface.drawBase(state, 160, 90);
+    expect(drawnText()).toContain('<New Banner>');
+  });
+
   it('rasterizes text at capped high DPR and blits it at logical dimensions', () => {
     const parent = document.createElement('div');
     const surface = new NameplateCanvasSurface(parent);

--- a/tests/nameplate_canvas.test.ts
+++ b/tests/nameplate_canvas.test.ts
@@ -168,13 +168,16 @@ describe('nameplate canvas surface', () => {
     expect(traces[0].drawImage).toHaveBeenCalledTimes(2);
   });
 
-  it('draws the byte-identical guild wrapper from the memo, rebuilt only on change', () => {
+  it('draws the byte-identical prebuilt guild wrapper, redrawn only on change', () => {
     const parent = document.createElement('div');
     const surface = new NameplateCanvasSurface(parent);
     const state = createNameplateCanvasState();
     state.initialized = true;
     state.name = 'Guilded Hero';
+    // resolveContent prebuilds the label alongside guild (its only writer);
+    // drawBase consumes it without allocating.
     state.guild = 'The Testers';
+    state.guildLabel = '<The Testers>';
 
     surface.beginFrame(320, 180, 1);
     surface.drawBase(state, 160, 90);
@@ -188,6 +191,7 @@ describe('nameplate canvas surface', () => {
     expect(drawnText().filter((text) => text === '<The Testers>')).toHaveLength(1);
 
     state.guild = 'New Banner';
+    state.guildLabel = '<New Banner>';
     surface.beginFrame(320, 180, 1);
     surface.drawBase(state, 160, 90);
     expect(drawnText()).toContain('<New Banner>');
@@ -438,6 +442,7 @@ describe('nameplate canvas surface', () => {
       name: 'Canvas Boss',
       level: '63+',
       guild: 'The Testers',
+      guildLabel: '<The Testers>',
       title: 'Gate Keeper',
       marker: '!',
       markerTone: 'active',
@@ -506,6 +511,7 @@ describe('nameplate canvas surface', () => {
         initialized: true,
         name: 'High Contrast Hero',
         guild: 'Readers',
+        guildLabel: '<Readers>',
         title: 'Visible',
         marker: '!',
         hpVisible: true,

--- a/tests/painter_host.test.ts
+++ b/tests/painter_host.test.ts
@@ -4,10 +4,17 @@
 // that the four originals cannot express. These tests are the regression guard for
 // Top risk 1 (a non-byte-identical key or a single-slot collapse silently breaks
 // elision and tanks the skip-rate), and they pin the multi-slot cache-key shape so
-// two props / two classes on one element never clobber each other.
+// two props / two classes on one element never clobber each other. They ALSO pin
+// the allocation contract (hitch-elimination B2): the skip path composes no key
+// string and mutates nothing, so an unchanged frame allocates nothing.
 
+import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
-import { makeWriterFacet } from '../src/ui/painter_host';
+import {
+  makeWriterFacet,
+  type PainterHostWriters,
+  type SingleSlotCache,
+} from '../src/ui/painter_host';
 
 // A DOM-free element that records every write the facet performs: textContent, the
 // three single-slot style facets, the multi-slot custom properties (setProperty),
@@ -40,7 +47,7 @@ function fakeEl() {
 }
 
 function fakeFacet() {
-  const cache = new Map<HTMLElement, string>();
+  const cache: SingleSlotCache = new Map();
   const stylePropCache = new Map<HTMLElement, Map<string, string>>();
   const classCache = new Map<HTMLElement, Map<string, string>>();
   const attrCache = new Map<HTMLElement, Map<string, string>>();
@@ -91,8 +98,8 @@ describe('makeWriterFacet: single-slot writers (setText/setDisplay/setTransform/
   it('namespaces by write type: same raw value via display vs width does not false-elide', () => {
     const { facet, counts } = fakeFacet();
     const { el, node } = fakeEl();
-    facet.setDisplay(el, 'block'); // key "display:block"
-    facet.setWidth(el, 'block'); // key "width:block" -> not elided by the display write
+    facet.setDisplay(el, 'block'); // slot (display, "block")
+    facet.setWidth(el, 'block'); // slot (width, "block") -> not elided by the display write
     expect(counts).toEqual({ writes: 2, skips: 0 });
     expect(node.style.display).toBe('block');
     expect(node.style.width).toBe('block');
@@ -209,7 +216,7 @@ describe('makeWriterFacet: shared caches keep one skip-rate (HUD + painter coher
     // Hud keeps its own writers AND hands painters a facet built from the SAME
     // caches; the second writer must see the first writer's cache entry so a repeat
     // is elided whichever path wrote it last (one skip-rate across HUD + painters).
-    const cache = new Map<HTMLElement, string>();
+    const cache: SingleSlotCache = new Map();
     const stylePropCache = new Map<HTMLElement, Map<string, string>>();
     const classCache = new Map<HTMLElement, Map<string, string>>();
     const attrCache = new Map<HTMLElement, Map<string, string>>();
@@ -242,5 +249,155 @@ describe('makeWriterFacet: shared caches keep one skip-rate (HUD + painter coher
     facetB.toggleClass(el, 'rested', true); // shared class cache -> elided
     facetB.setAttr(el, 'aria-label', 'Action slot 1: Attack'); // shared attr cache -> elided
     expect(b).toEqual({ writes: 0, skips: 4 });
+  });
+});
+
+// --- Allocation-free skip path (hitch-elimination B2) ---------------------------
+//
+// The old single-slot shape composed its cache key (backtick `display:` + value)
+// BEFORE the skip check, so every ELIDED write still allocated a key string:
+// millions of allocated-then-discarded strings per session. The fixed shape
+// compares (kind, value) components via shouldWriteSingleSlot and never composes
+// a string over the value on ANY path. The probe below is the mutant guard: every
+// JS string composition over a value (template literal, `+`, String(), .concat)
+// invokes ToPrimitive/toString on it, so a probe value whose conversion hooks are
+// counted turns a resurrected key-first (or any composing) shape red, while the
+// component-compare shape never converts it at all.
+
+function compositionProbe(text: string): { value: string; compositions: () => number } {
+  let count = 0;
+  const probe = {
+    [Symbol.toPrimitive](): string {
+      count++;
+      return text;
+    },
+    toString(): string {
+      count++;
+      return text;
+    },
+    valueOf(): string {
+      count++;
+      return text;
+    },
+  };
+  return { value: probe as unknown as string, compositions: () => count };
+}
+
+const SINGLE_SLOT_DRIVES: ReadonlyArray<
+  [name: string, drive: (f: PainterHostWriters, el: HTMLElement, v: string) => void]
+> = [
+  ['setText', (f, el, v) => f.setText(el, v)],
+  ['setDisplay', (f, el, v) => f.setDisplay(el, v)],
+  ['setTransform', (f, el, v) => f.setTransform(el, v)],
+  ['setWidth', (f, el, v) => f.setWidth(el, v)],
+];
+
+describe('write-elision skip path allocates nothing (B2 mutant guard)', () => {
+  it.each(SINGLE_SLOT_DRIVES)(
+    '%s never composes a string over its value, on the write path or the skip path',
+    (_name, drive) => {
+      const { facet, counts } = fakeFacet();
+      const { el } = fakeEl();
+      const probe = compositionProbe('none');
+      drive(facet, el, probe.value);
+      expect(counts).toEqual({ writes: 1, skips: 0 });
+      expect(probe.compositions()).toBe(0); // even the establishing write stores the raw value
+      for (let i = 0; i < 3; i++) drive(facet, el, probe.value);
+      expect(counts).toEqual({ writes: 1, skips: 3 });
+      expect(probe.compositions()).toBe(0); // an elided frame composes nothing
+    },
+  );
+
+  it('the skip path neither re-sets the cache nor mints a new entry; a change mutates in place', () => {
+    const { facet, cache } = fakeFacet();
+    const { el } = fakeEl();
+    facet.setWidth(el, '42.0%');
+    const entry = cache.get(el);
+    // The cache stores (kind, value) COMPONENTS, never a composed 'width:42.0%'
+    // key: resurrecting the string-keyed cache reds this line.
+    expect(entry).toEqual({ kind: 'width', value: '42.0%' });
+    let sets = 0;
+    const rawSet = cache.set.bind(cache);
+    cache.set = (k, v) => {
+      sets++;
+      return rawSet(k, v);
+    };
+    for (let i = 0; i < 5; i++) facet.setWidth(el, '42.0%');
+    expect(sets).toBe(0); // skip path: pure read, no Map mutation
+    expect(cache.get(el)).toBe(entry); // same entry object, nothing minted
+    facet.setWidth(el, '43.0%'); // a CHANGE mutates the existing entry, no new allocation
+    expect(sets).toBe(0);
+    expect(cache.get(el)).toBe(entry);
+    expect(entry).toEqual({ kind: 'width', value: '43.0%' });
+    expect(cache.size).toBe(1);
+  });
+
+  it('setStyleProp / setAttr skip paths never compose over the value either', () => {
+    const { facet, counts } = fakeFacet();
+    const { el } = fakeEl();
+    const a = compositionProbe('0.5000');
+    const b = compositionProbe('Action slot 1: Attack');
+    facet.setStyleProp(el, '--xp-fill', a.value);
+    facet.setAttr(el, 'aria-label', b.value);
+    facet.setStyleProp(el, '--xp-fill', a.value);
+    facet.setAttr(el, 'aria-label', b.value);
+    expect(counts).toEqual({ writes: 2, skips: 2 });
+    expect(a.compositions()).toBe(0);
+    expect(b.compositions()).toBe(0);
+  });
+});
+
+describe('single-slot semantics: kinds are components, the slot still clobbers across kinds', () => {
+  it('a text value shaped like an old prefixed key never false-elides a different kind', () => {
+    // The composed-key scheme had one latent collision: setText storing the
+    // literal 'display:none' made a later setDisplay(el, 'none') falsely skip a
+    // real write. Components cannot collide: the display write must happen.
+    const { facet, counts } = fakeFacet();
+    const { el, node } = fakeEl();
+    facet.setText(el, 'display:none');
+    facet.setDisplay(el, 'none');
+    expect(node.style.display).toBe('none');
+    expect(counts).toEqual({ writes: 2, skips: 0 });
+  });
+
+  it('cross-kind writes to one element keep the historical single-slot clobber (write set unchanged)', () => {
+    // One element, alternating kinds: the single slot holds the LAST (kind, value),
+    // so each alternation is a real write, exactly as the composed-key cache
+    // behaved. This pins that the DOM writes that DO happen are unchanged.
+    const { facet, counts } = fakeFacet();
+    const { el, node } = fakeEl();
+    facet.setText(el, 'Ready');
+    facet.setDisplay(el, 'flex');
+    facet.setText(el, 'Ready'); // the display write stole the slot -> a real write again
+    expect(counts).toEqual({ writes: 3, skips: 0 });
+    expect(node.textContent).toBe('Ready');
+    facet.setText(el, 'Ready'); // now cached -> elided
+    expect(counts).toEqual({ writes: 3, skips: 1 });
+  });
+});
+
+// --- Source pins: key-first composition stays banished (both writer hosts) ------
+//
+// The behavioral probe above covers makeWriterFacet; Hud's two private mirrors
+// (setText/setDisplay in src/ui/hud.ts) cannot be driven without a full DOM boot,
+// so their half of the contract is pinned at the source level: they must route
+// their decision through the one shared shouldWriteSingleSlot helper (which the
+// probe DOES cover), and neither host may regrow a composed prefix key.
+
+describe('elision key composition stays banished (hud.ts + painter_host.ts source pins)', () => {
+  const read = (rel: string): string => readFileSync(new URL(rel, import.meta.url), 'utf8');
+
+  it('neither writer host composes a prefixed elision key', () => {
+    for (const src of [read('../src/ui/painter_host.ts'), read('../src/ui/hud.ts')]) {
+      expect(src).not.toMatch(/`display:\$\{/);
+      expect(src).not.toMatch(/`transform:\$\{/);
+      expect(src).not.toMatch(/`width:\$\{/);
+    }
+  });
+
+  it('Hud private single-slot writers route through the shared decision helper', () => {
+    const hud = read('../src/ui/hud.ts');
+    expect(hud).toContain("shouldWriteSingleSlot(this.hotWriteCache, el, 'text', text)");
+    expect(hud).toContain("shouldWriteSingleSlot(this.hotWriteCache, el, 'display', display)");
   });
 });

--- a/tests/text_sprite_cache.test.ts
+++ b/tests/text_sprite_cache.test.ts
@@ -353,21 +353,104 @@ describe('text_sprite_cache: cache identity', () => {
     expect(cache.size).toBe(6);
   });
 
+  it('serves a fill-only label from the cache on the second draw', () => {
+    const trace = newTrace();
+    installDocument(trace);
+    const cache = new TextSpriteCache();
+    const ctx = targetContext(trace);
+
+    // The map window's quest-badge digits are exactly this shape: { font, fill },
+    // no stroke. lookup and bucketFor must derive the SAME width key on the
+    // stroke-undefined arm (outlineWidth, 0 here): a bucketFor keyed on
+    // lineWidth ?? 1 instead would insert under 1 while lookup reads 0, so every
+    // draw of every badge digit would silently re-mint its sprite.
+    const style = { font: 'bold 12px Georgia', fill: 'gold' };
+    cache.draw(ctx, '7', 0, 0, style);
+    cache.draw(ctx, '7', 0, 0, style);
+
+    expect(trace.sprites).toHaveLength(1);
+    expect(cache.size).toBe(1);
+    expect(trace.blits).toHaveLength(2);
+    expect(trace.blits[1].sprite).toBe(trace.sprites[0]);
+  });
+
+  it('keys structurally, so a naive fused-field key cannot collide two labels', () => {
+    const trace = newTrace();
+    installDocument(trace);
+    const cache = new TextSpriteCache();
+    const ctx = targetContext(trace);
+
+    // Each neighbouring pair concatenates to the same character run; only the
+    // field split differs. A key built by fusing the fields (or hashing that
+    // fusion) serves the later draw of a pair from the earlier one's sprite.
+    cache.draw(ctx, 'X', 0, 0, { font: 'ab', fill: 'c', stroke: 'd', lineWidth: 2 });
+    cache.draw(ctx, 'X', 0, 0, { font: 'a', fill: 'bc', stroke: 'd', lineWidth: 2 });
+    cache.draw(ctx, 'X', 0, 0, { font: 'a', fill: 'b', stroke: 'cd', lineWidth: 2 });
+    cache.draw(ctx, 'oX', 0, 0, { font: 'a', fill: 'b', stroke: 'cd', lineWidth: 2 });
+    cache.draw(ctx, 'X', 0, 0, { font: 'a', fill: 'b', stroke: 'cdo', lineWidth: 2 });
+    expect(trace.sprites).toHaveLength(5);
+
+    // And each resolves back to its OWN sprite: the second pass mints nothing
+    // and blits the same five sprites in the order the first pass made them.
+    cache.draw(ctx, 'X', 0, 0, { font: 'ab', fill: 'c', stroke: 'd', lineWidth: 2 });
+    cache.draw(ctx, 'X', 0, 0, { font: 'a', fill: 'bc', stroke: 'd', lineWidth: 2 });
+    cache.draw(ctx, 'X', 0, 0, { font: 'a', fill: 'b', stroke: 'cd', lineWidth: 2 });
+    cache.draw(ctx, 'oX', 0, 0, { font: 'a', fill: 'b', stroke: 'cd', lineWidth: 2 });
+    cache.draw(ctx, 'X', 0, 0, { font: 'a', fill: 'b', stroke: 'cdo', lineWidth: 2 });
+    expect(trace.sprites).toHaveLength(5);
+    expect(cache.size).toBe(5);
+    expect(trace.blits).toHaveLength(10);
+    for (const [index, blit] of trace.blits.slice(5).entries()) {
+      expect(blit.sprite).toBe(trace.sprites[index]);
+    }
+  });
+
   it('never aliases a fill-only label onto one whose outline token is unresolved', () => {
     const trace = newTrace();
     installDocument(trace);
     const cache = new TextSpriteCache();
     const ctx = targetContext(trace);
 
-    // The two styles differ ONLY in stroke being absent vs present-but-unresolved:
-    // same font, same fill, and both default to lineWidth 0, so the key's
-    // dedicated outlined field is the only thing separating them.
+    // The two styles differ in stroke being absent vs present-but-unresolved:
+    // same font, same fill. They do NOT share a width key (stroke undefined keys
+    // width 0 while stroke '' strokes, and so keys, at the lineWidth ?? 1
+    // default), so the stroke level parts them before width gets a say; the
+    // width-key collision case is pinned on its own below.
     cache.draw(ctx, '7', 0, 0, { font: 'bold 12px Georgia', fill: 'gold' });
     cache.draw(ctx, '7', 0, 0, { font: 'bold 12px Georgia', fill: 'gold', stroke: '' });
 
     expect(trace.sprites).toHaveLength(2);
     expect(trace.sprites[0].ink.map((i) => i.op)).toEqual(['fill']);
     expect(trace.sprites[1].ink.map((i) => i.op)).toEqual(['stroke', 'fill']);
+  });
+
+  it('keys the stroke level itself: distinct sprites even when the width keys collide', () => {
+    const trace = newTrace();
+    installDocument(trace);
+    const cache = new TextSpriteCache();
+    const ctx = targetContext(trace);
+
+    // outlineWidth gives 0 for BOTH styles here (stroke undefined keys 0; an
+    // explicit lineWidth 0 passes through lineWidth ?? 1 as 0), so font, fill
+    // and width levels all agree and ONLY the dedicated stroke level separates
+    // the pair. A stroke of '' cannot pin this: the unresolved-token guard
+    // refuses to cache it, and '' keys width at lineWidth ?? 1 = 1 anyway.
+    const fillOnly = { font: 'bold 12px Georgia', fill: 'gold' };
+    const outlined = { font: 'bold 12px Georgia', fill: 'gold', stroke: '#000', lineWidth: 0 };
+    cache.draw(ctx, '7', 0, 0, fillOnly);
+    cache.draw(ctx, '7', 0, 0, outlined);
+
+    expect(trace.sprites).toHaveLength(2);
+    expect(cache.size).toBe(2);
+    expect(trace.sprites[0].ink.map((i) => i.op)).toEqual(['fill']);
+    expect(trace.sprites[1].ink.map((i) => i.op)).toEqual(['stroke', 'fill']);
+
+    // And each resolves back to its OWN sprite rather than the other's.
+    cache.draw(ctx, '7', 0, 0, fillOnly);
+    cache.draw(ctx, '7', 0, 0, outlined);
+    expect(trace.sprites).toHaveLength(2);
+    expect(trace.blits[2].sprite).toBe(trace.sprites[0]);
+    expect(trace.blits[3].sprite).toBe(trace.sprites[1]);
   });
 
   it('does not cache a sprite whose 2D context failed', () => {
@@ -436,6 +519,52 @@ describe('text_sprite_cache: cache identity', () => {
   });
 });
 
+describe('text_sprite_cache: the hit path allocates nothing', () => {
+  // The mechanism the old key scheme paid PER CALL, hits included: a key array
+  // plus a joined string per draw/measure, then a Map delete + re-insert per
+  // hit for recency. Spying the three primitives pins that the steady state
+  // (every visible label already cached, the per-frame nameplate case) builds
+  // no key and churns no map; the join spy is the observable half of the
+  // string build, since the key string WAS the join's return value.
+  it('serves hits without building a key or churning any map', () => {
+    const trace = newTrace();
+    installDocument(trace);
+    const cache = new TextSpriteCache();
+    const ctx = targetContext(trace);
+    cache.beginRedraw();
+    cache.draw(ctx, 'Aldous Veyne', 10, 10, OUTLINED); // the miss may allocate
+    cache.measureAdvance('Aldous Veyne', OUTLINED);
+
+    const mapSet = vi.spyOn(Map.prototype, 'set');
+    const mapDelete = vi.spyOn(Map.prototype, 'delete');
+    const arrayJoin = vi.spyOn(Array.prototype, 'join');
+    let sets: number;
+    let deletes: number;
+    let joins: number;
+    try {
+      cache.beginRedraw();
+      for (let frame = 0; frame < 3; frame++) {
+        cache.draw(ctx, 'Aldous Veyne', 10 + frame, 10, OUTLINED);
+        cache.measureAdvance('Aldous Veyne', OUTLINED);
+      }
+      // Counts captured before any assertion machinery runs, so a matcher that
+      // itself touches a Map cannot pollute the verdict.
+      sets = mapSet.mock.calls.length;
+      deletes = mapDelete.mock.calls.length;
+      joins = arrayJoin.mock.calls.length;
+    } finally {
+      mapSet.mockRestore();
+      mapDelete.mockRestore();
+      arrayJoin.mockRestore();
+    }
+    expect(sets).toBe(0);
+    expect(deletes).toBe(0);
+    expect(joins).toBe(0);
+    expect(trace.sprites).toHaveLength(1);
+    expect(trace.blits).toHaveLength(4);
+  });
+});
+
 describe('text_sprite_cache: the bound and its eviction', () => {
   it('ships the budget it documents', () => {
     // Pinned to the literal: every other assertion here is parameterized on the
@@ -493,16 +622,17 @@ describe('text_sprite_cache: the bound and its eviction', () => {
     ).toBeGreaterThanOrEqual(worstCase);
   });
 
-  it('keys a label containing the key separator apart from its prefix', () => {
+  it('keys player-supplied text at its own structural level, immune to injection', () => {
     const trace = newTrace();
     installDocument(trace);
     const cache = new TextSpriteCache();
     const ctx = targetContext(trace);
 
-    // Ally names are player-supplied, so a label can carry whatever the key uses
-    // as a separator. Text is the LAST key field for exactly this reason: a
-    // newline in a label appends to the key rather than shifting the fields that
-    // would have followed it.
+    // Ally names are player-supplied, so a label can carry anything, including a
+    // run that spells out another style field. The key is STRUCTURAL (one map
+    // level per field, text last), so there is no separator to inject: a newline
+    // plus a font string is just a longer key at the text level, never a shifted
+    // field boundary.
     cache.draw(ctx, 'A', 0, 0, OUTLINED);
     cache.draw(ctx, 'A\nbold 12px Georgia', 0, 0, OUTLINED);
     cache.draw(ctx, 'A\nbold 12px Georgia', 0, 0, OUTLINED);
@@ -510,10 +640,10 @@ describe('text_sprite_cache: the bound and its eviction', () => {
     expect(trace.sprites).toHaveLength(2);
     expect(trace.blits).toHaveLength(3);
 
-    // And the separator has to actually be there. Text is keyed immediately after
-    // the outline width, so these two differ only in where that boundary falls:
-    // a key built by plain concatenation reads both as ...312 and serves the
-    // second label from the first one's sprite.
+    // Adjacent levels can never fuse either. Width 3 + text '12' and width 31 +
+    // text '2' concatenate to the same character run (the pair a joined-string
+    // key would read as ...312 and collide), but the width level is its own
+    // numeric map key, so the two part ways before text is even consulted.
     cache.draw(ctx, '12', 0, 0, { ...OUTLINED, lineWidth: 3 });
     cache.draw(ctx, '2', 0, 0, { ...OUTLINED, lineWidth: 31 });
     expect(trace.sprites).toHaveLength(4);
@@ -531,6 +661,7 @@ describe('text_sprite_cache: the bound and its eviction', () => {
 
     cache.clear();
     expect(cache.size).toBe(0);
+    expect(cache.bytes).toBe(0);
     // And the next draw genuinely re-rasterizes rather than serving a stale hit.
     cache.draw(ctx, 'Eastbrook Vale', 0, 0, OUTLINED);
     expect(trace.sprites).toHaveLength(3);
@@ -628,6 +759,38 @@ describe('text_sprite_cache: the bound and its eviction', () => {
     cache.draw(ctx, 'B', 0, 0, OUTLINED);
     expect(trace.sprites).toHaveLength(4);
     expect(cache.bytes).toBeLessThanOrEqual(byteBudget);
+  });
+
+  it('evicts to empty when the byte budget is below one sprite, and stays coherent', () => {
+    const trace = newTrace();
+    installDocument(trace);
+    // 'AB' rasterizes 40x47 at DPR 1 (7520 bytes of backing store, see the
+    // geometry pin above), so a 1000-byte budget cannot retain even one sprite.
+    const cache = new TextSpriteCache(10, 1000);
+    const ctx = targetContext(trace);
+
+    cache.draw(ctx, 'AB', 0, 0, OUTLINED);
+    // Drawn this redraw, but too large to keep: the cache empties completely.
+    expect(trace.blits).toHaveLength(1);
+    expect(cache.size).toBe(0);
+    expect(cache.bytes).toBe(0);
+
+    // Guards the lruTail reset in evictOldest: a stale tail would make the next
+    // insert hook onto the dead entry with the head left null, so eviction goes
+    // blind and the "empty" cache silently retains the new sprite over budget.
+    cache.draw(ctx, 'CD', 0, 0, OUTLINED);
+    expect(trace.blits).toHaveLength(2);
+    expect(cache.size).toBe(0);
+    expect(cache.bytes).toBe(0);
+
+    cache.beginRedraw();
+    expect(cache.size).toBe(0);
+    expect(cache.bytes).toBe(0);
+    // And the cycle keeps working: a later draw re-rasterizes and blits again.
+    cache.draw(ctx, 'AB', 0, 0, OUTLINED);
+    expect(trace.blits).toHaveLength(3);
+    expect(cache.size).toBe(0);
+    expect(cache.bytes).toBe(0);
   });
 });
 


### PR DESCRIPTION
## Summary

Production telemetry shows a GC pause roughly every 4 seconds driven by 3 to 5 MB/s of per-frame allocation, preset-independent. This PR removes the three dominant UI-side allocation treadmills, each proven byte-identical in output:

1. TextSpriteCache built a 6-element array plus a joined string of a few hundred bytes on EVERY draw and measure call, cache hits included, and re-inserted the map entry per hit to maintain LRU order; the nameplate painter drives this per visible plate per frame. Keys are now a structural map tree (font, fill, stroke, drawn outline width, then text as an opaque map level, so player-supplied strings cannot inject a delimiter or fuse adjacent fields) with recency as an intrusive doubly-linked list: a hit is five map gets plus pointer swaps, zero allocation, zero map churn. A 300k-operation differential fuzz against the old implementation (1500 seeds x 200 ops across eight budget configurations, comparing sprite identity per blit, eviction order, size, and bytes) found zero divergence.
2. The single-slot write-elision layer composed its elision key string BEFORE the skip decision, so every elided DOM write still allocated a discarded key. The cache now stores kind and value components compared by a shared pure decision helper on the painter-host seam; neither the skip path nor the repeat-write path allocates, pinned by a conversion-counting probe (any composition over the value fires it) and source pins on both hosts.
3. Per-frame t() and tEntity() calls split the key, walked the catalog, and ran regex interpolation with a fresh closure every call. Resolution now caches the leaf entry per key behind the existing resolution revision (language switches and late-arriving locale chunks invalidate atomically; untracked-key policy and release pending checks still run per call), interpolation compiles a per-key plan once and serves unchanged params with zero allocation, and tEntity resolves through a static id map. Nothing bypasses t(): rendered text still always comes from the pipeline, pinned by a legacy-vs-plan byte-identity matrix and spies holding String split and replace and RegExp exec at exactly zero across 200 repeated calls with fresh params objects.

Honest macro framing: at the referee's 36-plate scale the combined MB/s effect is below single-run measurement noise; the wins are proven at the mechanism level (spies, mutants, fuzz), scale with plate count and locale complexity in production, and fleet heapSawtooth telemetry is the designed judge post-release.

## Related issues

No overlap with open PRs 3219/3217 (different subsystems entirely). The frozen hitch referee (PR 3220) is the verification instrument; parity screenshots held within the calibrated same-build noise floor at every step.

## Type of change

- [x] Refactor or performance (no behavior change)
- [x] Tests

## How was this tested?

- Commands:
  - The five owned suites plus hud_perf_budget, architecture, and the S3 localization guard: all green (196 + 197 across the two verification passes).
  - Every memo, guard, and eviction arm mutant-proven red (structural-key drift, LRU tail reset, invalidation removal, params-compare bounding, key-first composition resurrection, and more).
  - npx tsc --noEmit green; biome clean on changed files.
- Manual steps:
  - Verified on the hitch-elimination branch against the frozen referee across multiple sessions: zero page errors, no long-frame or compile regressions, parity within noise.

---

## Checklist

### Quality

- [x] Decisive tests for every changed behavior; mutants proven red; QA-review hardening pins included (fill-only cache hit, evict-to-empty, stroke-level keying, clear() bytes).

### Cross-platform

- N/A: UI-internal, no visual or layout change on any preset.

### Localization (i18n)

- [x] Every player string still flows through t(); both invalidation arms (language switch, late locale chunk) pinned; S3 guard green.

### Hygiene

- [x] No secrets; no generated files hand-edited.