### PR TITLE
perf(ci): keep half-cores workers, measured 3-worker trial recorded

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -639,8 +639,9 @@ jobs:
       # merged selective leg is a bare vitest-related invocation with no npm
       # lifecycle, so scripts/ci_shard_test.mjs runs pretest before spawning
       # and the npm-test legs skip their lifecycle copy). The freshness diff
-      # lives in pr-checks. Workers stay at half the runner's cores inside the
-      # script.
+      # lives in pr-checks. Worker count resolves inside the script: the
+      # half-cores measured default unless the step env sets a valid
+      # WOC_TEST_WORKERS (see the env note below).
       #
       # Phase 2 (docs/qa-gate.md, "Selective PR-tier CI"): the runner reads the
       # changes job's selection decision. test_mode=full spawns the old step

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -640,8 +640,11 @@ jobs:
       # lifecycle, so scripts/ci_shard_test.mjs runs pretest before spawning
       # and the npm-test legs skip their lifecycle copy). The freshness diff
       # lives in pr-checks. Worker count resolves inside the script: the
-      # half-cores measured default unless the step env sets a valid
-      # WOC_TEST_WORKERS (see the env note below).
+      # half-cores measured default unless a step env sets a valid
+      # WOC_TEST_WORKERS. None is set: both alternatives were measured and
+      # regressed (4 workers, run 31107474546; 3 workers, run 31771637461,
+      # three unrelated default-timeout blowouts for at most a minute of
+      # wall). The ruling lives in scripts/ci_shard_test.mjs.
       #
       # Phase 2 (docs/qa-gate.md, "Selective PR-tier CI"): the runner reads the
       # changes job's selection decision. test_mode=full spawns the old step
@@ -660,11 +663,6 @@ jobs:
           TEST_MODE: ${{ needs.changes.outputs.test_mode }}
           TEST_MODE_REASON: ${{ needs.changes.outputs.test_mode_reason }}
           CHANGED_FILES: ${{ needs.changes.outputs.changed_files }}
-          # Measured 3-worker trial (the entry validates the value and falls
-          # back to the half-cores default on junk; scripts/ci_shard_test.mjs
-          # carries the ruling this trial answers). Watch the per-test budget
-          # compliance, not just the walls: the budgets are calibrated at 2.
-          WOC_TEST_WORKERS: '3'
         run: node scripts/ci_shard_test.mjs --shard=${{ matrix.shard }}/8
 
   # The long-sims lanes (Phase 4 of the CI/CD performance packet; split into
@@ -816,8 +814,6 @@ jobs:
           TEST_MODE: ${{ needs.changes.outputs.test_mode }}
           TEST_MODE_REASON: ${{ needs.changes.outputs.test_mode_reason }}
           CHANGED_FILES: ${{ needs.changes.outputs.changed_files }}
-          # Same 3-worker trial as the shard step; see its note.
-          WOC_TEST_WORKERS: '3'
         run: node scripts/ci_shard_test.mjs --lane=long-sims-a
 
   # Second half of the long-sims lane pair; every design note sits on
@@ -899,8 +895,6 @@ jobs:
           TEST_MODE: ${{ needs.changes.outputs.test_mode }}
           TEST_MODE_REASON: ${{ needs.changes.outputs.test_mode_reason }}
           CHANGED_FILES: ${{ needs.changes.outputs.changed_files }}
-          # Same 3-worker trial as the shard step; see its note.
-          WOC_TEST_WORKERS: '3'
         run: node scripts/ci_shard_test.mjs --lane=long-sims-b
 
   # Runs in parallel with pr-gate: same if-condition, no needs edge in either

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -659,6 +659,11 @@ jobs:
           TEST_MODE: ${{ needs.changes.outputs.test_mode }}
           TEST_MODE_REASON: ${{ needs.changes.outputs.test_mode_reason }}
           CHANGED_FILES: ${{ needs.changes.outputs.changed_files }}
+          # Measured 3-worker trial (the entry validates the value and falls
+          # back to the half-cores default on junk; scripts/ci_shard_test.mjs
+          # carries the ruling this trial answers). Watch the per-test budget
+          # compliance, not just the walls: the budgets are calibrated at 2.
+          WOC_TEST_WORKERS: '3'
         run: node scripts/ci_shard_test.mjs --shard=${{ matrix.shard }}/8
 
   # The long-sims lanes (Phase 4 of the CI/CD performance packet; split into
@@ -810,6 +815,8 @@ jobs:
           TEST_MODE: ${{ needs.changes.outputs.test_mode }}
           TEST_MODE_REASON: ${{ needs.changes.outputs.test_mode_reason }}
           CHANGED_FILES: ${{ needs.changes.outputs.changed_files }}
+          # Same 3-worker trial as the shard step; see its note.
+          WOC_TEST_WORKERS: '3'
         run: node scripts/ci_shard_test.mjs --lane=long-sims-a
 
   # Second half of the long-sims lane pair; every design note sits on
@@ -891,6 +898,8 @@ jobs:
           TEST_MODE: ${{ needs.changes.outputs.test_mode }}
           TEST_MODE_REASON: ${{ needs.changes.outputs.test_mode_reason }}
           CHANGED_FILES: ${{ needs.changes.outputs.changed_files }}
+          # Same 3-worker trial as the shard step; see its note.
+          WOC_TEST_WORKERS: '3'
         run: node scripts/ci_shard_test.mjs --lane=long-sims-b
 
   # Runs in parallel with pr-gate: same if-condition, no needs edge in either

--- a/scripts/ci_shard_test.mjs
+++ b/scripts/ci_shard_test.mjs
@@ -77,12 +77,28 @@ const workerResolution = resolveWorkerCount({
 });
 const workers = workerResolution.workers;
 if (workerResolution.source === 'invalid') {
+  // Loud twice by design: the log line for the transcript, the ::warning
+  // annotation (same channel as the known-flake retry in
+  // lib/ci_leg_runner.mjs, and gated the same way so a local repro never
+  // prints a raw workflow command) so a measured-trial run that silently
+  // fell back to the default cannot be mistaken for one that ran at the
+  // trial value.
+  const shown = JSON.stringify(process.env.WOC_TEST_WORKERS);
   console.log(
-    `[ci-shard] WOC_TEST_WORKERS=${JSON.stringify(process.env.WOC_TEST_WORKERS)} is not an ` +
+    `[ci-shard] WOC_TEST_WORKERS=${shown} is not an ` +
       `integer between 1 and the core count; using the measured default ${workers}`,
   );
+  if (process.env.GITHUB_ACTIONS === 'true') {
+    console.log(
+      `::warning title=ci-shard invalid WOC_TEST_WORKERS::${shown} rejected; ` +
+        `this job ran at the measured default of ${workers} workers`,
+    );
+  }
 }
-const workersLabel = `workers=${workers}${workerResolution.source === 'env' ? ' (WOC_TEST_WORKERS)' : ''}`;
+// The label always names its arm, so every job log states which resolution
+// produced the number and a trial run is self-auditing even when nobody is
+// diffing env blocks.
+const workersLabel = `workers=${workers} (${workerResolution.source === 'env' ? 'WOC_TEST_WORKERS' : 'default'})`;
 
 const mode = process.env.TEST_MODE ?? '';
 // Echoed into the log only. The producer already strips CR/LF; re-stripping

--- a/scripts/ci_shard_test.mjs
+++ b/scripts/ci_shard_test.mjs
@@ -23,7 +23,12 @@ import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { formatLegHeader, runLegsWithFlakeRetry } from './lib/ci_leg_runner.mjs';
-import { buildLanePlan, buildShardPlan, parseShardArg } from './lib/ci_shard_plan.mjs';
+import {
+  buildLanePlan,
+  buildShardPlan,
+  parseShardArg,
+  resolveWorkerCount,
+} from './lib/ci_shard_plan.mjs';
 import { shouldRunEntryPretest, WOC_SKIP_PRETEST } from './lib/gate_artifact_skip.mjs';
 import { collectSuiteVisibility } from './lib/gate_discovery.mjs';
 
@@ -63,8 +68,21 @@ const planOnly = argv.includes('--plan-only');
 // contention and pushed the eastbrook integration sweep past its own 180 s
 // budget, while the half-cores run finished green with a 432 s wall. Every
 // per-test budget in the suite is calibrated against this bound; raise it
-// only with a green measured run at the new value.
-const workers = Math.max(1, Math.floor(os.availableParallelism() / 2));
+// only with a green measured run at the new value. WOC_TEST_WORKERS is the
+// knob that produces such a run (resolveWorkerCount validates it; anything
+// malformed or out of range falls back to this default, loudly).
+const workerResolution = resolveWorkerCount({
+  cores: os.availableParallelism(),
+  envValue: process.env.WOC_TEST_WORKERS,
+});
+const workers = workerResolution.workers;
+if (workerResolution.source === 'invalid') {
+  console.log(
+    `[ci-shard] WOC_TEST_WORKERS=${JSON.stringify(process.env.WOC_TEST_WORKERS)} is not an ` +
+      `integer between 1 and the core count; using the measured default ${workers}`,
+  );
+}
+const workersLabel = `workers=${workers}${workerResolution.source === 'env' ? ' (WOC_TEST_WORKERS)' : ''}`;
 
 const mode = process.env.TEST_MODE ?? '';
 // Echoed into the log only. The producer already strips CR/LF; re-stripping
@@ -122,8 +140,8 @@ const plan = lane
 
 console.log(
   lane
-    ? `[ci-shard] long-sims-${laneHalf} lane, workers=${workers}`
-    : `[ci-shard] shard ${shard.index}/${shard.total}, workers=${workers}`,
+    ? `[ci-shard] long-sims-${laneHalf} lane, ${workersLabel}`
+    : `[ci-shard] shard ${shard.index}/${shard.total}, ${workersLabel}`,
 );
 console.log(
   `[ci-shard] changes-job decision: mode=${mode || '(unset)'}${modeReason ? ` (${modeReason})` : ''}`,

--- a/scripts/ci_shard_test.mjs
+++ b/scripts/ci_shard_test.mjs
@@ -66,11 +66,16 @@ const planOnly = argv.includes('--plan-only');
 // workers on the 4-vCPU runner, run 31107474546) inflated the four sims'
 // aggregate CPU time from 644 s to 1027 s through memory-bandwidth
 // contention and pushed the eastbrook integration sweep past its own 180 s
-// budget, while the half-cores run finished green with a 432 s wall. Every
-// per-test budget in the suite is calibrated against this bound; raise it
-// only with a green measured run at the new value. WOC_TEST_WORKERS is the
-// knob that produces such a run (resolveWorkerCount validates it; anything
-// malformed or out of range falls back to this default, loudly).
+// budget, while the half-cores run finished green with a 432 s wall. A
+// 3-worker trial (run 31771637461, 2026-08-14) confirmed the bound from
+// the other side: three unrelated suites blew DEFAULT timeouts under the
+// contention (coverage_c 20 s, a terrain_streaming 10 s hook, groveheart
+// 20 s) while the green shards gained at most about a minute of wall, so
+// half cores stands at both neighbors. Every per-test budget in the suite
+// is calibrated against this bound; raise it only with a green measured
+// run at the new value. WOC_TEST_WORKERS is the knob that produces such a
+// run (resolveWorkerCount validates it; anything malformed or out of
+// range falls back to this default, loudly).
 const workerResolution = resolveWorkerCount({
   cores: os.availableParallelism(),
   envValue: process.env.WOC_TEST_WORKERS,

--- a/scripts/lib/ci_shard_plan.d.mts
+++ b/scripts/lib/ci_shard_plan.d.mts
@@ -12,6 +12,11 @@ export function collectedLaneFiles(opts: {
 
 export function parseShardArg(argv: string[]): { index: number; total: number } | null;
 
+export function resolveWorkerCount(opts: { cores: number; envValue?: string }): {
+  workers: number;
+  source: 'default' | 'env' | 'invalid';
+};
+
 export function buildFloor(opts: {
   alwaysRun: string[];
   testFiles: string[];

--- a/scripts/lib/ci_shard_plan.mjs
+++ b/scripts/lib/ci_shard_plan.mjs
@@ -217,11 +217,12 @@ export function parseShardArg(argv) {
  * timed out the eastbrook sweep); every per-test budget is calibrated
  * against it. WOC_TEST_WORKERS is the sanctioned trial knob for producing
  * the green measured run that ruling requires before any new default: an
- * integer between 1 and the core count is honored, anything else (unset,
- * empty, junk, out of range) falls back to the measured default and reports
- * `source: 'invalid'` so the entry can say so in the job log. Worker count
- * never changes WHICH tests run, so the fallback direction is safety toward
- * the calibrated bound, not toward fewer tests.
+ * integer between 1 and the core count is honored; a malformed or
+ * out-of-range value falls back to the measured default and reports
+ * `source: 'invalid'` so the entry announces it in the job log; unset or
+ * empty is the ordinary default (`source: 'default'`) and stays quiet.
+ * Worker count never changes WHICH tests run, so the fallback direction is
+ * safety toward the calibrated bound, not toward fewer tests.
  *
  * @param {{ cores: number, envValue?: string }} opts
  * @returns {{ workers: number, source: 'default' | 'env' | 'invalid' }}

--- a/scripts/lib/ci_shard_plan.mjs
+++ b/scripts/lib/ci_shard_plan.mjs
@@ -211,6 +211,31 @@ export function parseShardArg(argv) {
 }
 
 /**
+ * Resolve the vitest worker count for a CI test job. The default is half the
+ * runner's cores, a MEASURED ruling (full-core run 31107474546 inflated the
+ * long sims' aggregate CPU ~1.6x through memory-bandwidth contention and
+ * timed out the eastbrook sweep); every per-test budget is calibrated
+ * against it. WOC_TEST_WORKERS is the sanctioned trial knob for producing
+ * the green measured run that ruling requires before any new default: an
+ * integer between 1 and the core count is honored, anything else (unset,
+ * empty, junk, out of range) falls back to the measured default and reports
+ * `source: 'invalid'` so the entry can say so in the job log. Worker count
+ * never changes WHICH tests run, so the fallback direction is safety toward
+ * the calibrated bound, not toward fewer tests.
+ *
+ * @param {{ cores: number, envValue?: string }} opts
+ * @returns {{ workers: number, source: 'default' | 'env' | 'invalid' }}
+ */
+export function resolveWorkerCount({ cores, envValue }) {
+  const fallback = Math.max(1, Math.floor(cores / 2));
+  if (envValue === undefined || envValue === '') return { workers: fallback, source: 'default' };
+  if (!/^[1-9]\d*$/.test(envValue)) return { workers: fallback, source: 'invalid' };
+  const parsed = Number(envValue);
+  if (parsed > cores) return { workers: fallback, source: 'invalid' };
+  return { workers: parsed, source: 'env' };
+}
+
+/**
  * Resolve the floor for a selective run.
  *
  * @param {{

--- a/tests/ci_shard_plan.test.ts
+++ b/tests/ci_shard_plan.test.ts
@@ -15,6 +15,7 @@ import {
   collectedLaneFiles,
   FLOOR_SANITY_MIN,
   parseShardArg,
+  resolveWorkerCount,
 } from '../scripts/lib/ci_shard_plan.mjs';
 import { collectSuiteVisibility } from '../scripts/lib/gate_discovery.mjs';
 
@@ -51,6 +52,35 @@ describe('parseShardArg', () => {
     [[], null],
   ])('%j -> %j', (argv, expected) => {
     expect(parseShardArg(argv as string[])).toEqual(expected);
+  });
+});
+
+describe('resolveWorkerCount', () => {
+  // The half-cores default is the MEASURED ruling (run 31107474546; the
+  // entry's comment); WOC_TEST_WORKERS is its sanctioned trial knob. Every
+  // rejected shape falls back to the ruling value with source 'invalid' so
+  // the entry reports it, and a bad value can never mean fewer tests, only
+  // the calibrated worker bound.
+  it.each([
+    [4, undefined, { workers: 2, source: 'default' }],
+    [4, '', { workers: 2, source: 'default' }],
+    [4, '3', { workers: 3, source: 'env' }],
+    [4, '1', { workers: 1, source: 'env' }],
+    [4, '4', { workers: 4, source: 'env' }],
+    [4, '5', { workers: 2, source: 'invalid' }],
+    [4, '0', { workers: 2, source: 'invalid' }],
+    [4, '-2', { workers: 2, source: 'invalid' }],
+    [4, '2.5', { workers: 2, source: 'invalid' }],
+    [4, '03', { workers: 2, source: 'invalid' }],
+    [4, ' 3', { workers: 2, source: 'invalid' }],
+    [4, 'banana', { workers: 2, source: 'invalid' }],
+    [1, undefined, { workers: 1, source: 'default' }],
+    [1, '1', { workers: 1, source: 'env' }],
+    [1, '2', { workers: 1, source: 'invalid' }],
+  ])('cores=%j env=%j -> %j', (cores, envValue, expected) => {
+    expect(resolveWorkerCount({ cores, envValue: envValue as string | undefined })).toEqual(
+      expected,
+    );
   });
 });
 
@@ -804,6 +834,31 @@ describe('ci_shard_test.mjs entry (subprocess, --plan-only)', () => {
     expect(bad.log).toContain('usage:');
     const malformed = await runEntry(['--shard=9/8'], {});
     expect(malformed.exitCode).toBe(1);
+  });
+
+  it('honors a valid WOC_TEST_WORKERS and reports the source in the job log', async () => {
+    // The entry, not just the resolver: the ci.yml trial env line only works
+    // if the spawned entry reads it. workers=1 is valid on every core count,
+    // so this arm is machine-independent.
+    const run = await runEntry(['--shard=1/8', '--plan-only'], {
+      TEST_MODE: 'full',
+      WOC_TEST_WORKERS: '1',
+    });
+    expect(run.exitCode).toBe(0);
+    expect(run.log).toContain('shard 1/8, workers=1 (WOC_TEST_WORKERS)');
+    expect(run.log).toContain('--maxWorkers=1');
+  });
+
+  it('falls back loudly to the measured default on a junk WOC_TEST_WORKERS', async () => {
+    const fallback = Math.max(1, Math.floor(os.availableParallelism() / 2));
+    const run = await runEntry(['--shard=1/8', '--plan-only'], {
+      TEST_MODE: 'full',
+      WOC_TEST_WORKERS: 'banana',
+    });
+    expect(run.exitCode).toBe(0);
+    expect(run.log).toContain('WOC_TEST_WORKERS="banana" is not an integer');
+    expect(run.log).toContain(`shard 1/8, workers=${fallback}`);
+    expect(run.log).not.toContain('(WOC_TEST_WORKERS)');
   });
 
   it('fails loud on an unknown lane or an ambiguous lane-plus-shard spec', async () => {

--- a/tests/ci_shard_plan.test.ts
+++ b/tests/ci_shard_plan.test.ts
@@ -846,18 +846,28 @@ describe('ci_shard_test.mjs entry (subprocess, --plan-only)', () => {
     });
     expect(run.exitCode).toBe(0);
     expect(run.log).toContain('shard 1/8, workers=1 (WOC_TEST_WORKERS)');
-    expect(run.log).toContain('--maxWorkers=1');
+    // \b so a --maxWorkers=10..19 from a wide-cores regression cannot satisfy
+    // a bare prefix match.
+    expect(run.log).toMatch(/--maxWorkers=1\b/);
   });
 
   it('falls back loudly to the measured default on a junk WOC_TEST_WORKERS', async () => {
     const fallback = Math.max(1, Math.floor(os.availableParallelism() / 2));
+    // GITHUB_ACTIONS gates the ::warning (same idiom as the leg runner's
+    // known-flake annotation): set it so the annotation arm is exercised; a
+    // local repro without it prints only the plain log line.
     const run = await runEntry(['--shard=1/8', '--plan-only'], {
       TEST_MODE: 'full',
       WOC_TEST_WORKERS: 'banana',
+      GITHUB_ACTIONS: 'true',
     });
     expect(run.exitCode).toBe(0);
     expect(run.log).toContain('WOC_TEST_WORKERS="banana" is not an integer');
-    expect(run.log).toContain(`shard 1/8, workers=${fallback}`);
+    expect(run.log).toContain('::warning title=ci-shard invalid WOC_TEST_WORKERS::');
+    // The ` (default)` suffix bounds the number AND names the arm; the
+    // honored marker must be absent (its positive control is the sibling
+    // test above).
+    expect(run.log).toContain(`shard 1/8, workers=${fallback} (default)`);
     expect(run.log).not.toContain('(WOC_TEST_WORKERS)');
   });
 
@@ -903,13 +913,16 @@ describe('ci_shard_test.mjs entry (subprocess, --plan-only)', () => {
       expect(run.log).toContain('plan: mode=full (mode=full from the changes job)');
       for (const f of CI_LONG_SUITE_HALVES[half]) expect(run.log).toContain(f);
       expect(run.log).not.toContain('--shard=');
-      // The lane keeps the half-cores bound, a MEASURED decision (see the
-      // entry's comment: the full-core trial in run 31107474546 inflated the
-      // sims' aggregate CPU time ~1.6x through contention and timed out the
-      // eastbrook sweep). Pinned so neither direction changes silently: the
-      // budgets are calibrated against this bound.
+      // This pins the resolver DEFAULT: runEntry spawns with a scrubbed env,
+      // so the assertion holds even inside a CI job that exports
+      // WOC_TEST_WORKERS (the lane's real CI worker count is pinned in
+      // tests/ci_workflow.test.ts). The default is the half-cores MEASURED
+      // ruling (the full-core trial in run 31107474546 inflated the sims'
+      // aggregate CPU time ~1.6x through contention and timed out the
+      // eastbrook sweep); the budgets are calibrated against this bound, and
+      // the ` (default)` suffix proves no env override leaked in.
       expect(run.log).toContain(
-        `long-sims-${half} lane, workers=${Math.max(1, Math.floor(os.availableParallelism() / 2))}`,
+        `long-sims-${half} lane, workers=${Math.max(1, Math.floor(os.availableParallelism() / 2))} (default)`,
       );
     }
     // Each half runs ITS files and none of the other's; together they cover

--- a/tests/ci_workflow.test.ts
+++ b/tests/ci_workflow.test.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import { isCodePath } from '../scripts/lib/ci_change_classify.mjs';
-import { CI_LONG_SUITE_HALVES } from '../scripts/lib/ci_shard_plan.mjs';
+import { CI_LONG_SUITE_HALVES, resolveWorkerCount } from '../scripts/lib/ci_shard_plan.mjs';
 import { decideTestMode } from '../scripts/lib/ci_test_select.mjs';
 import {
   GENERATED_I18N_ARTIFACT_FILES,
@@ -1151,12 +1151,21 @@ describe('CI workflow parity', () => {
           String.raw` {10}TEST_MODE: \$\{\{ needs\.changes\.outputs\.test_mode \}\}\n` +
           String.raw` {10}TEST_MODE_REASON: \$\{\{ needs\.changes\.outputs\.test_mode_reason \}\}\n` +
           String.raw` {10}CHANGED_FILES: \$\{\{ needs\.changes\.outputs\.changed_files \}\}\n` +
+          String.raw`( {10}#[^\n]*\n)*` +
+          String.raw` {10}WOC_TEST_WORKERS: '3'\n` +
           String.raw` {8}run: node scripts/ci_shard_test\.mjs --shard=\$\{\{ matrix\.shard \}\}/${SHARD_N}\n`,
       ),
     );
     // Exactly three entry invocations: the shard matrix and the two long-sims
     // lane halves.
     expect(workflow.match(/run: node scripts\/ci_shard_test\.mjs/g)).toHaveLength(3);
+    // The 3-worker value rides exactly those three entry steps (the entry
+    // validates it; scripts/ci_shard_test.mjs carries the measured ruling
+    // this trial answers). Release-gate keeps its inline half-cores default
+    // until the trial's green run justifies moving it.
+    expect(workflow.match(/WOC_TEST_WORKERS: '3'/g)).toHaveLength(3);
+    expect(workflow).not.toMatch(/WOC_TEST_WORKERS: (?!'3'\n)/);
+    expect(jobSource('release-gate')).not.toContain('WOC_TEST_WORKERS');
     // Each lane job mirrors the shard step's hardened relay (env block, never
     // run-line interpolation) and runs the entry in its lane-half mode:
     // unsharded, no matrix, two jobs that between them own the
@@ -1174,6 +1183,8 @@ describe('CI workflow parity', () => {
             String.raw` {10}TEST_MODE: \$\{\{ needs\.changes\.outputs\.test_mode \}\}\n` +
             String.raw` {10}TEST_MODE_REASON: \$\{\{ needs\.changes\.outputs\.test_mode_reason \}\}\n` +
             String.raw` {10}CHANGED_FILES: \$\{\{ needs\.changes\.outputs\.changed_files \}\}\n` +
+            String.raw`( {10}#[^\n]*\n)*` +
+            String.raw` {10}WOC_TEST_WORKERS: '3'\n` +
             String.raw` {8}run: node scripts/ci_shard_test\.mjs --lane=${laneFlag}\n`,
         ),
       );
@@ -1219,15 +1230,25 @@ describe('CI workflow parity', () => {
       expect(job).not.toContain('--exclude');
     }
     // The half-cores worker bound moved from pr-gate's run line into the shard
-    // runner. Derive the expected expression FROM halfCoreCap (the release-gate
-    // pin) so the two forms cannot drift apart: same formula, minus the shell
-    // wrapper and with the runner's `os` import in place of require().
+    // runner, and from there into resolveWorkerCount (the WOC_TEST_WORKERS
+    // trial knob's validated resolver). Derive the expected expression FROM
+    // halfCoreCap (the release-gate pin) so the forms cannot drift apart:
+    // same formula, minus the shell wrapper and with the runner's `os` import
+    // in place of require().
     const capExpression = halfCoreCap
       .replace(/^--maxWorkers="\$\(node -p '/, '')
       .replace(/'\)"$/, '')
       .replace('require("node:os")', 'os');
     expect(capExpression).toBe('Math.max(1, Math.floor(os.availableParallelism() / 2))');
-    expect(ciShardEntry).toContain(capExpression);
+    // Behavioral weld, not just source text: the resolver's default must
+    // compute the SAME value as release-gate's inline formula on any core
+    // count, and the entry must wire the resolver to the real inputs.
+    for (const cores of [1, 2, 3, 4, 8]) {
+      expect(resolveWorkerCount({ cores }).workers).toBe(Math.max(1, Math.floor(cores / 2)));
+    }
+    expect(ciShardEntry).toContain('resolveWorkerCount({');
+    expect(ciShardEntry).toContain('cores: os.availableParallelism()');
+    expect(ciShardEntry).toContain('envValue: process.env.WOC_TEST_WORKERS');
     // Legacy N=4 run lines must not remain once SHARD_N has moved on.
     // String(SHARD_N) comparison avoids tsc folding a constant always-true arm.
     if (String(SHARD_N) !== '4') {

--- a/tests/ci_workflow.test.ts
+++ b/tests/ci_workflow.test.ts
@@ -1170,44 +1170,33 @@ describe('CI workflow parity', () => {
           String.raw` {10}TEST_MODE: \$\{\{ needs\.changes\.outputs\.test_mode \}\}\n` +
           String.raw` {10}TEST_MODE_REASON: \$\{\{ needs\.changes\.outputs\.test_mode_reason \}\}\n` +
           String.raw` {10}CHANGED_FILES: \$\{\{ needs\.changes\.outputs\.changed_files \}\}\n` +
-          String.raw`( {10}#[^\n]*\n)*` +
-          String.raw` {10}WOC_TEST_WORKERS: '3'\n` +
           String.raw` {8}run: node scripts/ci_shard_test\.mjs --shard=\$\{\{ matrix\.shard \}\}/${SHARD_N}\n`,
       ),
     );
     // Exactly three entry invocations: the shard matrix and the two long-sims
     // lane halves.
     expect(workflow.match(/run: node scripts\/ci_shard_test\.mjs/g)).toHaveLength(3);
-    // The 3-worker value rides exactly those three entry steps (the entry
-    // validates it; scripts/ci_shard_test.mjs carries the measured ruling
-    // this trial answers). Release-gate keeps its inline half-cores default
-    // until the trial's green run justifies moving it. All three pins run on
-    // the comment-stripped workflow: the BARE-KEY count catches a stray
-    // override in any YAML value form (same-line, next-line, block scalar),
-    // shapes a value-form lookahead alone would miss, and a doc comment
-    // quoting the line can neither satisfy nor redden them.
-    expect(workflowCode.match(/WOC_TEST_WORKERS:/g)).toHaveLength(3);
-    expect(workflowCode.match(/WOC_TEST_WORKERS: '3'\n/g)).toHaveLength(3);
-    expect(jobSource('release-gate')).not.toContain('WOC_TEST_WORKERS');
-    // The trial literal is WELDED to the resolver's accept range at the
-    // documented runner size (4 vCPU on ubuntu-latest): the value ci.yml
-    // actually carries must be HONORED there, or the whole trial would
-    // silently measure the default while every job stays green.
-    const trialValue = workflowCode.match(/WOC_TEST_WORKERS: '(\d+)'\n/)?.[1];
-    expect(trialValue).toBeDefined();
-    expect(resolveWorkerCount({ cores: 4, envValue: trialValue })).toEqual({
-      workers: Number(trialValue),
-      source: 'env',
-    });
-    // The declaration must not silently vanish, for two mechanisms: biome's
-    // suspicious/noUndeclaredEnvVars warns on any process.env read absent
-    // from turbo.json, and turbo's strict env sandbox strips undeclared
-    // variables from task environments (the turbo-run paths would silently
-    // default). WOC_TEST_WORKERS lives in the pass-through list, never a
-    // hashed input: worker count cannot change task outcomes.
+    // WOC_TEST_WORKERS must not be set ANYWHERE in the workflow: both
+    // alternatives to the half-cores default were measured and regressed
+    // (4 workers, run 31107474546; 3 workers, run 31771637461, three
+    // unrelated default-timeout blowouts for about a minute of wall), so a
+    // reappearing override means someone re-trialing without a new ruling.
+    // Counted as the BARE key on the comment-stripped workflow, which
+    // catches every YAML value form (same-line, next-line, block scalar)
+    // while a doc comment naming the knob stays legal.
+    expect(workflowCode).not.toContain('WOC_TEST_WORKERS');
+    // The knob's declaration must not silently vanish while the entry reads
+    // it, for two mechanisms: biome's suspicious/noUndeclaredEnvVars warns
+    // on any process.env read absent from turbo.json, and turbo's strict
+    // env sandbox strips undeclared variables from task environments (the
+    // turbo-run paths would silently default). Both entries live in the
+    // pass-through list, never a hashed input: neither can change task
+    // outcomes.
     expect(turboJson).toContain('"WOC_TEST_WORKERS"');
-    // The F3 weld above assumes the documented 4-vCPU public runner; pin the
-    // assumption where it is used so a runner move re-opens the decision.
+    expect(turboJson).toContain('"GITHUB_ACTIONS"');
+    // The per-test budgets and the half-cores ruling are calibrated on the
+    // documented 4-vCPU public runner; pin the assumption so a runner move
+    // re-opens the worker decision instead of inheriting it.
     for (const job of ['pr-gate', 'pr-long-sims-a', 'pr-long-sims-b']) {
       expect(jobSource(job), job).toContain('runs-on: ubuntu-latest');
     }
@@ -1228,8 +1217,6 @@ describe('CI workflow parity', () => {
             String.raw` {10}TEST_MODE: \$\{\{ needs\.changes\.outputs\.test_mode \}\}\n` +
             String.raw` {10}TEST_MODE_REASON: \$\{\{ needs\.changes\.outputs\.test_mode_reason \}\}\n` +
             String.raw` {10}CHANGED_FILES: \$\{\{ needs\.changes\.outputs\.changed_files \}\}\n` +
-            String.raw`( {10}#[^\n]*\n)*` +
-            String.raw` {10}WOC_TEST_WORKERS: '3'\n` +
             String.raw` {8}run: node scripts/ci_shard_test\.mjs --lane=${laneFlag}\n`,
         ),
       );

--- a/tests/ci_workflow.test.ts
+++ b/tests/ci_workflow.test.ts
@@ -20,6 +20,25 @@ const detectEntry = readFileSync(
   'utf8',
 );
 const ciShardEntry = readFileSync(new URL('../scripts/ci_shard_test.mjs', import.meta.url), 'utf8');
+// Comment-stripped (same idiom as gateCode below): a source-text pin on the
+// entry must not stay green when the pinned call survives only in a comment.
+const ciShardEntryCode = ciShardEntry
+  .replace(/\/\*[\s\S]*?\*\//g, '')
+  .replace(/(^|[^:])\/\/.*$/gm, '$1');
+const ciShardPlanSource = readFileSync(
+  new URL('../scripts/lib/ci_shard_plan.mjs', import.meta.url),
+  'utf8',
+);
+// Stripped for the formula weld: the module's docblocks discuss the default
+// in prose, and a weld a comment can satisfy is not a weld.
+const ciShardPlanCode = ciShardPlanSource
+  .replace(/\/\*[\s\S]*?\*\//g, '')
+  .replace(/(^|[^:])\/\/.*$/gm, '$1');
+// ci.yml with full-line YAML comments removed: the worker-trial pins below
+// count KEY occurrences, and a doc comment quoting the env line must neither
+// satisfy a count nor turn it red.
+const workflowCode = workflow.replace(/^[ \t]*#.*$/gm, '');
+const turboJson = readFileSync(new URL('../turbo.json', import.meta.url), 'utf8');
 const packageJson = JSON.parse(
   readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
 ) as { packageManager?: string };
@@ -1162,10 +1181,36 @@ describe('CI workflow parity', () => {
     // The 3-worker value rides exactly those three entry steps (the entry
     // validates it; scripts/ci_shard_test.mjs carries the measured ruling
     // this trial answers). Release-gate keeps its inline half-cores default
-    // until the trial's green run justifies moving it.
-    expect(workflow.match(/WOC_TEST_WORKERS: '3'/g)).toHaveLength(3);
-    expect(workflow).not.toMatch(/WOC_TEST_WORKERS: (?!'3'\n)/);
+    // until the trial's green run justifies moving it. All three pins run on
+    // the comment-stripped workflow: the BARE-KEY count catches a stray
+    // override in any YAML value form (same-line, next-line, block scalar),
+    // shapes a value-form lookahead alone would miss, and a doc comment
+    // quoting the line can neither satisfy nor redden them.
+    expect(workflowCode.match(/WOC_TEST_WORKERS:/g)).toHaveLength(3);
+    expect(workflowCode.match(/WOC_TEST_WORKERS: '3'\n/g)).toHaveLength(3);
     expect(jobSource('release-gate')).not.toContain('WOC_TEST_WORKERS');
+    // The trial literal is WELDED to the resolver's accept range at the
+    // documented runner size (4 vCPU on ubuntu-latest): the value ci.yml
+    // actually carries must be HONORED there, or the whole trial would
+    // silently measure the default while every job stays green.
+    const trialValue = workflowCode.match(/WOC_TEST_WORKERS: '(\d+)'\n/)?.[1];
+    expect(trialValue).toBeDefined();
+    expect(resolveWorkerCount({ cores: 4, envValue: trialValue })).toEqual({
+      workers: Number(trialValue),
+      source: 'env',
+    });
+    // The declaration must not silently vanish, for two mechanisms: biome's
+    // suspicious/noUndeclaredEnvVars warns on any process.env read absent
+    // from turbo.json, and turbo's strict env sandbox strips undeclared
+    // variables from task environments (the turbo-run paths would silently
+    // default). WOC_TEST_WORKERS lives in the pass-through list, never a
+    // hashed input: worker count cannot change task outcomes.
+    expect(turboJson).toContain('"WOC_TEST_WORKERS"');
+    // The F3 weld above assumes the documented 4-vCPU public runner; pin the
+    // assumption where it is used so a runner move re-opens the decision.
+    for (const job of ['pr-gate', 'pr-long-sims-a', 'pr-long-sims-b']) {
+      expect(jobSource(job), job).toContain('runs-on: ubuntu-latest');
+    }
     // Each lane job mirrors the shard step's hardened relay (env block, never
     // run-line interpolation) and runs the entry in its lane-half mode:
     // unsharded, no matrix, two jobs that between them own the
@@ -1240,15 +1285,22 @@ describe('CI workflow parity', () => {
       .replace(/'\)"$/, '')
       .replace('require("node:os")', 'os');
     expect(capExpression).toBe('Math.max(1, Math.floor(os.availableParallelism() / 2))');
-    // Behavioral weld, not just source text: the resolver's default must
-    // compute the SAME value as release-gate's inline formula on any core
-    // count, and the entry must wire the resolver to the real inputs.
+    // The weld's consumer: the formula's new home is resolveWorkerCount's
+    // fallback, so the DERIVED expression (cores in place of the os call)
+    // must appear in the plan module. Without this line capExpression is
+    // inert and both sides of the loop below are test-file literals, which
+    // is drift, not a weld.
+    expect(ciShardPlanCode).toContain(capExpression.replace('os.availableParallelism()', 'cores'));
+    // Behavioral weld, second layer: the resolver's default must compute the
+    // SAME value as release-gate's inline formula (sampled core counts, not
+    // an exhaustive proof), and the entry must wire the resolver to the real
+    // inputs (comment-stripped source, so a commented-out call fails).
     for (const cores of [1, 2, 3, 4, 8]) {
       expect(resolveWorkerCount({ cores }).workers).toBe(Math.max(1, Math.floor(cores / 2)));
     }
-    expect(ciShardEntry).toContain('resolveWorkerCount({');
-    expect(ciShardEntry).toContain('cores: os.availableParallelism()');
-    expect(ciShardEntry).toContain('envValue: process.env.WOC_TEST_WORKERS');
+    expect(ciShardEntryCode).toContain('resolveWorkerCount({');
+    expect(ciShardEntryCode).toContain('cores: os.availableParallelism()');
+    expect(ciShardEntryCode).toContain('envValue: process.env.WOC_TEST_WORKERS');
     // Legacy N=4 run lines must not remain once SHARD_N has moved on.
     // String(SHARD_N) comparison avoids tsc folding a constant always-true arm.
     if (String(SHARD_N) !== '4') {

--- a/turbo.json
+++ b/turbo.json
@@ -90,6 +90,7 @@
     "UPDATE_PARITY",
     "UPDATE_TERRAIN_HEIGHT_PARITY",
     "WOC_SKIP_PRETEST",
+    "WOC_TEST_WORKERS",
     "CI",
     "PATH",
     "HOME",

--- a/turbo.json
+++ b/turbo.json
@@ -91,6 +91,7 @@
     "UPDATE_TERRAIN_HEIGHT_PARITY",
     "WOC_SKIP_PRETEST",
     "WOC_TEST_WORKERS",
+    "GITHUB_ACTIONS",
     "CI",
     "PATH",
     "HOME",


### PR DESCRIPTION
## Summary

Sixth act of the CI-speed program (follows #3370, #3371, #3375, #3378, #3380). The PR-tier test jobs run vitest at half the runner's cores (2 workers on the 4-vCPU runner), a measured ruling: the full-core trial in run 31107474546 inflated the long sims' aggregate CPU about 1.6x through memory-bandwidth contention. That ruling requires a measured run before adopting any new value, and 3 workers was never tested. This PR ran that trial and records its answer.

**The trial failed, and that verdict is the deliverable.** The instrumented run (31771637461, this PR's second commit with WOC_TEST_WORKERS: '3' on the three PR-tier entry steps) produced three unrelated DEFAULT-timeout blowouts (tests/parity/coverage_c.test.ts at 20s on shard 2, a tests/terrain_streaming.test.ts 10s hook on shard 3, tests/owned_class_balance_groveheart.test.ts at 20s in lane B) while the green shards gained at most about a minute of wall (7.9 to 10 min against the 8.8 to 11.5 baseline of run 31768778440). A minute of throughput is not worth eating the timeout margin of every ordinary test: the same verdict as the 4-worker trial, from the other side. Half cores now stands measured at both neighbors.

What lands: resolveWorkerCount in the shard planner (a validated WOC_TEST_WORKERS override; honored integers in [1, cores], loud gated-annotation fallback on junk, quiet default when unset), the entry consuming it with a self-auditing arm label (workers=N (WOC_TEST_WORKERS) or (default)), the updated ruling comment recording both trials, and the pins: resolver unit table, two entry subprocess arms, an ABSENCE pin (any reappearing WOC_TEST_WORKERS in the comment-stripped workflow is someone re-trialing without a new ruling), the release-gate formula weld on comment-stripped plan code, turbo.json pass-through declarations, and a runs-on pin so a runner move re-opens the worker decision. The env lines themselves are gone; ci.yml runs exactly as before this PR.

## Type of change

- [x] Refactor or performance (no behavior change)
- [x] Build, CI, or tooling

## How was this tested?

- Commands:
  - The instrumented CI run itself (31771637461): the measurement this PR exists to produce, read via the failure annotations and per-job walls
  - npx vitest run tests/ci_shard_plan.test.ts tests/ci_workflow.test.ts tests/ci_leg_runner.test.ts tests/ci_selection_pipeline.test.ts tests/suite_duration_budget.test.ts (126 tests green)
  - Mutation checks: a next-line YAML override form fails the bare-key pin; a commented-out resolver call fails the stripped source pin
  - npx tsc --noEmit clean; biome clean on changed files
  - node scripts/gate_select.mjs: PASS
- Manual steps: verified workers feeds only --maxWorkers in both plan builders (no selection surface); verified nothing parses the workers= log line format outside the updated pins.

## Checklist

### Quality

- [x] **The gate passes.** node scripts/gate_select.mjs is green.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or .env committed, and ALLOW_DEV_COMMANDS is not enabled in any production path.
- [x] I didn't hand-edit generated files. They're regenerated by the build.
