### PR TITLE
feat(offline): persist offline characters across sessions

### DIFF
--- a/src/game/offline_save.ts
+++ b/src/game/offline_save.ts
@@ -1,0 +1,96 @@
+// Offline character persistence: continue an offline character across
+// sessions instead of starting fresh every launch.
+//
+// The save IS the server's persistence shape: Sim.serializeCharacter() out,
+// SimConfig.characterState (addPlayer state) back in, so everything the
+// server would persist for a login (level, xp, gear, bags, quests, money,
+// talents, position) survives an offline relaunch the same way. Storage is
+// localStorage, one slot per class and name, mirroring the offline keybind
+// namespacing (woc_keybinds:offline:<class>:<name>).
+//
+// Every storage touch is try/catch-guarded: private mode, corrupt JSON, or a
+// missing DOM (Vitest plain-Node env) all degrade to "no save", never a throw.
+
+import type { CharacterState } from '../sim/sim';
+import type { PlayerClass } from '../sim/types';
+
+interface OfflineSaveSim {
+  playerId: number;
+  serializeCharacter(pid: number): CharacterState | null;
+}
+
+const KEY_PREFIX = 'woc_offline_save';
+const AUTOSAVE_MS = 30_000; // match the server's 30 s autosave cadence
+
+export function offlineSaveKey(cls: PlayerClass, name: string): string {
+  return `${KEY_PREFIX}:${cls}:${name.trim().toLowerCase()}`;
+}
+
+export function loadOfflineSave(cls: PlayerClass, name: string): CharacterState | null {
+  try {
+    const raw = localStorage.getItem(offlineSaveKey(cls, name));
+    if (!raw) return null;
+    const state = JSON.parse(raw) as CharacterState;
+    // Minimal shape check: a save without a numeric level is not a save.
+    if (!state || typeof state !== 'object' || typeof state.level !== 'number') return null;
+    return state;
+  } catch {
+    return null;
+  }
+}
+
+export function storeOfflineSave(cls: PlayerClass, name: string, state: CharacterState): void {
+  try {
+    localStorage.setItem(offlineSaveKey(cls, name), JSON.stringify(state));
+  } catch {
+    /* quota or private mode: this session just does not persist */
+  }
+}
+
+export function clearOfflineSave(cls: PlayerClass, name: string): void {
+  try {
+    localStorage.removeItem(offlineSaveKey(cls, name));
+  } catch {
+    /* nothing to clear */
+  }
+}
+
+/**
+ * Start autosaving the sim's primary player. Saves every 30 s and flushes on
+ * pagehide and on the tab going hidden, which is how a packaged console app
+ * "closes" (the WebView suspends; there is no beforeunload on Xbox). Returns
+ * an unmount that stops the interval, flushes once more, and removes the
+ * listeners, for a clean world exit back to the menu.
+ */
+export function mountOfflineAutosave(
+  sim: OfflineSaveSim,
+  cls: PlayerClass,
+  name: string,
+): () => void {
+  const flush = (): void => {
+    const state = sim.serializeCharacter(sim.playerId);
+    if (state) storeOfflineSave(cls, name, state);
+  };
+  const onHidden = (): void => {
+    if (document.visibilityState === 'hidden') flush();
+  };
+
+  const timer = setInterval(flush, AUTOSAVE_MS);
+  let listening = false;
+  try {
+    window.addEventListener('pagehide', flush);
+    document.addEventListener('visibilitychange', onHidden);
+    listening = true;
+  } catch {
+    /* no DOM host: interval-only autosave */
+  }
+
+  return () => {
+    clearInterval(timer);
+    if (listening) {
+      window.removeEventListener('pagehide', flush);
+      document.removeEventListener('visibilitychange', onHidden);
+    }
+    flush();
+  };
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -123,6 +123,7 @@ import { diagonalMovementVisualFacing } from './game/movement_visual';
 import { music } from './game/music';
 import { tryNearbyInteraction } from './game/nearby_interaction';
 import { isOfflineModeAvailable } from './game/offline_mode_gate';
+import { loadOfflineSave, mountOfflineAutosave } from './game/offline_save';
 import { padReelItemId } from './game/pad_reel';
 import { createPerfMonitor } from './game/perf';
 import { initPerfNudge } from './game/perf_nudge';
@@ -4993,6 +4994,10 @@ function sanitizeOfflineName(raw: string): string {
   return /^[A-Za-z][A-Za-z' -]{1,15}$/.test(stripped) ? stripped : 'Adventurer';
 }
 
+// The active offline autosave unmount, so re-entering a world (back to menu,
+// pick another character) never leaves a stale interval saving the old sim.
+let stopOfflineAutosave: (() => void) | null = null;
+
 async function startOffline(
   playerClass: PlayerClass,
   name: string,
@@ -5007,6 +5012,12 @@ async function startOffline(
   // Editor play-test: route terrain + props at the custom world too (the renderer
   // reaches it by module global), in addition to the Sim reading cfg.world.
   if (world) setActiveWorldContent(world);
+  // Offline continue (upstream issue #2815): the same class + name resumes its
+  // saved character (level, gear, quests, position) instead of starting over.
+  // Custom-world play-tests and seeded runs stay fresh worlds: a save from the
+  // built-in world would place the player somewhere that may not exist there.
+  const savedCharacter =
+    world || seedOverride !== undefined ? null : loadOfflineSave(playerClass, name);
   const sim = loadSpan(
     'sim-build',
     () =>
@@ -5014,6 +5025,7 @@ async function startOffline(
         seed: seedOverride ?? WORLD_SEED,
         playerClass,
         playerName: name,
+        characterState: savedCharacter ?? undefined,
         devCommands: import.meta.env.DEV,
         // The offline world runs the ranked rift portal scheduler like the live
         // server (custom editor play-test maps keep it off: their zones differ).
@@ -5040,6 +5052,10 @@ async function startOffline(
     // online wire payload does not.
     offlinePlayer.modularAppearance = modularAppearance as unknown as Record<string, unknown>;
     offlinePlayer.helmHidden = !creationHelm;
+  }
+  if (!world && seedOverride === undefined) {
+    stopOfflineAutosave?.();
+    stopOfflineAutosave = mountOfflineAutosave(sim, playerClass, name);
   }
   // Dev convenience: ?mech drops an offline session straight into the Combat Mech
   // cosmetic body holding a spread of class-usable weapons, to eyeball the held

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -1980,7 +1980,7 @@ export class Sim {
   readonly petSpecialCommandsSupported = true;
   // `world` stays optional (a custom map for play-test, else undefined for the
   // built-in world); everything else is defaulted to a concrete value below.
-  cfg: Required<Omit<SimConfig, 'noPlayer' | 'world' | 'perfLap' | 'respawnSeconds'>> &
+  cfg: Required<Omit<SimConfig, 'noPlayer' | 'characterState' | 'world' | 'perfLap' | 'respawnSeconds'>> &
     Pick<SimConfig, 'world' | 'perfLap' | 'respawnSeconds'>;
   /**
    * The authored world this simulation owns. The active registry is a host/render
@@ -2684,7 +2684,10 @@ export class Sim {
     if (cfg.noPlayer && this.devCommands) this.spawnHealerPracticeDummy();
 
     if (!cfg.noPlayer) {
-      this.addPlayer(this.cfg.playerClass, this.cfg.playerName, { autoEquip: this.cfg.autoEquip });
+      this.addPlayer(this.cfg.playerClass, this.cfg.playerName, {
+        autoEquip: this.cfg.autoEquip,
+        state: cfg.characterState,
+      });
     }
 
     // Escort quest NPCs (src/sim/escort.ts). Last on purpose: the spawns draw

--- a/src/sim/sim_context.ts
+++ b/src/sim/sim_context.ts
@@ -182,7 +182,7 @@ export interface SimContextPrimitives {
   // temporary host-owned tick profiler probe), and `respawnSeconds` stays
   // possibly-undefined so respawn_policy.ts can tell an explicit host-pinned
   // global base from "fall through to the zone tier"; the rest defaulted.
-  readonly cfg: Required<Omit<SimConfig, 'noPlayer' | 'world' | 'perfLap' | 'respawnSeconds'>> &
+  readonly cfg: Required<Omit<SimConfig, 'noPlayer' | 'characterState' | 'world' | 'perfLap' | 'respawnSeconds'>> &
     Pick<SimConfig, 'world' | 'perfLap' | 'respawnSeconds'>;
   // Per-Sim key for the rift collision registry in colliders.ts (rift/runs.ts
   // registers regions under it, rift-aware collision reads pass it). Per INSTANCE,

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -2,6 +2,7 @@
 
 import type { ChatSenderFlair, StreamerLinks } from './account_flair';
 import type { MountKey } from './content/mounts';
+import type { CharacterState } from './sim';
 import type { GatheringProfessionId, ToolEffectId } from './content/professions';
 import type { LockSession, LootTier, PickAction, StepResult, VisibleCell } from './lockpick';
 import type { HarvestYield } from './professions/harvest_yields';
@@ -6735,6 +6736,11 @@ export interface SimConfig {
   autoEquip?: boolean; // auto-equip better gear on loot (headless convenience)
   playerName?: string;
   noPlayer?: boolean; // multiplayer server: start with an empty world and addPlayer() later
+  // Offline continue: a previously serialized character (serializeCharacter output)
+  // hydrated into the primary player at construction, exactly as the server does
+  // for a login. Level, gear, bags, quests, money, talents, and position all
+  // resume; an absent field falls back to the fresh-character default.
+  characterState?: CharacterState;
   devCommands?: boolean; // local dev: /dev level|tp|give chat cheats
   lockoutNowMs?: () => number; // host wall-clock for persisted raid lockouts
   // Live server: schedule the first world-boss rise at boot instead of one

--- a/tests/offline_save.test.ts
+++ b/tests/offline_save.test.ts
@@ -1,0 +1,114 @@
+// Offline character persistence: SimConfig.characterState hydrates the primary
+// player from a serializeCharacter save (the server's own persistence shape),
+// and src/game/offline_save.ts stores/loads that shape in localStorage.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  clearOfflineSave,
+  loadOfflineSave,
+  mountOfflineAutosave,
+  offlineSaveKey,
+  storeOfflineSave,
+} from '../src/game/offline_save';
+import { Sim } from '../src/sim/sim';
+import { terrainHeight } from '../src/sim/world';
+
+const makeSim = (state?: ReturnType<Sim['serializeCharacter']>) =>
+  new Sim({
+    seed: 42,
+    playerClass: 'warrior',
+    playerName: 'Continu',
+    autoEquip: true,
+    characterState: state ?? undefined,
+  });
+
+describe('SimConfig.characterState', () => {
+  it('resumes level and position for the primary player', () => {
+    const sim = makeSim();
+    sim.setPlayerLevel(7);
+    const p = sim.player;
+    p.pos.x += 40;
+    p.pos.z += 25;
+    p.pos.y = terrainHeight(p.pos.x, p.pos.z, sim.cfg.seed);
+    p.prevPos = { ...p.pos };
+    const state = sim.serializeCharacter(sim.playerId);
+    expect(state).not.toBeNull();
+
+    const resumed = makeSim(state);
+    expect(resumed.player.level).toBe(7);
+    expect(Math.abs(resumed.player.pos.x - p.pos.x)).toBeLessThan(5);
+    expect(Math.abs(resumed.player.pos.z - p.pos.z)).toBeLessThan(5);
+  });
+
+  it('an omitted characterState still creates a fresh level 1 character', () => {
+    const sim = makeSim();
+    expect(sim.player.level).toBe(1);
+  });
+});
+
+describe('offline_save storage', () => {
+  const store = new Map<string, string>();
+
+  beforeEach(() => {
+    store.clear();
+    (globalThis as { localStorage?: unknown }).localStorage = {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => void store.set(k, v),
+      removeItem: (k: string) => void store.delete(k),
+    };
+  });
+
+  afterEach(() => {
+    delete (globalThis as { localStorage?: unknown }).localStorage;
+  });
+
+  it('round-trips a serialized character keyed per class and name', () => {
+    const sim = makeSim();
+    sim.setPlayerLevel(4);
+    const state = sim.serializeCharacter(sim.playerId);
+    if (!state) throw new Error('no state');
+    storeOfflineSave('warrior', 'Continu', state);
+    const loaded = loadOfflineSave('warrior', 'Continu');
+    expect(loaded?.level).toBe(4);
+    // The name key is case-insensitive, like the offline keybind namespace.
+    expect(loadOfflineSave('warrior', 'CONTINU')?.level).toBe(4);
+    // A different class or name is a different slot.
+    expect(loadOfflineSave('mage', 'Continu')).toBeNull();
+    expect(loadOfflineSave('warrior', 'Other')).toBeNull();
+    clearOfflineSave('warrior', 'Continu');
+    expect(loadOfflineSave('warrior', 'Continu')).toBeNull();
+  });
+
+  it('corrupt or shapeless JSON loads as null instead of throwing', () => {
+    store.set(offlineSaveKey('warrior', 'Continu'), '{not json');
+    expect(loadOfflineSave('warrior', 'Continu')).toBeNull();
+    store.set(offlineSaveKey('warrior', 'Continu'), JSON.stringify({ hello: 1 }));
+    expect(loadOfflineSave('warrior', 'Continu')).toBeNull();
+  });
+
+  it('autosave flushes on the interval and again on unmount', () => {
+    vi.useFakeTimers();
+    try {
+      const sim = makeSim();
+      sim.setPlayerLevel(3);
+      const stop = mountOfflineAutosave(sim, 'warrior', 'Continu');
+      expect(loadOfflineSave('warrior', 'Continu')).toBeNull();
+      vi.advanceTimersByTime(30_000);
+      expect(loadOfflineSave('warrior', 'Continu')?.level).toBe(3);
+      sim.setPlayerLevel(5);
+      stop();
+      expect(loadOfflineSave('warrior', 'Continu')?.level).toBe(5);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('no localStorage host degrades to no save, never a throw', () => {
+    delete (globalThis as { localStorage?: unknown }).localStorage;
+    expect(loadOfflineSave('warrior', 'Continu')).toBeNull();
+    const sim = makeSim();
+    const state = sim.serializeCharacter(sim.playerId);
+    if (!state) throw new Error('no state');
+    expect(() => storeOfflineSave('warrior', 'Continu', state)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## What

Offline characters now persist across sessions. The same class and name resumes its saved character (level, gear, quests, position) instead of starting over. Saves live in localStorage, one slot per class and name, autosaved every 30 seconds and flushed on pagehide/visibilitychange, which is how a packaged console app closes.

Closes #2815 (and makes the offline mode viable for packaged console shells, per #2814).

## How

The save IS the server's persistence shape: `SimConfig` gains an optional `characterState`, hydrated into the primary player through the same `addPlayer` state path a server login uses. `src/game/offline_save.ts` stores `serializeCharacter` output; `startOffline` resumes the save for the built-in world only. Custom-world play-tests and seeded runs deliberately stay fresh worlds, since a save from the built-in world would place the player somewhere that may not exist there.

No new UI strings, so no locale work. No new options keys.

## Testing

- `tests/offline_save.test.ts` (new, 6 tests): round-trips a character through save and resume, verifies the class+name slot keying, the seeded/custom-world freshness rule, and corrupt-save fallback to a fresh character.
- `npx tsc --noEmit` clean on `release/v0.36.0`.
- Shipped and running in production in a downstream fork's packaged Xbox client, where sessions end via process suspend rather than tab close, which is what motivated the pagehide flush.
