### PR TITLE
fix(docker): copy pnpm patch files into the install layer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,9 @@ WORKDIR /app
 # .npmrc carries node-linker=hoisted so the install layout matches local/CI.
 RUN npm install -g pnpm@10.34.5
 COPY package.json pnpm-lock.yaml .npmrc ./
+# pnpm patchedDependencies: the lockfile pins patch file hashes, so a frozen
+# install needs the patch files present or it fails with ENOENT.
+COPY patches ./patches
 RUN pnpm install --frozen-lockfile
 COPY .browserslistrc tsconfig.json vite.config.ts svelte.config.js index.html admin.html play.html guide.html editor.html wallet-handoff.html ./
 COPY src ./src

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,9 @@ RUN VITE_TURNSTILE_SITEKEY="$VITE_TURNSTILE_SITEKEY" \
 FROM node:26-slim
 WORKDIR /app
 ENV NODE_ENV=production
+# server/parse/build_version.ts reads the version from package.json in the
+# working directory; without it every telemetry batch reports build unknown.
+COPY --from=build /app/package.json ./package.json
 COPY --from=build /app/dist ./dist
 COPY --from=build /app/media-build ./media-build
 COPY --from=build /app/dist-server ./dist-server


### PR DESCRIPTION
## Summary

Commit 470d8096e7 (three r165 compileAsync disposal race) added a `patchedDependencies` entry, but the Dockerfile's install layer copies only `package.json pnpm-lock.yaml .npmrc` before `pnpm install --frozen-lockfile`. The frozen lockfile pins the patch file's hash, so pnpm fails with `ENOENT: patches/three@0.165.0.patch` and the game image cannot build at all: release/v0.36.0 is currently undeployable to any compose host. CI does not catch this because the gate builds with vite/esbuild outside Docker.

One line: copy `patches/` into the layer before the install (with a comment explaining why it must be there).

## Type of change

- [x] Bug fix

## How was this tested?

- Commands: reproduced the exact failure via a real deploy's `docker compose build` (exit 254, ENOENT on the patch file), then rebuilt the isolated install layer (`node:26-slim` + `pnpm@10.34.5` + the four copied files) with and without `patches/` on the same host: fails without, builds clean with.
- Manual steps: N/A

## Screenshots / recordings

N/A (no visual change).