### PR TITLE
balance(rogue): re-band combat to the 200 DPS band top

### DIFF
--- a/src/sim/content/spec_baselines.ts
+++ b/src/sim/content/spec_baselines.ts
@@ -68,8 +68,8 @@ export const SPEC_BASELINES: SpecBaselineTable = {
       ],
     },
     combat: {
-      stats: { ap: 24, crit: 0.14, apPct: 0.55 },
-      global: { meleeDmgPct: 0.36 },
+      stats: { ap: 24, crit: 0.14, apPct: 0.2 },
+      global: { meleeDmgPct: 0.16 },
       ability: [{ ability: 'sinister_strike', dmgPct: 0.2, costPct: -0.16 }],
     },
     subtlety: {

--- a/tests/spec_baselines.test.ts
+++ b/tests/spec_baselines.test.ts
@@ -52,9 +52,14 @@ const EXPECTED_BASELINES: Record<string, BaselineSnapshot> = {
       eviscerate: { dmgPct: 0.32 },
     },
   },
+  // fight-6498 re-band: combat sat ~50 DPS over assassination and ~60 over
+  // subtlety on the heroic Nythraxis check (~240 vs ~189 / ~179, behind the
+  // boss's 798 armor in the /dev BiS probe). apPct and meleeDmgPct were both the
+  // highest of the three rogue specs and drove its auto-heavy kit; trimming them
+  // lands combat at ~200 (the 150-200 band top), leaving the other two untouched.
   'rogue/combat': {
-    stats: { ap: 24, crit: 0.14, apPct: 0.55 },
-    global: { meleeDmgPct: 0.36 },
+    stats: { ap: 24, crit: 0.14, apPct: 0.2 },
+    global: { meleeDmgPct: 0.16 },
     abilities: { sinister_strike: { dmgPct: 0.2, costPct: -0.16 } },
   },
   'rogue/subtlety': {
@@ -345,8 +350,9 @@ describe('v0.28 passive restoration hotfix', () => {
     };
     const bare = apFor(null);
     for (const spec of ['assassination', 'combat']) {
-      // apPct is 0.36 to 0.55 across these specs, plus crit/flat AP; both clear
-      // a 1.3x AP floor over the spec-less rogue. A dropped apPct wiring fails here.
+      // apPct is 0.20 to 0.36 across these specs, plus crit/flat AP (combat's flat
+      // AP 24 carries it over the floor even at the lower apPct); both clear a 1.3x
+      // AP floor over the spec-less rogue. A dropped apPct wiring fails here.
       expect(apFor(spec), spec).toBeGreaterThan(bare * 1.3);
     }
     // 2026-08-09 120s band round: subtlety's apPct stepped 0.35 to 0.12 to


### PR DESCRIPTION
Combat rogue sat ~40 DPS above its sibling specs on the heroic Nythraxis check (the fight-6498 parse: 232 live; ~240 vs ~189 assassination / ~179 subtlety in the /dev BiS probe behind the boss's 798 armor at La Luna's rows). Its two damage baselines were both the highest of the three rogue specs and drove its auto-attack-heavy kit: apPct 0.55 and meleeDmgPct 0.36.

Trim them to 0.20 and 0.16. That lands combat at ~200 DPS (the top of the shared 150-200 band, still the strongest rogue spec) while leaving assassination (~189) and subtlety (~176) byte identical, both in baseline and measured DPS. Numbers only: no ability effect or tooltip text changes, since apPct/meleeDmgPct are hidden spec baselines. The spec-baseline pin in tests/spec_baselines.test.ts records the new values.

<!--
Thanks for contributing to World of ClaudeCraft!

New here? The contributing guide is available in your language:
https://github.com/levy-street/world-of-claudecraft/blob/main/CONTRIBUTING.md

Filling this out helps reviewers understand and merge your work faster. Anything
that doesn't apply to your change, feel free to delete or mark as N/A.
-->

## Summary

<!-- What does this PR change, and why? Link the motivation or design if there is one. -->

## Related issues

<!-- e.g. "Closes #123" or "Part of #456". Remove this section if it doesn't apply. -->

## Type of change

<!-- Check all that apply. -->

- [ ] Feature: new functionality
- [ ] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [ ] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

<!-- The commands you ran and the manual steps you walked through. Be specific. -->

- Commands:
- Manual steps:

## Screenshots / recordings

<!--
If this PR changes anything a player or operator sees (HUD, windows, tooltips,
mobile controls, admin dashboard), please add before/after screenshots or a
short clip, on desktop and mobile where relevant. Remove this section for non-UI
changes.
-->

---

## Checklist

Tick the items that apply to your change. It's fine to leave the rest unchecked
or strike them through (`~like this~`) when they don't.

### Quality

- [ ] **The gate passes.** `node scripts/gate_select.mjs` is green (or `npm run gate` for
      the full suite). I added or updated decisive
      tests for changed behavior and recorded any manual checks above.

### Cross-platform

- [ ] **Tested on desktop and mobile.** Verified on a desktop and on a
      phone-sized viewport in both portrait and landscape. Touch targets stay at
      least 40x40px and inputs at least 16px font (see `src/ui/CLAUDE.md`).
- [ ] **Accessible.** Keyboard-operable, with visible focus, sensible ARIA, and
      respect for `prefers-reduced-motion` (only if this change adds or edits UI).

### Localization (i18n)

- [ ] **New player-visible strings follow the contributor policy.** Every user-facing
      string is a `t()` key added to the matching English catalog. I did not edit locale
      overlays, except for the five required non-Latin fills when the M16 wordy-copy
      rule applies (see `src/ui/CLAUDE.md`).
- [ ] Numbers, money, dates, units, and percents go through the i18n formatters
      (`formatNumber`, `formatMoney`, `formatDateTime`, `Intl`).
- [ ] Player-facing text emitted from `src/sim/` or `server/` is re-localized at
      the client boundary in this same change, and
      `npx vitest run tests/localization_fixes.test.ts` passes.
- [ ] N/A. This PR adds no player-visible strings.

### Hygiene

- [ ] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [ ] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.

> Commit messages and PR titles use [Conventional Commits](https://www.conventionalcommits.org/)
> with a required scope (`feat(talents): ...`, `fix(net): ...`).

---

A complete checklist and a green CI run (tests, typecheck, and builds) are what
we look for before merging. Smaller, focused PRs land faster than large ones, and
reviewers may suggest changes, which is a normal and friendly part of the
process. Thank you for helping build World of ClaudeCraft. Questions? Join us on
[Discord](https://discord.com/invite/worldofclaudecraft).
