### PR TITLE
fix(render): one writer for the render-side sheathe cache, so swimming animates

### DIFF
--- a/docs/screenshots/eastbrook-vale-rebuild/polish/metadata/after-desktop-ultra.json
+++ b/docs/screenshots/eastbrook-vale-rebuild/polish/metadata/after-desktop-ultra.json
@@ -11,7 +11,7 @@
     "mode": "composite-sha256",
     "algorithm": "sha256",
     "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-    "fingerprint": "e069626230576fa39ed87eeb94a78cb0ec111156f031fd8063bf2471a99db070",
+    "fingerprint": "c4072dfd85c6b8eec47180e3b1eb4ebab0228a7dd00ca1a743aadbeecdc0bd01",
     "components": {
       "townAsset": {
         "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -40,7 +40,7 @@
         },
         "renderer": {
           "path": "src/render/renderer.ts",
-          "sha256": "66c2e434b5568296f46f0af668abf6575a3b5fb490479e0f632c34444d3a9803"
+          "sha256": "ce6cc9914612c24f674bebe1866afbaeab348eaf708610a38bf9abf596f0f229"
         },
         "entityViewPolicy": {
           "path": "src/render/entity_view_policy_core.ts",
@@ -89,7 +89,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "e069626230576fa39ed87eeb94a78cb0ec111156f031fd8063bf2471a99db070",
+        "fingerprint": "c4072dfd85c6b8eec47180e3b1eb4ebab0228a7dd00ca1a743aadbeecdc0bd01",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -118,7 +118,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "66c2e434b5568296f46f0af668abf6575a3b5fb490479e0f632c34444d3a9803"
+              "sha256": "ce6cc9914612c24f674bebe1866afbaeab348eaf708610a38bf9abf596f0f229"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -1385,7 +1385,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "e069626230576fa39ed87eeb94a78cb0ec111156f031fd8063bf2471a99db070",
+        "fingerprint": "c4072dfd85c6b8eec47180e3b1eb4ebab0228a7dd00ca1a743aadbeecdc0bd01",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -1414,7 +1414,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "66c2e434b5568296f46f0af668abf6575a3b5fb490479e0f632c34444d3a9803"
+              "sha256": "ce6cc9914612c24f674bebe1866afbaeab348eaf708610a38bf9abf596f0f229"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -2681,7 +2681,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "e069626230576fa39ed87eeb94a78cb0ec111156f031fd8063bf2471a99db070",
+        "fingerprint": "c4072dfd85c6b8eec47180e3b1eb4ebab0228a7dd00ca1a743aadbeecdc0bd01",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -2710,7 +2710,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "66c2e434b5568296f46f0af668abf6575a3b5fb490479e0f632c34444d3a9803"
+              "sha256": "ce6cc9914612c24f674bebe1866afbaeab348eaf708610a38bf9abf596f0f229"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -3977,7 +3977,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "e069626230576fa39ed87eeb94a78cb0ec111156f031fd8063bf2471a99db070",
+        "fingerprint": "c4072dfd85c6b8eec47180e3b1eb4ebab0228a7dd00ca1a743aadbeecdc0bd01",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -4006,7 +4006,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "66c2e434b5568296f46f0af668abf6575a3b5fb490479e0f632c34444d3a9803"
+              "sha256": "ce6cc9914612c24f674bebe1866afbaeab348eaf708610a38bf9abf596f0f229"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -5273,7 +5273,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "e069626230576fa39ed87eeb94a78cb0ec111156f031fd8063bf2471a99db070",
+        "fingerprint": "c4072dfd85c6b8eec47180e3b1eb4ebab0228a7dd00ca1a743aadbeecdc0bd01",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -5302,7 +5302,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "66c2e434b5568296f46f0af668abf6575a3b5fb490479e0f632c34444d3a9803"
+              "sha256": "ce6cc9914612c24f674bebe1866afbaeab348eaf708610a38bf9abf596f0f229"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -6569,7 +6569,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "e069626230576fa39ed87eeb94a78cb0ec111156f031fd8063bf2471a99db070",
+        "fingerprint": "c4072dfd85c6b8eec47180e3b1eb4ebab0228a7dd00ca1a743aadbeecdc0bd01",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -6598,7 +6598,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "66c2e434b5568296f46f0af668abf6575a3b5fb490479e0f632c34444d3a9803"
+              "sha256": "ce6cc9914612c24f674bebe1866afbaeab348eaf708610a38bf9abf596f0f229"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -7865,7 +7865,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "e069626230576fa39ed87eeb94a78cb0ec111156f031fd8063bf2471a99db070",
+        "fingerprint": "c4072dfd85c6b8eec47180e3b1eb4ebab0228a7dd00ca1a743aadbeecdc0bd01",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -7894,7 +7894,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "66c2e434b5568296f46f0af668abf6575a3b5fb490479e0f632c34444d3a9803"
+              "sha256": "ce6cc9914612c24f674bebe1866afbaeab348eaf708610a38bf9abf596f0f229"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -9161,7 +9161,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "e069626230576fa39ed87eeb94a78cb0ec111156f031fd8063bf2471a99db070",
+        "fingerprint": "c4072dfd85c6b8eec47180e3b1eb4ebab0228a7dd00ca1a743aadbeecdc0bd01",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -9190,7 +9190,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "66c2e434b5568296f46f0af668abf6575a3b5fb490479e0f632c34444d3a9803"
+              "sha256": "ce6cc9914612c24f674bebe1866afbaeab348eaf708610a38bf9abf596f0f229"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -10457,7 +10457,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "e069626230576fa39ed87eeb94a78cb0ec111156f031fd8063bf2471a99db070",
+        "fingerprint": "c4072dfd85c6b8eec47180e3b1eb4ebab0228a7dd00ca1a743aadbeecdc0bd01",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -10486,7 +10486,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "66c2e434b5568296f46f0af668abf6575a3b5fb490479e0f632c34444d3a9803"
+              "sha256": "ce6cc9914612c24f674bebe1866afbaeab348eaf708610a38bf9abf596f0f229"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -11753,7 +11753,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "e069626230576fa39ed87eeb94a78cb0ec111156f031fd8063bf2471a99db070",
+        "fingerprint": "c4072dfd85c6b8eec47180e3b1eb4ebab0228a7dd00ca1a743aadbeecdc0bd01",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -11782,7 +11782,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "66c2e434b5568296f46f0af668abf6575a3b5fb490479e0f632c34444d3a9803"
+              "sha256": "ce6cc9914612c24f674bebe1866afbaeab348eaf708610a38bf9abf596f0f229"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -13049,7 +13049,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "e069626230576fa39ed87eeb94a78cb0ec111156f031fd8063bf2471a99db070",
+        "fingerprint": "c4072dfd85c6b8eec47180e3b1eb4ebab0228a7dd00ca1a743aadbeecdc0bd01",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -13078,7 +13078,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "66c2e434b5568296f46f0af668abf6575a3b5fb490479e0f632c34444d3a9803"
+              "sha256": "ce6cc9914612c24f674bebe1866afbaeab348eaf708610a38bf9abf596f0f229"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -14345,7 +14345,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "e069626230576fa39ed87eeb94a78cb0ec111156f031fd8063bf2471a99db070",
+        "fingerprint": "c4072dfd85c6b8eec47180e3b1eb4ebab0228a7dd00ca1a743aadbeecdc0bd01",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -14374,7 +14374,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "66c2e434b5568296f46f0af668abf6575a3b5fb490479e0f632c34444d3a9803"
+              "sha256": "ce6cc9914612c24f674bebe1866afbaeab348eaf708610a38bf9abf596f0f229"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -15641,7 +15641,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "e069626230576fa39ed87eeb94a78cb0ec111156f031fd8063bf2471a99db070",
+        "fingerprint": "c4072dfd85c6b8eec47180e3b1eb4ebab0228a7dd00ca1a743aadbeecdc0bd01",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -15670,7 +15670,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "66c2e434b5568296f46f0af668abf6575a3b5fb490479e0f632c34444d3a9803"
+              "sha256": "ce6cc9914612c24f674bebe1866afbaeab348eaf708610a38bf9abf596f0f229"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -16937,7 +16937,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "e069626230576fa39ed87eeb94a78cb0ec111156f031fd8063bf2471a99db070",
+        "fingerprint": "c4072dfd85c6b8eec47180e3b1eb4ebab0228a7dd00ca1a743aadbeecdc0bd01",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -16966,7 +16966,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "66c2e434b5568296f46f0af668abf6575a3b5fb490479e0f632c34444d3a9803"
+              "sha256": "ce6cc9914612c24f674bebe1866afbaeab348eaf708610a38bf9abf596f0f229"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -19198,7 +19198,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "e069626230576fa39ed87eeb94a78cb0ec111156f031fd8063bf2471a99db070",
+        "fingerprint": "c4072dfd85c6b8eec47180e3b1eb4ebab0228a7dd00ca1a743aadbeecdc0bd01",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -19227,7 +19227,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "66c2e434b5568296f46f0af668abf6575a3b5fb490479e0f632c34444d3a9803"
+              "sha256": "ce6cc9914612c24f674bebe1866afbaeab348eaf708610a38bf9abf596f0f229"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -20494,7 +20494,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "e069626230576fa39ed87eeb94a78cb0ec111156f031fd8063bf2471a99db070",
+        "fingerprint": "c4072dfd85c6b8eec47180e3b1eb4ebab0228a7dd00ca1a743aadbeecdc0bd01",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -20523,7 +20523,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "66c2e434b5568296f46f0af668abf6575a3b5fb490479e0f632c34444d3a9803"
+              "sha256": "ce6cc9914612c24f674bebe1866afbaeab348eaf708610a38bf9abf596f0f229"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -21790,7 +21790,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "e069626230576fa39ed87eeb94a78cb0ec111156f031fd8063bf2471a99db070",
+        "fingerprint": "c4072dfd85c6b8eec47180e3b1eb4ebab0228a7dd00ca1a743aadbeecdc0bd01",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -21819,7 +21819,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "66c2e434b5568296f46f0af668abf6575a3b5fb490479e0f632c34444d3a9803"
+              "sha256": "ce6cc9914612c24f674bebe1866afbaeab348eaf708610a38bf9abf596f0f229"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -23086,7 +23086,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "e069626230576fa39ed87eeb94a78cb0ec111156f031fd8063bf2471a99db070",
+        "fingerprint": "c4072dfd85c6b8eec47180e3b1eb4ebab0228a7dd00ca1a743aadbeecdc0bd01",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -23115,7 +23115,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "66c2e434b5568296f46f0af668abf6575a3b5fb490479e0f632c34444d3a9803"
+              "sha256": "ce6cc9914612c24f674bebe1866afbaeab348eaf708610a38bf9abf596f0f229"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -24382,7 +24382,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "e069626230576fa39ed87eeb94a78cb0ec111156f031fd8063bf2471a99db070",
+        "fingerprint": "c4072dfd85c6b8eec47180e3b1eb4ebab0228a7dd00ca1a743aadbeecdc0bd01",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -24411,7 +24411,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "66c2e434b5568296f46f0af668abf6575a3b5fb490479e0f632c34444d3a9803"
+              "sha256": "ce6cc9914612c24f674bebe1866afbaeab348eaf708610a38bf9abf596f0f229"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -25678,7 +25678,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "e069626230576fa39ed87eeb94a78cb0ec111156f031fd8063bf2471a99db070",
+        "fingerprint": "c4072dfd85c6b8eec47180e3b1eb4ebab0228a7dd00ca1a743aadbeecdc0bd01",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -25707,7 +25707,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "66c2e434b5568296f46f0af668abf6575a3b5fb490479e0f632c34444d3a9803"
+              "sha256": "ce6cc9914612c24f674bebe1866afbaeab348eaf708610a38bf9abf596f0f229"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -26974,7 +26974,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "e069626230576fa39ed87eeb94a78cb0ec111156f031fd8063bf2471a99db070",
+        "fingerprint": "c4072dfd85c6b8eec47180e3b1eb4ebab0228a7dd00ca1a743aadbeecdc0bd01",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -27003,7 +27003,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "66c2e434b5568296f46f0af668abf6575a3b5fb490479e0f632c34444d3a9803"
+              "sha256": "ce6cc9914612c24f674bebe1866afbaeab348eaf708610a38bf9abf596f0f229"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -28323,7 +28323,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "e069626230576fa39ed87eeb94a78cb0ec111156f031fd8063bf2471a99db070",
+        "fingerprint": "c4072dfd85c6b8eec47180e3b1eb4ebab0228a7dd00ca1a743aadbeecdc0bd01",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -28352,7 +28352,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "66c2e434b5568296f46f0af668abf6575a3b5fb490479e0f632c34444d3a9803"
+              "sha256": "ce6cc9914612c24f674bebe1866afbaeab348eaf708610a38bf9abf596f0f229"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -29619,7 +29619,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "e069626230576fa39ed87eeb94a78cb0ec111156f031fd8063bf2471a99db070",
+        "fingerprint": "c4072dfd85c6b8eec47180e3b1eb4ebab0228a7dd00ca1a743aadbeecdc0bd01",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -29648,7 +29648,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "66c2e434b5568296f46f0af668abf6575a3b5fb490479e0f632c34444d3a9803"
+              "sha256": "ce6cc9914612c24f674bebe1866afbaeab348eaf708610a38bf9abf596f0f229"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",

--- a/docs/screenshots/eastbrook-vale-rebuild/polish/metadata/after-mobile-low.json
+++ b/docs/screenshots/eastbrook-vale-rebuild/polish/metadata/after-mobile-low.json
@@ -11,7 +11,7 @@
     "mode": "composite-sha256",
     "algorithm": "sha256",
     "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-    "fingerprint": "e069626230576fa39ed87eeb94a78cb0ec111156f031fd8063bf2471a99db070",
+    "fingerprint": "c4072dfd85c6b8eec47180e3b1eb4ebab0228a7dd00ca1a743aadbeecdc0bd01",
     "components": {
       "townAsset": {
         "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -40,7 +40,7 @@
         },
         "renderer": {
           "path": "src/render/renderer.ts",
-          "sha256": "66c2e434b5568296f46f0af668abf6575a3b5fb490479e0f632c34444d3a9803"
+          "sha256": "ce6cc9914612c24f674bebe1866afbaeab348eaf708610a38bf9abf596f0f229"
         },
         "entityViewPolicy": {
           "path": "src/render/entity_view_policy_core.ts",
@@ -89,7 +89,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "e069626230576fa39ed87eeb94a78cb0ec111156f031fd8063bf2471a99db070",
+        "fingerprint": "c4072dfd85c6b8eec47180e3b1eb4ebab0228a7dd00ca1a743aadbeecdc0bd01",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -118,7 +118,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "66c2e434b5568296f46f0af668abf6575a3b5fb490479e0f632c34444d3a9803"
+              "sha256": "ce6cc9914612c24f674bebe1866afbaeab348eaf708610a38bf9abf596f0f229"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -1368,7 +1368,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "e069626230576fa39ed87eeb94a78cb0ec111156f031fd8063bf2471a99db070",
+        "fingerprint": "c4072dfd85c6b8eec47180e3b1eb4ebab0228a7dd00ca1a743aadbeecdc0bd01",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -1397,7 +1397,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "66c2e434b5568296f46f0af668abf6575a3b5fb490479e0f632c34444d3a9803"
+              "sha256": "ce6cc9914612c24f674bebe1866afbaeab348eaf708610a38bf9abf596f0f229"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -2647,7 +2647,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "e069626230576fa39ed87eeb94a78cb0ec111156f031fd8063bf2471a99db070",
+        "fingerprint": "c4072dfd85c6b8eec47180e3b1eb4ebab0228a7dd00ca1a743aadbeecdc0bd01",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -2676,7 +2676,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "66c2e434b5568296f46f0af668abf6575a3b5fb490479e0f632c34444d3a9803"
+              "sha256": "ce6cc9914612c24f674bebe1866afbaeab348eaf708610a38bf9abf596f0f229"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -3926,7 +3926,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "e069626230576fa39ed87eeb94a78cb0ec111156f031fd8063bf2471a99db070",
+        "fingerprint": "c4072dfd85c6b8eec47180e3b1eb4ebab0228a7dd00ca1a743aadbeecdc0bd01",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -3955,7 +3955,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "66c2e434b5568296f46f0af668abf6575a3b5fb490479e0f632c34444d3a9803"
+              "sha256": "ce6cc9914612c24f674bebe1866afbaeab348eaf708610a38bf9abf596f0f229"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -5205,7 +5205,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "e069626230576fa39ed87eeb94a78cb0ec111156f031fd8063bf2471a99db070",
+        "fingerprint": "c4072dfd85c6b8eec47180e3b1eb4ebab0228a7dd00ca1a743aadbeecdc0bd01",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -5234,7 +5234,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "66c2e434b5568296f46f0af668abf6575a3b5fb490479e0f632c34444d3a9803"
+              "sha256": "ce6cc9914612c24f674bebe1866afbaeab348eaf708610a38bf9abf596f0f229"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -6484,7 +6484,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "e069626230576fa39ed87eeb94a78cb0ec111156f031fd8063bf2471a99db070",
+        "fingerprint": "c4072dfd85c6b8eec47180e3b1eb4ebab0228a7dd00ca1a743aadbeecdc0bd01",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -6513,7 +6513,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "66c2e434b5568296f46f0af668abf6575a3b5fb490479e0f632c34444d3a9803"
+              "sha256": "ce6cc9914612c24f674bebe1866afbaeab348eaf708610a38bf9abf596f0f229"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -7763,7 +7763,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "e069626230576fa39ed87eeb94a78cb0ec111156f031fd8063bf2471a99db070",
+        "fingerprint": "c4072dfd85c6b8eec47180e3b1eb4ebab0228a7dd00ca1a743aadbeecdc0bd01",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -7792,7 +7792,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "66c2e434b5568296f46f0af668abf6575a3b5fb490479e0f632c34444d3a9803"
+              "sha256": "ce6cc9914612c24f674bebe1866afbaeab348eaf708610a38bf9abf596f0f229"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -9042,7 +9042,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "e069626230576fa39ed87eeb94a78cb0ec111156f031fd8063bf2471a99db070",
+        "fingerprint": "c4072dfd85c6b8eec47180e3b1eb4ebab0228a7dd00ca1a743aadbeecdc0bd01",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -9071,7 +9071,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "66c2e434b5568296f46f0af668abf6575a3b5fb490479e0f632c34444d3a9803"
+              "sha256": "ce6cc9914612c24f674bebe1866afbaeab348eaf708610a38bf9abf596f0f229"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -10321,7 +10321,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "e069626230576fa39ed87eeb94a78cb0ec111156f031fd8063bf2471a99db070",
+        "fingerprint": "c4072dfd85c6b8eec47180e3b1eb4ebab0228a7dd00ca1a743aadbeecdc0bd01",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -10350,7 +10350,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "66c2e434b5568296f46f0af668abf6575a3b5fb490479e0f632c34444d3a9803"
+              "sha256": "ce6cc9914612c24f674bebe1866afbaeab348eaf708610a38bf9abf596f0f229"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -11600,7 +11600,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "e069626230576fa39ed87eeb94a78cb0ec111156f031fd8063bf2471a99db070",
+        "fingerprint": "c4072dfd85c6b8eec47180e3b1eb4ebab0228a7dd00ca1a743aadbeecdc0bd01",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -11629,7 +11629,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "66c2e434b5568296f46f0af668abf6575a3b5fb490479e0f632c34444d3a9803"
+              "sha256": "ce6cc9914612c24f674bebe1866afbaeab348eaf708610a38bf9abf596f0f229"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -12879,7 +12879,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "e069626230576fa39ed87eeb94a78cb0ec111156f031fd8063bf2471a99db070",
+        "fingerprint": "c4072dfd85c6b8eec47180e3b1eb4ebab0228a7dd00ca1a743aadbeecdc0bd01",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -12908,7 +12908,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "66c2e434b5568296f46f0af668abf6575a3b5fb490479e0f632c34444d3a9803"
+              "sha256": "ce6cc9914612c24f674bebe1866afbaeab348eaf708610a38bf9abf596f0f229"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -14158,7 +14158,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "e069626230576fa39ed87eeb94a78cb0ec111156f031fd8063bf2471a99db070",
+        "fingerprint": "c4072dfd85c6b8eec47180e3b1eb4ebab0228a7dd00ca1a743aadbeecdc0bd01",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -14187,7 +14187,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "66c2e434b5568296f46f0af668abf6575a3b5fb490479e0f632c34444d3a9803"
+              "sha256": "ce6cc9914612c24f674bebe1866afbaeab348eaf708610a38bf9abf596f0f229"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -15437,7 +15437,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "e069626230576fa39ed87eeb94a78cb0ec111156f031fd8063bf2471a99db070",
+        "fingerprint": "c4072dfd85c6b8eec47180e3b1eb4ebab0228a7dd00ca1a743aadbeecdc0bd01",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -15466,7 +15466,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "66c2e434b5568296f46f0af668abf6575a3b5fb490479e0f632c34444d3a9803"
+              "sha256": "ce6cc9914612c24f674bebe1866afbaeab348eaf708610a38bf9abf596f0f229"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -16716,7 +16716,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "e069626230576fa39ed87eeb94a78cb0ec111156f031fd8063bf2471a99db070",
+        "fingerprint": "c4072dfd85c6b8eec47180e3b1eb4ebab0228a7dd00ca1a743aadbeecdc0bd01",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -16745,7 +16745,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "66c2e434b5568296f46f0af668abf6575a3b5fb490479e0f632c34444d3a9803"
+              "sha256": "ce6cc9914612c24f674bebe1866afbaeab348eaf708610a38bf9abf596f0f229"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -18960,7 +18960,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "e069626230576fa39ed87eeb94a78cb0ec111156f031fd8063bf2471a99db070",
+        "fingerprint": "c4072dfd85c6b8eec47180e3b1eb4ebab0228a7dd00ca1a743aadbeecdc0bd01",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -18989,7 +18989,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "66c2e434b5568296f46f0af668abf6575a3b5fb490479e0f632c34444d3a9803"
+              "sha256": "ce6cc9914612c24f674bebe1866afbaeab348eaf708610a38bf9abf596f0f229"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -20239,7 +20239,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "e069626230576fa39ed87eeb94a78cb0ec111156f031fd8063bf2471a99db070",
+        "fingerprint": "c4072dfd85c6b8eec47180e3b1eb4ebab0228a7dd00ca1a743aadbeecdc0bd01",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -20268,7 +20268,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "66c2e434b5568296f46f0af668abf6575a3b5fb490479e0f632c34444d3a9803"
+              "sha256": "ce6cc9914612c24f674bebe1866afbaeab348eaf708610a38bf9abf596f0f229"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -21518,7 +21518,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "e069626230576fa39ed87eeb94a78cb0ec111156f031fd8063bf2471a99db070",
+        "fingerprint": "c4072dfd85c6b8eec47180e3b1eb4ebab0228a7dd00ca1a743aadbeecdc0bd01",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -21547,7 +21547,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "66c2e434b5568296f46f0af668abf6575a3b5fb490479e0f632c34444d3a9803"
+              "sha256": "ce6cc9914612c24f674bebe1866afbaeab348eaf708610a38bf9abf596f0f229"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -22797,7 +22797,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "e069626230576fa39ed87eeb94a78cb0ec111156f031fd8063bf2471a99db070",
+        "fingerprint": "c4072dfd85c6b8eec47180e3b1eb4ebab0228a7dd00ca1a743aadbeecdc0bd01",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -22826,7 +22826,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "66c2e434b5568296f46f0af668abf6575a3b5fb490479e0f632c34444d3a9803"
+              "sha256": "ce6cc9914612c24f674bebe1866afbaeab348eaf708610a38bf9abf596f0f229"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -24076,7 +24076,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "e069626230576fa39ed87eeb94a78cb0ec111156f031fd8063bf2471a99db070",
+        "fingerprint": "c4072dfd85c6b8eec47180e3b1eb4ebab0228a7dd00ca1a743aadbeecdc0bd01",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -24105,7 +24105,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "66c2e434b5568296f46f0af668abf6575a3b5fb490479e0f632c34444d3a9803"
+              "sha256": "ce6cc9914612c24f674bebe1866afbaeab348eaf708610a38bf9abf596f0f229"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -25355,7 +25355,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "e069626230576fa39ed87eeb94a78cb0ec111156f031fd8063bf2471a99db070",
+        "fingerprint": "c4072dfd85c6b8eec47180e3b1eb4ebab0228a7dd00ca1a743aadbeecdc0bd01",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -25384,7 +25384,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "66c2e434b5568296f46f0af668abf6575a3b5fb490479e0f632c34444d3a9803"
+              "sha256": "ce6cc9914612c24f674bebe1866afbaeab348eaf708610a38bf9abf596f0f229"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -26634,7 +26634,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "e069626230576fa39ed87eeb94a78cb0ec111156f031fd8063bf2471a99db070",
+        "fingerprint": "c4072dfd85c6b8eec47180e3b1eb4ebab0228a7dd00ca1a743aadbeecdc0bd01",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -26663,7 +26663,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "66c2e434b5568296f46f0af668abf6575a3b5fb490479e0f632c34444d3a9803"
+              "sha256": "ce6cc9914612c24f674bebe1866afbaeab348eaf708610a38bf9abf596f0f229"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -27966,7 +27966,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "e069626230576fa39ed87eeb94a78cb0ec111156f031fd8063bf2471a99db070",
+        "fingerprint": "c4072dfd85c6b8eec47180e3b1eb4ebab0228a7dd00ca1a743aadbeecdc0bd01",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -27995,7 +27995,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "66c2e434b5568296f46f0af668abf6575a3b5fb490479e0f632c34444d3a9803"
+              "sha256": "ce6cc9914612c24f674bebe1866afbaeab348eaf708610a38bf9abf596f0f229"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -29245,7 +29245,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "e069626230576fa39ed87eeb94a78cb0ec111156f031fd8063bf2471a99db070",
+        "fingerprint": "c4072dfd85c6b8eec47180e3b1eb4ebab0228a7dd00ca1a743aadbeecdc0bd01",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -29274,7 +29274,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "66c2e434b5568296f46f0af668abf6575a3b5fb490479e0f632c34444d3a9803"
+              "sha256": "ce6cc9914612c24f674bebe1866afbaeab348eaf708610a38bf9abf596f0f229"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",

--- a/docs/screenshots/eastbrook-vale-rebuild/polish/performance/after-desktop-ultra-town.json
+++ b/docs/screenshots/eastbrook-vale-rebuild/polish/performance/after-desktop-ultra-town.json
@@ -14,7 +14,7 @@
     "mode": "composite-sha256",
     "algorithm": "sha256",
     "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-    "fingerprint": "e069626230576fa39ed87eeb94a78cb0ec111156f031fd8063bf2471a99db070",
+    "fingerprint": "c4072dfd85c6b8eec47180e3b1eb4ebab0228a7dd00ca1a743aadbeecdc0bd01",
     "components": {
       "townAsset": {
         "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -43,7 +43,7 @@
         },
         "renderer": {
           "path": "src/render/renderer.ts",
-          "sha256": "66c2e434b5568296f46f0af668abf6575a3b5fb490479e0f632c34444d3a9803"
+          "sha256": "ce6cc9914612c24f674bebe1866afbaeab348eaf708610a38bf9abf596f0f229"
         },
         "entityViewPolicy": {
           "path": "src/render/entity_view_policy_core.ts",

--- a/docs/screenshots/eastbrook-vale-rebuild/polish/performance/after-mobile-low-town.json
+++ b/docs/screenshots/eastbrook-vale-rebuild/polish/performance/after-mobile-low-town.json
@@ -14,7 +14,7 @@
     "mode": "composite-sha256",
     "algorithm": "sha256",
     "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-    "fingerprint": "e069626230576fa39ed87eeb94a78cb0ec111156f031fd8063bf2471a99db070",
+    "fingerprint": "c4072dfd85c6b8eec47180e3b1eb4ebab0228a7dd00ca1a743aadbeecdc0bd01",
     "components": {
       "townAsset": {
         "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -43,7 +43,7 @@
         },
         "renderer": {
           "path": "src/render/renderer.ts",
-          "sha256": "66c2e434b5568296f46f0af668abf6575a3b5fb490479e0f632c34444d3a9803"
+          "sha256": "ce6cc9914612c24f674bebe1866afbaeab348eaf708610a38bf9abf596f0f229"
         },
         "entityViewPolicy": {
           "path": "src/render/entity_view_policy_core.ts",

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -11222,12 +11222,15 @@ export class Renderer {
       v.visual.setFerocityStage(petFrenzy ? 3 : ferocityStage);
       v.visual.setPresentationScale(hunterPetVisualScale(ferocityStage, petFrenzy));
 
-      // live sheathe toggle (Z key): the sim's weaponStowed bit moves held
-      // props between the hands and the on-back pose (self or a peer)
-      if (e.weaponStowed !== v.weaponStowed) {
-        v.weaponStowed = e.weaponStowed;
-        v.visual.setWeaponStowed(e.weaponStowed);
-      }
+      // The live sheathe toggle (Z key) is diffed further down, folded into the
+      // swim stow overlay, and `v.weaponStowed` has exactly ONE writer for a
+      // reason: two diffs against it FIGHT, because they compute different
+      // targets (the bare sim bit here, the union with `swimming` there). A
+      // swimmer holding a drawn weapon flips the field on every frame, which
+      // replays the sheathe one-shot forever and pins `currentIsOneShot` true,
+      // and that suppresses every base-state fade in CharacterVisual: the
+      // authored strokes never play. tests/weapon_stow_single_writer.test.ts
+      // pins the rule; see the comment on the surviving diff below.
 
       // lazy form visuals, swapped by visibility like the old sheep/bear rigs
       // A null build leaves the field unset; the shared gate retries after its cooldown.
@@ -11453,6 +11456,9 @@ export class Renderer {
       // drawn, and a peer's weapon rides their back the moment they start
       // swimming without any wire traffic. (This diff sits here, after the swim
       // latch, precisely so both halves are known in the same frame.)
+      // THE ONLY WRITER of `v.weaponStowed` in this loop: a second diff against
+      // the bare sim bit reverts this one every frame and replays the sheathe
+      // gesture forever, which freezes the rig mid-gesture (see above).
       const stowed = e.weaponStowed || swimming;
       if (stowed !== v.weaponStowed) {
         v.weaponStowed = stowed;

--- a/tests/eastbrook_polish_artifact_integrity.test.ts
+++ b/tests/eastbrook_polish_artifact_integrity.test.ts
@@ -752,10 +752,13 @@ const ACCEPTED_POLISH_V2_METADATA_PATH = path.join(REPO_ROOT, POLISH_SEAL_PATH);
 // the release monolith ratchet. Behavior is unchanged; no capture was retaken.
 // Re-minted again after registering the extracted policy as its own provenance
 // leaf. The captures remain unchanged and were not retaken.
+// Re-minted after deleting the duplicate weapon-stow diff from renderer.ts (the
+// swim animation fix): the composite follows that leaf, and the metadata sha
+// follows the swept provenance blocks. No capture was retaken.
 const ACCEPTED_POLISH_V2_METADATA_SHA256 =
-  '3a45257ca823deae6c5971b4d9ca1be9b66f3aac9449f19408c918c9bef85812';
+  '9e3b15e0459ec9be931cbe56f4b08c8d01767be6ef44d1673bbf43fd3ecf9fa5';
 const ACCEPTED_POLISH_V2_COMPOSITE_PROVENANCE =
-  'e069626230576fa39ed87eeb94a78cb0ec111156f031fd8063bf2471a99db070';
+  'c4072dfd85c6b8eec47180e3b1eb4ebab0228a7dd00ca1a743aadbeecdc0bd01';
 const ACCEPTED_POLISH_V2_METADATA = readJsonFile<CaptureMetadata>(ACCEPTED_POLISH_V2_METADATA_PATH);
 const ACCEPTED_POLISH_V2_PROVENANCE = ACCEPTED_POLISH_V2_METADATA.polishProvenance;
 const ACCEPTED_POLISH_V2_TOWN_CONTRACT = ACCEPTED_POLISH_V2_METADATA.records[0]?.townContract;
@@ -1740,10 +1743,14 @@ describe('Eastbrook polish performance and contact evidence', () => {
     // monolith ratchet. The seal follows the swept bytes; no capture was retaken.
     // Re-pinned again after the policy became an explicit provenance leaf. The
     // performance records changed only in their swept provenance blocks.
+    // Re-pinned for the swim animation fix (the duplicate weapon-stow diff
+    // deleted from renderer.ts). The first-order composite follows renderer.ts,
+    // then this second-order seal follows the swept evidence bytes. No capture
+    // was retaken.
     expect(
       fingerprint.digest('hex'),
       `the second-order performance digest moved; if every input moved legitimately, re-mint with: ${REMINT_COMMAND} (it recomputes this literal LAST, from the swept files)`,
-    ).toBe('05ade62f3e9a75cf0cea69d7a7fd3397fef92ed5f6d79d36ab4d1a1c1e29607d');
+    ).toBe('fcdb4146bb51368297baec5ae4d763694bce3bef5f03e8d52e170c9fd4acd459');
   });
 
   it('binds every historical after record to its accepted source and asset provenance', () => {

--- a/tests/eastbrook_polish_capture_contract.test.ts
+++ b/tests/eastbrook_polish_capture_contract.test.ts
@@ -168,8 +168,11 @@ interface AttributionTargetFixture {
 // the release monolith ratchet. Behavior is unchanged; no capture was retaken.
 // Re-minted again after making that extracted policy an explicit provenance
 // leaf. The evidence now follows policy-only changes; no capture was retaken.
+// Re-minted after deleting the duplicate weapon-stow diff from renderer.ts (the
+// swim animation fix): renderer.ts is a provenance leaf, so the composite
+// follows its bytes. No capture was retaken.
 const PINNED_POLISH_COMPOSITE_FINGERPRINT =
-  'e069626230576fa39ed87eeb94a78cb0ec111156f031fd8063bf2471a99db070';
+  'c4072dfd85c6b8eec47180e3b1eb4ebab0228a7dd00ca1a743aadbeecdc0bd01';
 
 function validPolishAttributionTargets(): AttributionTargetFixture[] {
   return [

--- a/tests/weapon_stow_single_writer.test.ts
+++ b/tests/weapon_stow_single_writer.test.ts
@@ -1,0 +1,43 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+// `EntityView.weaponStowed` is a LAST-RENDERED cache, diffed to decide when to
+// play the sheathe gesture. It must have exactly one writer in the per-entity
+// loop, and that writer must be the swim overlay (`e.weaponStowed || swimming`).
+//
+// The failure this pins is not obvious from either diff on its own. With two
+// diffs against the same field computing different targets, a swimmer holding a
+// drawn weapon (`e.weaponStowed === false`, `swimming === true`) has the first
+// write `false` and the second write `true` on every single frame. Each write
+// is a genuine target change, so `requestStow` replays the sheathe one-shot
+// forever; `CharacterVisual.currentIsOneShot` never clears, and the base-state
+// machine's `baseChanged && !this.currentIsOneShot` gate then suppresses every
+// fade. The state machine still latches swim/swimSurface/swimIdle correctly and
+// the authored clips are all bound — nothing ever fades in, and the rig sits
+// frozen a third of a second into the sheathe gesture (for a player rig that
+// clip is 1H_Melee_Attack_Chop) for as long as the swim lasts.
+//
+// It regressed exactly once already: the swimming PR removed the older Z-key
+// diff, and a later release merge resurrected it.
+const rendererSource = readFileSync(path.join(__dirname, '..', 'src/render/renderer.ts'), 'utf8');
+
+describe('the weapon stow overlay is the single writer of the render-side cache', () => {
+  it('drives the sheathe gesture from exactly one call site', () => {
+    const calls = rendererSource.match(/\.setWeaponStowed\(/g) ?? [];
+    expect(calls).toHaveLength(1);
+    expect(rendererSource).toMatch(/v\.visual\.setWeaponStowed\(stowed\)/);
+  });
+
+  it('feeds that call the union of the sim bit and the swim latch', () => {
+    expect(rendererSource).toMatch(/const stowed = e\.weaponStowed \|\| swimming/);
+  });
+
+  it('has no second diff against the bare sim bit', () => {
+    expect(rendererSource).not.toMatch(/if \(e\.weaponStowed !== v\.weaponStowed\)/);
+    // One reset (`= false`) on the visual-swap path plus the overlay's own
+    // write. A third assignment is a second writer by another name.
+    const writes = rendererSource.match(/v\.weaponStowed = /g) ?? [];
+    expect(writes).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## The bug

Swimming plays no animation at all. Every authored stroke is dead — `Swim_Freestyle`
on the surface, `Swim_Breaststroke` submerged, `Swim_Tread` when you stop — and the
body sits frozen about a third of a second into a sword-chop windup for as long as
you are in the water. Wading is unaffected.

Measured in the live game at the Veiled Hollow lake, holding forward on the surface:

```
state=swimSurface  current=1H_Melee_Attack_Chop  running=[1H_Melee_Attack_Chop w=1.00 t=0.29]
stow={attached:false, target:true, timer:0.0097}      <- reset every frame
Swim_Freestyle: run=false   Swim_Breaststroke: run=false   Swim_Tread: run=false
```

## Root cause

`EntityView.weaponStowed` is a last-rendered cache, diffed to decide when to play the
sheathe gesture. It ended up with **two** writers in the per-entity loop, computing
different targets:

- `if (e.weaponStowed !== v.weaponStowed)` — the bare sim bit (the Z-key toggle)
- `const stowed = e.weaponStowed || swimming` — the swim overlay

Swim with a weapon drawn (`e.weaponStowed === false`, `swimming === true`) and they
disagree permanently: the first writes `false`, the second writes `true`, every frame.
Each write is a genuine target change, so `requestStow` returns true and replays the
sheathe one-shot — for a player rig that clip is `1H_Melee_Attack_Chop`. It never gets
to finish, `CharacterVisual.currentIsOneShot` never clears, and the base-state machine's
`baseChanged && !this.currentIsOneShot` gate then suppresses every fade.

Worth stressing: nothing about the swim lane is broken. The state machine latches
`swim` / `swimSurface` / `swimIdle` correctly the whole time and all four water clips
are bound — they just never get faded in. The zero-weight watchdog cannot catch it
either, because the orphaned gesture drives the pose at full weight, so nothing reads
as starved.

## How it got here

#3035 (the swimming update) added the overlay and **removed** the older Z-key diff —
correctly, since the overlay's target is a superset. The merge in #3285
(`release/v0.36.0` → `main`, `0f7d09d59a`) then resurrected the deleted block: one
parent had the deletion, the other still had the original lines, and the resolution
kept both. It has been on `main` and `release/v0.38.0` ever since.

## The fix

Delete the resurrected diff and leave the overlay as the single writer. The two sites
sit at the same brace depth in the same loop with no `continue` or `return` between
them, so the overlay already covers exactly the same entities — the Z-key behaviour is
unchanged, since `stowed` includes `e.weaponStowed`.

`tests/weapon_stow_single_writer.test.ts` pins the rule so a future merge cannot
quietly re-add a second writer (source-pin style, following
`tests/ambient_critters_removed.test.ts`). It fails on the current source and passes
with the fix.

## Verification

Driven headless through Playwright against the offline build, at the deepest built-in
lake, reading the live mixer off `renderer.views.get(id).visual`:

| phase | base state | driving action |
|---|---|---|
| surface, moving | `swimSurface` | `Swim_Freestyle` w=1.00 |
| stopped | `swimIdle` | `Swim_Tread` w=1.00 |
| submerged, moving | `swim` | `Swim_Breaststroke` w=1.00 |

The sheathe gesture now completes as designed on water entry (`stow` reaches
`{attached: true, target: true, timer: 0}`) and hands the rig back to the stroke.
Wading and the dry gaits are unchanged, and the Z-key sheathe still works on land.
