### PR TITLE
fix(server): close the rift forge wire commands behind RIFT_FORGE_ENABLED

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -366,6 +366,13 @@ WIKI_URL=http://localhost:8080/wiki/index.php/Main_Page
 #WOC_DAILY_REWARD_SERVICE_SECRET=local-dev-secret
 #WOC_DAILY_REWARD_CONFIG_TTL_MS=300000
 
+# Rift forge wire commands (upgrade / enchant / socket on Riftbound bands).
+# The client forge UI has not shipped, so the server refuses the three wire
+# commands unless this is exactly 1 (server/rift_forge_gate.ts). Leave unset
+# in production until the forge intentionally ships; enable only on PTR or
+# internal playtest realms.
+#RIFT_FORGE_ENABLED=1
+
 # Optional Rift Dungeon Upgrader. Server-side only: never prefix these with
 # VITE_. A dedicated service takes precedence when RIFT_UPGRADER_URL is set.
 #RIFT_UPGRADER_URL=

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -476,6 +476,10 @@ For off-box safety, sync the directory to S3 occasionally:
 - **Never** set `ALLOW_DEV_COMMANDS=1` in production: it enables the full
   `/dev` cheat set (the level/teleport cheats the test bots use, plus item
   grants, mob spawns, instance teleports, and the dev command GUI).
+- Leave `RIFT_FORGE_ENABLED` unset in production: it opens the Rift forge
+  wire commands (upgrade/enchant/socket), whose client UI has not shipped.
+  Enable it only on PTR or internal playtest realms
+  (`server/rift_forge_gate.ts`).
 - **Community test profile**: on a disposable public test realm, set
   `PROVISION_TEST_ACCOUNTS=1` in the host `.env`, then restart the game
   container. The flag gives newly created accounts nine level-20 characters,

--- a/docs/design/rift-mode.md
+++ b/docs/design/rift-mode.md
@@ -104,3 +104,18 @@ enchantment, sockets, and gems. Their rolled stats apply while equipped, survive
 save/load and wire round-trips, and are rebuilt from bounded inputs at load rather
 than trusted from JSONB. Gear can be upgraded, enchanted, socketed, unequipped
 without losing its payload, or salvaged back into power-scaled Rift Essence.
+
+The forge (upgrade, enchant, socket) has no shipped client UI yet, so the
+authoritative server refuses its three wire commands unless the realm opts in
+with RIFT_FORGE_ENABLED=1 (server/rift_forge_gate.ts, pinned by
+tests/rift_forge_gate.test.ts). Absent UI is not a gate: a crafted frame
+reaches the wire regardless, and players used exactly that path for premature
+progression before the gate landed. The sim methods stay live offline and in
+tests; only the online dispatch arms are closed. Each refused attempt books
+the woc_rift_forge_refused_total counter, the ops signal that probing
+continues (or that a realm forgot the flag once the UI ships).
+
+Note for whoever ships the forge UI: send the three commands through
+ClientWorld's cmdWithOutcome (not the fire-and-forget cmd sender), because a
+realm with the flag still off refuses with only a commandOutcome ok:false
+ack, and a rid-less sender would surface that as pure silence to the player.

--- a/server/game.ts
+++ b/server/game.ts
@@ -310,6 +310,7 @@ import { nextRaidResetMs, resetDayKey } from './raid_reset';
 import { REALM, REALM_PUBLIC_ORIGIN, REALM_RESET_TIME_ZONE } from './realm';
 import { createRealmReadoutMemo, realmReadoutJson, realmReadoutObject } from './realm_readout_memo';
 import { RiftAssetCoordinator, riftAssetConfigFromEnv } from './rift_assets';
+import { refusedRiftForgeCommand } from './rift_forge_gate';
 import { RiftUpgradeCoordinator, riftUpgraderConfigFromEnv } from './rift_upgrader';
 import { createSerialWriter } from './serial_writer';
 import {
@@ -6600,6 +6601,19 @@ export class GameServer {
     if (session.jailed && typeof msg.cmd === 'string' && JAILED_BLOCKED_COMMANDS.has(msg.cmd)) {
       if (msg.cmd === 'unstuck') this.sendUnstuckBlocked(session, 'jailed');
       else this.sendChatNotice(session, 'You cannot do that while jailed.');
+      this.sendCommandOutcome(session, msg, false);
+      return;
+    }
+    // The Rift forge trio shipped sim+wire complete with no client UI, so the
+    // arms stay closed until the realm explicitly opts in (RIFT_FORGE_ENABLED=1;
+    // rationale in server/rift_forge_gate.ts): a crafted frame must not buy
+    // progression the stock client cannot reach. Refused ABOVE the heavy-self
+    // dirty flag below, so a blocked command cannot force a re-diff either.
+    if (refusedRiftForgeCommand(msg.cmd)) {
+      // Label-free by contract (game_signals.ts): the stock client never sends
+      // these, so the counter is the ops signal that a modified client probes
+      // the closed forge (and that a realm forgot the flag once the UI ships).
+      gameMetricsCounters().riftForgeRefused();
       this.sendCommandOutcome(session, msg, false);
       return;
     }

--- a/server/http/game_metrics.ts
+++ b/server/http/game_metrics.ts
@@ -115,6 +115,9 @@ export const WOC_CHARACTERS_CREATED_TOTAL = 'woc_characters_created_total';
 /** Total guild-bank incidents on the dupe-sensitive paths, by kind. */
 export const WOC_GUILD_BANK_INCIDENTS_TOTAL = 'woc_guild_bank_incidents_total';
 
+/** Rift forge wire commands refused while the gate is closed (server/rift_forge_gate.ts). */
+export const WOC_RIFT_FORGE_REFUSED_TOTAL = 'woc_rift_forge_refused_total';
+
 /** Guild bank activity log cache readout, labeled by counter name. ONE metric
  *  with a `kind` label rather than six names: the vocabulary is closed and
  *  fixed, and an operator reads them together or not at all. */
@@ -379,6 +382,12 @@ export function registerGameStateMetrics(
     registers: [registry],
   });
 
+  const riftForgeRefusals = new Counter({
+    name: WOC_RIFT_FORGE_REFUSED_TOTAL,
+    help: 'Total rift forge wire commands refused while the gate is closed; the stock client sends none, so a non-zero rate means a modified client is probing.',
+    registers: [registry],
+  });
+
   const chatMessages = new Counter({
     name: WOC_CHAT_MESSAGES_TOTAL,
     help: 'Total player chat messages routed to other players (any channel).',
@@ -571,6 +580,13 @@ export function registerGameStateMetrics(
         inputFramesMissed.inc(missed);
       } catch {
         // Drop the sample rather than propagate into the input path.
+      }
+    },
+    riftForgeRefused(): void {
+      try {
+        riftForgeRefusals.inc();
+      } catch {
+        // Drop the sample rather than propagate into the dispatch path.
       }
     },
     chatMessage(): void {

--- a/server/http/game_signals.ts
+++ b/server/http/game_signals.ts
@@ -2,7 +2,7 @@
 // exporter (woc_ws_messages_total, woc_ws_messages_dropped_total,
 // woc_ws_rate_kicks_total, woc_input_frames_missed_total,
 // woc_chat_messages_total, woc_characters_created_total,
-// woc_guild_bank_incidents_total) reach the exporter
+// woc_guild_bank_incidents_total, woc_rift_forge_refused_total) reach the exporter
 // through this one process-wide slot instead of each emission site (game.ts
 // message dispatch and inbound gate/lanes, chat routing, characters.ts create
 // path) threading a sink through its constructors. main.ts
@@ -166,6 +166,14 @@ export interface GameMetricsCounters {
    * server-side loss on its own (soak-packet-3.md carries the scrape guidance).
    */
   wsInputSeqGap(missed: number): void;
+  /**
+   * One Rift forge wire command refused while the gate is closed
+   * (server/rift_forge_gate.ts). The stock client never sends these, so a
+   * non-zero rate means a modified client is probing the closed forge; the
+   * counter is deliberately label-free (nothing per-player, per-account, or
+   * per-token) so a prober cannot drive cardinality.
+   */
+  riftForgeRefused(): void;
   /** One player chat message routed to other players (any channel). */
   chatMessage(): void;
   /** One character successfully created. */
@@ -250,6 +258,7 @@ export const noopGameMetricsCounters: GameMetricsCounters = {
   wsMessageDropped() {},
   wsRateKick() {},
   wsInputSeqGap() {},
+  riftForgeRefused() {},
   chatMessage() {},
   characterCreated() {},
   guildBankIncident() {},

--- a/server/rift_forge_gate.ts
+++ b/server/rift_forge_gate.ts
@@ -1,0 +1,65 @@
+// The Rift forge wire gate.
+//
+// The forge (upgrade / enchant / socket on Riftbound bands) shipped end to end
+// in the sim and on the wire, but its client UI never did: no stock caller
+// exists (none ever has, per git history), the wiki deliberately does not name
+// the feature, and the only live users are crafted wire frames from modified
+// clients spending real essence and gems for real combat stats. Hiding a
+// feature from the stock UI does not hide it from DevTools or a custom client,
+// so the authoritative server refuses the three dispatch arms unless the realm
+// explicitly opts in.
+//
+// RIFT_FORGE_ENABLED=1 opens the wire (PTR, internal playtests, or the future
+// intentional ship). Anything else, including unset, keeps it closed in every
+// environment, the same strict opt-in convention as ALLOW_DEV_COMMANDS. The
+// env var is read per verdict, never captured at import, so tests and a
+// supervised restart both see the live value. That per-verdict read is
+// affordable ONLY because the dispatch call site sits behind the per-session
+// command lane (~30/s) and short-circuits to forge tokens; never call these
+// from the 20 Hz world loop or the per-viewer broadcast pass (capture the
+// verdict once per pass there instead).
+//
+// Scope is deliberately the server boundary only. The sim methods stay live
+// for the offline single-player world, the headless RL env, the existing
+// tests (tests/rift_progression.test.ts), and the future UI; none of those
+// can turn a crafted frame into realm-visible progression, which is the only
+// surface this gate exists to close.
+
+import type { CommandName } from '../src/world_api';
+
+/** The three forge wire tokens, pinned to the shared command vocabulary. */
+export const RIFT_FORGE_WIRE_COMMANDS = [
+  'rift_upgrade_item',
+  'rift_enchant_item',
+  'rift_socket_gem',
+] as const satisfies readonly CommandName[];
+
+const RIFT_FORGE_CMD_SET: ReadonlySet<string> = new Set(RIFT_FORGE_WIRE_COMMANDS);
+
+/** True when the realm has explicitly opted the forge wire open. */
+export function riftForgeWireEnabled(
+  env: Readonly<Record<string, string | undefined>> = process.env,
+): boolean {
+  return env.RIFT_FORGE_ENABLED === '1';
+}
+
+/**
+ * The dispatch-time verdict: true when `cmd` is a forge command and the wire
+ * is closed, in which case the caller refuses without touching the sim. A
+ * non-forge command (or a non-string) is never refused here and follows the
+ * normal dispatch path.
+ *
+ * `env` is optional rather than defaulted so the hot dispatch call pays the
+ * `process.env` object load only on forge tokens (the `??` sits behind the
+ * short-circuit), not on every command frame.
+ */
+export function refusedRiftForgeCommand(
+  cmd: unknown,
+  env?: Readonly<Record<string, string | undefined>>,
+): boolean {
+  return (
+    typeof cmd === 'string' &&
+    RIFT_FORGE_CMD_SET.has(cmd) &&
+    !riftForgeWireEnabled(env ?? process.env)
+  );
+}

--- a/src/guide/pages/rifts.ts
+++ b/src/guide/pages/rifts.ts
@@ -6,8 +6,10 @@
 // rates, loot tables, coin amounts, or boss scripts. Modeled on delves.ts.
 //
 // Deliberately absent: the "Rift Forge". The upgrade/enchant/socket seam exists in the
-// sim and on the wire but has no client caller, so no player can reach it and the wiki
-// must not name it.
+// sim and on the wire but has no client caller, and the server refuses the wire
+// commands behind RIFT_FORGE_ENABLED (server/rift_forge_gate.ts). "No client caller"
+// alone never made it unreachable (a crafted frame reaches the wire fine); the server
+// gate is what does. The wiki must not name it until the feature intentionally ships.
 
 import { esc } from '../../ui/esc';
 import { formatNumber, t } from '../../ui/i18n';

--- a/src/ui/i18n.catalog/guide.ts
+++ b/src/ui/i18n.catalog/guide.ts
@@ -1895,7 +1895,8 @@ export const guideStrings = {
     // rule are all broadcast to the whole realm in chat, so they are public. NO rank
     // multipliers, mob levels, drop rates, coin amounts, or boss scripts. The "Rift
     // Forge" is deliberately unnamed: the upgrade/enchant/socket seam has no client
-    // caller, so no player can reach it.
+    // caller and the server refuses its wire commands until the feature ships
+    // (server/rift_forge_gate.ts).
     heading: 'Rifts',
     intro:
       'A rift is a tear in the world itself, not a door you walk to. Step through one and you get a descent nobody has run before: the floors, the monsters, and the thing waiting at the bottom are all built fresh for that rift alone, so the same rank never plays out the same way twice.',

--- a/tests/game_state_metrics.test.ts
+++ b/tests/game_state_metrics.test.ts
@@ -424,6 +424,9 @@ function recordingSink() {
     wsInputSeqGap(missed) {
       seqGaps.push(missed);
     },
+    // Not exercised here: the refusal site has its own recording-sink pins in
+    // tests/rift_forge_gate.test.ts.
+    riftForgeRefused() {},
     chatMessage() {
       chats++;
     },

--- a/tests/rift_forge_gate.test.ts
+++ b/tests/rift_forge_gate.test.ts
@@ -1,0 +1,319 @@
+// The Rift forge wire gate (server/rift_forge_gate.ts).
+//
+// The forge trio (rift_upgrade_item / rift_enchant_item / rift_socket_gem)
+// shipped sim+wire complete with no client UI, and players proved the obvious:
+// a crafted authenticated frame reaches the dispatch arms fine, buying real
+// combat stats the stock client has no path to. The gate closes the wire
+// unless the realm opts in with RIFT_FORGE_ENABLED=1.
+//
+// Pins, both arms of the flag:
+//  - closed (default): each forge command refuses BEFORE the sim (no essence
+//    or gem spend, no payload mutation, zero riftForgeResult events), answers
+//    ok:false on the commandOutcome ack channel for rid frames AND stays
+//    refused for the rid-less frame shape an attacker actually sends, books
+//    one riftForgeRefused metric per attempt, and never sets the heavy-self
+//    dirty flag;
+//  - open: the same wire frames drive the sim forge exactly as
+//    tests/rift_progression.test.ts pins it offline (which is also the proof
+//    that the OFFLINE Sim stays ungated: that suite runs with no env set),
+//    with NO commandOutcome ack (so the closed arm's ok:false provably comes
+//    from the gate) and no refusal metric;
+//  - the flag is read per verdict on a LIVE server, not captured at
+//    construction;
+//  - completeness: every `case 'rift_*'` dispatch arm is either in
+//    RIFT_FORGE_WIRE_COMMANDS or carries a written exemption, so the next
+//    forge command cannot ship ungated, and the env key stays pinned in its
+//    ops surfaces (.env.example, DEPLOY.md, turbo.json).
+//
+// Db is mocked so no Postgres runs (the afk_wire / bags_money_refresh idiom).
+
+import { readFileSync } from 'node:fs';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../server/db', () => ({
+  pool: { query: vi.fn(async () => ({ rows: [] })) },
+  saveCharacterState: vi.fn(async () => {}),
+  saveCharacterAndMarketState: vi.fn(async () => {}),
+  openPlaySession: vi.fn(async () => 1),
+  touchCharacterLogin: vi.fn(async () => {}),
+  closePlaySession: vi.fn(async () => {}),
+  insertChatLogs: vi.fn(async () => {}),
+  loadAccountFlair: vi.fn(async () => null),
+  walletForAccount: vi.fn(async () => null),
+  markAccountQuestComplete: vi.fn(async () => ({ completedQuestIds: [], mechChromaIds: [] })),
+  grantAccountMechChroma: vi.fn(async () => ({ completedQuestIds: [], mechChromaIds: [] })),
+}));
+
+import { GameServer } from '../server/game';
+import { noopGameMetricsCounters, setGameMetricsCounters } from '../server/http/game_signals';
+import {
+  RIFT_FORGE_WIRE_COMMANDS,
+  refusedRiftForgeCommand,
+  riftForgeWireEnabled,
+} from '../server/rift_forge_gate';
+import { RIFT_ESSENCE_ITEM_ID, RIFT_GEM_IDS } from '../src/sim/content/rift/items';
+import { createRiftGearInstance } from '../src/sim/rift/progression';
+import { fakeWs, joinServer } from './helpers/bare_client';
+
+/** A joined session holding one S-rank band, 20 essence, and one gem. */
+function forgeReadySession() {
+  const server = new GameServer();
+  const fc = fakeWs();
+  const session = joinServer(server, fc, 7101, 'Forgeproof');
+  const pid = session.pid;
+  const gear = createRiftGearInstance('forge-gate-test', 'S', 'warrior', pid);
+  server.sim.addItemInstance(gear.itemId, gear.instance, pid);
+  server.sim.addItem(RIFT_ESSENCE_ITEM_ID, 20, pid);
+  server.sim.addItem(RIFT_GEM_IDS[0], 1, pid);
+  return { server, fc, session, pid, itemId: gear.itemId };
+}
+
+function riftPayload(server: GameServer, pid: number, itemId: string) {
+  const slot = server.sim.meta(pid)?.inventory.find((s) => s.itemId === itemId);
+  return slot?.instance?.rift;
+}
+
+/** Count riftForgeResult events pending in the sim (the server drains on tick). */
+function forgeResults(server: GameServer): Array<{ ok?: boolean }> {
+  // biome-ignore lint/suspicious/noExplicitAny: SimEvent union narrowed by type tag
+  return (server.sim.drainEvents() as any[]).filter((ev) => ev.type === 'riftForgeResult');
+}
+
+/** A metrics sink that counts riftForgeRefused and drops everything else. */
+function recordingRefusalSink(): { count: () => number } {
+  let refused = 0;
+  setGameMetricsCounters({
+    ...noopGameMetricsCounters,
+    riftForgeRefused() {
+      refused++;
+    },
+  });
+  return { count: () => refused };
+}
+
+describe('rift forge wire gate: the pure verdict', () => {
+  it('is closed unless RIFT_FORGE_ENABLED is exactly 1', () => {
+    expect(riftForgeWireEnabled({})).toBe(false);
+    expect(riftForgeWireEnabled({ RIFT_FORGE_ENABLED: undefined })).toBe(false);
+    expect(riftForgeWireEnabled({ RIFT_FORGE_ENABLED: '0' })).toBe(false);
+    // Strict opt-in, not truthiness: "true"/"yes" must not open a realm.
+    expect(riftForgeWireEnabled({ RIFT_FORGE_ENABLED: 'true' })).toBe(false);
+    expect(riftForgeWireEnabled({ RIFT_FORGE_ENABLED: 'TRUE' })).toBe(false);
+    expect(riftForgeWireEnabled({ RIFT_FORGE_ENABLED: 'yes' })).toBe(false);
+    // The near-miss shapes a hand-edited .env actually produces stay closed too.
+    expect(riftForgeWireEnabled({ RIFT_FORGE_ENABLED: '' })).toBe(false);
+    expect(riftForgeWireEnabled({ RIFT_FORGE_ENABLED: ' 1' })).toBe(false);
+    expect(riftForgeWireEnabled({ RIFT_FORGE_ENABLED: '1 ' })).toBe(false);
+    expect(riftForgeWireEnabled({ RIFT_FORGE_ENABLED: '1' })).toBe(true);
+  });
+
+  it('refuses exactly the three forge tokens while closed, and nothing else ever', () => {
+    expect(RIFT_FORGE_WIRE_COMMANDS).toEqual([
+      'rift_upgrade_item',
+      'rift_enchant_item',
+      'rift_socket_gem',
+    ]);
+    for (const cmd of RIFT_FORGE_WIRE_COMMANDS) {
+      expect(refusedRiftForgeCommand(cmd, {}), `${cmd} must refuse while closed`).toBe(true);
+      expect(
+        refusedRiftForgeCommand(cmd, { RIFT_FORGE_ENABLED: '1' }),
+        `${cmd} must pass while open`,
+      ).toBe(false);
+    }
+    // Non-forge traffic never draws a verdict from this gate, open or closed.
+    expect(refusedRiftForgeCommand('salvage_item', {})).toBe(false);
+    expect(refusedRiftForgeCommand('castSlot', {})).toBe(false);
+    expect(refusedRiftForgeCommand(undefined, {})).toBe(false);
+    expect(refusedRiftForgeCommand(42, {})).toBe(false);
+  });
+});
+
+describe('rift forge wire gate: completeness and the ops contract', () => {
+  /**
+   * A future rift dispatch arm that must NOT be forge-gated earns an entry
+   * here with a written reason (the item_copy_addressing_guard shape). Empty
+   * today: every rift_* wire command is a forge command.
+   */
+  const EXEMPT: ReadonlyArray<{ cmd: string; why: string }> = [];
+
+  it("every case 'rift_*' dispatch arm is gated or exempted with a reason", () => {
+    // Source scan, like tests/item_copy_addressing_guard.test.ts: behavior
+    // tests cover what the gate DOES; only a sweep can say the NEXT forge
+    // command did not ship around it.
+    const source = readFileSync(new URL('../server/game.ts', import.meta.url), 'utf8');
+    const labels = new Set<string>();
+    for (const m of source.matchAll(/case '(rift_[a-z_]+)':/g)) labels.add(m[1]);
+    expect(labels.size, 'expected the scan to find the forge arms').toBeGreaterThanOrEqual(3);
+    const classified = new Set<string>([
+      ...RIFT_FORGE_WIRE_COMMANDS,
+      ...EXEMPT.map((row) => row.cmd),
+    ]);
+    for (const row of EXEMPT) {
+      expect(row.why.length, `${row.cmd} needs a real reason`).toBeGreaterThan(30);
+    }
+    const unclassified = [...labels].filter((cmd) => !classified.has(cmd)).sort();
+    expect(
+      unclassified,
+      'a new rift_* wire command must join RIFT_FORGE_WIRE_COMMANDS or be exempted with a reason',
+    ).toEqual([]);
+    // And the gate list itself must not name a token the dispatch no longer has.
+    const stale = RIFT_FORGE_WIRE_COMMANDS.filter((cmd) => !labels.has(cmd));
+    expect(stale, 'gated token with no dispatch arm').toEqual([]);
+  });
+
+  it('the env key is pinned in its ops surfaces', () => {
+    // The flag is a five-place contract (module, .env.example, DEPLOY.md,
+    // turbo.json, this suite); a rename must not leave the ops half stale.
+    for (const file of ['../.env.example', '../DEPLOY.md', '../turbo.json']) {
+      const text = readFileSync(new URL(file, import.meta.url), 'utf8');
+      expect(text, `${file} must document RIFT_FORGE_ENABLED`).toContain('RIFT_FORGE_ENABLED');
+    }
+  });
+});
+
+describe('rift forge wire gate: server dispatch', () => {
+  // process.env is safe to flip here because vitest's default forks pool gives
+  // each test file its own process and files in one fork run sequentially;
+  // under a threads pool this would need vi.stubEnv instead.
+  const saved = process.env.RIFT_FORGE_ENABLED;
+  afterEach(() => {
+    if (saved === undefined) delete process.env.RIFT_FORGE_ENABLED;
+    else process.env.RIFT_FORGE_ENABLED = saved;
+    setGameMetricsCounters(noopGameMetricsCounters);
+  });
+
+  it('closed (default): all three commands spend nothing, mutate nothing, answer ok:false', () => {
+    delete process.env.RIFT_FORGE_ENABLED;
+    const refusals = recordingRefusalSink();
+    const { server, fc, session, pid, itemId } = forgeReadySession();
+    const essenceBefore = server.sim.countItem(RIFT_ESSENCE_ITEM_ID, pid);
+    const gemBefore = server.sim.countItem(RIFT_GEM_IDS[0], pid);
+    expect(essenceBefore).toBe(20);
+    session.selfHeavyDirty = false;
+    server.sim.drainEvents();
+
+    server.handleMessage(
+      session,
+      JSON.stringify({ t: 'cmd', cmd: 'rift_upgrade_item', item: itemId, rid: 11 }),
+    );
+    server.handleMessage(
+      session,
+      JSON.stringify({
+        t: 'cmd',
+        cmd: 'rift_enchant_item',
+        item: itemId,
+        stat: 'critRating',
+        rid: 12,
+      }),
+    );
+    server.handleMessage(
+      session,
+      JSON.stringify({
+        t: 'cmd',
+        cmd: 'rift_socket_gem',
+        item: itemId,
+        gem: RIFT_GEM_IDS[0],
+        rid: 13,
+      }),
+    );
+    // The frame shape an attacker actually sends: no rid at all. It must be
+    // refused identically, not slip through because there is no ack to send
+    // (the gate must not be conditional on the ack).
+    server.handleMessage(
+      session,
+      JSON.stringify({ t: 'cmd', cmd: 'rift_upgrade_item', item: itemId }),
+    );
+
+    const rift = riftPayload(server, pid, itemId);
+    expect(rift?.upgradeLevel).toBe(0);
+    expect(rift?.enchant).toBeUndefined();
+    expect(rift?.gems).toEqual([]);
+    expect(server.sim.countItem(RIFT_ESSENCE_ITEM_ID, pid)).toBe(essenceBefore);
+    expect(server.sim.countItem(RIFT_GEM_IDS[0], pid)).toBe(gemBefore);
+    // Refused before the sim: no riftForgeResult ever forms (drained straight
+    // from the sim, where a run WOULD have queued it; see the open arm's 3).
+    expect(forgeResults(server)).toEqual([]);
+    // The refusal answers on the commandOutcome ack channel, ok:false per rid,
+    // and only for the rid frames.
+    expect(fc.sent.filter((m) => m.t === 'commandOutcome')).toEqual([
+      { t: 'commandOutcome', rid: 11, ok: false },
+      { t: 'commandOutcome', rid: 12, ok: false },
+      { t: 'commandOutcome', rid: 13, ok: false },
+    ]);
+    // Every attempt books the ops counter, the rid-less one included.
+    expect(refusals.count()).toBe(4);
+    // Refused ABOVE the heavy-self dirty flag: a blocked frame cannot force a re-diff.
+    expect(session.selfHeavyDirty).toBe(false);
+  });
+
+  it('open (RIFT_FORGE_ENABLED=1): the same wire frames drive the sim forge as before', () => {
+    process.env.RIFT_FORGE_ENABLED = '1';
+    const refusals = recordingRefusalSink();
+    const { server, fc, session, pid, itemId } = forgeReadySession();
+    const essenceBefore = server.sim.countItem(RIFT_ESSENCE_ITEM_ID, pid);
+    session.selfHeavyDirty = false;
+    server.sim.drainEvents();
+
+    // Same rid-carrying shape as the closed arm, so the ack channel is the
+    // differential: the allowed arms send NO commandOutcome, proving the
+    // closed arm's ok:false frames come from the gate and nowhere else.
+    server.handleMessage(
+      session,
+      JSON.stringify({ t: 'cmd', cmd: 'rift_upgrade_item', item: itemId, rid: 21 }),
+    );
+    server.handleMessage(
+      session,
+      JSON.stringify({
+        t: 'cmd',
+        cmd: 'rift_enchant_item',
+        item: itemId,
+        stat: 'critRating',
+        rid: 22,
+      }),
+    );
+    server.handleMessage(
+      session,
+      JSON.stringify({
+        t: 'cmd',
+        cmd: 'rift_socket_gem',
+        item: itemId,
+        gem: RIFT_GEM_IDS[0],
+        rid: 23,
+      }),
+    );
+
+    const rift = riftPayload(server, pid, itemId);
+    expect(rift?.upgradeLevel).toBe(1);
+    // S rank is power 4, so the enchant value is ceil(4 / 2) = 2.
+    expect(rift?.enchant).toEqual({ stat: 'critRating', value: 2 });
+    expect(rift?.gems).toEqual([RIFT_GEM_IDS[0]]);
+    // Upgrade at level 0 costs 2 essence, the enchant a flat 4.
+    expect(server.sim.countItem(RIFT_ESSENCE_ITEM_ID, pid)).toBe(essenceBefore - 6);
+    expect(server.sim.countItem(RIFT_GEM_IDS[0], pid)).toBe(0);
+    // Positive control for the closed arm's zero: the sim really does queue
+    // one ok result per forge action when allowed to run.
+    const results = forgeResults(server);
+    expect(results).toHaveLength(3);
+    expect(results.every((ev) => ev.ok === true)).toBe(true);
+    expect(fc.sent.filter((m) => m.t === 'commandOutcome')).toEqual([]);
+    expect(refusals.count()).toBe(0);
+    // An allowed forge command is inventory-mutating, so HEAVY_SELF_CMDS re-arms
+    // the heavy self diff exactly as it did before the gate existed.
+    expect(session.selfHeavyDirty).toBe(true);
+  });
+
+  it('reads the flag per verdict on a live server, not captured at construction', () => {
+    delete process.env.RIFT_FORGE_ENABLED;
+    const { server, session, pid, itemId } = forgeReadySession();
+    const frame = JSON.stringify({ t: 'cmd', cmd: 'rift_upgrade_item', item: itemId });
+
+    server.handleMessage(session, frame);
+    expect(riftPayload(server, pid, itemId)?.upgradeLevel).toBe(0);
+
+    // Flip the env on the SAME server instance: the very next frame forges,
+    // which a constructor-captured flag could not do.
+    process.env.RIFT_FORGE_ENABLED = '1';
+    server.handleMessage(session, frame);
+    expect(riftPayload(server, pid, itemId)?.upgradeLevel).toBe(1);
+  });
+});

--- a/turbo.json
+++ b/turbo.json
@@ -70,6 +70,7 @@
     "OUT",
     "PERF_TICK_LOG",
     "PROBE",
+    "RIFT_FORGE_ENABLED",
     "SCAN",
     "SHOT_EXPECT_PICKER",
     "SHOT_H",


### PR DESCRIPTION
## Summary

Players discovered the three Rift forge wire commands (`rift_upgrade_item`, `rift_enchant_item`, `rift_socket_gem`) are dispatchable by any authenticated online client, even though the client forge UI never shipped: crafted WS frames let them spend legitimately earned Rift Essence and gems for real combat stats while the rest of the realm has no intended path to do so (premature progression access, not free loot). The engineer handoff report documenting the exploit was verified claim by claim against this branch before any code was written; every substantive claim held (ungated dispatch arms, sim rules and costs, registrations, zero UI callers past or present in git history, overconfident "no player can reach it" comments).

This implements the report's recommended Option A: close the wire until the UI ships.

- New pure module `server/rift_forge_gate.ts`: the three forge commands are refused unless the realm explicitly opts in with `RIFT_FORGE_ENABLED=1` (strict match, default closed in every environment, read per verdict on the live server; same opt-in convention as `ALLOW_DEV_COMMANDS`).
- One pre-switch check in `dispatchMessage` (`server/game.ts`), after the jailed refusal and above the `HEAVY_SELF_CMDS` dirty flag, so a refused frame mutates nothing and cannot force a heavy self re-diff. The refusal answers `ok:false` on the existing rid-correlated `commandOutcome` ack channel: no new player-facing text, no new i18n surface. Placement keeps every inbound flood-defense contract: the bot detector still observes the frame and every attempt spends a command-lane token.
- Each refused attempt books a new label-free `woc_rift_forge_refused_total` counter (`server/http/game_signals.ts` seam plus the `game_metrics.ts` exporter), so ops can see whether modified clients keep probing, and whether a realm forgot the flag once the UI ships.
- Offline `Sim` and the headless RL env deliberately stay ungated: neither can mint realm-visible progression, and `tests/rift_progression.test.ts` depends on the sim path. Rationale recorded in the module header.
- Stale comments claiming the seam was unreachable are corrected (`src/guide/pages/rifts.ts`, `src/ui/i18n.catalog/guide.ts`, `docs/design/rift-mode.md`), the design doc now tells the future forge UI to use `cmdWithOutcome` so a closed realm does not read as silence, and the flag is documented in `.env.example` and `DEPLOY.md` (beside the `ALLOW_DEV_COMMANDS` never-in-production bullet) and declared in `turbo.json` env.

Reviewed before opening: `qa-checklist` (READY, zero blocking), `privacy-security-review` (all checks passed), `server-hot-path-reviewer` (no blocking; its observability should-fix became the metrics counter, and it confirmed the gate closes a pre-existing self-heavy-dirty amplification lever for these tokens), `test-coverage-auditor` (its findings drove the rid-less attacker-frame pin, the `drainEvents`-based `riftForgeResult` zero/three pins, the live per-verdict env test, and the completeness scan), and `cross-platform-sync`.

Remaining ops follow-ups (out of scope, tracked in the handoff report): confirm the live deploy artifact, count already-forged rings in production JSONB (`rift.upgradeLevel > 0`, `rift.enchant`, non-empty `rift.gems`), and decide grandfather vs rollback vs moderation response. Also noted during verification: `server/economy_telemetry.ts` never counted the forge commands, so historical use is only measurable from raw logs or the JSONB sweep.

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [x] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx vitest run tests/rift_forge_gate.test.ts` (new suite, 7 tests: pure verdict truth table with near-miss env shapes, dispatch completeness scan over the `case 'rift_*'` arms, ops-surface pins for the env key, closed and open wire arms through a real `GameServer` with mocked db, and a live flag-flip on one server instance proving the per-verdict read)
  - Closed-arm decisiveness proven red-first: with the `server/game.ts` gate stashed, the closed-arm dispatch test fails; restored, all green
  - `npx vitest run tests/rift_progression.test.ts tests/ghost_dead_gate.test.ts tests/item_copy_addressing_guard.test.ts tests/world_api_parity.test.ts tests/command_schema.test.ts tests/monolith_budget.test.ts tests/game_state_metrics.test.ts` green (sim forge behavior, dead gate, copy addressing, parity pins, command schema, monolith ratchet, metrics wiring all unaffected)
  - `npx tsc --noEmit` clean; `npx @biomejs/biome check` clean on all changed files
  - `node scripts/gate_select.mjs` green (selective pre-merge gate, run on the committed branch diff)
- Manual steps:
  - Verified the handoff report's reproduction preconditions against source (wire payload shapes, costs, caps) rather than probing production

## Checklist

### Quality

- [x] **The gate passes.** `node scripts/gate_select.mjs` is green (or `npm run gate` for
      the full suite). I added or updated decisive
      tests for changed behavior and recorded any manual checks above.

### Cross-platform

- ~Tested on desktop and mobile.~ N/A: server-side wire gate, no UI change.
- ~Accessible.~ N/A: no UI change.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings (the refusal is a wire-level `commandOutcome` ack; the catalog-file edit is comment-only and touches no string values).

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
