### PR TITLE
test(ci): add the declared duration-budget ratchet

### DIFF
--- a/docs/qa-gate.md
+++ b/docs/qa-gate.md
@@ -233,6 +233,18 @@ same `[ci-shard]` audit lines as the shards. `release-gate` is deliberately not
 lane-split: `release/**` pushes keep the full suite in their 8 shards; a push to `main`
 or `dev-*` runs the PR tier, so it gets the shards-plus-lanes layout.
 
+**Declared duration budgets.** `tests/suite_duration_budget.test.ts` is the anti-whale
+ratchet: it scrapes every test file's DECLARED vitest timeouts (diet arm of ternaries,
+comments stripped; parsing contract in `tests/helpers/declared_timeouts.ts`) and
+enforces two conscious-decision rules in the `monolith_budget` mold: a single test may
+not declare more than the worker-chain cap without an exact exception row (one test is
+one worker chain and cannot parallelize, which is how the pre-split owned-class harness
+came to set whole job walls), and a file whose summed allowance exceeds the default
+needs an exact ledger row, with splitting along cost clusters as the preferred remedy.
+It reads allowances, not runtimes, so lane membership stays a MEASURED decision owned
+by `CI_LONG_SUITES` and its 90-second rule; the guard classifies blind and rides every
+selective floor.
+
 **The balance-harness diet.** The heavy balance suites in the lane are regression
 tripwires, not measurements (the authoritative instrument is the offline Monte Carlo
 sweep), so at PR time they run a reduced configuration: fewer fixed seeds, the

--- a/docs/qa-gate.md
+++ b/docs/qa-gate.md
@@ -234,16 +234,20 @@ lane-split: `release/**` pushes keep the full suite in their 8 shards; a push to
 or `dev-*` runs the PR tier, so it gets the shards-plus-lanes layout.
 
 **Declared duration budgets.** `tests/suite_duration_budget.test.ts` is the anti-whale
-ratchet: it scrapes every test file's DECLARED vitest timeouts (diet arm of ternaries,
-comments stripped; parsing contract in `tests/helpers/declared_timeouts.ts`) and
-enforces two conscious-decision rules in the `monolith_budget` mold: a single test may
-not declare more than the worker-chain cap without an exact exception row (one test is
-one worker chain and cannot parallelize, which is how the pre-split owned-class harness
-came to set whole job walls), and a file whose summed allowance exceeds the default
-needs an exact ledger row, with splitting along cost clusters as the preferred remedy.
-It reads allowances, not runtimes, so lane membership stays a MEASURED decision owned
-by `CI_LONG_SUITES` and its 90-second rule; the guard classifies blind and rides every
-selective floor.
+ratchet: it reads every DECLARED vitest timeout under `tests/` (all `.ts`/`.mjs`, so
+`.test.mjs` files and `vi.setConfig` allowances in imported helpers count too) through
+the masking parser in `tests/helpers/declared_timeouts.ts` (comments and string
+contents can never count; only registration-head positions do; the diet arm of a
+sweep ternary; same-file constants resolve, and an unresolvable identifier FAILS the
+suite rather than vanishing). It enforces two conscious-decision rules in the
+`monolith_budget` mold: a single test or hook may not declare more than the
+worker-chain cap without an exact exception row (one test is one worker chain and
+cannot parallelize, which is how the pre-split owned-class harness came to set whole
+job walls), and a file whose summed allowance exceeds the default needs an exact
+ledger row, with splitting along cost clusters as the preferred remedy. It reads
+allowances, not runtimes, so lane membership stays a MEASURED decision owned by
+`CI_LONG_SUITES` and its 90-second rule; the guard classifies onto the always-run
+floor and is also named in `CI_GUARD_SUITES` as drift insurance.
 
 **The balance-harness diet.** The heavy balance suites in the lane are regression
 tripwires, not measurements (the authoritative instrument is the offline Monte Carlo

--- a/scripts/lib/ci_shard_plan.mjs
+++ b/scripts/lib/ci_shard_plan.mjs
@@ -58,6 +58,7 @@ export const CI_GUARD_SUITES = Object.freeze([
   'tests/architecture.test.ts',
   'tests/localization_fixes.test.ts',
   'tests/localization_coverage.test.ts',
+  'tests/suite_duration_budget.test.ts',
   'tests/world_api_parity.test.ts',
 ]);
 

--- a/tests/ci_shard_plan.test.ts
+++ b/tests/ci_shard_plan.test.ts
@@ -88,6 +88,7 @@ describe('the floor union', () => {
       'tests/architecture.test.ts',
       'tests/localization_fixes.test.ts',
       'tests/localization_coverage.test.ts',
+      'tests/suite_duration_budget.test.ts',
       'tests/world_api_parity.test.ts',
     ]);
     expect([...CI_GUARD_PREFIXES]).toEqual(['tests/parity/']);
@@ -195,10 +196,11 @@ describe('buildShardPlan: selective mode', () => {
     const plan = buildShardPlan({ ...BASE });
     // Derived from the fixture, not the implementation's own formula: FILLER
     // (FLOOR_SANITY_MIN + 20) + architecture + localization_fixes always-run,
-    // plus localization_coverage, world_api_parity, and the parity file via
-    // the guard union = FLOOR_SANITY_MIN + 25; COLLECTED holds two more pure
-    // tests, which are exactly the outside-floor remainder.
-    expect(plan.floorCount).toBe(FLOOR_SANITY_MIN + 25);
+    // plus localization_coverage, suite_duration_budget, world_api_parity,
+    // and the parity file via the guard union = FLOOR_SANITY_MIN + 26;
+    // COLLECTED holds two more pure tests, exactly the outside-floor
+    // remainder.
+    expect(plan.floorCount).toBe(FLOOR_SANITY_MIN + 26);
     expect(plan.relatedCount).toBe(1);
     expect(plan.outsideFloorCount).toBe(2);
   });
@@ -467,7 +469,7 @@ describe('the long-sims lane (Phase 4)', () => {
     // base fixture's FLOOR_SANITY_MIN + 25 plus LANE_BLIND (added to
     // alwaysRun above); the one lane member then moves to the lane, so the
     // leg is back at the base figure.
-    expect(plan.floorCount).toBe(FLOOR_SANITY_MIN + 25);
+    expect(plan.floorCount).toBe(FLOOR_SANITY_MIN + 26);
     expect(relatedLeg.args).not.toContain(`--exclude=${LANE_BLIND}`);
     expect(relatedLeg.args.join(' ')).not.toContain('--exclude');
   });

--- a/tests/helpers/declared_timeouts.ts
+++ b/tests/helpers/declared_timeouts.ts
@@ -1,61 +1,291 @@
 // Pure scraper for DECLARED vitest timeouts in a test file's source text.
 // Consumed by tests/suite_duration_budget.test.ts (the anti-whale ratchet) and
-// driven directly by its mkdtemp fixture, so the producer's parsing semantics
-// are pinned by execution rather than assumed.
+// driven directly by that consumer's inline source fixtures, so the parsing
+// semantics are pinned by execution rather than assumed. The guard is this
+// module's paired test, deliberately in one place: the fixtures below it are
+// the parser's specification.
 //
-// What counts as a declared timeout, matching this repo's real forms:
-//   it('...', () => { ... }, 120_000)            trailing-argument form
-//   it('...', { timeout: 240_000 }, () => ...)   option-object form
-//   it(..., fn, FULL_SWEEP ? 900_000 : 300_000)  ternary: the DIET (second) arm
-//     counts, because that is the PR-time allowance; the sweep arm runs on the
-//     nightly, which runs the whole suite regardless.
-// Comments are stripped FIRST so a number in prose (or a commented-out old
-// value) can never count, and values under 10 seconds are ignored (default
-// vitest timeouts and fake-clock constants live below that line).
+// The parser is a masking scanner, not a bare regex, because the first cut's
+// unanchored regexes were caught counting spawn options
+// (execFileSync(..., { timeout: 300_000 })), ordinary function arguments
+// (someOptions({...}, 120_000)), fixture objects inside test bodies, and
+// numbers inside string literals. Pass 1 masks comments and string CONTENTS
+// (indices preserved), so nothing quoted can ever count; pass 2 finds
+// REGISTRATION HEADS (it/test/bench/describe, their .each curried form and
+// dotted modifiers, the four hooks, and vi.setConfig), bracket-matches each
+// call's argument span, splits it at top-level commas, and reads timeouts only
+// from the two places vitest defines them:
+//   - a trailing numeric (or FLAG ? full : diet ternary) argument; the DIET
+//     (second) arm counts, because that is the PR-time allowance, and the
+//     sweep arm runs on the nightly, which runs the whole suite regardless;
+//   - a top-level options-object argument's timeout / testTimeout /
+//     hookTimeout keys (vi.setConfig's object counts the same way, since a
+//     file-wide testTimeout is a per-test allowance on every test in the
+//     file).
+// A timeout bound to a BARE identifier resolves through a same-file
+// `const NAME = <number>` binding when one exists (two suites declare their
+// hook budgets that way); anything unresolvable is reported in `unparsed`
+// rather than silently skipped, and the consumer fails the suite on it, so
+// moving an allowance behind an opaque constant cannot evade the ledger.
 //
-// Deliberate limitation, documented where the consumer states its contract:
-// this reads ALLOWANCES, not runtimes. A file's sum is its declared worst
-// case; describe-body collection work and it.each expansion are invisible
-// here. The guard built on this is a conscious-decision ratchet, not a
-// measurement.
+// Values at or below the repo default testTimeout (20s, vite.config.ts) are
+// ignored: a declaration that lowers a test's allowance is not added
+// allowance (vitest's HOOK default is 10s, so a 10-to-20s hook declaration is
+// technically added allowance this floor ignores; recorded, accepted).
+// Deliberate limitations, stated where the consumer states its contract: this
+// reads ALLOWANCES, not runtimes; describe-body collection work and it.each
+// expansion are invisible; a describe-level timeout counts ONCE though it
+// applies to every case in the block; hook timeouts count as single
+// allowances (a hook is a serial chain too).
 
 export interface DeclaredTimeouts {
   perTest: number[];
   sum: number;
+  /** Timeout declarations bound to bare identifiers this parser cannot read. */
+  unparsed: string[];
 }
 
-const MIN_COUNTED_MS = 10_000;
+// Count only allowances strictly above the repo default testTimeout of 20s.
+const MIN_COUNTED_MS = 20_001;
 
-export function stripComments(source: string): string {
-  return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
+// The dotted suffix is restricted to vitest's REAL modifiers: an unrestricted
+// `(?:\.\w+)*` let an ordinary method call on a local variable named `test`
+// (tests/lockpick_controller.test.ts has `test.controller.end(...)`) parse as
+// a registration head and mint phantom allowances from its numeric arguments.
+const HEAD_RE =
+  /(?:\b(?:it|test|bench|describe)\b(?:\.(?:only|skip|todo|fails|concurrent|sequential|shuffle|each|for|skipIf|runIf|extend)\b)*|\b(?:beforeAll|beforeEach|afterAll|afterEach)\b|\bvi\.setConfig)\s*\(/g;
+
+/**
+ * Replace comment text and string CONTENTS with spaces, preserving length and
+ * indices. Template literals mask to spaces too, with `${` re-entering code
+ * state so brackets inside interpolations still balance.
+ */
+export function maskCommentsAndStrings(source: string): string {
+  const out = source.split('');
+  type State = 'code' | 'line' | 'block' | 'single' | 'double' | 'template' | 'regex';
+  const stack: State[] = [];
+  let state: State = 'code';
+  // The last significant code character, for the division-vs-regex-literal
+  // decision: a `/` after a value continues an expression (division); after an
+  // operator, opener, or line start it begins a regex literal. Without this
+  // state a regex containing an odd number of quotes (`/it's/`) flipped the
+  // scanner into string state and silently masked the rest of the file.
+  let lastCode = '';
+  let inClass = false;
+  for (let i = 0; i < source.length; i++) {
+    const ch = source[i];
+    const next = source[i + 1];
+    if (state === 'code') {
+      if (ch === '/' && next === '/') {
+        state = 'line';
+        out[i] = ' ';
+      } else if (ch === '/' && next === '*') {
+        state = 'block';
+        out[i] = ' ';
+      } else if (ch === '/' && (lastCode === '' || /[(,=:[!&|?{};+\-*%<>~^]/.test(lastCode))) {
+        state = 'regex';
+        inClass = false;
+      } else if (ch === "'") state = 'single';
+      else if (ch === '"') state = 'double';
+      else if (ch === '`') state = 'template';
+      else if (ch === '}' && stack.length > 0) {
+        // Close of a template interpolation: back into the template.
+        state = stack.pop() as State;
+      }
+      if (state === 'code' && !/\s/.test(ch)) lastCode = ch;
+      continue;
+    }
+    if (state === 'regex') {
+      if (ch === '\\') {
+        out[i] = ' ';
+        if (i + 1 < source.length && source[i + 1] !== '\n') out[i + 1] = ' ';
+        i++;
+        continue;
+      }
+      if (ch === '[') inClass = true;
+      else if (ch === ']') inClass = false;
+      if ((ch === '/' && !inClass) || ch === '\n') {
+        state = 'code';
+        lastCode = '/';
+        continue;
+      }
+      out[i] = ' ';
+      continue;
+    }
+    if (state === 'line') {
+      if (ch === '\n') state = 'code';
+      else out[i] = ' ';
+      continue;
+    }
+    if (state === 'block') {
+      if (ch === '*' && next === '/') {
+        out[i] = ' ';
+        out[i + 1] = ' ';
+        i++;
+        state = 'code';
+      } else if (ch !== '\n') out[i] = ' ';
+      continue;
+    }
+    // Inside a string. Quotes stay visible; contents mask to spaces.
+    if (ch === '\\') {
+      out[i] = ' ';
+      if (i + 1 < source.length && source[i + 1] !== '\n') out[i + 1] = ' ';
+      i++;
+      continue;
+    }
+    if (state === 'single' && ch === "'") state = 'code';
+    else if (state === 'double' && ch === '"') state = 'code';
+    else if (state === 'template' && ch === '`') state = 'code';
+    else if (state === 'template' && ch === '$' && next === '{') {
+      out[i] = ' ';
+      // Leave the `{` visible so bracket depth stays balanced with the `}`.
+      stack.push('template');
+      state = 'code';
+      i++;
+    } else if (ch !== '\n') out[i] = ' ';
+  }
+  return out.join('');
 }
 
-const NUM = '([0-9][0-9_]*)';
-const TERNARY = `\\?\\s*${NUM}\\s*:\\s*${NUM}`;
-// Option-object form: `timeout: N` or `timeout: FLAG ? A : B`.
-const OPTION_RE = new RegExp(`timeout:\\s*(?:[A-Za-z_$][\\w$]*\\s*${TERNARY}|${NUM})`, 'g');
-// Trailing-argument form: a function body close, comma, the timeout, then the
-// registration's closing paren (optionally via a trailing comma/newline).
-const TRAILING_RE = new RegExp(
-  `\\}\\s*,\\s*(?:[A-Za-z_$][\\w$]*\\s*${TERNARY}|${NUM})\\s*,?\\s*\\)`,
-  'g',
-);
-
-function dietArm(match: RegExpMatchArray): number {
-  const raw = match[2] ?? match[3] ?? match[1];
-  return Number(raw.replace(/_/g, ''));
+/** Index just past the matching close paren, or -1 when unbalanced. */
+function matchParen(masked: string, openIndex: number): number {
+  let depth = 0;
+  for (let i = openIndex; i < masked.length; i++) {
+    const ch = masked[i];
+    if (ch === '(' || ch === '[' || ch === '{') depth++;
+    else if (ch === ')' || ch === ']' || ch === '}') {
+      depth--;
+      if (depth === 0) return i + 1;
+    }
+  }
+  return -1;
 }
+
+/** Split a call's argument span at top-level commas (masked indices). */
+function splitArgs(masked: string, start: number, end: number): { from: number; to: number }[] {
+  const args: { from: number; to: number }[] = [];
+  let depth = 0;
+  let from = start;
+  for (let i = start; i < end; i++) {
+    const ch = masked[i];
+    if (ch === '(' || ch === '[' || ch === '{') depth++;
+    else if (ch === ')' || ch === ']' || ch === '}') depth--;
+    else if (ch === ',' && depth === 0) {
+      args.push({ from, to: i });
+      from = i + 1;
+    }
+  }
+  if (end > from) args.push({ from, to: end });
+  return args;
+}
+
+const NUMERIC_ARG_RE = /^\s*([0-9][0-9_]*)\s*,?\s*$/;
+const TERNARY_ARG_RE = /^\s*[A-Za-z_$][\w$.]*\s*\?\s*([0-9][0-9_]*)\s*:\s*([0-9][0-9_]*)\s*,?\s*$/;
+const IDENT_ARG_RE = /^\s*([A-Za-z_$][\w$.]*)\s*,?\s*$/;
+const OPTION_KEY_RE =
+  /\b(timeout|testTimeout|hookTimeout):\s*(?:[A-Za-z_$][\w$.]*\s*\?\s*([0-9][0-9_]*)\s*:\s*([0-9][0-9_]*)|([0-9][0-9_]*)|([A-Za-z_$][\w$.]*))/g;
 
 export function declaredTimeouts(source: string): DeclaredTimeouts {
-  const clean = stripComments(source);
+  const masked = maskCommentsAndStrings(source);
   const perTest: number[] = [];
-  for (const match of clean.matchAll(OPTION_RE)) {
-    const value = dietArm(match);
+  const unparsed: string[] = [];
+  const record = (value: number) => {
     if (value >= MIN_COUNTED_MS) perTest.push(value);
+  };
+  const resolveConst = (name: string): number | null => {
+    const short = name.split('.').pop() ?? name;
+    const binding = masked.match(
+      new RegExp(`\\bconst\\s+${short.replace(/\$/g, '\\$')}\\s*=\\s*([0-9][0-9_]*)\\s*[;\\n]`),
+    );
+    return binding ? Number(binding[1].replace(/_/g, '')) : null;
+  };
+
+  for (const head of masked.matchAll(HEAD_RE)) {
+    const isSetConfig = head[0].includes('setConfig');
+    const isHook = /^(?:before|after)/.test(head[0]);
+    let open = head.index + head[0].length - 1;
+    let close = matchParen(masked, open);
+    if (close < 0) continue;
+    // The curried it.each(TABLE)('title', fn, timeout) form: the registration
+    // arguments live in the SECOND call group.
+    const following = masked.slice(close).match(/^\s*\(/);
+    if (following && !isSetConfig && !isHook) {
+      open = close + following[0].length - 1;
+      close = matchParen(masked, open);
+      if (close < 0) continue;
+    }
+    const args = splitArgs(masked, open + 1, close - 1);
+    for (const [argIndex, arg] of args.entries()) {
+      const maskedArg = masked.slice(arg.from, arg.to);
+      const sourceArg = source.slice(arg.from, arg.to);
+      const trimmed = maskedArg.trim();
+      if (trimmed.startsWith('{')) {
+        // A top-level options object (or setConfig's config object): read its
+        // timeout keys at the object's own top level only, so a nested
+        // fixture cannot count.
+        const inner = maskedArg.slice(maskedArg.indexOf('{') + 1);
+        let cut = inner.length;
+        {
+          let depth = 0;
+          for (let i = 0; i < inner.length; i++) {
+            const ch = inner[i];
+            if (ch === '(' || ch === '[' || ch === '{') depth++;
+            else if (ch === ')' || ch === ']' || ch === '}') {
+              if (depth === 0) {
+                cut = i;
+                break;
+              }
+              depth--;
+            }
+          }
+        }
+        const top = inner
+          .slice(0, cut)
+          .replace(/[[{(][\s\S]*?[)\]}]/g, (m) => ' '.repeat(m.length));
+        for (const key of top.matchAll(OPTION_KEY_RE)) {
+          if (key[5]) {
+            const resolved = resolveConst(key[5]);
+            if (resolved !== null) record(resolved);
+            else unparsed.push(`${key[1]}: ${key[5]}`);
+          } else {
+            const value = Number((key[3] ?? key[4]).replace(/_/g, ''));
+            record(value);
+          }
+        }
+        continue;
+      }
+      // Only a LAST argument can be the trailing timeout form.
+      if (argIndex !== args.length - 1 || argIndex === 0 || isSetConfig) continue;
+      const numeric = maskedArg.match(NUMERIC_ARG_RE);
+      if (numeric) {
+        record(Number(numeric[1].replace(/_/g, '')));
+        continue;
+      }
+      const ternary = maskedArg.match(TERNARY_ARG_RE);
+      if (ternary) {
+        record(Number(ternary[2].replace(/_/g, '')));
+        continue;
+      }
+      const ident = maskedArg.match(IDENT_ARG_RE);
+      // A trailing bare identifier: POSITION decides whether it is a timeout,
+      // not the name (a name gate was caught letting `it('x', fn, BUDGET)`
+      // slip through green). When the PREVIOUS argument is a function literal,
+      // the trailing identifier occupies vitest's timeout slot and must
+      // resolve or fail; when the previous argument is an options object or a
+      // string, the trailing identifier is a test-fn reference and is skipped.
+      // The timeout-looking-name check stays as a fallback trigger for
+      // unusual shapes (a fn REFERENCE in the middle slot).
+      if (ident && !isSetConfig) {
+        const prev =
+          argIndex > 0 ? masked.slice(args[argIndex - 1].from, args[argIndex - 1].to).trim() : '';
+        const prevIsFunction = /^(?:async\b|function\b|\()/.test(prev);
+        if (prevIsFunction || /TIMEOUT|_MS$/i.test(ident[1])) {
+          const resolved = resolveConst(ident[1]);
+          if (resolved !== null) record(resolved);
+          else unparsed.push(`trailing ${ident[1]} (${sourceArg.trim().slice(0, 40)})`);
+        }
+      }
+    }
   }
-  for (const match of clean.matchAll(TRAILING_RE)) {
-    const value = dietArm(match);
-    if (value >= MIN_COUNTED_MS) perTest.push(value);
-  }
-  return { perTest, sum: perTest.reduce((total, value) => total + value, 0) };
+  return { perTest, sum: perTest.reduce((total, value) => total + value, 0), unparsed };
 }

--- a/tests/helpers/declared_timeouts.ts
+++ b/tests/helpers/declared_timeouts.ts
@@ -1,0 +1,61 @@
+// Pure scraper for DECLARED vitest timeouts in a test file's source text.
+// Consumed by tests/suite_duration_budget.test.ts (the anti-whale ratchet) and
+// driven directly by its mkdtemp fixture, so the producer's parsing semantics
+// are pinned by execution rather than assumed.
+//
+// What counts as a declared timeout, matching this repo's real forms:
+//   it('...', () => { ... }, 120_000)            trailing-argument form
+//   it('...', { timeout: 240_000 }, () => ...)   option-object form
+//   it(..., fn, FULL_SWEEP ? 900_000 : 300_000)  ternary: the DIET (second) arm
+//     counts, because that is the PR-time allowance; the sweep arm runs on the
+//     nightly, which runs the whole suite regardless.
+// Comments are stripped FIRST so a number in prose (or a commented-out old
+// value) can never count, and values under 10 seconds are ignored (default
+// vitest timeouts and fake-clock constants live below that line).
+//
+// Deliberate limitation, documented where the consumer states its contract:
+// this reads ALLOWANCES, not runtimes. A file's sum is its declared worst
+// case; describe-body collection work and it.each expansion are invisible
+// here. The guard built on this is a conscious-decision ratchet, not a
+// measurement.
+
+export interface DeclaredTimeouts {
+  perTest: number[];
+  sum: number;
+}
+
+const MIN_COUNTED_MS = 10_000;
+
+export function stripComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
+}
+
+const NUM = '([0-9][0-9_]*)';
+const TERNARY = `\\?\\s*${NUM}\\s*:\\s*${NUM}`;
+// Option-object form: `timeout: N` or `timeout: FLAG ? A : B`.
+const OPTION_RE = new RegExp(`timeout:\\s*(?:[A-Za-z_$][\\w$]*\\s*${TERNARY}|${NUM})`, 'g');
+// Trailing-argument form: a function body close, comma, the timeout, then the
+// registration's closing paren (optionally via a trailing comma/newline).
+const TRAILING_RE = new RegExp(
+  `\\}\\s*,\\s*(?:[A-Za-z_$][\\w$]*\\s*${TERNARY}|${NUM})\\s*,?\\s*\\)`,
+  'g',
+);
+
+function dietArm(match: RegExpMatchArray): number {
+  const raw = match[2] ?? match[3] ?? match[1];
+  return Number(raw.replace(/_/g, ''));
+}
+
+export function declaredTimeouts(source: string): DeclaredTimeouts {
+  const clean = stripComments(source);
+  const perTest: number[] = [];
+  for (const match of clean.matchAll(OPTION_RE)) {
+    const value = dietArm(match);
+    if (value >= MIN_COUNTED_MS) perTest.push(value);
+  }
+  for (const match of clean.matchAll(TRAILING_RE)) {
+    const value = dietArm(match);
+    if (value >= MIN_COUNTED_MS) perTest.push(value);
+  }
+  return { perTest, sum: perTest.reduce((total, value) => total + value, 0) };
+}

--- a/tests/suite_duration_budget.test.ts
+++ b/tests/suite_duration_budget.test.ts
@@ -1,0 +1,183 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { declaredTimeouts } from './helpers/declared_timeouts';
+import { expectScansOnlyThroughSharedWalkers } from './helpers/scan_guard_self_audit';
+import { tsFilesUnder } from './helpers/ts_files_under';
+
+// THE ANTI-WHALE RATCHET (docs/qa-gate.md, "Declared duration budgets").
+//
+// One giant test file sets the wall clock of whichever 2-worker CI job draws
+// it: the owned-class balance harness reached 788 to 842 seconds as ONE file
+// before it was split, and the warlock sustain suite drifted to 359 seconds in
+// the shard pool with nothing to say so. This guard makes that drift a red
+// diff instead of a slow surprise, off DECLARED vitest timeouts, which are the
+// only deterministic signal available at review time.
+//
+// It reads ALLOWANCES, not runtimes (tests/helpers/declared_timeouts.ts states
+// the parsing contract and its limits: diet arm of ternaries, comments
+// stripped, describe-body collection work invisible). So the rules are
+// conscious-decision ratchets, in the monolith_budget mold:
+//  - a single test may not declare more than SINGLE_TEST_CAP unless its file
+//    has an exact-match exception row here. One test is one worker chain: it
+//    cannot parallelize, so its allowance IS a job-wall floor. Shrink an
+//    exception when the test splits; growing one is a maintainer decision that
+//    needs its reasoning in the PR body.
+//  - a file whose declared sum exceeds DEFAULT_FILE_ALLOWANCE needs an
+//    exact-match ledger row. The remedies, in preference order: split the file
+//    along its cost clusters (the owned-class and chronomancy splits are the
+//    worked precedent, and the extract-and-test skill has the recipe), move
+//    the heavy case to a lane-owned suite (scripts/lib/ci_shard_plan.mjs,
+//    CI_LONG_SUITES, whose own comment carries the measured 90-second rule),
+//    or add the row deliberately.
+//  - rows and exceptions are EXACT, so any timeout edit in a listed file
+//    touches this ledger in the same change, and a row for a file that no
+//    longer exceeds the default must be deleted (the ratchet direction).
+//
+// Lane membership itself stays a MEASURED decision, deliberately not enforced
+// here: tests/audit_conservation_property.test.ts declares 2,700 seconds of
+// allowance across its property cases yet measured 55.1 seconds in-lane and
+// was evicted, so declared sums must never drive the lane list.
+
+const SINGLE_TEST_CAP = 480_000;
+
+// file -> the exact largest single declared timeout it is allowed to carry.
+const SINGLE_TEST_EXCEPTIONS: ReadonlyMap<string, number> = new Map([
+  // The Nythraxis matrix runs its full boss ladder as one case. Splitting it
+  // is the standing follow-up; shrink this when that lands.
+  ['tests/nythraxis_matrix.test.ts', 720_000],
+]);
+
+const DEFAULT_FILE_ALLOWANCE = 300_000;
+
+// file -> exact declared diet-arm sum, for every file above the default.
+const FILE_ALLOWANCE_LEDGER: ReadonlyMap<string, number> = new Map([
+  ['tests/audit_conservation_property.test.ts', 2_700_000],
+  ['tests/battleground_band.test.ts', 660_000],
+  ['tests/chronomancy_balance_targets.test.ts', 360_000],
+  ['tests/discord_db_integration.test.ts', 420_000],
+  ['tests/dragonkin_whelp_litter.test.ts', 420_000],
+  ['tests/druid_balance_probe.test.ts', 570_000],
+  ['tests/emerald_deck_escape.test.ts', 540_000],
+  ['tests/guild_bank_pg_integration.test.ts', 840_000],
+  ['tests/mob_portrait_source_manifest.test.ts', 360_000],
+  ['tests/nythraxis_matrix.test.ts', 1_320_000],
+  ['tests/owned_class_balance_dps_probes.test.ts', 360_000],
+  ['tests/perf_tour_entry.test.ts', 450_000],
+]);
+
+// This file excludes ITSELF from the scan: its parser fixtures below are real
+// declaration text by necessity, so the scraper would read them as this file's
+// own allowances (the diet-flag registry splits its needle for the same
+// reason; string fixtures cannot be split without losing what they test).
+const SELF = 'tests/suite_duration_budget.test.ts';
+
+function suiteTimeouts(): Map<string, { perTest: number[]; sum: number }> {
+  const out = new Map<string, { perTest: number[]; sum: number }>();
+  for (const found of tsFilesUnder('tests')) {
+    if (!found.file.endsWith('.test.ts')) continue;
+    if (`tests/${found.file}` === SELF) continue;
+    out.set(`tests/${found.file}`, declaredTimeouts(readFileSync(found.full, 'utf8')));
+  }
+  return out;
+}
+
+describe('suite duration budget (declared-timeout ratchet)', () => {
+  const suite = suiteTimeouts();
+
+  it('walks the whole suite recursively and actually parses timeouts', () => {
+    // Deep root, so the real tree pins recursion directly: a subdirectory
+    // member must be present, and the corpus floor sits near the real count
+    // (2,730 on 2026-08-13) so a walk that silently narrowed would fail.
+    expect(suite.size).toBeGreaterThanOrEqual(2_600);
+    expect(suite.has('tests/server/new_endpoint.test.ts')).toBe(true);
+    const withTimeouts = [...suite.values()].filter((entry) => entry.sum > 0).length;
+    // Vacuity floor near the real count (106 on 2026-08-13): a scraper change
+    // that stopped matching the repo's real declaration forms fails here, not
+    // by quietly emptying every rule below.
+    expect(withTimeouts).toBeGreaterThanOrEqual(90);
+    const nythraxis = suite.get('tests/nythraxis_matrix.test.ts');
+    expect(nythraxis?.sum).toBe(1_320_000);
+    expect(Math.max(...(nythraxis?.perTest ?? [0]))).toBe(720_000);
+  });
+
+  it('parses every declared-timeout form and strips comments first', () => {
+    // Producer semantics pinned by execution: the trailing-argument form, the
+    // option-object form, the ternary diet arm, a trailing comma close, a
+    // commented-out timeout (not counted), and a sub-10s value (not counted).
+    expect(declaredTimeouts(`it('a', () => { run(); }, 120_000);`).perTest).toEqual([120_000]);
+    expect(declaredTimeouts(`it('b', { timeout: 240_000 }, () => { run(); });`).perTest).toEqual([
+      240_000,
+    ]);
+    expect(
+      declaredTimeouts(`it('c', () => { run(); }, FULL ? 900_000 : 300_000);`).perTest,
+    ).toEqual([300_000]);
+    expect(declaredTimeouts(`it('d', { timeout: FULL ? 720_000 : 90_000 }, fn);`).perTest).toEqual([
+      90_000,
+    ]);
+    expect(
+      declaredTimeouts(`it(\n  'e',\n  () => {\n    run();\n  },\n  60_000,\n);`).perTest,
+    ).toEqual([60_000]);
+    expect(declaredTimeouts(`// it('old', () => { run(); }, 900_000);`).perTest).toEqual([]);
+    expect(
+      declaredTimeouts(`/* }, 800_000) */ it('f', () => { run(); }, 30_000);`).perTest,
+    ).toEqual([30_000]);
+    expect(declaredTimeouts(`setTimeout(() => { poll(); }, 5_000);`).perTest).toEqual([]);
+  });
+
+  it('caps every single declared test timeout at the worker-chain bound', () => {
+    for (const [file, { perTest }] of suite) {
+      const largest = Math.max(0, ...perTest);
+      const exception = SINGLE_TEST_EXCEPTIONS.get(file);
+      if (exception !== undefined) {
+        expect(
+          largest,
+          `${file}: the single-test exception is exact; shrink the row when the test splits, ` +
+            'and growing it is a maintainer decision that needs its reasoning in the PR body',
+        ).toBe(exception);
+        continue;
+      }
+      expect(
+        largest,
+        `${file} declares a ${Math.round(largest / 1000)}s single-test allowance (cap ` +
+          `${SINGLE_TEST_CAP / 1000}s). One test is one worker chain and cannot parallelize: ` +
+          'split it along its cost clusters (the owned-class balance split is the precedent), ' +
+          'or add an exact exception row in tests/suite_duration_budget.test.ts deliberately.',
+      ).toBeLessThanOrEqual(SINGLE_TEST_CAP);
+    }
+    for (const file of SINGLE_TEST_EXCEPTIONS.keys()) {
+      expect(suite.has(file), `${file}: stale single-test exception row`).toBe(true);
+    }
+  });
+
+  it('pins the per-file declared allowance ledger exactly, both directions', () => {
+    for (const [file, { sum }] of suite) {
+      const row = FILE_ALLOWANCE_LEDGER.get(file);
+      if (row !== undefined) {
+        expect(
+          sum,
+          `${file}: the ledger row is exact; any timeout edit here updates the row in the ` +
+            'same change (and a split LOWERS it)',
+        ).toBe(row);
+        continue;
+      }
+      expect(
+        sum,
+        `${file} declares ${Math.round(sum / 1000)}s of summed allowance (default ` +
+          `${DEFAULT_FILE_ALLOWANCE / 1000}s). Split the file along its cost clusters, move the ` +
+          'heavy case to a lane-owned suite (scripts/lib/ci_shard_plan.mjs, CI_LONG_SUITES), or ' +
+          'add an exact ledger row in tests/suite_duration_budget.test.ts deliberately.',
+      ).toBeLessThanOrEqual(DEFAULT_FILE_ALLOWANCE);
+    }
+    for (const [file, row] of FILE_ALLOWANCE_LEDGER) {
+      expect(suite.has(file), `${file}: stale ledger row (file gone; delete the row)`).toBe(true);
+      expect(
+        row,
+        `${file}: ledger row at or under the default is dead weight; delete it`,
+      ).toBeGreaterThan(DEFAULT_FILE_ALLOWANCE);
+    }
+  });
+
+  it('reads the tree only through the shared walker', () => {
+    expectScansOnlyThroughSharedWalkers(import.meta.url, ['ts_files_under']);
+  });
+});

--- a/tests/suite_duration_budget.test.ts
+++ b/tests/suite_duration_budget.test.ts
@@ -1,8 +1,8 @@
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
-import { declaredTimeouts } from './helpers/declared_timeouts';
+import { declaredTimeouts, maskCommentsAndStrings } from './helpers/declared_timeouts';
 import { expectScansOnlyThroughSharedWalkers } from './helpers/scan_guard_self_audit';
-import { tsFilesUnder } from './helpers/ts_files_under';
+import { sourceFilesUnder } from './helpers/source_files_under';
 
 // THE ANTI-WHALE RATCHET (docs/qa-gate.md, "Declared duration budgets").
 //
@@ -13,25 +13,28 @@ import { tsFilesUnder } from './helpers/ts_files_under';
 // diff instead of a slow surprise, off DECLARED vitest timeouts, which are the
 // only deterministic signal available at review time.
 //
-// It reads ALLOWANCES, not runtimes (tests/helpers/declared_timeouts.ts states
-// the parsing contract and its limits: diet arm of ternaries, comments
-// stripped, describe-body collection work invisible). So the rules are
-// conscious-decision ratchets, in the monolith_budget mold:
-//  - a single test may not declare more than SINGLE_TEST_CAP unless its file
-//    has an exact-match exception row here. One test is one worker chain: it
-//    cannot parallelize, so its allowance IS a job-wall floor. Shrink an
-//    exception when the test splits; growing one is a maintainer decision that
-//    needs its reasoning in the PR body.
+// It reads ALLOWANCES, not runtimes (tests/helpers/declared_timeouts.ts is
+// the parser, a masking scanner anchored to registration heads; the fixtures
+// below are its executable specification). The rules are conscious-decision
+// ratchets, in the monolith_budget mold:
+//  - a single test (or hook) may not declare more than SINGLE_TEST_CAP unless
+//    its file has an exact-match exception row here. One test is one worker
+//    chain: it cannot parallelize, so its allowance IS a job-wall floor. For a
+//    test, split it along its cost clusters; for a hook, shrink the hook's
+//    work. Shrink an exception when the test splits; growing one is a
+//    maintainer decision that needs its reasoning in the PR body.
 //  - a file whose declared sum exceeds DEFAULT_FILE_ALLOWANCE needs an
 //    exact-match ledger row. The remedies, in preference order: split the file
-//    along its cost clusters (the owned-class and chronomancy splits are the
-//    worked precedent, and the extract-and-test skill has the recipe), move
-//    the heavy case to a lane-owned suite (scripts/lib/ci_shard_plan.mjs,
-//    CI_LONG_SUITES, whose own comment carries the measured 90-second rule),
-//    or add the row deliberately.
+//    (the owned-class and chronomancy splits are the worked precedent, and the
+//    extract-and-test skill has the recipe), move the heavy case to a
+//    lane-owned suite (a MEASURED decision under the 90-second rule that
+//    scripts/lib/ci_shard_plan.mjs documents beside CI_LONG_SUITES), or add
+//    the row deliberately.
 //  - rows and exceptions are EXACT, so any timeout edit in a listed file
 //    touches this ledger in the same change, and a row for a file that no
 //    longer exceeds the default must be deleted (the ratchet direction).
+//  - a timeout the parser cannot size (an unresolvable identifier) fails the
+//    suite outright: hiding an allowance behind a constant is not an escape.
 //
 // Lane membership itself stays a MEASURED decision, deliberately not enforced
 // here: tests/audit_conservation_property.test.ts declares 2,700 seconds of
@@ -41,6 +44,8 @@ import { tsFilesUnder } from './helpers/ts_files_under';
 const SINGLE_TEST_CAP = 480_000;
 
 // file -> the exact largest single declared timeout it is allowed to carry.
+// Every entry must exceed SINGLE_TEST_CAP (an exception at or under the cap
+// is dead weight and fails below).
 const SINGLE_TEST_EXCEPTIONS: ReadonlyMap<string, number> = new Map([
   // The Nythraxis matrix runs its full boss ladder as one case. Splitting it
   // is the standing follow-up; shrink this when that lands.
@@ -52,30 +57,25 @@ const DEFAULT_FILE_ALLOWANCE = 300_000;
 // file -> exact declared diet-arm sum, for every file above the default.
 const FILE_ALLOWANCE_LEDGER: ReadonlyMap<string, number> = new Map([
   ['tests/audit_conservation_property.test.ts', 2_700_000],
-  ['tests/battleground_band.test.ts', 660_000],
+  ['tests/battleground_band.test.ts', 480_000],
   ['tests/chronomancy_balance_targets.test.ts', 360_000],
   ['tests/discord_db_integration.test.ts', 420_000],
   ['tests/dragonkin_whelp_litter.test.ts', 420_000],
-  ['tests/druid_balance_probe.test.ts', 570_000],
+  ['tests/druid_balance_probe.test.ts', 540_000],
   ['tests/emerald_deck_escape.test.ts', 540_000],
   ['tests/guild_bank_pg_integration.test.ts', 840_000],
-  ['tests/mob_portrait_source_manifest.test.ts', 360_000],
-  ['tests/nythraxis_matrix.test.ts', 1_320_000],
+  ['tests/nythraxis_matrix.test.ts', 720_000],
   ['tests/owned_class_balance_dps_probes.test.ts', 360_000],
-  ['tests/perf_tour_entry.test.ts', 450_000],
 ]);
 
-// This file excludes ITSELF from the scan: its parser fixtures below are real
-// declaration text by necessity, so the scraper would read them as this file's
-// own allowances (the diet-flag registry splits its needle for the same
-// reason; string fixtures cannot be split without losing what they test).
-const SELF = 'tests/suite_duration_budget.test.ts';
-
-function suiteTimeouts(): Map<string, { perTest: number[]; sum: number }> {
-  const out = new Map<string, { perTest: number[]; sum: number }>();
-  for (const found of tsFilesUnder('tests')) {
-    if (!found.file.endsWith('.test.ts')) continue;
-    if (`tests/${found.file}` === SELF) continue;
+// The corpus is every .ts and .mjs under tests/, NOT just *.test.ts: vitest
+// collects .test.mjs files too, and a vi.setConfig({ testTimeout }) in an
+// imported helper (tests/tank_crit_immunity_util.ts declares one) is a real
+// file-wide allowance that a test-files-only scan would never see.
+function suiteTimeouts(): Map<string, ReturnType<typeof declaredTimeouts>> {
+  const out = new Map<string, ReturnType<typeof declaredTimeouts>>();
+  for (const found of sourceFilesUnder('tests')) {
+    if (!/\.(ts|mjs)$/.test(found.file)) continue;
     out.set(`tests/${found.file}`, declaredTimeouts(readFileSync(found.full, 'utf8')));
   }
   return out;
@@ -85,43 +85,72 @@ describe('suite duration budget (declared-timeout ratchet)', () => {
   const suite = suiteTimeouts();
 
   it('walks the whole suite recursively and actually parses timeouts', () => {
-    // Deep root, so the real tree pins recursion directly: a subdirectory
-    // member must be present, and the corpus floor sits near the real count
-    // (2,730 on 2026-08-13) so a walk that silently narrowed would fail.
-    expect(suite.size).toBeGreaterThanOrEqual(2_600);
-    expect(suite.has('tests/server/new_endpoint.test.ts')).toBe(true);
+    // Recursion pinning per the scan-guard rules: the floor sits ABOVE the
+    // depth-2 truncation count (2,734 on 2026-08-13, vs 2,802 full and 2,499
+    // flat), and the pinned member lives three segments deep, so a walk that
+    // silently stopped descending fails both ways.
+    expect(suite.size).toBeGreaterThanOrEqual(2_760);
+    expect(suite.has('tests/server/http/characterization.test.ts')).toBe(true);
     const withTimeouts = [...suite.values()].filter((entry) => entry.sum > 0).length;
-    // Vacuity floor near the real count (106 on 2026-08-13): a scraper change
+    // Vacuity floor near the real count (82 on 2026-08-13): a parser change
     // that stopped matching the repo's real declaration forms fails here, not
     // by quietly emptying every rule below.
-    expect(withTimeouts).toBeGreaterThanOrEqual(90);
+    expect(withTimeouts).toBeGreaterThanOrEqual(70);
     const nythraxis = suite.get('tests/nythraxis_matrix.test.ts');
-    expect(nythraxis?.sum).toBe(1_320_000);
+    expect(nythraxis?.sum).toBe(720_000);
     expect(Math.max(...(nythraxis?.perTest ?? [0]))).toBe(720_000);
   });
 
-  it('parses every declared-timeout form and strips comments first', () => {
-    // Producer semantics pinned by execution: the trailing-argument form, the
-    // option-object form, the ternary diet arm, a trailing comma close, a
-    // commented-out timeout (not counted), and a sub-10s value (not counted).
-    expect(declaredTimeouts(`it('a', () => { run(); }, 120_000);`).perTest).toEqual([120_000]);
-    expect(declaredTimeouts(`it('b', { timeout: 240_000 }, () => { run(); });`).perTest).toEqual([
-      240_000,
+  it('refuses any timeout the parser cannot size', () => {
+    for (const [file, { unparsed }] of suite) {
+      expect(
+        unparsed,
+        `${file} declares a timeout behind an identifier this parser cannot resolve; bind it ` +
+          'to a same-file numeric const or inline the literal, so the ledger can see it',
+      ).toEqual([]);
+    }
+  });
+
+  it('parses every declared-timeout form, the executable spec', () => {
+    const per = (src: string) => declaredTimeouts(src).perTest;
+    // The forms that COUNT.
+    expect(per(`it('a', () => { run(); }, 120_000);`)).toEqual([120_000]);
+    expect(per(`it('b', { timeout: 240_000 }, () => { run(); });`)).toEqual([240_000]);
+    expect(per(`it('c', () => { run(); }, FULL ? 900_000 : 300_000);`)).toEqual([300_000]);
+    expect(per(`it('d', { timeout: FULL ? 720_000 : 90_000 }, fn);`)).toEqual([90_000]);
+    expect(per(`it.each(['x'] as const)('%s runs', (s) => { run(s); }, 180_000);`)).toEqual([
+      180_000,
     ]);
-    expect(
-      declaredTimeouts(`it('c', () => { run(); }, FULL ? 900_000 : 300_000);`).perTest,
-    ).toEqual([300_000]);
-    expect(declaredTimeouts(`it('d', { timeout: FULL ? 720_000 : 90_000 }, fn);`).perTest).toEqual([
-      90_000,
+    expect(per(`beforeAll(async () => { await seed(); }, 120_000);`)).toEqual([120_000]);
+    expect(per(`vi.setConfig({ testTimeout: 30_000 });`)).toEqual([30_000]);
+    expect(per(`const HOOK_MS = 60_000;\nbeforeAll(() => { seed(); }, HOOK_MS);`)).toEqual([
+      60_000,
     ]);
-    expect(
-      declaredTimeouts(`it(\n  'e',\n  () => {\n    run();\n  },\n  60_000,\n);`).perTest,
-    ).toEqual([60_000]);
-    expect(declaredTimeouts(`// it('old', () => { run(); }, 900_000);`).perTest).toEqual([]);
-    expect(
-      declaredTimeouts(`/* }, 800_000) */ it('f', () => { run(); }, 30_000);`).perTest,
-    ).toEqual([30_000]);
-    expect(declaredTimeouts(`setTimeout(() => { poll(); }, 5_000);`).perTest).toEqual([]);
+    // The forms that MUST NOT count: spawn options, ordinary call arguments,
+    // fixture objects inside a body, string and comment text, and values at
+    // or under the repo default testTimeout.
+    expect(per(`execFileSync(cmd, args, { timeout: 300_000 });`)).toEqual([]);
+    expect(per(`const o = makeOptions({ visible: true }, 120_000);`)).toEqual([]);
+    expect(per(`it('e', () => { expect(rows).toEqual([{ timeout: 120_000 }]); });`)).toEqual([]);
+    expect(per(`it('f', () => { log('statement_timeout: 900000'); });`)).toEqual([]);
+    expect(per(`// it('old', () => { run(); }, 900_000);`)).toEqual([]);
+    expect(per(`it('g', () => { run(); }, 15_000);`)).toEqual([]);
+    expect(per(`setTimeout(() => { poll(); }, 30_000);`)).toEqual([]);
+    // A method call on a LOCAL VARIABLE named test is not a registration.
+    expect(per(`test.controller.advance('a', 'b', 60_000);`)).toEqual([]);
+    // A regex literal with an odd quote count must not swallow the rest of
+    // the file into string state.
+    expect(per(`const R = /it's/;\nit('r', () => { run(); }, 600_000);`)).toEqual([600_000]);
+    // A trailing identifier in the TIMEOUT SLOT (previous argument is a
+    // function literal) counts by position, whatever its name; a trailing
+    // identifier after an options object is a test-fn reference and does not.
+    expect(per(`const BUDGET = 600_000;\nit('x', () => { run(); }, BUDGET);`)).toEqual([600_000]);
+    expect(per(`it('y', { timeout: 240_000 }, myTestFn);`)).toEqual([240_000]);
+    // Unresolvable identifiers surface instead of vanishing.
+    expect(declaredTimeouts(`it('h', { timeout: IMPORTED_MS }, fn);`).unparsed).toHaveLength(1);
+    expect(declaredTimeouts(`it('i', () => { run(); }, importedBudget);`).unparsed).toHaveLength(1);
+    // The mask keeps template interpolations bracket-balanced.
+    expect(maskCommentsAndStrings('`a ${b(1)} c`').includes('b(1)')).toBe(true);
   });
 
   it('caps every single declared test timeout at the worker-chain bound', () => {
@@ -140,12 +169,17 @@ describe('suite duration budget (declared-timeout ratchet)', () => {
         largest,
         `${file} declares a ${Math.round(largest / 1000)}s single-test allowance (cap ` +
           `${SINGLE_TEST_CAP / 1000}s). One test is one worker chain and cannot parallelize: ` +
-          'split it along its cost clusters (the owned-class balance split is the precedent), ' +
-          'or add an exact exception row in tests/suite_duration_budget.test.ts deliberately.',
+          'split a test along its cost clusters (the owned-class balance split is the ' +
+          'precedent), shrink a hook, or add an exact exception row in ' +
+          'tests/suite_duration_budget.test.ts deliberately.',
       ).toBeLessThanOrEqual(SINGLE_TEST_CAP);
     }
-    for (const file of SINGLE_TEST_EXCEPTIONS.keys()) {
+    for (const [file, value] of SINGLE_TEST_EXCEPTIONS) {
       expect(suite.has(file), `${file}: stale single-test exception row`).toBe(true);
+      expect(
+        value,
+        `${file}: a single-test exception at or under the cap is dead weight; delete it`,
+      ).toBeGreaterThan(SINGLE_TEST_CAP);
     }
   });
 
@@ -164,8 +198,9 @@ describe('suite duration budget (declared-timeout ratchet)', () => {
         sum,
         `${file} declares ${Math.round(sum / 1000)}s of summed allowance (default ` +
           `${DEFAULT_FILE_ALLOWANCE / 1000}s). Split the file along its cost clusters, move the ` +
-          'heavy case to a lane-owned suite (scripts/lib/ci_shard_plan.mjs, CI_LONG_SUITES), or ' +
-          'add an exact ledger row in tests/suite_duration_budget.test.ts deliberately.',
+          'heavy case to a lane-owned suite (a MEASURED decision; scripts/lib/ci_shard_plan.mjs, ' +
+          'CI_LONG_SUITES), or add an exact ledger row in tests/suite_duration_budget.test.ts ' +
+          'deliberately.',
       ).toBeLessThanOrEqual(DEFAULT_FILE_ALLOWANCE);
     }
     for (const [file, row] of FILE_ALLOWANCE_LEDGER) {
@@ -178,6 +213,6 @@ describe('suite duration budget (declared-timeout ratchet)', () => {
   });
 
   it('reads the tree only through the shared walker', () => {
-    expectScansOnlyThroughSharedWalkers(import.meta.url, ['ts_files_under']);
+    expectScansOnlyThroughSharedWalkers(import.meta.url, ['source_files_under']);
   });
 });


### PR DESCRIPTION
## Summary

Third act of the CI-speed program (follows #3370 and #3371, which split the giant balance suites). This makes the giant-file class structurally unrepeatable: tests/suite_duration_budget.test.ts scrapes every test file's DECLARED vitest timeouts (parsing contract in tests/helpers/declared_timeouts.ts: comments stripped first, trailing-argument and option-object forms, ternary DIET arm only, sub-10s ignored) and enforces two exact conscious-decision rules in the monolith_budget mold:

- A 480-second single-test cap, with one exact exception row (the Nythraxis matrix at 720s, to shrink when that test splits). One test is one worker chain and cannot parallelize, which is how the pre-split owned-class harness came to set whole job walls.
- A 300-second per-file summed allowance, with a 12-row exact ledger for the files above it. Any timeout edit in a listed file touches the ledger in the same change, and a split LOWERS the row.

The guard reads allowances, not runtimes, so lane membership deliberately stays a MEASURED decision owned by CI_LONG_SUITES: audit_conservation_property declares 2,700 seconds of allowance yet measured 55.1 in-lane and was just evicted, which is why declared sums must never drive the lane list (the ruling is written in the guard's header). It classifies blind (verified against the real classifier), so it rides every selective floor; it excludes itself from the scan because its parser fixtures are real declaration text (the diet-flag registry's needle-split precedent). Recursion and vacuity are pinned per the repo's scan-guard rules: a subdirectory member assertion, a corpus floor near the real 2,730, a files-with-timeouts floor near the real 106, and the shared-walker self-audit.

## Type of change

- [x] Tests
- [x] Build, CI, or tooling

## How was this tested?

- Commands:
  - npx vitest run tests/suite_duration_budget.test.ts (5/5) and tests/duplicate_test_blocks.test.ts (green over the new file)
  - npx tsc --noEmit clean; biome clean on touched files
  - node scripts/gate_select.mjs: PASS, all 8 steps green
  - The ledger rows were generated by running the real scraper over the tree, not hand-derived
- Manual steps: verified the guard's blind classification with scripts/lib/test_visibility.mjs directly, and that the guard fails correctly when un-excluding itself (its fixtures then count as allowances).

## Checklist

### Quality

- [x] **The gate passes.** node scripts/gate_select.mjs is green.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or .env committed, and ALLOW_DEV_COMMANDS is not enabled in any production path.
- [x] I didn't hand-edit generated files. They're regenerated by the build.