### PR TITLE
balance(rogue): re-band combat to the 200 DPS band top

### DIFF
--- a/src/sim/content/spec_baselines.ts
+++ b/src/sim/content/spec_baselines.ts
@@ -68,8 +68,8 @@ export const SPEC_BASELINES: SpecBaselineTable = {
       ],
     },
     combat: {
-      stats: { ap: 24, crit: 0.14, apPct: 0.55 },
-      global: { meleeDmgPct: 0.36 },
+      stats: { ap: 24, crit: 0.14, apPct: 0.2 },
+      global: { meleeDmgPct: 0.16 },
       ability: [{ ability: 'sinister_strike', dmgPct: 0.2, costPct: -0.16 }],
     },
     subtlety: {

--- a/tests/spec_baselines.test.ts
+++ b/tests/spec_baselines.test.ts
@@ -52,9 +52,14 @@ const EXPECTED_BASELINES: Record<string, BaselineSnapshot> = {
       eviscerate: { dmgPct: 0.32 },
     },
   },
+  // fight-6498 re-band: combat sat ~50 DPS over assassination and ~60 over
+  // subtlety on the heroic Nythraxis check (~240 vs ~189 / ~179, behind the
+  // boss's 798 armor in the /dev BiS probe). apPct and meleeDmgPct were both the
+  // highest of the three rogue specs and drove its auto-heavy kit; trimming them
+  // lands combat at ~200 (the 150-200 band top), leaving the other two untouched.
   'rogue/combat': {
-    stats: { ap: 24, crit: 0.14, apPct: 0.55 },
-    global: { meleeDmgPct: 0.36 },
+    stats: { ap: 24, crit: 0.14, apPct: 0.2 },
+    global: { meleeDmgPct: 0.16 },
     abilities: { sinister_strike: { dmgPct: 0.2, costPct: -0.16 } },
   },
   'rogue/subtlety': {
@@ -345,8 +350,9 @@ describe('v0.28 passive restoration hotfix', () => {
     };
     const bare = apFor(null);
     for (const spec of ['assassination', 'combat']) {
-      // apPct is 0.36 to 0.55 across these specs, plus crit/flat AP; both clear
-      // a 1.3x AP floor over the spec-less rogue. A dropped apPct wiring fails here.
+      // apPct is 0.20 to 0.36 across these specs, plus crit/flat AP (combat's flat
+      // AP 24 carries it over the floor even at the lower apPct); both clear a 1.3x
+      // AP floor over the spec-less rogue. A dropped apPct wiring fails here.
       expect(apFor(spec), spec).toBeGreaterThan(bare * 1.3);
     }
     // 2026-08-09 120s band round: subtlety's apPct stepped 0.35 to 0.12 to


### PR DESCRIPTION
## Summary

Combat rogue was overtuned on single target. On the heroic Nythraxis check it sat well clear of its sibling specs: the fight-6498 parse measured combat at 232 DPS live, and the `/dev` BiS probe (La Luna's exact rows, 8 seeds, behind the boss's 798 armor) puts it at ~240 vs ~189 assassination and ~179 subtlety, roughly 40 to 60 DPS ahead of the pack.

The cause is combat's two hidden spec baselines in `src/sim/content/spec_baselines.ts`, both the highest of the three rogue specs: `apPct` 0.55 (attack power, which drives its auto-attack-heavy kit) and `meleeDmgPct` 0.36. This trims them to **0.20** and **0.16**, landing combat at ~200 DPS, the top of the shared 150-200 band and still the strongest rogue spec, without touching the other two.

Numbers only: no ability effect, cooldown, or tooltip text changes, since `apPct`/`meleeDmgPct` are hidden baselines. The whole diff is two values plus the baseline pin that records them.

### Measured effect (`/dev` BiS probe, La Luna's rows, vs heroic Nythraxis armor 798, 8 seeds)

| Spec | Before | After |
|---|---|---|
| **combat** | 239.7 | **200.2** |
| assassination | 189.8 | 188.7 |
| subtlety | 179.3 | 176.1 |

Assassination and subtlety are byte identical in baseline and effectively unchanged in DPS (seed noise); the re-band is combat-only.

## Related issues

None on file. Prompted by the fight-6498 combat-rogue parse.

## Type of change

- [x] Balance / tuning (numbers only)  <!-- the list below has no balance category -->
- [ ] Feature: new functionality
- [ ] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change

## How was this tested?

- Commands:
  - `npx tsc --noEmit` -> exit 0
  - `npx vitest run tests/spec_baselines.test.ts tests/parity/ tests/woc_balance.test.ts tests/progression.test.ts tests/rogue_engines.test.ts` -> green (the full determinism/parity suite included)
  - `npx @biomejs/biome check` on the two changed files -> clean
  - `node scripts/gate_select.mjs` -> green on every step except the one portrait-manifest test noted below
- Method: a headless probe drives the real deterministic `Sim`, a level-20 combat rogue with the parse's exact talent rows and `/dev` BiS gear, 123 s against a dummy carrying heroic Nythraxis's armor (798), averaged over 8 fixed seeds. It reproduced the live parse within ~4% before the change (241 sim vs 232 live), then measured 200.2 after.
- A per-ability damage tally confirmed combat's damage is auto-attack dominated (~58%), which is why `apPct` (attack power) is the effective lever rather than any single ability.
- Combat-only verified: assassination and subtlety measure identically before and after.

## Screenshots / recordings

N/A. No visual, UI, or tooltip change.

---

## Checklist

### Quality

- [ ] **The gate passes.** Left unchecked deliberately. `node scripts/gate_select.mjs` is green on every step (i18n freshness, malware scan, biome, the parity determinism suite, and all other vitest batches) EXCEPT `tests/mob_portrait_source_manifest.test.ts`. That fails only because `spec_baselines.ts` is sim content esbuild-bundled into the mob-portrait renderer fingerprint (via `data.ts`): the change alters no portrait image, only the bundle hash, so the committed portrait manifest needs a re-bless on the canonical renderer (see Notes below). Decisive test added: the spec-baseline pin records the new values, and the sim measurements are recorded above.

### Cross-platform

- [x] N/A. No UI, markup, CSS, or control is added or changed. This is a hidden sim-baseline number, shared by every host and viewport; there is nothing to test per platform, and no accessibility surface.

### Localization (i18n)

- [x] N/A. This PR adds, changes, or removes no player-visible strings. `apPct`/`meleeDmgPct` are hidden baselines with no description or tooltip text.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] No generated files were hand-edited. The diff is two authored baseline values plus the test pin.

## Notes for reviewers

One known CI item, flagged rather than hidden: `tests/mob_portrait_source_manifest.test.ts` fails because `spec_baselines.ts` is bundled into the mob-portrait renderer fingerprint. This change touches no portrait art, only the bundle hash, so the committed manifest needs re-blessing on the canonical renderer (the routine `scripts/render_finder_portraits.mjs` receipt + `--write`, as in prior "re-bless the portrait seals" commits). I did not re-bless it here: on macOS that script renders with Metal (GPU), which is machine-specific, so re-blessing on this machine risks committing non-canonical portrait bytes. Any sim-content change trips this seal; it is a mechanical re-bless, not a balance regression.

Generated with Claude Code.
