### PR TITLE
fix(ci): size the long-sim job bounds from measured slow-runner ratios

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,18 +39,18 @@ concurrency:
 # to its kill. The runner-side checkout-stall class (the timeout-minutes
 # rationale on each job below) presents as a git fetch at ZERO throughput for
 # tens of minutes: run 31392590628 (2026-08-10) bound-killed the same lane
-# three attempts in a row, 20 minutes each, on fetches that produced nothing
-# and then completed moments after the kill. git's own low-speed abort ends
-# any HTTP transfer whose received payload stays under 1000 bytes per second
-# for 120 consecutive seconds (mechanism proven: a live HTTPS fetch under an
-# absurd floor dies in 2 s with curl 28), and actions/checkout then retries
-# the fetch in-step (3 attempts, 10 to 20 second backoff). HONEST LIMIT,
-# measured, not assumed: the floor polices an in-progress transfer that
-# slows to a trickle, but the hang variant observed on 2026-08-10 (run
-# 31402711619: four fetches sat 19m52s producing NOTHING, WITH this floor
-# confirmed in each step's env) dies in a phase curl's speed timer never
-# polices, so this env block did not catch it. Keep it (it is free and
-# covers the trickle variant); the reliable net for the hang variant is
+# three attempts in a row, at its then-20-minute bound each time, on fetches
+# that produced nothing and then completed moments after the kill. git's own
+# low-speed abort ends any HTTP transfer whose received payload stays under
+# 1000 bytes per second for 120 consecutive seconds (mechanism proven: a live
+# HTTPS fetch under an absurd floor dies in 2 s with curl 28), and
+# actions/checkout then retries the fetch in-step (3 attempts, 10 to 20
+# second backoff). HONEST LIMIT, measured, not assumed: the floor polices an
+# in-progress transfer that slows to a trickle, but the hang variant observed
+# on 2026-08-10 (run 31402711619: four fetches sat 19m52s producing NOTHING,
+# WITH this floor confirmed in each step's env) dies in a phase curl's speed
+# timer never polices, so this env block did not catch it. Keep it (it is
+# free and covers the trickle variant); the reliable net for the hang variant is
 # ci-stall-rerun.yml, which reruns the run's failed jobs once (nothing
 # after the dead checkout ran, so nothing can be masked). Workflow-wide on
 # purpose: it also covers the lint job's base-ref fetch and the changes
@@ -620,20 +620,27 @@ jobs:
     # That projection did not survive CI measurement, and this comment is the
     # re-derivation the lane-diet note asks for whenever a member's cost moves.
     # On run 31450179645 (2026-08-11, a healthy runner, full mode) lane A ran
-    # 13.73 minutes and lane B 12.55, because owned_class_balance_harness alone
-    # measured 739268ms in-lane: the local aggregate for all three half-A files
-    # understates that ONE file by most of a factor of two, and lane isolation
-    # does not shrink it (the same file measured 527s and 842s inside a
-    # release-gate shard, so the harness is simply long, not contended).
+    # a 13.73 minute JOB wall and lane B 12.55, because owned_class_balance_harness
+    # alone measured 739268ms in-lane: the local aggregate for all three half-A
+    # files understates that ONE file by most of a factor of two. Lane A's wall
+    # breaks down as 66s of setup plus a 753s test step, so the job and step
+    # figures are close here only because its caches were warm; size from the
+    # JOB wall regardless, because a setup spike counts inside the bound.
+    # Lane isolation does not reliably shrink the harness either: in-lane it
+    # measured 739s, which sits BETWEEN the two in-shard figures (527s fast,
+    # 842s slow). Those three samples are not controlled against each other,
+    # so read them as runner-to-runner variance dominating, not as a proof
+    # about contention.
     #
-    # 30 applies the same arithmetic as release-gate's bound: healthy wall
+    # 30 applies the same arithmetic as release-gate's bound: healthy JOB wall
     # times the 1.60 fast-to-slow runner ratio measured at b160a1ba18
     # (13.73 x 1.60 = 22.0 for the slower half), then the 1.37x margin the
     # original bounds were chosen with. At 20 this REQUIRED check was roughly
     # one slow runner away from bound-killing and blocking the merge queue,
     # which is the more expensive failure than the release backstop's, so it
     # is raised in the same change. Both halves share one bound so the a/b
-    # assignment can still rebalance freely without re-sizing.
+    # assignment can still rebalance freely without re-sizing. The queue-side
+    # ceiling this has to fit under is recorded in docs/merge-queue.md.
     timeout-minutes: 30
     runs-on: ubuntu-latest
 
@@ -753,7 +760,7 @@ jobs:
     if: ((github.event_name == 'pull_request' && (github.base_ref != 'main' || !startsWith(github.head_ref, 'release/'))) || (github.event_name == 'push' && !startsWith(github.ref, 'refs/heads/release/')) || github.event_name == 'workflow_dispatch' || github.event_name == 'merge_group') && needs.changes.outputs.code != 'false'
     # Unmatrixed single toolchain-setup-plus-checks job, comparable in shape to
     # browser-gate, but heavier: i18n generation, the malware gate, a
-    # typecheck, and four builds. 20 matches the shard matrices' bound so a
+    # typecheck, and four builds. 20 matches the pr-gate shard bound so a
     # stalled runner here dies and reruns instead of holding a required check
     # for hours.
     timeout-minutes: 20
@@ -861,10 +868,16 @@ jobs:
     # runner speed, with owned_class_balance_harness measured at 527s on the
     # fast runner and 842s on the slow one, a ratio of 1.60.
     #
-    # Sizing, stated as the arithmetic rather than a feel: the healthy wall is
-    # the 16 minute passing attempt, so the slow-runner projection is
-    # 16 x 1.60 = 25.6 minutes, and 35 holds the 1.37x margin the 20 bound was
-    # originally chosen with (20 / 14.63). Do NOT re-derive this from the
+    # Sizing, stated as the arithmetic rather than a feel. Every figure below
+    # is a JOB wall, which is what timeout-minutes actually polices: setup
+    # (checkout, pnpm, node, install, cache restore) counts inside the bound
+    # and can spike on its own, so a base taken from the test STEP alone would
+    # under-size this. Label the kind whenever you re-derive it. The healthy
+    # job wall is the 16 minute passing attempt, so the slow-runner projection
+    # is 16 x 1.60 = 25.6 minutes, and 35 holds the 1.37x margin the 20 bound
+    # was originally chosen with (20 / 14.63). Scaling the whole job wall by a
+    # CPU ratio is deliberately conservative, since setup is I/O bound and does
+    # not scale with it. Do NOT re-derive this from the
     # killed attempt's file count: it had finished 271 of 330 files at 18m53s,
     # but druid_balance_probe was still unfinished, so the remaining time was
     # bounded below by a multi-minute file rather than by a per-file average,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -612,13 +612,29 @@ jobs:
     # sibling shard to report around it, so a hang would otherwise hold a
     # required check for GitHub's 6 hour default. The single-job lane's bound
     # was 60 (run 31290316610 measured ~4400s aggregate suite time on a
-    # slow-quartile runner). The lane-diet PR cut the nine suites' aggregate
-    # from 1786s to 901s local-measured and split the list (half A 403s /
-    # half B 498s aggregate; per-suite evidence in the PR body), so each
-    # half's healthy wall projects under 10 minutes on a standard runner; 20
-    # matches the pr-gate shard bound and keeps slow-quartile margin while
-    # killing stalls well before GitHub's default.
-    timeout-minutes: 20
+    # slow-quartile runner). The lane-diet PR then cut the nine suites'
+    # aggregate from 1786s to 901s LOCAL-measured and split the list (half A
+    # 403s / half B 498s aggregate; per-suite evidence in the PR body), and
+    # sized 20 from a projection of under 10 minutes per half.
+    #
+    # That projection did not survive CI measurement, and this comment is the
+    # re-derivation the lane-diet note asks for whenever a member's cost moves.
+    # On run 31450179645 (2026-08-11, a healthy runner, full mode) lane A ran
+    # 13.73 minutes and lane B 12.55, because owned_class_balance_harness alone
+    # measured 739268ms in-lane: the local aggregate for all three half-A files
+    # understates that ONE file by most of a factor of two, and lane isolation
+    # does not shrink it (the same file measured 527s and 842s inside a
+    # release-gate shard, so the harness is simply long, not contended).
+    #
+    # 30 applies the same arithmetic as release-gate's bound: healthy wall
+    # times the 1.60 fast-to-slow runner ratio measured at b160a1ba18
+    # (13.73 x 1.60 = 22.0 for the slower half), then the 1.37x margin the
+    # original bounds were chosen with. At 20 this REQUIRED check was roughly
+    # one slow runner away from bound-killing and blocking the merge queue,
+    # which is the more expensive failure than the release backstop's, so it
+    # is raised in the same change. Both halves share one bound so the a/b
+    # assignment can still rebalance freely without re-sizing.
+    timeout-minutes: 30
     runs-on: ubuntu-latest
 
     steps:
@@ -682,8 +698,9 @@ jobs:
     name: PR gate (long sims B)
     needs: changes
     if: ((github.event_name == 'pull_request' && (github.base_ref != 'main' || !startsWith(github.head_ref, 'release/'))) || (github.event_name == 'push' && !startsWith(github.ref, 'refs/heads/release/')) || github.event_name == 'workflow_dispatch' || github.event_name == 'merge_group') && needs.changes.outputs.code != 'false'
-    # Sized with pr-long-sims-a (evidence there and in the lane-diet PR).
-    timeout-minutes: 20
+    # Sized with pr-long-sims-a (evidence there, in the lane-diet PR, and in
+    # the run 31450179645 re-derivation the sibling comment carries).
+    timeout-minutes: 30
     runs-on: ubuntu-latest
 
     steps:
@@ -835,24 +852,34 @@ jobs:
     # median is what made it fragile.
     #
     # 20 was sized from a 14.63 minute healthy worst case (run 31117143257).
-    # That premise died on 2026-08-11 at b160a1ba18, where shard 1 drew
-    # owned_class_balance_harness, nythraxis_matrix, and hunter_dps_balance
-    # together and was bound-killed four times (run 31443047694 attempts 1
-    # through 3, run 31443040285 attempt 1) while attempt 2 of that same push
-    # run passed the identical scope in 16 minutes. Same commit, same warm
-    # transform cache: the differentiator was runner speed, with
-    # owned_class_balance_harness measured at 527s on the fast runner and 842s
-    # on the slow one. A killed attempt had finished 271 of its 330 files at
-    # 18m53s, so the slow-runner completion is an ESTIMATE near 23 minutes
-    # rather than a measurement (the job never finished); 30 keeps roughly the
-    # proportional margin 20 was chosen with, over that estimate instead of
-    # over the median. Raising it costs stall-kill latency on this job only,
-    # which is the right trade for a post-merge backstop: the stall reactor
-    # (.github/workflows/ci-stall-rerun.yml) is what actually handles hangs,
-    # and pr-gate keeps the tight bound for fast feedback.
-    # The nightly workflow deliberately keeps its own generous bounds and is
-    # untouched.
-    timeout-minutes: 30
+    # That premise died on 2026-08-11 at b160a1ba18, where shard 1 drew FOUR
+    # of the nine long suites (owned_class_balance_harness, nythraxis_matrix,
+    # hunter_dps_balance, and druid_balance_probe) and was bound-killed four
+    # times (run 31443047694 attempts 1 through 3, run 31443040285 attempt 1)
+    # while attempt 2 of that same push run passed the identical scope in 16
+    # minutes. Same commit, same warm transform cache: the differentiator was
+    # runner speed, with owned_class_balance_harness measured at 527s on the
+    # fast runner and 842s on the slow one, a ratio of 1.60.
+    #
+    # Sizing, stated as the arithmetic rather than a feel: the healthy wall is
+    # the 16 minute passing attempt, so the slow-runner projection is
+    # 16 x 1.60 = 25.6 minutes, and 35 holds the 1.37x margin the 20 bound was
+    # originally chosen with (20 / 14.63). Do NOT re-derive this from the
+    # killed attempt's file count: it had finished 271 of 330 files at 18m53s,
+    # but druid_balance_probe was still unfinished, so the remaining time was
+    # bounded below by a multi-minute file rather than by a per-file average,
+    # and the linear extrapolation that suggests (about 23 minutes) reads low.
+    #
+    # Raising this costs stall-kill latency on this job only, which is the
+    # right trade for a post-merge backstop. Note what does NOT cover it: the
+    # stall reactor (.github/workflows/ci-stall-rerun.yml) reruns a bound-killed
+    # SETUP step or a failed checkout, never a test-step kill like this one, and
+    # it stays inert until its workflow file reaches the default branch. A
+    # test-step kill here is a manual rerun by design. pr-gate keeps the tight
+    # bound for fast feedback; its shards exclude these suites, so this evidence
+    # does not touch it. The nightly workflow deliberately keeps its own
+    # generous bounds and is untouched.
+    timeout-minutes: 35
     runs-on: ubuntu-latest
 
     # No I18N_RELEASE_TIER here BY DESIGN (D8 revised, issue #2820). This job runs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -824,14 +824,35 @@ jobs:
     # the label is what an operator reads in the checks list to tell the two reds apart.
     name: Release gate (tests)
     if: (github.event_name == 'pull_request' && github.base_ref == 'main' && startsWith(github.head_ref, 'release/')) || (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release/'))
-    # Same checkout-stall bound as pr-gate (rationale and evidence there).
-    # This matrix keeps the long sims in-shard by design; its slowest
-    # healthy shard observed is 14.63 minutes (run 31117143257, a sample
-    # that also carried a 4.68 minute runner "Set up job" spike, a
-    # component that counts inside the bound), so 20 keeps a 5 minute
-    # margin. The nightly workflow deliberately keeps its own generous
-    # bounds and is untouched.
-    timeout-minutes: 20
+    # Larger than pr-gate's checkout-stall bound BECAUSE this matrix keeps the
+    # long sims in-shard by design: pr-gate hands its CI_LONG_SUITES files to
+    # the lane pair, and release-gate deliberately does not
+    # (scripts/lib/ci_shard_plan.mjs states that ruling), so a release shard
+    # can draw several multi-minute harnesses at once. Default vitest --shard
+    # is sha1-contiguous (vite.config.ts records that the balanced sequencers
+    # were measured and left unwired), so WHICH shard draws them moves with any
+    # change to the collected file set; sizing this bound for the healthy
+    # median is what made it fragile.
+    #
+    # 20 was sized from a 14.63 minute healthy worst case (run 31117143257).
+    # That premise died on 2026-08-11 at b160a1ba18, where shard 1 drew
+    # owned_class_balance_harness, nythraxis_matrix, and hunter_dps_balance
+    # together and was bound-killed four times (run 31443047694 attempts 1
+    # through 3, run 31443040285 attempt 1) while attempt 2 of that same push
+    # run passed the identical scope in 16 minutes. Same commit, same warm
+    # transform cache: the differentiator was runner speed, with
+    # owned_class_balance_harness measured at 527s on the fast runner and 842s
+    # on the slow one. A killed attempt had finished 271 of its 330 files at
+    # 18m53s, so the slow-runner completion is an ESTIMATE near 23 minutes
+    # rather than a measurement (the job never finished); 30 keeps roughly the
+    # proportional margin 20 was chosen with, over that estimate instead of
+    # over the median. Raising it costs stall-kill latency on this job only,
+    # which is the right trade for a post-merge backstop: the stall reactor
+    # (.github/workflows/ci-stall-rerun.yml) is what actually handles hangs,
+    # and pr-gate keeps the tight bound for fast feedback.
+    # The nightly workflow deliberately keeps its own generous bounds and is
+    # untouched.
+    timeout-minutes: 30
     runs-on: ubuntu-latest
 
     # No I18N_RELEASE_TIER here BY DESIGN (D8 revised, issue #2820). This job runs

--- a/docs/merge-queue.md
+++ b/docs/merge-queue.md
@@ -45,6 +45,17 @@ automatically instead of by hand.
   docs/qa-gate.md, "The balance-harness diet").
 - If the queue run is green, GitHub merges automatically. No close/reopen, no
   re-merge of the base: base movement is the queue's job now.
+- The queue gives a candidate **90 minutes** for its checks to report
+  (`check_response_timeout_minutes` on the merge_queue rule; grouping is
+  ALLGREEN, and it builds at most 2 entries at a time). That value is the
+  ceiling every job bound has to fit under, so keep this invariant true when
+  resizing any bound: the `changes` bound, plus the largest REQUIRED job
+  bound, plus runner-acquisition slack (which `timeout-minutes` does not count
+  but the queue's timer does) must stay comfortably under it. Today that is
+  8 + 30, so a required critical path of 38 minutes against a 90 minute
+  ceiling. A candidate that blows the queue timeout is ejected, which blocks
+  the merge rather than merging anything unproven, but it costs a full queue
+  cycle and reads like a mystery without this number written down.
 - The queue merges with one repo-wide method (merge commit). The per-PR
   squash/merge choice does not apply on the protected branches.
 - Direct pushes to the protected branches are blocked by the
@@ -70,8 +81,9 @@ the Checks tab (filter by event: merge_group).
 5. A job that failed with "exceeded the maximum execution time of N minutes"
    hit its checkout-stall bound (the test and browser jobs carry job-level
    timeout-minutes sized from measured healthy worst cases, or, where a job
-   has repeatedly died before finishing on a slow runner, from its healthy
-   wall scaled by the measured fast-to-slow runner ratio; the stall class
+   has repeatedly died before finishing on a slow runner OR has been measured
+   sitting inside its own margin on a healthy one, from its healthy JOB wall
+   scaled by the measured fast-to-slow runner ratio; the stall class
    is runner-side and runs tens of minutes inside actions/checkout, 9.6 to
    24.4 in the incident sample and up to 68 in the 24 hour replay). First open the killed job's log: if a test step was
    already failing or still running near the bound, treat it as a real

--- a/docs/merge-queue.md
+++ b/docs/merge-queue.md
@@ -69,7 +69,9 @@ the Checks tab (filter by event: merge_group).
    it greens, re-queue. Judge red CI by clean-runner reruns.
 5. A job that failed with "exceeded the maximum execution time of N minutes"
    hit its checkout-stall bound (the test and browser jobs carry job-level
-   timeout-minutes sized from measured healthy worst cases; the stall class
+   timeout-minutes sized from measured healthy worst cases, or, where a job
+   has repeatedly died before finishing on a slow runner, from its healthy
+   wall scaled by the measured fast-to-slow runner ratio; the stall class
    is runner-side and runs tens of minutes inside actions/checkout, 9.6 to
    24.4 in the incident sample and up to 68 in the 24 hour replay). First open the killed job's log: if a test step was
    already failing or still running near the bound, treat it as a real

--- a/scripts/lib/ci_shard_plan.mjs
+++ b/scripts/lib/ci_shard_plan.mjs
@@ -89,7 +89,10 @@ export const CI_LONG_SUITES = Object.freeze([
   'tests/chronomancy_balance.test.ts',
   // The five-class-overhauls balance harnesses (review 3050): the owned-class
   // matrices grew to 8 specs and the raid loop to ~510s, pushing shards 1 and
-  // 4 past the 20-minute job budget; they are exactly what this lane is for.
+  // 4 past the then-20-minute pr-gate shard budget; they are exactly what this
+  // lane is for. Their cost kept growing after that: see the ci.yml bounds,
+  // where the same harnesses later outgrew the release-gate and lane bounds
+  // too and forced both to be re-sized from measured slow-runner ratios.
   'tests/druid_balance_probe.test.ts',
   'tests/eastbrook_gameplay_integration.test.ts',
   'tests/hunter_dps_balance.test.ts',

--- a/scripts/lib/ci_stall_rerun.mjs
+++ b/scripts/lib/ci_stall_rerun.mjs
@@ -3,8 +3,9 @@
 //
 // The stall class this reacts to: a runner-side git fetch that trickles at
 // zero throughput for tens of minutes inside a setup step (9.6 to 24.4
-// minutes in the Phase 6 incident sample; three consecutive 20-minute bound
-// kills of "PR gate (long sims A)" on run 31392590628, 2026-08-10). The job
+// minutes in the Phase 6 incident sample; three consecutive bound kills of
+// "PR gate (long sims A)", then bounded at 20 minutes, on run 31392590628,
+// 2026-08-10). The job
 // bounds in ci.yml kill such a job, and docs/merge-queue.md routes the kill
 // to "re-run the failed jobs and re-queue". This module is that triage rule
 // as code, so attempt 1 of the rerun no longer needs a human.

--- a/tests/ci_workflow.test.ts
+++ b/tests/ci_workflow.test.ts
@@ -832,7 +832,15 @@ describe('CI workflow parity', () => {
     // every job in this file carries a conscious timeout-minutes value.
     const bounds = [
       ['pr-gate', 20],
-      ['release-gate', 20],
+      // release-gate is the one shard matrix that keeps its CI_LONG_SUITES
+      // files in-shard (pr-gate hands them to the lanes), so a single shard
+      // can draw several multi-minute harnesses and the bound has to cover a
+      // slow runner rather than the healthy median. 20 was sized from a 14.63
+      // minute healthy worst case and was bound-killing shard 1 by 2026-08-11
+      // at b160a1ba18; the ci.yml comment carries the run ids, the per-suite
+      // fast/slow measurements, and the note that the slow-runner completion
+      // is an estimate rather than a measurement.
+      ['release-gate', 30],
       // The single-job lane's bound reached 60 after run 31290316610 measured
       // ~4400s aggregate suite time on a slow-quartile runner. The lane-diet
       // PR cut the aggregate several-fold and split the lane in two, so each

--- a/tests/ci_workflow.test.ts
+++ b/tests/ci_workflow.test.ts
@@ -834,21 +834,25 @@ describe('CI workflow parity', () => {
       ['pr-gate', 20],
       // release-gate is the one shard matrix that keeps its CI_LONG_SUITES
       // files in-shard (pr-gate hands them to the lanes), so a single shard
-      // can draw several multi-minute harnesses and the bound has to cover a
-      // slow runner rather than the healthy median. 20 was sized from a 14.63
+      // can draw four of them at once and the bound has to cover a slow
+      // runner rather than the healthy median. 20 was sized from a 14.63
       // minute healthy worst case and was bound-killing shard 1 by 2026-08-11
-      // at b160a1ba18; the ci.yml comment carries the run ids, the per-suite
-      // fast/slow measurements, and the note that the slow-runner completion
-      // is an estimate rather than a measurement.
-      ['release-gate', 30],
+      // at b160a1ba18; 35 is the 16 minute healthy wall scaled by the 1.60
+      // fast-to-slow runner ratio measured there, at the same 1.37x margin.
+      // The ci.yml comment carries the run ids, the per-suite measurements,
+      // and why the killed attempt's file count must not be extrapolated.
+      ['release-gate', 35],
       // The single-job lane's bound reached 60 after run 31290316610 measured
       // ~4400s aggregate suite time on a slow-quartile runner. The lane-diet
-      // PR cut the aggregate several-fold and split the lane in two, so each
-      // half projects under 10 minutes healthy on a standard runner; 20
-      // matches the pr-gate shard bound (sizing evidence on the ci.yml
-      // bounds and in the lane-diet PR body).
-      ['pr-long-sims-a', 20],
-      ['pr-long-sims-b', 20],
+      // PR cut the aggregate several-fold and split the lane in two and sized
+      // 20 from a local-measured projection of under 10 minutes per half.
+      // Run 31450179645 falsified that projection on a healthy CI runner
+      // (lane A 13.73 minutes, lane B 12.55, owned_class_balance_harness
+      // alone 739268ms in-lane), leaving these REQUIRED checks about one slow
+      // runner from bound-killing the merge queue, so both halves take the
+      // same slow-runner sizing as release-gate. Evidence on the ci.yml bound.
+      ['pr-long-sims-a', 30],
+      ['pr-long-sims-b', 30],
       ['browser-gate', 10],
       // 8 is a measured decision like the rest (healthy worst 4.42 min, all
       // observed stalls over 8), so it is pinned exactly here beside the

--- a/tests/ci_workflow.test.ts
+++ b/tests/ci_workflow.test.ts
@@ -850,7 +850,9 @@ describe('CI workflow parity', () => {
       // (lane A 13.73 minutes, lane B 12.55, owned_class_balance_harness
       // alone 739268ms in-lane), leaving these REQUIRED checks about one slow
       // runner from bound-killing the merge queue, so both halves take the
-      // same slow-runner sizing as release-gate. Evidence on the ci.yml bound.
+      // same slow-runner sizing METHOD as release-gate (the same formula over
+      // their own healthy job wall, which lands on 30, not on its 35).
+      // Evidence on the ci.yml bound.
       ['pr-long-sims-a', 30],
       ['pr-long-sims-b', 30],
       ['browser-gate', 10],


### PR DESCRIPTION
## Summary

Three CI job bounds were sized before the five-class-overhaul balance harnesses
grew, and measurement shows all three are now too tight. This re-sizes them from
measured slow-runner ratios and corrects the comments the evidence falsified.

| job | was | now | healthy wall (measured) |
|---|---|---|---|
| `release-gate` | 20 | 35 | 16m (shard 1, full scope) |
| `pr-long-sims-a` | 20 | 30 | 13.73m (run 31450179645) |
| `pr-long-sims-b` | 20 | 30 | 12.55m (run 31450179645) |

### The evidence

At `b160a1ba18`, `Release gate (tests) (1)` was bound-killed four times with
`exceeded the maximum execution time of 20m0s` (run 31443047694 attempts 1 through 3,
run 31443040285 attempt 1), while attempt 2 of that same push run passed the
identical 330 file scope in 16 minutes. Same commit, same warm transform cache, so
the differentiator is runner speed: `owned_class_balance_harness` measured 527s on
the fast runner and 842s on the slow one, a ratio of 1.60.

`release-gate` is the one shard matrix that keeps its `CI_LONG_SUITES` files
in-shard (`scripts/lib/ci_shard_plan.mjs` states that ruling), and shard 1 draws
four of the nine. Sizing is therefore the healthy wall scaled by the measured
ratio, 16 x 1.60 = 25.6, at the 1.37x margin the original bounds used, giving 35.

### The lane pair matters more, and was the reason this PR grew

Review flagged that the priority was inverted in the first pass. `PR gate (long sims A)`
and `(B)` are REQUIRED checks (`docs/merge-queue.md`), and half A carries
`owned_class_balance_harness`. Their bound comment justified 20 with a local-measured
projection of "under 10 minutes per half". Measurement on run 31450179645 (healthy
runner, full mode) falsifies it: lane A ran 13.73 minutes, lane B 12.55, with
`owned_class_balance_harness` alone at 739268ms in-lane. Lane isolation does not
shrink that file (527s / 842s in-shard versus 739s in-lane), so at 20 these required
checks sat roughly one slow runner from bound-killing and blocking the merge queue.
That is a costlier failure than the release backstop's, so both halves move to 30 in
the same change.

### Why not the alternatives

- Lane-splitting `release-gate` was considered and rejected: it runs raw
  `npm test -- --shard=i/8` on purpose so the backstop does not depend on the
  selection machinery it backstops, and `tests/ci_workflow.test.ts` pins that no
  release job contains `ci_shard_test.mjs`, `TEST_MODE`, or `--exclude`.
- Cost-balanced sharding was already measured and left unwired (`vite.config.ts`).
- The balance-harness diet flag is already the tighter setting and is nightly-only;
  ci.yml is pinned to never set `WOC_FULL_BALANCE_SWEEP`.

Raising a bound can only let more tests finish; a bound kill is a red job, never a
skipped one, so this cannot reduce coverage.

### Comments this evidence falsified, corrected here

- The lane bound's "under 10 minutes per half" projection (local-measured, did not
  survive CI). This is the re-derivation the lane-diet note asks for whenever a
  member's cost moves.
- `release-gate`'s comment said shard 1 draws three long suites; it draws four
  (`druid_balance_probe` included).
- The stall reactor was cited as the compensating control. It only reruns a
  bound-killed setup step or a failed checkout, and is inert until its workflow file
  reaches the default branch, so a test-step kill stays manual. Said plainly now.
- `scripts/lib/ci_shard_plan.mjs` now reads "the then-20-minute pr-gate shard budget".
- `docs/merge-queue.md` now admits ratio-scaled sizing for a job that repeatedly dies
  before finishing.

## Related issues

Part of finalizing v0.36.0 (unblocks the release-to-main PR #3285).

## Type of change

- [x] Build, CI, or tooling

## How was this tested?

- Commands:
  - `node scripts/gate_select.mjs`: PASS, all 12 steps green (run against the first pass).
  - `npx vitest run tests/ci_workflow.test.ts tests/ci_shard_plan.test.ts tests/nightly_workflow.test.ts tests/ci_stall_rerun.test.ts tests/deploy_node_version.test.ts`: 127 passed.
  - `npx tsc --noEmit`: exit 0. `npx @biomejs/biome check` on the changed files: clean.
- Manual steps: derived every duration in this PR from real job logs (runs 31443047694,
  31443040285, 31450179645), and confirmed the killed jobs carry the runner timeout
  annotation rather than a test failure or a superseded-concurrency cancel, which look
  identical in the checks list.

The `gate-integrity-reviewer` audited this change and mutation-proved that the bounds
table stays decisive in both directions (yml-without-test and test-without-yml both go
red, plus duplicate, step-level, and completeness assertions). Its findings are applied
in the second commit.

## Screenshots / recordings

N/A, no player or operator visible surface.

---

## Checklist

### Quality

- [x] **The gate passes.** `node scripts/gate_select.mjs` is green, and every pinned
      bound in `tests/ci_workflow.test.ts` moves in the same change as the yml.

### Cross-platform

- [x] N/A. CI configuration only.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not
      enabled in any production path.
- [x] I didn't hand-edit generated files.
