### PR TITLE
fix(sim): key tank crit immunity on the attacker so pets crit tanks in PvP

### DIFF
--- a/docs/design/spell-ranks.md
+++ b/docs/design/spell-ranks.md
@@ -433,7 +433,8 @@ stamina budgets, prot mastery, Litany, elixirs, masterwork), while the heal
 ladders above stood still: a top heal restored 6.5-8% of a buffed tank pool
 against a classic-era reference of 15-25%. The fix keeps leveling untouched and
 lands entirely at the cap, alongside the heal-side Spell Power doubling
-(`HEALING_SP_SCALE`, 1 healing per point of Intellect) and tank crit immunity:
+(`HEALING_SP_SCALE`, 1 healing per point of Intellect) and tank crit immunity
+(from hostile creatures only; players and their pets always keep their crits):
 
 - Ladders whose top rank was already learned AT 20 are revalued in place
   (endgame-only by construction): heal R2 335-390, renew R3 205/15s,

--- a/src/sim/combat/tank_crit_immunity.ts
+++ b/src/sim/combat/tank_crit_immunity.ts
@@ -6,9 +6,12 @@
 //
 // Committed means the SPEC for warriors and paladins (Protection), and the
 // spec PLUS the form for druids: a Feral druid is only crit-immune while in
-// Sloth Form. PvP is untouched: this guards the one mob crit roll in
-// Sim.mobSwing, and that roll is still DRAWN for an immune tank so every
-// downstream rng draw keeps its stream position (the parity contract).
+// Sloth Form. PvP is untouched: the rule is keyed on the ATTACKER as well as
+// the target, because Sim.mobSwing is a shared swing shell (hostile mobs,
+// player pets, delve companions): only a HOSTILE creature's swing is
+// suppressed, so a player pet crits a committed tank like any player attack
+// does. The crit roll is still DRAWN for an immune tank so every downstream
+// rng draw keeps its stream position (the parity contract).
 //
 // Pure leaf module: no Sim import, structural meta parameter, so a Vitest
 // imports it directly and the mobSwing shell stays a thin consumer.
@@ -25,7 +28,15 @@ export interface TankCritImmunityMeta {
   talentMods?: { spec: string | null } | null;
 }
 
-export function isCritImmuneTank(target: Entity, meta: TankCritImmunityMeta | undefined): boolean {
+export function isCritImmuneTank(
+  attacker: Entity,
+  target: Entity,
+  meta: TankCritImmunityMeta | undefined,
+): boolean {
+  // Creature rule only: a friendly creature sharing the mobSwing path (a player
+  // pet, a delve companion) and any player attacker keep their crits against a
+  // committed tank; only a hostile mob's swing is suppressed.
+  if (!attacker.hostile) return false;
   if (target.kind !== 'player' || !meta) return false;
   const spec = meta.talentMods?.spec ?? null;
   if (spec === null) return false;

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -7908,9 +7908,10 @@ export class Sim {
       this.rng.range(mob.weapon.min, mob.weapon.max) +
       (this.effectiveAttackPower(mob) / 14) * mob.weapon.speed;
     // Tank crit immunity: the 5% roll is still DRAWN (stream position), a
-    // committed tank just never suffers it (combat/tank_crit_immunity.ts).
+    // committed tank just never suffers it from a HOSTILE creature; a player
+    // pet sharing this swing shell keeps its crit (combat/tank_crit_immunity.ts).
     const critRoll = this.rng.chance(0.05);
-    const crit = critRoll && !isCritImmuneTank(target, this.players.get(target.id));
+    const crit = critRoll && !isCritImmuneTank(mob, target, this.players.get(target.id));
     if (crit) dmg *= 2;
     const enrage = MOBS[mob.templateId]?.enrage;
     if (mob.enraged && enrage) dmg *= enrage.dmgMult;

--- a/tests/tank_crit_immunity_attacker.test.ts
+++ b/tests/tank_crit_immunity_attacker.test.ts
@@ -1,0 +1,123 @@
+// Tank crit immunity is a CREATURE rule, keyed on the attacker: only a hostile
+// mob's swing is crit-suppressed against a committed tank. A player pet swings
+// through the same shared Sim.mobSwing shell, and before the attacker gate it
+// inherited the suppression, which made committed tanks crit-immune to pets in
+// PvP. These tests pin both arms at the swing level (the real code path) plus
+// the pure leaf's attacker classification.
+// The fight-level hostile-mob coverage per class lives in the
+// tank_crit_immunity_*_pair.test.ts suite; this file owns the attacker side.
+
+import { describe, expect, test } from 'vitest';
+import { isCritImmuneTank, type TankCritImmunityMeta } from '../src/sim/combat/tank_crit_immunity';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+import { Sim } from '../src/sim/sim';
+import type { Entity } from '../src/sim/types';
+import { EMPTY_TEST_WORLD } from './sim_shared';
+
+const SEED = 90210;
+const SWINGS = 2000; // ~100 expected crits at the flat 5% mob crit roll
+
+// Drive Sim.mobSwing directly against a committed Protection warrior and count
+// landed swings and crits. The attacker is hand-configured per case (hostile
+// wild mob vs player-owned pet); swings are called directly so the mob AI never
+// runs and the only rng consumers are the swing rolls themselves. The tank's
+// hp pool is re-inflated before EVERY swing: aura applications along the way
+// re-run recalcPlayerStats, which would squash the pool back to normal and let
+// the wolf kill the tank (dealDamage returns silently for a dead target).
+function swingsAgainstProtWarrior(
+  configureAttacker: (attacker: Entity, ownerPid: number) => void,
+): {
+  landed: number;
+  crits: number;
+} {
+  const sim = new Sim({
+    seed: SEED,
+    playerClass: 'warrior',
+    noPlayer: true,
+    world: EMPTY_TEST_WORLD,
+  });
+  const pid = sim.addPlayer('warrior', 'Defender');
+  sim.setPlayerLevel(20, pid);
+  sim.applyTalents({ spec: 'prot', rows: {} }, pid);
+  const tank = sim.entities.get(pid);
+  expect(tank).toBeDefined();
+  if (!tank) throw new Error('defender missing');
+
+  const attacker = createMob(sim.nextId++, MOBS.forest_wolf, 20, {
+    x: tank.pos.x + 1,
+    y: tank.pos.y,
+    z: tank.pos.z,
+  });
+  configureAttacker(attacker, pid);
+
+  for (let swing = 0; swing < SWINGS; swing++) {
+    tank.maxHp = 1e9;
+    tank.hp = tank.maxHp;
+    sim.mobSwing(attacker, tank);
+  }
+  let landed = 0;
+  let crits = 0;
+  for (const event of sim.drainEvents()) {
+    if (
+      event.type === 'damage' &&
+      event.sourceId === attacker.id &&
+      event.targetId === pid &&
+      (event.kind === 'hit' || event.kind === 'block')
+    ) {
+      landed++;
+      if (event.crit) crits++;
+    }
+  }
+  expect(landed).toBeGreaterThan(500); // the swings actually resolved
+  return { landed, crits };
+}
+
+describe('tank crit immunity is keyed on the attacker', () => {
+  test('a player pet swinging through mobSwing can crit a committed tank', () => {
+    const { landed, crits } = swingsAgainstProtWarrior((attacker, ownerPid) => {
+      attacker.hostile = false;
+      attacker.ownerId = ownerPid;
+    });
+    // Rate band, not a raw count: the shared rng stream shifts on content adds,
+    // so pin the ~5% creature crit roll rather than a seed-exact tally.
+    expect(crits / landed).toBeGreaterThan(0.02);
+    expect(crits / landed).toBeLessThan(0.1);
+  });
+
+  test('a hostile mob still cannot crit a committed tank', () => {
+    const { crits } = swingsAgainstProtWarrior((attacker) => {
+      attacker.hostile = true;
+      attacker.ownerId = null;
+    });
+    expect(crits).toBe(0);
+  });
+});
+
+describe('isCritImmuneTank attacker classification (pure leaf)', () => {
+  const protWarriorMeta: TankCritImmunityMeta = {
+    cls: 'warrior',
+    talentMods: { spec: 'prot' },
+  };
+  const tankTarget = { kind: 'player', auras: [] } as unknown as Entity;
+
+  function creatureAttacker(hostile: boolean, ownerId: number | null): Entity {
+    const mob = createMob(1, MOBS.forest_wolf, 20, { x: 0, y: 0, z: 0 });
+    mob.hostile = hostile;
+    mob.ownerId = ownerId;
+    return mob;
+  }
+
+  test('a hostile wild mob is crit-suppressed against a committed tank', () => {
+    expect(isCritImmuneTank(creatureAttacker(true, null), tankTarget, protWarriorMeta)).toBe(true);
+  });
+
+  test('a friendly player pet is never crit-suppressed', () => {
+    expect(isCritImmuneTank(creatureAttacker(false, 7), tankTarget, protWarriorMeta)).toBe(false);
+  });
+
+  test('a player attacker is never crit-suppressed', () => {
+    const playerAttacker = { kind: 'player', hostile: false } as unknown as Entity;
+    expect(isCritImmuneTank(playerAttacker, tankTarget, protWarriorMeta)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Committed tanks (Protection warrior, Protection paladin, Feral druid in Sloth Form, Stonebound-posture shaman) were crit-immune to enemy player pets in PvP, which made them substantially harder to kill than intended. The tank crit immunity check sat inside the shared `Sim.mobSwing` swing shell keyed only on the target, and `mobSwing` is also the melee attack path for player pets, so a hunter beast or warlock demon could never critically strike a committed tank.

This change keys the immunity on the attacker as well: `isCritImmuneTank` now takes the attacking entity and returns false unless the attacker is a hostile creature (`attacker.hostile`), the same guard convention the `mob_swing.ts` affix cascade already uses to distinguish hostile mobs from friendly pets on this shared path. The result is the intended rule: only mobs cannot crit committed tanks; players and their pets can, everywhere.

Notes:

- Player melee, ranged, and spell paths never checked this immunity, so direct player attacks against tanks are unchanged (they could already crit).
- The 5 percent creature crit roll is still always drawn, so the shared rng stream position is unchanged and the parity gate stays green.
- Hostile mob behavior is byte-identical: the existing per-class fight suite (`tests/tank_crit_immunity_*_pair.test.ts`) passes unmodified.

## Type of change

- [x] Bug fix

## How was this tested?

- Commands:
  - `npx vitest run tests/tank_crit_immunity_attacker.test.ts` (new): pins both arms at the real swing path. A player pet driving `Sim.mobSwing` against a Protection warrior now crits (red on the old code with 0 crits over 2000 swings); a hostile mob still cannot crit. Plus pure-leaf attacker classification cases (hostile wild mob, friendly pet, player attacker).
  - `npx vitest run tests/tank_crit_immunity_warrior_pair.test.ts tests/tank_crit_immunity_paladin_pair.test.ts tests/tank_crit_immunity_druid_pair.test.ts tests/tank_crit_immunity_shaman_pair.test.ts`: 9 passed, unchanged.
  - `npx vitest run tests/parity`: 207 passed, no rng draw-order drift.
  - `node scripts/gate_select.mjs`: green.
- Manual steps: none (sim-only change, no UI surface).

## Checklist

### Quality

- [x] **The gate passes.** `node scripts/gate_select.mjs` is green. New decisive tests cover the changed behavior.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] No generated files hand-edited.
