### PR TITLE
docs(ci): name the audit check as protection sees it

### DIFF
--- a/docs/merge-queue.md
+++ b/docs/merge-queue.md
@@ -166,10 +166,12 @@ Never require these, deliberately:
   `Release checks`, `Release version gate`):
   release-process lanes, legitimately red or skipped mid-cycle. Release i18n in
   particular is red by design until the release-time locale fill.
-- `Dependency audit`: its workflow is path-filtered to dependency changes, so
-  on most PRs (and on every queue run) the check never reports at all, and a
-  required check that never reports blocks the merge forever. Skipped jobs
-  satisfy protection; absent workflows do not.
+- `pnpm audit` (the job in the `Dependency audit` workflow; protection sees
+  JOB names, and this list keeps the exact form protection sees): its
+  workflow is path-filtered to dependency changes, so on most PRs (and on
+  every queue run) the check never reports at all, and a required check that
+  never reports blocks the merge forever. Skipped jobs satisfy protection;
+  absent workflows do not.
 
 The same rule generalizes: a check may only join the required list if ci.yml
 produces (or explicitly skips) it on every `pull_request` AND every


### PR DESCRIPTION
Close-out rider from the CI-speed program's rename review: the never-require list in docs/merge-queue.md named the Dependency audit WORKFLOW where protection actually sees the pnpm audit JOB context. Docs-only. Gate: PASS.