### PR TITLE
chore(ci): rename the check contexts to the clean scheme

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,7 +207,7 @@ jobs:
   # (unit-tested by tests/ci_change_classify.test.ts). Release jobs never need
   # this job and never read its output.
   changes:
-    name: Detect code path changes
+    name: Classify changes
     runs-on: ubuntu-latest
     # Every PR-tier job waits on this one, so a wedged runner must fail fast
     # and be retried, never hang for an hour and a half. 8, not 5: the
@@ -258,7 +258,7 @@ jobs:
   # `--no-errors-on-unmatched` keeps the job green when a change touches no
   # Biome-eligible file (docs, assets, generated i18n).
   lint:
-    name: Format + lint (Biome, changed files)
+    name: Lint (changed files)
     # Unmatrixed single toolchain-setup-plus-checks job, comparable in shape to
     # browser-gate: checkout, pnpm install, a base-ref fetch, then one biome
     # pass. 15 keeps a margin over browser-gate's 10 minute bound for the extra
@@ -348,7 +348,7 @@ jobs:
         run: npx @biomejs/biome ci --changed --since="$BASE_REF_RESOLVED" --no-errors-on-unmatched
 
   browser-gate:
-    name: Browser regressions (Chromium)
+    name: Browser tests
     # Skip on confirmed docs-only PRs (no browser tests/code touched). Non-PR
     # and code PRs keep the job (changes.code defaults true off PR events).
     # != 'false', not == 'true': only an explicit docs-only verdict may skip.
@@ -357,7 +357,7 @@ jobs:
     # SKIP, and under the merge queue a skipped required check reads satisfied.
     # This covers a green-but-empty output only: a FAILED changes job still
     # skips dependents through needs regardless of this expression, which is
-    # why "Detect code path changes" must itself be a required check.
+    # why "Classify changes" must itself be a required check.
     needs: changes
     if: needs.changes.outputs.code != 'false'
     # Fail fast on the checkout-stall class (rationale and evidence on the
@@ -422,7 +422,7 @@ jobs:
   # with ONE full unsharded vitest run by design (bounded workers); keep that
   # script's step list in sync when adding or removing a step in either job.
   pr-gate:
-    name: PR gate (English-only legal)
+    name: PR tests
     # Two-level gate, split on purpose (docs/merge-queue.md, "The required-check
     # contract"). The JOB if carries only the event routing, so every
     # pull_request and merge_group run expands the matrix and reports all eight
@@ -711,7 +711,7 @@ jobs:
   # release-gate is deliberately NOT lane-split: release/** pushes keep the
   # full suite in their 8 shards.
   pr-long-sims-a:
-    name: PR gate (long sims A)
+    name: PR long sims A
     needs: changes
     if: ((github.event_name == 'pull_request' && (github.base_ref != 'main' || !startsWith(github.head_ref, 'release/'))) || (github.event_name == 'push' && !startsWith(github.ref, 'refs/heads/release/')) || github.event_name == 'workflow_dispatch' || github.event_name == 'merge_group') && needs.changes.outputs.code != 'false'
     # Each lane half concentrates slow suites in one required job with no
@@ -855,7 +855,7 @@ jobs:
   # pr-long-sims-a above (identical shape, its own CI_LONG_SUITE_HALVES half
   # and its own cache key segment).
   pr-long-sims-b:
-    name: PR gate (long sims B)
+    name: PR long sims B
     needs: changes
     if: ((github.event_name == 'pull_request' && (github.base_ref != 'main' || !startsWith(github.head_ref, 'release/'))) || (github.event_name == 'push' && !startsWith(github.ref, 'refs/heads/release/')) || github.event_name == 'workflow_dispatch' || github.event_name == 'merge_group') && needs.changes.outputs.code != 'false'
     # Sized with pr-long-sims-a (evidence there, in the lane-diet PR, and in
@@ -938,7 +938,7 @@ jobs:
   # here: the freshness diff checks the MERGE RESULT against the base branch,
   # not just the PR head.
   pr-checks:
-    name: PR checks (freshness, typecheck, builds)
+    name: PR checks
     # Same composition as pr-gate: release exclusion + code path filter. Skipped
     # entirely on docs-only PRs (malware/typecheck/builds are code-path gates).
     # merge_group lands here too: the queue re-proves freshness, typecheck, and
@@ -1047,7 +1047,7 @@ jobs:
   release-gate:
     # NOT "21-locale": since #2820 the 21-locale assertions live in release-i18n, and
     # the label is what an operator reads in the checks list to tell the two reds apart.
-    name: Release gate (tests)
+    name: Release tests
     if: (github.event_name == 'pull_request' && github.base_ref == 'main' && startsWith(github.head_ref, 'release/')) || (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release/'))
     # Sized from this matrix's own workload, independently of pr-gate's
     # bound: this matrix keeps the long sims in-shard by design, since
@@ -1211,7 +1211,7 @@ jobs:
   # of tests/ for readers of the flag) by tests/release_i18n_tier_coverage.test.ts,
   # so a new tier-sensitive suite cannot silently stop running under the tier.
   release-i18n:
-    name: Release i18n (21-locale fill)
+    name: Release i18n
     if: (github.event_name == 'pull_request' && github.base_ref == 'main' && startsWith(github.head_ref, 'release/')) || (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release/'))
     # Unsharded and seconds long by design (five test files, see the job
     # comment above): the toolchain setup dominates the wall time. 10 mirrors
@@ -1281,7 +1281,7 @@ jobs:
   # either direction. Does not set I18N_RELEASE_TIER; the checks here do not
   # depend on it, and the release-i18n job alone owns the tier flag.
   release-checks:
-    name: Release checks (freshness, typecheck, builds)
+    name: Release checks
     if: (github.event_name == 'pull_request' && github.base_ref == 'main' && startsWith(github.head_ref, 'release/')) || (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release/'))
     # Mirrors pr-checks: same step list (i18n generation, malware gate,
     # typecheck, four builds), so the same 20 minute bound.

--- a/docs/merge-queue.md
+++ b/docs/merge-queue.md
@@ -17,8 +17,8 @@ merged into the target branch (`PR gate (long sims)` was the first case), and
 expect open PRs whose heads predate the job to need a base re-merge before
 they can queue, since a required context that never reports blocks the merge
 forever. Renames follow the same choreography in reverse plus forward: when
-the lane-diet PR split `PR gate (long sims)` into `PR gate (long sims A)` and
-`PR gate (long sims B)`, the old context had to leave the ruleset at the same
+the lane-diet PR split `PR gate (long sims)` into `PR long sims A` and
+`PR long sims B`, the old context had to leave the ruleset at the same
 time the two new ones joined (after the split merged), because a required
 name no run produces anymore blocks every later merge.
 
@@ -117,7 +117,7 @@ the Checks tab (filter by event: merge_group).
 
 Required on both `main` and `release/**`, all sourced from GitHub Actions:
 
-- `Detect code path changes`. Required itself, and load-bearing: when it fails,
+- `Classify changes`. Required itself, and load-bearing: when it fails,
   its non-matrix dependents report skipped under their exact names, and branch
   protection treats skipped as satisfied (the shard matrix instead collapses to
   an unsuffixed check run, which blocks by accident rather than by decision).
@@ -128,7 +128,7 @@ Required on both `main` and `release/**`, all sourced from GitHub Actions:
   (`.github/workflows/`) and the selection pipeline's own scripts are
   themselves fail-closed triggers (always `code=true`, always full mode); a
   hostile edit is a review problem, not something protection can solve.
-- `PR gate (English-only legal) (1)` through `(8)`: the sharded test suite.
+- `PR tests (1)` through `(8)`: the sharded test suite.
   The matrix legs START on every `pull_request` and `merge_group` run and gate
   their work at STEP level: on a run the suite does not apply to (a docs-only
   PR, a release-to-main PR) each leg skips its steps and reports green in
@@ -137,7 +137,7 @@ Required on both `main` and `release/**`, all sourced from GitHub Actions:
   which string-matches none of these required contexts and leaves them
   "expected" forever, so the PR could never be queued or merged (observed live
   on the Phase 3 queue drills).
-- `PR gate (long sims A)` and `PR gate (long sims B)`: the dedicated lane
+- `PR long sims A` and `PR long sims B`: the dedicated lane
   pair for the long rotation sims (`CI_LONG_SUITES` split by
   `CI_LONG_SUITE_HALVES` in `scripts/lib/ci_shard_plan.mjs`). The shard
   matrix deliberately excludes those files, so these jobs carry coverage
@@ -146,20 +146,20 @@ Required on both `main` and `release/**`, all sourced from GitHub Actions:
   `merge_group` run; unlike the shard matrix, a job-level skip is safe here
   because a non-matrix job's skipped check run keeps its exact required name,
   which satisfies protection.
-- `PR checks (freshness, typecheck, builds)`.
-- `Format + lint (Biome, changed files)`: deterministic, diff-scoped, minutes
+- `PR checks`.
+- `Lint (changed files)`: deterministic, diff-scoped, minutes
   long, and a red here is always a real defect in the changed files. On queue
   runs it diffs against the merge group's base SHA, falling back to the live
   target-branch tip if that SHA is unreachable, so a `release/**` queue run
   never sweeps the release-vs-main delta (and its intentionally-red whole-repo
   debt) into biome.
-- `Browser regressions (Chromium)`: the real-browser net for a browser game.
+- `Browser tests`: the real-browser net for a browser game.
   It reports (or is skipped, which satisfies) on every PR and queue run.
 
 Never require these, deliberately:
 
-- The release lanes (`Release gate (tests)`, `Release i18n (21-locale fill)`,
-  `Release checks (freshness, typecheck, builds)`, `Release version gate`):
+- The release lanes (`Release tests`, `Release i18n`,
+  `Release checks`, `Release version gate`):
   release-process lanes, legitimately red or skipped mid-cycle. Release i18n in
   particular is red by design until the release-time locale fill.
 - `Dependency audit`: its workflow is path-filtered to dependency changes, so

--- a/docs/merge-queue.md
+++ b/docs/merge-queue.md
@@ -17,10 +17,14 @@ merged into the target branch (`PR gate (long sims)` was the first case), and
 expect open PRs whose heads predate the job to need a base re-merge before
 they can queue, since a required context that never reports blocks the merge
 forever. Renames follow the same choreography in reverse plus forward: when
-the lane-diet PR split `PR gate (long sims)` into `PR long sims A` and
-`PR long sims B`, the old context had to leave the ruleset at the same
-time the two new ones joined (after the split merged), because a required
-name no run produces anymore blocks every later merge.
+the lane-diet PR split `PR gate (long sims)` into `PR gate (long sims A)`
+and `PR gate (long sims B)` (the names those jobs carried then), the old
+context had to leave the ruleset at the same time the two new ones joined
+(after the split merged), because a required name no run produces anymore
+blocks every later merge. The 2026-08-14 clean-scheme rename is the same
+choreography at full width: all fourteen required contexts swapped in one
+ruleset edit at merge time, with every open PR needing a base update
+afterward so its next run reports under the new names.
 
 Why: on 2026-08-05 two merges landed on an already-red release tip, every open
 PR inherited 67 broken tests, and repair took a day of close/reopen churn. The

--- a/docs/qa-gate.md
+++ b/docs/qa-gate.md
@@ -216,7 +216,7 @@ seconds inside a full-mode shard, the chronomancy balance sweep among them, plus
 owned-class balance family, which is lane-owned as a unit since its 2026-08-13 split
 so the diet-flag registry and its lane accounting stay in one place; the measured
 per-file lane duration ledgers live in the lane-split PR bodies, #3370 first) run in the
-dedicated `PR gate (long sims A)` / `PR gate (long sims B)` job pair
+dedicated `PR long sims A` / `PR long sims B` job pair
 (`node scripts/ci_shard_test.mjs --lane=long-sims-a` / `--lane=long-sims-b`, one
 `CI_LONG_SUITE_HALVES` half each), and every shard leg excludes the whole union, so a
 single multi-minute file no longer sets the slowest shard's wall clock and the lane's

--- a/docs/qa-gate.md
+++ b/docs/qa-gate.md
@@ -13,7 +13,7 @@ Codex have different entry points and share the same deterministic scripts and c
 | Day-loop fast path | `npm run gate:fast` through `scripts/gate_fast.mjs` | While iterating (agents and mid/low-tier machines) | No (local only; not merge) |
 | **Selective gate** | `node scripts/gate_select.mjs` | **Before implementation is called ready / pre-merge** | **Yes (the merge bar)** |
 | Full local gate | `npm run gate` through `scripts/gate.mjs` | When you want the whole suite locally, or the planner falls back | Yes (deeper check) |
-| Selective PR-tier CI | ci.yml `pr-gate` shards through `scripts/ci_shard_test.mjs` (same selection semantics, sharded; full suite on any unprovable diff) | Every pull request | Yes (PR checks) |
+| Selective PR-tier CI | ci.yml `pr-gate` shards through `scripts/ci_shard_test.mjs` (same selection semantics, sharded; full suite on any unprovable diff) | Every pull request | Yes (required checks) |
 | Merge queue | ci.yml on the `merge_group` event: the full PR tier over the exact merge result about to become the branch tip (see `docs/merge-queue.md`, including rollout status: `release/**` first, `main` at the next release-to-main merge) | Every queued merge into a queue-protected branch | Yes (required checks on the merge group) |
 | Nightly full gate | `.github/workflows/nightly.yml`: full suite + checks + browser over the tips of main and the active `release/**` branch | Scheduled nightly (04:47 UTC) | No (alerting: files and closes one tracking issue) |
 | Judgment review | Claude `/qa` or Codex `$woc-qa`, plus scoped reviewers | End of a contribution | Advisory locally |

--- a/scripts/ci_shard_test.mjs
+++ b/scripts/ci_shard_test.mjs
@@ -39,7 +39,7 @@ const usage =
 
 const argv = process.argv.slice(2);
 const shard = parseShardArg(argv);
-// The long-sims lanes ("PR gate (long sims A)" / "PR gate (long sims B)"):
+// The long-sims lanes ("PR long sims A" / "PR long sims B"):
 // the two jobs that split the CI_LONG_SUITES files the shard legs exclude
 // (CI_LONG_SUITE_HALVES). Exactly one --lane flag with one of the two exact
 // literals; any other value, a duplicate, or ANY --shard token beside it
@@ -189,7 +189,7 @@ if (lane) {
     // every leg below and owned by the two long-sims lane jobs in this run.
     console.log(
       `[ci-shard] long-sims lane: ${plan.laneExcluded.length} suite(s) excluded from this ` +
-        'shard and owned by the "PR gate (long sims A)" and "PR gate (long sims B)" jobs',
+        'shard and owned by the "PR long sims A" and "PR long sims B" jobs',
     );
   }
   if (plan.mode === 'selective') {

--- a/scripts/detect_code_changes.mjs
+++ b/scripts/detect_code_changes.mjs
@@ -1,4 +1,4 @@
-// CI entry for the ci.yml `changes` job ("Detect code path changes"): decide
+// CI entry for the ci.yml `changes` job ("Classify changes"): decide
 // whether the run touches the code path set and write the `code` step output,
 // plus the PR-tier selection decision (`test_mode`,
 // `test_mode_reason`, `changed_files`) the pr-gate shards consume (the CI/CD

--- a/scripts/lib/ci_change_classify.mjs
+++ b/scripts/lib/ci_change_classify.mjs
@@ -1,5 +1,5 @@
 // Pure classification + fail-closed decision logic for the ci.yml `changes`
-// job ("Detect code path changes"). The job used to answer "does this PR touch
+// job ("Classify changes"). The job used to answer "does this PR touch
 // the code path set" with a full-history checkout plus `git diff`, which cost
 // about 10 serial minutes on every PR (binary-heavy history) and twice wedged
 // for 90+ minutes on the checkout step. The answer now comes from the GitHub

--- a/scripts/lib/ci_shard_plan.mjs
+++ b/scripts/lib/ci_shard_plan.mjs
@@ -137,8 +137,8 @@ export const CI_LONG_SUITES = Object.freeze([
 ]);
 
 /**
- * The two parallel lane jobs ("PR long sims A" / "PR gate (long sims
- * B)" in ci.yml): a literal partition of CI_LONG_SUITES, so the pair's wall
+ * The two parallel lane jobs ("PR long sims A" / "PR long sims B"
+ * in ci.yml): a literal partition of CI_LONG_SUITES, so the pair's wall
  * clock is roughly half of the single-job lane's. Halves are balanced by
  * MEASURED post-diet suite duration, not file count (re-balanced 2026-08-13
  * from the per-file durations in the harness-split PR after the owned-class

--- a/scripts/lib/ci_shard_plan.mjs
+++ b/scripts/lib/ci_shard_plan.mjs
@@ -22,7 +22,7 @@
 //               (scripts/ci_shard_test.mjs) regenerates the artifacts once
 //               per job before spawning, and the guard suites still read
 //               fresh bytes on every shard.
-//   lane        the "PR gate (long sims A)" / "PR gate (long sims B)" jobs
+//   lane        the "PR long sims A" / "PR long sims B" jobs
 //               (buildLanePlan, one CI_LONG_SUITE_HALVES half each): the
 //               half's collected CI_LONG_SUITES files, all of them in full
 //               mode and on any unprovable input, only the floor/changed
@@ -73,7 +73,7 @@ export const CI_GUARD_PREFIXES = Object.freeze(['tests/parity/']);
 
 /**
  * Long rotation sims the PR tier runs in the dedicated lane jobs
- * ("PR gate (long sims A)" / "PR gate (long sims B)" in ci.yml, one
+ * ("PR long sims A" / "PR long sims B" in ci.yml, one
  * CI_LONG_SUITE_HALVES half each) instead of inside the shard matrix, so a
  * single multi-minute file stops setting the slowest shard's wall clock.
  * Membership is measured, not automated: a file joins when it costs more than
@@ -137,7 +137,7 @@ export const CI_LONG_SUITES = Object.freeze([
 ]);
 
 /**
- * The two parallel lane jobs ("PR gate (long sims A)" / "PR gate (long sims
+ * The two parallel lane jobs ("PR long sims A" / "PR gate (long sims
  * B)" in ci.yml): a literal partition of CI_LONG_SUITES, so the pair's wall
  * clock is roughly half of the single-job lane's. Halves are balanced by
  * MEASURED post-diet suite duration, not file count (re-balanced 2026-08-13
@@ -481,8 +481,8 @@ export function buildShardPlan({
 }
 
 /**
- * Build the legs one long-sims lane job ("PR gate (long sims A)" or
- * "PR gate (long sims B)") executes over its CI_LONG_SUITE_HALVES half.
+ * Build the legs one long-sims lane job ("PR long sims A" or
+ * "PR long sims B") executes over its CI_LONG_SUITE_HALVES half.
  *
  * Mirror image of buildShardPlan over the SAME inputs: full mode and every
  * unprovable input run every collected lane file of this half; selective mode

--- a/tests/ci_shard_plan.test.ts
+++ b/tests/ci_shard_plan.test.ts
@@ -1107,9 +1107,7 @@ describe('ci_shard_test.mjs entry (subprocess, --plan-only)', () => {
     });
     expect(run.exitCode).toBe(0);
     for (const f of CI_LONG_SUITES) expect(run.log).toContain(`--exclude=${f}`);
-    expect(run.log).toContain(
-      'owned by the "PR gate (long sims A)" and "PR gate (long sims B)" jobs',
-    );
+    expect(run.log).toContain('owned by the "PR long sims A" and "PR long sims B" jobs');
   });
 
   it('plans the full suite when the mode env is missing (fail closed)', async () => {

--- a/tests/ci_stall_rerun.test.ts
+++ b/tests/ci_stall_rerun.test.ts
@@ -17,7 +17,8 @@ import {
 // is a SAFETY predicate: a wrong "rerun" can resurrect a superseded run or
 // blur a real failure's triage, so every case that is not positively the
 // stall shape must decide no. The primary fixture is the real incident:
-// run 31392590628 attempt 2 (2026-08-10), "PR long sims A" killed by
+// run 31392590628 attempt 2 (2026-08-10), the job then named "PR gate
+// (long sims A)" (now "PR long sims A"; fixture data uses the live name) killed by
 // its 20-minute bound inside "Check out repository", steps and annotation
 // text verbatim from the GitHub API.
 

--- a/tests/ci_stall_rerun.test.ts
+++ b/tests/ci_stall_rerun.test.ts
@@ -17,7 +17,7 @@ import {
 // is a SAFETY predicate: a wrong "rerun" can resurrect a superseded run or
 // blur a real failure's triage, so every case that is not positively the
 // stall shape must decide no. The primary fixture is the real incident:
-// run 31392590628 attempt 2 (2026-08-10), "PR gate (long sims A)" killed by
+// run 31392590628 attempt 2 (2026-08-10), "PR long sims A" killed by
 // its 20-minute bound inside "Check out repository", steps and annotation
 // text verbatim from the GitHub API.
 
@@ -65,7 +65,7 @@ function greenJob(name: string): FixtureJob {
 
 function stalledLaneA(): FixtureJob {
   return {
-    name: 'PR gate (long sims A)',
+    name: 'PR long sims A',
     conclusion: 'cancelled',
     steps: structuredClone(LANE_A_STALL_STEPS),
     annotationMessages: [TIMEOUT_ANNOTATION, CANCEL_ANNOTATION],
@@ -77,13 +77,13 @@ function incidentRun(): { runAttempt: number; runConclusion: string | null; jobs
     runAttempt: 1,
     runConclusion: 'cancelled',
     jobs: [
-      greenJob('Detect code path changes'),
-      greenJob('PR gate (English-only legal) (1)'),
-      greenJob('PR gate (English-only legal) (2)'),
-      greenJob('PR gate (long sims B)'),
-      greenJob('PR checks (freshness, typecheck, builds)'),
-      greenJob('Format + lint (Biome, changed files)'),
-      greenJob('Browser regressions (Chromium)'),
+      greenJob('Classify changes'),
+      greenJob('PR tests (1)'),
+      greenJob('PR tests (2)'),
+      greenJob('PR long sims B'),
+      greenJob('PR checks'),
+      greenJob('Lint (changed files)'),
+      greenJob('Browser tests'),
       stalledLaneA(),
     ],
   };
@@ -93,7 +93,7 @@ describe('ci stall rerun decision core', () => {
   it('reruns the real incident shape: bound-killed setup step, no test step ran', () => {
     const decision = decide(incidentRun());
     expect(decision.rerun).toBe(true);
-    expect(decision.stalledJobs).toEqual(['PR gate (long sims A)']);
+    expect(decision.stalledJobs).toEqual(['PR long sims A']);
     expect(TIMEOUT_ANNOTATION).toContain(TIMEOUT_ANNOTATION_FRAGMENT);
   });
 
@@ -163,7 +163,7 @@ describe('ci stall rerun decision core', () => {
     // means the whole run belongs to a human.
     const run = incidentRun();
     run.jobs[1] = {
-      name: 'PR gate (English-only legal) (1)',
+      name: 'PR tests (1)',
       conclusion: 'failure',
       steps: [
         { name: 'Check out repository', conclusion: 'success' },
@@ -190,7 +190,7 @@ describe('ci stall rerun decision core', () => {
   it('refuses unrecognized job conclusions: timed_out, action_required, still running', () => {
     for (const conclusion of ['timed_out', 'action_required', null]) {
       const run = incidentRun();
-      run.jobs[3] = { name: 'PR gate (long sims B)', conclusion, steps: [] };
+      run.jobs[3] = { name: 'PR long sims B', conclusion, steps: [] };
       expect(decide(run).rerun).toBe(false);
     }
   });
@@ -211,7 +211,7 @@ describe('ci stall rerun decision core', () => {
     const run = incidentRun();
     run.runConclusion = 'failure';
     run.jobs[run.jobs.length - 1] = {
-      name: 'PR gate (long sims A)',
+      name: 'PR long sims A',
       conclusion: 'failure',
       steps: [
         { name: 'Set up job', conclusion: 'success' },
@@ -227,7 +227,7 @@ describe('ci stall rerun decision core', () => {
     };
     const decision = decide(run);
     expect(decision.rerun).toBe(true);
-    expect(decision.stalledJobs).toEqual(['PR gate (long sims A)']);
+    expect(decision.stalledJobs).toEqual(['PR long sims A']);
   });
 
   it('refuses a failed job whose failed step is anything but a checkout', () => {
@@ -246,7 +246,7 @@ describe('ci stall rerun decision core', () => {
       const run = incidentRun();
       run.runConclusion = 'failure';
       run.jobs[run.jobs.length - 1] = {
-        name: 'PR gate (long sims A)',
+        name: 'PR long sims A',
         conclusion: 'failure',
         steps: [
           { name: 'Check out repository', conclusion: 'success' },
@@ -262,7 +262,7 @@ describe('ci stall rerun decision core', () => {
     const run = incidentRun();
     run.runConclusion = 'failure';
     run.jobs[run.jobs.length - 1] = {
-      name: 'PR gate (long sims A)',
+      name: 'PR long sims A',
       conclusion: 'failure',
       steps: [
         { name: 'Check out repository', conclusion: 'failure' },
@@ -279,7 +279,7 @@ describe('ci stall rerun decision core', () => {
     // both died, one rerun-failed-jobs call covers them together.
     const run = incidentRun();
     run.jobs[2] = {
-      name: 'PR gate (English-only legal) (2)',
+      name: 'PR tests (2)',
       conclusion: 'failure',
       steps: [
         { name: 'Set up job', conclusion: 'success' },
@@ -290,10 +290,7 @@ describe('ci stall rerun decision core', () => {
     };
     const decision = decide(run);
     expect(decision.rerun).toBe(true);
-    expect(decision.stalledJobs).toEqual([
-      'PR gate (English-only legal) (2)',
-      'PR gate (long sims A)',
-    ]);
+    expect(decision.stalledJobs).toEqual(['PR tests (2)', 'PR long sims A']);
   });
 });
 
@@ -442,10 +439,10 @@ describe('driver wiring', () => {
       const jobsJson = options.jobsJson ?? {
         total_count: 2,
         jobs: [
-          { id: 1, name: 'PR gate (long sims B)', conclusion: 'success', steps: [] },
+          { id: 1, name: 'PR long sims B', conclusion: 'success', steps: [] },
           {
             id: 93473897038,
-            name: 'PR gate (long sims A)',
+            name: 'PR long sims A',
             conclusion: 'cancelled',
             steps: LANE_A_STALL_STEPS,
           },
@@ -556,7 +553,7 @@ describe('driver wiring', () => {
       {
         jobsJson: {
           total_count: 3,
-          jobs: [{ id: 1, name: 'PR gate (long sims B)', conclusion: 'success', steps: [] }],
+          jobs: [{ id: 1, name: 'PR long sims B', conclusion: 'success', steps: [] }],
         },
       },
     );

--- a/tests/ci_workflow.test.ts
+++ b/tests/ci_workflow.test.ts
@@ -126,7 +126,7 @@ const PR_TIER_EVENT_FRAGMENT =
 // classifier's fail-closed doctrine; under the merge queue a skipped required
 // check reads satisfied, so failing toward SKIP would be the wrong direction.
 // (Covers green-but-empty output only: a FAILED changes job skips dependents
-// via needs regardless, which requiring "Detect code path changes" closes.)
+// via needs regardless, which requiring "Classify changes" closes.)
 const PR_TIER_IF_LINE = `    if: (${PR_TIER_EVENT_FRAGMENT}) && needs.changes.outputs.code != 'false'`;
 
 // pr-gate alone splits those two arms across levels (the docs-only matrix
@@ -995,13 +995,13 @@ describe('CI workflow parity', () => {
     // each name exactly.
     const mergeQueueDoc = readFileSync(new URL('../docs/merge-queue.md', import.meta.url), 'utf8');
     const requiredCheckNames = [
-      'Detect code path changes',
-      'PR gate (English-only legal)',
-      'PR gate (long sims A)',
-      'PR gate (long sims B)',
-      'PR checks (freshness, typecheck, builds)',
-      'Format + lint (Biome, changed files)',
-      'Browser regressions (Chromium)',
+      'Classify changes',
+      'PR tests',
+      'PR long sims A',
+      'PR long sims B',
+      'PR checks',
+      'Lint (changed files)',
+      'Browser tests',
     ] as const;
     for (const name of requiredCheckNames) {
       // Anchored to the job-level name: line (4-space indent), so a
@@ -1023,13 +1023,13 @@ describe('CI workflow parity', () => {
     expect(neverSectionEnd).toBeGreaterThan(neverIdx);
     const neverSection = mergeQueueDoc.slice(neverIdx, neverSectionEnd);
     const docRequiredNameForms = [
-      '`Detect code path changes`',
-      `\`PR gate (English-only legal) (1)\` through \`(${SHARD_N})\``,
-      '`PR gate (long sims A)`',
-      '`PR gate (long sims B)`',
-      '`PR checks (freshness, typecheck, builds)`',
-      '`Format + lint (Biome, changed files)`',
-      '`Browser regressions (Chromium)`',
+      '`Classify changes`',
+      `\`PR tests (1)\` through \`(${SHARD_N})\``,
+      '`PR long sims A`',
+      '`PR long sims B`',
+      '`PR checks`',
+      '`Lint (changed files)`',
+      '`Browser tests`',
     ] as const;
     for (const form of docRequiredNameForms) {
       expect(requiredHalf).toContain(form);


### PR DESCRIPTION
## Summary

Ninth act of the CI-speed program. The check display names accreted implementation detail (English-only legal, 21-locale fill, tool lists) that reads as noise in the checks panel and the ruleset. The new scheme names what each check IS. Job KEYS and step names are untouched (the stall reactor keys on step names; jobSource lookups key on job keys).

| Today | After |
|---|---|
| Detect code path changes | Classify changes |
| Format + lint (Biome, changed files) | Lint (changed files) |
| Browser regressions (Chromium) | Browser tests |
| PR gate (English-only legal) (1..8) | PR tests (1..8) |
| PR gate (long sims A) / (B) | PR long sims A / B |
| PR checks (freshness, typecheck, builds) | PR checks |
| Release gate (tests) | Release tests |
| Release i18n (21-locale fill) | Release i18n |
| Release checks (freshness, typecheck, builds) | Release checks |

Every live reference moves in lockstep: ci.yml name lines, the required-name and doc-name pins in tests/ci_workflow.test.ts, the verbatim required and never-require lists in docs/merge-queue.md, the lane and classifier audit strings, the stall-reactor fixtures, and docs/qa-gate.md. The dated incident narrative in scripts/lib/ci_stall_rerun.mjs deliberately keeps the name the job had when the incident happened.

## DO NOT MERGE until the ruleset flip is scheduled

Merging this requires the documented choreography (docs/merge-queue.md): ruleset 20533396 must swap the old required contexts for the new ones at the same moment this merges, or every open PR deadlocks on contexts that will never report again. PRs opened before the flip need a rebase or rerun after it. Expected artifact on THIS PR pre-flip: its checks report under the NEW names while the ruleset requires the OLD ones, so the required contexts show as expected-and-waiting forever; that is the known pre-flip state, not a red flag.

## How was this tested?

- npx vitest run over the six pin files touched (235 tests green: the renamed requiredCheckNames/doc pins, stall-reactor fixtures, lane audit strings)
- npx tsc --noEmit clean; biome clean on changed files (two pre-existing warnings on an untouched env read)
- node scripts/gate_select.mjs: PASS, all 16 steps

## Checklist

- [x] **The gate passes.** node scripts/gate_select.mjs is green.
- [x] i18n N/A (operator-facing check names are CI metadata, not player-visible strings).
- [x] No secrets; no generated files hand-edited.