### PR TITLE
fix(art): build the portrait bundle from the repo root so its hash is location-independent

### DIFF
--- a/scripts/lib/mob_portrait_jobs.mjs
+++ b/scripts/lib/mob_portrait_jobs.mjs
@@ -199,6 +199,12 @@ export async function buildPortraitRendererContract(repoRoot, browserBundleBytes
   if (!bundleBytes) {
     const built = await esbuild.build({
       entryPoints: [path.join(repoRoot, PORTRAIT_BROWSER_ENTRY)],
+      // Build from the repo root regardless of the process working directory. esbuild records each
+      // bundled module path relative to its working directory, so the same sources built inside a
+      // linked worktree under .wt/ gain ../../ prefixes: different bytes, different sha256. That
+      // hash is pinned by tests/placeholder_art_completion.test.ts, so a manifest regenerated in a
+      // worktree is then rejected at the root, and the repair that re-pins it is rejected in turn.
+      absWorkingDir: repoRoot,
       bundle: true,
       format: 'iife',
       platform: 'browser',


### PR DESCRIPTION
## The problem

`mob-portrait-source-manifest.json` records a sha256 of the esbuild browser bundle, and `tests/placeholder_art_completion.test.ts` pins that manifest's own hash.

esbuild writes each bundled module path into the output **relative to its working directory**. The same sources built inside a linked worktree under `.wt/` therefore gain `../../` prefixes — different bytes, different sha256, with no source change at all:

| build location | bundle sha256 | bytes |
|---|---|---|
| repo root | `d930d68d8e38ac13d154…` | 3709347 |
| nested worktree | `2adc30e09dd0c5c4f9d3…` | 3710274 |

## Why it matters

The pin becomes unsatisfiable across the two places the suite actually runs. A manifest regenerated inside a worktree is rejected at the repo root; re-pinning it at the root is rejected by the next worktree run.

On 2026-08-10 an automated release spent **three repair cycles and about 2.5 hours** alternating between those two states and merged nothing. Each cycle re-pinned the hash, which is why it never converged — the pin was never the defect.

## The fix

`absWorkingDir: repoRoot` pins the build directory, so every location produces identical bytes.

| build location | with `absWorkingDir` |
|---|---|
| repo root | `d930d68d8e38ac13d154…` |
| nested worktree | `d930d68d8e38ac13d154…` |

It resolves to the **same hash the root build already produced**, so the committed manifest and its pin stay valid unchanged — no regeneration, no re-pinning.

Only the bundle that feeds the fingerprint is changed. The other `esbuild.build` call in this file already pins `resolveDir: repoRoot` and its output is not hashed, so it is left alone.
