### PR TITLE
test(ci): spawn vitest directly in the exact-path exclude assumption test

### DIFF
--- a/tests/ci_shard_plan.test.ts
+++ b/tests/ci_shard_plan.test.ts
@@ -775,16 +775,14 @@ describe('ci_shard_test.mjs entry (subprocess, --plan-only)', () => {
     // If a vitest bump changed either semantic, the lane files would run in
     // both halves (duplicate work, never a gap) and the perf win would vanish
     // silently; this spawn makes that loud. `vitest list --filesOnly` prints
-    // the collected set without running anything.
+    // the collected set without running anything. Spawns the resolved local
+    // binary directly (same helper the real shard planner uses, resolveLocalBin),
+    // never through `npx`: npm's own "npm notice run ..." banner line echoes the
+    // args back onto stdout and, on a config that prints it, that echoed line can
+    // itself end with the excluded path, producing a false match in the parser below.
     const child = spawn(
-      'npx',
-      [
-        '--no-install',
-        'vitest',
-        'list',
-        '--filesOnly',
-        `--exclude=${'tests/battleground.test.ts'}`,
-      ],
+      resolveLocalBin('vitest'),
+      ['list', '--filesOnly', `--exclude=${'tests/battleground.test.ts'}`],
       { cwd: repoRoot, env: { ...process.env } },
     );
     let out = '';


### PR DESCRIPTION
## Summary

Found while root-causing repeated CI failures on `release/v0.36.0` (see the
companion PR for the dominant driver, the portrait-manifest bookkeeping-only
false-fail). This is a smaller, separate, unrelated finding: the "the one
external assumption" test in `tests/ci_shard_plan.test.ts` intermittently
fails when the whole test suite runs under heavy local parallelism, and it
turns out to be a real, reproducible, fixable bug in the test itself, not a
regression in the CI shard-planning logic it's meant to guard.

The test proves vitest still honors exact-path `--exclude` additively (the
lane-splitting perf optimization's one external assumption) by spawning
`npx --no-install vitest list --filesOnly --exclude=tests/battleground.test.ts`
and asserting the excluded file is absent from the printed list. On an npm
configuration that prints an `npm notice run '<pkg>' <args>` banner line to
stdout (mine locally does), that banner line echoes the same `--exclude=...`
argument back onto stdout, and since it happens to end with the exact excluded
path, the test's naive `out.split('\n')` line parser counts it as a match,
failing a test that never actually regressed.

## Root cause

```mermaid
flowchart TD
    A["tests/ci_shard_plan.test.ts red<br/>under the full local suite"] --> B["spawn('npx', ['--no-install', 'vitest', 'list', ...])"]
    B --> C["npm prints its own banner:<br/>npm notice run 'vitest' list --filesOnly --exclude=tests/battleground.test.ts"]
    C --> D["banner line lands in the SAME stdout stream<br/>the test parses as the file list"]
    D --> E["banner line itself ends with the excluded path"]
    E --> F["files.some(f => f.endsWith(excludedPath)) === true<br/>even though the excluded file is correctly absent"]
    F --> G["test asserts false, gets true, fails"]

    H["scripts/lib/ci_shard_plan.mjs already exports resolveLocalBin()<br/>used by the REAL shard planner's own vitest leg"] --> I["THIS PR: spawn resolveLocalBin('vitest') directly,<br/>never through npx"]
    I --> J["No npm/npx wrapper in the child process at all.<br/>Verified clean over 3 consecutive runs, 57/57 in the file."]

    style F fill:#3d1418,stroke:#ff7b72,color:#c9d1d9
    style G fill:#3d1418,stroke:#ff7b72,color:#c9d1d9
    style I fill:#1e4429,stroke:#3fb950,color:#c9d1d9
    style J fill:#1e4429,stroke:#3fb950,color:#c9d1d9
```

The fix reuses `resolveLocalBin` from `scripts/lib/ci_shard_plan.mjs`, the
same helper the real shard planner already uses for its own `vitest related`
leg, so the test now spawns the resolved local vitest binary directly instead
of going through `npx`. This removes the dependency on npm/npx wrapper output
entirely rather than working around one specific banner string, and matches
this same file's own existing convention two hundred lines above (the
`ci_shard_test.mjs` subprocess test already spawns `process.execPath` +
the script path directly, never through `npx`).

## Related issues

N/A.

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [x] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx vitest run tests/ci_shard_plan.test.ts -t "exact-path"` run 3 consecutive
    times, all green (the pre-fix version was reliably red on this machine)
  - `npx vitest run tests/ci_shard_plan.test.ts` (57/57)
  - `npx @biomejs/biome check --write tests/ci_shard_plan.test.ts` (clean, one
    pre-existing unrelated info-level suggestion at an unrelated line)
  - `npx tsc --noEmit` (clean)
- Manual steps:
  - Reproduced the failure locally, traced it to the exact npm-notice banner
    line before writing the fix (`node`-level repro comparing `npx vitest list`
    output against a direct `node_modules/.bin/vitest list` invocation).

## Screenshots / recordings

Not applicable, no player/operator-visible surface.

---

## Checklist

### Quality

- [x] **The gate passes.** Pre-push QA floor green (typecheck, guard tests, changed-file
      lint). The changed test itself verified green across repeated runs.

### Cross-platform

- ~~Tested on desktop and mobile.~~ N/A, no UI.
- ~~Accessible.~~ N/A, no UI.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not
      enabled in any production path.
- [x] I didn't hand-edit generated files.