### PR TITLE
perf(ci): blobless sparse checkout for the test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -508,6 +508,51 @@ jobs:
       - name: Check out repository
         if: (github.event_name != 'pull_request' || github.base_ref != 'main' || !startsWith(github.head_ref, 'release/')) && needs.changes.outputs.code != 'false'
         uses: actions/checkout@v6
+        with:
+          # Blobless sparse checkout (the sparse-checkout input implies
+          # filter=blob:none in actions/checkout): docs/screenshots is
+          # 794 MB of committed PR evidence the test jobs never read except
+          # the referenced subtrees below, and the measured checkout pathology
+          # (run 31741012359: lane A spent 11m21s fetching before an 8m25s
+          # test step) scales with the blob payload. Non-cone patterns,
+          # last match wins: everything in, screenshot DIRECTORIES out (the
+          # trailing slash leaves root-level files in), every subtree the
+          # repo actually references back in. The list is DERIVED and
+          # COUPLED: tests/ci_workflow.test.ts rescrapes every tracked file
+          # outside docs/screenshots (enumerated from the git index, so new
+          # directories join the corpus automatically) and requires SET
+          # EQUALITY with this list, so a reference this cone omits, or a
+          # cone entry nothing references anymore, fails the pin in the same
+          # change. pr-checks, browser-gate, release-checks, and
+          # release-version-gate deliberately keep the full tree.
+          sparse-checkout: |
+            /*
+            !/docs/screenshots/*/
+            /docs/screenshots/admin-guild-bank-panel/
+            /docs/screenshots/class-skin-color-wash/
+            /docs/screenshots/eastbrook-grand-armoury/
+            /docs/screenshots/eastbrook-vale-rebuild/
+            /docs/screenshots/far-foliage-impostors/
+            /docs/screenshots/fenbridge-rebuild/
+            /docs/screenshots/guild-bank-member-readonly/
+            /docs/screenshots/guild-bank-tab/
+            /docs/screenshots/guild-social-v1/
+            /docs/screenshots/item-art-consistency-2026-08-09/
+            /docs/screenshots/mobile-mount-quick-summon/
+            /docs/screenshots/placeholder-art-completion-2026-08-09/
+            /docs/screenshots/prof-tool-effects/
+            /docs/screenshots/r35-admin-professions-inspector/
+            /docs/screenshots/raw-fish-cooking-reagents/
+            /docs/screenshots/release-v036-skill-normalization-2026-08-10/
+            /docs/screenshots/rift-floor-timer-hud/
+            /docs/screenshots/wiki-v036-refresh/
+            /docs/screenshots/wiki-v036-round2/
+            /docs/screenshots/wildheart/
+            /docs/screenshots/wildheart_hit_stagger/
+          sparse-checkout-cone-mode: false
+          # Explicit for the reader; the sparse-checkout input
+          # already implies it (matching the changes job's step).
+          filter: blob:none
 
       - name: Set up pnpm
         if: (github.event_name != 'pull_request' || github.base_ref != 'main' || !startsWith(github.head_ref, 'release/')) && needs.changes.outputs.code != 'false'
@@ -683,6 +728,38 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
+        with:
+          # Same blobless sparse cone as pr-gate's checkout (rationale and
+          # the reader coupling live there); pinned identical by
+          # tests/ci_workflow.test.ts.
+          sparse-checkout: |
+            /*
+            !/docs/screenshots/*/
+            /docs/screenshots/admin-guild-bank-panel/
+            /docs/screenshots/class-skin-color-wash/
+            /docs/screenshots/eastbrook-grand-armoury/
+            /docs/screenshots/eastbrook-vale-rebuild/
+            /docs/screenshots/far-foliage-impostors/
+            /docs/screenshots/fenbridge-rebuild/
+            /docs/screenshots/guild-bank-member-readonly/
+            /docs/screenshots/guild-bank-tab/
+            /docs/screenshots/guild-social-v1/
+            /docs/screenshots/item-art-consistency-2026-08-09/
+            /docs/screenshots/mobile-mount-quick-summon/
+            /docs/screenshots/placeholder-art-completion-2026-08-09/
+            /docs/screenshots/prof-tool-effects/
+            /docs/screenshots/r35-admin-professions-inspector/
+            /docs/screenshots/raw-fish-cooking-reagents/
+            /docs/screenshots/release-v036-skill-normalization-2026-08-10/
+            /docs/screenshots/rift-floor-timer-hud/
+            /docs/screenshots/wiki-v036-refresh/
+            /docs/screenshots/wiki-v036-round2/
+            /docs/screenshots/wildheart/
+            /docs/screenshots/wildheart_hit_stagger/
+          sparse-checkout-cone-mode: false
+          # Explicit for the reader; the sparse-checkout input
+          # already implies it (matching the changes job's step).
+          filter: blob:none
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
@@ -750,6 +827,38 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
+        with:
+          # Same blobless sparse cone as pr-gate's checkout (rationale and
+          # the reader coupling live there); pinned identical by
+          # tests/ci_workflow.test.ts.
+          sparse-checkout: |
+            /*
+            !/docs/screenshots/*/
+            /docs/screenshots/admin-guild-bank-panel/
+            /docs/screenshots/class-skin-color-wash/
+            /docs/screenshots/eastbrook-grand-armoury/
+            /docs/screenshots/eastbrook-vale-rebuild/
+            /docs/screenshots/far-foliage-impostors/
+            /docs/screenshots/fenbridge-rebuild/
+            /docs/screenshots/guild-bank-member-readonly/
+            /docs/screenshots/guild-bank-tab/
+            /docs/screenshots/guild-social-v1/
+            /docs/screenshots/item-art-consistency-2026-08-09/
+            /docs/screenshots/mobile-mount-quick-summon/
+            /docs/screenshots/placeholder-art-completion-2026-08-09/
+            /docs/screenshots/prof-tool-effects/
+            /docs/screenshots/r35-admin-professions-inspector/
+            /docs/screenshots/raw-fish-cooking-reagents/
+            /docs/screenshots/release-v036-skill-normalization-2026-08-10/
+            /docs/screenshots/rift-floor-timer-hud/
+            /docs/screenshots/wiki-v036-refresh/
+            /docs/screenshots/wiki-v036-round2/
+            /docs/screenshots/wildheart/
+            /docs/screenshots/wildheart_hit_stagger/
+          sparse-checkout-cone-mode: false
+          # Explicit for the reader; the sparse-checkout input
+          # already implies it (matching the changes job's step).
+          filter: blob:none
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
@@ -958,6 +1067,38 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
+        with:
+          # Same blobless sparse cone as pr-gate's checkout (rationale and
+          # the reader coupling live there); pinned identical by
+          # tests/ci_workflow.test.ts.
+          sparse-checkout: |
+            /*
+            !/docs/screenshots/*/
+            /docs/screenshots/admin-guild-bank-panel/
+            /docs/screenshots/class-skin-color-wash/
+            /docs/screenshots/eastbrook-grand-armoury/
+            /docs/screenshots/eastbrook-vale-rebuild/
+            /docs/screenshots/far-foliage-impostors/
+            /docs/screenshots/fenbridge-rebuild/
+            /docs/screenshots/guild-bank-member-readonly/
+            /docs/screenshots/guild-bank-tab/
+            /docs/screenshots/guild-social-v1/
+            /docs/screenshots/item-art-consistency-2026-08-09/
+            /docs/screenshots/mobile-mount-quick-summon/
+            /docs/screenshots/placeholder-art-completion-2026-08-09/
+            /docs/screenshots/prof-tool-effects/
+            /docs/screenshots/r35-admin-professions-inspector/
+            /docs/screenshots/raw-fish-cooking-reagents/
+            /docs/screenshots/release-v036-skill-normalization-2026-08-10/
+            /docs/screenshots/rift-floor-timer-hud/
+            /docs/screenshots/wiki-v036-refresh/
+            /docs/screenshots/wiki-v036-round2/
+            /docs/screenshots/wildheart/
+            /docs/screenshots/wildheart_hit_stagger/
+          sparse-checkout-cone-mode: false
+          # Explicit for the reader; the sparse-checkout input
+          # already implies it (matching the changes job's step).
+          filter: blob:none
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
@@ -1022,6 +1163,37 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
+        with:
+          # Same blobless sparse cone as pr-gate's checkout (rationale and
+          # the reader coupling live there): the release-tier i18n suites
+          # read locale sources and docs/i18n prose, none of it under
+          # docs/screenshots; pinned identical by tests/ci_workflow.test.ts.
+          sparse-checkout: |
+            /*
+            !/docs/screenshots/*/
+            /docs/screenshots/admin-guild-bank-panel/
+            /docs/screenshots/class-skin-color-wash/
+            /docs/screenshots/eastbrook-grand-armoury/
+            /docs/screenshots/eastbrook-vale-rebuild/
+            /docs/screenshots/far-foliage-impostors/
+            /docs/screenshots/fenbridge-rebuild/
+            /docs/screenshots/guild-bank-member-readonly/
+            /docs/screenshots/guild-bank-tab/
+            /docs/screenshots/guild-social-v1/
+            /docs/screenshots/item-art-consistency-2026-08-09/
+            /docs/screenshots/mobile-mount-quick-summon/
+            /docs/screenshots/placeholder-art-completion-2026-08-09/
+            /docs/screenshots/prof-tool-effects/
+            /docs/screenshots/r35-admin-professions-inspector/
+            /docs/screenshots/raw-fish-cooking-reagents/
+            /docs/screenshots/release-v036-skill-normalization-2026-08-10/
+            /docs/screenshots/rift-floor-timer-hud/
+            /docs/screenshots/wiki-v036-refresh/
+            /docs/screenshots/wiki-v036-round2/
+            /docs/screenshots/wildheart/
+            /docs/screenshots/wildheart_hit_stagger/
+          sparse-checkout-cone-mode: false
+          filter: blob:none
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v4

--- a/docs/qa-gate.md
+++ b/docs/qa-gate.md
@@ -236,6 +236,18 @@ same `[ci-shard]` audit lines as the shards. `release-gate` is deliberately not
 lane-split: `release/**` pushes keep the full suite in their 8 shards; a push to `main`
 or `dev-*` runs the PR tier, so it gets the shards-plus-lanes layout.
 
+**The sparse test-job checkout.** The five sparse CI test jobs (the pr-gate shards,
+both long-sims lanes, release-gate, release-i18n) check out a blobless non-cone sparse
+set: everything in, `docs/screenshots` DIRECTORIES out (root-level files stay), and
+every subtree the repo references back in. The re-include list is DERIVED, not
+curated: `tests/ci_workflow.test.ts` recomputes the referenced set over tests,
+scripts, src, and all of docs minus the screenshots tree itself (acceptance manifests
+carry evidence paths suites follow at runtime; a test-literal-only coupling shipped
+once and went red on exactly that), with existence taken from the git index because
+an excluded directory does not exist on disk under the cone being verified. A new
+reference to an un-coned subtree fails that pin in the same change. `pr-checks`,
+`browser-gate`, and `release-checks` deliberately keep the full tree.
+
 **Declared duration budgets.** `tests/suite_duration_budget.test.ts` is the anti-whale
 ratchet: it reads every DECLARED vitest timeout under `tests/` (all `.ts`/`.mjs`, so
 `.test.mjs` files and `vi.setConfig` allowances in imported helpers count too) through

--- a/tests/ci_workflow.test.ts
+++ b/tests/ci_workflow.test.ts
@@ -1,4 +1,7 @@
+import { spawnSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import { isCodePath } from '../scripts/lib/ci_change_classify.mjs';
 import { CI_LONG_SUITE_HALVES } from '../scripts/lib/ci_shard_plan.mjs';
@@ -9,6 +12,7 @@ import {
   isGeneratedI18nArtifactPath,
 } from '../scripts/lib/gate_select_plan.mjs';
 import { buildFullGateSteps, I18N_ARTIFACTS } from '../scripts/lib/gate_steps.mjs';
+import { expectScansOnlyThroughSharedWalkers } from './helpers/scan_guard_self_audit';
 
 const workflow = readFileSync(new URL('../.github/workflows/ci.yml', import.meta.url), 'utf8');
 const detectEntry = readFileSync(
@@ -201,6 +205,137 @@ function jobSource(name: string): string {
 }
 
 describe('CI workflow parity', () => {
+  it('sparse-checkout on the test jobs covers every referenced screenshot subtree', () => {
+    // The five sparse test-job checkouts (pr-gate, both long-sims lanes,
+    // release-gate, release-i18n) exclude docs/screenshots DIRECTORIES
+    // (794 MB of committed PR evidence; the measured 11m21s checkout
+    // pathology scales with the blob payload) except every subtree the repo
+    // actually references. The coupling corpus is EVERY tracked
+    // reference-carrying file outside docs/screenshots, enumerated from the
+    // git index rather than a curated root list: a test-literal-only
+    // coupling shipped and missed two acceptance manifests on its first CI
+    // run, and a curated four-root walk is the same failure shape one level
+    // up (a reference from a root nobody curated in stays invisible).
+    // Existence comes from the GIT INDEX, not the working tree: under the
+    // very cone this verifies, an excluded directory does not exist on disk.
+    const SPARSE_CONE = [
+      '          sparse-checkout: |',
+      '            /*',
+      '            !/docs/screenshots/*/',
+      '            /docs/screenshots/admin-guild-bank-panel/',
+      '            /docs/screenshots/class-skin-color-wash/',
+      '            /docs/screenshots/eastbrook-grand-armoury/',
+      '            /docs/screenshots/eastbrook-vale-rebuild/',
+      '            /docs/screenshots/far-foliage-impostors/',
+      '            /docs/screenshots/fenbridge-rebuild/',
+      '            /docs/screenshots/guild-bank-member-readonly/',
+      '            /docs/screenshots/guild-bank-tab/',
+      '            /docs/screenshots/guild-social-v1/',
+      '            /docs/screenshots/item-art-consistency-2026-08-09/',
+      '            /docs/screenshots/mobile-mount-quick-summon/',
+      '            /docs/screenshots/placeholder-art-completion-2026-08-09/',
+      '            /docs/screenshots/prof-tool-effects/',
+      '            /docs/screenshots/r35-admin-professions-inspector/',
+      '            /docs/screenshots/raw-fish-cooking-reagents/',
+      '            /docs/screenshots/release-v036-skill-normalization-2026-08-10/',
+      '            /docs/screenshots/rift-floor-timer-hud/',
+      '            /docs/screenshots/wiki-v036-refresh/',
+      '            /docs/screenshots/wiki-v036-round2/',
+      '            /docs/screenshots/wildheart/',
+      '            /docs/screenshots/wildheart_hit_stagger/',
+      '          sparse-checkout-cone-mode: false',
+    ].join('\n');
+    // Job-anchored, not a bare workflow-wide count: each sparse job carries
+    // the block exactly once, the full-tree jobs carry it never (their
+    // freshness diffs, builds, and the browser suite read wider), and the
+    // workflow-wide total closes the no-sixth-copy direction.
+    for (const job of [
+      'pr-gate',
+      'pr-long-sims-a',
+      'pr-long-sims-b',
+      'release-gate',
+      'release-i18n',
+    ]) {
+      expect(jobSource(job).split(SPARSE_CONE), job).toHaveLength(2);
+    }
+    for (const job of ['pr-checks', 'browser-gate', 'release-checks', 'release-version-gate']) {
+      expect(jobSource(job).includes(SPARSE_CONE), job).toBe(false);
+    }
+    expect(workflow.split(SPARSE_CONE)).toHaveLength(6);
+    const coneDirs = new Set<string>(
+      [...SPARSE_CONE.matchAll(/\/docs\/screenshots\/([A-Za-z0-9._-]+)\//g)].map((m) => m[1]),
+    );
+    const repoRootUrl = new URL('..', import.meta.url);
+    const indexDirs = new Set<string>();
+    {
+      const ls = spawnSync('git', ['ls-files', 'docs/screenshots'], {
+        cwd: fileURLToPath(repoRootUrl),
+        encoding: 'utf8',
+      });
+      expect(ls.status).toBe(0);
+      for (const line of ls.stdout.split('\n')) {
+        const match = line.match(/^docs\/screenshots\/([A-Za-z0-9._-]+)\//);
+        if (match) indexDirs.add(match[1]);
+      }
+      // Vacuity floor near the real count (166 subtrees on 2026-08-14).
+      expect(indexDirs.size).toBeGreaterThanOrEqual(160);
+    }
+    // The guard's own file is excluded from the corpus: its SPARSE_CONE
+    // literal above names every cone subtree, so counting it would satisfy
+    // the coupling even over an otherwise empty corpus (the
+    // release_i18n_tier_coverage SELF idiom).
+    const SELF = 'tests/ci_workflow.test.ts';
+    const REFERENCE_EXTENSIONS = [
+      '.ts',
+      '.mts',
+      '.cts',
+      '.tsx',
+      '.mjs',
+      '.cjs',
+      '.js',
+      '.json',
+      '.md',
+    ];
+    const referenced = new Set<string>();
+    {
+      const ls = spawnSync('git', ['ls-files', '-z'], {
+        cwd: fileURLToPath(repoRootUrl),
+        encoding: 'utf8',
+        maxBuffer: 64 * 1024 * 1024,
+      });
+      expect(ls.status).toBe(0);
+      const corpus = ls.stdout
+        .split('\0')
+        .filter(
+          (file) =>
+            file.length > 0 &&
+            file !== SELF &&
+            !file.startsWith('docs/screenshots/') &&
+            REFERENCE_EXTENSIONS.some((ext) => file.endsWith(ext)),
+        );
+      // Vacuity floor near the real count (about 6,600 tracked
+      // reference-carrying files on 2026-08-14): an emptied enumeration
+      // cannot green the coupling by scanning nothing.
+      expect(corpus.length).toBeGreaterThanOrEqual(6_000);
+      for (const file of corpus) {
+        const source = readFileSync(join(fileURLToPath(repoRootUrl), file), 'utf8');
+        for (const match of source.matchAll(/docs\/screenshots\/([A-Za-z0-9._-]+)/g)) {
+          if (indexDirs.has(match[1])) referenced.add(match[1]);
+        }
+      }
+    }
+    // SET EQUALITY, both directions in one assertion: a referenced subtree
+    // missing from the cone is the missing-evidence-in-a-shard failure, and
+    // a cone entry nothing references anymore is dead weight that must leave
+    // (a one-way floor with slack would let a quietly narrowed corpus drop
+    // entries and stay green).
+    expect([...referenced].sort()).toEqual([...coneDirs].sort());
+  });
+
+  it('performs no hand-rolled directory reads (the corpus is the git index)', () => {
+    expectScansOnlyThroughSharedWalkers(import.meta.url, []);
+  });
+
   it('installs with pnpm frozen-lockfile and pins the packageManager version', () => {
     // Full migration: no npm ci install path, cache and install are pnpm-only,
     // and every pnpm/action-setup version matches package.json packageManager so

--- a/tests/skill_icons.test.ts
+++ b/tests/skill_icons.test.ts
@@ -661,7 +661,13 @@ describe('class ability webp icons', () => {
     );
   });
 
-  it('E) pins the normalized shipping bytes while preserving source-art ownership', async () => {
+  it('E) pins the normalized shipping bytes while preserving source-art ownership', {
+    // Sharp re-normalization over the whole shipping icon set: measured
+    // ~19s inside a loaded 2-worker CI shard (timed out at the 20s default
+    // on run 31768, the borderline-default class), ~1s solo. 60s follows
+    // the suite's ~2.5x-measured-plus-contention sizing convention.
+    timeout: 60_000,
+  }, async () => {
     const manifest = skillNormalizationManifest();
     const expected = Object.entries(NORMALIZED_SKILL_IDS)
       .flatMap(([className, ids]) => ids.map((id) => `${className}/${id}`))


### PR DESCRIPTION
## Summary

Fifth act of the CI-speed program (follows #3370, #3371, #3375, #3378). docs/screenshots is 794 MB of committed PR evidence the test jobs mostly never read, and the measured checkout pathology (run 31741012359: lane A spent 11m21s in actions/checkout before an 8m25s test step) scales with the blob payload. The pr-gate shards, both long-sims lanes, release-gate, and release-i18n (18 checkouts per full PR run) now use a non-cone sparse set: everything in, the screenshot subtrees out, every subtree the repo actually references back in (21 of 166 on this base). The sparse-checkout input makes actions/checkout fetch blobless automatically, so roughly 380 MB of blobs are skipped per job.

The re-include list is derived, not curated. tests/ci_workflow.test.ts rescrapes every tracked reference-carrying file outside docs/screenshots, enumerated straight from the git index (6,635 files; new directories join the corpus automatically), and requires set equality with the cone: a referenced subtree the cone omits and a cone entry nothing references anymore both fail the pin in the same change, with a message naming the fix. Existence also comes from the git index, because under the very cone being verified an excluded directory does not exist on disk. The block is job-anchored: it must appear exactly once in each of the five sparse job definitions and never in pr-checks, browser-gate, release-checks, or release-version-gate (freshness diffs, builds, and the browser suite read wider), with an exact workflow-wide copy count.

The corpus width is a lesson written into the pin. The first cut coupled to test literals only and went red on its first CI run: two suites follow evidence paths carried in acceptance manifests under docs/, invisible to a test-literal scrape. The second cut walked four curated roots, which is the same failure shape one level up; the landed version scans the whole index so nothing depends on curation.

## Type of change

- [x] Refactor or performance (no behavior change)
- [x] Build, CI, or tooling

## How was this tested?

- Commands:
  - Scratch-worktree proof of the exact non-cone pattern set (presence and absence checks, sizes) before landing
  - npx vitest run tests/ci_workflow.test.ts (24/24 including the coupling pin), plus a lockstep mutation check: removing one cone entry everywhere fails the set-equality assertion naming the subtree
  - npx tsc --noEmit clean; biome clean on changed files
  - node scripts/gate_select.mjs: PASS (all steps)
  - Green CI run 31768778440 on the final head: all 14 PR jobs pass, evidence floor suites green inside the cone
- Manual steps: verified the malware scanner's real-tree walk is unaffected (it never descends docs/), and that the nine evidence floor suites keep every path they read.

Measured outcome, stated honestly: on healthy runners the checkout wall is unchanged (56 to 71s on the sparse jobs vs 56 to 60s on the full-tree jobs in the same run); the win is the tail and the transfer, since the 11m21s pathology scales with blob payload and each of the 18 test checkouts now moves roughly 380 MB less.

## Checklist

### Quality

- [x] **The gate passes.** node scripts/gate_select.mjs is green.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or .env committed, and ALLOW_DEV_COMMANDS is not enabled in any production path.
- [x] I didn't hand-edit generated files. They're regenerated by the build.
