### PR TITLE
fix(ui): arm the queue-pop popups until the offer snapshot arrives

### DIFF
--- a/src/ui/dungeon_finder_proposal_popup.ts
+++ b/src/ui/dungeon_finder_proposal_popup.ts
@@ -6,10 +6,20 @@
 // buttons are tab-reachable and localized.
 //
 // Perf contract: closed it does zero work (hud.update() gates on isOpen; it
-// only OPENS from the dfProposal SimEvent). While open it polls the finder
+// only ARMS from the dfProposal SimEvent). While open it polls the finder
 // snapshot at the mediumHud cadence, rebuilds DOM only when the structural
 // signature changes, refreshes the countdown text slot in place, and closes
 // itself the moment the proposal resolves (formed, declined, or expired).
+//
+// Arrival order, the reason show() arms instead of opening outright: online,
+// the dfProposal event rides the events frame while the proposal state rides
+// the `df` self snapshot at its own 2 Hz cadence, so at show() time
+// `dungeonFinderInfo.proposal` may trail the event by up to half a second
+// (the battleground twin pins the shared ordering in
+// tests/battleground_pop_wire_order.test.ts). Reading that gap as "proposal
+// resolved" and closing is the queue-pop outage shape: while armed the root
+// stays hidden but isOpen reports true so hud.update keeps polling until the
+// snapshot lands, bounded by OFFER_SNAPSHOT_GRACE_POLLS.
 
 import { audio } from '../game/audio';
 import type { IWorld } from '../world_api';
@@ -24,33 +34,37 @@ export interface DungeonFinderProposalPopupDeps {
   world(): IWorld;
 }
 
+/**
+ * MediumHud polls (about 4 Hz) an armed popup waits for the proposal snapshot
+ * before giving up: about five seconds, comfortably past the `df` key's 2 Hz
+ * worst case. The bound only exists so a proposal that died before its first
+ * snapshot cannot hold an invisible armed popup forever.
+ */
+export const OFFER_SNAPSHOT_GRACE_POLLS = 20;
+
 export class DungeonFinderProposalPopup {
   private lastSig = '';
   private lastRemainingText = '';
+  /** Polls left to wait for the proposal snapshot after show(); 0 = not armed. */
+  private pendingPolls = 0;
 
   constructor(private readonly deps: DungeonFinderProposalPopupDeps) {}
 
   get isOpen(): boolean {
-    return this.deps.root().style.display === 'block';
+    return this.pendingPolls > 0 || this.deps.root().style.display === 'block';
   }
 
-  // Opened from the dfProposal SimEvent (hud.handleEvents), with the prompt cue.
+  // Armed from the dfProposal SimEvent (hud.handleEvents), with the prompt
+  // cue. The DOM opens on the first render that can read the proposal.
   show(): void {
-    if (!this.isOpen) {
-      const root = this.deps.root();
-      // The popup deliberately never steals focus (the player may be fighting), so
-      // a screen reader would otherwise miss the whole 30-second answer window:
-      // role=alert announces the prompt where it stands, without moving focus.
-      root.setAttribute('role', 'alert');
-      root.setAttribute('aria-live', 'assertive');
-      root.style.display = 'block';
-      audio.duelChallenge();
-    }
+    if (!this.isOpen) audio.duelChallenge();
+    this.pendingPolls = OFFER_SNAPSHOT_GRACE_POLLS;
     this.lastSig = '';
     this.render();
   }
 
   close(): void {
+    this.pendingPolls = 0;
     const el = this.deps.root();
     if (el.style.display !== 'block') return;
     el.style.display = 'none';
@@ -60,7 +74,9 @@ export class DungeonFinderProposalPopup {
   }
 
   relocalize(): void {
-    if (!this.isOpen) return;
+    // Displayed, not isOpen: an armed popup has no painted text to re-localize,
+    // and running render() from here would burn one of its grace polls.
+    if (this.deps.root().style.display !== 'block') return;
     this.lastSig = '';
     this.render();
   }
@@ -69,10 +85,29 @@ export class DungeonFinderProposalPopup {
     if (!this.isOpen) return;
     const view = buildFinderProposalPopupView(this.deps.world().dungeonFinderInfo);
     if (!view) {
+      if (this.pendingPolls > 0) {
+        // Armed: the proposal rode the events frame but its snapshot has not
+        // landed yet. Wait it out (bounded) rather than reading the gap as a
+        // resolved proposal; close() when the bound runs dry.
+        this.pendingPolls--;
+        if (this.pendingPolls === 0) this.close();
+        return;
+      }
       this.close();
       return;
     }
     const el = this.deps.root();
+    if (el.style.display !== 'block') {
+      // First readable proposal: take the DOM open here rather than in
+      // show(), so the role=alert announcement carries a real prompt instead
+      // of an empty box. The popup deliberately never steals focus (the
+      // player may be fighting): role=alert announces the prompt where it
+      // stands, without moving focus.
+      el.setAttribute('role', 'alert');
+      el.setAttribute('aria-live', 'assertive');
+      el.style.display = 'block';
+    }
+    this.pendingPolls = 0;
     if (view.sig !== this.lastSig) {
       this.lastSig = view.sig;
       this.lastRemainingText = '';

--- a/src/ui/hud/battleground/CLAUDE.md
+++ b/src/ui/hud/battleground/CLAUDE.md
@@ -50,9 +50,14 @@ The Thornhollow Fields 5v5 capture-the-flag HUD surface behind the `index.ts` ba
   to break it with). A backfill is a materially different offer (a live match,
   a scoreline the joiner had no part in, no rating either way), so the prompt
   body says so itself rather than relying on the chat line that scrolls away.
-  Perf contract: closed it does zero work (it only OPENS from the bgProposed
+  Perf contract: closed it does zero work (it only ARMS from the bgProposed
   SimEvent); open, it rebuilds DOM only when the structural sig changes and
-  refreshes the countdown text slot in place.
+  refreshes the countdown text slot in place. The event and the offer state
+  travel separately online (the events frame lands before the `bg` snapshot),
+  so show() arms a hidden pending state and the DOM opens on the first render
+  that can read the offer, bounded by OFFER_SNAPSHOT_GRACE_POLLS; reading the
+  gap as a resolved offer was the v0.36.0 queue-pop outage
+  (tests/battleground_pop_wire_order.test.ts pins the arrival order).
 - `battleground_map_view.ts` + `battleground_map_painter.ts`: the M-key world
   map's Thornhollow surface. The view is the HONEST marker model (self plus
   same-team mates and the static flag stands; never enemies, never live flag

--- a/src/ui/hud/battleground/battleground_proposal_popup.ts
+++ b/src/ui/hud/battleground/battleground_proposal_popup.ts
@@ -9,10 +9,20 @@
 // role=alert instead of moving focus.
 //
 // Perf contract: closed it does zero work (hud.update() gates on isOpen; it only
-// OPENS from the bgProposed SimEvent). While open it polls the battleground
+// ARMS from the bgProposed SimEvent). While open it polls the battleground
 // snapshot at the mediumHud cadence, rebuilds DOM only when the structural
 // signature changes, refreshes the countdown text slot in place, and closes
 // itself the moment the offer resolves (seated, declined, or lapsed).
+//
+// Arrival order, the reason show() arms instead of opening outright: online,
+// the bgProposed event rides the events frame while the offer state rides the
+// next `bg` self snapshot, so at show() time `bgInfo.proposal` may not have
+// arrived yet (tests/battleground_pop_wire_order.test.ts pins the ordering).
+// Reading that gap as "offer resolved" and closing is the v0.36.0 queue-pop
+// outage: the popup never showed, silence counted as a decline, and no match
+// could seat. While armed the root stays hidden (there is nothing truthful to
+// paint) but isOpen reports true so hud.update keeps polling until the
+// snapshot lands, bounded by OFFER_SNAPSHOT_GRACE_POLLS.
 
 import { audio } from '../../../game/audio';
 import type { IWorld } from '../../../world_api';
@@ -26,6 +36,15 @@ export interface BgProposalPopupDeps {
   world(): IWorld;
 }
 
+/**
+ * MediumHud polls (about 4 Hz) an armed popup waits for the offer snapshot
+ * before giving up: about five seconds. The snapshot normally lands within a
+ * frame of the event (the server resets the bg readout throttle as it
+ * delivers bgProposed); the bound only exists so an offer that died before
+ * its first snapshot cannot hold an invisible armed popup forever.
+ */
+export const OFFER_SNAPSHOT_GRACE_POLLS = 20;
+
 function num(v: number): string {
   return formatNumber(v, { maximumFractionDigits: 0, useGrouping: false });
 }
@@ -33,29 +52,26 @@ function num(v: number): string {
 export class BgProposalPopup {
   private lastSig = '';
   private lastRemainingText = '';
+  /** Polls left to wait for the offer snapshot after show(); 0 = not armed. */
+  private pendingPolls = 0;
 
   constructor(private readonly deps: BgProposalPopupDeps) {}
 
   get isOpen(): boolean {
-    return this.deps.root().style.display === 'block';
+    return this.pendingPolls > 0 || this.deps.root().style.display === 'block';
   }
 
-  /** Opened from the bgProposed SimEvent (hud.handleEvents), with the cue. */
+  /** Armed from the bgProposed SimEvent (hud.handleEvents), with the cue. The
+   *  DOM opens on the first render that can read the offer (see header). */
   show(): void {
-    if (!this.isOpen) {
-      const root = this.deps.root();
-      // A screen reader would otherwise miss the whole 30 second answer window,
-      // since the prompt never moves focus.
-      root.setAttribute('role', 'alert');
-      root.setAttribute('aria-live', 'assertive');
-      root.style.display = 'block';
-      audio.duelChallenge();
-    }
+    if (!this.isOpen) audio.duelChallenge();
+    this.pendingPolls = OFFER_SNAPSHOT_GRACE_POLLS;
     this.lastSig = '';
     this.render();
   }
 
   close(): void {
+    this.pendingPolls = 0;
     const el = this.deps.root();
     if (el.style.display !== 'block') return;
     el.style.display = 'none';
@@ -65,7 +81,9 @@ export class BgProposalPopup {
   }
 
   relocalize(): void {
-    if (!this.isOpen) return;
+    // Displayed, not isOpen: an armed popup has no painted text to re-localize,
+    // and running render() from here would burn one of its grace polls.
+    if (this.deps.root().style.display !== 'block') return;
     this.lastSig = '';
     this.render();
   }
@@ -74,12 +92,30 @@ export class BgProposalPopup {
     if (!this.isOpen) return;
     const view = buildBgProposalPopupView(this.deps.world().bgInfo);
     if (!view) {
+      if (this.pendingPolls > 0) {
+        // Armed: the offer rode the events frame but its snapshot has not
+        // landed yet. Wait it out (bounded) rather than reading the gap as a
+        // resolved offer; close() when the bound runs dry.
+        this.pendingPolls--;
+        if (this.pendingPolls === 0) this.close();
+        return;
+      }
       // The offer resolved (seated, declined, or lapsed): the snapshot dropping
       // it is the close signal, so no event needs to carry one.
       this.close();
       return;
     }
     const el = this.deps.root();
+    if (el.style.display !== 'block') {
+      // First readable offer: take the DOM open here rather than in show(),
+      // so the role=alert announcement carries a real prompt instead of an
+      // empty box. A screen reader would otherwise miss the whole 30 second
+      // answer window, since the prompt never moves focus.
+      el.setAttribute('role', 'alert');
+      el.setAttribute('aria-live', 'assertive');
+      el.style.display = 'block';
+    }
+    this.pendingPolls = 0;
     if (view.sig !== this.lastSig) {
       this.lastSig = view.sig;
       this.lastRemainingText = '';

--- a/tests/battleground_pop_wire_order.test.ts
+++ b/tests/battleground_pop_wire_order.test.ts
@@ -1,0 +1,122 @@
+// The online arrival order the queue-pop popups must survive, pinned with the
+// real server and the real client mirror. In the production loop a tick's
+// events frame (carrying bgProposed) is routed BEFORE broadcastSnapshots sends
+// the `bg` self readout that carries the offer, so a client that drains its
+// event queue on a frame boundary between the two messages sees the event
+// while `bgInfo.proposal` is still null. The popups bridge that gap with the
+// armed pending state (tests/battleground_proposal_popup.test.ts); this suite
+// exists so a change to either half of the ordering is a conscious one.
+
+import { describe, expect, it, vi } from 'vitest';
+
+// Mock the db layer so no Postgres is needed; wire ordering is under test
+// (the tests/battleground_wire.test.ts mock, unchanged).
+vi.mock('../server/db', () => ({
+  pool: { query: vi.fn(async () => ({ rows: [] })) },
+  saveCharacterState: vi.fn(async () => {}),
+  saveCharacterAndMarketState: vi.fn(async () => {}),
+  saveMarketState: vi.fn(async () => {}),
+  saveMailState: vi.fn(async () => {}),
+  loadMarketState: vi.fn(async () => null),
+  loadMailState: vi.fn(async () => null),
+  openPlaySession: vi.fn(async () => 1),
+  touchCharacterLogin: vi.fn(async () => {}),
+  closePlaySession: vi.fn(async () => {}),
+  insertChatLogs: vi.fn(async () => {}),
+  walletForAccount: vi.fn(async () => null),
+  markAccountQuestComplete: vi.fn(async () => ({ completedQuestIds: [], mechChromaIds: [] })),
+  grantAccountMechChroma: vi.fn(async () => ({ completedQuestIds: [], mechChromaIds: [] })),
+  revokeAccountMechChroma: vi.fn(async () => ({ completedQuestIds: [], mechChromaIds: [] })),
+  setAccountWeaponSkinLoadout: vi.fn(async () => ({
+    completedQuestIds: [],
+    mechChromaIds: [],
+    weaponSkinIds: [],
+    weaponSkinLoadout: {},
+  })),
+  loadAccountFlair: vi.fn(async () => ({ ai: false, streamer: false, links: {} })),
+  // bank_ledger.ts (imported via game.ts recordBankOp) reads this at call time.
+  insertBankLedgerRow: vi.fn(async () => {}),
+  acquireCharacterLease: vi.fn(async () => true),
+  releaseCharacterLease: vi.fn(async () => {}),
+  heartbeatCharacterLeases: vi.fn(async () => {}),
+  releaseAllCharacterLeases: vi.fn(async () => {}),
+}));
+
+import { type ClientSession, GameServer } from '../server/game';
+import type { SimEvent } from '../src/sim/types';
+import { buildBgProposalPopupView } from '../src/ui/hud/battleground/battleground_proposal_view';
+import { bareClient, type FakeClient, fakeWs, joinServer } from './helpers/bare_client';
+
+interface WireFrame {
+  t?: string;
+  list?: SimEvent[];
+  self?: { bg?: { proposal?: unknown } | null };
+}
+
+function joinBg(server: GameServer, fc: FakeClient, id: number, name: string): ClientSession {
+  const session = joinServer(server, fc, id, name);
+  const e = server.sim.entities.get(session.pid);
+  if (e) e.level = 20;
+  return session;
+}
+
+function cmd(server: GameServer, session: ClientSession, payload: Record<string, unknown>): void {
+  server.handleMessage(session, JSON.stringify({ t: 'cmd', ...payload }));
+}
+
+/** One loop pass in the production ORDER (tick, then events, then snapshots).
+ *  Production batches catch-up ticks before one broadcastSnapshots; the pinned
+ *  property, events routed before the snapshot broadcast, holds either way. */
+function fullTick(server: GameServer): void {
+  // biome-ignore lint/suspicious/noExplicitAny: reaches the loop's private steps
+  const s = server as any;
+  const events = server.sim.tick();
+  s.routeEvents(events);
+  s.broadcastSnapshots();
+}
+
+describe('battleground queue pop wire ordering', () => {
+  it('sends the bgProposed events frame before the snapshot carrying the offer', () => {
+    const server = new GameServer();
+    const clients: { fc: FakeClient; session: ClientSession }[] = [];
+    for (let i = 0; i < 10; i++) {
+      const fc = fakeWs();
+      clients.push({ fc, session: joinBg(server, fc, 100 + i, `Fighter${i}`) });
+    }
+    for (const { session } of clients) cmd(server, session, { cmd: 'bg_queue' });
+
+    let popped = false;
+    for (let t = 0; t < 400 && !popped; t++) {
+      fullTick(server);
+      popped = clients[0].fc.sent.some(
+        (m: WireFrame) => m.t === 'events' && (m.list ?? []).some((ev) => ev.type === 'bgProposed'),
+      );
+    }
+    expect(popped, 'a queue pop opened for the ten queued fighters').toBe(true);
+
+    const sent = clients[0].fc.sent as WireFrame[];
+    const evIdx = sent.findIndex(
+      (m) => m.t === 'events' && (m.list ?? []).some((ev) => ev.type === 'bgProposed'),
+    );
+    const snapIdx = sent.findIndex((m) => m.t === 'snap' && m.self?.bg?.proposal);
+    expect(evIdx).toBeGreaterThanOrEqual(0);
+    expect(snapIdx).toBeGreaterThanOrEqual(0);
+    // The ordering the popup's pending state exists for.
+    expect(evIdx, 'events frame precedes the offer snapshot').toBeLessThan(snapIdx);
+
+    // Replay into a real ClientWorld the way the browser sees it: every frame
+    // up to and including the events frame has arrived, then a frame boundary
+    // drains the event queue BEFORE the next message is parsed.
+    const client = bareClient(clients[0].session.pid);
+    // biome-ignore lint/suspicious/noExplicitAny: drives the private onMessage
+    const apply = (frame: WireFrame) => (client as any).onMessage(JSON.stringify(frame));
+    for (let i = 0; i <= evIdx; i++) apply(sent[i]);
+    const drained = client.drainEvents();
+    expect(drained.some((ev) => ev.type === 'bgProposed')).toBe(true);
+    // At drain time the offer state has NOT arrived: the popup must arm and
+    // wait rather than read this as a resolved offer.
+    expect(buildBgProposalPopupView(client.bgInfo)).toBeNull();
+    for (let i = evIdx + 1; i <= snapIdx; i++) apply(sent[i]);
+    expect(buildBgProposalPopupView(client.bgInfo)).not.toBeNull();
+  });
+});

--- a/tests/battleground_proposal_popup.test.ts
+++ b/tests/battleground_proposal_popup.test.ts
@@ -1,0 +1,143 @@
+// @vitest-environment happy-dom
+//
+// The Thornhollow Fields queue-pop popup against the ONLINE arrival order.
+// The bgProposed SimEvent rides the events frame while the offer state rides
+// the next `bg` self snapshot, so at show() time `bgInfo.proposal` may not
+// have arrived yet. The popup must ARM and wait for the snapshot (bounded by
+// OFFER_SNAPSHOT_GRACE_POLLS of the mediumHud band that polls it), not read
+// the gap as "offer resolved" and close for good: that misread is exactly the
+// v0.36.0 "queue never pops" outage (zero matches seated from the v0.36.0
+// deploy onward; the wire ordering itself is pinned by
+// tests/battleground_pop_wire_order.test.ts).
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { audio } from '../src/game/audio';
+import {
+  BgProposalPopup,
+  OFFER_SNAPSHOT_GRACE_POLLS,
+} from '../src/ui/hud/battleground/battleground_proposal_popup';
+import type { BgInfo, IWorld } from '../src/world_api';
+
+function bgInfoWith(proposal: BgInfo['proposal']): BgInfo {
+  return {
+    rating: 1500,
+    wins: 0,
+    losses: 0,
+    draws: 0,
+    captures: 0,
+    queued: true,
+    queueSize: 10,
+    queuedParty: 1,
+    proposal,
+    requeueIn: 0,
+    firstWinBonusReady: false,
+    match: null,
+    ladder: [],
+  };
+}
+
+const OFFER: BgInfo['proposal'] = {
+  id: 1,
+  kind: 'match',
+  size: 10,
+  accepted: 0,
+  myResponse: 'pending',
+  remaining: 30,
+};
+
+interface Harness {
+  popup: BgProposalPopup;
+  root: HTMLElement;
+  world: { bgInfo: BgInfo | null; bgRespond: ReturnType<typeof vi.fn> };
+}
+
+function makePopup(bgInfo: BgInfo | null): Harness {
+  const root = document.createElement('div');
+  root.style.display = 'none';
+  const world = { bgInfo, bgRespond: vi.fn() };
+  const popup = new BgProposalPopup({
+    root: () => root,
+    world: () => world as unknown as IWorld,
+  });
+  return { popup, root, world };
+}
+
+beforeEach(() => {
+  vi.spyOn(audio, 'duelChallenge').mockImplementation(() => {});
+  vi.spyOn(audio, 'click').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('BgProposalPopup pending arrival (the online race)', () => {
+  it('stays armed when the snapshot has not arrived, then opens when it lands', () => {
+    const { popup, root, world } = makePopup(bgInfoWith(null));
+    popup.show();
+    // Armed, polled by hud.update, but not yet visible: there is nothing
+    // truthful to paint before the snapshot arrives.
+    expect(popup.isOpen).toBe(true);
+    expect(root.style.display).not.toBe('block');
+    // The snapshot lands one mediumHud poll later.
+    world.bgInfo = bgInfoWith(OFFER);
+    popup.render();
+    expect(root.style.display).toBe('block');
+    expect(root.getAttribute('role')).toBe('alert');
+    const accept = root.querySelector<HTMLButtonElement>('[data-bgp="accept"]');
+    expect(accept).not.toBeNull();
+    accept?.click();
+    expect(world.bgRespond).toHaveBeenCalledWith(true);
+  });
+
+  it('plays the cue once at show(), not per pending poll', () => {
+    const { popup, world } = makePopup(bgInfoWith(null));
+    popup.show();
+    popup.render();
+    popup.render();
+    world.bgInfo = bgInfoWith(OFFER);
+    popup.render();
+    expect(audio.duelChallenge).toHaveBeenCalledTimes(1);
+  });
+
+  it('stays armed through the whole grace window, then gives up exactly at the budget', () => {
+    const { popup, root } = makePopup(bgInfoWith(null));
+    popup.show(); // burns poll 1 of the budget itself
+    for (let i = 0; i < OFFER_SNAPSHOT_GRACE_POLLS - 2; i++) popup.render();
+    // One poll left: still armed, still polled by hud.update, still hidden.
+    expect(popup.isOpen).toBe(true);
+    expect(root.style.display).not.toBe('block');
+    popup.render(); // the last allowed poll runs the budget dry
+    expect(popup.isOpen).toBe(false);
+    expect(root.style.display).not.toBe('block');
+  });
+
+  it('opens when the offer arrives on the last allowed poll', () => {
+    const { popup, root, world } = makePopup(bgInfoWith(null));
+    popup.show();
+    for (let i = 0; i < OFFER_SNAPSHOT_GRACE_POLLS - 2; i++) popup.render();
+    expect(popup.isOpen).toBe(true);
+    world.bgInfo = bgInfoWith(OFFER);
+    popup.render();
+    expect(root.style.display).toBe('block');
+    expect(root.querySelector('[data-bgp="accept"]')).not.toBeNull();
+  });
+
+  it('opens immediately when the snapshot already carries the offer', () => {
+    const { popup, root } = makePopup(bgInfoWith(OFFER));
+    popup.show();
+    expect(root.style.display).toBe('block');
+    expect(root.querySelector('[data-bgp="decline"]')).not.toBeNull();
+  });
+
+  it('still closes the moment a shown offer resolves', () => {
+    const { popup, root, world } = makePopup(bgInfoWith(OFFER));
+    popup.show();
+    expect(root.style.display).toBe('block');
+    world.bgInfo = bgInfoWith(null);
+    popup.render();
+    expect(popup.isOpen).toBe(false);
+    expect(root.style.display).toBe('none');
+    expect(root.innerHTML).toBe('');
+  });
+});

--- a/tests/dungeon_finder_proposal_popup.test.ts
+++ b/tests/dungeon_finder_proposal_popup.test.ts
@@ -1,0 +1,135 @@
+// @vitest-environment happy-dom
+//
+// The Dungeon Finder "group found" popup against the ONLINE arrival order:
+// the same pending-arrival contract as the battleground twin
+// (tests/battleground_proposal_popup.test.ts), and the same defect when it is
+// absent. The `df` self key rides a 2 Hz cadence with NO event-driven reset,
+// so here the snapshot can trail the dfProposal event by up to half a second:
+// this popup needs the armed grace even more than the battleground one.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { audio } from '../src/game/audio';
+import {
+  DungeonFinderProposalPopup,
+  OFFER_SNAPSHOT_GRACE_POLLS,
+} from '../src/ui/dungeon_finder_proposal_popup';
+import type { DungeonFinderInfo, IWorld } from '../src/world_api';
+
+function finderInfoWith(proposal: DungeonFinderInfo['proposal']): DungeonFinderInfo {
+  return {
+    roles: ['dps'],
+    eligibleRoles: ['dps'],
+    queue: null,
+    cooldown: 0,
+    proposal,
+    myListing: null,
+    myApplication: null,
+  };
+}
+
+const OFFER: DungeonFinderInfo['proposal'] = {
+  id: 1,
+  activityId: 'hollow_crypt_normal',
+  role: 'dps',
+  size: 5,
+  accepted: 0,
+  acceptedByRole: { tank: 0, healer: 0, dps: 0 },
+  myResponse: 'pending',
+  remaining: 30,
+};
+
+interface Harness {
+  popup: DungeonFinderProposalPopup;
+  root: HTMLElement;
+  world: {
+    dungeonFinderInfo: DungeonFinderInfo | null;
+    dungeonFinderRespond: ReturnType<typeof vi.fn>;
+  };
+}
+
+function makePopup(info: DungeonFinderInfo | null): Harness {
+  const root = document.createElement('div');
+  root.style.display = 'none';
+  const world = { dungeonFinderInfo: info, dungeonFinderRespond: vi.fn() };
+  const popup = new DungeonFinderProposalPopup({
+    root: () => root,
+    world: () => world as unknown as IWorld,
+  });
+  return { popup, root, world };
+}
+
+beforeEach(() => {
+  vi.spyOn(audio, 'duelChallenge').mockImplementation(() => {});
+  vi.spyOn(audio, 'click').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('DungeonFinderProposalPopup pending arrival (the online race)', () => {
+  it('stays armed when the snapshot has not arrived, then opens when it lands', () => {
+    const { popup, root, world } = makePopup(finderInfoWith(null));
+    popup.show();
+    expect(popup.isOpen).toBe(true);
+    expect(root.style.display).not.toBe('block');
+    world.dungeonFinderInfo = finderInfoWith(OFFER);
+    popup.render();
+    expect(root.style.display).toBe('block');
+    expect(root.getAttribute('role')).toBe('alert');
+    const accept = root.querySelector<HTMLButtonElement>('[data-dfp="accept"]');
+    expect(accept).not.toBeNull();
+    accept?.click();
+    expect(world.dungeonFinderRespond).toHaveBeenCalledWith(true);
+  });
+
+  it('plays the cue once at show(), not per pending poll', () => {
+    const { popup, world } = makePopup(finderInfoWith(null));
+    popup.show();
+    popup.render();
+    popup.render();
+    world.dungeonFinderInfo = finderInfoWith(OFFER);
+    popup.render();
+    expect(audio.duelChallenge).toHaveBeenCalledTimes(1);
+  });
+
+  it('stays armed through the whole grace window, then gives up exactly at the budget', () => {
+    const { popup, root } = makePopup(finderInfoWith(null));
+    popup.show(); // burns poll 1 of the budget itself
+    for (let i = 0; i < OFFER_SNAPSHOT_GRACE_POLLS - 2; i++) popup.render();
+    expect(popup.isOpen).toBe(true);
+    expect(root.style.display).not.toBe('block');
+    popup.render(); // the last allowed poll runs the budget dry
+    expect(popup.isOpen).toBe(false);
+    expect(root.style.display).not.toBe('block');
+  });
+
+  it('opens when the proposal arrives on the last allowed poll', () => {
+    const { popup, root, world } = makePopup(finderInfoWith(null));
+    popup.show();
+    for (let i = 0; i < OFFER_SNAPSHOT_GRACE_POLLS - 2; i++) popup.render();
+    expect(popup.isOpen).toBe(true);
+    world.dungeonFinderInfo = finderInfoWith(OFFER);
+    popup.render();
+    expect(root.style.display).toBe('block');
+    expect(root.querySelector('[data-dfp="accept"]')).not.toBeNull();
+  });
+
+  it('opens immediately when the snapshot already carries the offer', () => {
+    const { popup, root } = makePopup(finderInfoWith(OFFER));
+    popup.show();
+    expect(root.style.display).toBe('block');
+    expect(root.querySelector('[data-dfp="decline"]')).not.toBeNull();
+  });
+
+  it('still closes the moment a shown offer resolves', () => {
+    const { popup, root, world } = makePopup(finderInfoWith(OFFER));
+    popup.show();
+    expect(root.style.display).toBe('block');
+    world.dungeonFinderInfo = finderInfoWith(null);
+    popup.render();
+    expect(popup.isOpen).toBe(false);
+    expect(root.style.display).toBe('none');
+    expect(root.innerHTML).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary

Battlegrounds have seated zero matches since the v0.36.0 deploy (Prometheus: `woc_battleground_matches_total` flatlined at the deploy restart on Aug 11 and never incremented; the parse DB holds hundreds of prod dungeon/rift/raid/arena fights on builds 0.36.0 and 0.37.0 and not one battleground fight). Players hear the queue-pop cue and see the chat line but never get the Accept/Decline prompt, silence counts as a decline, and the pop churns; the community workaround is pasting `__game.sim.bgRespond(true)` in the console.

Root cause: online, the `bgProposed` SimEvent rides the events frame while the offer state rides the next `bg` self snapshot. The server routes events before it broadcasts snapshots, so the events frame always arrives first; events drain on the next animation frame while snapshots apply on message arrival. When the frame boundary lands between the two messages, `BgProposalPopup.show()` ran `render()` against a `bgInfo` that had no proposal yet, and `render()` read the null view as "offer resolved" and closed the popup permanently. Nothing reopens it (the only opener is the SimEvent), so one affected player out of ten fails the whole pop. The dungeon finder popup has the identical flaw, with a wider window: the `df` key rides a 2 Hz cadence with no event-driven reset.

The fix: `show()` now ARMS the popup (plays the cue, keeps the root hidden, reports `isOpen` so `Hud.update()` keeps polling) and the DOM opens on the first render that can read the offer, bounded by `OFFER_SNAPSHOT_GRACE_POLLS` (20 mediumHud polls, about five seconds) so an offer that died before its first snapshot cannot hold an invisible armed popup forever. `relocalize()` gates on the displayed state so a language switch cannot burn a grace poll. Both popups get the same treatment (two queues that prompt differently would read as a bug).

## Related issues

The v0.36.0 confirm-before-seat feature (`b6e0e8e0dd`) shipped this; nothing in v0.37.0 touched the path (the pipeline is byte-identical between the tags, verified by running the wire-order probe on both).

## Type of change

- [x] Bug fix

## How was this tested?

- Commands:
  - `npx vitest run tests/battleground_proposal_popup.test.ts tests/dungeon_finder_proposal_popup.test.ts tests/battleground_pop_wire_order.test.ts` (new suites; the popup tests reproduce the failure red before the fix)
  - `npx vitest run tests/hud_update_drive.test.ts tests/architecture.test.ts tests/language_fanout_registry.test.ts tests/language_fanout_relocalize.test.ts tests/hud_perf_budget.test.ts`
  - `npx tsc --noEmit`
  - `node scripts/gate_select.mjs`
- Manual steps: root-caused against production evidence (Prometheus battleground match counter across v0.35.1/v0.36.0/v0.37.0; parse-service fight DB; a GameServer + ClientWorld replay of a real 10-player queue pop, now committed as `tests/battleground_pop_wire_order.test.ts`).

Test-first: `tests/battleground_proposal_popup.test.ts` drives the real popup with a world whose `bgInfo` gains the proposal one poll after `show()`; it fails on the pre-fix code (popup closed, no prompt) and passes with the fix. The wire-order test pins the events-before-snapshot arrival with the real `GameServer` and real `ClientWorld`, so a change to either half of the ordering is a conscious one.

## Screenshots / recordings

N/A: the change restores an existing prompt (`#bg-proposal-popup`, unchanged markup and styles); reproducing it visually needs ten live queued players.

## Notes for review

- The armed state is deliberately invisible: there is nothing truthful to paint before the snapshot arrives (a fresh pop and a backfill prompt differ, and the event does not say which), and the snapshot normally lands within one frame.
- Known accepted corners (documented, not fixed here): an offer whose snapshot never arrives within the grace closes unanswered with no snapshot-driven reopen (the pre-existing event-only-open contract); a second offer arriving inside a dead offer's grace window plays no fresh cue. Both need a snapshot-driven self-heal in `Hud.update()` to fix properly; follow-up material, not hotfix material.
