### PR TITLE
fix(parse): allow http ingest URLs toward RFC1918 private IP literals

### DIFF
--- a/server/parse/CLAUDE.md
+++ b/server/parse/CLAUDE.md
@@ -33,7 +33,8 @@ section 14).
 
 ## Env flags
 `PARSE_CAPTURE=1` master (default off), `PARSE_INGEST_URL` (https, or http to
-loopback only), `PARSE_INGEST_TOKEN`,
+loopback or an RFC1918 private IP literal: the VPC-internal push path),
+`PARSE_INGEST_TOKEN`,
 `PARSE_CAPTURE_SURFACES=arena,battleground,raid,dungeon,rift`,
 `PARSE_SPOOL_DIR`, `PARSE_SPOOL_MAX_MB`, `PARSE_ENV_LABEL=prod|qa|pbe|dev`,
 `PARSE_CENSUS=0` (census opt-out), `PARSE_CENSUS_HOUR` (UTC hour of the daily

--- a/server/parse/flags.ts
+++ b/server/parse/flags.ts
@@ -9,10 +9,29 @@ const ALL_SURFACES: readonly Surface[] = ['arena', 'raid', 'dungeon', 'rift', 'b
 const ENV_LABELS = new Set<ParseEnv>(['prod', 'qa', 'pbe', 'dev']);
 
 /**
+ * RFC1918 IPv4 literal (10/8, 172.16/12, 192.168/16): the VPC-internal case.
+ * Only IP literals qualify: a DNS name cannot be classified at boot without a
+ * resolve, so a "private-looking" hostname is still rejected for http.
+ */
+function isPrivateIpv4Literal(hostname: string): boolean {
+  const match = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(hostname);
+  if (match === null) return false;
+  const octets = match.slice(1).map((part) => Number.parseInt(part, 10));
+  if (octets.some((octet) => octet > 255)) return false;
+  const [a, b] = octets;
+  if (a === 10) return true;
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  return a === 192 && b === 168;
+}
+
+/**
  * The shipper attaches the shared secret to every request, so the transport
- * must be TLS: plain http is allowed only toward loopback (local dev). A
- * non-loopback http URL is rejected at boot rather than silently leaking the
- * token in the clear.
+ * must not cross the open internet in the clear: https always passes; plain
+ * http passes only toward loopback (local dev) or an RFC1918 private IP
+ * literal (the production topology: game hosts push to the parse service over
+ * the VPC private network, bearer-gated and security-group-gated, per the
+ * parse plan's transport decision). Anything else is rejected at boot rather
+ * than silently leaking the token in the clear.
  */
 function validatedIngestUrl(raw: string | null): string | null {
   if (raw === null) return null;
@@ -23,9 +42,9 @@ function validatedIngestUrl(raw: string | null): string | null {
     // compare against '[::1]', never a bare '::1'.
     const loopback =
       url.hostname === 'localhost' || url.hostname === '127.0.0.1' || url.hostname === '[::1]';
-    if (url.protocol === 'http:' && loopback) return raw;
+    if (url.protocol === 'http:' && (loopback || isPrivateIpv4Literal(url.hostname))) return raw;
     console.error(
-      `[parse] PARSE_INGEST_URL must be https (or http to loopback), got ${url.protocol}//${url.hostname}: capture stays off`,
+      `[parse] PARSE_INGEST_URL must be https (or http to loopback or a private IP), got ${url.protocol}//${url.hostname}: capture stays off`,
     );
     return null;
   } catch {

--- a/tests/parse_flags.test.ts
+++ b/tests/parse_flags.test.ts
@@ -46,6 +46,28 @@ describe('loadParseFlags', () => {
     }
   });
 
+  test('http to an RFC1918 private IP literal is allowed (VPC-internal ingest)', () => {
+    for (const host of ['10.0.23.7', '172.16.4.9', '172.31.255.1', '192.168.1.50']) {
+      const flags = loadParseFlags({ ...BASE, PARSE_INGEST_URL: `http://${host}:8788/ingest` });
+      expect(flags.enabled).toBe(true);
+      expect(flags.ingestUrl).toBe(`http://${host}:8788/ingest`);
+    }
+  });
+
+  test('http to a public IP literal or near-private range is still rejected', () => {
+    for (const host of ['8.8.8.8', '172.32.0.1', '172.15.0.1', '11.0.0.1', '192.169.0.1']) {
+      const flags = loadParseFlags({ ...BASE, PARSE_INGEST_URL: `http://${host}:8788/ingest` });
+      expect(flags.enabled).toBe(false);
+      expect(flags.ingestUrl).toBeNull();
+    }
+  });
+
+  test('http to a private-looking DNS name is rejected (only IP literals can be checked at boot)', () => {
+    const flags = loadParseFlags({ ...BASE, PARSE_INGEST_URL: 'http://parses.internal:8788/x' });
+
+    expect(flags.enabled).toBe(false);
+  });
+
   test('a malformed URL is rejected rather than shipped to', () => {
     const flags = loadParseFlags({ ...BASE, PARSE_INGEST_URL: 'not a url' });
 


### PR DESCRIPTION
## Summary

The parse telemetry service is reached over the VPC private network: game hosts push ingest batches by plain http to a private address, bearer-gated in-app and security-group-gated at the network, with TLS reserved for the service's browser dashboard. The recorder's boot validation only admitted https or loopback http, so a private-network `PARSE_INGEST_URL` was rejected and capture silently stayed off.

This admits plain http toward RFC1918 IPv4 literals (10/8, 172.16/12, 192.168/16). Only IP literals qualify: a private-looking DNS name still requires https, since it cannot be classified at boot without a resolve. `server/parse/CLAUDE.md`'s env-flag doc is updated in the same change.

## Type of change

- [x] Bug fix

## How was this tested?

- Commands: `npx vitest run tests/parse_flags.test.ts` (18 passed: three new tests cover acceptance across the private ranges, rejection of public and near-private IPs (`8.8.8.8`, `172.32.0.1`, `172.15.0.1`, `11.0.0.1`, `192.169.0.1`), and rejection of a private-looking DNS name), `npx @biomejs/biome check` on the changed files, `npx tsc --noEmit` (remaining errors are pre-existing on the base, none in these files).
- Manual steps: N/A (boot-time validation only).

## Screenshots / recordings

N/A (no visual change).