### PR TITLE
fix(sim): clear channel state when an entity dies mid-channel (issue #3400)

### DIFF
--- a/src/sim/combat/damage.ts
+++ b/src/sim/combat/damage.ts
@@ -102,6 +102,7 @@ import {
   DEBT_OF_LIGHT_DEVOTION,
   debtOfLightAura,
 } from './paladin_debt_of_light';
+import { clearRadiantResonanceReservation } from './paladin_radiant_resonance';
 import { stripSunGodVerdicts } from './paladin_sun_verdict';
 import { stripPaladinDevotionsFromSource } from './paladin_support';
 import { masteredPaladinAuraValue } from './paladin_talents';
@@ -1328,6 +1329,20 @@ export function handleDeath(
   emitRainOfFireStop(ctx, e);
   e.castingAbility = null;
   e.castTargetId = null;
+  // Death is a cast cancel: mirror cancelCast's teardown of the channel and
+  // queue state, not just castingAbility. An encounter force-channel (the
+  // Nythraxis wardstone, encounters/nythraxis.ts) clears itself only while
+  // castingAbility still names it, so a death that nulls castingAbility alone
+  // strands channeling=true with channelTickEvery 0, and the victim's next
+  // hard cast runs the channel tick branch once per sim tick for the whole
+  // cast bar (issue #3400).
+  e.castRemaining = 0;
+  e.channeling = false;
+  e.channelTicksLeft = 0;
+  e.castAim = null;
+  e.queuedCastAbility = null;
+  e.queuedCastAim = null;
+  clearRadiantResonanceReservation(e);
   // Hidden per-cast state: death ends any gather/fishing session, so
   // the fields must return to inert here too (the parity samplers rely on them
   // being 0/'' at every sampled frame outside a live cast; cancelCast owns the

--- a/tests/nythraxis_encounter.test.ts
+++ b/tests/nythraxis_encounter.test.ts
@@ -6,7 +6,9 @@
 // fall-through, and the raid lockout grant.
 
 import { describe, expect, it } from 'vitest';
+import { MOBS } from '../src/sim/data';
 import * as nythraxis from '../src/sim/encounters/nythraxis';
+import { createMob } from '../src/sim/entity';
 import { Sim } from '../src/sim/sim';
 import type { SimContext } from '../src/sim/sim_context';
 import { dist2d, type Entity, NYTHRAXIS_BOSS_ID } from '../src/sim/types';
@@ -513,5 +515,106 @@ describe('Nythraxis encounter module (N1)', () => {
     nythraxis.grantNythraxisLockout(ctx, boss);
     expect(sim.players.get(tank.id)!.raidLockouts.has('nythraxis_boss_arena')).toBe(true);
     expect(sim.players.get(outsiderPid)!.raidLockouts.has('nythraxis_boss_arena')).toBe(false);
+  });
+});
+
+describe('death mid-wardstone-channel (issue #3400)', () => {
+  // Claim a wardstone with dps[0], then resolve Deathless Rage while their channel is
+  // still incomplete: on heroic the rage deals 115% max hp and kills the channeler,
+  // exactly the prod chain behind fights 373/386/647/1765 on 2026-08-11.
+  function killMidWardChannel(kit: ReturnType<typeof setup>): AnyEntity {
+    const { sim, ctx, boss, dps } = kit;
+    const st = nythraxis.initNythraxisEncounter(boss);
+    st.phase = 2;
+    nythraxis.startNythraxisDeathlessRage(ctx, boss, st);
+    const ward = nythraxis.nythraxisWardstones(ctx, boss)[0] as AnyEntity;
+    const victim = dps[0];
+    teleport(sim, victim, ward.pos.x, ward.pos.z, ward.pos.y);
+    expect(nythraxis.tryStartNythraxisWardChannel(ctx, ward, victim)).toBe(true);
+    expect(victim.channeling).toBe(true);
+    st.deathlessCastRemaining = 0.01;
+    nythraxis.updateNythraxisDeathlessRage(ctx, boss, st);
+    expect(victim.dead).toBe(true);
+    return victim;
+  }
+
+  it('death leaves no channel state armed on the corpse', () => {
+    const victim = killMidWardChannel(setup({ difficulty: 'heroic' }));
+    // handleDeath owns this teardown: it nulls castingAbility, after which
+    // clearNythraxisWardChannelCast can never match and clear the rest. If the
+    // channeling flag survives the corpse, the victim's next hard cast runs the
+    // channel tick branch with channelTickEvery still 0 and pulses every sim tick.
+    expect(victim.castingAbility).toBe(null);
+    expect(victim.channeling).toBe(false);
+    expect(victim.castRemaining).toBe(0);
+    expect(victim.channelTicksLeft).toBe(0);
+    expect(victim.castAim).toBe(null);
+    expect(victim.queuedCastAbility).toBe(null);
+    expect(victim.queuedCastAim).toBe(null);
+  });
+
+  it('the next hard cast after the corpse run lands exactly one impact', () => {
+    const kit = setup({ difficulty: 'heroic' });
+    const { sim } = kit;
+    const mage = killMidWardChannel(kit);
+
+    // The prod flow: release, run back, spirit-resurrect at the corpse.
+    sim.releaseSpirit(mage.id);
+    const corpse = mage.corpsePos;
+    expect(corpse).toBeTruthy();
+    teleport(sim, mage, corpse!.x, corpse!.z);
+    sim.resurrectAtCorpse(mage.id);
+    expect(mage.dead).toBe(false);
+
+    // A practice target far outside the room (x-ward: arena slots stack in z, so
+    // distant x is empty world), so no encounter timer or dungeon geometry can
+    // touch the assertion window. Same level as the caster: no resist roll noise.
+    sim.setPlayerLevel(5, mage.id);
+    teleport(sim, mage, mage.pos.x + 2000, mage.pos.z);
+    const dummy = createMob((sim as AnySim).nextId++, MOBS.gravecaller_summoner, 5, {
+      x: mage.pos.x + 20,
+      y: mage.pos.y,
+      z: mage.pos.z,
+    }) as AnyEntity;
+    dummy.hostile = true;
+    dummy.maxHp = 100000;
+    dummy.hp = 100000;
+    (sim as AnySim).addEntity(dummy);
+    mage.hp = mage.maxHp;
+    mage.resource = mage.maxResource;
+
+    mage.targetId = dummy.id;
+    sim.castAbility('fireball', mage.id);
+    const pressEvents = sim.tick() as Array<Record<string, unknown>>;
+    // Surface any rejection reason (out of range, line of sight, mana) in the
+    // failure output instead of a bare null castingAbility.
+    expect(pressEvents.filter((ev) => ev.type === 'error' && ev.pid === mage.id)).toEqual([]);
+    expect(mage.castingAbility).toBe('fireball');
+    const stream: Array<Record<string, unknown>> = [...pressEvents];
+    for (let i = 0; i < 20 * 6; i++) {
+      stream.push(...(sim.tick() as Array<Record<string, unknown>>));
+    }
+    // amount > 1 excludes the rank 1 dot, whose ticks share the display name.
+    const bolts = stream.filter(
+      (ev) =>
+        ev.type === 'damage' &&
+        ev.sourceId === mage.id &&
+        ev.ability === 'Cinderbolt' &&
+        (ev.amount as number) > 1,
+    );
+    // The bug signature is the pulse stream: display-name-only hits with no
+    // abilityId, one per sim tick for the whole cast bar (the 4 to 9k opener
+    // spikes in prod fights 383/391/672/1800). A healthy cast has zero of them
+    // and at most the one id-carrying impact (the real impact still rolls the
+    // ordinary miss table, so 0 impacts is not a failure of THIS bug).
+    const pulses = bolts.filter((ev) => ev.abilityId === undefined);
+    const impacts = bolts.filter((ev) => ev.abilityId === 'fireball');
+    expect(pulses.length).toBe(0);
+    expect(impacts.length).toBeLessThanOrEqual(1);
+    expect(pulses.length + impacts.length).toBe(bolts.length);
+    // The cast itself completed: the discharge must not have eaten the cast.
+    expect(
+      stream.some((ev) => ev.type === 'castStop' && ev.entityId === mage.id && ev.success === true),
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Fixes the 4 to 9k single-second opener damage spikes from issue #3400 (prod fights 383/391/672/1800 on 2026-08-11), and with them the old unreproduced "a mage cast 100 fireballs" report.

Root cause, demonstrated end to end by the new tests:

1. The heroic Nythraxis wardstone interrupt (`tryStartNythraxisWardChannel` / `updateNythraxisWardChannels`) force-sets `player.channeling = true` with a fake `castingAbility` and never seeds `channelTickEvery` (entity default 0).
2. A channeler killed mid-channel (typically by the Deathless Rage resolution itself, 115% max hp on heroic) went through `handleDeath`, which nulled `castingAbility` but left `channeling`, `castRemaining`, `channelTicksLeft` and the queued cast armed on the corpse.
3. The encounter's own cleanup (`clearNythraxisWardChannelCast`) early-returns unless `castingAbility` still names the ward channel, which death just nulled, so nothing could ever clear the flag. `updateCasting` early-returns while `castingAbility` is null, so the state sat inert through release, corpse run and resurrection.
4. The victim's next hard cast then entered the channel branch of `updateCasting` with `channelTickEvery` 0: `channelTickTimer += 0` keeps the timer at or below zero, so `applyChannelTick` fired once per 20 Hz tick for the whole cast bar. Each pulse is an independently rolled, crit-capable hit carrying only the ability's display name (no `abilityId`), delivered as a projectile. The fake channel completion then reset `channeling`, so the corruption self-discharged after exactly one cast and that cast's real impact never fired.

This matches the recorded parses in every detail: 38 to 41 display-name-only damage events at 1 to 2 per tick spanning one cast bar plus flight, per-event crit rolls, the missing id-carrying impact for the corrupted cast, always the puller's opener of the pull after a Deathless Rage wipe, and always exactly one cast's worth. Reproduced in the new test: one Cinderbolt hard cast after a wardstone death produced 30 impacts before the fix, 1 after.

The fix: `handleDeath` now performs the same cast-state teardown as `cancelCast` (castRemaining, channeling, channelTicksLeft, castAim, queued cast, and the Radiant Resonance reservation, the last one flagged by the qa-checklist review as the one gap in the mirror). This also covers the milder general variant, dying mid real channel, where the stale state stole the next cast's impact and added pulses at the channel's own interval, and the same shape on pet Water Jet (also seeded without `channelTickEvery`). Hardening the encounter to seed `channelTickEvery`, or `startCast` to reset `channeling`, were considered and dropped: death is the one exit that bypasses every existing clear, and fixing it at that seam covers force-channels and real channels alike with the smallest diff.

Follow-up noted, not taken here (scope): a `tests/parity` scenario that kills a tracked caster mid hard cast and mid channel would pin this corpse state in the goldens; today no scenario routes an armed cast through `handleDeath`.

## Related issues

Closes #3400.

## Type of change

- [x] Bug fix

## How was this tested?

- Commands:
  - `npx vitest run tests/nythraxis_encounter.test.ts` (2 new tests: red before the fix, 30 impacts from one cast; all 20 green after)
  - `npx vitest run tests/parity` (green with no golden re-mint: the traces are byte-identical, no parity scenario samples a mid-cast death)
  - `npx tsc --noEmit`
  - `node scripts/gate_select.mjs`
- Manual steps: root-caused against the raw prod event streams via the parse service (`/api/fights/{383,391,672,1800}/events`), including the corruption chain in the preceding fights (373/386/647/1765: the spiking player dies to the Deathless Rage resolution while ward-channeling).
