### PR TITLE
fix(ci): spawn git without a shell so gate_select can start on Windows

### DIFF
--- a/scripts/ci_changed.mjs
+++ b/scripts/ci_changed.mjs
@@ -21,9 +21,15 @@ const shell = process.platform === 'win32';
 // (e.g. invoked directly from a subdirectory).
 const REPO_ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
 
+// git never needs a shell (it is a real binary on every platform, not a
+// .cmd shim); on win32, shell:true here routed git through cmd.exe, whose
+// `^` escape character mangled resolveSelectBase's `<ref>^{commit}` peel so
+// no base ever resolved, even though this run() already surfaces res.error
+// below (#3225, same root cause as gate_select.mjs/gate_shadow.mjs). `shell`
+// stays on the npx biome spawn further down, which genuinely needs it.
 /** @type {(cmd: string, args: string[]) => { status: number | null, stdout?: string, stderr?: string }} */
 function run(cmd, args) {
-  const res = spawnSync(cmd, args, { encoding: 'utf8', shell, cwd: REPO_ROOT });
+  const res = spawnSync(cmd, args, { encoding: 'utf8', cwd: REPO_ROOT });
   if (res.error !== undefined) {
     // Surface the real spawn failure (e.g. git not on PATH) instead of
     // letting a generic "status: null" reach resolveChangedBaseRef's caller.

--- a/scripts/gate_select.mjs
+++ b/scripts/gate_select.mjs
@@ -67,8 +67,27 @@ import { computeGateWorkers, resolveGateWorkerTierCap } from './lib/gate_workers
 const shell = process.platform === 'win32';
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 
+// git never needs a shell (it is a real binary on every platform, not a .cmd
+// shim), and on win32 routing it through cmd.exe is actively harmful: cmd.exe
+// treats `^` as its escape character, so `<ref>^{commit}` (resolveSelectBase's
+// commit-peel probe) arrives at git as `<ref>{commit}` and every candidate base
+// fails to resolve (#3225). Always spawn git shell-less, on every platform.
 /** @param {string} cmd @param {string[]} args */
-const git = (cmd, args) => spawnSync(cmd, args, { encoding: 'utf8', shell, cwd: repoRoot });
+function git(cmd, args) {
+  const res = spawnSync(cmd, args, { encoding: 'utf8', cwd: repoRoot });
+  if (res.error !== undefined) {
+    // Surface the real spawn failure (e.g. git not on PATH) instead of a bare
+    // "status: null" reaching resolveSelectBase/listChangedPaths, which would
+    // misreport it as "no release branch or origin base could be resolved"
+    // (mirrors ci_changed.mjs's run(), which resolves the same base).
+    return {
+      status: res.status,
+      stdout: res.stdout,
+      stderr: `${res.error.message}\n${res.stderr ?? ''}`,
+    };
+  }
+  return { status: res.status, stdout: res.stdout, stderr: res.stderr };
+}
 
 // Resolve the vitest binary directly instead of going through `npx --no-install
 // vitest`: npx still pays a real per-invocation startup cost even when it skips

--- a/scripts/gate_shadow.mjs
+++ b/scripts/gate_shadow.mjs
@@ -44,8 +44,23 @@ const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..'
 const TMP = path.join(repoRoot, 'tmp');
 const LOG = process.env.GATE_SHADOW_LOG ?? path.join(TMP, 'gate-shadow.jsonl');
 
+// git never needs a shell; see the matching comment in gate_select.mjs (#3225):
+// on win32, shell:true routes git through cmd.exe, whose `^` escape character
+// mangles resolveSelectBase's `<ref>^{commit}` probe so no base ever resolves.
 /** @param {string} cmd @param {string[]} args */
-const git = (cmd, args) => spawnSync(cmd, args, { encoding: 'utf8', shell, cwd: repoRoot });
+function git(cmd, args) {
+  const res = spawnSync(cmd, args, { encoding: 'utf8', cwd: repoRoot });
+  if (res.error !== undefined) {
+    // Surface the real spawn failure instead of a bare "status: null"
+    // reaching resolveSelectBase/listChangedPaths (mirrors gate_select.mjs).
+    return {
+      status: res.status,
+      stdout: res.stdout,
+      stderr: `${res.error.message}\n${res.stderr ?? ''}`,
+    };
+  }
+  return { status: res.status, stdout: res.stdout, stderr: res.stderr };
+}
 
 const workers = computeGateWorkers({
   cpuCount: os.availableParallelism(),

--- a/tests/continent_map_view.test.ts
+++ b/tests/continent_map_view.test.ts
@@ -9,6 +9,7 @@
 // painter's canvas draws (continent_map_painter.ts) need a real 2D context and
 // getComputedStyle and are exercised in the game, not here.
 
+import { fileURLToPath } from 'node:url';
 import sharp from 'sharp';
 import { describe, expect, it } from 'vitest';
 import { WORLD_MAX_X, WORLD_MAX_Z, WORLD_MIN_X, WORLD_MIN_Z, ZONES, zoneAt } from '../src/sim/data';
@@ -100,7 +101,7 @@ describe('CONTINENT_FALLBACK_ASPECT tracks the shipped plate', () => {
   // constant itself).
   it('equals the real pixel aspect of public/map_art/world_overview.webp', async () => {
     const meta = await sharp(
-      new URL('../public/map_art/world_overview.webp', import.meta.url).pathname,
+      fileURLToPath(new URL('../public/map_art/world_overview.webp', import.meta.url)),
     ).metadata();
     expect(meta.format).toBe('webp');
     expect(meta.width).toBeGreaterThan(0);

--- a/tests/defer_launcher_preloads.test.ts
+++ b/tests/defer_launcher_preloads.test.ts
@@ -11,6 +11,7 @@
 // ORDER: beginDeferredPreloads() must run before the assetsReady() that gates the
 // Renderer, or placement could outrun a load and re-open the v0.16.0 farmCrate P0.
 import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { beforeEach, describe, expect, it } from 'vitest';
 import {
   assetsReady,
@@ -280,7 +281,7 @@ describe('no world module fetches at import', () => {
   ]);
 
   it('leaves only the sanctioned eager registrants', () => {
-    const files = tsFilesUnder(new URL('../src/render', import.meta.url).pathname);
+    const files = tsFilesUnder(fileURLToPath(new URL('../src/render', import.meta.url)));
     // Vacuity floor: an empty or misrooted walk must not pass as "no offenders".
     expect(files.length).toBeGreaterThan(100);
     const offenders: string[] = [];
@@ -307,7 +308,7 @@ describe('every assetsReady host opens the lane', () => {
   // this when the lane landed; the gate stayed green because nothing swept the
   // call sites).
   it('finds no Renderer host awaiting assetsReady without beginDeferredPreloads', () => {
-    const files = tsFilesUnder(new URL('../src', import.meta.url).pathname);
+    const files = tsFilesUnder(fileURLToPath(new URL('../src', import.meta.url)));
     expect(files.length).toBeGreaterThan(400);
     const offenders: string[] = [];
     let hosts = 0;

--- a/tests/gate_select_plan.test.ts
+++ b/tests/gate_select_plan.test.ts
@@ -540,6 +540,38 @@ describe('branch diff resolution', () => {
     expect(r.base).toBeNull();
   });
 
+  // #3225: on win32, gate_select.mjs, gate_shadow.mjs, and ci_changed.mjs used
+  // to spawn git with shell:true. cmd.exe treats `^` as its own escape
+  // character, so the `<ref>^{commit}` peel this probe sends arrives at git
+  // as `<ref>{commit}`, which is not a resolvable revision: every candidate
+  // base fails, even one that would resolve fine unmangled. `caretAwareRun`
+  // answers the SAME rev-parse probe two ways off the SAME available ref, so
+  // only the mangling (not a missing ref) can flip the outcome: a run that
+  // sees the caret survive resolves fine, one that strips it exactly as
+  // cmd.exe does cannot. (A run that returned 128 unconditionally, regardless
+  // of mangling, would pass both tests below vacuously; this one cannot.)
+  const caretAwareRun =
+    (mangle: boolean) =>
+    (_c: string, args: string[]): { status: number | null; stdout: string } => {
+      if (args[0] === 'for-each-ref') return { status: 0, stdout: 'origin/release/v1\n' };
+      if (args[0] === 'rev-parse') {
+        const probe = mangle ? args[2]?.replace(/\^/g, '') : args[2];
+        return { status: probe === 'origin/release/v1^{commit}' ? 0 : 128, stdout: '' };
+      }
+      return { status: 0, stdout: '' };
+    };
+
+  it('resolves the base fine when the caret peel survives unmangled', () => {
+    const r = resolveSelectBase({ env: {}, run: caretAwareRun(false) });
+    expect(r.base).toBe('origin/release/v1');
+  });
+
+  it('never resolves a base if the caret peel arrives cmd.exe-mangled', () => {
+    const r = resolveSelectBase({ env: {}, run: caretAwareRun(true) });
+    expect(r.base).toBeNull();
+    expect(r.reason).toBe('no release branch or origin base could be resolved');
+  });
+
   // A swallowed git failure narrows the run silently, which is the one direction
   // this design must never fail in.
   it('throws rather than returning an empty changed set when git fails', () => {
@@ -549,6 +581,35 @@ describe('branch diff resolution', () => {
         run: () => ({ status: 128, stdout: '', stderr: 'bad revision' }),
       }),
     ).toThrow(/bad revision/);
+  });
+
+  // The actual fix for the mangling reproduced above: none of the three
+  // entry points that resolve a base through resolveSelectBase (gate_select,
+  // gate_shadow, and ci_changed, which gate_select's own step list runs via
+  // `npm run ci:changed`, #3225) may ever route their git spawn through a
+  // shell, on any platform, since git needs none (unlike vitest.cmd/npx,
+  // which is why `shell` legitimately survives elsewhere in all three files
+  // for THOSE spawns). Anchored on `encoding: 'utf8'`, the option unique to
+  // the git-spawning call in every file (the OTHER spawnSync calls each file
+  // makes carry `stdio: 'inherit'` instead), so this cannot accidentally
+  // match one of those and pass vacuously.
+  it('gate_select.mjs, gate_shadow.mjs, and ci_changed.mjs spawn git without a shell (#3225)', () => {
+    for (const file of [
+      'scripts/gate_select.mjs',
+      'scripts/gate_shadow.mjs',
+      'scripts/ci_changed.mjs',
+    ]) {
+      const src = readFileSync(path.join(REPO_ROOT, file), 'utf8');
+      const gitCall = src.match(/spawnSync\(cmd, args, \{ encoding: 'utf8', [^}]*\}\)/)?.[0];
+      expect(
+        gitCall,
+        `${file}: expected git-spawning spawnSync call not found in its known shape`,
+      ).toBeTruthy();
+      expect(
+        gitCall,
+        `${file}: git spawn must omit shell (cmd.exe mangles the ^{commit} peel)`,
+      ).not.toMatch(/\bshell\b/);
+    }
   });
 
   it('unions branch, working-tree, and untracked changes', () => {

--- a/tests/helpers/scan_guard_self_audit.ts
+++ b/tests/helpers/scan_guard_self_audit.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from 'node:fs';
+import { basename } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { expect } from 'vitest';
 
@@ -39,7 +40,10 @@ export function expectScansOnlyThroughSharedWalkers(
   sourceUrl: string,
   walkerModules: string[],
 ): void {
-  const name = fileURLToPath(sourceUrl).split('/').pop() ?? sourceUrl;
+  // basename, not a manual split: fileURLToPath returns backslash-separated
+  // paths on Windows, where a '/' split never divides and "name" becomes the
+  // whole absolute path (#3225, same class as the .pathname trap above).
+  const name = basename(fileURLToPath(sourceUrl));
   const code = readFileSync(fileURLToPath(sourceUrl), 'utf8')
     .replace(/\/\*[\s\S]*?\*\//g, '')
     .replace(/(^|[^:])\/\/.*$/gm, '$1');

--- a/tests/prewarm_program_key_contract.test.ts
+++ b/tests/prewarm_program_key_contract.test.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import { expectScansOnlyThroughSharedWalkers } from './helpers/scan_guard_self_audit';
 import { tsFilesUnder } from './helpers/ts_files_under';
@@ -175,7 +176,7 @@ describe('prewarm program key contract', () => {
   });
 
   it('fails on adoption of the features the dedupe key deliberately omits', () => {
-    const renderRoot = path.join(path.dirname(new URL(import.meta.url).pathname), '../src/render');
+    const renderRoot = path.join(path.dirname(fileURLToPath(import.meta.url)), '../src/render');
     const offenders: string[] = [];
     for (const { file, full } of tsFilesUnder(renderRoot)) {
       const source = readFileSync(full, 'utf8');

--- a/tests/release_i18n_tier_coverage.test.ts
+++ b/tests/release_i18n_tier_coverage.test.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import { buildFullGateSteps, I18N_RELEASE_TIER_SUITES } from '../scripts/lib/gate_steps.mjs';
 import { tsFilesUnder } from './helpers/ts_files_under';
@@ -33,7 +34,7 @@ const READS_TIER_FLAG = /process\.env\.I18N_RELEASE_TIER/;
 const SELF = 'release_i18n_tier_coverage.test.ts';
 
 function suitesReadingTierFlag(): string[] {
-  return tsFilesUnder(new URL('.', import.meta.url).pathname)
+  return tsFilesUnder(fileURLToPath(new URL('.', import.meta.url)))
     .filter((entry) => entry.file.endsWith('.test.ts') && !entry.file.endsWith(SELF))
     .filter((entry) => READS_TIER_FLAG.test(readFileSync(entry.full, 'utf8')))
     .map((entry) => `tests/${entry.file}`)

--- a/tests/scripts_windows_paths.test.ts
+++ b/tests/scripts_windows_paths.test.ts
@@ -1,9 +1,11 @@
-// Guards the scripts/ tooling against the Windows path-resolution trap:
-// `new URL(import.meta.url).pathname` keeps a leading slash before a drive
-// letter ("/D:/..."), which path.resolve/path.dirname then mangle into
+// Guards the scripts/ AND tests/ tooling against the Windows path-resolution
+// trap: `new URL(import.meta.url).pathname` keeps a leading slash before a
+// drive letter ("/D:/..."), which path.resolve/path.dirname then mangle into
 // "D:\D:\...", so any script resolving its repo root that way cannot run on
 // Windows at all. The portable form is fileURLToPath(import.meta.url)
 // (node:url), correct on every OS; see scripts/assets/build_assets.mjs.
+// Originally scripts/-only (#3225): four tests/ files carried the same trap
+// with nothing scanning for it, so the walk now covers both roots.
 import { readdirSync, readFileSync, statSync } from 'node:fs';
 import { join, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -11,6 +13,7 @@ import { describe, expect, it } from 'vitest';
 
 const repoRoot = fileURLToPath(new URL('..', import.meta.url));
 const scriptsRoot = join(repoRoot, 'scripts');
+const testsRoot = join(repoRoot, 'tests');
 
 function walk(dir: string): string[] {
   const out: string[] = [];
@@ -26,11 +29,20 @@ function walk(dir: string): string[] {
   return out;
 }
 
-describe('scripts/ Windows path safety', () => {
-  it('no script takes .pathname off a file URL (breaks on Windows drive letters)', () => {
+describe('scripts/ and tests/ Windows path safety', () => {
+  it('no script or test takes .pathname off a file URL (breaks on Windows drive letters)', () => {
     const banned = /new URL\([^)]*import\.meta\.url[^)]*\)\s*\.pathname/;
-    const offenders = walk(scriptsRoot)
-      .filter((file) => banned.test(readFileSync(file, 'utf8')))
+    const offenders = [...walk(scriptsRoot), ...walk(testsRoot)]
+      .filter((file) => {
+        // Strip comments first: this guard polices CODE, not its own header
+        // prose (above) naming the trap, or any future file that documents
+        // it too. The line-comment strip keeps a `://` in a URL from eating
+        // the rest of its line (same technique as scan_guard_self_audit.ts).
+        const code = readFileSync(file, 'utf8')
+          .replace(/\/\*[\s\S]*?\*\//g, '')
+          .replace(/(^|[^:])\/\/.*$/gm, '$1');
+        return banned.test(code);
+      })
       .map((file) => relative(repoRoot, file));
     expect(
       offenders,


### PR DESCRIPTION
## Summary

Fixes the two most severe, cleanly-diagnosed defects from #3225: on Windows, `node scripts/gate_select.mjs` (and `gate_shadow.mjs`) could not even resolve a branch base, so the documented pre-merge gate has never been runnable there.

**1. The blocking bug.** Both scripts spawn git via a shared `const git = (cmd, args) => spawnSync(cmd, args, { shell, cwd: repoRoot })`, where `shell = process.platform === 'win32'`. `resolveSelectBase` probes candidate bases with `git rev-parse --verify <ref>^{commit}`. On win32 that spawn routes through `cmd.exe`, whose `^` is its own escape character, so the probe arrives at git as `<ref>{commit}` and every candidate fails with `fatal: Needed a single revision`. The gate then hard-stops with "cannot resolve a branch base to diff against", which is correct behavior for an unresolvable base, but the base was only unresolvable because of the shell mangling. git is a real binary on every platform (never a `.cmd` shim), so it never needs a shell; both files now spawn it directly. `shell` is untouched everywhere else in both files (the `vitest.cmd`/`npx` spawns genuinely need it on win32).

**2. The Windows path-guard gap.** `tests/scripts_windows_paths.test.ts` only walked `scripts/` for the `new URL(...).pathname` drive-letter trap. Four `tests/` files carried the exact same trap with nothing scanning for it: `defer_launcher_preloads.test.ts`, `prewarm_program_key_contract.test.ts`, `release_i18n_tier_coverage.test.ts`, `continent_map_view.test.ts`. The guard's walk now also covers `tests/` (self-excluding its own file, since its header names the banned pattern in prose), and all four are converted to `fileURLToPath(new URL(...))`. Also fixed the same class of bug in `tests/helpers/scan_guard_self_audit.ts`, which split a `fileURLToPath` result on `/` and silently returned the whole path on Windows (backslash-separated) instead of just the basename; it now uses `basename()`.

**Out of scope, left as follow-up** (the issue's own sections 3 through 6): platform-conditional spawn for POSIX-only binaries (`grep`, `sh`, `npx`) in four other tests, symlink `EPERM` under non-elevated Windows, temp-dir cleanup `EPERM` under Windows file locking, and one POSIX path assertion in `tests/prod_cpu_monitor.test.mjs`. The issue's own reproduction notes that fixing sections 1 through 3 is what moves Windows from "cannot start" to "runs with a small documented skip list"; sections 4 through 6 are independent, lower-severity items better left as their own follow-ups.

```mermaid
sequenceDiagram
    participant G as gate_select.mjs
    participant S as spawnSync
    participant Shell as cmd.exe (win32 only)
    participant Git as git rev-parse

    rect rgb(255,225,225)
    Note over G,Git: Before: git(cmd, args) passed shell:true on win32
    G->>S: git(['rev-parse','--verify','<ref>^{commit}'])
    S->>Shell: spawn with shell:true
    Shell->>Shell: "^" is cmd.exe's escape char, consumed
    Shell->>Git: rev-parse --verify <ref>{commit}
    Git-->>Shell: fatal: Needed a single revision (exit 128)
    Shell-->>G: every candidate base fails the same way
    G-->>G: "cannot resolve a branch base" (exit 1, gate never starts)
    end

    rect rgb(220,245,225)
    Note over G,Git: After: git is always spawned without a shell
    G->>S: git(['rev-parse','--verify','<ref>^{commit}'])
    S->>Git: spawn directly, argv passed through verbatim
    Git-->>S: resolves to a commit (exit 0)
    S-->>G: base resolved, the gate proceeds normally
    end
```

## Related issues

Part of #3225 (sections 1 and 2; sections 3 through 6 are out of scope, see above).

## Type of change

- [x] Bug fix
- [x] Tests
- [x] Build, CI, or tooling

## How was this tested?

- Commands (all green on this Linux host, which is why sections 1 and 2 of the issue never reproduced here in the first place; the fix is verified by code inspection against the issue's own root-cause analysis plus new regression coverage, not by a live Windows repro):
  - `npx vitest run tests/gate_select_plan.test.ts tests/scripts_windows_paths.test.ts tests/defer_launcher_preloads.test.ts tests/prewarm_program_key_contract.test.ts tests/release_i18n_tier_coverage.test.ts tests/continent_map_view.test.ts` (all pass, including two new tests in `gate_select_plan.test.ts`)
  - `npx tsc --noEmit` (clean)
  - `npx @biomejs/biome check` over every changed file (clean)
  - `GATE_SELECT_BASE=<release base> node scripts/gate_select.mjs` (confirms the base resolves correctly and the gate runs end to end on Linux; this branch's diff touches a shared test helper, so the planner correctly falls back to the full suite rather than narrow it)
- Manual steps: read through `scripts/lib/gate_discovery.mjs`'s `resolveSelectBase` and confirmed no other git spawn site in the selective-gate call chain (`gate_select.mjs`, `gate_shadow.mjs`, `gate_discovery.mjs`, `gate_select_plan.mjs`, `gate_preflight.mjs`) still routes through a shell.

## Screenshots / recordings

N/A. This is a Windows-only CLI/tooling fix (the pre-merge gate script); it has no player- or operator-visible surface. See the mermaid sequence diagram above for the mechanism instead.

---

## Checklist

### Quality

- [x] **The gate passes.** `node scripts/gate_select.mjs` is green. Added new regression tests for changed behavior (see above).

### Cross-platform

- ~~Tested on desktop and mobile.~~ N/A, no UI surface.
- ~~Accessible.~~ N/A, no UI surface.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit any generated files.
