### PR TITLE
fix(server): one-off rift forge rollback data migration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -17,6 +17,8 @@ scripts/*
 !scripts/build_bot.mjs
 !scripts/migrate_old_cragmaw_pelt.ts
 !scripts/old_cragmaw_pelt_migration.ts
+!scripts/migrate_rift_forge_rollback.ts
+!scripts/rift_forge_rollback_migration.ts
 !scripts/build_sitemap.mjs
 !scripts/browserslist_targets.mjs
 !scripts/check_backdrop_survival.mjs

--- a/scripts/build_server.mjs
+++ b/scripts/build_server.mjs
@@ -30,4 +30,14 @@ await esbuild.build({
   alias: { '#bot-detector': usePrivate ? privateImpl : stubImpl },
 });
 
+await esbuild.build({
+  entryPoints: ['scripts/migrate_rift_forge_rollback.ts'],
+  bundle: true,
+  platform: 'node',
+  format: 'cjs',
+  external: ['pg-native'],
+  outfile: 'dist-server/migrate_rift_forge_rollback.cjs',
+  alias: { '#bot-detector': usePrivate ? privateImpl : stubImpl },
+});
+
 console.log(`[build:server] bot detector: ${usePrivate ? 'private' : 'stub (no-op)'}`);

--- a/scripts/migrate_rift_forge_rollback.ts
+++ b/scripts/migrate_rift_forge_rollback.ts
@@ -1,0 +1,6 @@
+import { runRiftForgeRollbackMigration } from './rift_forge_rollback_migration';
+
+runRiftForgeRollbackMigration(process.argv.slice(2)).catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/scripts/rift_forge_rollback_migration.ts
+++ b/scripts/rift_forge_rollback_migration.ts
@@ -1,0 +1,468 @@
+// One-off remediation for the Rift forge wire exploit (PR #3329 closed the
+// hole; this reverses its gains). The three forge commands were dispatchable
+// by any authenticated client while the forge UI never shipped, so every
+// forge effect in production data is exploit-derived: upgrade levels,
+// enchants, and socketed gems on Riftbound gear. This migration resets each
+// affected item instance to its as-dropped state and refunds what the forge
+// consumed: essence for upgrades and enchants, gem items for sockets.
+//
+// Costs mirror src/sim/rift/progression.ts and are pinned against it by
+// tests/rift_forge_rollback_migration.test.ts:
+//   upgrade step k costs 2 + 2k essence, so reaching level N cost N * (N + 1)
+//   enchant costs a flat 4 essence
+//   socketing consumes the gem item only, no essence
+//
+// THIS IS A ONE-OFF, NOT A STANDING MIGRATION. The cragmaw migration can run
+// on every deploy because its matching condition (a retired item id) can
+// never legitimately reappear. This one is the opposite: if the Rift forge
+// ships for real later, forge effects on items become LEGITIMATE state, and
+// re-running this rollback would wipe honest players' progress. Two guards
+// enforce the one-off contract:
+//   1. The deploy playbook gates it behind eastbrook_run_rift_forge_rollback,
+//      which defaults to false and is passed explicitly for one deploy only.
+//   2. On a successful --apply this script writes a completion marker row
+//      (world_state key below) in the same transaction, and every later run
+//      refuses outright while the marker exists.
+//
+// Run with no flags for a dry run; --apply writes. Otherwise modeled on
+// old_cragmaw_pelt_migration.ts, the deploy-time precedent.
+
+import { Pool } from 'pg';
+
+const RIFT_ESSENCE_ITEM_ID = 'rift_essence';
+const REFUND_STACK_SIZE = 20;
+const ENCHANT_ESSENCE_COST = 4;
+
+/** Completion marker: present in world_state means this one-off already ran
+ *  and must never run again (see the header comment). */
+export const COMPLETION_MARKER_KEY = 'migration:rift-forge-rollback-2026-08-13';
+
+interface Options {
+  apply: boolean;
+  realm?: string;
+}
+
+export interface RiftPayloadLike {
+  upgradeLevel?: unknown;
+  enchant?: unknown;
+  gems?: unknown;
+  baseStats?: unknown;
+  [key: string]: unknown;
+}
+
+export interface InstanceLike {
+  rift?: RiftPayloadLike;
+  rolled?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+export interface SlotLike {
+  itemId?: unknown;
+  count?: unknown;
+  instance?: unknown;
+  [key: string]: unknown;
+}
+
+export interface RollbackRefund {
+  essence: number;
+  gems: string[];
+}
+
+interface InstanceRollback {
+  changed: boolean;
+  value: InstanceLike;
+  refund: RollbackRefund;
+}
+
+export function upgradeEssenceSpent(level: number): number {
+  if (!Number.isFinite(level) || level <= 0) return 0;
+  return level * (level + 1);
+}
+
+function asNumber(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0;
+}
+
+/** Mirrors rebuildRolledStats in src/sim/rift/progression.ts at the reset
+ *  state (level 0, no enchant, no gems): base stats only, with `sta`
+ *  materialized the same way the live rebuild materializes it. */
+function resetRolledStats(instance: InstanceLike, rift: RiftPayloadLike): Record<string, unknown> {
+  const base =
+    rift.baseStats && typeof rift.baseStats === 'object'
+      ? (rift.baseStats as Record<string, unknown>)
+      : {};
+  const stats: Record<string, number> = {};
+  for (const [key, value] of Object.entries(base)) stats[key] = asNumber(value);
+  stats.sta = stats.sta ?? 0;
+  return { ...(instance.rolled ?? {}), quality: 'epic', stats };
+}
+
+export function rollbackInstance(instance: unknown): InstanceRollback {
+  const empty: RollbackRefund = { essence: 0, gems: [] };
+  if (!instance || typeof instance !== 'object' || !('rift' in instance)) {
+    return { changed: false, value: instance as InstanceLike, refund: empty };
+  }
+  const source = instance as InstanceLike;
+  const rift = source.rift;
+  if (!rift || typeof rift !== 'object') {
+    return { changed: false, value: source, refund: empty };
+  }
+
+  const upgradeLevel = asNumber(rift.upgradeLevel);
+  const hasEnchant = rift.enchant != null && typeof rift.enchant === 'object';
+  const gems = Array.isArray(rift.gems)
+    ? rift.gems.filter((gem): gem is string => typeof gem === 'string')
+    : [];
+  if (upgradeLevel <= 0 && !hasEnchant && gems.length === 0) {
+    return { changed: false, value: source, refund: empty };
+  }
+
+  const nextRift: RiftPayloadLike = { ...rift, upgradeLevel: 0, gems: [] };
+  delete nextRift.enchant;
+  const value: InstanceLike = {
+    ...source,
+    rift: nextRift,
+    rolled: resetRolledStats(source, rift),
+  };
+  return {
+    changed: true,
+    value,
+    refund: {
+      essence: upgradeEssenceSpent(upgradeLevel) + (hasEnchant ? ENCHANT_ESSENCE_COST : 0),
+      gems,
+    },
+  };
+}
+
+interface SlotsRollback {
+  changed: boolean;
+  value: unknown;
+  refund: RollbackRefund;
+  instancesReset: number;
+}
+
+function mergeRefund(into: RollbackRefund, from: RollbackRefund): void {
+  into.essence += from.essence;
+  into.gems.push(...from.gems);
+}
+
+export function rollbackSlots(slots: unknown): SlotsRollback {
+  const refund: RollbackRefund = { essence: 0, gems: [] };
+  if (!Array.isArray(slots)) return { changed: false, value: slots, refund, instancesReset: 0 };
+
+  let changed = false;
+  let instancesReset = 0;
+  const value = slots.map((slot) => {
+    if (!slot || typeof slot !== 'object' || !('instance' in slot)) return slot;
+    const slotRecord = slot as SlotLike;
+    const result = rollbackInstance(slotRecord.instance);
+    if (!result.changed) return slot;
+    changed = true;
+    instancesReset += 1;
+    mergeRefund(refund, result.refund);
+    return { ...slotRecord, instance: result.value };
+  });
+
+  return { changed, value: changed ? value : slots, refund, instancesReset };
+}
+
+export function rollbackInstanceRecord(record: unknown): SlotsRollback {
+  const refund: RollbackRefund = { essence: 0, gems: [] };
+  if (!record || typeof record !== 'object' || Array.isArray(record)) {
+    return { changed: false, value: record, refund, instancesReset: 0 };
+  }
+
+  let changed = false;
+  let instancesReset = 0;
+  const next: Record<string, unknown> = {};
+  for (const [slot, instance] of Object.entries(record)) {
+    const result = rollbackInstance(instance);
+    if (result.changed) {
+      changed = true;
+      instancesReset += 1;
+      mergeRefund(refund, result.refund);
+      next[slot] = result.value;
+    } else {
+      next[slot] = instance;
+    }
+  }
+
+  return { changed, value: changed ? next : record, refund, instancesReset };
+}
+
+/** Adds refunded items to an inventory immutably: tops up existing plain
+ *  stacks of the same item first, then appends new stacks. The sim load path
+ *  tolerates an over-capacity inventory (capacity only blocks new pickups),
+ *  so appending is always safe. */
+export function addRefundToInventory(inventory: unknown, itemId: string, count: number): unknown {
+  if (count <= 0) return inventory;
+  const slots = Array.isArray(inventory) ? [...inventory] : [];
+  let remaining = count;
+
+  for (let i = 0; i < slots.length && remaining > 0; i += 1) {
+    const slot = slots[i];
+    if (!slot || typeof slot !== 'object') continue;
+    const slotRecord = slot as SlotLike;
+    if (slotRecord.itemId !== itemId || slotRecord.instance != null) continue;
+    const current = asNumber(slotRecord.count);
+    if (current >= REFUND_STACK_SIZE) continue;
+    const add = Math.min(REFUND_STACK_SIZE - current, remaining);
+    slots[i] = { ...slotRecord, count: current + add };
+    remaining -= add;
+  }
+
+  while (remaining > 0) {
+    const add = Math.min(REFUND_STACK_SIZE, remaining);
+    slots.push({ itemId, count: add });
+    remaining -= add;
+  }
+
+  return slots;
+}
+
+export interface CharacterRollbackReport {
+  instancesReset: number;
+  essenceRefunded: number;
+  gemsReturned: Record<string, number>;
+}
+
+interface CharacterRollback {
+  changed: boolean;
+  value: unknown;
+  report: CharacterRollbackReport;
+}
+
+export function rollbackCharacterState(state: unknown): CharacterRollback {
+  const report: CharacterRollbackReport = {
+    instancesReset: 0,
+    essenceRefunded: 0,
+    gemsReturned: {},
+  };
+  if (!state || typeof state !== 'object') return { changed: false, value: state, report };
+
+  const source = state as Record<string, unknown>;
+  const next: Record<string, unknown> = { ...source };
+  const refund: RollbackRefund = { essence: 0, gems: [] };
+  let changed = false;
+  let instancesReset = 0;
+
+  for (const key of ['inventory', 'vendorBuyback']) {
+    const result = rollbackSlots(source[key]);
+    if (result.changed) {
+      changed = true;
+      instancesReset += result.instancesReset;
+      mergeRefund(refund, result.refund);
+      next[key] = result.value;
+    }
+  }
+
+  const bank = source.bank;
+  if (bank && typeof bank === 'object') {
+    const bankRecord = bank as Record<string, unknown>;
+    const result = rollbackSlots(bankRecord.inventory);
+    if (result.changed) {
+      changed = true;
+      instancesReset += result.instancesReset;
+      mergeRefund(refund, result.refund);
+      next.bank = { ...bankRecord, inventory: result.value };
+    }
+  }
+
+  for (const key of ['equipmentInstance', 'equipmentInstances']) {
+    const result = rollbackInstanceRecord(source[key]);
+    if (result.changed) {
+      changed = true;
+      instancesReset += result.instancesReset;
+      mergeRefund(refund, result.refund);
+      next[key] = result.value;
+    }
+  }
+
+  if (!changed) return { changed: false, value: state, report };
+
+  let inventory = next.inventory ?? source.inventory;
+  inventory = addRefundToInventory(inventory, RIFT_ESSENCE_ITEM_ID, refund.essence);
+  const gemCounts: Record<string, number> = {};
+  for (const gem of refund.gems) gemCounts[gem] = (gemCounts[gem] ?? 0) + 1;
+  for (const [gemId, gemCount] of Object.entries(gemCounts)) {
+    inventory = addRefundToInventory(inventory, gemId, gemCount);
+  }
+  next.inventory = inventory;
+
+  report.instancesReset = instancesReset;
+  report.essenceRefunded = refund.essence;
+  report.gemsReturned = gemCounts;
+  return { changed: true, value: next, report };
+}
+
+function parseArgs(argv: readonly string[]): Options {
+  let realm: string | undefined;
+  let apply = false;
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--apply') {
+      apply = true;
+      continue;
+    }
+    if (arg === '--realm') {
+      realm = argv[i + 1]?.trim();
+      i += 1;
+      continue;
+    }
+    if (arg.startsWith('--realm=')) {
+      realm = arg.slice('--realm='.length).trim();
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return { apply, realm: realm || undefined };
+}
+
+const REMAINING_FORGE_EFFECTS_PATH =
+  '$.**.rift ? (@.upgradeLevel > 0 || exists(@.enchant) || @.gems.size() > 0)';
+
+export async function runRiftForgeRollbackMigration(argv: readonly string[]): Promise<void> {
+  try {
+    process.loadEnvFile?.();
+  } catch {
+    // .env is optional; production injects DATABASE_URL through Docker Compose.
+  }
+
+  const { apply, realm } = parseArgs(argv);
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    throw new Error('DATABASE_URL is required.');
+  }
+
+  const pool = new Pool({ connectionString: databaseUrl, max: 2 });
+  const likeNeedle = '%"rift":%';
+  const realmParams: string[] = realm ? [likeNeedle, realm] : [likeNeedle];
+  const realmClause = realm ? ' AND realm = $2' : '';
+
+  let scanned = 0;
+  let changedCharacters = 0;
+  let totalInstances = 0;
+  let totalEssence = 0;
+  const totalGems: Record<string, number> = {};
+  let committed = false;
+
+  try {
+    const marker = await pool.query<{ data: unknown }>(
+      'SELECT data FROM world_state WHERE key = $1',
+      [COMPLETION_MARKER_KEY],
+    );
+    if (marker.rows.length > 0) {
+      console.log(
+        `Refusing to run: completion marker ${COMPLETION_MARKER_KEY} exists. ` +
+          'This rollback is a one-off that already applied; forge effects found now ' +
+          `are presumed legitimate. Marker: ${JSON.stringify(marker.rows[0].data)}`,
+      );
+      return;
+    }
+
+    await pool.query('BEGIN');
+
+    const characters = await pool.query<{
+      id: number;
+      name: string;
+      realm: string;
+      state: unknown;
+    }>(
+      `SELECT id, name, realm, state
+       FROM characters
+       WHERE state IS NOT NULL AND state::text LIKE $1${realmClause}
+       ORDER BY id ASC`,
+      realmParams,
+    );
+
+    for (const row of characters.rows) {
+      scanned += 1;
+      const result = rollbackCharacterState(row.state);
+      if (!result.changed) continue;
+
+      changedCharacters += 1;
+      totalInstances += result.report.instancesReset;
+      totalEssence += result.report.essenceRefunded;
+      for (const [gemId, gemCount] of Object.entries(result.report.gemsReturned)) {
+        totalGems[gemId] = (totalGems[gemId] ?? 0) + gemCount;
+      }
+      const gems = Object.entries(result.report.gemsReturned)
+        .map(([gemId, gemCount]) => `${gemId} x${gemCount}`)
+        .join(', ');
+      console.log(
+        `character ${row.id} "${row.name}" (${row.realm}): ` +
+          `reset ${result.report.instancesReset} item(s), ` +
+          `refunded ${result.report.essenceRefunded} essence` +
+          (gems ? `, returned ${gems}` : ''),
+      );
+
+      if (apply) {
+        await pool.query('UPDATE characters SET state = $1 WHERE id = $2', [
+          JSON.stringify(result.value),
+          row.id,
+        ]);
+      }
+    }
+
+    if (apply) {
+      const remaining = await pool.query<{ count: string }>(
+        `SELECT count(*)::text AS count
+         FROM characters
+         WHERE state IS NOT NULL
+           AND jsonb_path_exists(state::jsonb, $1)${realm ? ' AND realm = $2' : ''}`,
+        realm ? [REMAINING_FORGE_EFFECTS_PATH, realm] : [REMAINING_FORGE_EFFECTS_PATH],
+      );
+      if (Number(remaining.rows[0]?.count ?? 0) > 0) {
+        throw new Error('Migration verification failed: forge effects remain after rollback.');
+      }
+      await pool.query(
+        `INSERT INTO world_state (key, data, updated_at) VALUES ($1, $2, now())
+         ON CONFLICT (key) DO NOTHING`,
+        [
+          COMPLETION_MARKER_KEY,
+          JSON.stringify({
+            charactersUpdated: changedCharacters,
+            instancesReset: totalInstances,
+            essenceRefunded: totalEssence,
+            gemsReturned: totalGems,
+            realmScope: realm ?? 'all',
+          }),
+        ],
+      );
+      await pool.query('COMMIT');
+      committed = true;
+    } else {
+      await pool.query('ROLLBACK');
+    }
+  } catch (err) {
+    if (!committed) {
+      try {
+        await pool.query('ROLLBACK');
+      } catch {
+        // Ignore rollback errors after a failed or already closed transaction.
+      }
+    }
+    throw err;
+  } finally {
+    await pool.end();
+  }
+
+  const scope = realm ? `realm "${realm}"` : 'all realms';
+  const mode = apply ? 'updated' : 'would update';
+  const gemSummary = Object.entries(totalGems)
+    .map(([gemId, gemCount]) => `${gemId} x${gemCount}`)
+    .join(', ');
+  console.log(
+    [
+      `Rift forge rollback (${scope}):`,
+      `characters scanned=${scanned}, ${mode}=${changedCharacters},`,
+      `instances reset=${totalInstances}, essence refunded=${totalEssence}` +
+        (gemSummary ? `, gems returned: ${gemSummary}` : ''),
+    ].join(' '),
+  );
+  if (!apply) {
+    console.log('Dry run only. Re-run with --apply to write rolled-back state.');
+  }
+}

--- a/tests/rift_forge_rollback_migration.test.ts
+++ b/tests/rift_forge_rollback_migration.test.ts
@@ -1,0 +1,253 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, test } from 'vitest';
+import {
+  addRefundToInventory,
+  COMPLETION_MARKER_KEY,
+  rollbackCharacterState,
+  rollbackInstance,
+  upgradeEssenceSpent,
+} from '../scripts/rift_forge_rollback_migration';
+import { RIFT_ITEMS } from '../src/sim/content/rift/items';
+
+function forgedRing(overrides: Record<string, unknown> = {}) {
+  return {
+    rolled: { quality: 'epic', stats: { str: 11, sta: 9, int: 4 } } as Record<string, unknown>,
+    rift: {
+      sourceEventId: 'rift-1-test',
+      tier: 'S',
+      power: 4,
+      upgradeLevel: 5,
+      maxUpgradeLevel: 5,
+      baseStats: { str: 4, sta: 2 },
+      enchant: { stat: 'str', value: 2 },
+      gemSlots: 2,
+      gems: ['rift_gem_crimson', 'rift_gem_azure'],
+      ...overrides,
+    },
+  };
+}
+
+describe('one-off contract', () => {
+  const migrationSource = readFileSync('scripts/rift_forge_rollback_migration.ts', 'utf8');
+
+  test('the completion marker key is namespaced and date-stamped', () => {
+    expect(COMPLETION_MARKER_KEY).toMatch(/^migration:rift-forge-rollback-\d{4}-\d{2}-\d{2}$/);
+  });
+
+  test('the runner refuses while the marker exists and writes it inside the apply transaction', () => {
+    // Source pins rather than a live database: the refusal must happen before
+    // BEGIN, and the marker insert must happen between verification and COMMIT,
+    // so a failed apply never records completion.
+    const refusalIndex = migrationSource.indexOf('Refusing to run: completion marker');
+    const beginIndex = migrationSource.indexOf("await pool.query('BEGIN')");
+    const markerInsertIndex = migrationSource.indexOf('INSERT INTO world_state');
+    const commitIndex = migrationSource.indexOf("await pool.query('COMMIT')");
+    expect(refusalIndex).toBeGreaterThan(-1);
+    expect(beginIndex).toBeGreaterThan(refusalIndex);
+    expect(markerInsertIndex).toBeGreaterThan(beginIndex);
+    expect(commitIndex).toBeGreaterThan(markerInsertIndex);
+  });
+});
+
+describe('cost model parity with src/sim/rift/progression.ts', () => {
+  const progressionSource = readFileSync('src/sim/rift/progression.ts', 'utf8');
+
+  test('upgrade step cost in the sim is 2 + 2 * level', () => {
+    expect(progressionSource).toContain('const cost = 2 + gear.upgradeLevel * 2;');
+  });
+
+  test('enchant cost in the sim is a flat 4', () => {
+    expect(progressionSource).toContain('const cost = 4;');
+  });
+
+  test('socketing consumes exactly one gem item and no essence', () => {
+    expect(progressionSource).toContain('ctx.removeItem(gemId, 1, r.meta.entityId);');
+  });
+
+  test('refund stack size matches the essence and gem item stack size', () => {
+    expect(RIFT_ITEMS.rift_essence.stackSize).toBe(20);
+    expect(RIFT_ITEMS.rift_gem_crimson.stackSize).toBe(20);
+  });
+});
+
+describe('upgradeEssenceSpent', () => {
+  test('sums the per-step ladder: reaching level N cost N * (N + 1)', () => {
+    // Steps cost 2, 4, 6, 8, 10: cumulative 2, 6, 12, 20, 30.
+    expect(upgradeEssenceSpent(0)).toBe(0);
+    expect(upgradeEssenceSpent(1)).toBe(2);
+    expect(upgradeEssenceSpent(2)).toBe(6);
+    expect(upgradeEssenceSpent(3)).toBe(12);
+    expect(upgradeEssenceSpent(4)).toBe(20);
+    expect(upgradeEssenceSpent(5)).toBe(30);
+  });
+
+  test('tolerates junk input', () => {
+    expect(upgradeEssenceSpent(Number.NaN)).toBe(0);
+    expect(upgradeEssenceSpent(-3)).toBe(0);
+  });
+});
+
+describe('rollbackInstance', () => {
+  test('fully forged ring refunds 34 essence and both gems', () => {
+    const result = rollbackInstance(forgedRing());
+    expect(result.changed).toBe(true);
+    expect(result.refund.essence).toBe(34);
+    expect(result.refund.gems).toEqual(['rift_gem_crimson', 'rift_gem_azure']);
+  });
+
+  test('resets the payload to its as-dropped state', () => {
+    const result = rollbackInstance(forgedRing());
+    const rift = result.value.rift as Record<string, unknown>;
+    expect(rift.upgradeLevel).toBe(0);
+    expect(rift.gems).toEqual([]);
+    expect('enchant' in rift).toBe(false);
+    expect(rift.baseStats).toEqual({ str: 4, sta: 2 });
+    expect(rift.maxUpgradeLevel).toBe(5);
+    expect(rift.sourceEventId).toBe('rift-1-test');
+  });
+
+  test('rebuilds rolled stats to base stats, materializing sta like the live rebuild', () => {
+    const result = rollbackInstance(forgedRing({ baseStats: { int: 4, spi: 2 } }));
+    expect(result.value.rolled).toEqual({
+      quality: 'epic',
+      stats: { int: 4, spi: 2, sta: 0 },
+    });
+  });
+
+  test('preserves unrelated rolled fields and instance fields', () => {
+    const instance = { ...forgedRing(), signer: 'Somebody' };
+    instance.rolled = { ...instance.rolled, masterwork: true };
+    const result = rollbackInstance(instance);
+    expect(result.value.signer).toBe('Somebody');
+    expect((result.value.rolled as Record<string, unknown>).masterwork).toBe(true);
+  });
+
+  test('does not mutate the input instance', () => {
+    const instance = forgedRing();
+    const snapshot = JSON.parse(JSON.stringify(instance));
+    rollbackInstance(instance);
+    expect(instance).toEqual(snapshot);
+  });
+
+  test('an unforged rift item is untouched', () => {
+    const result = rollbackInstance(forgedRing({ upgradeLevel: 0, enchant: undefined, gems: [] }));
+    expect(result.changed).toBe(false);
+    expect(result.refund.essence).toBe(0);
+  });
+
+  test('a non-rift instance is untouched', () => {
+    const instance = { rolled: { quality: 'rare', stats: { agi: 3 } } };
+    const result = rollbackInstance(instance);
+    expect(result.changed).toBe(false);
+  });
+
+  test('upgrade-only ring refunds essence with no gems', () => {
+    const result = rollbackInstance(forgedRing({ enchant: undefined, gems: [] }));
+    expect(result.refund.essence).toBe(30);
+    expect(result.refund.gems).toEqual([]);
+  });
+});
+
+describe('addRefundToInventory', () => {
+  test('tops up an existing plain stack before appending', () => {
+    const inventory = [{ itemId: 'rift_essence', count: 15 }];
+    const result = addRefundToInventory(inventory, 'rift_essence', 30) as Array<{
+      itemId: string;
+      count: number;
+    }>;
+    expect(result).toEqual([
+      { itemId: 'rift_essence', count: 20 },
+      { itemId: 'rift_essence', count: 20 },
+      { itemId: 'rift_essence', count: 5 },
+    ]);
+  });
+
+  test('never tops up a stack that carries an instance payload', () => {
+    const inventory = [{ itemId: 'rift_essence', count: 1, instance: { signer: 'X' } }];
+    const result = addRefundToInventory(inventory, 'rift_essence', 2) as Array<{ count: number }>;
+    expect(result[0].count).toBe(1);
+    expect(result[1]).toEqual({ itemId: 'rift_essence', count: 2 });
+  });
+
+  test('appends past capacity rather than dropping a refund', () => {
+    const inventory = Array.from({ length: 16 }, (_, i) => ({ itemId: `filler_${i}`, count: 1 }));
+    const result = addRefundToInventory(inventory, 'rift_essence', 68) as unknown[];
+    expect(result.length).toBe(20);
+  });
+
+  test('does not mutate the input inventory', () => {
+    const inventory = [{ itemId: 'rift_essence', count: 15 }];
+    addRefundToInventory(inventory, 'rift_essence', 30);
+    expect(inventory).toEqual([{ itemId: 'rift_essence', count: 15 }]);
+  });
+});
+
+describe('rollbackCharacterState', () => {
+  test('covers equipped, bagged, banked, buyback, and legacy-key instances', () => {
+    const state = {
+      inventory: [
+        { itemId: 'riftbound_band_of_might', count: 1, instance: forgedRing() },
+        { itemId: 'rift_essence', count: 3 },
+      ],
+      vendorBuyback: [{ itemId: 'riftbound_band_of_guile', count: 1, instance: forgedRing() }],
+      bank: {
+        inventory: [{ itemId: 'riftbound_band_of_insight', count: 1, instance: forgedRing() }],
+        purchasedSlots: 0,
+        bonusSlots: 0,
+      },
+      equipmentInstance: { ring1: forgedRing() },
+      equipmentInstances: { ring2: forgedRing() },
+    };
+
+    const result = rollbackCharacterState(state);
+    expect(result.changed).toBe(true);
+    expect(result.report.instancesReset).toBe(5);
+    expect(result.report.essenceRefunded).toBe(170);
+    expect(result.report.gemsReturned).toEqual({
+      rift_gem_crimson: 5,
+      rift_gem_azure: 5,
+    });
+
+    const inventory = (result.value as Record<string, unknown>).inventory as Array<{
+      itemId: string;
+      count: number;
+    }>;
+    const essenceTotal = inventory
+      .filter((slot) => slot.itemId === 'rift_essence')
+      .reduce((sum, slot) => sum + slot.count, 0);
+    expect(essenceTotal).toBe(173);
+  });
+
+  test('is idempotent: a second pass changes nothing', () => {
+    const state = {
+      inventory: [{ itemId: 'riftbound_band_of_might', count: 1, instance: forgedRing() }],
+    };
+    const first = rollbackCharacterState(state);
+    const second = rollbackCharacterState(first.value);
+    expect(second.changed).toBe(false);
+  });
+
+  test('a character with no forge effects is untouched', () => {
+    const state = {
+      inventory: [
+        {
+          itemId: 'riftbound_band_of_might',
+          count: 1,
+          instance: forgedRing({ upgradeLevel: 0, enchant: undefined, gems: [] }),
+        },
+      ],
+    };
+    const result = rollbackCharacterState(state);
+    expect(result.changed).toBe(false);
+    expect(result.value).toBe(state);
+  });
+
+  test('does not mutate the input state', () => {
+    const state = {
+      inventory: [{ itemId: 'riftbound_band_of_might', count: 1, instance: forgedRing() }],
+    };
+    const snapshot = JSON.parse(JSON.stringify(state));
+    rollbackCharacterState(state);
+    expect(state).toEqual(snapshot);
+  });
+});


### PR DESCRIPTION
## Summary

Reverses the gains of the Rift forge wire exploit that PR #3329 gated off. The three forge commands were dispatchable by any authenticated client while the forge UI never shipped, so every forge effect in production data is exploit-derived. The migration, run in the deploy's stopped-game window:

- Resets upgrade level, enchant, and socketed gems on every forged item instance, across inventory, vendor buyback, bank, and both equipment-instance keys (including the legacy plural key).
- Refunds the exact essence the forge consumed: the upgrade ladder totals N * (N + 1) for level N, plus a flat 4 per enchant, matching src/sim/rift/progression.ts (pinned by the test suite).
- Returns socketed gems as items (socketing consumed the gem, no essence).
- Rebuilds rolled stats to the as-dropped base, replicating rebuildRolledStats at the reset state.
- Refund delivery tops up existing plain stacks then appends new ones; the sim load path tolerates over-capacity inventories, so no refund can be dropped.

Current production blast radius (read-only query, 2026-08-13): 6 characters on Claudemoon, 12 rings, all at max upgrade with enchant and two gems each; 408 essence and 24 gems total to refund.

### One-off contract (the critical property)

If the forge ships for real later, forge effects become legitimate state, and a standing migration would wipe honest players. Two independent guards:

1. On a successful apply, a completion marker row is written to world_state inside the same transaction; any later run refuses outright while the marker exists. A test pins that the refusal happens before BEGIN and the marker write sits between verification and COMMIT, so a failed apply never records completion.
2. The deploy playbook (woc-deploy) gates the tasks behind eastbrook_run_rift_forge_rollback, default false, passed explicitly for one deploy only.

Dry-run by default; --apply writes in one transaction with post-verification that zero forge effects remain. Modeled on old_cragmaw_pelt_migration.ts.

Also allowlists both new scripts in .dockerignore (the same omission that broke the first v0.37.0 production deploy for build_bundle_pregen.mjs) and adds the dist-server esbuild entry.

## Type of change

- [x] Bug fix
- [x] Build, CI, or tooling

## How was this tested?

- Commands: npx vitest run tests/rift_forge_rollback_migration.test.ts (24 tests: cost-model parity pins against progression.ts, payload reset fidelity, refund stacking and over-capacity append, all five container walks, idempotence, immutability, one-off marker contract). npx tsc --noEmit clean. Biome clean on changed files.
- Manual steps: read-only jsonb queries against production enumerated the affected characters and payloads; the dry run against production during the deploy is the final verification before --apply.