### PR TITLE
fix(docker): allowlist build_bundle_pregen.mjs in the image build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,6 +12,7 @@ tests
 scripts/*
 !scripts/build_media_manifest.mjs
 !scripts/build_sfx_manifest.mjs
+!scripts/build_bundle_pregen.mjs
 !scripts/build_server.mjs
 !scripts/build_bot.mjs
 !scripts/migrate_old_cragmaw_pelt.ts


### PR DESCRIPTION
## Summary

The v0.37.0 pregen concurrency change made `build:bundle` invoke `scripts/build_bundle_pregen.mjs`, but `.dockerignore`'s `scripts/*` allowlist never gained the exception. The Docker build context therefore omits the file and the game image build fails with:

```
Error: Cannot find module '/app/scripts/build_bundle_pregen.mjs'
```

CI never catches this class of breakage because its four builds run on the raw checkout, never through Docker. The first production deploy of v0.37.0 caught it at the pre-countdown build gate (no player-visible impact; the deploy stopped before the restart countdown, old version still serving).

The script imports only node builtins (`node:child_process`, `node:url`), and everything it spawns (`build_sitemap`, `build_sfx_manifest`, `build_media_manifest`) is already allowlisted, so this one-line exception is the complete fix.

## How was this tested?

- Reproduced on the prod host: `docker compose build` fails at Dockerfile step 32 with the missing-module error.
- The deploy will be re-run after this merges; the image build is the verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)