### PR TITLE
perf(ci): merge the selective floor and related legs into one invocation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -588,20 +588,24 @@ jobs:
           path: node_modules/.experimental-vitest-cache
           key: vitest-fsmodule-${{ runner.os }}-shard${{ matrix.shard }}-${{ hashFiles('pnpm-lock.yaml', 'vite.config.ts', '.npmrc', 'package.json') }}
 
-      # The shard runner spawns `npm test` itself, so pretest still regenerates
-      # the i18n artifacts in EVERY shard BY DESIGN (the S3 guard, guide
-      # freshness, and the git-subprocess suites need the generated artifacts no
-      # matter which shard they hash into); the freshness diff lives in
-      # pr-checks. Workers stay at half the runner's cores inside the script.
+      # The shard entry regenerates the artifacts itself, once per job, BY
+      # DESIGN (the S3 guard, guide freshness, and the git-subprocess suites
+      # need the generated artifacts no matter which shard they hash into; the
+      # merged selective leg is a bare vitest-related invocation with no npm
+      # lifecycle, so scripts/ci_shard_test.mjs runs pretest before spawning
+      # and the npm-test legs skip their lifecycle copy). The freshness diff
+      # lives in pr-checks. Workers stay at half the runner's cores inside the
+      # script.
       #
       # Phase 2 (docs/qa-gate.md, "Selective PR-tier CI"): the runner reads the
       # changes job's selection decision. test_mode=full spawns the old step
       # (`npm test -- --shard=i/8`) minus the long-sims lane files, which the
       # pr-long-sims-a/-b jobs run in this same run (Phase 4); test_mode=selective
-      # runs the always-run floor (blind/partial tests + invariant guard
-      # suites + changed tests, recomputed in this tree, minus the lane's
-      # floor members) plus `vitest related` over the changed sources, both
-      # sharded. Decisions and skip counts print in the job log.
+      # runs ONE merged sharded vitest-related leg: the changed sources plus
+      # the always-run floor (blind/partial tests + invariant guard suites +
+      # changed tests, recomputed in this tree, minus the lane's floor
+      # members) as self-selecting seeds. Decisions and skip counts print in
+      # the job log.
       # Release-gate below keeps the unconditional full run line; the nightly
       # workflow re-proves the full suite daily (docs/qa-gate.md).
       - name: Run tests (PR tier, shard ${{ matrix.shard }} of 8)
@@ -721,8 +725,9 @@ jobs:
           key: vitest-fsmodule-${{ runner.os }}-lane-long-sims-a-${{ hashFiles('pnpm-lock.yaml', 'vite.config.ts', '.npmrc', 'package.json') }}
 
       # Same selection relay as the shard step (env, never run-line
-      # interpolation); the lane entry spawns `npm test` itself, so pretest
-      # regenerates the i18n artifacts here exactly as in every shard.
+      # interpolation); the lane entry regenerates the i18n artifacts once
+      # before spawning, exactly as in every shard (its npm-test legs skip
+      # their lifecycle copy so nothing regenerates twice).
       - name: Run tests (PR tier, long-sims lane A)
         env:
           TEST_MODE: ${{ needs.changes.outputs.test_mode }}
@@ -769,8 +774,9 @@ jobs:
           key: vitest-fsmodule-${{ runner.os }}-lane-long-sims-b-${{ hashFiles('pnpm-lock.yaml', 'vite.config.ts', '.npmrc', 'package.json') }}
 
       # Same selection relay as the shard step (env, never run-line
-      # interpolation); the lane entry spawns `npm test` itself, so pretest
-      # regenerates the i18n artifacts here exactly as in every shard.
+      # interpolation); the lane entry regenerates the i18n artifacts once
+      # before spawning, exactly as in every shard (its npm-test legs skip
+      # their lifecycle copy so nothing regenerates twice).
       - name: Run tests (PR tier, long-sims lane B)
         env:
           TEST_MODE: ${{ needs.changes.outputs.test_mode }}

--- a/docs/qa-gate.md
+++ b/docs/qa-gate.md
@@ -201,8 +201,11 @@ Since Phase 2 of the CI/CD performance packet, the
 API-fetched file listing that decides `code` (`scripts/lib/ci_test_select.mjs`), and each
 `pr-gate` shard builds its legs through `scripts/lib/ci_shard_plan.mjs` via
 `scripts/ci_shard_test.mjs`: in full mode, the old `npm test -- --shard=i/8` step minus
-the long-sims lane files (below); in selective mode, the always-run floor plus
-`vitest related` over the changed sources, both sharded.
+the long-sims lane files (below); in selective mode, ONE merged sharded `vitest related`
+leg over the changed sources plus the floor files as self-selecting seeds (vitest seeds
+its affected set with the given paths themselves; the property is pinned by execution in
+`tests/ci_shard_plan.test.ts`). The entry regenerates the generated artifacts once per
+job before spawning, since `npx vitest` has no npm lifecycle.
 
 **The long-sims lanes** (Phase 4; split in two by the lane-diet PR). The
 `CI_LONG_SUITES` files (`scripts/lib/ci_shard_plan.mjs`: the suites measured over 90
@@ -218,14 +221,14 @@ own wall clock is the slower HALF, not the whole list. Completeness is a pinned
 invariant, not an intention: each lane fails closed to its whole half on exactly the
 inputs that make a shard fail closed to full, the shard legs exclude exactly the files
 the two lanes own between them, and in selective mode each lane runs just its half's
-lane files the floor or the PR's diff would have carried (the related legs stay
+lane files the floor or the PR's diff would have carried (the merged leg's related side stays
 unfiltered, so a reached lane file re-runs there: duplicate work, never a gap). Mode for
 mode, the ten PR-tier test jobs together therefore run exactly what the pre-lane
 8-shard layout would have run (`tests/ci_shard_plan.test.ts` pins the partition;
 selective mode still skips the outside-floor remainder by design, exactly as before the
 lane). The latency win is concentrated in FULL mode: most lane files are
-graph-visible, so on a sim-heavy selective PR the `related` legs pull them back into a
-shard exactly as they did before the lane, and only the blind members (plus any lane
+graph-visible, so on a sim-heavy selective PR the merged leg's related side pulls them back into a
+shard exactly as the old related legs did before the lane, and only the blind members (plus any lane
 test the PR itself changed) ride the lanes.
 The lanes reproduce locally with
 `node scripts/ci_shard_test.mjs --lane=long-sims-a --plan-only` (and `-b`), printing the
@@ -310,8 +313,8 @@ rests on three structural facts, each pinned:
    mechanism: it floors the direct artifact-naming importers on every selective run,
    with witnesses floored SOLELY by it (`tests/i18n_lazy_loader.test.ts`,
    `tests/i18n_dialect_resolution.test.ts`) pinned in `tests/gate_select_plan.test.ts`.
-   Each `npm test` leg's pretest also regenerates the artifacts, so selected suites
-   always assert over fresh content.
+   The shard entry also regenerates the artifacts once per job before its legs run,
+   so selected suites always assert over fresh content.
 3. **Deletions and unprovable shapes widen.** The freshness diff cannot flag a
    deleted-then-regenerated file (regeneration recreates it UNTRACKED, and `git diff`
    never shows untracked files), so a removed or renamed-away artifact forces full in

--- a/scripts/ci_shard_test.mjs
+++ b/scripts/ci_shard_test.mjs
@@ -17,12 +17,14 @@
 // Selection applies to PR-tier CI only: release-gate keeps its unconditional
 // `npm test -- --shard=i/N` run line and never runs this script, and the
 // nightly workflow re-proves the full suite on the tips daily (docs/qa-gate.md).
+import { spawnSync } from 'node:child_process';
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { formatLegHeader, runLegsWithFlakeRetry } from './lib/ci_leg_runner.mjs';
 import { buildLanePlan, buildShardPlan, parseShardArg } from './lib/ci_shard_plan.mjs';
+import { shouldRunEntryPretest, WOC_SKIP_PRETEST } from './lib/gate_artifact_skip.mjs';
 import { collectSuiteVisibility } from './lib/gate_discovery.mjs';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
@@ -153,11 +155,12 @@ if (lane) {
   }
   if (plan.mode === 'selective') {
     console.log(
-      `[ci-shard] runs: ${plan.floorCount} floor file(s) sharded ${shard.total} ways` +
+      `[ci-shard] runs: one merged vitest related leg, ${plan.floorCount} floor file(s) as ` +
+        `self-selecting seeds plus ${plan.relatedCount} changed source(s), sharded ` +
+        `${shard.total} ways` +
         (plan.laneFloorCount > 0
           ? ` (${plan.laneFloorCount} more floor file(s) ride the long-sims lane)`
-          : '') +
-        `, plus vitest related over ${plan.relatedCount} changed source(s)`,
+          : ''),
     );
     // Honest accounting: the related leg covers an unknown further share of the
     // outside-floor files (it can only be known by running vitest), so this line
@@ -176,33 +179,72 @@ if (planOnly) {
   }
   console.log(`\n[ci-shard] plan-only: ${plan.legs.length} leg(s) printed, nothing spawned`);
 } else {
-  // The leg runner (lib/ci_leg_runner.mjs) streams each leg's output through
-  // unchanged, keeps a bounded tail, and applies the ONE sanctioned
-  // known-flake retry: a leg that exits 1 with the exact teardown-rpc
-  // signature (every test passed) reruns once, loudly; nothing else ever
-  // retries. Spawning stays shell-less there: argv elements (which embed
-  // PR-controlled filenames) pass verbatim to execvp, and the floor leg's
-  // long file list is safe under the POSIX arg limits this ubuntu-only entry
-  // runs under. The win32 cmd.exe 8191-char ceiling that forces
-  // gate_select.mjs to chunk does not apply here; local reproduction on
-  // Windows is --plan-only (spawns nothing) per docs/qa-gate.md.
-  const result = await runLegsWithFlakeRetry({ legs: plan.legs, cwd: repoRoot });
-  if (!result.ok) {
-    // exitCode, never process.exit(): the legs' output is piped through this
-    // process now, and a forced exit discards whatever is still queued on
-    // the async stdout pipe (measured: everything past one 64 KB pipe
-    // buffer), which would truncate exactly the failing-shard log a human
-    // needs. Setting exitCode lets the event loop drain and then exit.
-    process.exitCode = result.status;
+  // Artifact regeneration happens ONCE here, at the entry, for every mode:
+  // the merged selective leg is a bare `npx vitest related` with no npm
+  // lifecycle, so pretest cannot ride it, and the npm-test legs then skip
+  // their own lifecycle copy via WOC_SKIP_PRETEST so no job regenerates
+  // twice. Per-JOB regeneration is unchanged (ci.yml records the ruling: the
+  // S3 guard, guide freshness, and the git-subprocess suites need the
+  // artifacts no matter which shard they hash into). Zero-leg lane plans skip
+  // it: nothing below will read the artifacts.
+  let pretestOk = true;
+  if (!shouldRunEntryPretest({ legCount: plan.legs.length })) {
+    // Both arms speak: an unlogged skip would let stale artifacts reach the
+    // guard suites with no audit trace in the job log.
+    if (plan.legs.length > 0) {
+      console.log(
+        '[ci-shard] pretest: SKIPPED (WOC_SKIP_PRETEST=1); legs read whatever is on disk',
+      );
+    }
   } else {
-    console.log(
-      `\n[ci-shard] PASS: ${plan.legs.length} leg(s) green on ${
-        lane ? `the long-sims-${laneHalf} lane` : `shard ${shard.index}/${shard.total}`
-      }${
-        result.retriedLegNames.length > 0
-          ? ` (known-flake retry used on: ${result.retriedLegNames.join(', ')})`
-          : ''
-      }`,
-    );
+    console.log('[ci-shard] pretest: regenerating generated artifacts once for this job');
+  }
+  if (shouldRunEntryPretest({ legCount: plan.legs.length })) {
+    // stdio inherit: nothing is piped through this process yet, so the
+    // no-process.exit pipe-drain rule below is not in play for this step.
+    const pretest = spawnSync(process.execPath, [path.join(repoRoot, 'scripts', 'pretest.mjs')], {
+      cwd: repoRoot,
+      stdio: 'inherit',
+    });
+    if (pretest.status !== 0) {
+      console.error(`[ci-shard] pretest failed (exit ${pretest.status ?? 'signal'})`);
+      process.exitCode = pretest.status ?? 1;
+      pretestOk = false;
+    } else {
+      // The npm-test legs (full mode, lanes) inherit this and skip their own
+      // lifecycle copy, so no job regenerates twice.
+      process.env[WOC_SKIP_PRETEST] = '1';
+    }
+  }
+  if (pretestOk) {
+    // The leg runner (lib/ci_leg_runner.mjs) streams each leg's output through
+    // unchanged, keeps a bounded tail, and applies the ONE sanctioned
+    // known-flake retry: a leg that exits 1 with the exact teardown-rpc
+    // signature (every test passed) reruns once, loudly; nothing else ever
+    // retries. Spawning stays shell-less there: argv elements (which embed
+    // PR-controlled filenames) pass verbatim to execvp, and the floor leg's
+    // long file list is safe under the POSIX arg limits this ubuntu-only entry
+    // runs under. The win32 cmd.exe 8191-char ceiling that forces
+    // gate_select.mjs to chunk does not apply here; local reproduction on
+    // Windows is --plan-only (spawns nothing) per docs/qa-gate.md.
+    const result = await runLegsWithFlakeRetry({ legs: plan.legs, cwd: repoRoot });
+    if (!result.ok) {
+      // exitCode, never process.exit(): the legs' output is piped through this
+      // process now, and a forced exit discards whatever is still queued on
+      // the async stdout pipe (measured: everything past one 64 KB pipe
+      // buffer), which would truncate exactly the failing-shard log a human
+      // needs. Setting exitCode lets the event loop drain and then exit.
+      process.exitCode = result.status;
+    } else {
+      console.log(
+        `\n[ci-shard] PASS: ${plan.legs.length} leg(s) green on ${
+          lane ? `the long-sims-${laneHalf} lane` : `shard ${shard.index}/${shard.total}`
+        }${
+          result.retriedLegNames.length > 0
+            ? ` (known-flake retry used on: ${result.retriedLegNames.join(', ')})`
+            : ''
+        }`,
+      );
+    }
   }
 }

--- a/scripts/lib/ci_shard_plan.mjs
+++ b/scripts/lib/ci_shard_plan.mjs
@@ -9,14 +9,19 @@
 //               dedicated lane job runs exactly those files in the same run,
 //               so in FULL mode the shards plus the lane run the whole old
 //               suite and a fail-closed decision can never cost coverage.
-//   selective   two sharded legs. Leg 1 runs the always-run FLOOR through
-//               `npm test` (its pretest regenerates the i18n artifacts the
-//               guard suites read, in every shard, exactly as today), minus
-//               the lane files, which the lane job carries instead. Leg 2
-//               runs `vitest related` over the changed sources; pretest has
-//               already run by then. The related leg is deliberately NOT
-//               lane-filtered: a lane file it reaches re-runs there, which
-//               duplicates work but never opens a gap.
+//   selective   ONE merged sharded leg: `vitest related` over the changed
+//               sources PLUS the always-run floor files as self-selecting
+//               seeds (vitest seeds its affected set with the given paths
+//               themselves), minus the lane files on the floor side, which
+//               the lane job carries instead. One collection, one transform
+//               pass, one sharding, where the former floor and related legs
+//               paid a second vitest startup per shard. The related side is
+//               deliberately NOT lane-filtered: a lane file the graph walk
+//               reaches re-runs here, which duplicates work but never opens
+//               a gap. `npx vitest` has no npm lifecycle, so the entry
+//               (scripts/ci_shard_test.mjs) regenerates the artifacts once
+//               per job before spawning, and the guard suites still read
+//               fresh bytes on every shard.
 //   lane        the "PR gate (long sims A)" / "PR gate (long sims B)" jobs
 //               (buildLanePlan, one CI_LONG_SUITE_HALVES half each): the
 //               half's collected CI_LONG_SUITES files, all of them in full
@@ -39,10 +44,11 @@
 //      or the import graph shifts underneath them;
 //   3. every test file the PR itself changed.
 //
-// Sharding: vitest partitions the COLLECTED file set, so `--shard=i/N` on an
-// explicit file list (leg 1) and on a related run (leg 2) each split their own
-// set 8 ways. The two legs may overlap on partial tests; that re-runs a few
-// files and is wasted time, never a correctness gap.
+// Sharding: vitest partitions the COLLECTED file set, so `--shard=i/N` on the
+// merged related invocation splits the floor-union-related selection 8 ways in
+// one draw. A file both floor-classified and graph-reachable appears once in
+// the argv and once in the collection: vitest's related set is a Set, so the
+// old two-leg overlap re-runs are gone by construction.
 
 import { isRelayablePath } from './ci_test_select.mjs';
 import { classifySelectPaths } from './gate_select_plan.mjs';
@@ -378,36 +384,52 @@ export function buildShardPlan({
   // put the multi-minute files right back on the shard tail.
   const floorFiles = floor.filter((f) => !laneSet.has(f));
   const laneFloorCount = floor.length - floorFiles.length;
+  const liveSources = relatedSources.filter((p) => exists(p));
+  // ONE merged leg (2026-08-14; formerly a floor `npm test` leg plus a
+  // separate `vitest related` leg): `vitest related` keeps a spec whose own
+  // moduleId is among the given paths (vitest 4.1.10, specifications.ts,
+  // filterTestsBySource's `path === specification.moduleId` arm), so a floor
+  // TEST file passed as a positional selects itself. Feeding the floor beside the changed sources therefore
+  // runs floor-union-related in one collection, one transform pass, and one
+  // sharding, where the two sequential legs paid a second vitest startup and
+  // re-imported the shared setup on every shard.
+  // tests/ci_shard_plan.test.ts pins the self-selection property by EXECUTION
+  // so a vitest upgrade that dropped it goes red there instead of silently
+  // un-flooring every selective shard. The related side stays deliberately
+  // NOT lane-filtered: a lane file `related` reaches re-runs here (duplicate
+  // work, never a gap). `npx vitest` has no npm lifecycle, so pretest runs
+  // once at the entry (scripts/ci_shard_test.mjs) instead of per leg; the
+  // per-JOB artifact regeneration the S3 guard and freshness suites rely on
+  // is unchanged.
   const legs = [
     {
-      name: `npm test (always-run floor, ${floorFiles.length} files, shard ${shard.index}/${shard.total})`,
-      cmd: 'npm',
-      args: ['test', '--', ...floorFiles, shardArg, workersArg],
-    },
-  ];
-  const liveSources = relatedSources.filter((p) => exists(p));
-  if (liveSources.length > 0) {
-    // Deliberately NOT lane-filtered: a lane file `related` reaches re-runs
-    // here (duplicate work, never a gap), exactly the overlap contract the two
-    // selective legs already have with each other.
-    legs.push({
       // "path(s)", not "changed source file(s)": liveSources is the union of
       // changed sources and fed-through generated i18n artifacts; the mode
       // reason carries the split counts.
-      name: `vitest related (${liveSources.length} path(s), shard ${shard.index}/${shard.total})`,
+      name:
+        `vitest related (merged: ${floorFiles.length} floor file(s) + ` +
+        `${liveSources.length} changed path(s), shard ${shard.index}/${shard.total})`,
       cmd: 'npx',
+      // EXPLICIT --passWithNoTests=false: the related subcommand defaults
+      // the option to TRUE internally (options.passWithNoTests ??= true in
+      // vitest's cac wiring), so omitting the flag is NOT loud; only an
+      // explicit false sticks through the ??=. With it, a merged leg that
+      // collects nothing exits 1 (measured both directions), which is the
+      // red a floor-seeding collapse must produce in real CI; a healthy leg
+      // always collects the floor, so no false red is possible.
       args: [
         '--no-install',
         'vitest',
         'related',
         ...liveSources,
+        ...floorFiles,
         '--run',
-        '--passWithNoTests',
+        '--passWithNoTests=false',
         shardArg,
         workersArg,
       ],
-    });
-  }
+    },
+  ];
   return {
     mode: 'selective',
     reason: `selective: floor ${floorFiles.length} + related over ${liveSources.length} source(s)`,

--- a/scripts/lib/ci_test_select.mjs
+++ b/scripts/lib/ci_test_select.mjs
@@ -62,6 +62,7 @@ export const SELECTION_PIPELINE_FILES = Object.freeze([
   'scripts/lib/ci_test_select.mjs',
   'scripts/lib/ci_shard_plan.mjs',
   'scripts/lib/ci_leg_runner.mjs',
+  'scripts/lib/gate_artifact_skip.mjs',
   'scripts/lib/gate_discovery.mjs',
   'scripts/lib/gate_select_plan.mjs',
   'scripts/lib/gate_fast_plan.mjs',

--- a/scripts/lib/gate_artifact_skip.d.mts
+++ b/scripts/lib/gate_artifact_skip.d.mts
@@ -5,3 +5,8 @@ export function shouldSkipPretest(
 ): boolean;
 
 export function gateVitestSkipPretestEnv(): Record<string, string>;
+
+export function shouldRunEntryPretest(opts: {
+  legCount: number;
+  env?: NodeJS.ProcessEnv | Record<string, string | undefined>;
+}): boolean;

--- a/scripts/lib/gate_artifact_skip.mjs
+++ b/scripts/lib/gate_artifact_skip.mjs
@@ -23,3 +23,18 @@ export function shouldSkipPretest(env = process.env) {
 export function gateVitestSkipPretestEnv() {
   return { [WOC_SKIP_PRETEST]: '1' };
 }
+
+/**
+ * The CI shard entry's pretest decision (scripts/ci_shard_test.mjs): the
+ * merged selective leg is a bare vitest-related invocation with no npm
+ * lifecycle, so the entry regenerates the artifacts itself, once per job,
+ * BEFORE any leg spawns, then sets the skip flag so the npm-test legs do not
+ * regenerate a second time. Pure so its three arms (zero legs, skip flag,
+ * run) are unit-testable without spawning anything.
+ *
+ * @param {{ legCount: number, env?: NodeJS.ProcessEnv | Record<string, string | undefined> }} opts
+ * @returns {boolean} whether the entry must run scripts/pretest.mjs now
+ */
+export function shouldRunEntryPretest({ legCount, env = process.env }) {
+  return legCount > 0 && !shouldSkipPretest(env);
+}

--- a/scripts/lib/gate_select_plan.mjs
+++ b/scripts/lib/gate_select_plan.mjs
@@ -12,10 +12,16 @@
 //   2. related      `vitest related` over the changed source files, which models
 //                   the remaining ~80% of the suite correctly.
 //
-// Two invocations rather than one because `related` is a subcommand, not a flag,
-// so it cannot be mixed with an explicit file list. The overlap between the two
-// (a 'partial' test selected by both) re-runs a handful of files and is pure
-// wasted time, never a correctness gap.
+// Two invocations here BY REMAINING CHOICE: `related` seeds its affected set
+// with the given paths themselves, so a merged floor-plus-sources invocation
+// is possible and the CI shards use exactly that (scripts/lib/ci_shard_plan.mjs,
+// merged 2026-08-14, with the seed property pinned by execution in
+// tests/ci_shard_plan.test.ts). The local gate keeps two legs for now simply
+// as a not-yet-taken follow-up (its artifacts are already generated once at
+// the gate entry, so nothing blocks the same merge here); take it with its
+// own pin round. The overlap between the two (a 'partial' test selected by
+// both) re-runs a handful of files and is pure wasted time, never a
+// correctness gap.
 //
 // SAFETY FALLBACK: any change this planner cannot reason about (a broad config
 // file, a lockfile, a vitest/vite/tsconfig edit) drops the whole plan to the FULL

--- a/tests/ci_leg_runner.test.ts
+++ b/tests/ci_leg_runner.test.ts
@@ -509,8 +509,23 @@ describe('entry wiring', () => {
     expect(code).toContain("from './lib/ci_leg_runner.mjs'");
     expect(code).toContain('runLegsWithFlakeRetry({ legs: plan.legs, cwd: repoRoot })');
     // The one retry policy lives in the runner; the entry must not grow its
-    // own spawn path around it.
-    expect(code).not.toContain('spawnSync');
+    // own TEST-spawning path around it. The single sanctioned spawnSync is
+    // the entry-level pretest step (the merged selective leg is a bare
+    // vitest-related invocation with no npm lifecycle, so artifact
+    // regeneration cannot ride a leg): pin it to exactly one occurrence,
+    // aimed at pretest.mjs, so a second raw spawn still fails here.
+    const spawnSyncSites = code.match(/spawnSync\(/g) ?? [];
+    expect(spawnSyncSites).toHaveLength(1);
+    const site = code.slice(code.indexOf('spawnSync('), code.indexOf('spawnSync(') + 200);
+    expect(site).toContain('pretest.mjs');
+    // Ordering: the pretest spawn must sit BEFORE the leg runner in the
+    // entry, so a refactor that moves regeneration after (or out of) the leg
+    // path fails here rather than shipping stale artifacts to the guards.
+    expect(code.indexOf('spawnSync(')).toBeLessThan(code.indexOf('runLegsWithFlakeRetry('));
+    // The skip handshake shares the ONE exported env constant with
+    // scripts/pretest.mjs's own reader, so the two spellings cannot drift.
+    expect(code).toContain("from './lib/gate_artifact_skip.mjs'");
+    expect(code).toContain('process.env[WOC_SKIP_PRETEST]');
     expect(code).not.toContain('spawn(');
     // The failure path must set exitCode and let the piped output drain; a
     // forced process.exit() discards queued stdout and truncates the

--- a/tests/ci_shard_plan.test.ts
+++ b/tests/ci_shard_plan.test.ts
@@ -1,5 +1,5 @@
 import { spawn } from 'node:child_process';
-import { readdirSync, readFileSync } from 'node:fs';
+import { mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -145,43 +145,55 @@ describe('buildShardPlan: full mode replays the old step minus the lane', () => 
 });
 
 describe('buildShardPlan: selective mode', () => {
-  it('builds the floor leg through npm test and the related leg through vitest related', () => {
+  it('builds ONE merged vitest related leg carrying the sources and the floor as seeds', () => {
     const plan = buildShardPlan({ ...BASE });
     expect(plan.mode).toBe('selective');
-    expect(plan.legs).toHaveLength(2);
-    const [floorLeg, relatedLeg] = plan.legs;
-    // npm test, never bare vitest: pretest must regenerate the i18n artifacts
-    // in every shard exactly as the old run line did.
-    expect(floorLeg.cmd).toBe('npm');
-    expect(floorLeg.args.slice(0, 2)).toEqual(['test', '--']);
-    expect(floorLeg.args).toContain('tests/architecture.test.ts');
-    expect(floorLeg.args).toContain('tests/world_api_parity.test.ts');
-    expect(floorLeg.args).toContain('tests/parity/golden_warrior.test.ts');
-    expect(floorLeg.args).toContain('--shard=3/8');
-    expect(floorLeg.args).toContain('--maxWorkers=2');
-    expect(floorLeg.args).not.toContain('--passWithNoTests');
-    expect(relatedLeg.cmd).toBe('npx');
-    expect(relatedLeg.args).toEqual([
-      '--no-install',
-      'vitest',
-      'related',
-      'src/ui/unit_portrait.ts',
+    expect(plan.legs).toHaveLength(1);
+    const [merged] = plan.legs;
+    expect(merged.cmd).toBe('npx');
+    // Argv order: the vitest related invocation, the changed sources, then
+    // every floor file as a SELF-SELECTING seed (vitest seeds its affected
+    // set with the given paths themselves; the subprocess describe below
+    // pins that property by execution), then the flags. The floor files ride
+    // this leg because `npx vitest` has no npm lifecycle: pretest moved to
+    // the entry (scripts/ci_shard_test.mjs), once per job.
+    expect(merged.args.slice(0, 3)).toEqual(['--no-install', 'vitest', 'related']);
+    expect(merged.args[3]).toBe('src/ui/unit_portrait.ts');
+    expect(merged.args).toContain('tests/architecture.test.ts');
+    expect(merged.args).toContain('tests/world_api_parity.test.ts');
+    expect(merged.args).toContain('tests/parity/golden_warrior.test.ts');
+    expect(merged.args.slice(-4)).toEqual([
       '--run',
-      '--passWithNoTests',
+      '--passWithNoTests=false',
       '--shard=3/8',
       '--maxWorkers=2',
     ]);
+    // EXPLICIT =false, never the bare flag and never omitted: the related
+    // subcommand defaults passWithNoTests to TRUE internally, so only an
+    // explicit false makes an empty collection exit 1. That is the loud
+    // direction a floor-seeding collapse must take in real CI (measured both
+    // ways in the gate-integrity round).
+    expect(merged.args).not.toContain('--passWithNoTests');
+    // Every floor member is a positional: sources (1) + floor + the 3 fixed
+    // leading/4 trailing tokens accounts for the whole argv. (The genuine
+    // completeness proof is the partition test below, which recomputes
+    // buildFloor independently; this count only pins the argv shape.)
+    const positionals = merged.args.slice(3, -4);
+    expect(positionals.length).toBe(1 + (plan.floorCount ?? 0));
   });
 
-  it('omits the related leg when the diff has no live sources', () => {
+  it('keeps the merged leg when the diff has no live sources (floor seeds only)', () => {
     const docsOnly = buildShardPlan({ ...BASE, changedPaths: ['docs/a.md', 'README.md'] });
     expect(docsOnly.mode).toBe('selective');
     expect(docsOnly.legs).toHaveLength(1);
+    expect(docsOnly.legs[0].args.filter((a) => a.startsWith('src/'))).toEqual([]);
+    expect(docsOnly.legs[0].args).toContain('tests/architecture.test.ts');
     const deleted = buildShardPlan({ ...BASE, exists: (p) => !p.startsWith('src/') });
     expect(deleted.legs).toHaveLength(1);
+    expect(deleted.legs[0].args.filter((a) => a.startsWith('src/'))).toEqual([]);
   });
 
-  it('adds a changed test file to the floor leg and drops a deleted one from the argv', () => {
+  it('adds a changed test file to the merged seeds and drops a deleted one from the argv', () => {
     const plan = buildShardPlan({
       ...BASE,
       changedPaths: ['tests/pure_b.test.ts', 'tests/deleted.test.ts'],
@@ -458,20 +470,24 @@ describe('the long-sims lane (Phase 4)', () => {
     }
   });
 
-  it('selective mode moves floor lane files to the lane and leaves related unfiltered', () => {
+  it('selective mode moves floor lane files to the lane and keeps the merged leg unfiltered', () => {
     const plan = buildShardPlan({ ...LANE_BASE });
     expect(plan.mode).toBe('selective');
-    const [floorLeg, relatedLeg] = plan.legs;
-    expect(floorLeg.args).not.toContain(LANE_BLIND);
-    expect(floorLeg.args).not.toContain(LANE_GRAPH);
+    expect(plan.legs).toHaveLength(1);
+    const [merged] = plan.legs;
+    // The FLOOR-SEED half of the merged argv is lane-filtered (the lane job
+    // owns those files); the RELATED side stays unfiltered: no --exclude may
+    // appear, so a lane file vitest's graph walk reaches still re-runs here
+    // (duplicate work, never a gap).
+    expect(merged.args).not.toContain(LANE_BLIND);
+    expect(merged.args).not.toContain(LANE_GRAPH);
     expect(plan.laneFloorCount).toBe(1);
-    // floorCount reports what THIS leg runs. The fixture's whole floor is the
-    // base fixture's FLOOR_SANITY_MIN + 25 plus LANE_BLIND (added to
-    // alwaysRun above); the one lane member then moves to the lane, so the
-    // leg is back at the base figure.
+    // floorCount reports what this leg SEEDS. The fixture's whole floor is
+    // the base fixture's floor plus LANE_BLIND (added to alwaysRun above);
+    // the one lane member then moves to the lane, so the seed list is back
+    // at the base figure.
     expect(plan.floorCount).toBe(FLOOR_SANITY_MIN + 26);
-    expect(relatedLeg.args).not.toContain(`--exclude=${LANE_BLIND}`);
-    expect(relatedLeg.args.join(' ')).not.toContain('--exclude');
+    expect(merged.args.join(' ')).not.toContain('--exclude');
   });
 
   it('a changed lane test rides the lane, not the floor leg', () => {
@@ -620,14 +636,14 @@ describe('the long-sims lane (Phase 4)', () => {
     expect(
       shardFull.legs[0].args.filter((a) => a.startsWith('--exclude=')).map((a) => a.slice(10)),
     ).toEqual([...laneFullA.laneFiles, ...laneFullB.laneFiles].sort());
-    // Selective mode: the floor leg plus both halves' lane files re-cover the
-    // whole floor with no overlap and no loss.
+    // Selective mode: the merged leg's floor SEEDS plus both halves' lane
+    // files re-cover the whole floor with no overlap and no loss. Only the
+    // tests/ positionals are floor seeds; the changed src/ source rides the
+    // same argv but is not a floor member.
     const shardSel = buildShardPlan({ ...LANE_BASE });
     const laneSelA = buildLanePlan({ ...LANE_BASE, half: 'a' });
     const laneSelB = buildLanePlan({ ...LANE_BASE, half: 'b' });
-    const floorLegFiles = shardSel.legs[0].args.filter(
-      (a) => a.startsWith('tests/') || a.startsWith('src/'),
-    );
+    const floorLegFiles = shardSel.legs[0].args.filter((a) => a.startsWith('tests/'));
     const { floor } = buildFloor({
       alwaysRun: LANE_BASE.alwaysRun,
       testFiles: LANE_BASE.testFiles,
@@ -646,6 +662,107 @@ describe('the long-sims lane (Phase 4)', () => {
 // cannot hide behind unit tests of the parts.
 describe('ci_shard_test.mjs entry (subprocess, --plan-only)', () => {
   const repoRoot = fileURLToPath(new URL('..', import.meta.url));
+
+  it('vitest related runs a TEST-file seed and goes RED on an empty collection', async () => {
+    // The merged selective leg feeds the floor files to `vitest related` as
+    // positionals, relying on vitest keeping a spec whose own moduleId is
+    // among the given paths (specifications.ts, filterTestsBySource's
+    // `path === specification.moduleId` arm). This pins BOTH halves of that
+    // contract by EXECUTION against the REAL installed vitest: the seed runs,
+    // and with --passWithNoTests=false an empty collection exits 1 (the
+    // related subcommand defaults the flag to TRUE internally, so the loud
+    // direction only exists with the explicit false). A vitest upgrade that
+    // dropped either half would otherwise silently un-floor every selective
+    // shard, the worst failure class this planner has.
+    //
+    // A mkdtemp FIXTURE PROJECT, not the repo corpus: `vitest related`
+    // transforms every collected spec for its reverse graph, and over the
+    // repo's ~2,700 specs that took minutes under CI contention (a 60s
+    // watchdog killed the first cut of this pin on a loaded runner). The
+    // property under test is vitest's, not the repo's, so a one-file corpus
+    // proves it in seconds with the same installed binary.
+    const fixtureRoot = mkdtempSync(path.join(os.tmpdir(), 'wocc-seed-pin-'));
+    try {
+      writeFileSync(
+        path.join(fixtureRoot, 'vitest.config.mjs'),
+        "export default { test: { include: ['*.test.mjs'] } };\n",
+      );
+      writeFileSync(
+        path.join(fixtureRoot, 'a.test.mjs'),
+        "import { expect, it } from 'vitest';\nit('seed runs', () => { expect(1).toBe(1); });\n",
+      );
+      writeFileSync(path.join(fixtureRoot, 'notes.md'), 'inert non-test seed\n');
+      const runChild = (seeds: string[]) => {
+        const child = spawn(
+          'npx',
+          [
+            '--no-install',
+            'vitest',
+            'related',
+            ...seeds,
+            '--run',
+            '--passWithNoTests=false',
+            '--root',
+            fixtureRoot,
+            '--config',
+            path.join(fixtureRoot, 'vitest.config.mjs'),
+          ],
+          {
+            cwd: repoRoot,
+            // A SCRUBBED env, like runEntry below: this test itself runs
+            // inside vitest, and an inherited VITEST_* worker environment
+            // makes the child vitest misbehave (observed: it prints the RUN
+            // header, runs nothing, and exits 0). HOME rides along for the
+            // npx cache.
+            env: {
+              PATH: process.env.PATH ?? '',
+              ...(process.env.HOME ? { HOME: process.env.HOME } : {}),
+            },
+          },
+        );
+        let log = '';
+        child.stdout.on('data', (chunk) => {
+          log += String(chunk);
+        });
+        child.stderr.on('data', (chunk) => {
+          log += String(chunk);
+        });
+        return new Promise<{ exitCode: number | null; log: string }>((resolve, reject) => {
+          const killer = setTimeout(() => {
+            child.kill('SIGKILL');
+            reject(new Error(`nested vitest hung; log tail:\n${log.slice(-2000)}`));
+          }, 60_000);
+          child.on('error', (error) => {
+            clearTimeout(killer);
+            reject(error);
+          });
+          child.on('close', (code) => {
+            clearTimeout(killer);
+            resolve({ exitCode: code, log });
+          });
+        });
+      };
+      // The MIXED argv shape the planner emits: an inert non-test path beside
+      // the test-file seed. The seed must run.
+      const seeded = await runChild(['notes.md', 'a.test.mjs']);
+      // Full ANSI strip, ESC byte included (a CSI-tail-only strip leaves raw
+      // ESC bytes between the summary tokens and \s does not match them);
+      // constructed, not a literal, so no control character sits in a regex.
+      const esc = String.fromCharCode(27);
+      const clean = seeded.log
+        .replace(new RegExp(`${esc}\\[[0-9;]*m`, 'g'), '')
+        .split(esc)
+        .join('');
+      expect(seeded.exitCode, clean.slice(-2000)).toBe(0);
+      expect(clean).toContain('a.test.mjs');
+      expect(clean).toMatch(/Test Files\s+1 passed/);
+      // The loud direction: a collection that matches nothing exits 1.
+      const empty = await runChild(['missing.test.mjs']);
+      expect(empty.exitCode, empty.log.slice(-1000)).toBe(1);
+    } finally {
+      rmSync(fixtureRoot, { recursive: true, force: true });
+    }
+  }, 120_000);
 
   async function runEntry(args: string[], env: Record<string, string>) {
     const child = spawn(process.execPath, ['scripts/ci_shard_test.mjs', ...args], {
@@ -787,6 +904,15 @@ describe('ci_shard_test.mjs entry (subprocess, --plan-only)', () => {
     // Binding negative: zero legs means no npm test invocation is printed at
     // all (a filename negative would be vacuous against the "nothing" line).
     expect(runB.log).not.toContain('npm test');
+    // The same zero-leg path FOR REAL (no --plan-only): the entry must exit
+    // green without spawning a leg AND without running pretest (nothing
+    // below reads the artifacts), so the legCount arm of the entry decision
+    // executes here rather than living only in its unit test.
+    const runBReal = await runEntry(['--lane=long-sims-b'], env);
+    expect(runBReal.exitCode).toBe(0);
+    expect(runBReal.log).toContain('lane runs: nothing');
+    expect(runBReal.log).toContain('PASS: 0 leg(s) green');
+    expect(runBReal.log).not.toContain('i18n:gen');
   });
 
   async function listVitestFilesExcluding(
@@ -912,11 +1038,10 @@ describe('ci_shard_test.mjs entry (subprocess, --plan-only)', () => {
     expect(run.exitCode).toBe(0);
     expect(run.log).toContain('plan: mode=full (mode=full from the changes job)');
     expect(run.log).toContain('npm test -- --shard=4/8');
-    expect(run.log).not.toContain('npm test (always-run floor');
     expect(run.log).not.toContain('vitest related');
   });
 
-  it('plans the two selective legs over the real tree and prints the audit trail', async () => {
+  it('plans the merged selective leg over the real tree and prints the audit trail', async () => {
     const run = await runEntry(['--shard=5/8', '--plan-only'], {
       TEST_MODE: 'selective',
       TEST_MODE_REASON:

--- a/tests/ci_workflow.test.ts
+++ b/tests/ci_workflow.test.ts
@@ -479,8 +479,11 @@ describe('CI workflow parity', () => {
     expect(prGate).not.toMatch(/needs:\s*\[?[^\n]*pr-long-sims/);
     expect(prChecks).not.toMatch(/needs:\s*\[?[^\n]*pr-long-sims/);
     // Phase 2: pr-gate's test step runs through the selection-aware shard
-    // runner; the runner itself spawns `npm test` (pretest preserved), which
-    // tests/ci_shard_plan.test.ts pins behaviorally.
+    // runner; the entry regenerates the generated artifacts once per job
+    // before its legs (the merged selective leg is a bare vitest-related
+    // invocation with no npm lifecycle), which tests/ci_leg_runner.test.ts
+    // pins at the source level and tests/gate_artifact_skip.test.ts drives
+    // arm by arm.
     expect(prGate).toContain('run: node scripts/ci_shard_test.mjs');
     expect(prGate).not.toContain('run: npm test');
     expect(prChecks).not.toContain('run: npm test');
@@ -978,10 +981,10 @@ describe('CI workflow parity', () => {
     // Both test jobs fan the ONE suite across the same N-shard matrix.
     // release-gate keeps the raw `npm test -- --shard` run line (selection
     // never touches a release ref); pr-gate runs the same suite through the
-    // selection-aware shard runner, which spawns `npm test` itself so pretest
-    // still regenerates the i18n artifacts in every shard (the S3 guard, guide
-    // freshness, and the git-subprocess suites need them regardless of which
-    // shard they hash into). Never a bare vitest invocation in the workflow.
+    // selection-aware shard runner, whose entry regenerates the i18n
+    // artifacts once per job before any leg (the S3 guard, guide freshness,
+    // and the git-subprocess suites need them regardless of which shard they
+    // hash into). Never a bare vitest invocation in the workflow YAML.
     // fail-fast stays off so shards pass or fail independently and a red run
     // always reports the whole suite.
     const halfCoreCap =

--- a/tests/gate_artifact_skip.test.ts
+++ b/tests/gate_artifact_skip.test.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 import {
   gateVitestSkipPretestEnv,
+  shouldRunEntryPretest,
   shouldSkipPretest,
   WOC_SKIP_PRETEST,
 } from '../scripts/lib/gate_artifact_skip.mjs';
@@ -24,6 +25,24 @@ describe('shouldSkipPretest', () => {
 
   it('exports the gate vitest overlay as WOC_SKIP_PRETEST=1', () => {
     expect(gateVitestSkipPretestEnv()).toEqual({ [WOC_SKIP_PRETEST]: '1' });
+  });
+});
+
+describe('shouldRunEntryPretest (the CI shard entry decision)', () => {
+  // The three arms of scripts/ci_shard_test.mjs's entry-level pretest,
+  // unit-driven so the always-executed CI branch has executing coverage:
+  // zero legs (a selective lane that owns nothing) must not regenerate,
+  // an inherited skip flag must not regenerate twice, and the normal shape
+  // must regenerate exactly once before any leg.
+  it('runs for a populated plan with no skip flag', () => {
+    expect(shouldRunEntryPretest({ legCount: 1, env: {} })).toBe(true);
+  });
+  it('skips for a zero-leg plan (nothing below reads the artifacts)', () => {
+    expect(shouldRunEntryPretest({ legCount: 0, env: {} })).toBe(false);
+  });
+  it('skips when the flag is already set, exact-string contract', () => {
+    expect(shouldRunEntryPretest({ legCount: 3, env: { WOC_SKIP_PRETEST: '1' } })).toBe(false);
+    expect(shouldRunEntryPretest({ legCount: 3, env: { WOC_SKIP_PRETEST: 'true' } })).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

Fourth act of the CI-speed program (follows #3370, #3371, #3375). Every selective shard used to run two sequential vitest legs: the always-run floor through npm test, then vitest related over the changed sources, paying a second startup (transform + setup + import) per shard. vitest seeds its related set with the given paths THEMSELVES (verified in the installed 4.1.10: filterTestsBySource builds the affected set as new Set(related) before the reverse-graph walk), so the floor files can ride the related invocation as self-selecting seeds and the two legs become ONE: one collection, one transform pass, one sharding.

The seed property is now pinned by EXECUTION against the real installed vitest (a subprocess runs vitest related with a test file as the only seed and asserts it ran), so a future vitest upgrade that dropped the property goes red in the pins instead of silently un-flooring every selective shard, which would be the worst failure class this planner has.

npx vitest has no npm lifecycle, so the shard entry (scripts/ci_shard_test.mjs) now regenerates the generated artifacts once per job before spawning, and the npm-test legs skip their lifecycle copy; per-JOB regeneration is unchanged and the BY DESIGN ruling comments in ci.yml moved with the mechanism. The leg-runner pin was re-aimed rather than deleted: exactly one spawnSync is allowed in the entry and it must target pretest.mjs, so a second raw spawn path around the flake-retry runner still fails. The floor side of the merged argv stays lane-filtered and the related side stays deliberately unfiltered, preserving both lane contracts; an empty floor still cannot reach the merged leg (the FLOOR_SANITY_MIN fallback is the loud direction the old floor leg's missing --passWithNoTests used to provide). The local gate keeps its two legs as a recorded follow-up (note in scripts/lib/gate_select_plan.mjs); the duration ratchet gains a row for this file's new 180s execution pin.

## Type of change

- [x] Refactor or performance (no behavior change)
- [x] Build, CI, or tooling
- [x] Tests

## How was this tested?

- Commands:
  - Full pin sweep: tests/ci_shard_plan.test.ts, ci_workflow, ci_selection_pipeline, suite_duration_budget, ci_leg_runner, gate_select_plan, ci_test_select: 245/245
  - End-to-end execution: TEST_MODE=selective node scripts/ci_shard_test.mjs --shard=5/8 (no --plan-only): entry pretest ran, ONE merged leg, 99 floor seeds self-selected, 98 passed / 1 skipped, exit 0
  - The new seeds execution pin runs the real vitest in a scrubbed env (inherited VITEST_* worker vars make a nested vitest misbehave; noted in the pin)
  - npx tsc --noEmit clean; biome clean on touched files
  - node scripts/gate_select.mjs: PASS
- Manual steps: verified both lane plan shapes and the full-mode leg are byte-identical to before (full mode and lanes are untouched).

## Checklist

### Quality

- [x] **The gate passes.** node scripts/gate_select.mjs is green.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or .env committed, and ALLOW_DEV_COMMANDS is not enabled in any production path.
- [x] I didn't hand-edit generated files. They're regenerated by the build.