### PR TITLE
fix(sim,server): close two dropped-provenance container boundaries

### DIFF
--- a/server/characters.ts
+++ b/server/characters.ts
@@ -469,6 +469,36 @@ export async function rekeyReclaimedCharacterWorldState(
 }
 
 /**
+ * The renamed character's OWN signer sweep (#2837). The market and mail rekeys
+ * above cover the world-state books (ownership keys, display names, and the
+ * renamer's own escrowed payload signers); this covers the five signer-bearing
+ * regions of the persisted character state itself (carried inventory, bank,
+ * vendor buyback, and equipped, under both `equipmentInstance` spellings), so
+ * the #1145 self-signed crafting discount, Battlefield Experience attribution,
+ * and the eqi inspect wire all follow the new name. A live entity/meta needs no
+ * sweep: the caller's isCharacterOnline/online-session guard runs first, so
+ * there is never a live one at rename time. Foreign-held copies signed with the
+ * old name live in other characters' blobs or parcels and stay out of scope.
+ *
+ * Exported so BOTH rename dispatch arms share one behavior: this module's
+ * renameHandler below and the retained legacy ladder arm in main.ts (the
+ * API_DISPATCH=legacy rollback path), the purge/reclaim precedent above. Call
+ * it only with the RETURNING row from a successful rename: a rename that
+ * matched no row must never sweep a character's live blob.
+ */
+export async function rekeyRenamedCharacterOwnSigner(
+  characterId: number,
+  level: number,
+  state: CharacterState | null,
+  oldName: string,
+  newName: string,
+): Promise<void> {
+  if (state && rekeyInstanceSigner(state, oldName, newName)) {
+    await charactersDb.saveCharacterState(characterId, level, state);
+  }
+}
+
+/**
  * The world-state purge that follows a successful character delete (R43). A deleted
  * character can never collect again, so its World Market listings, its Merchant
  * collection, and its Ravenpost mailbox leave the realm's shared books here instead
@@ -786,22 +816,10 @@ async function renameHandler(ctx: Ctx): Promise<void> {
     if (rt.rekeyMailOwner(character.id, character.name, c.name)) {
       await rt.saveMail();
     }
-    // The renamed character's OWN signed instances still carry the old signer
-    // name; two sweeps split the work by WHERE the copies live. The market and
-    // mail rekeys above cover the world-state books (ownership keys, display
-    // names, AND the renamer's own escrowed payload signers, the fix-round
-    // completion); this blob sweep covers the five signer-bearing regions of
-    // the persisted character state, so the self-signed crafting discount,
-    // Battlefield Experience attribution, and the eqi inspect wire follow the
-    // new name everywhere a copy can come back from. A live entity/meta needs
-    // no sweep: the isCharacterOnline gate above guarantees there is none at
-    // rename time. Foreign-held copies signed with the old name live in other
-    // characters' blobs or parcels and are out of scope. renameCharacter's
-    // RETURNING row carries the current blob, and the no-nonce save is safe
-    // for the same offline reason.
-    if (c.state && rekeyInstanceSigner(c.state, character.name, c.name)) {
-      await charactersDb.saveCharacterState(c.id, c.level, c.state);
-    }
+    // renameCharacter's RETURNING row carries the current blob, and the
+    // no-nonce save is safe for the same offline reason the market/mail
+    // rekeys above are: isCharacterOnline already guarantees no live session.
+    await rekeyRenamedCharacterOwnSigner(c.id, c.level, c.state, character.name, c.name);
     json(ctx.res, 200, {
       id: c.id,
       name: c.name,

--- a/server/main.ts
+++ b/server/main.ts
@@ -98,6 +98,7 @@ import {
   parseCreationCosmetics,
   purgeDeletedCharacterWorldState,
   rekeyReclaimedCharacterWorldState,
+  rekeyRenamedCharacterOwnSigner,
   withCreationHelm,
 } from './characters';
 import { pruneChatViolationsBatch } from './chat_filter_db';
@@ -1899,6 +1900,11 @@ async function handleApi(req: http.IncomingMessage, res: http.ServerResponse): P
         if (liveGame().rekeyMailOwner(characterId, character.name, c.name)) {
           await liveGame().saveMail();
         }
+        // The renamed character's OWN signed instances (#2837): the same
+        // shared sweep the migrated renameHandler runs, so the API_DISPATCH=
+        // legacy rollback cannot quietly leave a character's blob signed with
+        // its old name.
+        await rekeyRenamedCharacterOwnSigner(characterId, c.level, c.state, character.name, c.name);
         return json(res, 200, {
           id: c.id,
           name: c.name,

--- a/src/sim/bags.ts
+++ b/src/sim/bags.ts
@@ -26,7 +26,11 @@
 // Date.now (enforced by tests/architecture.test.ts). This module draws NO rng.
 
 import { ITEMS } from './data';
-import { consumeSelectedInventorySlot } from './item_copy_ref';
+import {
+  consumeSelectedInventorySlot,
+  newestMatchingSlot,
+  selectedInventorySlot,
+} from './item_copy_ref';
 import { canStackInstancePayloads, isMergeableInstancePayload } from './item_instance_merge';
 import type { PlayerMeta } from './sim';
 import type { SimContext } from './sim_context';
@@ -418,15 +422,41 @@ export function equipBag(
     ctx.error(meta.entityId, 'You have too many items to swap to that bag.');
     return;
   }
+  // Bags store only a bare item id in meta.bags (#2837): there is nowhere to
+  // park an instance payload or a craftedRecipeId while a bag is worn, so
+  // equipping a payload-bearing copy would silently destroy it on the next
+  // unequip's plain addStacked grant. Not reachable through shipped content
+  // today: no bag recipe or grant currently carries one (tests/bags.test.ts
+  // pins that no CRAFTABLE bag-kind item def is authored at a signable
+  // material rarity, the one live-content vector craftedRecipeId's own kind
+  // check does not close; two shipped bags already sit at rare/epic quality,
+  // but both are recipe-free loot drops granted plain). Bags are DECLARED
+  // payload-free here rather than merely assumed: peek the copy that would
+  // be consumed BEFORE consuming it (refusing late would have already
+  // removed it) and refuse the equip outright the moment one ever does carry
+  // a payload, whatever the source, rather than dropping it.
+  const peeked =
+    slotIndex !== undefined
+      ? selectedInventorySlot(meta.inventory, itemId, slotIndex)
+      : newestMatchingSlot(meta.inventory, itemId);
+  if (peeked === null) {
+    ctx.error(meta.entityId, "You don't have that item.");
+    return;
+  }
+  if (peeked?.instance || peeked?.craftedRecipeId !== undefined) {
+    ctx.error(meta.entityId, 'That bag cannot be equipped while it carries a special property.');
+    return;
+  }
   // A named slot consumes exactly that copy; an id-only call keeps the legacy
-  // newest-first walk (ctx.removeItem) untouched.
+  // newest-first walk (ctx.removeItem) untouched. Both consumers stay
+  // tri-state-aware even though the peek above already refused every
+  // legitimate case: a silent no-op keeps a future divergence between the
+  // peek and consume halves from equipping a bag AND leaving its source copy
+  // behind (item_copy_ref.ts's own "branch on all three" contract).
   if (slotIndex !== undefined) {
     // No onInventoryChangedForQuests here: the shared call below already fires for
     // both arms, and running it twice re-evaluated collect objectives on one equip.
-    if (consumeSelectedInventorySlot(meta.inventory, itemId, slotIndex) === null) {
-      ctx.error(meta.entityId, "You don't have that item.");
-      return;
-    }
+    if (consumeSelectedInventorySlot(meta.inventory, itemId, slotIndex) === null) return;
   } else {
     ctx.removeItem(itemId, 1, meta.entityId);
   }

--- a/src/sim/item_copy_ref.ts
+++ b/src/sim/item_copy_ref.ts
@@ -143,6 +143,22 @@ export function consumeNewestInventoryUnit(inventory: InvSlot[], itemId: string)
 }
 
 /**
+ * The non-consuming twin of `consumeNewestInventoryUnit` above: SAME walk (highest
+ * bag index down), SAME match predicate, but returns the live slot rather than
+ * taking a unit from it. For a caller that must inspect the copy an id-only
+ * command would consume BEFORE committing to consume it (equipBag's bag-payload
+ * refusal, bags.ts, #2837): peeking through this function rather than a
+ * bespoke walk is what keeps it locked to the real selection `ctx.removeItem`
+ * (`Sim.removeItem`) makes, instead of drifting into its own guess.
+ */
+export function newestMatchingSlot(inventory: InvSlot[], itemId: string): InvSlot | undefined {
+  for (let i = inventory.length - 1; i >= 0; i--) {
+    if (inventory[i].itemId === itemId) return inventory[i];
+  }
+  return undefined;
+}
+
+/**
  * Resolve the bag slot the caller NAMED without consuming anything, for actions
  * that MUTATE a copy in place rather than destroying it (the rift forge upgrades,
  * enchants and sockets the slot's own payload).

--- a/src/ui/sim_i18n.ts
+++ b/src/ui/sim_i18n.ts
@@ -36,6 +36,7 @@ const baseEnTable = {
   'error.bagSocketsFull': 'All your bag slots are full.',
   'error.bagSwapTooManyItems': 'You have too many items to swap to that bag.',
   'error.bagRemoveTooManyItems': 'You have too many items to remove that bag.',
+  'error.bagEquipHasProperty': 'That bag cannot be equipped while it carries a special property.',
   'error.tradeBagSpace': 'Trade failed: not enough bag space.',
   'log.bagsMigrated': 'Your belongings have been packed into new bags.',
   // Bank (guild-bank-ready pooled bank; src/sim/bank.ts). The error.* lines are the

--- a/tests/bags.test.ts
+++ b/tests/bags.test.ts
@@ -15,9 +15,11 @@ import {
   migrationBagsFor,
   stackSizeOf,
 } from '../src/sim/bags';
-import { ITEMS } from '../src/sim/data';
+import { ALL_RECIPES, ITEMS } from '../src/sim/data';
 import { removePreferFungible } from '../src/sim/items';
+import { isCommissionEligibleKind } from '../src/sim/professions/commission';
 import { isEnchantedInstance } from '../src/sim/professions/enchanting';
+import { isSignableMaterialRarity } from '../src/sim/professions/gathering';
 import { Sim } from '../src/sim/sim';
 import type { InvSlot } from '../src/sim/types';
 
@@ -262,6 +264,105 @@ describe('capacity budget and the equip/unequip commands', () => {
     const ev = sim.drainEvents();
     expect(ok).toBe(false);
     expect(ev.some((e) => e.type === 'error' && e.text === 'Your bags are full.')).toBe(true);
+  });
+
+  it('equipping a payload-bearing copy by id is refused, not stripped (#2837)', () => {
+    // meta.bags stores only a bare item id: not reachable through shipped
+    // content today, but the copy must be refused rather than silently
+    // stripped the moment one ever does carry a payload.
+    const sim = makeSim();
+    sim.addItemInstance('linen_pouch', { signer: 'Provenance' }, sim.playerId, 1, {
+      craftedRecipeId: 'recipe_eastbrook_chain_vest',
+    });
+    sim.drainEvents();
+    sim.equipBag('linen_pouch');
+    const ev = sim.drainEvents();
+    expect(
+      ev.some(
+        (e) =>
+          e.type === 'error' &&
+          e.text === 'That bag cannot be equipped while it carries a special property.',
+      ),
+    ).toBe(true);
+    expect(sim.bags.every((b) => b === null)).toBe(true);
+    const slot = sim.inventory.find((s) => s.itemId === 'linen_pouch');
+    expect(slot?.instance?.signer).toBe('Provenance');
+    expect(slot?.craftedRecipeId).toBe('recipe_eastbrook_chain_vest');
+  });
+
+  it('equipping a payload-bearing copy by named slot index is refused, not stripped (#2837)', () => {
+    // The shipped UI/wire path always names a slot index (bags_window.ts,
+    // server/game.ts): this is the arm nearly every real equip goes through,
+    // distinct from the id-only fallback covered above.
+    const sim = makeSim();
+    sim.addItemInstance('linen_pouch', { signer: 'Provenance' }, sim.playerId, 1, {
+      craftedRecipeId: 'recipe_eastbrook_chain_vest',
+    });
+    const slotIndex = sim.inventory.findIndex((s) => s.itemId === 'linen_pouch');
+    sim.drainEvents();
+    sim.equipBag('linen_pouch', undefined, { slotIndex });
+    const ev = sim.drainEvents();
+    expect(
+      ev.some(
+        (e) =>
+          e.type === 'error' &&
+          e.text === 'That bag cannot be equipped while it carries a special property.',
+      ),
+    ).toBe(true);
+    expect(sim.bags.every((b) => b === null)).toBe(true);
+    const slot = sim.inventory.find((s) => s.itemId === 'linen_pouch');
+    expect(slot?.instance?.signer).toBe('Provenance');
+    expect(slot?.craftedRecipeId).toBe('recipe_eastbrook_chain_vest');
+  });
+
+  it('a plain copy still equips by named slot index while another copy of the same id carries a payload', () => {
+    const sim = makeSim();
+    sim.addItemInstance('linen_pouch', { signer: 'Provenance' }, sim.playerId, 1, {
+      craftedRecipeId: 'recipe_eastbrook_chain_vest',
+    });
+    sim.addItem('linen_pouch', 1);
+    const plainIndex = sim.inventory.findIndex(
+      (s) => s.itemId === 'linen_pouch' && !s.instance && s.craftedRecipeId === undefined,
+    );
+    expect(plainIndex).toBeGreaterThanOrEqual(0);
+    sim.equipBag('linen_pouch', undefined, { slotIndex: plainIndex });
+    expect(sim.bags[0]).toBe('linen_pouch');
+    const remaining = sim.inventory.find((s) => s.itemId === 'linen_pouch');
+    expect(remaining?.instance?.signer, 'the payload-bearing copy is untouched').toBe('Provenance');
+  });
+});
+
+describe('bags are declared payload-free (#2837)', () => {
+  // equipBag/unequipBag store only a bare item id in meta.bags: there is
+  // nowhere to park an instance payload or a craftedRecipeId while a bag is
+  // worn. craftedRecipeId is already impossible for a bag (crafting.ts
+  // isCraftedDisenchantTrackedOutput and the commission opt-in are both
+  // weapon/armor/held_offhand-only, checked below), but an `instance.signer`
+  // payload is NOT gated by kind: resolveCraftForRecipe's
+  // isSignableMaterialRarity arm mints one for ANY rare-or-better CRAFTED
+  // output, bag included (a loot-only bag never reaches it: two shipped bags
+  // already sit at rare/epic, gravewoven_bag and mistcallers_duffel, both
+  // recipe-free dungeon drops granted plain, which is why the pin below is
+  // scoped to bags a recipe can actually produce, not every bag-kind def).
+  // This pins the content-authoring half of the equip-time guard (bags.ts
+  // equipBag): the day a bag RECIPE crosses this line, this fails at test
+  // time instead of the first player equip.
+  it('no craftable bag-kind item def is authored at a signable material rarity', () => {
+    const bagRecipes = ALL_RECIPES.filter((r) => ITEMS[r.resultItemId]?.kind === 'bag');
+    expect(bagRecipes.length, 'sanity: there is a bag recipe to check').toBeGreaterThan(0);
+    for (const recipe of bagRecipes) {
+      const def = ITEMS[recipe.resultItemId];
+      const outputQuality =
+        def?.quality === undefined || def.quality === 'poor' ? 'common' : def.quality;
+      expect(
+        isSignableMaterialRarity(outputQuality),
+        `${recipe.id} -> ${recipe.resultItemId}: a craftable bag must never be rare or better`,
+      ).toBe(false);
+    }
+  });
+
+  it('bags are never a commission-eligible kind', () => {
+    expect(isCommissionEligibleKind('bag')).toBe(false);
   });
 });
 

--- a/tests/instance_provenance_boundaries.test.ts
+++ b/tests/instance_provenance_boundaries.test.ts
@@ -127,6 +127,37 @@ describe('provenance survives every container boundary', () => {
     expectFullyMarked(fullSlot(), 'fixture');
   });
 
+  it('bags: equipping a payload-bearing copy is refused, not stripped', () => {
+    // The bag-equip boundary has no round trip to pin (#2837): meta.bags
+    // stores only a bare item id, with nowhere to park an instance payload or
+    // a craftedRecipeId while a bag is worn. Not reachable through shipped
+    // content today (no bag is ever craft-marked or instance-granted), but
+    // bags are declared payload-free with a guard that refuses the equip the
+    // moment one ever does carry a payload, rather than silently dropping it
+    // on the next unequip's plain grant.
+    const sim = makeSim(4106);
+    const pid = sim.playerId;
+    const meta = metaFor(sim, pid);
+    const bagId = 'linen_pouch';
+    inv(sim, pid).push({
+      itemId: bagId,
+      count: 1,
+      instance: payload(),
+      craftedRecipeId: GEAR_RECIPE,
+    });
+
+    sim.equipBag(bagId, undefined, pid);
+
+    expect(
+      meta.bags.every((b) => b === null),
+      'no socket was filled',
+    ).toBe(true);
+    expectFullyMarked(
+      inv(sim, pid).find((s) => s.itemId === bagId),
+      'bags after refused equip',
+    );
+  });
+
   it('bank: deposit -> withdraw', () => {
     const sim = makeSim(4101);
     const pid = sim.playerId;

--- a/tests/item_copy_ref.test.ts
+++ b/tests/item_copy_ref.test.ts
@@ -14,6 +14,7 @@ import {
   consumeNewestInventoryUnit,
   consumeSelectedInventorySlot,
   itemCopyPin,
+  newestMatchingSlot,
   selectedInventorySlot,
 } from '../src/sim/item_copy_ref';
 import type { InvSlot } from '../src/sim/types';
@@ -161,6 +162,36 @@ describe('consumeNewestInventoryUnit: the legacy fallback, unchanged', () => {
       craftedRecipeId: undefined,
     });
     expect(inv).toHaveLength(1);
+  });
+});
+
+describe('newestMatchingSlot: the non-consuming twin of consumeNewestInventoryUnit', () => {
+  it('picks the SAME slot consumeNewestInventoryUnit would consume', () => {
+    // The whole point of the peek: a caller that inspects this slot before
+    // deciding whether to consume (equipBag's bag-payload refusal, #2837)
+    // must be looking at the exact copy the consuming walk would take.
+    const inv = [enchanted('girdle', 'power'), plain('girdle')];
+    const peeked = newestMatchingSlot(inv, 'girdle');
+    expect(peeked).toBe(inv[1]);
+    const unit = consumeNewestInventoryUnit(inv, 'girdle');
+    expect(unit.instance, 'the consumed copy matches what was peeked').toBeUndefined();
+  });
+
+  it('consumes nothing and leaves the bag untouched', () => {
+    const inv = [enchanted('girdle', 'power'), plain('girdle')];
+    newestMatchingSlot(inv, 'girdle');
+    expect(inv).toHaveLength(2);
+    expect(inv[0].count).toBe(1);
+    expect(inv[1].count).toBe(1);
+  });
+
+  it('returns the live slot object, so a caller reading its payload sees the real one', () => {
+    const inv = [enchanted('girdle', 'power')];
+    expect(newestMatchingSlot(inv, 'girdle')).toBe(inv[0]);
+  });
+
+  it('returns undefined when nothing matches', () => {
+    expect(newestMatchingSlot([plain('boots')], 'girdle')).toBeUndefined();
   });
 });
 

--- a/tests/localization_fixes.test.ts
+++ b/tests/localization_fixes.test.ts
@@ -1027,6 +1027,11 @@ describe('S3: every sim.ts emit is recognized (drift guard)', () => {
     // move, so their hud/sim_i18n matchers are unchanged; scan them here so they stay
     // under the drift guard now that they live outside sim.ts.
     fs.readFileSync(path.resolve(process.cwd(), 'src/sim/items.ts'), 'utf8'),
+    // #2837: pooled bag capacity (equip/unequip a bag item, the full-bags,
+    // full-sockets, and swap/remove-capacity refusals, plus the new
+    // bag-payload-refuses-not-strips guard). None of this file's emits were
+    // previously under the drift guard.
+    fs.readFileSync(path.resolve(process.cwd(), 'src/sim/bags.ts'), 'utf8'),
     // L1: the loot-distribution layer's player-facing loot emits ("You loot ...",
     // "Everyone passed on ...", "<name> wins ...").
     fs.readFileSync(path.resolve(process.cwd(), 'src/sim/loot/loot_roll.ts'), 'utf8'),

--- a/tests/server/characters.test.ts
+++ b/tests/server/characters.test.ts
@@ -25,6 +25,7 @@ import {
   type CharactersRuntime,
   configureCharactersRuntime,
   purgeDeletedCharacterWorldState,
+  rekeyRenamedCharacterOwnSigner,
   resetCharactersDbForTests,
   resetCharactersRuntimeForTests,
   routes,
@@ -1810,6 +1811,101 @@ describe('legacy DELETE dispatch arm (main.ts)', () => {
     expect(rekeyCall).toContain('liveGame().saveMarket()');
     expect(rekeyCall).toContain('liveGame().saveMail()');
     expect(rekeyCall).toContain('reclaimed,');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The renamed character's own-signer sweep, shared by BOTH rename dispatch
+// arms: the migrated renameHandler above and the retained legacy ladder arm
+// in main.ts. Unit it directly, plus a wiring pin on the legacy arm, so an
+// API_DISPATCH=legacy rollback cannot quietly leave a character's own blob
+// signed with its old name (#2837).
+// ---------------------------------------------------------------------------
+
+describe('rekeyRenamedCharacterOwnSigner', () => {
+  it('sweeps every signer-bearing region and persists the swept state', async () => {
+    const state = {
+      inventory: [{ itemId: 'bone_fragments', count: 1, instance: { signer: 'Oldname' } }],
+      bank: {
+        inventory: [{ itemId: 'iron_bar', count: 1, instance: { signer: 'Oldname' } }],
+        purchasedSlots: 0,
+        bonusSlots: 0,
+      },
+      equipmentInstance: { chest: { signer: 'Oldname', enchant: 'ench_minor_stamina' } },
+    } as unknown as CharacterState;
+    const saveCharacterState = vi.fn(
+      async (_characterId: number, _level: number, _state: CharacterState) => true,
+    );
+    setCharactersDbForTests({ saveCharacterState });
+
+    await rekeyRenamedCharacterOwnSigner(5, 8, state, 'Oldname', 'Newname');
+
+    expect(saveCharacterState).toHaveBeenCalledTimes(1);
+    expect(saveCharacterState).toHaveBeenCalledWith(5, 8, state);
+    expect(state.inventory?.[0].instance?.signer).toBe('Newname');
+    expect(state.bank?.inventory[0].instance?.signer).toBe('Newname');
+    expect(state.equipmentInstance?.chest?.signer).toBe('Newname');
+    expect(state.equipmentInstance?.chest?.enchant).toBe('ench_minor_stamina');
+  });
+
+  it('skips the save when no held instance carried the old name', async () => {
+    const state = {
+      inventory: [{ itemId: 'bone_fragments', count: 1, instance: { signer: 'SomeoneElse' } }],
+    } as unknown as CharacterState;
+    const saveCharacterState = vi.fn(
+      async (_characterId: number, _level: number, _state: CharacterState) => true,
+    );
+    setCharactersDbForTests({ saveCharacterState });
+
+    await rekeyRenamedCharacterOwnSigner(5, 8, state, 'Oldname', 'Newname');
+    expect(saveCharacterState).not.toHaveBeenCalled();
+    expect(state.inventory?.[0].instance?.signer).toBe('SomeoneElse');
+  });
+
+  it('skips the save when the renamed row carries no state blob', async () => {
+    const saveCharacterState = vi.fn(
+      async (_characterId: number, _level: number, _state: CharacterState) => true,
+    );
+    setCharactersDbForTests({ saveCharacterState });
+
+    await rekeyRenamedCharacterOwnSigner(5, 8, null, 'Oldname', 'Newname');
+    expect(saveCharacterState).not.toHaveBeenCalled();
+  });
+});
+
+describe('legacy RENAME dispatch arm (main.ts)', () => {
+  it('runs the same shared own-signer sweep as the migrated handler, after a successful rename', () => {
+    // The symmetric pin to the DELETE and CREATE arms above: an
+    // API_DISPATCH=legacy rollback must not lose the renamed character's own
+    // signer sweep, or its bags/bank/buyback/equipped instances keep reading
+    // as signed by a name that no longer exists.
+    const src = readFileSync(new URL('../../server/main.ts', import.meta.url), 'utf8');
+    const stripComments = (s: string): string => s.replace(/(^|[^:])\/\/.*$/gm, '$1');
+    const start = src.indexOf("if (req.method === 'POST' && renameMatch) {");
+    expect(start).toBeGreaterThan(-1);
+    const end = src.indexOf("if (req.method === 'POST' && takeoverMatch) {", start);
+    expect(end).toBeGreaterThan(start);
+    const arm = stripComments(src.slice(start, end));
+    const renameAt = arm.indexOf('await renameCharacter(accountId, characterId, name)');
+    expect(renameAt).toBeGreaterThan(-1);
+    // AFTER the market rekey, which itself only runs past the null-row
+    // re-resolve guard: a rename that matched no row never sweeps a blob.
+    const marketRekeyAt = arm.indexOf(
+      'if (liveGame().rekeyMarketSeller(characterId, character.name, c.name))',
+    );
+    expect(marketRekeyAt).toBeGreaterThan(renameAt);
+    const sweepAt = arm.indexOf('await rekeyRenamedCharacterOwnSigner(');
+    expect(sweepAt).toBeGreaterThan(marketRekeyAt);
+    // BEFORE the response is sent, and handed the SAME row the market/mail
+    // rekeys use: the renamed row's own id/level/state plus old and new names.
+    const responseAt = arm.indexOf('return json(res, 200, {', sweepAt);
+    expect(responseAt).toBeGreaterThan(sweepAt);
+    const sweepCall = arm.slice(sweepAt, arm.indexOf(');', sweepAt));
+    expect(sweepCall).toContain('characterId');
+    expect(sweepCall).toContain('c.level');
+    expect(sweepCall).toContain('c.state');
+    expect(sweepCall).toContain('character.name');
+    expect(sweepCall).toContain('c.name');
   });
 });
 


### PR DESCRIPTION
## Summary

Two container boundaries in the instance-provenance family had no round trip for a marked item copy (signer, crafted marker, rolled stats, enchant): equipping a bag and the retained legacy character-rename route. Neither is reachable through shipped content today, which is exactly why the tracking issue asked for a fix rather than a silent TODO: both go live the moment adjacent content changes, and the change that makes them live will not look related.

**Bag equip (`src/sim/bags.ts`).** `equipBag` consumed the copy being equipped and stored only a bare item id in `meta.bags`, with nowhere to park an `instance` payload or a `craftedRecipeId` while the bag is worn. A future craft-tracked or instance-granted bag would have its payload silently dropped on the next unequip's plain grant. Fixed by declaring bags durably payload-free: `equipBag` now peeks the slot it is about to consume (`selectedInventorySlot` for a named slot, and the new `newestMatchingSlot` peek twin of `consumeNewestInventoryUnit` in `item_copy_ref.ts` for an id-only call) and refuses the equip outright, with a player-facing error, if that slot carries a payload. `unequipBag` needed no change: with the equip-side guard in place, `meta.bags` can never hold an id whose grantor slot carried a payload. A content-level test pins the one live-content vector this does not structurally close on its own (`resolveCraftForRecipe`'s `isSignableMaterialRarity` arm, gated on quality alone rather than item kind): no craftable bag recipe may ever output a rare-or-better bag. (Two shipped bags already sit at rare/epic quality, `gravewoven_bag` and `mistcallers_duffel`, but both are recipe-free dungeon loot drops granted plain, so they are unaffected.)

**Legacy rename route (`server/main.ts`).** The migrated `server/characters.ts` rename handler sweeps a renamed character's own signed item instances (`rekeyInstanceSigner`, across carried inventory, bank, vendor buyback, and equipped) so the #1145 self-signed crafting discount and Battlefield Experience attribution keep tracking the new name. The retained legacy rename route (`API_DISPATCH=legacy`, the one-flag rollback path) never ran that sweep at all, so a rename performed under the rollback flag left the character's own items signed with the old name indefinitely. Fixed by extracting the sweep, previously inline in `characters.ts`, into a shared `rekeyRenamedCharacterOwnSigner` function next to its existing siblings `rekeyReclaimedCharacterWorldState` and `purgeDeletedCharacterWorldState` (both already shared between the migrated route and the legacy ladder for the same reason), and wiring both dispatch arms to call it.

```mermaid
flowchart TD
    subgraph B1["Boundary 1: equipping a bag"]
        A1["equipBag(itemId, socket, pid, slotIndex)"] --> P1["peek the target slot<br/>selectedInventorySlot or newestMatchingSlot"]
        P1 --> D1{"slot has instance<br/>or craftedRecipeId?"}
        D1 -- yes --> R1["refuse: error.bagEquipHasProperty<br/>slot left untouched in meta.inventory"]
        D1 -- no --> C1["consume the slot, store bare id in meta.bags"]
    end

    subgraph B2["Boundary 2: character rename"]
        M1["migrated renameHandler<br/>server/characters.ts, API_DISPATCH=new"] --> S1["rekeyRenamedCharacterOwnSigner(...)"]
        L1["legacy rename route<br/>server/main.ts, API_DISPATCH=legacy"] --> S1
        S1 --> S2["rekeyInstanceSigner sweeps<br/>inventory, bank, buyback, equipped"]
        S2 --> S3{"any signer changed?"}
        S3 -- yes --> S4["charactersDb.saveCharacterState(...)"]
        S3 -- no --> S5["no write"]
    end
```

## Related issues

Closes #2837

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx tsc --noEmit`
  - `npx vitest run tests/bags.test.ts tests/item_copy_ref.test.ts tests/instance_provenance_boundaries.test.ts tests/item_copy_refusal.test.ts tests/ladder_crafting.test.ts tests/localization_fixes.test.ts tests/architecture.test.ts tests/server/characters.test.ts`
  - `npm run i18n:gen` (the new `error.bagEquipHasProperty` key resolves through `baseEnTable` in `src/ui/sim_i18n.ts` directly, so no locale bundle changed)
  - `node scripts/gate_select.mjs` (the pre-merge gate, green: all 8 steps)
- Manual steps: none. This is a non-visual server/sim correctness fix (no gameplay UI, HUD, or admin dashboard surface changed), so there is no before/after screenshot to attach.

## Screenshots / recordings

N/A. Neither fix touches anything a player or operator sees: the bag-equip fix changes a refusal path that only fires for a payload no shipped content can currently produce, and the rename fix is a server-side data-sweep wiring change behind a rollback flag.

---

## Checklist

### Quality

- [x] **The gate passes.** `node scripts/gate_select.mjs` is green. I added or updated
      decisive tests for changed behavior and recorded any manual checks above.

### Cross-platform

- ~~**Tested on desktop and mobile.**~~ N/A, no UI changed.
- ~~**Accessible.**~~ N/A, no UI changed.

### Localization (i18n)

- [x] **New player-visible strings follow the contributor policy.** Added one new
      sim-emitted error string (`error.bagEquipHasProperty` in `src/ui/sim_i18n.ts`'s
      `baseEnTable`, matching the S3 client-boundary re-localization rule for
      `src/sim/` emits). English only, matcher registered in the same change.
- [ ] Numbers, money, dates, units, and percents go through the i18n formatters
      (`formatNumber`, `formatMoney`, `formatDateTime`, `Intl`).
- [x] Player-facing text emitted from `src/sim/` or `server/` is re-localized at
      the client boundary in this same change, and
      `npx vitest run tests/localization_fixes.test.ts` passes.
- [ ] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.
