### PR TITLE
fix(ci): send plugin_version in the OTA publish verification probe

### DIFF
--- a/.github/workflows/ota-publish.yml
+++ b/.github/workflows/ota-publish.yml
@@ -144,10 +144,15 @@ jobs:
           # proves the whole chain, not just the upload; an offer WITHOUT the
           # embedded delta manifest means the entry list failed validation and
           # every device would silently take the full zip, so that fails too.
+          # The probe MUST send a delta-capable plugin_version: the server
+          # fail-safes the plugin gate (pluginSupportsDeltaManifest) to
+          # zip-only when the field is absent, so a probe without it reads a
+          # healthy delta channel as a validation failure (the 0.37.0 deploy
+          # false-alarmed on exactly this).
           for attempt in $(seq 1 12); do
             offer="$(curl -sS --max-time 30 -X POST https://worldofclaudecraft.com/api/ota/updates \
               -H 'content-type: application/json' \
-              -d '{"platform":"ios","version_name":"builtin","version_build":"0.0.1"}')"
+              -d '{"platform":"ios","version_name":"builtin","version_build":"0.0.1","plugin_version":"8.0.0"}')"
             offered="$(echo "${offer}" | jq -r '.version // empty')"
             if [ "${offered}" = "${VERSION}" ]; then
               entries="$(echo "${offer}" | jq -r '.manifest | length // 0')"


### PR DESCRIPTION
## Summary

The OTA publish workflow's end-to-end verification probes /api/ota/updates without a plugin_version. The server deliberately fail-safes the delta plugin gate (pluginSupportsDeltaManifest) to a zip-only offer when the field is absent, so the probe can never see an embedded manifest and the step fails with "the entry list failed validation" even when the delta channel is fully healthy.

This is exactly what happened on the 0.37.0 production deploy: the run failed at verification, but replaying the same probe with plugin_version 8.0.0 returned the 0.37.0 offer with all 5,119 delta manifest entries embedded. Production was healthy the whole time; the verifier could not qualify for the delta offer it was asserting on.

The fix sends a delta-capable plugin_version (8.0.0, above the 6.1.0 minimum) in the probe body, and the step comment now records the trap.

## Type of change

- [x] Build, CI, or tooling

## How was this tested?

- Commands: replayed both probe bodies against production. Without plugin_version: offer with no manifest field. With plugin_version 8.0.0: offer with 5,119 manifest entries. The fixed probe body is byte-identical to the verified curl.
- The next release deploy exercises the fixed step end to end.