### PR TITLE
fix(delves): bonus Marks ride the daily window; settle the tool-row pricing review

### DIFF
--- a/docs/design/professions.md
+++ b/docs/design/professions.md
@@ -725,7 +725,13 @@ must be re-derived if either number is ever tuned on its own.
   the hub rule with the ladder top routed through content (R23, the delve
   Marks prototype), R22 wield requirements reachable on the ladder below,
   the gatherer chronicle and first-cast deeds, and wiki presence. Shipping
-  an incomplete zone reds the gate instead of relying on memory.
+  an incomplete zone reds the gate instead of relying on memory. The first
+  zone that ships a tier-4 node or water also flips the tier-4/5 tools from
+  comfort items into ACCESS items, so the Drowned Litany's Marks tool rows
+  (`src/sim/content/delves/shop.ts`, priced for a world whose ladder tops
+  out at tier 3) and the wield table are re-derived in that SAME change;
+  the shop file's RE-CHECK TRIGGER comment is the other half of this
+  tripwire.
 - CAP SCALING when zone 4 arrives (design note, phase 13; implementation
   rides the first new zone): the land cap and the fishing cap are today
   authored constants (`GATHERING_PROFESSIONS` maxSkill 100 / 200) that

--- a/docs/prd/delves.md
+++ b/docs/prd/delves.md
@@ -136,12 +136,13 @@ delveDaily: {
 
 - **FR-5.1** On UTC date change, reset `delveDaily` to `{ date: today, firstClearXp: empty, markClears: 0 }`.
 - **FR-5.2** **First-clear XP bonus** (Normal 700 / Heroic 1050 solo): granted only if `${delveId}:${tierId}` not in `firstClearXp` for today; else repeat XP (420 / 650).
-- **FR-5.3** **Mark payout:** full Marks for first **3** completions per UTC day (`markClears < 3`). After 3: Normal 50% chance for 1 Mark; Heroic 1 Mark guaranteed.
+- **FR-5.3** **Mark payout:** full Marks for first **3** completions per UTC day (`markClears < 3`). After 3: Normal 50% chance for 1 Mark; Heroic 1 Mark guaranteed. The chest/rite loot-tier **bonus Marks** ride the same window: they pay only on a clear that was one of the day's first 3 (`delveBonusMarksFor`); the copper half of the bonus and the loot tier itself are not windowed.
 - **FR-5.4** Copper and basic loot always available regardless of daily caps.
 
 > **Implementation note (v0.10.0).** This formula is implemented in
 > `delveMarkPayout` (full = 1 base Mark × tier `rewardMult`; after 3/day the
-> diminished rule applies; the lockpick ante adds a separate tier bonus). The
+> diminished rule applies; the lockpick ante adds a separate tier bonus, which
+> since v0.38.0 pays only inside the 3-clear window per FR-5.3). The
 > §6.7 Heroic "+30% Marks" rides `rewardMult` (1.3) but rounds to no per-clear
 > change at the base of 1 Mark, so the Heroic mark advantage is realised through
 > the post-3 guaranteed-vs-50% rule (and the ante bonus). The §6.6 per-tier XP
@@ -158,15 +159,15 @@ delveDaily: {
 | Normal | 700 | 420 | 8–14 |
 | Heroic | 1,050 | 650 | 16–24 |
 
-- **FR-6.3** Companion upgrade costs (Acolyte Tessa):
+- **FR-6.3** Companion upgrade costs (shared by every companion via
+  `COMPANION_UPGRADE_COSTS`; max rank `DELVE_COMPANION_MAX_RANK` = 3, no
+  copper component):
 
 | Rank | Cost | Cumulative marks |
 |------|------|------------------|
 | 1 | Free (intro) | 0 |
-| 2 | 4 Marks + 20 copper | 4 |
-| 3 | 9 Marks + 60 copper | 13 |
-| 4 | 16 Marks + 1s 20c | 29 |
-| 5 | 28 Marks + 2 silver | **57** |
+| 2 | 3 Marks | 3 |
+| 3 | 5 Marks | **8** |
 
 - **FR-6.4** Lore journal: `delveLoreUnlocked: Set<string>` — five entries unlock across repeat clears.
 - **FR-6.5** Completion chest uses `rollGroup` loot tables per tier (see §9).

--- a/docs/prd/delves.md
+++ b/docs/prd/delves.md
@@ -134,30 +134,33 @@ delveDaily: {
 }
 ```
 
-- **FR-5.1** On UTC date change, reset `delveDaily` to `{ date: today, firstClearXp: empty, markClears: 0 }`.
+- **FR-5.1** On reset-day change (the realm daily boundary supplied by the host as `resetDay`, not a UTC calendar date; see `refreshDelveDaily`), reset `delveDaily` to `{ date: today, firstClearXp: empty, markClears: 0 }`.
 - **FR-5.2** **First-clear XP bonus** (Normal 700 / Heroic 1050 solo): granted only if `${delveId}:${tierId}` not in `firstClearXp` for today; else repeat XP (420 / 650).
-- **FR-5.3** **Mark payout:** full Marks for first **3** completions per UTC day (`markClears < 3`). After 3: Normal 50% chance for 1 Mark; Heroic 1 Mark guaranteed. The chest/rite loot-tier **bonus Marks** ride the same window: they pay only on a clear that was one of the day's first 3 (`delveBonusMarksFor`); the copper half of the bonus and the loot tier itself are not windowed.
+- **FR-5.3** **Mark payout:** full Marks for first **3** completions per reset day (`markClears < 3`). After 3: Normal 50% chance for 1 Mark; Heroic 1 Mark guaranteed. The chest/rite loot-tier **bonus Marks** ride the same window: they pay only on a clear that was one of the day's first 3 (`delveBonusMarksFor`); the copper half of the bonus and the loot tier itself are not windowed.
 - **FR-5.4** Copper and basic loot always available regardless of daily caps.
 
-> **Implementation note (v0.10.0).** This formula is implemented in
-> `delveMarkPayout` (full = 1 base Mark × tier `rewardMult`; after 3/day the
-> diminished rule applies; the lockpick ante adds a separate tier bonus, which
-> since v0.38.0 pays only inside the 3-clear window per FR-5.3). The
-> §6.7 Heroic "+30% Marks" rides `rewardMult` (1.3) but rounds to no per-clear
-> change at the base of 1 Mark, so the Heroic mark advantage is realised through
-> the post-3 guaranteed-vs-50% rule (and the ante bonus). The §6.6 per-tier XP
-> table (Heroic 1050/650, copper 16–24) is **not** yet wired — XP/copper are the
-> same both tiers today; a per-tier XP pass is tracked roadmap.
+> **Implementation note (v0.38.0).** This formula is implemented in
+> `delveMarkPayout`: an in-window clear pays 1 Mark on Normal and 2 on Heroic
+> (the Drowned Litany doubles both), after 3/day the diminished rule applies,
+> and the lockpick ante adds a separate tier bonus, which since v0.38.0 pays
+> only inside the 3-clear window per FR-5.3. The §6.7 Heroic "+30% Marks"
+> rides `rewardMult` (1.3) but rounds to no per-clear change at the base of
+> 1 Mark; the realised Heroic mark advantage is the in-window 2-vs-1, the
+> post-3 guaranteed-vs-50% rule, and the ante bonus. The §6.6 per-tier XP and
+> copper premiums ARE wired: each tier's `firstClearXp` / `repeatClearXp` /
+> copper band is authored on the tier record and read by `grantDelveClearTo`.
 
 ### 6.6 Rewards & economy
 
 - **FR-6.1** `delveMarks: number` on `PlayerMeta` (meta counter, not inventory item).
-- **FR-6.2** XP/copper per tier (solo); duo ~80% per member via `eligible.length` party split.
+- **FR-6.2** XP/copper per tier (solo); duo ~80% per member via `eligible.length` party split. Each delve authors its own bands (tier records in `src/sim/content/delves/`):
 
-| Tier | First clear XP | Repeat clear XP | Copper |
-|------|---------------:|----------------:|-------:|
-| Normal | 700 | 420 | 8–14 |
-| Heroic | 1,050 | 650 | 16–24 |
+| Delve | Tier | First clear XP | Repeat clear XP | Copper |
+|-------|------|---------------:|----------------:|-------:|
+| Collapsed Reliquary | Normal | 700 | 420 | 8-14 |
+| Collapsed Reliquary | Heroic | 1,050 | 650 | 16-24 |
+| Drowned Litany | Normal | 1,250 | 760 | 18-30 |
+| Drowned Litany | Heroic | 1,850 | 1,140 | 32-48 |
 
 - **FR-6.3** Companion upgrade costs (shared by every companion via
   `COMPANION_UPGRADE_COSTS`; max rank `DELVE_COMPANION_MAX_RANK` = 3, no
@@ -461,9 +464,9 @@ All strings via `t('delveUi.*')` + `entity_i18n` manifest entries for NPCs/mobs/
 - Recover `chapel_coffer_relic` + kill boss; **no** Hollow Crypt quest cross-credit.
 - Second run (new seed): different spawn set / side room.
 - Heroic: 1 affix + improved chest; intro candle burns blue.
-- Solo: **Acolyte Tessa** auto-spawns; rank 2 unlockable with 4 Marks after first clear.
+- Solo: **Acolyte Tessa** auto-spawns; rank 2 unlockable with 3 Marks after first clear.
 - Boss telegraphs match approved copy (Bell Toll + Raise Dead interrupt).
-- Rewards: Normal 700/420 XP first/repeat per daily rules; 57 Marks to max Tessa.
+- Rewards: Normal 700/420 XP first/repeat per daily rules; 8 Marks to max Tessa.
 - Five lore journal entries unlock across repeat clears.
 - Death: first = module entry 50% HP; second = fail + eject, no completion rewards.
 - Progress persists; online/offline identical; `npm test` green; full i18n all locales.

--- a/src/sim/content/delves/companions.ts
+++ b/src/sim/content/delves/companions.ts
@@ -17,9 +17,9 @@ export const DELVE_COMPANIONS: Record<string, DelveCompanionDef> = {
 
 /**
  * Rank-up costs (rank 1 is free at intro; max rank 3). Marks only, tuned so the
- * full companion (8 Marks) is a day-or-two goal against the windowed income
- * model (3-9 Marks/day Normal by lockpick skill, 12+ Heroic; the pricing-intent
- * comment in shop.ts is the authority), not a 2-week grind.
+ * full companion (8 Marks) is a one-to-three-day goal against the windowed
+ * income model (3-9 Marks/day Normal by lockpick skill, 12+ Heroic; the
+ * pricing-intent comment in shop.ts is the authority), not a 2-week grind.
  * Each rank also strengthens her heal (% of max HP, see DELVE_COMPANION_HEAL_PCT);
  * rank 3 additionally grants a once-per-run ally revive.
  */

--- a/src/sim/content/delves/companions.ts
+++ b/src/sim/content/delves/companions.ts
@@ -16,8 +16,10 @@ export const DELVE_COMPANIONS: Record<string, DelveCompanionDef> = {
 };
 
 /**
- * Rank-up costs (rank 1 is free at intro; max rank 3). Marks only, tuned to the
- * ~3-6 Marks/day income so the full companion is a ~2-3 day goal, not a 2-week grind.
+ * Rank-up costs (rank 1 is free at intro; max rank 3). Marks only, tuned so the
+ * full companion (8 Marks) is a day-or-two goal against the windowed income
+ * model (3-9 Marks/day Normal by lockpick skill, 12+ Heroic; the pricing-intent
+ * comment in shop.ts is the authority), not a 2-week grind.
  * Each rank also strengthens her heal (% of max HP, see DELVE_COMPANION_HEAL_PCT);
  * rank 3 additionally grants a once-per-run ally revive.
  */

--- a/src/sim/content/delves/shop.ts
+++ b/src/sim/content/delves/shop.ts
@@ -11,14 +11,21 @@
 //                      (difficulty ≥ 2) run.
 //
 // Pricing intent (the Collapsed Reliquary is the ENTRY-tier delve):
-//   Marks income is ~3 Marks/day for a Normal-only player and ~6-8 for a
-//   dedicated Heroic runner (see `delveMarkPayout` in sim.ts). Prices here are
-//   deliberately STEEP relative to that income, the reward gear is a clear
-//   upgrade over the silver-vendor armor of the same tier (Smith Haldren's
-//   commons: chainmail vest 60 armor, leather jerkin 40, robe 22, trousers 24),
-//   so each piece is uncommon-or-rare quality with stat bonuses on top. A casual
-//   player kits out over ~2-3 weeks; the Heroic signature rares are a multi-week
-//   goal each.
+//   Marks income rides the daily window: the first 3 clears of the day (a
+//   single tally shared across delves) pay full base Marks (1 Normal / 2
+//   Heroic; the Drowned Litany doubles both) PLUS any earned chest/rite bonus;
+//   every later clear pays a diminished base only, with no bonus Marks (see
+//   `delveMarkPayout` and `delveBonusMarksFor` in src/sim/delves/runs.ts).
+//   That puts a Normal-only player here around 3-9 Marks/day by lockpick
+//   skill (the chest's loot tier sets the bonus),
+//   and a flawless Heroic runner at 12 (24 at the Litany), a bounded daily
+//   ceiling rather than an open grind. Prices are deliberately STEEP relative
+//   to that income, the reward gear is a clear upgrade over the silver-vendor
+//   armor of the same tier (Smith Haldren's commons: chainmail vest 60 armor,
+//   leather jerkin 40, robe 22, trousers 24), so each piece is
+//   uncommon-or-rare quality with stat bonuses on top. A casual player kits
+//   out over ~2-3 weeks; the Heroic signature rares are a multi-week goal
+//   each.
 //
 //   FORWARD DESIGN: later delves are tuned to cost FAR more Marks (and reward
 //   far more Marks per clear), so this tier's prices are the floor of a long
@@ -100,13 +107,23 @@ const DROWNED_LITANY_SHOP: DelveShopEntry[] = [
   // widened to sweep this table (and the heroic vendor's) rather than only
   // NPCS[*].vendorItems, which would have let these rows through in silence.
   //
-  // These rows carry NO proficiency requirement, unlike the tier-2 and tier-3
-  // copper rows on the ordinary counters (content/vendor_row_gates.ts). That is
-  // not an oversight and not a decision made here: whether a tool's PURCHASE
-  // should be gated on the same proficiency its USE is gated on is an open
-  // question the maintainer holds. The clears gate is what paces these rows
-  // today, and it is a content gate rather than a profession one, so nothing
-  // here presumes an answer either way.
+  // These rows carry NO proficiency requirement, and that is the SETTLED
+  // answer (maintainer ruling, 2026-08-14), no longer an open question: under
+  // R22 every tool purchase gate in the game is advisory, and enforcement
+  // lives at the harvest via the wield gate (professions/wield_gate.ts, tiers
+  // 4/5 at gathering 85/100), which a Marks-bought land tool meets or waits on
+  // exactly like a crafted one. The item tooltip prints the same
+  // "Requires {craft} N" line the copper counters show
+  // (tests/gather_tool_tooltip.test.ts), so the buyer is warned before
+  // spending. The clears gate is what paces these rows; rods stay wield-exempt
+  // under R22 and are paced by the water-tier gate instead.
+  //
+  // RE-CHECK TRIGGER: these prices assume a world whose highest shipped node
+  // and fishing-water tier is 3, where a tier-4/5 tool opens no content and
+  // its value is fine-grade minting, cast speed, and comfort. The patch that
+  // ships the first tier-4 node or water (the post-level-20 zone expansion)
+  // turns these into ACCESS items: re-derive both Marks prices and the wield
+  // table in that SAME change, not after.
   { itemId: 'thorium_mining_pick', marks: 24, gate: 'clears:3' },
   { itemId: 'ashwood_axe', marks: 24, gate: 'clears:3' },
   { itemId: 'goldleaf_sickle', marks: 24, gate: 'clears:3' },

--- a/src/sim/content/delves/shop.ts
+++ b/src/sim/content/delves/shop.ts
@@ -18,15 +18,16 @@
 //   `delveMarkPayout` and `delveBonusMarksFor` in src/sim/delves/runs.ts).
 //   That puts a Normal-only player here around 3-9 Marks/day by lockpick
 //   skill (the chest's loot tier sets the bonus), and a flawless Heroic runner
-//   at 12 in-window (24 at the Litany). Past the window a grinder still drips
-//   diminished BASE Marks per clear without bound (Heroic 1, doubled at the
-//   Litany), so this is a bounded full-rate window plus a slow drip, not a
-//   hard daily cap. Prices are deliberately STEEP relative to that income, the reward gear is a clear upgrade over the silver-vendor
-//   armor of the same tier (Smith Haldren's commons: chainmail vest 60 armor,
-//   leather jerkin 40, robe 22, trousers 24), so each piece is
-//   uncommon-or-rare quality with stat bonuses on top. A casual player kits
-//   out over ~2-3 weeks; the Heroic signature rares are a multi-week goal
-//   each.
+//   at 12 in-window; the Litany's 2x lifts those bands to 18 flawless Normal
+//   and 24 flawless Heroic. Past the window a grinder still drips diminished
+//   BASE Marks per clear without bound (Heroic 1, doubled at the Litany), so
+//   this is a bounded full-rate window plus a slow drip, not a hard daily
+//   cap. Prices are deliberately STEEP relative to that income, the reward
+//   gear is a clear upgrade over the silver-vendor armor of the same tier
+//   (Smith Haldren's commons: chainmail vest 60 armor, leather jerkin 40,
+//   robe 22, trousers 24), so each piece is uncommon-or-rare quality with
+//   stat bonuses on top. A casual player kits out over ~2-3 weeks; the Heroic
+//   signature rares are a multi-week goal each.
 //
 //   FORWARD DESIGN: later delves are tuned to cost FAR more Marks (and reward
 //   far more Marks per clear), so this tier's prices are the floor of a long

--- a/src/sim/content/delves/shop.ts
+++ b/src/sim/content/delves/shop.ts
@@ -17,10 +17,11 @@
 //   every later clear pays a diminished base only, with no bonus Marks (see
 //   `delveMarkPayout` and `delveBonusMarksFor` in src/sim/delves/runs.ts).
 //   That puts a Normal-only player here around 3-9 Marks/day by lockpick
-//   skill (the chest's loot tier sets the bonus),
-//   and a flawless Heroic runner at 12 (24 at the Litany), a bounded daily
-//   ceiling rather than an open grind. Prices are deliberately STEEP relative
-//   to that income, the reward gear is a clear upgrade over the silver-vendor
+//   skill (the chest's loot tier sets the bonus), and a flawless Heroic runner
+//   at 12 in-window (24 at the Litany). Past the window a grinder still drips
+//   diminished BASE Marks per clear without bound (Heroic 1, doubled at the
+//   Litany), so this is a bounded full-rate window plus a slow drip, not a
+//   hard daily cap. Prices are deliberately STEEP relative to that income, the reward gear is a clear upgrade over the silver-vendor
 //   armor of the same tier (Smith Haldren's commons: chainmail vest 60 armor,
 //   leather jerkin 40, robe 22, trousers 24), so each piece is
 //   uncommon-or-rare quality with stat bonuses on top. A casual player kits

--- a/src/sim/delves/drowned_litany_rite.ts
+++ b/src/sim/delves/drowned_litany_rite.ts
@@ -18,7 +18,12 @@ import {
   type RiteShrineKind,
 } from '../types';
 import { RITE_INTENSITY } from './rite_tuning';
-import { collectDelveChestLoot, grantDelveRewards, openDelveSurfaceExit } from './runs';
+import {
+  collectDelveChestLoot,
+  delveBonusMarksFor,
+  grantDelveRewards,
+  openDelveSurfaceExit,
+} from './runs';
 
 const RITE_PLAYBACK_STEP = 0.6; // seconds between sequence lights
 const RITE_REPEAT_GAP = 1.2; // longer dark beat between repeat playbacks
@@ -81,10 +86,13 @@ function grantRiteBonus(ctx: SimContext, run: DelveRun, tier: LootTier): void {
   const bonusCopper = Math.round(baseCopper * (reward.copperMult - 1));
   // The Drowned Litany pays double Marks vs. the Collapsed Reliquary's lockpick
   // chest (delve index 1 vs. 0): a deliberate currency-curve step.
-  const bonusMarks = reward.bonusMarks * 2;
+  const fullBonusMarks = reward.bonusMarks * 2;
   for (const pid of members) {
     const meta = ctx.players.get(pid);
     if (!meta) continue;
+    // Bonus Marks only ride a clear inside the daily window (per member); the
+    // copper bonus and the loot tier are unaffected. See delveBonusMarksFor.
+    const bonusMarks = delveBonusMarksFor(meta, fullBonusMarks);
     meta.delveMarks += bonusMarks;
     meta.copper += bonusCopper;
     ctx.emit({ type: 'lockpickBonus', tier, marks: bonusMarks, copper: bonusCopper, pid });

--- a/src/sim/delves/drowned_litany_rite.ts
+++ b/src/sim/delves/drowned_litany_rite.ts
@@ -73,10 +73,16 @@ function emitPartyLog(ctx: SimContext, run: DelveRun, text: string, color: strin
   }
 }
 
-function grantRiteBonus(ctx: SimContext, run: DelveRun, tier: LootTier): void {
+// Paid to exactly the members grantDelveRewards just credited (see
+// delveBonusMarksFor in runs.ts for why the credited list is load-bearing).
+function grantRiteBonus(
+  ctx: SimContext,
+  run: DelveRun,
+  tier: LootTier,
+  creditedPids: number[],
+): void {
   const reward = LOCKPICK_TIER_REWARD[tier];
   const delve = DELVES[run.delveId];
-  const members = run.partyKey ? ctx.partyMembersForKey(run.partyKey) : [];
   const tierDef = delve.tiers.find((t) => t.id === run.tierId);
   const baseCopper = Math.round(
     ((tierDef?.copperMin ?? delve.baseRewards.copperMin) +
@@ -87,7 +93,7 @@ function grantRiteBonus(ctx: SimContext, run: DelveRun, tier: LootTier): void {
   // The Drowned Litany pays double Marks vs. the Collapsed Reliquary's lockpick
   // chest (delve index 1 vs. 0): a deliberate currency-curve step.
   const fullBonusMarks = reward.bonusMarks * 2;
-  for (const pid of members) {
+  for (const pid of creditedPids) {
     const meta = ctx.players.get(pid);
     if (!meta) continue;
     // Bonus Marks only ride a clear inside the daily window (per member); the
@@ -244,8 +250,8 @@ function openDrownedReliquary(
     obj.name = 'Opened Drowned Reliquary';
     obj.templateId = 'delve_drowned_reliquary_open';
   }
-  grantDelveRewards(ctx, run);
-  grantRiteBonus(ctx, run, tier);
+  const credited = grantDelveRewards(ctx, run);
+  grantRiteBonus(ctx, run, tier, credited);
   openDelveSurfaceExit(ctx, run);
   for (const pid of members) {
     ctx.emit({

--- a/src/sim/delves/lockpick_controller.ts
+++ b/src/sim/delves/lockpick_controller.ts
@@ -399,8 +399,8 @@ function lockpickSucceed(
     obj.name = 'Opened Chest';
     obj.templateId = 'delve_reward_chest';
   }
-  grantDelveRewards(ctx, run);
-  grantLockpickBonus(ctx, run, grantedTier);
+  const credited = grantDelveRewards(ctx, run);
+  grantLockpickBonus(ctx, run, grantedTier, credited);
   openDelveSurfaceExit(ctx, run);
   ctx.emit({
     type: 'delveChestLoot',
@@ -425,18 +425,19 @@ function lockpickSucceed(
   run.lockpick = null;
 }
 
-/** Loot-tier bonus on top of the base delve chest rewards (marks + copper). */
+/** Loot-tier bonus on top of the base delve chest rewards (marks + copper),
+ * paid to exactly the members grantDelveRewards just credited. */
 function grantLockpickBonus(
   ctx: SimContext,
   run: DelveRun,
   tier: 'premium' | 'medium' | 'low',
+  creditedPids: number[],
 ): void {
   const reward = LOCKPICK_TIER_REWARD[tier];
   const delve = DELVES[run.delveId];
-  const members = run.partyKey ? ctx.partyMembersForKey(run.partyKey) : [];
   const baseCopper = Math.round((delve.baseRewards.copperMin + delve.baseRewards.copperMax) / 2);
   const bonusCopper = Math.round(baseCopper * (reward.copperMult - 1));
-  for (const pid of members) {
+  for (const pid of creditedPids) {
     const meta = ctx.players.get(pid);
     if (!meta) continue;
     // Bonus Marks only ride a clear inside the daily window (per member); the
@@ -444,8 +445,9 @@ function grantLockpickBonus(
     const bonusMarks = delveBonusMarksFor(meta, reward.bonusMarks);
     meta.delveMarks += bonusMarks;
     meta.copper += bonusCopper;
-    // Structured (no prose crosses the sim boundary): the client builds the
-    // localized "spoils" line from the tier token and formats the numbers.
+    // Structured (no prose crosses the sim boundary): the client renders a
+    // tier-token "spoils" line from this event; the marks/copper fields carry
+    // the actually granted amounts for any consumer that does read them.
     ctx.emit({
       type: 'lockpickBonus',
       tier,

--- a/src/sim/delves/lockpick_controller.ts
+++ b/src/sim/delves/lockpick_controller.ts
@@ -61,7 +61,7 @@ import {
   dist2d,
   type Entity,
 } from '../types';
-import { grantDelveRewards, openDelveSurfaceExit } from './runs';
+import { delveBonusMarksFor, grantDelveRewards, openDelveSurfaceExit } from './runs';
 
 /** Resolve the locked-chest object + run for an acting player, with all the
  * proximity/eligibility guards. Returns null (after emitting an error) on any
@@ -439,14 +439,17 @@ function grantLockpickBonus(
   for (const pid of members) {
     const meta = ctx.players.get(pid);
     if (!meta) continue;
-    meta.delveMarks += reward.bonusMarks;
+    // Bonus Marks only ride a clear inside the daily window (per member); the
+    // copper bonus and the loot tier are unaffected. See delveBonusMarksFor.
+    const bonusMarks = delveBonusMarksFor(meta, reward.bonusMarks);
+    meta.delveMarks += bonusMarks;
     meta.copper += bonusCopper;
     // Structured (no prose crosses the sim boundary): the client builds the
     // localized "spoils" line from the tier token and formats the numbers.
     ctx.emit({
       type: 'lockpickBonus',
       tier,
-      marks: reward.bonusMarks,
+      marks: bonusMarks,
       copper: bonusCopper,
       pid,
     });

--- a/src/sim/delves/runs.ts
+++ b/src/sim/delves/runs.ts
@@ -600,9 +600,10 @@ export function freeDelveRun(ctx: SimContext, run: DelveRun): void {
 
 export function updateDelveRuns(ctx: SimContext): void {
   for (const run of ctx.delveRuns) {
-    // The lockpick per-step clock is enforced for EVERY run (a solo offline run
-    // has partyKey === null and is skipped by tickDelveRun below, but its lock
-    // must still time out identically to an online/headless one).
+    // The lockpick per-step clock is enforced for EVERY run slot. partyKey ===
+    // null means a FREE (unclaimed) slot, skipped by tickDelveRun below; a
+    // claimed solo run carries `solo:<pid>` (claimDelveRun via instanceKeyFor),
+    // so it ticks like any party run and its lock times out identically.
     ctx.tickLockpickTimeout(run);
     if (run.partyKey !== null) tickDelveRun(ctx, run);
   }
@@ -730,28 +731,40 @@ export function onDelveBossDefeated(ctx: SimContext, run: DelveRun): void {
 // Reads `markClears` BEFORE the caller increments it. NOTE: at the base of 1 Mark
 // the +30% rounds to no per-clear difference; the Heroic mark advantage comes from
 // the post-3 guaranteed-vs-50% rule. Uses `ctx.rng` only (deterministic).
+// The daily full-payout window: this many clears per reset day (one tally
+// shared across delves and tiers) pay full base Marks AND may carry chest/rite
+// bonus Marks. Both comparators below read this ONE constant so the base and
+// bonus windows cannot desync under a retune.
+export const DELVE_DAILY_FULL_CLEARS = 3;
+
 export function delveMarkPayout(ctx: SimContext, run: DelveRun, meta: PlayerMeta): number {
   const isHeroic = run.tierId === 'heroic';
-  // First 3 clears/day pay full: 1 Normal / 2 Heroic (§7.4). After that, Heroic
-  // still guarantees 1; Normal has a 50% shot. (The old `Math.round(rewardMult)`
-  // rounded Heroic's 1.3 down to 1, silently erasing the Heroic advantage.)
-  if (meta.delveDaily.markClears < 3) return isHeroic ? 2 : 1;
+  // The first DELVE_DAILY_FULL_CLEARS clears/day pay full: 1 Normal / 2 Heroic
+  // (§7.4); this reads markClears BEFORE the caller increments it, hence `<`.
+  // After that, Heroic still guarantees 1; Normal has a 50% shot. (The old
+  // `Math.round(rewardMult)` rounded Heroic's 1.3 down to 1, silently erasing
+  // the Heroic advantage.)
+  if (meta.delveDaily.markClears < DELVE_DAILY_FULL_CLEARS) return isHeroic ? 2 : 1;
   if (isHeroic) return 1;
   return ctx.rng.chance(0.5) ? 1 : 0;
 }
 
 // Chest/rite bonus Marks ride the SAME daily window as the base payout above: a
-// clear whose base Marks were paid inside the first-3-clears window may carry
-// its loot-tier bonus Marks; every later clear pays base Marks only. Without
-// this, the uncapped premium bonuses (+2 lockpick / +4 rite) let an all-day
-// grinder outrun the shop pricing the window exists to protect. Both callers
-// (grantLockpickBonus, grantRiteBonus) run AFTER grantDelveClearTo incremented
-// `markClears` for the clear the bonus rides, so that clear was in-window
-// exactly when the incremented tally is still <= 3. Bonus COPPER is
-// deliberately not windowed (copper is not the paced currency), and neither is
-// the loot tier itself. Draws no rng.
-export function delveBonusMarksFor(meta: PlayerMeta, bonusMarks: number): number {
-  return meta.delveDaily.markClears <= 3 ? bonusMarks : 0;
+// clear whose base Marks were paid inside the full-payout window may carry its
+// loot-tier bonus Marks; every later clear pays base Marks only. Without this,
+// the uncapped premium bonuses (+2 lockpick / +4 rite) let an all-day grinder
+// outrun the shop pricing the window exists to protect. Both callers
+// (grantLockpickBonus, grantRiteBonus) iterate the member list
+// grantDelveRewards just credited, so `markClears` was incremented for the
+// clear the bonus rides: that clear was in-window exactly when the incremented
+// tally is still `<=` the window (the payout above reads pre-increment, hence
+// its `<`). Bonus COPPER is deliberately not windowed (copper is not the paced
+// currency), and neither is the loot tier itself. Draws no rng.
+export function delveBonusMarksFor(
+  meta: Pick<PlayerMeta, 'delveDaily'>,
+  bonusMarks: number,
+): number {
+  return meta.delveDaily.markClears <= DELVE_DAILY_FULL_CLEARS ? bonusMarks : 0;
 }
 
 // Unlock the next un-owned lore journal entry (PRD §6.4 / §7.6, five entries
@@ -806,16 +819,24 @@ export function grantDelveClearTo(
   ctx.emit({ type: 'delveComplete', delveId: run.delveId, tierId: run.tierId, pid });
 }
 
-export function grantDelveRewards(ctx: SimContext, run: DelveRun): void {
-  if (run.completed) return;
+// Returns the members actually credited with this clear (empty when the run
+// was already completed). The chest/rite bonus granters iterate THAT list, so
+// a bonus can only ever ride a clear this call just granted: the per-member
+// `markClears` tally the window check reads is the one this pass incremented,
+// structurally, not by call-site convention.
+export function grantDelveRewards(ctx: SimContext, run: DelveRun): number[] {
+  if (run.completed) return [];
   run.completed = true;
   const delve = DELVES[run.delveId];
   const members = run.partyKey ? ctx.partyMembersForKey(run.partyKey) : [];
+  const credited: number[] = [];
   for (const pid of members) {
     const meta = ctx.players.get(pid);
     if (!meta) continue;
     grantDelveClearTo(ctx, run, delve, meta, pid);
+    credited.push(pid);
   }
+  return credited;
 }
 
 export function openDelveSurfaceExit(ctx: SimContext, run: DelveRun): void {

--- a/src/sim/delves/runs.ts
+++ b/src/sim/delves/runs.ts
@@ -740,6 +740,20 @@ export function delveMarkPayout(ctx: SimContext, run: DelveRun, meta: PlayerMeta
   return ctx.rng.chance(0.5) ? 1 : 0;
 }
 
+// Chest/rite bonus Marks ride the SAME daily window as the base payout above: a
+// clear whose base Marks were paid inside the first-3-clears window may carry
+// its loot-tier bonus Marks; every later clear pays base Marks only. Without
+// this, the uncapped premium bonuses (+2 lockpick / +4 rite) let an all-day
+// grinder outrun the shop pricing the window exists to protect. Both callers
+// (grantLockpickBonus, grantRiteBonus) run AFTER grantDelveClearTo incremented
+// `markClears` for the clear the bonus rides, so that clear was in-window
+// exactly when the incremented tally is still <= 3. Bonus COPPER is
+// deliberately not windowed (copper is not the paced currency), and neither is
+// the loot tier itself. Draws no rng.
+export function delveBonusMarksFor(meta: PlayerMeta, bonusMarks: number): number {
+  return meta.delveDaily.markClears <= 3 ? bonusMarks : 0;
+}
+
 // Unlock the next un-owned lore journal entry (PRD §6.4 / §7.6, five entries
 // across repeat clears). Emits a stable lore id (no English crosses the sim
 // boundary); the client localises it via the `delveUi.lore.*` keys.

--- a/src/sim/delves/runs.ts
+++ b/src/sim/delves/runs.ts
@@ -725,18 +725,19 @@ export function onDelveBossDefeated(ctx: SimContext, run: DelveRun): void {
   }
 }
 
-// Base Marks payout for one clear. PRD §6.5 FR-5.3: full Marks for the first 3
-// completions per UTC day, then a diminished payout (Heroic 1 guaranteed, Normal
-// 50% chance of 1). §6.7 FR-7.1 Heroic "+30% Marks" rides the tier `rewardMult`.
-// Reads `markClears` BEFORE the caller increments it. NOTE: at the base of 1 Mark
-// the +30% rounds to no per-clear difference; the Heroic mark advantage comes from
-// the post-3 guaranteed-vs-50% rule. Uses `ctx.rng` only (deterministic).
 // The daily full-payout window: this many clears per reset day (one tally
 // shared across delves and tiers) pay full base Marks AND may carry chest/rite
 // bonus Marks. Both comparators below read this ONE constant so the base and
 // bonus windows cannot desync under a retune.
 export const DELVE_DAILY_FULL_CLEARS = 3;
 
+// Base Marks payout for one clear. PRD §6.5 FR-5.3: full Marks for the first 3
+// completions per reset day (1 Normal / 2 Heroic), then a diminished payout
+// (Heroic 1 guaranteed, Normal 50% chance of 1). Reads `markClears` BEFORE the
+// caller increments it. NOTE: the §6.7 FR-7.1 Heroic "+30% Marks" rides the
+// tier `rewardMult` (1.3) but rounds to no per-clear difference at this base;
+// the real Heroic edge is the in-window 2-vs-1 plus the post-window
+// guaranteed-vs-50% rule. Uses `ctx.rng` only (deterministic).
 export function delveMarkPayout(ctx: SimContext, run: DelveRun, meta: PlayerMeta): number {
   const isHeroic = run.tierId === 'heroic';
   // The first DELVE_DAILY_FULL_CLEARS clears/day pay full: 1 Normal / 2 Heroic
@@ -825,6 +826,12 @@ export function grantDelveClearTo(
 // `markClears` tally the window check reads is the one this pass incremented,
 // structurally, not by call-site convention.
 export function grantDelveRewards(ctx: SimContext, run: DelveRun): number[] {
+  // An already-completed run credits nobody, so the downstream granters pay NO
+  // bonus at all (no marks, no copper, no lockpickBonus event); deliberate,
+  // and safer than the old double-pay, but it couples the whole bonus to this
+  // flag. A future second grant path must carry its own credited list rather
+  // than fall back to party membership. Pinned by the "already-completed"
+  // tests in tests/delves.test.ts.
   if (run.completed) return [];
   run.completed = true;
   const delve = DELVES[run.delveId];

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -11872,10 +11872,6 @@ export class Sim {
     runsMod.grantDelveClearTo(this.ctx, run, delve, meta, pid);
   }
 
-  private grantDelveRewards(run: DelveRun): void {
-    runsMod.grantDelveRewards(this.ctx, run);
-  }
-
   private openDelveSurfaceExit(run: DelveRun): void {
     runsMod.openDelveSurfaceExit(this.ctx, run);
   }

--- a/tests/delves.test.ts
+++ b/tests/delves.test.ts
@@ -1020,6 +1020,101 @@ describe('delve reward chest + surface exit flow', () => {
     expect(run.objectState[exitObj!].open).toBe(true);
   });
 
+  it('the third clear of the day still carries the premium chest bonus (window boundary)', () => {
+    const sim = makeSim();
+    sim.setPlayerLevel(DELVES.collapsed_reliquary.minLevel);
+    const meta = (sim as any).players.get(sim.playerId);
+    meta.delveDaily.markClears = 2; // this clear is #3: the last one inside the window
+    const run = enterFinale(sim);
+    killBoss(sim, run);
+    const marksBefore = sim.delveMarksFor(sim.playerId);
+    pickLockFlawless(sim, run, 1);
+    const events = sim.drainEvents();
+    // base in-window Normal (+1) + premium ante bonus (+2)
+    expect(sim.delveMarksFor(sim.playerId)).toBe(marksBefore + 3);
+    const bonus = events.find((e) => e.type === 'lockpickBonus');
+    expect(bonus).toBeDefined();
+    expect((bonus as Extract<typeof bonus, { type: 'lockpickBonus' }>).marks).toBe(2);
+  });
+
+  it('a post-window clear pays no chest bonus Marks; copper bonus and loot tier survive', () => {
+    const sim = makeSim();
+    sim.setPlayerLevel(DELVES.collapsed_reliquary.minLevel);
+    const meta = (sim as any).players.get(sim.playerId);
+    meta.delveDaily.markClears = 3; // the daily window is already spent
+    const run = enterFinale(sim);
+    killBoss(sim, run);
+    const marksBefore = sim.delveMarksFor(sim.playerId);
+    const chestId = pickLockFlawless(sim, run, 1);
+    const events = sim.drainEvents();
+    // Base post-window Normal is a 50% roll (0 or 1); the +2 premium bonus must not land.
+    expect(sim.delveMarksFor(sim.playerId) - marksBefore).toBeLessThanOrEqual(1);
+    const bonus = events.find((e) => e.type === 'lockpickBonus');
+    expect(bonus).toBeDefined();
+    const b = bonus as Extract<typeof bonus, { type: 'lockpickBonus' }>;
+    expect(b.tier).toBe('premium');
+    expect(b.marks).toBe(0);
+    expect(b.copper).toBeGreaterThan(0); // the copper half of the bonus is not windowed
+    expect(run.objectState[chestId].lootedTier).toBe('premium'); // nor is the loot tier
+  });
+
+  it('the Litany rite premium bonus pays doubled Marks inside the window and zero after it', () => {
+    for (const [markClearsBefore, expectedBonus] of [
+      [2, 4],
+      [3, 0],
+    ] as const) {
+      const sim = makeSim();
+      const meta = (sim as any).players.get(sim.playerId);
+      enterLitany(sim);
+      meta.delveDaily.markClears = markClearsBefore;
+      const run = sim.delveRunForPlayer(sim.playerId)!;
+      run.bountiful = false;
+      run.modules = ['litany_apse'];
+      run.moduleIndex = 0;
+      (sim as any).spawnDelveModule(run);
+      const boss = [...sim.entities.values()].find(
+        (e) => e.templateId === 'sister_nhalia_drowned_canticle',
+      )!;
+      (sim as any).dealDamage(
+        sim.player,
+        boss,
+        boss.maxHp + 1,
+        false,
+        'physical',
+        null,
+        'hit',
+        true,
+      );
+      sim.tick();
+      const st = run.drownedLitanyRite!;
+      // Choose Hard (the premium ceiling) at the reliquary, then skip the shrine
+      // playback phase: playback is presentation, the input rules are the test.
+      const reliquary = sim.entities.get(st.reliquaryId)!;
+      sim.player.pos = { ...reliquary.pos };
+      sim.player.prevPos = { ...reliquary.pos };
+      sim.delveRiteChoose('hard');
+      st.sequencePlaying = false;
+      const marksBefore = sim.delveMarksFor(sim.playerId);
+      for (const kind of [...st.sequence]) {
+        const shrineId = st.shrineEntityIds[kind];
+        const shrine = sim.entities.get(shrineId)!;
+        sim.player.pos = { ...shrine.pos };
+        sim.player.prevPos = { ...shrine.pos };
+        expect(sim.delveInteract(shrineId)).toBe(true);
+      }
+      const events = sim.drainEvents();
+      const bonus = events.find((e) => e.type === 'lockpickBonus');
+      expect(bonus).toBeDefined();
+      const b = bonus as Extract<typeof bonus, { type: 'lockpickBonus' }>;
+      expect(b.tier).toBe('premium');
+      expect(b.marks).toBe(expectedBonus); // the Litany's 2x rides the same window
+      const delta = sim.delveMarksFor(sim.playerId) - marksBefore;
+      // Base Litany Normal pays 2 in-window; post-window it is a 50% roll of 0 or 2.
+      if (markClearsBefore === 2) expect(delta).toBe(2 + 4);
+      else expect(delta).toBeLessThanOrEqual(2);
+    }
+  });
+
   it('flawless solve stages class-tuned gear loot and collect grants it to inventory', () => {
     const sim = makeSim(); // warrior
     sim.setPlayerLevel(DELVES.collapsed_reliquary.minLevel);

--- a/tests/delves.test.ts
+++ b/tests/delves.test.ts
@@ -1054,65 +1054,108 @@ describe('delve reward chest + surface exit flow', () => {
     const b = bonus as Extract<typeof bonus, { type: 'lockpickBonus' }>;
     expect(b.tier).toBe('premium');
     expect(b.marks).toBe(0);
-    expect(b.copper).toBeGreaterThan(0); // the copper half of the bonus is not windowed
+    // The copper half of the bonus is not windowed, and stays the full premium
+    // amount: round((8 + 14) / 2) * (copperMult 2 - 1) = 11.
+    expect(b.copper).toBe(11);
     expect(run.objectState[chestId].lootedTier).toBe('premium'); // nor is the loot tier
   });
 
-  it('the Litany rite premium bonus pays doubled Marks inside the window and zero after it', () => {
-    for (const [markClearsBefore, expectedBonus] of [
-      [2, 4],
-      [3, 0],
-    ] as const) {
-      const sim = makeSim();
-      const meta = (sim as any).players.get(sim.playerId);
-      enterLitany(sim);
-      meta.delveDaily.markClears = markClearsBefore;
-      const run = sim.delveRunForPlayer(sim.playerId)!;
-      run.bountiful = false;
-      run.modules = ['litany_apse'];
-      run.moduleIndex = 0;
-      (sim as any).spawnDelveModule(run);
-      const boss = [...sim.entities.values()].find(
-        (e) => e.templateId === 'sister_nhalia_drowned_canticle',
-      )!;
-      (sim as any).dealDamage(
-        sim.player,
-        boss,
-        boss.maxHp + 1,
-        false,
-        'physical',
-        null,
-        'hit',
-        true,
-      );
-      sim.tick();
-      const st = run.drownedLitanyRite!;
-      // Choose Hard (the premium ceiling) at the reliquary, then skip the shrine
-      // playback phase: playback is presentation, the input rules are the test.
-      const reliquary = sim.entities.get(st.reliquaryId)!;
-      sim.player.pos = { ...reliquary.pos };
-      sim.player.prevPos = { ...reliquary.pos };
-      sim.delveRiteChoose('hard');
-      st.sequencePlaying = false;
-      const marksBefore = sim.delveMarksFor(sim.playerId);
-      for (const kind of [...st.sequence]) {
-        const shrineId = st.shrineEntityIds[kind];
-        const shrine = sim.entities.get(shrineId)!;
-        sim.player.pos = { ...shrine.pos };
-        sim.player.prevPos = { ...shrine.pos };
-        expect(sim.delveInteract(shrineId)).toBe(true);
-      }
-      const events = sim.drainEvents();
-      const bonus = events.find((e) => e.type === 'lockpickBonus');
-      expect(bonus).toBeDefined();
-      const b = bonus as Extract<typeof bonus, { type: 'lockpickBonus' }>;
-      expect(b.tier).toBe('premium');
-      expect(b.marks).toBe(expectedBonus); // the Litany's 2x rides the same window
-      const delta = sim.delveMarksFor(sim.playerId) - marksBefore;
-      // Base Litany Normal pays 2 in-window; post-window it is a 50% roll of 0 or 2.
-      if (markClearsBefore === 2) expect(delta).toBe(2 + 4);
-      else expect(delta).toBeLessThanOrEqual(2);
+  it('the bonus window is per member: a spent partner earns 0 while a fresh one is paid', () => {
+    const sim = makeSim();
+    const p2 = sim.addPlayer('warrior', 'Duoist');
+    sim.partyInvite(p2, sim.playerId);
+    sim.partyAccept(p2);
+    for (const pid of [sim.playerId, p2]) {
+      sim.setPlayerLevel(DELVES.collapsed_reliquary.minLevel, pid);
     }
+    // The picker has ground out today's window; the partner is fresh.
+    (sim as any).players.get(sim.playerId).delveDaily.markClears = 3;
+    const door = DELVES.collapsed_reliquary.doorPos;
+    for (const pid of [sim.playerId, p2]) {
+      const e = sim.entities.get(pid)!;
+      e.pos.x = door.x;
+      e.pos.z = door.z;
+      e.pos.y = terrainHeight(door.x, door.z, sim.cfg.seed);
+      e.prevPos = { ...e.pos };
+      sim.enterDelve('collapsed_reliquary', 'normal', pid);
+    }
+    const run = sim.delveRunForPlayer(sim.playerId)!;
+    run.bountiful = false;
+    run.modules = ['reliquary_finale'];
+    run.moduleIndex = 0;
+    (sim as any).spawnDelveModule(run);
+    killBoss(sim, run);
+    pickLockFlawless(sim, run, 1);
+    const events = sim.drainEvents();
+    const bonuses = events.filter((e) => e.type === 'lockpickBonus') as Extract<
+      (typeof events)[number],
+      { type: 'lockpickBonus' }
+    >[];
+    expect(bonuses.map((b) => [b.pid, b.marks]).sort()).toEqual(
+      [
+        [sim.playerId, 0], // post-window: no bonus Marks off the same grant
+        [p2, 2], // fresh partner: full premium bonus
+      ].sort(),
+    );
+    for (const b of bonuses) expect(b.copper).toBe(11); // copper unwindowed for both
+  });
+
+  // Drive a full Drowned Litany rite (Hard intensity, flawless) and return the
+  // spoils facts the window tests assert against. Playback is skipped: it is
+  // presentation; the input rules are what the tests exercise.
+  function runLitanyRiteFlawless(markClearsBefore: number) {
+    const sim = makeSim();
+    const meta = (sim as any).players.get(sim.playerId);
+    enterLitany(sim);
+    meta.delveDaily.markClears = markClearsBefore;
+    const run = sim.delveRunForPlayer(sim.playerId)!;
+    run.bountiful = false;
+    run.modules = ['litany_apse'];
+    run.moduleIndex = 0;
+    (sim as any).spawnDelveModule(run);
+    const boss = [...sim.entities.values()].find(
+      (e) => e.templateId === 'sister_nhalia_drowned_canticle',
+    )!;
+    (sim as any).dealDamage(sim.player, boss, boss.maxHp + 1, false, 'physical', null, 'hit', true);
+    sim.tick();
+    const st = run.drownedLitanyRite!;
+    const reliquary = sim.entities.get(st.reliquaryId)!;
+    sim.player.pos = { ...reliquary.pos };
+    sim.player.prevPos = { ...reliquary.pos };
+    sim.delveRiteChoose('hard'); // the premium ceiling
+    st.sequencePlaying = false;
+    const marksBefore = sim.delveMarksFor(sim.playerId);
+    for (const kind of [...st.sequence]) {
+      const shrineId = st.shrineEntityIds[kind];
+      const shrine = sim.entities.get(shrineId)!;
+      sim.player.pos = { ...shrine.pos };
+      sim.player.prevPos = { ...shrine.pos };
+      expect(sim.delveInteract(shrineId)).toBe(true);
+    }
+    const events = sim.drainEvents();
+    const bonus = events.find((e) => e.type === 'lockpickBonus');
+    expect(bonus).toBeDefined();
+    const b = bonus as Extract<typeof bonus, { type: 'lockpickBonus' }>;
+    return { sim, run, st, b, delta: sim.delveMarksFor(sim.playerId) - marksBefore };
+  }
+
+  it('the Litany rite premium bonus pays doubled Marks inside the window', () => {
+    const { b, delta } = runLitanyRiteFlawless(2);
+    expect(b.tier).toBe('premium');
+    expect(b.marks).toBe(4); // the Litany's 2x on the premium bonus
+    expect(delta).toBe(2 + 4); // base Litany Normal in-window (2) + bonus
+  });
+
+  it('a post-window Litany rite pays zero bonus Marks; its copper and tier survive', () => {
+    const { run, st, b, delta } = runLitanyRiteFlawless(3);
+    expect(b.tier).toBe('premium');
+    expect(b.marks).toBe(0); // the 2x rides the same window
+    // Rite bonus copper comes from the Litany's own copper band, not the
+    // chest's: round((18 + 30) / 2) * (copperMult 2 - 1) = 24, unwindowed.
+    expect(b.copper).toBe(24);
+    expect(run.objectState[st.reliquaryId].lootedTier).toBe('premium');
+    // Base post-window Litany Normal is a 50% roll of 0 or 2; no bonus on top.
+    expect(delta).toBeLessThanOrEqual(2);
   });
 
   it('flawless solve stages class-tuned gear loot and collect grants it to inventory', () => {

--- a/tests/delves.test.ts
+++ b/tests/delves.test.ts
@@ -33,14 +33,18 @@ import {
   LITANY_PUZZLE_KINDS,
   litanyHatchlingSpawnClear,
 } from '../src/sim/delves/drowned_litany_rooms';
-import { clampDelveModuleBounds, rollDelveAffixes } from '../src/sim/delves/runs';
+import {
+  clampDelveModuleBounds,
+  grantDelveRewards,
+  rollDelveAffixes,
+} from '../src/sim/delves/runs';
 import { createMob } from '../src/sim/entity';
 import { polygonContainsPoint } from '../src/sim/geometry2d';
 import { solveLockActions } from '../src/sim/lockpick';
 import { PLAYER_BODY_RADIUS } from '../src/sim/pathfind';
 import { Rng } from '../src/sim/rng';
 import { DELVE_IMPLEMENTED_AFFIXES, Sim } from '../src/sim/sim';
-import { DT, type WorldContent } from '../src/sim/types';
+import { type DelveRun, DT, type WorldContent } from '../src/sim/types';
 import { terrainHeight } from '../src/sim/world';
 
 const DELVE_TEST_WORLD: WorldContent = {
@@ -1045,6 +1049,7 @@ describe('delve reward chest + surface exit flow', () => {
     const run = enterFinale(sim);
     killBoss(sim, run);
     const marksBefore = sim.delveMarksFor(sim.playerId);
+    const copperBefore = meta.copper;
     const chestId = pickLockFlawless(sim, run, 1);
     const events = sim.drainEvents();
     // Base post-window Normal is a 50% roll (0 or 1); the +2 premium bonus must not land.
@@ -1057,6 +1062,10 @@ describe('delve reward chest + surface exit flow', () => {
     // The copper half of the bonus is not windowed, and stays the full premium
     // amount: round((8 + 14) / 2) * (copperMult 2 - 1) = 11.
     expect(b.copper).toBe(11);
+    // The WALLET too, not just the event payload: base clear copper (8..14)
+    // plus the full unwindowed 11 bonus.
+    expect(meta.copper - copperBefore).toBeGreaterThanOrEqual(8 + 11);
+    expect(meta.copper - copperBefore).toBeLessThanOrEqual(14 + 11);
     expect(run.objectState[chestId].lootedTier).toBe('premium'); // nor is the loot tier
   });
 
@@ -1085,6 +1094,8 @@ describe('delve reward chest + surface exit flow', () => {
     run.moduleIndex = 0;
     (sim as any).spawnDelveModule(run);
     killBoss(sim, run);
+    const marksP1Before = sim.delveMarksFor(sim.playerId);
+    const marksP2Before = sim.delveMarksFor(p2);
     pickLockFlawless(sim, run, 1);
     const events = sim.drainEvents();
     const bonuses = events.filter((e) => e.type === 'lockpickBonus') as Extract<
@@ -1098,11 +1109,80 @@ describe('delve reward chest + surface exit flow', () => {
       ].sort(),
     );
     for (const b of bonuses) expect(b.copper).toBe(11); // copper unwindowed for both
+    // The WALLETS agree with the events: the fresh partner banks base
+    // in-window (1) + bonus (2); the spent picker gains at most the
+    // post-window 50% base roll.
+    expect(sim.delveMarksFor(p2)).toBe(marksP2Before + 3);
+    expect(sim.delveMarksFor(sim.playerId) - marksP1Before).toBeLessThanOrEqual(1);
   });
 
-  // Drive a full Drowned Litany rite (Hard intensity, flawless) and return the
-  // spoils facts the window tests assert against. Playback is skipped: it is
+  it('grantDelveRewards returns the credited members once and [] on a completed run', () => {
+    const sim = makeSim();
+    sim.setPlayerLevel(DELVES.collapsed_reliquary.minLevel);
+    const run = enterFinale(sim);
+    killBoss(sim, run);
+    const meta = (sim as any).players.get(sim.playerId);
+    const clearsBefore = meta.delveDaily.markClears;
+    // First grant: the solo picker is credited and the daily tally advances.
+    expect(grantDelveRewards((sim as any).ctx, run)).toEqual([sim.playerId]);
+    expect(meta.delveDaily.markClears).toBe(clearsBefore + 1);
+    // Second grant on the now-completed run: nobody is credited and the tally
+    // holds. This is what structurally starves the bonus granters.
+    expect(grantDelveRewards((sim as any).ctx, run)).toEqual([]);
+    expect(meta.delveDaily.markClears).toBe(clearsBefore + 1);
+  });
+
+  it('an already-completed run pays no chest bonus at all: no marks, no copper, no event', () => {
+    const sim = makeSim();
+    sim.setPlayerLevel(DELVES.collapsed_reliquary.minLevel);
+    const run = enterFinale(sim);
+    killBoss(sim, run);
+    const meta = (sim as any).players.get(sim.playerId);
+    run.completed = true; // a hypothetical earlier grant already consumed the clear
+    const marksBefore = sim.delveMarksFor(sim.playerId);
+    const copperBefore = meta.copper;
+    pickLockFlawless(sim, run, 1);
+    const events = sim.drainEvents();
+    // grantDelveRewards credits nobody, so the bonus granter pays nobody and
+    // stays silent; this pins that the granter follows the CREDITED list, not
+    // party membership.
+    expect(events.find((e) => e.type === 'lockpickBonus')).toBeUndefined();
+    expect(sim.delveMarksFor(sim.playerId)).toBe(marksBefore);
+    expect(meta.copper).toBe(copperBefore);
+    // The chest itself still opens and stages its loot (loot is not the bonus).
+    expect(events.find((e) => e.type === 'delveChestLoot')).toBeDefined();
+  });
+
+  function killLitanyBoss(sim: ReturnType<typeof makeSim>) {
+    const boss = [...sim.entities.values()].find(
+      (e) => e.templateId === 'sister_nhalia_drowned_canticle',
+    )!;
+    (sim as any).dealDamage(sim.player, boss, boss.maxHp + 1, false, 'physical', null, 'hit', true);
+    sim.tick();
+  }
+
+  // Walk the acting player through a flawless Hard rite via the real input path
+  // (delveRiteChoose + one delveInteract per shrine). Playback is skipped: it is
   // presentation; the input rules are what the tests exercise.
+  function driveRiteFlawless(sim: ReturnType<typeof makeSim>, run: DelveRun) {
+    const st = run.drownedLitanyRite!;
+    const reliquary = sim.entities.get(st.reliquaryId)!;
+    sim.player.pos = { ...reliquary.pos };
+    sim.player.prevPos = { ...reliquary.pos };
+    sim.delveRiteChoose('hard'); // the premium ceiling
+    st.sequencePlaying = false;
+    for (const kind of [...st.sequence]) {
+      const shrineId = st.shrineEntityIds[kind];
+      const shrine = sim.entities.get(shrineId)!;
+      sim.player.pos = { ...shrine.pos };
+      sim.player.prevPos = { ...shrine.pos };
+      expect(sim.delveInteract(shrineId)).toBe(true);
+    }
+    return st;
+  }
+
+  // Drive a full solo Drowned Litany rite and return the spoils facts the
+  // window tests assert against.
   function runLitanyRiteFlawless(markClearsBefore: number) {
     const sim = makeSim();
     const meta = (sim as any).players.get(sim.playerId);
@@ -1113,30 +1193,22 @@ describe('delve reward chest + surface exit flow', () => {
     run.modules = ['litany_apse'];
     run.moduleIndex = 0;
     (sim as any).spawnDelveModule(run);
-    const boss = [...sim.entities.values()].find(
-      (e) => e.templateId === 'sister_nhalia_drowned_canticle',
-    )!;
-    (sim as any).dealDamage(sim.player, boss, boss.maxHp + 1, false, 'physical', null, 'hit', true);
-    sim.tick();
-    const st = run.drownedLitanyRite!;
-    const reliquary = sim.entities.get(st.reliquaryId)!;
-    sim.player.pos = { ...reliquary.pos };
-    sim.player.prevPos = { ...reliquary.pos };
-    sim.delveRiteChoose('hard'); // the premium ceiling
-    st.sequencePlaying = false;
+    killLitanyBoss(sim);
     const marksBefore = sim.delveMarksFor(sim.playerId);
-    for (const kind of [...st.sequence]) {
-      const shrineId = st.shrineEntityIds[kind];
-      const shrine = sim.entities.get(shrineId)!;
-      sim.player.pos = { ...shrine.pos };
-      sim.player.prevPos = { ...shrine.pos };
-      expect(sim.delveInteract(shrineId)).toBe(true);
-    }
+    const copperBefore = meta.copper;
+    const st = driveRiteFlawless(sim, run);
     const events = sim.drainEvents();
     const bonus = events.find((e) => e.type === 'lockpickBonus');
     expect(bonus).toBeDefined();
     const b = bonus as Extract<typeof bonus, { type: 'lockpickBonus' }>;
-    return { sim, run, st, b, delta: sim.delveMarksFor(sim.playerId) - marksBefore };
+    return {
+      sim,
+      run,
+      st,
+      b,
+      delta: sim.delveMarksFor(sim.playerId) - marksBefore,
+      copperDelta: meta.copper - copperBefore,
+    };
   }
 
   it('the Litany rite premium bonus pays doubled Marks inside the window', () => {
@@ -1147,15 +1219,84 @@ describe('delve reward chest + surface exit flow', () => {
   });
 
   it('a post-window Litany rite pays zero bonus Marks; its copper and tier survive', () => {
-    const { run, st, b, delta } = runLitanyRiteFlawless(3);
+    const { run, st, b, delta, copperDelta } = runLitanyRiteFlawless(3);
     expect(b.tier).toBe('premium');
     expect(b.marks).toBe(0); // the 2x rides the same window
     // Rite bonus copper comes from the Litany's own copper band, not the
     // chest's: round((18 + 30) / 2) * (copperMult 2 - 1) = 24, unwindowed.
     expect(b.copper).toBe(24);
+    // The WALLET too, not just the event payload: base clear copper (18..30)
+    // plus the full unwindowed 24 bonus.
+    expect(copperDelta).toBeGreaterThanOrEqual(18 + 24);
+    expect(copperDelta).toBeLessThanOrEqual(30 + 24);
     expect(run.objectState[st.reliquaryId].lootedTier).toBe('premium');
     // Base post-window Litany Normal is a 50% roll of 0 or 2; no bonus on top.
     expect(delta).toBeLessThanOrEqual(2);
+  });
+
+  it('the rite bonus window is per member: a spent partner earns 0 while a fresh one is paid', () => {
+    const sim = makeSim();
+    const p2 = sim.addPlayer('warrior', 'Duoist');
+    sim.partyInvite(p2, sim.playerId);
+    sim.partyAccept(p2);
+    for (const pid of [sim.playerId, p2]) {
+      sim.setPlayerLevel(DELVES.drowned_litany.minLevel, pid);
+    }
+    // The picker has ground out today's window; the partner is fresh.
+    (sim as any).players.get(sim.playerId).delveDaily.markClears = 3;
+    const door = DELVES.drowned_litany.doorPos;
+    for (const pid of [sim.playerId, p2]) {
+      const e = sim.entities.get(pid)!;
+      e.pos.x = door.x;
+      e.pos.z = door.z;
+      e.pos.y = terrainHeight(door.x, door.z, sim.cfg.seed);
+      e.prevPos = { ...e.pos };
+      sim.enterDelve('drowned_litany', 'normal', pid);
+    }
+    const run = sim.delveRunForPlayer(sim.playerId)!;
+    run.bountiful = false;
+    run.modules = ['litany_apse'];
+    run.moduleIndex = 0;
+    (sim as any).spawnDelveModule(run);
+    killLitanyBoss(sim);
+    const marksP2Before = sim.delveMarksFor(p2);
+    driveRiteFlawless(sim, run);
+    const events = sim.drainEvents();
+    const bonuses = events.filter((e) => e.type === 'lockpickBonus') as Extract<
+      (typeof events)[number],
+      { type: 'lockpickBonus' }
+    >[];
+    expect(bonuses.map((b) => [b.pid, b.marks]).sort()).toEqual(
+      [
+        [sim.playerId, 0], // post-window: no bonus Marks off the same grant
+        [p2, 4], // fresh partner: the Litany's doubled premium bonus
+      ].sort(),
+    );
+    for (const b of bonuses) expect(b.copper).toBe(24); // copper unwindowed for both
+    // The fresh partner's wallet banks base in-window Litany Normal (2) + bonus (4).
+    expect(sim.delveMarksFor(p2)).toBe(marksP2Before + 6);
+  });
+
+  it('an already-completed Litany run pays no rite bonus at all: no marks, no copper, no event', () => {
+    const sim = makeSim();
+    enterLitany(sim);
+    const meta = (sim as any).players.get(sim.playerId);
+    const run = sim.delveRunForPlayer(sim.playerId)!;
+    run.bountiful = false;
+    run.modules = ['litany_apse'];
+    run.moduleIndex = 0;
+    (sim as any).spawnDelveModule(run);
+    killLitanyBoss(sim);
+    run.completed = true; // a hypothetical earlier grant already consumed the clear
+    const marksBefore = sim.delveMarksFor(sim.playerId);
+    const copperBefore = meta.copper;
+    driveRiteFlawless(sim, run);
+    const events = sim.drainEvents();
+    // Same structural starvation as the chest path: no credited members means
+    // the rite granter pays nobody and stays silent.
+    expect(events.find((e) => e.type === 'lockpickBonus')).toBeUndefined();
+    expect(sim.delveMarksFor(sim.playerId)).toBe(marksBefore);
+    expect(meta.copper).toBe(copperBefore);
   });
 
   it('flawless solve stages class-tuned gear loot and collect grants it to inventory', () => {

--- a/tests/delves_runs.test.ts
+++ b/tests/delves_runs.test.ts
@@ -7,6 +7,7 @@
 import { describe, expect, it } from 'vitest';
 import { DELVE_MODULES, DELVES } from '../src/sim/data';
 import {
+  DELVE_DAILY_FULL_CLEARS,
   DELVE_IMPLEMENTED_AFFIXES,
   delveBonusMarksFor,
   delveMarkPayout,
@@ -122,9 +123,18 @@ describe('delveBonusMarksFor', () => {
   // Callers run AFTER grantDelveClearTo incremented markClears for the clear the
   // bonus rides, so a post-increment tally of 1..3 means "this clear was one of
   // the day's first three" and 4+ means the window was already spent.
-  const meta = (markClears: number) => ({ delveDaily: { markClears } }) as unknown as PlayerMeta;
+  const meta = (markClears: number) => ({
+    delveDaily: { date: '', firstClearXp: new Set<string>(), markClears },
+  });
+
+  it('the base and bonus windows share ONE tuning constant, pinned at 3', () => {
+    expect(DELVE_DAILY_FULL_CLEARS).toBe(3);
+  });
 
   it('pays the full bonus while the clear rode the daily window, the 3rd clear included', () => {
+    // A tally of 0 is unreachable today (the granters only run on a credited
+    // clear, which increments first), but the intended answer is "in-window".
+    expect(delveBonusMarksFor(meta(0), 2)).toBe(2);
     expect(delveBonusMarksFor(meta(1), 2)).toBe(2);
     expect(delveBonusMarksFor(meta(2), 4)).toBe(4);
     expect(delveBonusMarksFor(meta(3), 4)).toBe(4);

--- a/tests/delves_runs.test.ts
+++ b/tests/delves_runs.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it } from 'vitest';
 import { DELVE_MODULES, DELVES } from '../src/sim/data';
 import {
   DELVE_IMPLEMENTED_AFFIXES,
+  delveBonusMarksFor,
   delveMarkPayout,
   delveShopGateMet,
   pickDelveModules,
@@ -114,6 +115,24 @@ describe('delveMarkPayout', () => {
     expect([0, 1]).toContain(
       delveMarkPayout({ rng: new Rng(7) } as unknown as SimContext, run('normal'), meta(3)),
     );
+  });
+});
+
+describe('delveBonusMarksFor', () => {
+  // Callers run AFTER grantDelveClearTo incremented markClears for the clear the
+  // bonus rides, so a post-increment tally of 1..3 means "this clear was one of
+  // the day's first three" and 4+ means the window was already spent.
+  const meta = (markClears: number) => ({ delveDaily: { markClears } }) as unknown as PlayerMeta;
+
+  it('pays the full bonus while the clear rode the daily window, the 3rd clear included', () => {
+    expect(delveBonusMarksFor(meta(1), 2)).toBe(2);
+    expect(delveBonusMarksFor(meta(2), 4)).toBe(4);
+    expect(delveBonusMarksFor(meta(3), 4)).toBe(4);
+  });
+
+  it('pays zero bonus Marks on every later clear of the day', () => {
+    expect(delveBonusMarksFor(meta(4), 2)).toBe(0);
+    expect(delveBonusMarksFor(meta(9), 4)).toBe(0);
   });
 });
 

--- a/tests/lockpick_session.test.ts
+++ b/tests/lockpick_session.test.ts
@@ -93,7 +93,8 @@ describe('lockpick controller (I2b module), success', () => {
     expect(st.lootOwnerId).toBe(sim.playerId); // picker owns the loot (no front-run)
     expect(st.pendingLoot.length).toBeGreaterThan(0);
     expect(run.surfaceExitId).not.toBeNull(); // exit opened on success
-    expect(sim.delveMarksFor(sim.playerId)).toBeGreaterThan(marksBefore); // bonus marks granted
+    // base in-window clear (+1) + premium ante bonus (+2)
+    expect(sim.delveMarksFor(sim.playerId)).toBe(marksBefore + 3);
 
     const events = sim.tick();
     expect(
@@ -102,7 +103,8 @@ describe('lockpick controller (I2b module), success', () => {
     expect(
       events.find((e) => e.type === 'lockpickEnd' && (e as any).outcome === 'success'),
     ).toBeDefined();
-    expect(events.find((e) => e.type === 'lockpickBonus')).toBeDefined();
+    // The event carries the actually granted (in-window premium) bonus Marks.
+    expect(events.find((e) => e.type === 'lockpickBonus' && (e as any).marks === 2)).toBeDefined();
   });
 
   it('lockpickViewFor returns the fogged projection the lockpickState accessor delegates to', () => {


### PR DESCRIPTION
## Summary

Closes out the "verify delve shop cost for tools vs the world market" review. The deep dive confirmed the tool rows and their 24/56 Mark prices are sound (the shop is a guaranteed floor for non-crafters; a functioning engineer market always undercuts it, which is the intended shape), but it surfaced one real drift: the premium lockpick chest (+2 Marks) and Litany rite (+4) bonuses paid on every clear, all day, outside the first-3-clears daily window entirely, so a grinder could far outrun the pricing the window exists to protect.

Per the maintainer ruling (window-only bonuses):

- Chest/rite bonus Marks now pay only on a clear that was itself inside the daily window; the copper half of the bonus and the loot tier are unchanged. One shared helper (`delveBonusMarksFor`) makes the rule; `grantDelveRewards` returns the members it credited and both granters iterate that list, so a bonus can only ride a clear that was just granted.
- The window size is one shared constant (`DELVE_DAILY_FULL_CLEARS`) read by both the base-payout and bonus comparators.
- The shop's stale pricing-intent comment now states the windowed income model with the real ceilings; the open question on the tool rows (purchase proficiency gate) is recorded as settled: no gate, per R22 the wield gate enforces at the harvest and the tooltip warns the buyer.
- A RE-CHECK TRIGGER comment plus a matching professions zone-rollout checklist line make the first tier-4 node or water re-derive the tool prices and wield table in the same change.
- The delves PRD records the window rule and its companion cost table now matches the shipped 3-rank ladder.

No new rng draws and no draw moved; the parity goldens are untouched and green. The `lockpickBonus` event now carries the actually granted (possibly zero) marks; the HUD renders a tier-only spoils line, so no UI change is needed.

## Type of change

- [x] Bug fix
- [x] Documentation
- [x] Tests

## How was this tested?

- Commands: `node scripts/gate_select.mjs` (PASS, all 12 steps); `npx vitest run tests/delves.test.ts tests/delves_runs.test.ts tests/lockpick_session.test.ts tests/lockpick_command.test.ts tests/delve_companion.test.ts tests/parity tests/architecture.test.ts`; `npx tsc --noEmit`; changed-files biome.
- New coverage: window boundary (3rd clear still pays in full), post-window zero-bonus with exact copper pins (11 chest / 24 rite) and loot-tier survival, the Litany 2x riding the same window, a duo test pinning the per-member window off one shared grant, the shared window constant, and a mutation probe confirmed the window check reddens 3 tests when neutered.
- Reviews: architecture-reviewer and test-coverage-auditor dispatched on the diff; all findings (2+2 should-fix, 5 notes) applied in the final commit.

- Round 2 (fresh full review pass): four reviewers dispatched on the final diff (architecture, test coverage with a 10-mutation battery, cross-platform parity over the lockpickBonus consumer chain, content obligations). All verified findings applied in the fourth commit: the credited-list contract and already-completed-run behavior are now pinned on both grant paths (the two mutations that survived round 1 now redden the suite), the wallet side of the unwindowed copper bonus is pinned, the rite path gained its duo window test, the delves PRD was trued (payout note, per-tier XP recorded as wired, FR-6.2 covers both delves, reset-day wording, companion ladder acceptance lines), and the dead Sim.grantDelveRewards delegate was deleted. Parity verdict: no wire, IWorld, event-consumer, or golden impact (marks: 0 has shipping precedent in the rift path).
