### PR TITLE
fix(delves): gate finale-room rewards on boss-summoned adds still alive

### DIFF
--- a/src/sim/delves/runs.ts
+++ b/src/sim/delves/runs.ts
@@ -1007,13 +1007,21 @@ export function findDelveExitPortal(ctx: SimContext, run: DelveRun): Entity | nu
   return null;
 }
 
-export function tryOpenDelveExitPortal(ctx: SimContext, run: DelveRun): void {
-  if (run.exitPortalOpen || run.moduleIndex >= run.modules.length - 1) return;
-  const liveMobs = run.mobIds.some((id) => {
+/** True while any mob tracked on this run's active module (spawn-set trash, waves,
+ * or a boss's own summoned adds, e.g. Raise Dead bonewalkers / Sister Nhalia's
+ * cantors) is still alive. Shared by every delve gate that must not open while a
+ * fight is still live: the mid-run module exit portal and the finale-room reward
+ * flows below. */
+export function delveHasLiveMobs(ctx: SimContext, run: DelveRun): boolean {
+  return run.mobIds.some((id) => {
     const e = ctx.entities.get(id);
     return e && !e.dead;
   });
-  if (liveMobs) return;
+}
+
+export function tryOpenDelveExitPortal(ctx: SimContext, run: DelveRun): void {
+  if (run.exitPortalOpen || run.moduleIndex >= run.modules.length - 1) return;
+  if (delveHasLiveMobs(ctx, run)) return;
   // Room puzzle gate: every pressure plate in the module must be triggered before
   // the exit opens (Drowned Litany "activate N valves/tablets/candles/ropes"; the
   // Reliquary's plated rooms already require all plates to raise the portcullis, so
@@ -1452,6 +1460,13 @@ export function delveInteract(ctx: SimContext, objectId: number, pid?: number): 
       ctx.error(r.meta.entityId, 'Move closer to the chest.');
       return false;
     }
+    // Boss-summoned adds (Raise Dead bonewalkers) can still be up when the boss
+    // itself dies; the chest must wait for them the same way the mid-run module
+    // exit waits for trash, or the surface exit opens while a fight is still live.
+    if (!state.looted && delveHasLiveMobs(ctx, run)) {
+      ctx.error(r.meta.entityId, 'Clear the remaining enemies first.');
+      return false;
+    }
     if (state.looted) {
       ctx.emit({
         type: 'log',
@@ -1492,6 +1507,10 @@ export function delveInteract(ctx: SimContext, objectId: number, pid?: number): 
         color: '#aaa',
         pid: r.meta.entityId,
       });
+      return false;
+    }
+    if (delveHasLiveMobs(ctx, run)) {
+      ctx.error(r.meta.entityId, 'Clear the remaining enemies first.');
       return false;
     }
     grantDelveRewards(ctx, run);
@@ -1582,6 +1601,13 @@ export function delveRiteChoose(ctx: SimContext, intensity: RiteIntensity, pid?:
   const reliquary = st ? ctx.entities.get(st.reliquaryId) : undefined;
   if (!reliquary || dist2d(r.e.pos, reliquary.pos) > DELVE_INTERACT_RANGE) {
     ctx.error(r.meta.entityId, 'Move closer to the reliquary.');
+    return;
+  }
+  // Sister Nhalia's own summoned cantors/choir thralls can still be up when she
+  // dies; the rite must wait for them, the same way the mid-run module exit waits
+  // for trash, or the surface exit opens while a fight is still live.
+  if (delveHasLiveMobs(ctx, run)) {
+    ctx.error(r.meta.entityId, 'Clear the remaining enemies first.');
     return;
   }
   chooseDrownedLitanyRiteIntensity(ctx, run, intensity);

--- a/src/ui/i18n.catalog/index.ts
+++ b/src/ui/i18n.catalog/index.ts
@@ -998,6 +998,7 @@ export const en = {
       shopSealPremiumOnly:
         "This seal yields only to a master's hand. Only the Premium ante can open it.",
       passageSealed: 'The passage is sealed.',
+      enemiesRemain: 'Clear the remaining enemies first.',
       moveCloserPassage: 'Move closer to the passage.',
       moveCloserChest: 'Move closer to the chest.',
       moveCloserReliquary: 'Move closer to the reliquary.',

--- a/src/ui/i18n.catalog/translation_keys.generated.ts
+++ b/src/ui/i18n.catalog/translation_keys.generated.ts
@@ -10765,6 +10765,7 @@ export type TranslationKeyFlat =
   | 'sim.delve.duringArena'
   | 'sim.delve.duringDuel'
   | 'sim.delve.eggSacBurst'
+  | 'sim.delve.enemiesRemain'
   | 'sim.delve.graveFalters'
   | 'sim.delve.graveSilent'
   | 'sim.delve.instancesBusy'

--- a/src/ui/i18n.locales/ja_JP.ts
+++ b/src/ui/i18n.locales/ja_JP.ts
@@ -7367,6 +7367,7 @@ export const ja_JP: Partial<Record<TranslationKey, string>> = {
   'sim.delve.moveCloserStairs': '階段にもっと近づけ。',
   'sim.delve.notInDelve': 'あなたはデルヴの中にいない。',
   'sim.delve.nothingHappens': '何も起こらない。',
+  'sim.delve.enemiesRemain': '残りの敵を先に倒せ。',
   'sim.delve.passageSealed': '通路は封じられている。',
   'sim.delve.raiseDead': '{name}が死者蘇生を唱え始める。',
   'sim.delve.runFailed': '{name}の攻略に失敗した。',

--- a/src/ui/i18n.locales/ko_KR.ts
+++ b/src/ui/i18n.locales/ko_KR.ts
@@ -7357,6 +7357,7 @@ export const ko_KR: Partial<Record<TranslationKey, string>> = {
   'sim.delve.moveCloserStairs': '계단에 더 가까이 다가가세요.',
   'sim.delve.notInDelve': '탐굴 중이 아닙니다.',
   'sim.delve.nothingHappens': '아무 일도 일어나지 않습니다.',
+  'sim.delve.enemiesRemain': '남은 적을 먼저 처치하세요.',
   'sim.delve.passageSealed': '통로가 봉인되어 있습니다.',
   'sim.delve.raiseDead': '{name}이(가) 죽음의 부활을 시전하기 시작합니다.',
   'sim.delve.runFailed': '{name} 진행에 실패했습니다.',

--- a/src/ui/i18n.locales/ru_RU.ts
+++ b/src/ui/i18n.locales/ru_RU.ts
@@ -7473,6 +7473,7 @@ export const ru_RU: Partial<Record<TranslationKey, string>> = {
   'sim.delve.moveCloserStairs': 'Подойдите ближе к лестнице.',
   'sim.delve.notInDelve': 'Вы не находитесь в вылазке.',
   'sim.delve.nothingHappens': 'Ничего не происходит.',
+  'sim.delve.enemiesRemain': 'Сначала расправьтесь с оставшимися врагами.',
   'sim.delve.passageSealed': 'Проход запечатан.',
   'sim.delve.raiseDead': '{name} начинает Поднятие мёртвых.',
   'sim.delve.runFailed': 'Вылазка {name} провалена.',

--- a/src/ui/i18n.locales/zh_CN.ts
+++ b/src/ui/i18n.locales/zh_CN.ts
@@ -7078,6 +7078,7 @@ export const zh_CN: Partial<Record<TranslationKey, string>> = {
   'sim.delve.moveCloserStairs': '靠近楼梯一些。',
   'sim.delve.notInDelve': '你不在探秘之中。',
   'sim.delve.nothingHappens': '什么也没有发生。',
+  'sim.delve.enemiesRemain': '先清除剩余的敌人。',
   'sim.delve.passageSealed': '通道被封住了。',
   'sim.delve.raiseDead': '{name}开始施放亡者复生。',
   'sim.delve.runFailed': '{name}探秘失败。',

--- a/src/ui/i18n.locales/zh_TW.ts
+++ b/src/ui/i18n.locales/zh_TW.ts
@@ -7078,6 +7078,7 @@ export const zh_TW: Partial<Record<TranslationKey, string>> = {
   'sim.delve.moveCloserStairs': '再靠近階梯一些。',
   'sim.delve.notInDelve': '你並不在秘探之中。',
   'sim.delve.nothingHappens': '沒有任何事發生。',
+  'sim.delve.enemiesRemain': '先清除剩餘的敵人。',
   'sim.delve.passageSealed': '通道被封住了。',
   'sim.delve.raiseDead': '{name} 開始施放喚醒亡者。',
   'sim.delve.runFailed': '{name} 旅程失敗。',

--- a/src/ui/i18n.resolved.generated/cs_CZ.ts
+++ b/src/ui/i18n.resolved.generated/cs_CZ.ts
@@ -7187,6 +7187,7 @@ export const cs_CZ: EnTranslations = {
       "shopMarksRequired": "K nákupu {name} potřebuješ {marks} známek výprav.",
       "shopSealPremiumOnly": "Tato pečeť povolí jen mistrovské ruce. Otevře ji pouze prémiová sázka.",
       "passageSealed": "Průchod je zapečetěný.",
+      "enemiesRemain": "Clear the remaining enemies first.",
       "moveCloserPassage": "Přibliž se k průchodu.",
       "moveCloserChest": "Přibliž se k truhle.",
       "moveCloserReliquary": "Přibliž se k relikviáři.",

--- a/src/ui/i18n.resolved.generated/da_DK.ts
+++ b/src/ui/i18n.resolved.generated/da_DK.ts
@@ -7187,6 +7187,7 @@ export const da_DK: EnTranslations = {
       "shopMarksRequired": "Du skal bruge {marks} Delve-mærker for at købe {name}.",
       "shopSealPremiumOnly": "Dette segl giver kun efter for en mesters hånd. Kun Premium-indsatsen kan åbne det.",
       "passageSealed": "Passagen er forseglet.",
+      "enemiesRemain": "Clear the remaining enemies first.",
       "moveCloserPassage": "Gå tættere på passagen.",
       "moveCloserChest": "Gå tættere på kisten.",
       "moveCloserReliquary": "Gå tættere på relikvariet.",

--- a/src/ui/i18n.resolved.generated/de_DE.ts
+++ b/src/ui/i18n.resolved.generated/de_DE.ts
@@ -7187,6 +7187,7 @@ export const de_DE: EnTranslations = {
       "shopMarksRequired": "Du benötigst {marks} Tiefgang-Marken, um {name} zu kaufen.",
       "shopSealPremiumOnly": "Dieses Siegel weicht nur der Hand eines Meisters: Nur der Erlesene Einsatz kann es öffnen.",
       "passageSealed": "Der Durchgang ist versiegelt.",
+      "enemiesRemain": "Clear the remaining enemies first.",
       "moveCloserPassage": "Geh näher an den Durchgang heran.",
       "moveCloserChest": "Geh näher an die Truhe heran.",
       "moveCloserReliquary": "Geh näher an das Reliquiar heran.",

--- a/src/ui/i18n.resolved.generated/en.ts
+++ b/src/ui/i18n.resolved.generated/en.ts
@@ -7187,6 +7187,7 @@ export const en: EnTranslations = {
       "shopMarksRequired": "You need {marks} Delve Marks to buy {name}.",
       "shopSealPremiumOnly": "This seal yields only to a master's hand. Only the Premium ante can open it.",
       "passageSealed": "The passage is sealed.",
+      "enemiesRemain": "Clear the remaining enemies first.",
       "moveCloserPassage": "Move closer to the passage.",
       "moveCloserChest": "Move closer to the chest.",
       "moveCloserReliquary": "Move closer to the reliquary.",

--- a/src/ui/i18n.resolved.generated/en_CA.ts
+++ b/src/ui/i18n.resolved.generated/en_CA.ts
@@ -7187,6 +7187,7 @@ export const en_CA: EnTranslations = {
       "shopMarksRequired": "You need {marks} Delve Marks to buy {name}.",
       "shopSealPremiumOnly": "This seal yields only to a master's hand. Only the Premium ante can open it.",
       "passageSealed": "The passage is sealed.",
+      "enemiesRemain": "Clear the remaining enemies first.",
       "moveCloserPassage": "Move closer to the passage.",
       "moveCloserChest": "Move closer to the chest.",
       "moveCloserReliquary": "Move closer to the reliquary.",

--- a/src/ui/i18n.resolved.generated/en_XA.ts
+++ b/src/ui/i18n.resolved.generated/en_XA.ts
@@ -7187,6 +7187,7 @@ export const en_XA: EnTranslations = {
       "shopMarksRequired": "[Ýóú ñééð {marks} Ðéļʋé Ɱáŕķš ţó ƀúý {name}.]",
       "shopSealPremiumOnly": "[Ţĥíš šéáļ ýíéļðš óñļý ţó á ɱášţéŕ'š ĥáñð. Óñļý ţĥé Þŕéɱíúɱ áñţé çáñ óþéñ íţ.]",
       "passageSealed": "[Ţĥé þáššáĝé íš šéáļéð.]",
+      "enemiesRemain": "[Çļéáŕ ţĥé ŕéɱáíñíñĝ éñéɱíéš ƒíŕšţ.]",
       "moveCloserPassage": "[Ɱóʋé çļóšéŕ ţó ţĥé þáššáĝé.]",
       "moveCloserChest": "[Ɱóʋé çļóšéŕ ţó ţĥé çĥéšţ.]",
       "moveCloserReliquary": "[Ɱóʋé çļóšéŕ ţó ţĥé ŕéļíɋúáŕý.]",

--- a/src/ui/i18n.resolved.generated/es.ts
+++ b/src/ui/i18n.resolved.generated/es.ts
@@ -7187,6 +7187,7 @@ export const es: EnTranslations = {
       "shopMarksRequired": "Necesitas {marks} Marcas de Expedición para comprar {name}.",
       "shopSealPremiumOnly": "Este sello solo cede a la mano de un maestro: solo la apuesta Selecta puede abrirlo.",
       "passageSealed": "El pasaje está sellado.",
+      "enemiesRemain": "Clear the remaining enemies first.",
       "moveCloserPassage": "Acércate al pasaje.",
       "moveCloserChest": "Acércate al cofre.",
       "moveCloserReliquary": "Acércate al relicario.",

--- a/src/ui/i18n.resolved.generated/es_ES.ts
+++ b/src/ui/i18n.resolved.generated/es_ES.ts
@@ -7187,6 +7187,7 @@ export const es_ES: EnTranslations = {
       "shopMarksRequired": "Necesitas {marks} Marcas de Expedición para comprar {name}.",
       "shopSealPremiumOnly": "Este sello solo cede a la mano de un maestro: solo la apuesta Selecta puede abrirlo.",
       "passageSealed": "El pasaje está sellado.",
+      "enemiesRemain": "Clear the remaining enemies first.",
       "moveCloserPassage": "Acércate más al pasaje.",
       "moveCloserChest": "Acércate más al cofre.",
       "moveCloserReliquary": "Acércate al relicario.",

--- a/src/ui/i18n.resolved.generated/fr_CA.ts
+++ b/src/ui/i18n.resolved.generated/fr_CA.ts
@@ -7187,6 +7187,7 @@ export const fr_CA: EnTranslations = {
       "shopMarksRequired": "Il vous faut {marks} Marques de plongée pour acheter {name}.",
       "shopSealPremiumOnly": "Ce sceau ne cède qu'à la main d'un maître : seule la mise Supérieure peut l'ouvrir.",
       "passageSealed": "Le passage est scellé.",
+      "enemiesRemain": "Clear the remaining enemies first.",
       "moveCloserPassage": "Rapprochez-vous du passage.",
       "moveCloserChest": "Rapprochez-vous du coffre.",
       "moveCloserReliquary": "Rapprochez-vous du reliquaire.",

--- a/src/ui/i18n.resolved.generated/fr_FR.ts
+++ b/src/ui/i18n.resolved.generated/fr_FR.ts
@@ -7187,6 +7187,7 @@ export const fr_FR: EnTranslations = {
       "shopMarksRequired": "Il vous faut {marks} Marques de plongée pour acheter {name}.",
       "shopSealPremiumOnly": "Ce sceau ne cède qu'à la main d'un maître : seule la mise Supérieure peut l'ouvrir.",
       "passageSealed": "Le passage est scellé.",
+      "enemiesRemain": "Clear the remaining enemies first.",
       "moveCloserPassage": "Rapprochez-vous du passage.",
       "moveCloserChest": "Rapprochez-vous du coffre.",
       "moveCloserReliquary": "Rapprochez-vous du reliquaire.",

--- a/src/ui/i18n.resolved.generated/id_ID.ts
+++ b/src/ui/i18n.resolved.generated/id_ID.ts
@@ -7187,6 +7187,7 @@ export const id_ID: EnTranslations = {
       "shopMarksRequired": "Kamu butuh {marks} Tanda Delve untuk membeli {name}.",
       "shopSealPremiumOnly": "Segel ini hanya tunduk pada tangan sang ahli. Hanya taruhan Premium yang dapat membukanya.",
       "passageSealed": "Lorong itu tersegel.",
+      "enemiesRemain": "Clear the remaining enemies first.",
       "moveCloserPassage": "Mendekatlah ke lorong.",
       "moveCloserChest": "Mendekatlah ke peti.",
       "moveCloserReliquary": "Mendekatlah ke relikuari.",

--- a/src/ui/i18n.resolved.generated/it_IT.ts
+++ b/src/ui/i18n.resolved.generated/it_IT.ts
@@ -7187,6 +7187,7 @@ export const it_IT: EnTranslations = {
       "shopMarksRequired": "Ti servono {marks} Sigilli d'Incursione per comprare {name}.",
       "shopSealPremiumOnly": "Questo sigillo cede solo alla mano di un maestro: solo la puntata Pregiata può aprirlo.",
       "passageSealed": "Il passaggio è sigillato.",
+      "enemiesRemain": "Clear the remaining enemies first.",
       "moveCloserPassage": "Avvicinati al passaggio.",
       "moveCloserChest": "Avvicinati allo scrigno.",
       "moveCloserReliquary": "Avvicinati al reliquiario.",

--- a/src/ui/i18n.resolved.generated/ja_JP.ts
+++ b/src/ui/i18n.resolved.generated/ja_JP.ts
@@ -7187,6 +7187,7 @@ export const ja_JP: EnTranslations = {
       "shopMarksRequired": "{name}を購入するにはデルヴの刻印が{marks}個必要だ。",
       "shopSealPremiumOnly": "この封印は達人の手にのみ応じる。極上の賭けだけが開くことができる。",
       "passageSealed": "通路は封じられている。",
+      "enemiesRemain": "残りの敵を先に倒せ。",
       "moveCloserPassage": "通路にもっと近づけ。",
       "moveCloserChest": "宝箱にもっと近づけ。",
       "moveCloserReliquary": "聖遺物匣にもっと近づけ。",

--- a/src/ui/i18n.resolved.generated/ko_KR.ts
+++ b/src/ui/i18n.resolved.generated/ko_KR.ts
@@ -7187,6 +7187,7 @@ export const ko_KR: EnTranslations = {
       "shopMarksRequired": "{name}을(를) 구매하려면 탐굴 증표 {marks}개가 필요합니다.",
       "shopSealPremiumOnly": "이 봉인은 대가의 손에만 응합니다. 최상급 베팅만이 열 수 있습니다.",
       "passageSealed": "통로가 봉인되어 있습니다.",
+      "enemiesRemain": "남은 적을 먼저 처치하세요.",
       "moveCloserPassage": "통로에 더 가까이 다가가세요.",
       "moveCloserChest": "상자에 더 가까이 다가가세요.",
       "moveCloserReliquary": "성물함에 더 가까이 다가가세요.",

--- a/src/ui/i18n.resolved.generated/nl_NL.ts
+++ b/src/ui/i18n.resolved.generated/nl_NL.ts
@@ -7187,6 +7187,7 @@ export const nl_NL: EnTranslations = {
       "shopMarksRequired": "Je hebt {marks} Delve-Merken nodig om {name} te kopen.",
       "shopSealPremiumOnly": "Dit zegel wijkt alleen voor een meesterhand. Alleen de Premium-inzet kan het openen.",
       "passageSealed": "De doorgang is verzegeld.",
+      "enemiesRemain": "Clear the remaining enemies first.",
       "moveCloserPassage": "Kom dichter bij de doorgang.",
       "moveCloserChest": "Kom dichter bij de kist.",
       "moveCloserReliquary": "Kom dichter bij het reliekschrijn.",

--- a/src/ui/i18n.resolved.generated/pending.ts
+++ b/src/ui/i18n.resolved.generated/pending.ts
@@ -21,7 +21,8 @@ export const pending: Record<string, readonly string[]> = {
     "hudChrome.lastkeepMap.story.state",
     "hudChrome.lastkeepMap.story.tower",
     "hudChrome.lastkeepMap.story.undercroft",
-    "hudChrome.lastkeepMap.title"
+    "hudChrome.lastkeepMap.title",
+    "sim.delve.enemiesRemain"
   ],
   "es_ES": [
     "entities.dungeons.dawnhold_castle.enterText",
@@ -35,7 +36,8 @@ export const pending: Record<string, readonly string[]> = {
     "hudChrome.lastkeepMap.story.state",
     "hudChrome.lastkeepMap.story.tower",
     "hudChrome.lastkeepMap.story.undercroft",
-    "hudChrome.lastkeepMap.title"
+    "hudChrome.lastkeepMap.title",
+    "sim.delve.enemiesRemain"
   ],
   "fr_FR": [
     "entities.dungeons.dawnhold_castle.enterText",
@@ -49,7 +51,8 @@ export const pending: Record<string, readonly string[]> = {
     "hudChrome.lastkeepMap.story.state",
     "hudChrome.lastkeepMap.story.tower",
     "hudChrome.lastkeepMap.story.undercroft",
-    "hudChrome.lastkeepMap.title"
+    "hudChrome.lastkeepMap.title",
+    "sim.delve.enemiesRemain"
   ],
   "fr_CA": [
     "entities.dungeons.dawnhold_castle.enterText",
@@ -63,7 +66,8 @@ export const pending: Record<string, readonly string[]> = {
     "hudChrome.lastkeepMap.story.state",
     "hudChrome.lastkeepMap.story.tower",
     "hudChrome.lastkeepMap.story.undercroft",
-    "hudChrome.lastkeepMap.title"
+    "hudChrome.lastkeepMap.title",
+    "sim.delve.enemiesRemain"
   ],
   "en_CA": [],
   "it_IT": [
@@ -78,7 +82,8 @@ export const pending: Record<string, readonly string[]> = {
     "hudChrome.lastkeepMap.story.state",
     "hudChrome.lastkeepMap.story.tower",
     "hudChrome.lastkeepMap.story.undercroft",
-    "hudChrome.lastkeepMap.title"
+    "hudChrome.lastkeepMap.title",
+    "sim.delve.enemiesRemain"
   ],
   "de_DE": [
     "entities.dungeons.dawnhold_castle.enterText",
@@ -92,7 +97,8 @@ export const pending: Record<string, readonly string[]> = {
     "hudChrome.lastkeepMap.story.state",
     "hudChrome.lastkeepMap.story.tower",
     "hudChrome.lastkeepMap.story.undercroft",
-    "hudChrome.lastkeepMap.title"
+    "hudChrome.lastkeepMap.title",
+    "sim.delve.enemiesRemain"
   ],
   "zh_CN": [
     "hudChrome.dawnholdMap.title",
@@ -122,7 +128,8 @@ export const pending: Record<string, readonly string[]> = {
     "hudChrome.lastkeepMap.story.state",
     "hudChrome.lastkeepMap.story.tower",
     "hudChrome.lastkeepMap.story.undercroft",
-    "hudChrome.lastkeepMap.title"
+    "hudChrome.lastkeepMap.title",
+    "sim.delve.enemiesRemain"
   ],
   "ru_RU": [
     "hudChrome.dawnholdMap.title",
@@ -140,7 +147,8 @@ export const pending: Record<string, readonly string[]> = {
     "hudChrome.lastkeepMap.story.state",
     "hudChrome.lastkeepMap.story.tower",
     "hudChrome.lastkeepMap.story.undercroft",
-    "hudChrome.lastkeepMap.title"
+    "hudChrome.lastkeepMap.title",
+    "sim.delve.enemiesRemain"
   ],
   "nl_NL": [
     "entities.dungeons.dawnhold_castle.enterText",
@@ -154,7 +162,8 @@ export const pending: Record<string, readonly string[]> = {
     "hudChrome.lastkeepMap.story.state",
     "hudChrome.lastkeepMap.story.tower",
     "hudChrome.lastkeepMap.story.undercroft",
-    "hudChrome.lastkeepMap.title"
+    "hudChrome.lastkeepMap.title",
+    "sim.delve.enemiesRemain"
   ],
   "pl_PL": [
     "entities.dungeons.dawnhold_castle.enterText",
@@ -168,7 +177,8 @@ export const pending: Record<string, readonly string[]> = {
     "hudChrome.lastkeepMap.story.state",
     "hudChrome.lastkeepMap.story.tower",
     "hudChrome.lastkeepMap.story.undercroft",
-    "hudChrome.lastkeepMap.title"
+    "hudChrome.lastkeepMap.title",
+    "sim.delve.enemiesRemain"
   ],
   "id_ID": [
     "entities.dungeons.dawnhold_castle.enterText",
@@ -182,7 +192,8 @@ export const pending: Record<string, readonly string[]> = {
     "hudChrome.lastkeepMap.story.state",
     "hudChrome.lastkeepMap.story.tower",
     "hudChrome.lastkeepMap.story.undercroft",
-    "hudChrome.lastkeepMap.title"
+    "hudChrome.lastkeepMap.title",
+    "sim.delve.enemiesRemain"
   ],
   "tr_TR": [
     "entities.dungeons.dawnhold_castle.enterText",
@@ -196,7 +207,8 @@ export const pending: Record<string, readonly string[]> = {
     "hudChrome.lastkeepMap.story.state",
     "hudChrome.lastkeepMap.story.tower",
     "hudChrome.lastkeepMap.story.undercroft",
-    "hudChrome.lastkeepMap.title"
+    "hudChrome.lastkeepMap.title",
+    "sim.delve.enemiesRemain"
   ],
   "sv_SE": [
     "entities.dungeons.dawnhold_castle.enterText",
@@ -210,7 +222,8 @@ export const pending: Record<string, readonly string[]> = {
     "hudChrome.lastkeepMap.story.state",
     "hudChrome.lastkeepMap.story.tower",
     "hudChrome.lastkeepMap.story.undercroft",
-    "hudChrome.lastkeepMap.title"
+    "hudChrome.lastkeepMap.title",
+    "sim.delve.enemiesRemain"
   ],
   "vi_VN": [
     "entities.dungeons.dawnhold_castle.enterText",
@@ -224,7 +237,8 @@ export const pending: Record<string, readonly string[]> = {
     "hudChrome.lastkeepMap.story.state",
     "hudChrome.lastkeepMap.story.tower",
     "hudChrome.lastkeepMap.story.undercroft",
-    "hudChrome.lastkeepMap.title"
+    "hudChrome.lastkeepMap.title",
+    "sim.delve.enemiesRemain"
   ],
   "da_DK": [
     "entities.dungeons.dawnhold_castle.enterText",
@@ -238,6 +252,7 @@ export const pending: Record<string, readonly string[]> = {
     "hudChrome.lastkeepMap.story.state",
     "hudChrome.lastkeepMap.story.tower",
     "hudChrome.lastkeepMap.story.undercroft",
-    "hudChrome.lastkeepMap.title"
+    "hudChrome.lastkeepMap.title",
+    "sim.delve.enemiesRemain"
   ]
 };

--- a/src/ui/i18n.resolved.generated/pl_PL.ts
+++ b/src/ui/i18n.resolved.generated/pl_PL.ts
@@ -7187,6 +7187,7 @@ export const pl_PL: EnTranslations = {
       "shopMarksRequired": "Potrzebujesz {marks} Znaków Eskapady, aby kupić: {name}.",
       "shopSealPremiumOnly": "Ta pieczęć ustępuje tylko ręce mistrza. Otworzyć ją może jedynie stawka Premium.",
       "passageSealed": "Przejście jest zapieczętowane.",
+      "enemiesRemain": "Clear the remaining enemies first.",
       "moveCloserPassage": "Podejdź bliżej przejścia.",
       "moveCloserChest": "Podejdź bliżej skrzyni.",
       "moveCloserReliquary": "Podejdź bliżej relikwiarza.",

--- a/src/ui/i18n.resolved.generated/pt_BR.ts
+++ b/src/ui/i18n.resolved.generated/pt_BR.ts
@@ -7187,6 +7187,7 @@ export const pt_BR: EnTranslations = {
       "shopMarksRequired": "Você precisa de {marks} Selos de Incursão para comprar {name}.",
       "shopSealPremiumOnly": "Este selo só cede à mão de um mestre: apenas a aposta Superior pode abri-lo.",
       "passageSealed": "A passagem está selada.",
+      "enemiesRemain": "Clear the remaining enemies first.",
       "moveCloserPassage": "Aproxime-se da passagem.",
       "moveCloserChest": "Aproxime-se do baú.",
       "moveCloserReliquary": "Aproxime-se do relicário.",

--- a/src/ui/i18n.resolved.generated/ru_RU.ts
+++ b/src/ui/i18n.resolved.generated/ru_RU.ts
@@ -7187,6 +7187,7 @@ export const ru_RU: EnTranslations = {
       "shopMarksRequired": "Чтобы купить {name}, нужно Меток Вылазок: {marks}.",
       "shopSealPremiumOnly": "Эта печать поддаётся лишь руке мастера: открыть её можно только Превосходной ставкой.",
       "passageSealed": "Проход запечатан.",
+      "enemiesRemain": "Сначала расправьтесь с оставшимися врагами.",
       "moveCloserPassage": "Подойдите ближе к проходу.",
       "moveCloserChest": "Подойдите ближе к сундуку.",
       "moveCloserReliquary": "Подойдите ближе к реликварию.",

--- a/src/ui/i18n.resolved.generated/sv_SE.ts
+++ b/src/ui/i18n.resolved.generated/sv_SE.ts
@@ -7187,6 +7187,7 @@ export const sv_SE: EnTranslations = {
       "shopMarksRequired": "Du behöver {marks} Fördjupningsmärken för att köpa {name}.",
       "shopSealPremiumOnly": "Detta sigill ger vika endast för en mästares hand. Endast Premium-insatsen kan öppna det.",
       "passageSealed": "Passagen är förseglad.",
+      "enemiesRemain": "Clear the remaining enemies first.",
       "moveCloserPassage": "Gå närmare passagen.",
       "moveCloserChest": "Gå närmare kistan.",
       "moveCloserReliquary": "Gå närmare relikvariet.",

--- a/src/ui/i18n.resolved.generated/tr_TR.ts
+++ b/src/ui/i18n.resolved.generated/tr_TR.ts
@@ -7187,6 +7187,7 @@ export const tr_TR: EnTranslations = {
       "shopMarksRequired": "{name} satın almak için {marks} Delve Nişanına ihtiyacın var.",
       "shopSealPremiumOnly": "Bu mühür yalnızca bir ustanın eline boyun eğer. Onu yalnızca Premium bedel açabilir.",
       "passageSealed": "Geçit mühürlü.",
+      "enemiesRemain": "Clear the remaining enemies first.",
       "moveCloserPassage": "Geçide yaklaş.",
       "moveCloserChest": "Sandığa yaklaş.",
       "moveCloserReliquary": "Emanetliğe yaklaş.",

--- a/src/ui/i18n.resolved.generated/vi_VN.ts
+++ b/src/ui/i18n.resolved.generated/vi_VN.ts
@@ -7187,6 +7187,7 @@ export const vi_VN: EnTranslations = {
       "shopMarksRequired": "Bạn cần {marks} Dấu Ấn Thám Hiểm để mua {name}.",
       "shopSealPremiumOnly": "Dấu niêm này chỉ chịu khuất phục trước bàn tay bậc thầy. Chỉ có mức cược Cao Cấp mới mở được nó.",
       "passageSealed": "Lối đi đã bị niêm phong.",
+      "enemiesRemain": "Clear the remaining enemies first.",
       "moveCloserPassage": "Hãy lại gần lối đi hơn.",
       "moveCloserChest": "Hãy lại gần chiếc rương hơn.",
       "moveCloserReliquary": "Hãy lại gần hộp thánh tích hơn.",

--- a/src/ui/i18n.resolved.generated/zh_CN.ts
+++ b/src/ui/i18n.resolved.generated/zh_CN.ts
@@ -7187,6 +7187,7 @@ export const zh_CN: EnTranslations = {
       "shopMarksRequired": "购买{name}需要 {marks} 枚探秘印记。",
       "shopSealPremiumOnly": "此封印只向大师之手屈服，唯有上乘投入方能开启。",
       "passageSealed": "通道被封住了。",
+      "enemiesRemain": "先清除剩余的敌人。",
       "moveCloserPassage": "靠近通道一些。",
       "moveCloserChest": "靠近宝箱一些。",
       "moveCloserReliquary": "靠近圣物匣一些。",

--- a/src/ui/i18n.resolved.generated/zh_TW.ts
+++ b/src/ui/i18n.resolved.generated/zh_TW.ts
@@ -7187,6 +7187,7 @@ export const zh_TW: EnTranslations = {
       "shopMarksRequired": "購買 {name} 需要 {marks} 枚秘探印記。",
       "shopSealPremiumOnly": "此封印只向大師之手屈服，唯有上等投入方能開啟。",
       "passageSealed": "通道被封住了。",
+      "enemiesRemain": "先清除剩餘的敵人。",
       "moveCloserPassage": "再靠近通道一些。",
       "moveCloserChest": "再靠近寶箱一些。",
       "moveCloserReliquary": "再靠近聖物匣一些。",

--- a/src/ui/sim_i18n.ts
+++ b/src/ui/sim_i18n.ts
@@ -11737,6 +11737,7 @@ const RULES: Rule[] = [
     build: () => t('sim.delve.cannotAffordCompanionUpgrade'),
   },
   { re: /^The passage is sealed\.$/, build: () => t('sim.delve.passageSealed') },
+  { re: /^Clear the remaining enemies first\.$/, build: () => t('sim.delve.enemiesRemain') },
   { re: /^Move closer to the passage\.$/, build: () => t('sim.delve.moveCloserPassage') },
   { re: /^Move closer to the chest\.$/, build: () => t('sim.delve.moveCloserChest') },
   { re: /^Move closer to the reliquary\.$/, build: () => t('sim.delve.moveCloserReliquary') },

--- a/tests/delves.test.ts
+++ b/tests/delves.test.ts
@@ -990,6 +990,44 @@ describe('delve reward chest + surface exit flow', () => {
     expect(run.lockpick).toBeNull();
   });
 
+  // Regression: Deacon Varric's Raise Dead can still have a bonewalker up when the
+  // boss himself dies. The chest (and the surface exit it unlocks) must wait for
+  // that add the same way the mid-run module exit waits for trash, not hand the
+  // party their reward while a fight is still live.
+  it('refuses the locked chest while a boss-summoned add is still alive', () => {
+    const sim = makeSim();
+    sim.setPlayerLevel(DELVES.collapsed_reliquary.minLevel);
+    const run = enterFinale(sim);
+    killBoss(sim, run);
+    const chestId = run.rewardChestId!;
+    const chestEnt = sim.entities.get(chestId)!;
+    sim.player.pos = { ...chestEnt.pos };
+    sim.player.prevPos = { ...chestEnt.pos };
+
+    const add = createMob((sim as any).nextId++, MOBS.reliquary_ledger_wraith, 9, {
+      ...chestEnt.pos,
+    });
+    (sim as any).addEntity(add);
+    run.mobIds.push(add.id);
+
+    expect(sim.delveInteract(chestId)).toBe(false);
+    const events = sim.tick();
+    expect(events).toContainEqual({
+      type: 'error',
+      text: 'Clear the remaining enemies first.',
+      pid: sim.playerId,
+    });
+    expect(events.some((e) => e.type === 'lockpickOffer')).toBe(false);
+    expect(run.objectState[chestId].open).toBe(false);
+    expect(run.lockpick).toBeNull();
+
+    // Once the add is dead, the same interaction succeeds.
+    add.dead = true;
+    expect(sim.delveInteract(chestId)).toBe(true);
+    const offer = sim.tick().find((e) => e.type === 'lockpickOffer');
+    expect(offer).toBeDefined();
+  });
+
   it('flawless solve grants marks (premium tier), completes the run, and spawns the surface exit', () => {
     const sim = makeSim();
     sim.setPlayerLevel(DELVES.collapsed_reliquary.minLevel);
@@ -3575,6 +3613,37 @@ describe('The Drowned Litany (Phase 7 Drowned Reliquary Rite)', () => {
     expect(run.drownedLitanyRite?.awaitingChoice).toBe(true);
     expect(run.drownedLitanyRite?.sequence.length).toBe(0);
     expect(run.drownedLitanyRite?.sequencePlaying).toBe(false);
+  });
+
+  // Regression: Sister Nhalia's own summoned cantors/choir thralls can still be
+  // up when she dies. The rite (and the surface exit it eventually unlocks) must
+  // wait for them, not let the party start it while a fight is still live.
+  it('refuses the rite difficulty commit while a boss-summoned add is still alive', () => {
+    const sim = makeSim();
+    const run = enterLitanyApse(sim);
+    killNhalia(sim);
+    const reliquary = sim.entities.get(run.drownedLitanyRite!.reliquaryId)!;
+    sim.player.pos = { ...reliquary.pos };
+    sim.player.prevPos = { ...reliquary.pos };
+
+    const add = createMob((sim as any).nextId++, MOBS.drowned_cantor, 15, { ...reliquary.pos });
+    (sim as any).addEntity(add);
+    run.mobIds.push(add.id);
+
+    (sim as Sim).delveRiteChoose('hard');
+    expect(run.drownedLitanyRite?.awaitingChoice).toBe(true); // still waiting
+    expect(run.drownedLitanyRite?.sequence.length).toBe(0);
+    expect(sim.drainEvents()).toContainEqual({
+      type: 'error',
+      text: 'Clear the remaining enemies first.',
+      pid: sim.playerId,
+    });
+
+    // Once the add is dead, the same commit succeeds.
+    add.dead = true;
+    (sim as Sim).delveRiteChoose('hard');
+    expect(run.drownedLitanyRite?.awaitingChoice).toBe(false);
+    expect(run.drownedLitanyRite?.sequence.length).toBe(6);
   });
 
   it('surfaces the rite phase on delveRun for the HUD guidance', () => {

--- a/tests/parity/golden/drowned_litany.json
+++ b/tests/parity/golden/drowned_litany.json
@@ -9,8 +9,8 @@
     "Sister Nhalia driver: Blackwater Mark + Tolling Bells volley rng draws",
     "cantor phases + Final Bell + rite choose -> playback pulses"
   ],
-  "draws": 4625,
-  "drawDigest": "16b9eb77",
+  "draws": 4604,
+  "drawDigest": "7f18bf5e",
   "frames": [
     {
       "tick": 0,
@@ -759,109 +759,109 @@
       "time": 21,
       "nextId": 1001,
       "state": "82c95c44",
-      "events": "c37daf72",
+      "events": "6c4b3395",
       "rng": {
-        "draws": 3814,
-        "digest": "cdc118a7"
+        "draws": 3812,
+        "digest": "d7edd480"
       }
     },
     {
       "tick": 430,
       "time": 21.5,
       "nextId": 1001,
-      "state": "ba45b195",
-      "events": "1fd6e700",
+      "state": "1838fcc5",
+      "events": "1d9fb746",
       "rng": {
-        "draws": 3891,
-        "digest": "0591240e"
+        "draws": 3882,
+        "digest": "565908ba"
       }
     },
     {
       "tick": 440,
       "time": 22,
       "nextId": 1001,
-      "state": "c2680067",
-      "events": "3965bc4d",
+      "state": "97b58300",
+      "events": "741638a5",
       "rng": {
-        "draws": 3994,
-        "digest": "9cbb388d"
+        "draws": 3984,
+        "digest": "9f4c784e"
       }
     },
     {
       "tick": 450,
       "time": 22.5,
       "nextId": 1001,
-      "state": "566f8ba1",
-      "events": "6d632836",
+      "state": "9c60af2f",
+      "events": "1d9fb746",
       "rng": {
-        "draws": 4087,
-        "digest": "034e4b3e"
+        "draws": 4070,
+        "digest": "84a90965"
       }
     },
     {
       "tick": 460,
       "time": 23,
       "nextId": 1001,
-      "state": "85693e91",
-      "events": "e7bac15b",
+      "state": "1d9166a8",
+      "events": "1d9fb746",
       "rng": {
-        "draws": 4191,
-        "digest": "235b3583"
+        "draws": 4166,
+        "digest": "f2ee953a"
       }
     },
     {
       "tick": 470,
       "time": 23.5,
       "nextId": 1001,
-      "state": "01377e21",
-      "events": "20530aa9",
+      "state": "f15968a5",
+      "events": "8c1115aa",
       "rng": {
-        "draws": 4285,
-        "digest": "fa35f141"
+        "draws": 4254,
+        "digest": "d245377d"
       }
     },
     {
       "tick": 480,
       "time": 24,
       "nextId": 1001,
-      "state": "a2ce4307",
-      "events": "f986aed6",
+      "state": "578d8fcc",
+      "events": "741638a5",
       "rng": {
-        "draws": 4372,
-        "digest": "b9d86412"
+        "draws": 4344,
+        "digest": "5429cb3f"
       }
     },
     {
       "tick": 490,
       "time": 24.5,
       "nextId": 1001,
-      "state": "491e1b2b",
-      "events": "91f83fd3",
+      "state": "d05c20c3",
+      "events": "741638a5",
       "rng": {
-        "draws": 4461,
-        "digest": "c54eaf8c"
+        "draws": 4446,
+        "digest": "e344a39f"
       }
     },
     {
       "tick": 500,
       "time": 25,
       "nextId": 1001,
-      "state": "158ccf70",
-      "events": "76e2f114",
+      "state": "a000bcc4",
+      "events": "1d9fb746",
       "rng": {
-        "draws": 4556,
-        "digest": "0633bfff"
+        "draws": 4533,
+        "digest": "0652763a"
       }
     },
     {
       "tick": 505,
       "time": 25.25,
       "nextId": 1001,
-      "state": "d23a6505",
+      "state": "839b226b",
       "events": "1d9fb746",
       "rng": {
-        "draws": 4612,
-        "digest": "174ffb8a"
+        "draws": 4588,
+        "digest": "c39f7f62"
       },
       "label": "rite-started",
       "players": [
@@ -883,7 +883,7 @@
           "companionUpgrades": {},
           "counters": {
             "damageDealt": 5563,
-            "damageTaken": 37296,
+            "damageTaken": 37148,
             "kills": 3,
             "xpGained": 469
           },
@@ -969,14 +969,14 @@
           ],
           "blockChance": 0.05,
           "blockValue": 6,
-          "combatTimer": 0.5,
+          "combatTimer": 4.8,
           "comboUntil": -1,
           "critChance": 0.0665,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.0665,
           "facing": -1.643603,
           "fiveSecondRule": 124.25,
-          "hp": 49973,
+          "hp": 50000,
           "id": 960,
           "inCombat": true,
           "kind": "player",
@@ -1094,11 +1094,11 @@
       "tick": 507,
       "time": 25.35,
       "nextId": 1001,
-      "state": "24a1b4dd",
+      "state": "ba5933cd",
       "events": "741638a5",
       "rng": {
-        "draws": 4625,
-        "digest": "16b9eb77"
+        "draws": 4604,
+        "digest": "7f18bf5e"
       },
       "label": "final",
       "players": [
@@ -1120,7 +1120,7 @@
           "companionUpgrades": {},
           "counters": {
             "damageDealt": 5563,
-            "damageTaken": 37296,
+            "damageTaken": 37148,
             "kills": 3,
             "xpGained": 469
           },
@@ -1206,14 +1206,14 @@
           ],
           "blockChance": 0.05,
           "blockValue": 6,
-          "combatTimer": 0.6,
+          "combatTimer": 4.9,
           "comboUntil": -1,
           "critChance": 0.0665,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.0665,
           "facing": -1.643603,
           "fiveSecondRule": 124.35,
-          "hp": 49973,
+          "hp": 50000,
           "id": 960,
           "inCombat": true,
           "kind": "player",

--- a/tests/parity/scenarios.ts
+++ b/tests/parity/scenarios.ts
@@ -1459,6 +1459,14 @@ function drownedLitany(): Scenario {
         );
         bossTicks(40);
         lethal(sim, p, boss);
+        // Nhalia's own summoned cantors/choir thralls (phase-2 adds, Final Bell's
+        // thralls) can still be alive when she dies. The rite gate now waits for
+        // them (delveHasLiveMobs), so clear the room the same way the choir loft
+        // did above before advancing to the rite choose step.
+        for (const id of [...run.mobIds]) {
+          const m = sim.entities.get(id) as AnyEntity | undefined;
+          if (m) m.dead = true;
+        }
       }
       rec.tick(6); // reliquary + shrines rise, rite awaits the intensity choice
       const reliquary = [...run.objectIds]


### PR DESCRIPTION
## Summary

Bug report: **"Gate open but mobs still alive (Delves)"** — the reward gate at the
end of a delve opens even though an enemy is still alive in the room, and the run
cannot properly finish while that enemy remains.

Root cause: Deacon Varric's Raise Dead (Collapsed Reliquary) can summon a bonewalker
mid-fight, and Sister Nhalia (Drowned Litany) summons her own cantors/choir thralls
the same way. If the party burns the boss down without also killing that add, the
add is still alive and tracked on the run (`run.mobIds`) when the boss dies. Every
mid-run room already refuses to open its exit while any tracked mob is alive
(`tryOpenDelveExitPortal`), but the **finale room's own reward paths never had that
check**: the locked chest's lockpick offer, the legacy `reward_chest` grant, and the
Drowned Litany rite's difficulty commit all opened unconditionally on boss death,
letting the party loot and walk out through the surface exit while the add was still
up and fighting.

```mermaid
flowchart TD
    subgraph before["Before (bug)"]
        direction TB
        B1["Boss casts Raise Dead\nadd spawns, tracked in run.mobIds"] --> B2["Party bursts the boss\nadd left alive"]
        B2 --> B3["Boss dies"]
        B3 --> B4["onDelveBossDefeated:\nchest / rite spawns unconditionally"]
        B4 --> B5["Player interacts with chest\nor commits the rite"]
        B5 --> B6["Reward granted +\nsurface exit opens"]
        B6 --> B7(["Party can leave\nwhile the add is still alive"]):::bad
    end

    subgraph after["After (fixed)"]
        direction TB
        A1["Boss casts Raise Dead\nadd spawns, tracked in run.mobIds"] --> A2["Party bursts the boss\nadd left alive"]
        A2 --> A3["Boss dies"]
        A3 --> A4["onDelveBossDefeated:\nchest / rite spawns unconditionally\n(unchanged)"]
        A4 --> A5["Player interacts with chest\nor commits the rite"]
        A5 --> A6{"delveHasLiveMobs(run)?"}
        A6 -- "yes, add still up" --> A7(["Refused:\n'Clear the remaining enemies first.'"]):::ok
        A7 -.->|"retry after the add dies"| A5
        A6 -- "no live mobs" --> A8["Reward granted +\nsurface exit opens"]
    end

    classDef bad fill:#4a1f1f,stroke:#c0392b,color:#f5b7b1
    classDef ok fill:#1f3a2a,stroke:#2ecc71,color:#a9dfbf
```

This mirrors the same `run.mobIds`-based check the mid-run module exit already uses
(`tryOpenDelveExitPortal`), extracted into a shared `delveHasLiveMobs` helper and
applied at every finale-room reward gate. The reward chest itself still spawns on
boss death as before (so the room state and HUD guidance don't change); only the
player-initiated interaction that would grant loot / start the rite / open the
surface exit now refuses while a tracked mob is still alive, with the same "sealed"
error-toast pattern the rest of the delve system already uses.

## Related issues

Reported as: "Gate open but mobs still alive (Delves) - Mobs alive, can't proceed to
next level. Expected: Gate should not be open when there's a mob alive."

## Type of change

- [x] Bug fix

## How was this tested?

- Commands:
  - `npx vitest run tests/delves.test.ts tests/delves_runs.test.ts` (165 passed,
    including the two new regression tests below)
  - `npx vitest run tests/localization_fixes.test.ts tests/architecture.test.ts
    tests/i18n_completeness.test.ts` (S3 i18n guard, sim purity, M16 wordy-copy
    non-Latin fills)
  - `npx vitest run tests/parity` (golden-trace determinism gate)
  - `npx tsc --noEmit`
  - `node scripts/gate_select.mjs`: the targeted delve/i18n/parity/tsc steps above
    are all green. The gate's opportunistic full-suite fallback also hit an
    `ECONNREFUSED 127.0.0.1:3000` failure spread across dozens of unrelated test
    files (discord bot config, economy SDK, asset pipeline, etc, none of them
    delve-related), which looks like a local environment/networking issue rather
    than something this change caused; flagging it here rather than hiding it, and
    happy to re-run once CI/reviewers confirm.
- Manual steps: none (this is a server-authoritative sim change with no HUD/render
  code touched, so I've relied on the automated tests above rather than a
  screenshot; see below).

Added two regression tests:
- `refuses the locked chest while a boss-summoned add is still alive` (Collapsed
  Reliquary): spawns a live add into `run.mobIds` after the boss dies, asserts the
  lockpick offer is refused with the new error, then succeeds once the add is dead.
- `refuses the rite difficulty commit while a boss-summoned add is still alive`
  (Drowned Litany): same shape against `delveRiteChoose`.

## Screenshots / recordings

N/A. This is a server-side sim/gameplay-logic fix (`src/sim/delves/runs.ts`); no
render/HUD code changed. The only visible surface is a new error toast text
("Clear the remaining enemies first."), which follows the same i18n'd
`ctx.error(...)` pattern the delve system already uses everywhere else (e.g. "The
passage is sealed."). Reproducing the exact live exploit for a screenshot would
require scripting a full delve clear (3 real combat rooms) through browser
automation to trigger the boss's Raise Dead mid-fight, which isn't a reliable use
of review time for a change this covers with focused sim tests.

---

## Checklist

### Quality

- [x] **The gate passes.** Targeted `node scripts/gate_select.mjs` steps (delve
      suites, i18n S3 guard + M16 completeness, architecture purity, golden-trace
      parity, `tsc`) are green; see the caveat above about the full-suite fallback's
      apparently-unrelated `ECONNREFUSED:3000` failures. Decisive regression tests
      added for the fixed behavior.

### Cross-platform

- ~~Tested on desktop and mobile.~~ N/A, no UI surface changed beyond a text-only
  error toast reusing the existing error-toast component.
- ~~Accessible.~~ N/A, same reason.

### Localization (i18n)

- [x] **New player-visible strings follow the contributor policy.** Added
      `sim.delve.enemiesRemain` ("Clear the remaining enemies first.") to
      `src/ui/i18n.catalog/index.ts` (English catalog) plus a matching `sim_i18n.ts`
      rule for the sim-emitted literal. Per the M16 wordy-copy rule, I also added the
      five required non-Latin fills (`zh_CN`, `zh_TW`, `ja_JP`, `ko_KR`, `ru_RU`)
      directly to those locale overlays in this same change, and regenerated the i18n
      artifacts (`npm run i18n:gen`).
- [x] N/A on formatters (no numbers/money/dates in the new string).
- [x] The new string is emitted from `src/sim/` and matched in `sim_i18n.ts`;
      `npx vitest run tests/localization_fixes.test.ts` passes.

### Hygiene

- [x] No secrets/credentials touched; `ALLOW_DEV_COMMANDS` untouched.
- [x] No generated files hand-edited; `i18n.resolved.generated/*` and
      `translation_keys.generated.ts` were produced by `npm run i18n:gen`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)