### PR TITLE
fix(ci): raise the pr-gate shard bound for sim-deep selective packs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -448,21 +448,34 @@ jobs:
     # runs sat 9.6 to 24.4 minutes inside actions/checkout before completing
     # (healthy checkout is under 3 minutes; worst stalled wall 32.8 minutes,
     # run 31111919431 attempt 1), and the stall, not any test, set those
-    # runs' tails. Sized from the measured healthy worst case plus margin:
-    # the slowest healthy GREEN shard observed is 13.6 minutes (the Phase 2
-    # content-only selective drill, PR #2991) and the slowest healthy RED
-    # one 18.6 minutes (run 31067745370, a 17.8 minute failing test step),
-    # so 20 kills only stalled jobs. Two independent 24 hour replays (the
-    # review's and its verifier's, different windows and counting bases)
-    # both found ZERO healthy jobs over their bound, and 21 to 31
-    # stalled-but-green jobs per day these bounds convert into reds needing
-    # a manual failed-jobs rerun: the buy is bounding the unbounded worst
-    # case (the pre-Phase-1 90 minute wedges) and making stalls visible as
-    # failures for the runner escalation, not the average tail. Full
-    # evidence: the CI/CD performance packet's detect-wedge postmortem note
-    # (an internal, untracked packet record; the run ids above are the
-    # in-repo anchors).
-    timeout-minutes: 20
+    # runs' tails. The original 20 was sized from a 13.6 minute healthy
+    # GREEN worst case (the Phase 2 content-only selective drill, PR #2991)
+    # and an 18.6 minute healthy RED one (run 31067745370), and two
+    # independent 24 hour replays then found zero healthy jobs over that
+    # bound. That zero did not survive sim-deep selective PRs: a selective
+    # run whose changed files sit deep in the sim import graph collects
+    # nearly the full suite (917 files on PR #3342 against 782 on a
+    # comparable net-only PR, the extras being the expensive sim suites),
+    # and the sha1-contiguous packs can concentrate several of those in one
+    # shard. On 2026-08-12 shard 1 of PR #3342 was bound-killed at a 20.25
+    # minute wall on two attempts, both with the test step at 19.0 minutes
+    # and still running (deterministic workload, not runner variance), and
+    # fix/item-provenance-boundaries died the same way at 20.08; sibling
+    # GREEN shards on the same run walked 16 to 17 minutes against the 13.6
+    # prior baseline, so that runner set ran about 1.25x slow. 40 applies
+    # release-gate's slow-runner arithmetic to this workload: the projected
+    # completed shard 1 wall is about 22 minutes on those runners, about 18
+    # fast-runner-equivalent, and 18 x 1.60 (the fast-to-slow runner ratio
+    # measured at b160a1ba18) x 1.37 (the margin the original bounds were
+    # chosen with) is 39.5. The stall-detection buy survives the raise: the
+    # stall class dies in checkout or setup, where ci-stall-rerun.yml's
+    # nothing-ran-after-it predicate reruns it regardless of the bound's
+    # value, and the git low-speed abort still ends trickle transfers in
+    # about 2 minutes; a healthy long test step, which both 2026-08-12
+    # kills interrupted, is exactly what this bound must not kill. The
+    # queue-side ceiling this has to fit under is recorded in
+    # docs/merge-queue.md.
+    timeout-minutes: 40
     runs-on: ubuntu-latest
 
     # fail-fast stays off: shards pass or fail independently, so one red shard
@@ -760,9 +773,12 @@ jobs:
     if: ((github.event_name == 'pull_request' && (github.base_ref != 'main' || !startsWith(github.head_ref, 'release/'))) || (github.event_name == 'push' && !startsWith(github.ref, 'refs/heads/release/')) || github.event_name == 'workflow_dispatch' || github.event_name == 'merge_group') && needs.changes.outputs.code != 'false'
     # Unmatrixed single toolchain-setup-plus-checks job, comparable in shape to
     # browser-gate, but heavier: i18n generation, the malware gate, a
-    # typecheck, and four builds. 20 matches the pr-gate shard bound so a
-    # stalled runner here dies and reruns instead of holding a required check
-    # for hours.
+    # typecheck, and four builds. 20 was sized beside the shard matrices'
+    # original bound and still fits this job's serialized check list;
+    # pr-gate's own bound has since moved for its sim-heavy selective test
+    # packs, which this job does not run, so the two values parted on
+    # purpose. A stalled runner here still dies and reruns instead of
+    # holding a required check for hours.
     timeout-minutes: 20
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -452,12 +452,15 @@ jobs:
     # GREEN worst case (the Phase 2 content-only selective drill, PR #2991)
     # and an 18.6 minute healthy RED one (run 31067745370), and two
     # independent 24 hour replays then found zero healthy jobs over that
-    # bound. That zero did not survive sim-deep selective PRs: a selective
-    # run whose changed files sit deep in the sim import graph collects
-    # nearly the full suite (917 files on PR #3342 against 782 on a
-    # comparable net-only PR, the extras being the expensive sim suites),
-    # and the sha1-contiguous packs can concentrate several of those in one
-    # shard. On 2026-08-12 shard 1 of PR #3342 was bound-killed at a 20.25
+    # bound. That zero did not survive sim-deep selective PRs. Selective
+    # mode always runs the computed blind/partial floor (779 of the 2674
+    # suite files when this was sized; the floor is recomputed in-job, see
+    # scripts/lib/test_visibility.mjs), and a diff deep in the sim import
+    # graph stacks the expensive sim suites on top of it: 917 collected
+    # files on PR #3342 against 782 on a comparable net-only PR, so the
+    # floor plus about 135 sim-heavy files, which the sha1-contiguous packs
+    # can concentrate in one shard. On 2026-08-12 shard 1 of PR #3342 was
+    # bound-killed at a 20.25
     # minute wall on two attempts, both with the test step at 19.0 minutes
     # and still running (deterministic workload, not runner variance), and
     # fix/item-provenance-boundaries died the same way at 20.08; sibling
@@ -467,12 +470,21 @@ jobs:
     # completed shard 1 wall is about 22 minutes on those runners, about 18
     # fast-runner-equivalent, and 18 x 1.60 (the fast-to-slow runner ratio
     # measured at b160a1ba18) x 1.37 (the margin the original bounds were
-    # chosen with) is 39.5. The stall-detection buy survives the raise: the
+    # chosen with) is 39.5. Label the base honestly when re-deriving: no
+    # killed attempt ever completed, so 22 is an extrapolation bounded
+    # below by the kill wall; if a healthy shard is bound-killed again,
+    # remeasure a completed wall rather than re-raising by feel. The
+    # stall-detection buy survives the raise: the
     # stall class dies in checkout or setup, where ci-stall-rerun.yml's
     # nothing-ran-after-it predicate reruns it regardless of the bound's
     # value, and the git low-speed abort still ends trickle transfers in
     # about 2 minutes; a healthy long test step, which both 2026-08-12
     # kills interrupted, is exactly what this bound must not kill. The
+    # accepted cost is the hang variant the low-speed floor does not
+    # police (the header's run 31402711619): a hung shard now burns 40
+    # minutes before the reactor can fire, double the old latency, taken
+    # because a false kill of a required healthy shard blocks PRs outright
+    # while a hang costs only latency. The
     # queue-side ceiling this has to fit under is recorded in
     # docs/merge-queue.md.
     timeout-minutes: 40
@@ -864,8 +876,9 @@ jobs:
     # the label is what an operator reads in the checks list to tell the two reds apart.
     name: Release gate (tests)
     if: (github.event_name == 'pull_request' && github.base_ref == 'main' && startsWith(github.head_ref, 'release/')) || (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release/'))
-    # Larger than pr-gate's checkout-stall bound BECAUSE this matrix keeps the
-    # long sims in-shard by design: pr-gate hands its CI_LONG_SUITES files to
+    # Sized from this matrix's own workload, independently of pr-gate's
+    # bound: this matrix keeps the long sims in-shard by design, since
+    # pr-gate hands its CI_LONG_SUITES files to
     # the lane pair, and release-gate deliberately does not
     # (scripts/lib/ci_shard_plan.mjs states that ruling), so a release shard
     # can draw several multi-minute harnesses at once. Default vitest --shard
@@ -904,9 +917,10 @@ jobs:
     # stall reactor (.github/workflows/ci-stall-rerun.yml) reruns a bound-killed
     # SETUP step or a failed checkout, never a test-step kill like this one, and
     # it stays inert until its workflow file reaches the default branch. A
-    # test-step kill here is a manual rerun by design. pr-gate keeps the tight
-    # bound for fast feedback; its shards exclude these suites, so this evidence
-    # does not touch it. The nightly workflow deliberately keeps its own
+    # test-step kill here is a manual rerun by design. pr-gate's bound is
+    # derived separately from its own selective-pack evidence (on its bound
+    # above); its shards exclude these suites, so this evidence does not
+    # size it. The nightly workflow deliberately keeps its own
     # generous bounds and is untouched.
     timeout-minutes: 35
     runs-on: ubuntu-latest

--- a/docs/merge-queue.md
+++ b/docs/merge-queue.md
@@ -52,8 +52,9 @@ automatically instead of by hand.
   resizing any bound: the `changes` bound, plus the largest REQUIRED job
   bound, plus runner-acquisition slack (which `timeout-minutes` does not count
   but the queue's timer does) must stay comfortably under it. Today that is
-  8 + 30, so a required critical path of 38 minutes against a 90 minute
-  ceiling. A candidate that blows the queue timeout is ejected, which blocks
+  8 + 40 (the `changes` bound plus the pr-gate shard bound, the largest
+  required one), so a required critical path of 48 minutes against a 90
+  minute ceiling. A candidate that blows the queue timeout is ejected, which blocks
   the merge rather than merging anything unproven, but it costs a full queue
   cycle and reads like a mystery without this number written down.
 - The queue merges with one repo-wide method (merge commit). The per-PR

--- a/docs/merge-queue.md
+++ b/docs/merge-queue.md
@@ -54,9 +54,10 @@ automatically instead of by hand.
   but the queue's timer does) must stay comfortably under it. Today that is
   8 + 40 (the `changes` bound plus the pr-gate shard bound, the largest
   required one), so a required critical path of 48 minutes against a 90
-  minute ceiling. A candidate that blows the queue timeout is ejected, which blocks
-  the merge rather than merging anything unproven, but it costs a full queue
-  cycle and reads like a mystery without this number written down.
+  minute ceiling. A candidate that blows the queue timeout is ejected,
+  which blocks the merge rather than merging anything unproven, but it
+  costs a full queue cycle and reads like a mystery without this number
+  written down.
 - The queue merges with one repo-wide method (merge commit). The per-PR
   squash/merge choice does not apply on the protected branches.
 - Direct pushes to the protected branches are blocked by the

--- a/tests/ci_workflow.test.ts
+++ b/tests/ci_workflow.test.ts
@@ -833,8 +833,9 @@ describe('CI workflow parity', () => {
     const bounds = [
       // pr-gate's 20 was sized when two 24 hour replays found zero healthy
       // jobs over it. Sim-deep selective PRs broke that zero: their runs
-      // collect nearly the full suite and the sha1-contiguous packs can
-      // concentrate the expensive sim suites in one shard (PR #3342's
+      // stack the expensive sim suites on top of the always-run
+      // blind/partial floor, and the sha1-contiguous packs can
+      // concentrate several in one shard (PR #3342's
       // shard 1 bound-killed at a 20.25 minute wall on two attempts with a
       // healthy 19 minute test step still running; fix/item-provenance-
       // boundaries died the same way at 20.08). 40 is release-gate's

--- a/tests/ci_workflow.test.ts
+++ b/tests/ci_workflow.test.ts
@@ -831,7 +831,16 @@ describe('CI workflow parity', () => {
     // in shape rather than lifted from the checkout-stall replay directly, so
     // every job in this file carries a conscious timeout-minutes value.
     const bounds = [
-      ['pr-gate', 20],
+      // pr-gate's 20 was sized when two 24 hour replays found zero healthy
+      // jobs over it. Sim-deep selective PRs broke that zero: their runs
+      // collect nearly the full suite and the sha1-contiguous packs can
+      // concentrate the expensive sim suites in one shard (PR #3342's
+      // shard 1 bound-killed at a 20.25 minute wall on two attempts with a
+      // healthy 19 minute test step still running; fix/item-provenance-
+      // boundaries died the same way at 20.08). 40 is release-gate's
+      // slow-runner sizing METHOD over this workload's projected healthy
+      // wall; derivation and run evidence on the ci.yml bound.
+      ['pr-gate', 40],
       // release-gate is the one shard matrix that keeps its CI_LONG_SUITES
       // files in-shard (pr-gate hands them to the lanes), so a single shard
       // can draw four of them at once and the bound has to cover a slow
@@ -867,7 +876,9 @@ describe('CI workflow parity', () => {
       ['lint', 15],
       // pr-checks and release-checks are the same shape as lint but heavier:
       // i18n generation, the malware gate, a typecheck, and four builds. 20
-      // matches the shard matrices' bound.
+      // was sized beside the shard matrices' original bound and still fits
+      // this serialized check list; the test matrices' bounds have since
+      // moved for their own workloads, deliberately without dragging these.
       ['pr-checks', 20],
       ['release-checks', 20],
       // release-version-gate and release-i18n are both unsharded jobs whose


### PR DESCRIPTION
## Summary

Raises the pr-gate shard bound from `timeout-minutes: 20` to `40`. The 20 minute bound is now bound-killing healthy, deterministic runs, which blocks PRs on a required check:

- PR #3342 (`fix/rift-xarreth-zone-reaction-budget`): shard (1) killed at a 20.25 minute wall on two consecutive attempts, the test step at 19.0 minutes and still running both times (18.98 then 19.00, so deterministic workload, not runner variance).
- `fix/item-provenance-boundaries`: the identical shard died at 20.08 the same way.

The mechanism: a selective run whose changed files sit deep in the sim import graph collects nearly the full suite (917 test files on #3342 against 782 on a comparable net-only PR, the extras being the expensive sim suites), and the sha1-contiguous shard packs can concentrate several of those in one shard. Sibling GREEN shards on the same run walked 16 to 17 minutes against the prior 13.6 minute healthy baseline.

The old rationale comment's core claim ("two independent 24 hour replays found ZERO healthy jobs over their bound") no longer holds, so the comment is rewritten with the new evidence and the sizing derivation. 40 applies the same slow-runner arithmetic release-gate's bound raise used (#3306): projected completed shard 1 wall about 22 minutes on runners measured about 1.25x slow, so about 18 fast-runner-equivalent, times the 1.60 fast-to-slow runner ratio measured at b160a1ba18, times the 1.37x margin the original bounds were chosen with, is 39.5.

Why not widen the shard matrix 8 to 12 instead: the required contexts `PR gate (English-only legal) (1)` through `(8)` live in a ruleset outside git, so widening leaves the new shards un-required until an admin edits the ruleset (fails toward fewer enforced tests); `SHARD_N` is shared with release-gate; and the failure mode is pack concentration, which more shards only dilute probabilistically while adding four toolchain setups per run.

The stall-detection property survives the raise: the checkout-stall class dies in checkout or setup, where `ci-stall-rerun.yml`'s nothing-ran-after-it predicate auto-reruns it regardless of the bound's value, and git's low-speed abort still ends trickle transfers in about 2 minutes. Both 2026-08-12 kills interrupted a healthy long test step, which is exactly what the bound must not kill (and the stall-rerun predicate correctly refused to resurrect them, since a test step had run).

Also updated in the same change, per the pins:

- `tests/ci_workflow.test.ts`: the exact-value bounds table row (`['pr-gate', 40]`) plus the pr-checks comment that claimed 20 "matches the shard matrices' bound" (pr-checks deliberately stays at 20; it never runs the test packs).
- `docs/merge-queue.md`: the queue-ceiling arithmetic, now 8 + 40 = 48 minutes of required critical path against the 90 minute `check_response_timeout_minutes` ceiling.

## Related issues

Unblocks #3342.

## Type of change

- [x] Build, CI, or tooling

## How was this tested?

- Commands:
  - `npx vitest run tests/ci_workflow.test.ts tests/ci_stall_rerun.test.ts` (53 tests green; the bounds table is an exact-value pin, so the ci.yml edit fails it unless both move together)
  - `npx @biomejs/biome check tests/ci_workflow.test.ts`
  - `node scripts/gate_select.mjs`
- Manual steps: pulled the check-run timings for the two killed runs via the GitHub API to confirm the kill walls and the sibling shard walls quoted above.

---

## Checklist

### Quality

- [x] **The gate passes.** `node scripts/gate_select.mjs` is green. The pinned bounds table and the doc arithmetic are updated in the same change.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files.
