### PR TITLE
feat(parse): ship a mob-name actor roster on fight_close

### DIFF
--- a/server/parse/contract.ts
+++ b/server/parse/contract.ts
@@ -192,6 +192,13 @@ export interface FightCloseRecord {
   truncated: boolean;
   /** Recorder-side totals, keyed by characterId as a string. */
   rollup: { perParticipant: Record<string, ParticipantTotals> };
+  /**
+   * Non-participant combatants seen in this fight (mobs, unresolved pets):
+   * entity id to display name, resolved at capture time by the recorder's
+   * state join, so event actors can be labeled instead of shown as raw ids.
+   * Optional and additive: absent from pre-roster senders.
+   */
+  actors?: { id: number; name: string }[];
 }
 
 /**

--- a/server/parse/fights.ts
+++ b/server/parse/fights.ts
@@ -64,6 +64,10 @@ export class OpenFight {
   readonly startedTick: number;
   /** Hostile npc ids seen fighting the participants (for boss-cast tracking). */
   readonly mobIds = new Set<number>();
+  /** Display names for tracked non-participant actors, shipped on close so
+   * the dashboard labels mob entity ids. Bounded by the mobIds tracking cap:
+   * names are only noted for ids admitted into mobIds. */
+  private readonly actorNames = new Map<number, string>();
   /** The encounter's boss entity, for kill/reset classification; null = trash. */
   primaryBossId: number | null = null;
   /** Tick of the last event routed here; drives trash-segment quiet closes. */
@@ -246,9 +250,17 @@ export class OpenFight {
       outcome,
       truncated: this.truncated,
       rollup: { perParticipant },
+      ...(this.actorNames.size > 0
+        ? { actors: [...this.actorNames].map(([id, name]) => ({ id, name })) }
+        : {}),
     });
     this.counters.recordsEmitted++;
     this.counters.fightsClosed++;
+  }
+
+  /** Note a tracked non-participant actor's display name for the close roster. */
+  noteActor(entityId: number, name: string): void {
+    if (!this.actorNames.has(entityId)) this.actorNames.set(entityId, name);
   }
 
   private track(p: FightParticipant): void {

--- a/server/parse/instances.ts
+++ b/server/parse/instances.ts
@@ -101,6 +101,7 @@ export class DungeonSegmenter {
     );
     if (isBoss) fight.primaryBossId = mobId;
     fight.mobIds.add(mobId);
+    fight.noteActor(mobId, mob.name);
     state.activeFight = fight;
     return fight;
   }

--- a/server/parse/recorder.ts
+++ b/server/parse/recorder.ts
@@ -350,6 +350,7 @@ export class ParseRecorder {
     // owner engaged here is a hostile npc.
     if (this.host.resolveParticipant(entityId) !== null) return;
     fight.mobIds.add(entityId);
+    fight.noteActor(entityId, entity.name);
     this.fightsByMob.set(entityId, fight);
   }
 }

--- a/server/parse/rifts.ts
+++ b/server/parse/rifts.ts
@@ -74,7 +74,11 @@ export class RiftSegmenter {
       host.sink,
       host.counters,
     );
-    if (inst.bossId !== null) fight.mobIds.add(inst.bossId);
+    if (inst.bossId !== null) {
+      fight.mobIds.add(inst.bossId);
+      const boss = host.sim.entities.get(inst.bossId);
+      if (boss !== undefined) fight.noteActor(inst.bossId, boss.name);
+    }
     this.tracked.set(inst.instanceId, {
       instanceId: inst.instanceId,
       floorIndex: inst.floorIndex,

--- a/server/parse/types.ts
+++ b/server/parse/types.ts
@@ -8,6 +8,9 @@ import type { ParseCounters } from './counters';
 export interface RecorderEntityView {
   id: number;
   templateId: string;
+  /** Display name; feeds the fight_close actor roster so the dashboard can
+   * label mob entity ids. The live Sim entity always carries one. */
+  name: string;
   level: number;
   hp?: number;
   maxHp?: number;

--- a/tests/fixtures/parse_golden.ndjson
+++ b/tests/fixtures/parse_golden.ndjson
@@ -14,4 +14,4 @@
 {"t":"bosscast","fightId":"golden-1","bossId":500,"tick":203,"ability":"grave_bolt","action":"interrupted"}
 {"t":"ev","fightId":"golden-1","tick":240,"ev":{"type":"damage","sourceId":5,"targetId":500,"amount":4700,"crit":true,"school":"frost","ability":"Ice Lance","kind":"hit"}}
 {"t":"ev","fightId":"golden-1","tick":240,"ev":{"type":"death","entityId":500,"killerId":5}}
-{"t":"fight_close","fightId":"golden-1","endedTick":240,"durationMs":1950,"outcome":"kill","truncated":false,"rollup":{"perParticipant":{"1005":{"damage":5000,"taken":0,"healing":0,"overheal":0,"absorbed":0,"deaths":0,"interrupts":0,"dispels":0,"activeMs":100}}}}
+{"t":"fight_close","fightId":"golden-1","endedTick":240,"durationMs":1950,"outcome":"kill","truncated":false,"rollup":{"perParticipant":{"1005":{"damage":5000,"taken":0,"healing":0,"overheal":0,"absorbed":0,"deaths":0,"interrupts":0,"dispels":0,"activeMs":100}}},"actors":[{"id":500,"name":"Morthen the Gravecaller"}]}

--- a/tests/helpers/parse_fake_sim.ts
+++ b/tests/helpers/parse_fake_sim.ts
@@ -35,7 +35,7 @@ export function fakeSim(): FakeSim {
 }
 
 export function fakePlayer(id: number, templateId = 'mage'): RecorderEntityView {
-  return { id, templateId, level: 20, dead: false };
+  return { id, templateId, name: `Fake${id}`, level: 20, dead: false };
 }
 
 export const FAKE_PARSE_FLAGS: ParseFlags = {

--- a/tests/parse_golden.test.ts
+++ b/tests/parse_golden.test.ts
@@ -69,7 +69,7 @@ function runScenario(): string {
     sim.entities.set(pid, fakePlayer(pid));
     sim.arenaMatches.set(pid, match);
   }
-  sim.entities.set(105, { id: 105, templateId: 'wolf', level: 20, ownerId: 5 });
+  sim.entities.set(105, { id: 105, templateId: 'wolf', name: 'Wolf', level: 20, ownerId: 5 });
   const targetSeven = sim.entities.get(7);
   if (targetSeven !== undefined) {
     (targetSeven as { auras: unknown }).auras = [
@@ -164,6 +164,7 @@ function runScenario(): string {
   sim.entities.set(500, {
     id: 500,
     templateId: 'morthen',
+    name: 'Morthen the Gravecaller',
     level: 20,
     hp: 5000,
     maxHp: 5000,

--- a/tests/parse_pve.test.ts
+++ b/tests/parse_pve.test.ts
@@ -7,7 +7,7 @@ import type { SimEvent } from '../src/sim/types';
 import { FAKE_PARSE_FLAGS, type FakeSim, fakeSim } from './helpers/parse_fake_sim';
 
 function player(id: number): RecorderEntityView {
-  return { id, templateId: 'mage', level: 20, dead: false };
+  return { id, templateId: 'mage', name: `Player${id}`, level: 20, dead: false };
 }
 
 const FLAGS = FAKE_PARSE_FLAGS;
@@ -72,6 +72,7 @@ function seedDungeon(sim: FakeSim, overrides: Partial<InstanceSlotView> = {}): I
   sim.entities.set(500, {
     id: 500,
     templateId: 'morthen',
+    name: 'Morthen the Gravecaller',
     level: 20,
     hp: 5000,
     maxHp: 5000,
@@ -85,6 +86,7 @@ function seedDungeon(sim: FakeSim, overrides: Partial<InstanceSlotView> = {}): I
   sim.entities.set(501, {
     id: 501,
     templateId: 'crypt_skeleton',
+    name: 'Crypt Skeleton',
     level: 19,
     hp: 400,
     maxHp: 400,
@@ -134,6 +136,12 @@ describe('DungeonSegmenter via ParseRecorder', () => {
 
     const close = records.find((r) => r.t === 'fight_close');
     expect(close).toMatchObject({ outcome: 'kill', endedTick: 30 });
+    // The actor roster names every tracked hostile npc so the dashboard can
+    // label mob entity ids instead of showing raw numbers.
+    expect((close as { actors?: { id: number; name: string }[] }).actors).toContainEqual({
+      id: 500,
+      name: 'Morthen the Gravecaller',
+    });
     const deathEvents = records.filter(
       (r) => r.t === 'ev' && (r.ev as { type: string }).type === 'death',
     );

--- a/tests/parse_recorder.test.ts
+++ b/tests/parse_recorder.test.ts
@@ -8,7 +8,7 @@ import type { SimEvent } from '../src/sim/types';
 import { FAKE_PARSE_FLAGS, type FakeSim, fakeSim } from './helpers/parse_fake_sim';
 
 function player(id: number): RecorderEntityView {
-  return { id, templateId: 'mage', level: 20 };
+  return { id, templateId: 'mage', name: `Player${id}`, level: 20 };
 }
 
 function participantResolver(sim: FakeSim): (pid: number) => FightParticipant | null {
@@ -191,7 +191,7 @@ describe('ParseRecorder enrichment', () => {
     const sim = fakeSim();
     const match = arenaMatch();
     seedArena(sim, match);
-    sim.entities.set(77, { id: 77, templateId: 'wolf', level: 20, ownerId: 5 });
+    sim.entities.set(77, { id: 77, templateId: 'wolf', name: 'Wolf', level: 20, ownerId: 5 });
     const { recorder, records } = makeRecorder(sim);
 
     sim.tickCount = 10;


### PR DESCRIPTION
## Summary

The parse dashboard shows mobs as raw entity numbers (`#1037`) because events carry only entity ids and no wire record maps ids to identity. Each open fight now notes the display name of every tracked hostile npc, at the tracking sites that already exist and already hold the live entity (recorder `trackMob`, the dungeon segmenter's fight-open seed, the rift segmenter's boss seed), and ships them as an optional additive `actors` array on `fight_close`. The roster inherits the existing per-fight mob tracking cap, so record size stays bounded.

Contract re-vendored verbatim from the service repo (which already validates, stores, and renders the roster). `RecorderEntityView` gains the required `name` field; the live `Sim` entity always carries one, so `game.ts` needs no change (structural typing).

Golden re-minted deliberately via `UPDATE_PARSE_GOLDEN=1` for the new close field, and the fixture is being re-copied to the service repo per the vendoring note.

## Type of change

- [x] Feature: new functionality

## How was this tested?

- Commands: `npx vitest run` over all eight parse suites (108 passed; new assertion pins the roster on a dungeon boss kill), `UPDATE_PARSE_GOLDEN=1` re-mint then a clean re-run, `npx tsc --noEmit` (0 errors), `npx @biomejs/biome check --write` on the changed files.
- Manual steps: N/A (service-side rendering verified in the service repo against a live dev fight).

## Screenshots / recordings

N/A (server-side telemetry; the visible change lands in the parse dashboard).