### PR TITLE
perf(ci): re-derive the CI bounds from mode-labeled measured walls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -465,12 +465,12 @@ jobs:
     # and still running (deterministic workload, not runner variance), and
     # fix/item-provenance-boundaries died the same way at 20.08; sibling
     # GREEN shards on the same run walked 16 to 17 minutes against the 13.6
-    # prior baseline, so that runner set ran about 1.25x slow. 40 applies
+    # prior baseline, so that runner set ran about 1.25x slow. 40 applied
     # release-gate's slow-runner arithmetic to this workload: the projected
-    # completed shard 1 wall is about 22 minutes on those runners, about 18
+    # completed shard 1 wall was about 22 minutes on those runners, about 18
     # fast-runner-equivalent, and 18 x 1.60 (the fast-to-slow runner ratio
     # measured at b160a1ba18) x 1.37 (the margin the original bounds were
-    # chosen with) is 39.5. Label the base honestly when re-deriving: no
+    # chosen with) was 39.5. Label the base honestly when re-deriving: no
     # killed attempt ever completed, so 22 is an extrapolation bounded
     # below by the kill wall; if a healthy shard is bound-killed again,
     # remeasure a completed wall rather than re-raising by feel. The
@@ -481,13 +481,40 @@ jobs:
     # about 2 minutes; a healthy long test step, which both 2026-08-12
     # kills interrupted, is exactly what this bound must not kill. The
     # accepted cost is the hang variant the low-speed floor does not
-    # police (the header's run 31402711619): a hung shard now burns 40
-    # minutes before the reactor can fire, double the old latency, taken
+    # police (the header's run 31402711619): a hung shard then burned 40
+    # minutes before the reactor could fire, double the old latency, taken
     # because a false kill of a required healthy shard blocks PRs outright
     # while a hang costs only latency. The
     # queue-side ceiling this has to fit under is recorded in
     # docs/merge-queue.md.
-    timeout-minutes: 40
+    #
+    # 2026-08-14 re-derivation. TWO MODES SHARE THIS ONE BOUND: selective
+    # (every ordinary pull_request) and full (merge_group, pushes, widened
+    # PRs), and selective is the expensive one, because it stacks the
+    # always-run floor under the related set. The measurement trap that
+    # briefly sized this at 26: any PR touching ci.yml widens to full by the
+    # workflow-side trigger, so a bounds PR can never observe a selective
+    # wall on its own run, and the two runs first cited as "the merged-leg
+    # PR's selective run" (31761236945, 31763736783) were in fact full-mode
+    # for exactly that reason. Label the MODE of every base when
+    # re-deriving. Measured bases, by mode AND tree: worst healthy
+    # SELECTIVE shard wall 16.55 minutes (run 31765273776 shard 4,
+    # merged-leg pipeline, pre-sparse tree). NO post-sparse selective wall
+    # has been observed yet (the sparse cone only trims checkout, so the
+    # test step should match; the nearest comparator is a post-split
+    # pre-sparse selective wall of 13.2, run 31770499114), and 16.55 stays
+    # the conservative base until post-sparse selective walls exist. Worst
+    # healthy FULL wall post-split is 11.5 (31768778440, 31774143931; a
+    # pre-split tree walked 12.03 in 31752830175). 16.55 x 1.60 x 1.37 = 36.3,
+    # so 37. On the reactor: it reruns only setup-phase kills, never a
+    # test-step kill, and never fires on merge_group at all, so this bound
+    # is the only thing that ends a hung test step, the rerun is manual,
+    # and a false kill blocks a REQUIRED check outright, which is why the
+    # base stays the conservative one. Candidate follow-up recorded in the
+    # program notes: shard 4 is the worst shard in every sampled selective
+    # run, so the sha1-contiguous packing concentrates cost and a packing
+    # rebalance could lower this bound honestly.
+    timeout-minutes: 37
     runs-on: ubuntu-latest
 
     # fail-fast stays off: shards pass or fail independently, so one red shard
@@ -714,19 +741,25 @@ jobs:
     # owned_class_balance_* / owned_class_raid_* single-responsibility files
     # and the halves were re-balanced, so no lane chain carries that single
     # 13-minute file any more. The figures above stay as the measured record;
-    # 30 predates the split and re-derives from fresh measured JOB walls in a
-    # follow-up change.
+    # the 2026-08-14 re-derivation below is the follow-up change that note
+    # promised.
     #
-    # 30 applies the same arithmetic as release-gate's bound: healthy JOB wall
-    # times the 1.60 fast-to-slow runner ratio measured at b160a1ba18
-    # (13.73 x 1.60 = 22.0 for the slower half), then the 1.37x margin the
-    # original bounds were chosen with. At 20 this REQUIRED check was roughly
-    # one slow runner away from bound-killing and blocking the merge queue,
-    # which is the more expensive failure than the release backstop's, so it
-    # is raised in the same change. Both halves share one bound so the a/b
-    # assignment can still rebalance freely without re-sizing. The queue-side
-    # ceiling this has to fit under is recorded in docs/merge-queue.md.
-    timeout-minutes: 30
+    # 30 applied the same arithmetic as release-gate's bound to the pre-split
+    # walls: healthy JOB wall times the 1.60 fast-to-slow runner ratio
+    # measured at b160a1ba18 (13.73 x 1.60 = 22.0 for the slower half), then
+    # the 1.37x margin the original bounds were chosen with. At 20 this
+    # REQUIRED check was roughly one slow runner away from bound-killing and
+    # blocking the merge queue, which is the more expensive failure than the
+    # release backstop's.
+    #
+    # 2026-08-14 re-derivation, from post-rebalance healthy JOB walls: across
+    # the full-mode green runs since the second-tier split and lane rebalance
+    # (31768778440, 31774143931), the worst lane wall is lane B at 12.5
+    # minutes. 12.5 x 1.60 x 1.37 = 27.4, so 28. Both halves share one bound
+    # so the a/b assignment can still rebalance freely without re-sizing. The
+    # queue-side ceiling this has to fit under is recorded in
+    # docs/merge-queue.md.
+    timeout-minutes: 28
     runs-on: ubuntu-latest
 
     steps:
@@ -824,8 +857,8 @@ jobs:
     needs: changes
     if: ((github.event_name == 'pull_request' && (github.base_ref != 'main' || !startsWith(github.head_ref, 'release/'))) || (github.event_name == 'push' && !startsWith(github.ref, 'refs/heads/release/')) || github.event_name == 'workflow_dispatch' || github.event_name == 'merge_group') && needs.changes.outputs.code != 'false'
     # Sized with pr-long-sims-a (evidence there, in the lane-diet PR, and in
-    # the run 31450179645 re-derivation the sibling comment carries).
-    timeout-minutes: 30
+    # the dated re-derivations the sibling comment carries).
+    timeout-minutes: 28
     runs-on: ubuntu-latest
 
     steps:
@@ -1052,7 +1085,17 @@ jobs:
     # above); its shards exclude these suites, so this evidence does not
     # size it. The nightly workflow deliberately keeps its own
     # generous bounds and is untouched.
-    timeout-minutes: 35
+    #
+    # 2026-08-14 re-derivation, from completed post-split walls: release-gate
+    # runs on every release/** push, and the healthy worsts across those runs
+    # are 15.00 to 16.43 minutes (31757915533 at 16.43, 31774886593 at
+    # 16.28, 31771748136 at 16.22, 31764380309, 31769545742; the 19.03 wall
+    # in 31746779792 shard 3 is a 9.6 minute CHECKOUT STALL over a 9.1
+    # minute test step, the class the bound exists to kill, so it is
+    # excluded from the base exactly like the lane stalls). 16.43 x 1.60 x
+    # 1.37 = 36.0, so 36: the same arithmetic that first produced 35, one
+    # minute looser now that the base is measured rather than projected.
+    timeout-minutes: 36
     runs-on: ubuntu-latest
 
     # No I18N_RELEASE_TIER here BY DESIGN (D8 revised, issue #2820). This job runs

--- a/docs/merge-queue.md
+++ b/docs/merge-queue.md
@@ -52,9 +52,16 @@ automatically instead of by hand.
   resizing any bound: the `changes` bound, plus the largest REQUIRED job
   bound, plus runner-acquisition slack (which `timeout-minutes` does not count
   but the queue's timer does) must stay comfortably under it. Today that is
-  8 + 40 (the `changes` bound plus the pr-gate shard bound, the largest
-  required one), so a required critical path of 48 minutes against a 90
-  minute ceiling. A candidate that blows the queue timeout is ejected,
+  8 + 37 (the `changes` bound plus the pr-gate shard bound, the largest
+  required one, re-derived 2026-08-14 from the worst healthy selective-mode
+  wall; the long-sims lanes sit at 28), so a required critical path of 45
+  minutes against a 90 minute ceiling. Read 45 as a ceiling, not an
+  expectation: queue runs always execute FULL mode (selection applies to
+  pull requests only), whose healthy shard walls are about 12 minutes, so
+  the realistic queue path is far shorter; the bound is sized for the
+  selective mode ordinary PRs share it with. These figures are welded to
+  the ci.yml bounds by `tests/ci_workflow.test.ts`, so resizing a bound
+  fails the pin until this sentence moves with it. A candidate that blows the queue timeout is ejected,
   which blocks the merge rather than merging anything unproven, but it
   costs a full queue cycle and reads like a mystery without this number
   written down.

--- a/tests/ci_workflow.test.ts
+++ b/tests/ci_workflow.test.ts
@@ -988,43 +988,32 @@ describe('CI workflow parity', () => {
     // in shape rather than lifted from the checkout-stall replay directly, so
     // every job in this file carries a conscious timeout-minutes value.
     const bounds = [
-      // pr-gate's 20 was sized when two 24 hour replays found zero healthy
-      // jobs over it. Sim-deep selective PRs broke that zero: their runs
-      // stack the expensive sim suites on top of the always-run
-      // blind/partial floor, and the sha1-contiguous packs can
-      // concentrate several in one shard (PR #3342's
-      // shard 1 bound-killed at a 20.25 minute wall on two attempts with a
-      // healthy 19 minute test step still running; fix/item-provenance-
-      // boundaries died the same way at 20.08). 40 is release-gate's
-      // slow-runner sizing METHOD over this workload's projected healthy
-      // wall; derivation and run evidence on the ci.yml bound.
-      ['pr-gate', 40],
+      // pr-gate: 37 is the 2026-08-14 re-derivation from the worst healthy
+      // SELECTIVE shard wall (16.55 minutes, run 31765273776; selective and
+      // full mode share this one bound and selective is the expensive one,
+      // x 1.60 slow-runner ratio x 1.37 margin = 36.3). The 20-then-40
+      // history, the full-mode measurement trap (a ci.yml-touching PR
+      // always widens to full, so a bounds PR cannot observe selective
+      // walls), and the derivation live on the ci.yml bound.
+      ['pr-gate', 37],
       // release-gate is the one shard matrix that keeps its CI_LONG_SUITES
       // files in-shard (pr-gate hands them to the lanes), so a single shard
       // can draw four of them at once and the bound has to cover a slow
       // runner rather than the healthy median. 20 was sized from a 14.63
       // minute healthy worst case and was bound-killing shard 1 by 2026-08-11
-      // at b160a1ba18; 35 is the 16 minute healthy wall scaled by the 1.60
-      // fast-to-slow runner ratio measured there, at the same 1.37x margin.
-      // The ci.yml comment carries the run ids, the per-suite measurements,
-      // and why the killed attempt's file count must not be extrapolated.
-      ['release-gate', 35],
-      // The single-job lane's bound reached 60 after run 31290316610 measured
-      // ~4400s aggregate suite time on a slow-quartile runner. The lane-diet
-      // PR cut the aggregate several-fold and split the lane in two and sized
-      // 20 from a local-measured projection of under 10 minutes per half.
-      // Run 31450179645 falsified that projection on a healthy CI runner
-      // (lane A 13.73 minutes, lane B 12.55, owned_class_balance_harness
-      // alone 739268ms in-lane), leaving these REQUIRED checks about one slow
-      // runner from bound-killing the merge queue, so both halves take the
-      // same slow-runner sizing METHOD as release-gate (the same formula over
-      // their own healthy job wall, which lands on 30, not on its 35).
-      // Evidence on the ci.yml bound. (The harness pair was split into the
-      // owned_class_balance_* / owned_class_raid_* files on 2026-08-13; the
-      // figures stay as the measured record, and the bounds re-derive from
-      // fresh walls in a follow-up change.)
-      ['pr-long-sims-a', 30],
-      ['pr-long-sims-b', 30],
+      // at b160a1ba18; 36 is the 2026-08-14 re-derivation from the measured
+      // post-split release-push worst (16.43 minutes, checkout-stall walls
+      // excluded) at the same 1.60 ratio and 1.37 margin; evidence on the
+      // ci.yml bound.
+      ['release-gate', 36],
+      // The lanes: 28 is the 2026-08-14 re-derivation from post-rebalance
+      // healthy walls (worst lane 12.5 minutes, same formula as pr-gate).
+      // The 60-to-20-to-30 history, including the falsified under-10
+      // projection that bans sizing these from estimates, lives on the
+      // ci.yml bound. Both halves share one bound so the a/b assignment can
+      // rebalance without re-sizing.
+      ['pr-long-sims-a', 28],
+      ['pr-long-sims-b', 28],
       ['browser-gate', 10],
       // 8 is a measured decision like the rest (healthy worst 4.42 min, all
       // observed stalls over 8), so it is pinned exactly here beside the
@@ -1065,6 +1054,13 @@ describe('CI workflow parity', () => {
       const next = rest.search(/\n {2}[A-Za-z][A-Za-z0-9_-]*:[ \t]*(?:#[^\n]*)?\n/);
       return next === -1 ? rest : rest.slice(0, next);
     };
+    // Positive control for the two step-bound regexes below: they are
+    // negative pins on tokens ci.yml never carries, so prove on a synthetic
+    // span that each shape would actually match before trusting the
+    // absences.
+    const stepBoundSample = '\n        timeout-minutes: 5\n      - timeout-minutes: 5\n';
+    expect(stepBoundSample).toMatch(/\n {8}timeout-minutes:/);
+    expect(stepBoundSample).toMatch(/\n {6}- timeout-minutes:/);
     for (const [name, minutes] of bounds) {
       const span = jobSpan(name);
       const jobLevel = span.match(/^ {4}timeout-minutes: \d+$/gm) ?? [];
@@ -1100,6 +1096,48 @@ describe('CI workflow parity', () => {
     // The routing is the entry's operational point: a timeout kill goes to
     // a rerun, never straight to a code investigation.
     expect(mergeQueueTriage).toContain('re-run the failed jobs and re-queue');
+    // The doc's critical-path arithmetic is WELDED to the table, both
+    // numbers derived rather than hard-coded: this is the second edit to
+    // that sentence in one program, and an unwelded number drifts. The
+    // required set matches the doc's own required-checks list; the changes
+    // bound is the serial prefix (every test job needs it).
+    const requiredJobs = [
+      'pr-gate',
+      'pr-long-sims-a',
+      'pr-long-sims-b',
+      'pr-checks',
+      'lint',
+      'browser-gate',
+    ];
+    const boundOf = (job: string) => bounds.find(([name]) => name === job)?.[1] ?? Number.NaN;
+    const largestRequired = Math.max(...requiredJobs.map(boundOf));
+    const changesBound = boundOf('changes');
+    // EXACTLY ONE occurrence of each welded shape, matched over the whole
+    // doc: a "historical note" decoy carrying the old numbers above the
+    // live sentence would otherwise satisfy a first-match weld while the
+    // live sentence drifts (adversarially demonstrated in review).
+    const pathMatches = [
+      ...mergeQueueTriage.matchAll(/(\d+) \+ (\d+) \(the `changes` bound plus/g),
+    ];
+    expect(pathMatches, 'exactly one critical-path sentence in docs/merge-queue.md').toHaveLength(
+      1,
+    );
+    expect(Number(pathMatches[0][1])).toBe(changesBound);
+    expect(Number(pathMatches[0][2])).toBe(largestRequired);
+    // \s+ because the doc hard-wraps near 72 columns and the wrap point
+    // moves as the number's width changes; the trailing "minute" anchors
+    // the ceiling's end so a 900 cannot satisfy the 90.
+    const sumMatches = [
+      ...mergeQueueTriage.matchAll(
+        /critical path of (\d+)\s+minutes\s+against\s+a\s+(\d+)\s+minute/g,
+      ),
+    ];
+    expect(sumMatches, 'exactly one critical-path sum in docs/merge-queue.md').toHaveLength(1);
+    expect(Number(sumMatches[0][1])).toBe(changesBound + largestRequired);
+    expect(Number(sumMatches[0][2])).toBe(90);
+    // The doc's stated invariant, executable: the required critical path
+    // must stay comfortably under the queue's 90 minute response ceiling.
+    expect(changesBound + largestRequired).toBeLessThan(90);
   });
 
   it('aborts dead checkout transfers workflow-wide instead of riding a job bound', () => {


### PR DESCRIPTION
## Summary

Seventh act of the CI-speed program (follows #3370, #3371, #3375, #3378, #3380, #3383): the bounds re-derivation the lane sizing comments promised once the splits landed. All three re-derived values use the documented arithmetic (healthy JOB wall x 1.60 fast-to-slow runner ratio x 1.37 margin), with every base labeled by mode and tree:

- pr-gate: 40 to 37. The round's central lesson, now written into the comment: this one bound covers selective mode (every ordinary PR) and full mode, selective is the expensive one, and a ci.yml-touching PR always widens to full, so a bounds PR can never observe a selective wall on its own run. A first cut sized 26 from full-mode walls alone; review measured the worst healthy selective wall at 16.55 minutes (run 31765273776, kept as the conservative base since no post-sparse selective wall exists yet), giving 36.3, so 37.
- long-sims lanes: 30 to 28, from the post-rebalance worst healthy lane wall of 12.5 (full mode is the lanes' expensive mode; the apparent 15+ walls are checkout stalls, excluded).
- release-gate: 35 to 36, from measured release-push worsts of 15.0 to 16.4 across five post-split runs (a 19.0 wall excluded as a 9.6-minute checkout stall), replacing a false no-evidence premise with the run ids.

docs/merge-queue.md's required critical path drops from 8 + 40 to 8 + 37 against the 90-minute queue ceiling, with a note that queue runs always execute full mode (about 12-minute walls), so 45 is a ceiling, not an expectation. That sentence is now WELDED to the bounds table in tests/ci_workflow.test.ts: both numbers derived from the table, exactly-one-occurrence matching (a historical-note decoy above the live sentence was adversarially demonstrated against the first-match form and now fails), an end-anchored ceiling regex, and the under-90 invariant as an executable assertion. A positive control proves the two step-bound negative regexes still match their shapes. The reactor claims are corrected in place: it reruns only setup-phase kills and never fires in merge_group, so the bound itself is what ends a hung test step.

Recorded follow-up, not in this PR: shard 4 dominates every sampled selective run, so the sha1-contiguous packing concentrates cost; a packing rebalance could lower the pr-gate bound honestly.

## Type of change

- [x] Refactor or performance (no behavior change)
- [x] Build, CI, or tooling

## How was this tested?

- Commands:
  - npx vitest run tests/ci_workflow.test.ts (24 tests green; the bounds table, the new weld, the positive control)
  - Mutation checks: every bound value mutation, duplicate and step-level bound shapes, a drifted doc number, and the historical-note decoy all fail their pins (three independent reviewers, one with a full mutation harness on scratch copies)
  - Measured evidence pulled from the GitHub API across 43 post-split runs: per-job walls with checkout/test step breakdowns, mode confirmed from job logs (TEST_MODE lines), trees confirmed post-split by file presence at the head SHA
  - npx tsc --noEmit clean; biome clean on changed files
  - node scripts/gate_select.mjs: PASS
- Manual steps: verified the stall reactor's predicate (setup-step names only, no merge_group) against .github/workflows/ci-stall-rerun.yml, and that no other doc, test, or script carries the old 40/30/35 values as live bounds.

## Checklist

### Quality

- [x] **The gate passes.** node scripts/gate_select.mjs is green.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or .env committed, and ALLOW_DEV_COMMANDS is not enabled in any production path.
- [x] I didn't hand-edit generated files. They're regenerated by the build.
