### PR TITLE
feat(pvp): pay ranked arena losers a third of the win Honor

### DIFF
--- a/src/sim/pvp/honor.ts
+++ b/src/sim/pvp/honor.ts
@@ -10,6 +10,29 @@ export const RANKED_ARENA_WIN_HONOR = {
   '2v2': 50,
 } as const;
 
+// What a ranked bout pays the side that did not win: one third of the bracket's
+// win award, rounded (1v1 pays 8, 2v2 pays 17). A draw pays this to both sides.
+//
+// Ranked arena was the one PvP mode that paid a loss nothing at all, so a player
+// who queued and lost had no path toward Warfare gear except winning: rating is
+// the ladder's answer to a loss, but rating buys nothing. The other two modes
+// already carry the rule this restores, both at the same third (Thornhollow
+// Fields pays 20 against a 60 win, Fiesta pays its 20 completion against a
+// 20 + 40 win), so the share is this repo's own convention rather than a new
+// number, and it stays a DERIVED fraction so retuning a win faucet carries the
+// loss award with it.
+//
+// A third, not more: a win must stay clearly the thing worth playing for, and the
+// gap between the two is the whole incentive to try to win rather than to farm
+// completions. Each pairing pays a player at most one win plus one loss per UTC
+// day (ARENA_REPEAT_DR zeroes the rest on both counters), so two accounts trading
+// wins are capped at exactly what one honest bout against a new opponent pays.
+export const ARENA_LOSS_HONOR_SHARE = 1 / 3;
+export const RANKED_ARENA_LOSS_HONOR = {
+  '1v1': Math.round(RANKED_ARENA_WIN_HONOR['1v1'] * ARENA_LOSS_HONOR_SHARE),
+  '2v2': Math.round(RANKED_ARENA_WIN_HONOR['2v2'] * ARENA_LOSS_HONOR_SHARE),
+} as const;
+
 export const FIESTA_KILL_HONOR = 20;
 export const FIESTA_COMPLETION_HONOR = 20;
 export const FIESTA_WIN_BONUS_HONOR = 40;
@@ -106,9 +129,13 @@ export function normalizeHonorDailyState(value: unknown): HonorArenaDailyState |
   if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
   const record = value as Record<string, unknown>;
   const bgResults = normalizeCountRecord(record.bgResultsByOpponent);
+  const losses = normalizeCountRecord(record.lossesByOpponent);
   return {
     date: typeof record.date === 'string' ? record.date : '',
     winsByOpponent: normalizeCountRecord(record.winsByOpponent),
+    // Same absent-until-set rule as the battleground counter below: a save
+    // written before ranked losses paid anything round-trips byte-identical.
+    ...(Object.keys(losses).length > 0 ? { lossesByOpponent: losses } : {}),
     fiestaCompletionsByOpponent: normalizeCountRecord(record.fiestaCompletionsByOpponent),
     // Optional: absent (not empty) when there are no results, so pre-Thornhollow Fields
     // saves round-trip byte-identical.
@@ -176,6 +203,9 @@ function dailyWindow(ctx: SimContext, meta: PlayerMeta) {
     daily.date = ctx.resetDay;
     daily.winsByOpponent = {};
     daily.fiestaCompletionsByOpponent = {};
+    // `undefined` rather than `{}` for the same byte-equality reason as the
+    // battleground counter and the first-win flag below.
+    daily.lossesByOpponent = undefined;
     // Back to `undefined` (not `{}`) so an untouched day stays byte-equal in
     // the save blob (the absent-until-first-result rule).
     daily.bgResultsByOpponent = undefined;
@@ -216,24 +246,50 @@ export function honorTeamIdentity(ctx: SimContext, pids: number[]): string {
   return JSON.stringify(members);
 }
 
-export function awardRankedArenaWinHonor(
+/**
+ * One played-out ranked arena result, for the winning side and the losing side
+ * alike. A win pays the bracket faucet; a loss pays RANKED_ARENA_LOSS_HONOR, and
+ * a draw pays that same loss award to both sides (what a drawn Thornhollow
+ * Fields match does, and the only reading that makes a timeout worth playing
+ * out). Forfeits never reach here: the caller pays nothing on a forfeit, which
+ * is also what stops "queue, concede, collect" being the cheapest honor in the
+ * game.
+ *
+ * Wins and losses decay on the SAME ARENA_REPEAT_DR curve but count on separate
+ * per-opponent counters, so the first meeting of a given team each day pays in
+ * full whichever way it goes and every rematch pays nothing. Deliberately not
+ * one shared counter: sharing it would mean a loss silently spends the win award
+ * for the rematch, which punishes exactly the honest player who queues into a
+ * stronger team and comes back.
+ *
+ * The daily taper reads `totalWins` for both outcomes, and only a WIN advances
+ * it: the taper is a cap on the day's arena income, and a player cannot pad it
+ * by losing.
+ */
+export function awardRankedArenaResultHonor(
   ctx: SimContext,
   meta: PlayerMeta,
   format: ArenaFormat,
   opponentTeamKey: string,
+  outcome: 'win' | 'loss' | 'draw',
 ): number {
   if (format !== '1v1' && format !== '2v2') return 0;
   const daily = dailyWindow(ctx, meta);
   const key = `${format}:${opponentTeamKey}`;
-  const repeats = daily.winsByOpponent[key] ?? 0;
+  const won = outcome === 'win';
+  const repeats = won ? (daily.winsByOpponent[key] ?? 0) : (daily.lossesByOpponent?.[key] ?? 0);
+  const base = won ? RANKED_ARENA_WIN_HONOR[format] : RANKED_ARENA_LOSS_HONOR[format];
   const amount = Math.floor(
-    RANKED_ARENA_WIN_HONOR[format] *
-      arenaRepeatHonorMultiplier(repeats) *
-      arenaDailyMultiplier(daily.totalWins),
+    base * arenaRepeatHonorMultiplier(repeats) * arenaDailyMultiplier(daily.totalWins),
   );
-  daily.winsByOpponent[key] = repeats + 1;
-  daily.totalWins++;
-  return grantHonor(ctx, meta, amount, 'arena_win');
+  if (won) {
+    daily.winsByOpponent[key] = repeats + 1;
+    daily.totalWins++;
+  } else {
+    if (!daily.lossesByOpponent) daily.lossesByOpponent = {};
+    daily.lossesByOpponent[key] = repeats + 1;
+  }
+  return grantHonor(ctx, meta, amount, won ? 'arena_win' : 'arena_complete');
 }
 
 /** What one played-out Thornhollow Fields result paid: the ordinary result award

--- a/src/sim/pvp/index.ts
+++ b/src/sim/pvp/index.ts
@@ -1,6 +1,7 @@
 export {
   ARENA_DAILY_TAPER_FLOOR_START,
   ARENA_DAILY_TAPER_START,
+  ARENA_LOSS_HONOR_SHARE,
   ARENA_REPEAT_DR,
   arenaRepeatHonorMultiplier,
   awardBattlegroundAssistHonor,
@@ -8,7 +9,7 @@ export {
   awardBattlegroundKillHonor,
   awardFiestaCompletionHonor,
   awardFiestaKillHonor,
-  awardRankedArenaWinHonor,
+  awardRankedArenaResultHonor,
   BATTLEGROUND_ASSIST_HONOR,
   BATTLEGROUND_FIRST_WIN_BONUS_HONOR,
   BATTLEGROUND_KILL_HONOR,
@@ -26,6 +27,7 @@ export {
   honorTeamIdentity,
   normalizeHonorCounter,
   normalizeHonorDailyState,
+  RANKED_ARENA_LOSS_HONOR,
   RANKED_ARENA_WIN_HONOR,
   repeatHonorMultiplier,
 } from './honor';

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -4046,6 +4046,13 @@ export class Sim {
             honorArenaDaily: {
               date: meta.honorArenaDaily.date,
               winsByOpponent: { ...meta.honorArenaDaily.winsByOpponent },
+              // Optional ranked-loss DR window, on the same absent-when-empty
+              // rule as the battleground one below: a day with no paying loss
+              // writes nothing, so pre-loss-award saves stay byte-equal.
+              ...(meta.honorArenaDaily.lossesByOpponent &&
+              Object.keys(meta.honorArenaDaily.lossesByOpponent).length > 0
+                ? { lossesByOpponent: { ...meta.honorArenaDaily.lossesByOpponent } }
+                : {}),
               fiestaCompletionsByOpponent: {
                 ...meta.honorArenaDaily.fiestaCompletionsByOpponent,
               },

--- a/src/sim/social/arena.ts
+++ b/src/sim/social/arena.ts
@@ -31,7 +31,7 @@ import {
   restoreMatchPet,
   snapshotMatchPet,
 } from '../pet/pet_match_return';
-import { awardFiestaCompletionHonor, awardRankedArenaWinHonor, honorTeamIdentity } from '../pvp';
+import { awardFiestaCompletionHonor, awardRankedArenaResultHonor, honorTeamIdentity } from '../pvp';
 import { aurasSurvivingCleanSlate, SICKNESS_AURA_IDS, UNSTUCK_SICKNESS_ID } from '../resurrection';
 import type { ArenaMatch, ArenaQueueUnit, ArenaReturnPools, PlayerMeta } from '../sim';
 import type { SimContext } from '../sim_context';
@@ -1206,9 +1206,19 @@ export function endArenaMatch(
         ));
         // Rating (addArenaResult above) and Deeds (onArenaMatchEndForDeeds below)
         // are deliberately forfeit-inclusive; Honor is not, mirroring Fiesta's
-        // completion-honor guard a few lines down.
-        if (won === true && reason !== 'forfeit')
-          awardRankedArenaWinHonor(ctx, meta, match.format, opponentTeamKey);
+        // completion-honor guard a few lines down. Every played-out result pays,
+        // win or not: the loss and draw share is the award module's call
+        // (RANKED_ARENA_LOSS_HONOR), so this call site stays a plain report of
+        // what happened.
+        if (reason !== 'forfeit') {
+          awardRankedArenaResultHonor(
+            ctx,
+            meta,
+            match.format,
+            opponentTeamKey,
+            won === true ? 'win' : won === null ? 'draw' : 'loss',
+          );
+        }
       } else {
         ratingBefore = ratingAfter = arenaStanding(meta, match.format).rating;
         if (match.fiesta && !match.practice && reason !== 'forfeit') {

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -77,6 +77,11 @@ export function hitFractionFromRating(rating: number): number {
 
 export type HonorReason =
   | 'arena_win'
+  // A ranked arena bout that did not end in a win: a loss, or a draw, which pays
+  // both sides the loss award. One reason for both, mirroring the battleground's
+  // own `battleground_complete`, because the player-facing fact is the same one
+  // (the match was fought and it paid) and a drawn bout has no loser to name.
+  | 'arena_complete'
   | 'fiesta_kill'
   | 'fiesta_complete'
   | 'fiesta_win'
@@ -94,6 +99,12 @@ export type HonorReason =
 export interface HonorArenaDailyState {
   date: string;
   winsByOpponent: Record<string, number>;
+  // Ranked LOSSES (and draws) per bracket plus opposing-team identity, on the
+  // same ARENA_REPEAT_DR curve as the wins beside it but on its OWN counter, so
+  // losing to a team first does not spend the win award for beating it later
+  // (optional so pre-loss-award saves stay byte-equal; absent until the first
+  // paying loss).
+  lossesByOpponent?: Record<string, number>;
   fiestaCompletionsByOpponent: Record<string, number>;
   // Thornhollow Fields results per opposing-team identity (optional so pre-battleground
   // saves stay byte-equal; absent until the first battleground result).

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -1070,6 +1070,7 @@ const MOTD_RESULT_KEYS: Record<MotdResultCode, TranslationKey> = {
 };
 const HONOR_REASON_KEYS: Record<HonorReason, TranslationKey> = {
   arena_win: 'hudChrome.warfare.reasons.arenaWin',
+  arena_complete: 'hudChrome.warfare.reasons.arenaComplete',
   fiesta_kill: 'hudChrome.warfare.reasons.fiestaKill',
   fiesta_complete: 'hudChrome.warfare.reasons.fiestaComplete',
   fiesta_win: 'hudChrome.warfare.reasons.fiestaWin',

--- a/src/ui/i18n.catalog/hud_chrome.ts
+++ b/src/ui/i18n.catalog/hud_chrome.ts
@@ -1822,6 +1822,9 @@ export const hudChromeStrings = {
     notEnoughHonor: 'Not enough Honor.',
     reasons: {
       arenaWin: 'Arena victory',
+      // Paid for a ranked loss and for a draw alike, so the line names the bout
+      // rather than the result (the same reading as battlegroundComplete below).
+      arenaComplete: 'Arena bout fought',
       fiestaKill: 'Fiesta takedown',
       fiestaComplete: 'Fiesta completed',
       fiestaWin: 'Fiesta victory',

--- a/src/ui/i18n.catalog/translation_keys.generated.ts
+++ b/src/ui/i18n.catalog/translation_keys.generated.ts
@@ -10010,6 +10010,7 @@ export type TranslationKeyFlat =
   | 'hudChrome.warfare.honorFloatReason'
   | 'hudChrome.warfare.honorGain'
   | 'hudChrome.warfare.notEnoughHonor'
+  | 'hudChrome.warfare.reasons.arenaComplete'
   | 'hudChrome.warfare.reasons.arenaWin'
   | 'hudChrome.warfare.reasons.battlegroundAssist'
   | 'hudChrome.warfare.reasons.battlegroundComplete'

--- a/src/ui/i18n.locales/ja_JP.ts
+++ b/src/ui/i18n.locales/ja_JP.ts
@@ -976,6 +976,7 @@ export const ja_JP: Partial<Record<TranslationKey, string>> = {
   'hudChrome.warfare.honorGain': '名誉を {amount} 獲得しました（{reason}）。',
   'hudChrome.warfare.notEnoughHonor': '名誉が足りません。',
   'hudChrome.warfare.reasons.arenaWin': 'アリーナ勝利',
+  'hudChrome.warfare.reasons.arenaComplete': 'アリーナ参戦',
   'hudChrome.warfare.reasons.fiestaKill': 'フィエスタ撃破',
   'hudChrome.warfare.reasons.fiestaComplete': 'フィエスタ完遂',
   'hudChrome.warfare.reasons.fiestaWin': 'フィエスタ勝利',

--- a/src/ui/i18n.locales/ko_KR.ts
+++ b/src/ui/i18n.locales/ko_KR.ts
@@ -974,6 +974,7 @@ export const ko_KR: Partial<Record<TranslationKey, string>> = {
   'hudChrome.warfare.honorGain': '명예를 {amount} 획득했습니다({reason}).',
   'hudChrome.warfare.notEnoughHonor': '명예가 부족합니다.',
   'hudChrome.warfare.reasons.arenaWin': '투기장 승리',
+  'hudChrome.warfare.reasons.arenaComplete': '투기장 참전',
   'hudChrome.warfare.reasons.fiestaKill': '피에스타 처치',
   'hudChrome.warfare.reasons.fiestaComplete': '피에스타 완료',
   'hudChrome.warfare.reasons.fiestaWin': '피에스타 승리',

--- a/src/ui/i18n.locales/ru_RU.ts
+++ b/src/ui/i18n.locales/ru_RU.ts
@@ -986,6 +986,7 @@ export const ru_RU: Partial<Record<TranslationKey, string>> = {
   'hudChrome.warfare.honorGain': 'Вы получаете {amount} очк. чести ({reason}).',
   'hudChrome.warfare.notEnoughHonor': 'Недостаточно чести.',
   'hudChrome.warfare.reasons.arenaWin': 'Победа на арене',
+  'hudChrome.warfare.reasons.arenaComplete': 'Бой на арене',
   'hudChrome.warfare.reasons.fiestaKill': 'Устранение на Фиесте',
   'hudChrome.warfare.reasons.fiestaComplete': 'Завершение Фиесты',
   'hudChrome.warfare.reasons.fiestaWin': 'Победа на Фиесте',

--- a/src/ui/i18n.locales/zh_CN.ts
+++ b/src/ui/i18n.locales/zh_CN.ts
@@ -948,6 +948,7 @@ export const zh_CN: Partial<Record<TranslationKey, string>> = {
   'hudChrome.warfare.honorGain': '你获得了 {amount} 点荣誉（{reason}）。',
   'hudChrome.warfare.notEnoughHonor': '荣誉不足。',
   'hudChrome.warfare.reasons.arenaWin': '竞技场胜利',
+  'hudChrome.warfare.reasons.arenaComplete': '竞技场参战',
   'hudChrome.warfare.reasons.fiestaKill': '嘉年华击倒',
   'hudChrome.warfare.reasons.fiestaComplete': '完成嘉年华',
   'hudChrome.warfare.reasons.fiestaWin': '嘉年华胜利',

--- a/src/ui/i18n.locales/zh_TW.ts
+++ b/src/ui/i18n.locales/zh_TW.ts
@@ -949,6 +949,7 @@ export const zh_TW: Partial<Record<TranslationKey, string>> = {
   'hudChrome.warfare.honorGain': '你獲得了 {amount} 點榮譽（{reason}）。',
   'hudChrome.warfare.notEnoughHonor': '榮譽不足。',
   'hudChrome.warfare.reasons.arenaWin': '競技場勝利',
+  'hudChrome.warfare.reasons.arenaComplete': '競技場參戰',
   'hudChrome.warfare.reasons.fiestaKill': '嘉年華擊倒',
   'hudChrome.warfare.reasons.fiestaComplete': '完成嘉年華',
   'hudChrome.warfare.reasons.fiestaWin': '嘉年華勝利',

--- a/src/ui/i18n.resolved.generated/cs_CZ.ts
+++ b/src/ui/i18n.resolved.generated/cs_CZ.ts
@@ -1739,6 +1739,7 @@ export const cs_CZ: EnTranslations = {
       "notEnoughHonor": "Nemáš dost cti.",
       "reasons": {
         "arenaWin": "Vítězství v aréně",
+        "arenaComplete": "Arena bout fought",
         "fiestaKill": "Vyřazení ve Fiestě",
         "fiestaComplete": "Dokončení Fiesty",
         "fiestaWin": "Vítězství ve Fiestě",

--- a/src/ui/i18n.resolved.generated/da_DK.ts
+++ b/src/ui/i18n.resolved.generated/da_DK.ts
@@ -1739,6 +1739,7 @@ export const da_DK: EnTranslations = {
       "notEnoughHonor": "Ikke nok Ære.",
       "reasons": {
         "arenaWin": "Arenasejr",
+        "arenaComplete": "Arena bout fought",
         "fiestaKill": "Fiesta-nedlæggelse",
         "fiestaComplete": "Fiesta gennemført",
         "fiestaWin": "Fiesta-sejr",

--- a/src/ui/i18n.resolved.generated/de_DE.ts
+++ b/src/ui/i18n.resolved.generated/de_DE.ts
@@ -1739,6 +1739,7 @@ export const de_DE: EnTranslations = {
       "notEnoughHonor": "Nicht genug Ehre.",
       "reasons": {
         "arenaWin": "Arenasieg",
+        "arenaComplete": "Arena bout fought",
         "fiestaKill": "Fiesta-Ausschaltung",
         "fiestaComplete": "Fiesta abgeschlossen",
         "fiestaWin": "Fiesta-Sieg",

--- a/src/ui/i18n.resolved.generated/en.ts
+++ b/src/ui/i18n.resolved.generated/en.ts
@@ -1739,6 +1739,7 @@ export const en: EnTranslations = {
       "notEnoughHonor": "Not enough Honor.",
       "reasons": {
         "arenaWin": "Arena victory",
+        "arenaComplete": "Arena bout fought",
         "fiestaKill": "Fiesta takedown",
         "fiestaComplete": "Fiesta completed",
         "fiestaWin": "Fiesta victory",

--- a/src/ui/i18n.resolved.generated/en_CA.ts
+++ b/src/ui/i18n.resolved.generated/en_CA.ts
@@ -1739,6 +1739,7 @@ export const en_CA: EnTranslations = {
       "notEnoughHonor": "Not enough Honor.",
       "reasons": {
         "arenaWin": "Arena victory",
+        "arenaComplete": "Arena bout fought",
         "fiestaKill": "Fiesta takedown",
         "fiestaComplete": "Fiesta completed",
         "fiestaWin": "Fiesta victory",

--- a/src/ui/i18n.resolved.generated/en_XA.ts
+++ b/src/ui/i18n.resolved.generated/en_XA.ts
@@ -1739,6 +1739,7 @@ export const en_XA: EnTranslations = {
       "notEnoughHonor": "[Ñóţ éñóúĝĥ Ĥóñóŕ.]",
       "reasons": {
         "arenaWin": "[Áŕéñá ʋíçţóŕý]",
+        "arenaComplete": "[Áŕéñá ƀóúţ ƒóúĝĥţ]",
         "fiestaKill": "[Ƒíéšţá ţáķéðóŵñ]",
         "fiestaComplete": "[Ƒíéšţá çóɱþļéţéð]",
         "fiestaWin": "[Ƒíéšţá ʋíçţóŕý]",

--- a/src/ui/i18n.resolved.generated/es.ts
+++ b/src/ui/i18n.resolved.generated/es.ts
@@ -1739,6 +1739,7 @@ export const es: EnTranslations = {
       "notEnoughHonor": "No tienes suficiente Honor.",
       "reasons": {
         "arenaWin": "Victoria en la arena",
+        "arenaComplete": "Arena bout fought",
         "fiestaKill": "Derribo en Fiesta",
         "fiestaComplete": "Fiesta completada",
         "fiestaWin": "Victoria en Fiesta",

--- a/src/ui/i18n.resolved.generated/es_ES.ts
+++ b/src/ui/i18n.resolved.generated/es_ES.ts
@@ -1739,6 +1739,7 @@ export const es_ES: EnTranslations = {
       "notEnoughHonor": "No tienes suficiente Honor.",
       "reasons": {
         "arenaWin": "Victoria en la arena",
+        "arenaComplete": "Arena bout fought",
         "fiestaKill": "Derribo en Fiesta",
         "fiestaComplete": "Fiesta completada",
         "fiestaWin": "Victoria en Fiesta",

--- a/src/ui/i18n.resolved.generated/fr_CA.ts
+++ b/src/ui/i18n.resolved.generated/fr_CA.ts
@@ -1739,6 +1739,7 @@ export const fr_CA: EnTranslations = {
       "notEnoughHonor": "Vous n’avez pas assez d’honneur.",
       "reasons": {
         "arenaWin": "Victoire en arène",
+        "arenaComplete": "Arena bout fought",
         "fiestaKill": "Élimination en Fiesta",
         "fiestaComplete": "Fiesta terminée",
         "fiestaWin": "Victoire en Fiesta",

--- a/src/ui/i18n.resolved.generated/fr_FR.ts
+++ b/src/ui/i18n.resolved.generated/fr_FR.ts
@@ -1739,6 +1739,7 @@ export const fr_FR: EnTranslations = {
       "notEnoughHonor": "Vous n’avez pas assez d’honneur.",
       "reasons": {
         "arenaWin": "Victoire en arène",
+        "arenaComplete": "Arena bout fought",
         "fiestaKill": "Élimination en Fiesta",
         "fiestaComplete": "Fiesta terminée",
         "fiestaWin": "Victoire en Fiesta",

--- a/src/ui/i18n.resolved.generated/id_ID.ts
+++ b/src/ui/i18n.resolved.generated/id_ID.ts
@@ -1739,6 +1739,7 @@ export const id_ID: EnTranslations = {
       "notEnoughHonor": "Tidak cukup Kehormatan.",
       "reasons": {
         "arenaWin": "Kemenangan arena",
+        "arenaComplete": "Arena bout fought",
         "fiestaKill": "Eliminasi Fiesta",
         "fiestaComplete": "Fiesta selesai",
         "fiestaWin": "Kemenangan Fiesta",

--- a/src/ui/i18n.resolved.generated/it_IT.ts
+++ b/src/ui/i18n.resolved.generated/it_IT.ts
@@ -1739,6 +1739,7 @@ export const it_IT: EnTranslations = {
       "notEnoughHonor": "Onore insufficiente.",
       "reasons": {
         "arenaWin": "Vittoria nell'Arena",
+        "arenaComplete": "Arena bout fought",
         "fiestaKill": "Abbattimento della Fiesta",
         "fiestaComplete": "Fiesta completata",
         "fiestaWin": "Vittoria nella Fiesta",

--- a/src/ui/i18n.resolved.generated/ja_JP.ts
+++ b/src/ui/i18n.resolved.generated/ja_JP.ts
@@ -1739,6 +1739,7 @@ export const ja_JP: EnTranslations = {
       "notEnoughHonor": "名誉が足りません。",
       "reasons": {
         "arenaWin": "アリーナ勝利",
+        "arenaComplete": "アリーナ参戦",
         "fiestaKill": "フィエスタ撃破",
         "fiestaComplete": "フィエスタ完遂",
         "fiestaWin": "フィエスタ勝利",

--- a/src/ui/i18n.resolved.generated/ko_KR.ts
+++ b/src/ui/i18n.resolved.generated/ko_KR.ts
@@ -1739,6 +1739,7 @@ export const ko_KR: EnTranslations = {
       "notEnoughHonor": "명예가 부족합니다.",
       "reasons": {
         "arenaWin": "투기장 승리",
+        "arenaComplete": "투기장 참전",
         "fiestaKill": "피에스타 처치",
         "fiestaComplete": "피에스타 완료",
         "fiestaWin": "피에스타 승리",

--- a/src/ui/i18n.resolved.generated/nl_NL.ts
+++ b/src/ui/i18n.resolved.generated/nl_NL.ts
@@ -1739,6 +1739,7 @@ export const nl_NL: EnTranslations = {
       "notEnoughHonor": "Niet genoeg eer.",
       "reasons": {
         "arenaWin": "Arena-overwinning",
+        "arenaComplete": "Arena bout fought",
         "fiestaKill": "Fiesta-uitschakeling",
         "fiestaComplete": "Fiesta voltooid",
         "fiestaWin": "Fiesta-overwinning",

--- a/src/ui/i18n.resolved.generated/pending.ts
+++ b/src/ui/i18n.resolved.generated/pending.ts
@@ -11,28 +11,34 @@
 export const pending: Record<string, readonly string[]> = {
   "es": [
     "entities.abilities.cheap_shot.descriptionNoStealth",
-    "hudChrome.itemHeroicLabel"
+    "hudChrome.itemHeroicLabel",
+    "hudChrome.warfare.reasons.arenaComplete"
   ],
   "es_ES": [
     "entities.abilities.cheap_shot.descriptionNoStealth",
-    "hudChrome.itemHeroicLabel"
+    "hudChrome.itemHeroicLabel",
+    "hudChrome.warfare.reasons.arenaComplete"
   ],
   "fr_FR": [
     "entities.abilities.cheap_shot.descriptionNoStealth",
-    "hudChrome.itemHeroicLabel"
+    "hudChrome.itemHeroicLabel",
+    "hudChrome.warfare.reasons.arenaComplete"
   ],
   "fr_CA": [
     "entities.abilities.cheap_shot.descriptionNoStealth",
-    "hudChrome.itemHeroicLabel"
+    "hudChrome.itemHeroicLabel",
+    "hudChrome.warfare.reasons.arenaComplete"
   ],
   "en_CA": [],
   "it_IT": [
     "entities.abilities.cheap_shot.descriptionNoStealth",
-    "hudChrome.itemHeroicLabel"
+    "hudChrome.itemHeroicLabel",
+    "hudChrome.warfare.reasons.arenaComplete"
   ],
   "de_DE": [
     "entities.abilities.cheap_shot.descriptionNoStealth",
-    "hudChrome.itemHeroicLabel"
+    "hudChrome.itemHeroicLabel",
+    "hudChrome.warfare.reasons.arenaComplete"
   ],
   "zh_CN": [],
   "zh_TW": [],
@@ -40,39 +46,48 @@ export const pending: Record<string, readonly string[]> = {
   "ja_JP": [],
   "pt_BR": [
     "entities.abilities.cheap_shot.descriptionNoStealth",
-    "hudChrome.itemHeroicLabel"
+    "hudChrome.itemHeroicLabel",
+    "hudChrome.warfare.reasons.arenaComplete"
   ],
   "ru_RU": [],
   "cs_CZ": [
     "entities.abilities.cheap_shot.descriptionNoStealth",
-    "hudChrome.itemHeroicLabel"
+    "hudChrome.itemHeroicLabel",
+    "hudChrome.warfare.reasons.arenaComplete"
   ],
   "nl_NL": [
     "entities.abilities.cheap_shot.descriptionNoStealth",
-    "hudChrome.itemHeroicLabel"
+    "hudChrome.itemHeroicLabel",
+    "hudChrome.warfare.reasons.arenaComplete"
   ],
   "pl_PL": [
     "entities.abilities.cheap_shot.descriptionNoStealth",
-    "hudChrome.itemHeroicLabel"
+    "hudChrome.itemHeroicLabel",
+    "hudChrome.warfare.reasons.arenaComplete"
   ],
   "id_ID": [
     "entities.abilities.cheap_shot.descriptionNoStealth",
-    "hudChrome.itemHeroicLabel"
+    "hudChrome.itemHeroicLabel",
+    "hudChrome.warfare.reasons.arenaComplete"
   ],
   "tr_TR": [
     "entities.abilities.cheap_shot.descriptionNoStealth",
-    "hudChrome.itemHeroicLabel"
+    "hudChrome.itemHeroicLabel",
+    "hudChrome.warfare.reasons.arenaComplete"
   ],
   "sv_SE": [
     "entities.abilities.cheap_shot.descriptionNoStealth",
-    "hudChrome.itemHeroicLabel"
+    "hudChrome.itemHeroicLabel",
+    "hudChrome.warfare.reasons.arenaComplete"
   ],
   "vi_VN": [
     "entities.abilities.cheap_shot.descriptionNoStealth",
-    "hudChrome.itemHeroicLabel"
+    "hudChrome.itemHeroicLabel",
+    "hudChrome.warfare.reasons.arenaComplete"
   ],
   "da_DK": [
     "entities.abilities.cheap_shot.descriptionNoStealth",
-    "hudChrome.itemHeroicLabel"
+    "hudChrome.itemHeroicLabel",
+    "hudChrome.warfare.reasons.arenaComplete"
   ]
 };

--- a/src/ui/i18n.resolved.generated/pl_PL.ts
+++ b/src/ui/i18n.resolved.generated/pl_PL.ts
@@ -1739,6 +1739,7 @@ export const pl_PL: EnTranslations = {
       "notEnoughHonor": "Za mało Honoru.",
       "reasons": {
         "arenaWin": "Zwycięstwo na arenie",
+        "arenaComplete": "Arena bout fought",
         "fiestaKill": "Upadek Fiesty",
         "fiestaComplete": "Fiesta zakończona",
         "fiestaWin": "Zwycięstwo Fiesty",

--- a/src/ui/i18n.resolved.generated/pt_BR.ts
+++ b/src/ui/i18n.resolved.generated/pt_BR.ts
@@ -1739,6 +1739,7 @@ export const pt_BR: EnTranslations = {
       "notEnoughHonor": "Honra insuficiente.",
       "reasons": {
         "arenaWin": "Vitória na arena",
+        "arenaComplete": "Arena bout fought",
         "fiestaKill": "Eliminação na Fiesta",
         "fiestaComplete": "Fiesta concluída",
         "fiestaWin": "Vitória na Fiesta",

--- a/src/ui/i18n.resolved.generated/ru_RU.ts
+++ b/src/ui/i18n.resolved.generated/ru_RU.ts
@@ -1739,6 +1739,7 @@ export const ru_RU: EnTranslations = {
       "notEnoughHonor": "Недостаточно чести.",
       "reasons": {
         "arenaWin": "Победа на арене",
+        "arenaComplete": "Бой на арене",
         "fiestaKill": "Устранение на Фиесте",
         "fiestaComplete": "Завершение Фиесты",
         "fiestaWin": "Победа на Фиесте",

--- a/src/ui/i18n.resolved.generated/sv_SE.ts
+++ b/src/ui/i18n.resolved.generated/sv_SE.ts
@@ -1739,6 +1739,7 @@ export const sv_SE: EnTranslations = {
       "notEnoughHonor": "Inte tillräckligt med heder.",
       "reasons": {
         "arenaWin": "Arenaseger",
+        "arenaComplete": "Arena bout fought",
         "fiestaKill": "Fiesta-nedtagning",
         "fiestaComplete": "Fiesta avklarad",
         "fiestaWin": "Fiesta-seger",

--- a/src/ui/i18n.resolved.generated/tr_TR.ts
+++ b/src/ui/i18n.resolved.generated/tr_TR.ts
@@ -1739,6 +1739,7 @@ export const tr_TR: EnTranslations = {
       "notEnoughHonor": "Yeterli Onur yok.",
       "reasons": {
         "arenaWin": "Arena zaferi",
+        "arenaComplete": "Arena bout fought",
         "fiestaKill": "Fiesta avlaması",
         "fiestaComplete": "Fiesta tamamlandı",
         "fiestaWin": "Fiesta zaferi",

--- a/src/ui/i18n.resolved.generated/vi_VN.ts
+++ b/src/ui/i18n.resolved.generated/vi_VN.ts
@@ -1739,6 +1739,7 @@ export const vi_VN: EnTranslations = {
       "notEnoughHonor": "Không đủ danh dự.",
       "reasons": {
         "arenaWin": "Chiến thắng đấu trường",
+        "arenaComplete": "Arena bout fought",
         "fiestaKill": "Hạ gục trong Fiesta",
         "fiestaComplete": "Fiesta đã hoàn thành",
         "fiestaWin": "Chiến thắng Fiesta",

--- a/src/ui/i18n.resolved.generated/zh_CN.ts
+++ b/src/ui/i18n.resolved.generated/zh_CN.ts
@@ -1739,6 +1739,7 @@ export const zh_CN: EnTranslations = {
       "notEnoughHonor": "荣誉不足。",
       "reasons": {
         "arenaWin": "竞技场胜利",
+        "arenaComplete": "竞技场参战",
         "fiestaKill": "嘉年华击倒",
         "fiestaComplete": "完成嘉年华",
         "fiestaWin": "嘉年华胜利",

--- a/src/ui/i18n.resolved.generated/zh_TW.ts
+++ b/src/ui/i18n.resolved.generated/zh_TW.ts
@@ -1739,6 +1739,7 @@ export const zh_TW: EnTranslations = {
       "notEnoughHonor": "榮譽不足。",
       "reasons": {
         "arenaWin": "競技場勝利",
+        "arenaComplete": "競技場參戰",
         "fiestaKill": "嘉年華擊倒",
         "fiestaComplete": "完成嘉年華",
         "fiestaWin": "嘉年華勝利",

--- a/tests/honor.test.ts
+++ b/tests/honor.test.ts
@@ -1,12 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import {
   ARENA_DAILY_TAPER_START,
+  ARENA_LOSS_HONOR_SHARE,
   awardBattlegroundAssistHonor,
   awardBattlegroundHonor,
   awardBattlegroundKillHonor,
   awardFiestaCompletionHonor,
   awardFiestaKillHonor,
-  awardRankedArenaWinHonor,
+  awardRankedArenaResultHonor,
   BATTLEGROUND_ASSIST_HONOR,
   BATTLEGROUND_FIRST_WIN_BONUS_HONOR,
   BATTLEGROUND_KILL_HONOR,
@@ -19,6 +20,7 @@ import {
   FIESTA_WIN_BONUS_HONOR,
   grantHonor,
   HONOR_REPEAT_DR,
+  RANKED_ARENA_LOSS_HONOR,
   RANKED_ARENA_WIN_HONOR,
   repeatHonorMultiplier,
 } from '../src/sim/pvp';
@@ -142,19 +144,64 @@ describe('honor currency', () => {
 });
 
 describe('ranked Arena honor', () => {
-  it('awards only the winner and records the result exactly once', () => {
+  it('pays the winner the faucet and the loser a third of it, exactly once', () => {
     const { sim, a, b, match } = liveArena();
     arena.endArenaMatch(sim.ctx, match, 'A', 'defeat');
 
-    expect(sim.meta(a)!.honor).toBe(RANKED_ARENA_WIN_HONOR['1v1']);
-    expect(sim.meta(b)!.honor).toBe(0);
+    // Pinned to the literals (not the constants) so a wrong 1v1 faucet or a
+    // wrong loss share reddens here.
+    expect(sim.meta(a)!.honor).toBe(25);
+    expect(sim.meta(b)!.honor).toBe(8);
+    expect(RANKED_ARENA_WIN_HONOR['1v1']).toBe(25);
+    expect(RANKED_ARENA_LOSS_HONOR['1v1']).toBe(8);
     expect(sim.meta(a)!.arenaWins).toBe(1);
     expect(sim.meta(b)!.arenaLosses).toBe(1);
 
     arena.endArenaMatch(sim.ctx, match, 'B', 'forfeit');
-    expect(sim.meta(a)!.honor).toBe(RANKED_ARENA_WIN_HONOR['1v1']);
+    expect(sim.meta(a)!.honor).toBe(25);
+    expect(sim.meta(b)!.honor).toBe(8);
     expect(sim.meta(a)!.arenaWins).toBe(1);
     expect(sim.meta(b)!.arenaWins).toBe(0);
+  });
+
+  it('pays both brackets a loss award of one third of their own win award', () => {
+    for (const format of ['1v1', '2v2'] as const) {
+      expect(RANKED_ARENA_LOSS_HONOR[format]).toBe(
+        Math.round(RANKED_ARENA_WIN_HONOR[format] * ARENA_LOSS_HONOR_SHARE),
+      );
+      // A loss is worth clearly less than a win: the gap is the whole reason to
+      // play to win rather than to farm completions.
+      expect(RANKED_ARENA_LOSS_HONOR[format]).toBeLessThan(RANKED_ARENA_WIN_HONOR[format]);
+      expect(RANKED_ARENA_LOSS_HONOR[format]).toBeGreaterThan(0);
+    }
+    expect(ARENA_LOSS_HONOR_SHARE).toBeCloseTo(1 / 3, 10);
+  });
+
+  it('pays a drawn bout the loss award to BOTH sides', () => {
+    const { sim, a, b, match } = liveArena();
+    arena.endArenaMatch(sim.ctx, match, null, 'timeout');
+
+    expect(sim.meta(a)!.honor).toBe(8);
+    expect(sim.meta(b)!.honor).toBe(8);
+    expect(sim.meta(a)!.arenaWins).toBe(0);
+    expect(sim.meta(b)!.arenaWins).toBe(0);
+    // The draw pays through the loss reason, not the win one: a drawn bout has
+    // no winner to name.
+    const reasons = sim.events
+      .filter((event) => event.type === 'honor')
+      .map((event) => (event as { reason: string }).reason);
+    expect(reasons).toEqual(['arena_complete', 'arena_complete']);
+  });
+
+  it('pays the 2v2 loss award to every member of the losing team', () => {
+    const { sim, match } = liveArena2v2();
+    arena.endArenaMatch(sim.ctx, match, 'A', 'defeat');
+
+    for (const pid of match.teamB) {
+      expect(sim.meta(pid)!.honor).toBe(17);
+      expect(RANKED_ARENA_LOSS_HONOR['2v2']).toBe(17);
+      expect(sim.meta(pid)!.arena2v2Losses).toBe(1);
+    }
   });
 
   it('pays no honor for a forfeit win but still moves rating, win count, and Deeds', () => {
@@ -162,7 +209,9 @@ describe('ranked Arena honor', () => {
     // forfeit (an opponent disconnect) must not be a free Honor farm, but the
     // rating swing and win/loss ledger stay forfeit-inclusive (deliberately,
     // per src/sim/deeds.ts's own comment) so a disconnect cannot grief the
-    // survivor's ladder standing.
+    // survivor's ladder standing. The LOSING side is the load-bearing half now
+    // that a played-out loss pays: conceding on sight must never be a way to
+    // buy the loss award.
     const { sim, a, b, match } = liveArena();
     const ratingBefore = sim.meta(a)!.arenaRating;
 
@@ -202,8 +251,8 @@ describe('ranked Arena honor', () => {
       expect(RANKED_ARENA_WIN_HONOR['2v2']).toBe(50);
       expect(sim.meta(pid)!.arena2v2Wins).toBe(1);
     }
+    // What the losing team is paid is pinned by its own case above.
     for (const pid of match.teamB) {
-      expect(sim.meta(pid)!.honor).toBe(0);
       expect(sim.meta(pid)!.arena2v2Losses).toBe(1);
     }
   });
@@ -215,7 +264,7 @@ describe('ranked Arena honor', () => {
     const meta = sim.meta(pid)!;
 
     const repeat = Array.from({ length: 4 }, () =>
-      awardRankedArenaWinHonor(sim.ctx, meta, '1v1', '["character:9"]'),
+      awardRankedArenaResultHonor(sim.ctx, meta, '1v1', '["character:9"]', 'win'),
     );
     expect(repeat).toEqual([25, 0, 0, 0]);
 
@@ -224,12 +273,78 @@ describe('ranked Arena honor', () => {
     const freshPid = fresh.addPlayer('warrior', 'Taper');
     const freshMeta = fresh.meta(freshPid)!;
     for (let i = 0; i < ARENA_DAILY_TAPER_START; i++) {
-      expect(awardRankedArenaWinHonor(fresh.ctx, freshMeta, '1v1', `["character:${i}"]`)).toBe(25);
+      expect(
+        awardRankedArenaResultHonor(fresh.ctx, freshMeta, '1v1', `["character:${i}"]`, 'win'),
+      ).toBe(25);
     }
-    expect(awardRankedArenaWinHonor(fresh.ctx, freshMeta, '1v1', '["character:next"]')).toBe(12);
+    expect(
+      awardRankedArenaResultHonor(fresh.ctx, freshMeta, '1v1', '["character:next"]', 'win'),
+    ).toBe(12);
 
     fresh.resetDay = '2026-07-12';
-    expect(awardRankedArenaWinHonor(fresh.ctx, freshMeta, '1v1', '["character:next"]')).toBe(25);
+    expect(
+      awardRankedArenaResultHonor(fresh.ctx, freshMeta, '1v1', '["character:next"]', 'win'),
+    ).toBe(25);
+  });
+
+  it('decays a repeated loss to the same team and rolls the counter over each day', () => {
+    const sim = world();
+    sim.resetDay = '2026-07-11';
+    const meta = sim.meta(sim.addPlayer('warrior', 'Loser'))!;
+    const key = '["character:9"]';
+
+    const repeat = Array.from({ length: 4 }, () =>
+      awardRankedArenaResultHonor(sim.ctx, meta, '1v1', key, 'loss'),
+    );
+    // The same ARENA_REPEAT_DR curve the win award is on: the day's first meeting
+    // pays, every rematch pays nothing, so a traded pair cannot farm the loss arm.
+    expect(repeat).toEqual([8, 0, 0, 0]);
+
+    sim.resetDay = '2026-07-12';
+    expect(awardRankedArenaResultHonor(sim.ctx, meta, '1v1', key, 'loss')).toBe(8);
+  });
+
+  it('keeps the loss counter off the win counter, in both directions', () => {
+    const sim = world();
+    sim.resetDay = '2026-07-11';
+    const meta = sim.meta(sim.addPlayer('warrior', 'Rematch'))!;
+    const key = '["character:9"]';
+
+    // Losing to a team first must not spend the award for beating it later.
+    expect(awardRankedArenaResultHonor(sim.ctx, meta, '1v1', key, 'loss')).toBe(8);
+    expect(awardRankedArenaResultHonor(sim.ctx, meta, '1v1', key, 'win')).toBe(25);
+    // And each counter is spent exactly once, so the pairing's whole day is
+    // win + loss and no more: the win-trading ceiling.
+    expect(awardRankedArenaResultHonor(sim.ctx, meta, '1v1', key, 'loss')).toBe(0);
+    expect(awardRankedArenaResultHonor(sim.ctx, meta, '1v1', key, 'win')).toBe(0);
+    expect(meta.honor).toBe(33);
+  });
+
+  it('tapers loss awards on the daily win count without letting losses advance it', () => {
+    const sim = world();
+    sim.resetDay = '2026-07-11';
+    const meta = sim.meta(sim.addPlayer('warrior', 'Grinder'))!;
+
+    // A day of nothing but losses never tapers itself: the taper caps arena
+    // INCOME, and a player must not be able to pad it by conceding bouts.
+    for (let i = 0; i < ARENA_DAILY_TAPER_START + 2; i++) {
+      expect(awardRankedArenaResultHonor(sim.ctx, meta, '1v1', `["character:${i}"]`, 'loss')).toBe(
+        8,
+      );
+    }
+    expect(meta.honorArenaDaily?.totalWins).toBe(0);
+    expect(awardRankedArenaResultHonor(sim.ctx, meta, '1v1', '["character:win"]', 'win')).toBe(25);
+
+    // Wins do taper the loss award, on the same curve they taper themselves.
+    const winner = world();
+    winner.resetDay = '2026-07-11';
+    const winnerMeta = winner.meta(winner.addPlayer('warrior', 'Champion'))!;
+    for (let i = 0; i < ARENA_DAILY_TAPER_START; i++) {
+      awardRankedArenaResultHonor(winner.ctx, winnerMeta, '1v1', `["character:${i}"]`, 'win');
+    }
+    expect(
+      awardRankedArenaResultHonor(winner.ctx, winnerMeta, '1v1', '["character:next"]', 'loss'),
+    ).toBe(4);
   });
 
   it('does not reset a persisted daily window when the host has no UTC day', () => {
@@ -238,9 +353,51 @@ describe('ranked Arena honor', () => {
     const pid = sim.addPlayer('warrior', 'Replay');
     const meta = sim.meta(pid)!;
     const key = '["name:opponent"]';
-    expect(awardRankedArenaWinHonor(sim.ctx, meta, '1v1', key)).toBe(25);
+    expect(awardRankedArenaResultHonor(sim.ctx, meta, '1v1', key, 'win')).toBe(25);
     sim.resetDay = '';
-    expect(awardRankedArenaWinHonor(sim.ctx, meta, '1v1', key)).toBe(0);
+    expect(awardRankedArenaResultHonor(sim.ctx, meta, '1v1', key, 'win')).toBe(0);
+  });
+
+  it('round-trips the loss counter and leaves an unused one out of the save', () => {
+    const sim = world();
+    sim.resetDay = '2026-07-11';
+    const pid = sim.addPlayer('warrior', 'Persist');
+    const meta = sim.meta(pid)!;
+
+    // Absent, not empty, until a loss pays: a save written before this existed
+    // must round-trip byte-identical.
+    awardRankedArenaResultHonor(sim.ctx, meta, '1v1', '["character:9"]', 'win');
+    expect(sim.serializeCharacter(pid)!.honorArenaDaily?.lossesByOpponent).toBeUndefined();
+
+    awardRankedArenaResultHonor(sim.ctx, meta, '1v1', '["character:9"]', 'loss');
+    const saved = sim.serializeCharacter(pid)!;
+    expect(saved.honorArenaDaily?.lossesByOpponent).toEqual({ '1v1:["character:9"]': 1 });
+
+    const loaded = world();
+    loaded.resetDay = '2026-07-11';
+    const loadedPid = loaded.addPlayer('warrior', 'Persist', { state: saved });
+    const loadedMeta = loaded.meta(loadedPid)!;
+    // The spent counter survives the reload, so relogging cannot re-arm it.
+    expect(
+      awardRankedArenaResultHonor(loaded.ctx, loadedMeta, '1v1', '["character:9"]', 'loss'),
+    ).toBe(0);
+  });
+
+  it('sanitizes a malformed persisted loss counter', () => {
+    const seed = world();
+    const seedPid = seed.addPlayer('warrior', 'Corrupt');
+    const state = seed.serializeCharacter(seedPid)! as unknown as Record<string, unknown>;
+    state.honorArenaDaily = {
+      date: '2026-07-11',
+      winsByOpponent: {},
+      lossesByOpponent: { valid: 3.7, negative: -2, nan: Number.NaN },
+      fiestaCompletionsByOpponent: {},
+      totalWins: 0,
+    };
+
+    const loaded = world();
+    const meta = loaded.meta(loaded.addPlayer('warrior', 'Corrupt', { state: state as never }))!;
+    expect(meta.honorArenaDaily?.lossesByOpponent).toEqual({ valid: 3 });
   });
 });
 

--- a/tests/honor_float_view.test.ts
+++ b/tests/honor_float_view.test.ts
@@ -13,6 +13,7 @@ import { ensureLocaleLoaded, setLanguage } from '../src/ui/i18n';
 // shipping a silently-plain float.
 const ALL_REASONS: HonorReason[] = [
   'arena_win',
+  'arena_complete',
   'fiesta_kill',
   'fiesta_complete',
   'fiesta_win',

--- a/tests/parity/golden/arena_1v1.json
+++ b/tests/parity/golden/arena_1v1.json
@@ -73,8 +73,8 @@
       "tick": 125,
       "time": 6.25,
       "nextId": 965,
-      "state": "8f986167",
-      "events": "071cd128",
+      "state": "bdd28287",
+      "events": "882e2781",
       "rng": {
         "draws": 787,
         "digest": "22f85826"
@@ -84,7 +84,7 @@
       "tick": 142,
       "time": 7.1,
       "nextId": 965,
-      "state": "9066cdc2",
+      "state": "48657484",
       "events": "741638a5",
       "rng": {
         "draws": 982,
@@ -256,6 +256,14 @@
           "equipmentInstance": {},
           "gatheringProficiency": {},
           "heroicDaily": {},
+          "honor": 8,
+          "honorArenaDaily": {
+            "fiestaCompletionsByOpponent": {},
+            "lossesByOpponent": {
+              "1v1:[\"name:aleph\"]": 1
+            },
+            "winsByOpponent": {}
+          },
           "inventory": [
             {
               "count": 5,
@@ -266,6 +274,7 @@
               "itemId": "spring_water"
             }
           ],
+          "lifetimeHonor": 8,
           "lifetimeXp": 78400,
           "mailWelcomed": true,
           "nodeHarvestReadyAt": {},

--- a/tests/parity/golden/arena_2v2_wipe.json
+++ b/tests/parity/golden/arena_2v2_wipe.json
@@ -1165,8 +1165,8 @@
       "tick": 103,
       "time": 5.15,
       "nextId": 967,
-      "state": "26fca97c",
-      "events": "d16bc573",
+      "state": "9532353e",
+      "events": "322d46ae",
       "rng": {
         "draws": 538,
         "digest": "989640f4"
@@ -1434,12 +1434,21 @@
           "equipmentInstance": {},
           "gatheringProficiency": {},
           "heroicDaily": {},
+          "honor": 17,
+          "honorArenaDaily": {
+            "fiestaCompletionsByOpponent": {},
+            "lossesByOpponent": {
+              "2v2:[\"name:aleph\",\"name:bet\"]": 1
+            },
+            "winsByOpponent": {}
+          },
           "inventory": [
             {
               "count": 5,
               "itemId": "baked_bread"
             }
           ],
+          "lifetimeHonor": 17,
           "lifetimeXp": 78400,
           "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
@@ -1522,6 +1531,14 @@
           "equipmentInstance": {},
           "gatheringProficiency": {},
           "heroicDaily": {},
+          "honor": 17,
+          "honorArenaDaily": {
+            "fiestaCompletionsByOpponent": {},
+            "lossesByOpponent": {
+              "2v2:[\"name:aleph\",\"name:bet\"]": 1
+            },
+            "winsByOpponent": {}
+          },
           "inventory": [
             {
               "count": 5,
@@ -1532,6 +1549,7 @@
               "itemId": "spring_water"
             }
           ],
+          "lifetimeHonor": 17,
           "lifetimeXp": 78400,
           "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
@@ -1770,7 +1788,7 @@
       "tick": 125,
       "time": 6.25,
       "nextId": 967,
-      "state": "b2fa4536",
+      "state": "9c5e7b98",
       "events": "741638a5",
       "rng": {
         "draws": 754,
@@ -1781,7 +1799,7 @@
       "tick": 150,
       "time": 7.5,
       "nextId": 967,
-      "state": "3b7c43c0",
+      "state": "4bf7be82",
       "events": "741638a5",
       "rng": {
         "draws": 1029,
@@ -1792,7 +1810,7 @@
       "tick": 175,
       "time": 8.75,
       "nextId": 967,
-      "state": "3e88f86f",
+      "state": "f4393c39",
       "events": "741638a5",
       "rng": {
         "draws": 1349,
@@ -1803,7 +1821,7 @@
       "tick": 200,
       "time": 10,
       "nextId": 967,
-      "state": "4e16decb",
+      "state": "7f85ffc5",
       "events": "741638a5",
       "rng": {
         "draws": 1668,
@@ -1814,7 +1832,7 @@
       "tick": 225,
       "time": 11.25,
       "nextId": 967,
-      "state": "98a49cf0",
+      "state": "0303bbe6",
       "events": "de7d14f9",
       "rng": {
         "draws": 1860,
@@ -1825,7 +1843,7 @@
       "tick": 243,
       "time": 12.15,
       "nextId": 967,
-      "state": "730f0ed9",
+      "state": "ad58a89f",
       "events": "741638a5",
       "rng": {
         "draws": 2000,
@@ -2103,12 +2121,21 @@
           "equipmentInstance": {},
           "gatheringProficiency": {},
           "heroicDaily": {},
+          "honor": 17,
+          "honorArenaDaily": {
+            "fiestaCompletionsByOpponent": {},
+            "lossesByOpponent": {
+              "2v2:[\"name:aleph\",\"name:bet\"]": 1
+            },
+            "winsByOpponent": {}
+          },
           "inventory": [
             {
               "count": 5,
               "itemId": "baked_bread"
             }
           ],
+          "lifetimeHonor": 17,
           "lifetimeXp": 78400,
           "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
@@ -2194,6 +2221,14 @@
           "equipmentInstance": {},
           "gatheringProficiency": {},
           "heroicDaily": {},
+          "honor": 17,
+          "honorArenaDaily": {
+            "fiestaCompletionsByOpponent": {},
+            "lossesByOpponent": {
+              "2v2:[\"name:aleph\",\"name:bet\"]": 1
+            },
+            "winsByOpponent": {}
+          },
           "inventory": [
             {
               "count": 5,
@@ -2204,6 +2239,7 @@
               "itemId": "spring_water"
             }
           ],
+          "lifetimeHonor": 17,
           "lifetimeXp": 78400,
           "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
@@ -2447,7 +2483,7 @@
       "tick": 243,
       "time": 12.15,
       "nextId": 967,
-      "state": "730f0ed9",
+      "state": "ad58a89f",
       "events": "741638a5",
       "rng": {
         "draws": 2000,
@@ -2725,12 +2761,21 @@
           "equipmentInstance": {},
           "gatheringProficiency": {},
           "heroicDaily": {},
+          "honor": 17,
+          "honorArenaDaily": {
+            "fiestaCompletionsByOpponent": {},
+            "lossesByOpponent": {
+              "2v2:[\"name:aleph\",\"name:bet\"]": 1
+            },
+            "winsByOpponent": {}
+          },
           "inventory": [
             {
               "count": 5,
               "itemId": "baked_bread"
             }
           ],
+          "lifetimeHonor": 17,
           "lifetimeXp": 78400,
           "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
@@ -2816,6 +2861,14 @@
           "equipmentInstance": {},
           "gatheringProficiency": {},
           "heroicDaily": {},
+          "honor": 17,
+          "honorArenaDaily": {
+            "fiestaCompletionsByOpponent": {},
+            "lossesByOpponent": {
+              "2v2:[\"name:aleph\",\"name:bet\"]": 1
+            },
+            "winsByOpponent": {}
+          },
           "inventory": [
             {
               "count": 5,
@@ -2826,6 +2879,7 @@
               "itemId": "spring_water"
             }
           ],
+          "lifetimeHonor": 17,
           "lifetimeXp": 78400,
           "mailWelcomed": true,
           "nodeHarvestReadyAt": {},


### PR DESCRIPTION
## Summary

Ranked arena was the only PvP mode that paid a loss nothing at all. A player who
queued into 1v1 or 2v2 and lost walked away with a rating change and no currency,
so there was no way to progress toward Warfare gear except winning, and nothing to
show for a session that went badly.

The other two modes already carry the rule this restores, both at the same share:
Thornhollow Fields pays a non-winner 20 against a 60 win, and Fiesta pays its 20
completion against a 20 + 40 win. This gives ranked arena the same third.

| Bracket | Win | Loss (new) | Draw (new) |
|---|---|---|---|
| 1v1 | 25 | 8 | 8 to both |
| 2v2 | 50 | 17 | 17 to both |

The loss award is DERIVED from the win faucet (`ARENA_LOSS_HONOR_SHARE = 1/3`,
rounded), not authored beside it, so retuning a bracket carries its loss award
along instead of silently drifting apart.

Anti-win-trading, which is what makes this safe:

- Losses decay on the existing per-opponent daily curve (`ARENA_REPEAT_DR`), so the
  first meeting of a team each UTC day pays and every rematch pays nothing.
- Wins and losses count on SEPARATE counters. Sharing one would mean losing to a
  team spends the award for beating it later, which punishes exactly the honest
  player who queues into a stronger team and comes back. Separate counters cap a
  traded pair at one win plus one loss per pairing per day, which is what one
  honest bout against a fresh opponent already pays.
- Only a win advances the daily taper, so a player cannot pad the day with losses.
- Forfeits still pay nothing to either side, so "queue, concede, collect" is not a
  faucet.

A draw pays the loss award to both sides, which is what a drawn Thornhollow Fields
match does, and it makes a timeout worth playing out. Draws and losses share one
Honor reason (`arena_complete`, "Arena bout fought") for the same reason the
battleground has `battleground_complete`: a drawn bout has no loser to name.

## Related issues

Related to #1576 (PvP currency and long-term PvP progression). Does not close it:
that issue asks for a broader progression system, this is the missing faucet.

## Type of change

- [x] Feature: new functionality
- [ ] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change

## How was this tested?

- Commands:
  - `node scripts/gate_select.mjs` (green)
  - `npx vitest run tests/honor.test.ts tests/honor_float_view.test.ts tests/arena.test.ts`
  - `npx vitest run tests/localization_fixes.test.ts tests/i18n_completeness.test.ts tests/i18n_status_registry.test.ts tests/localization_coverage.test.ts`
  - `npx vitest run tests/parity`, then `UPDATE_PARITY=1 npx vitest run tests/parity` in its own commit
  - `npx tsc --noEmit`
- New and updated tests in `tests/honor.test.ts`, driven through real ranked matches
  (`arena.endArenaMatch`) rather than the award function alone:
  - winner 25 / loser 8 in 1v1 and 17 per member of the losing 2v2 team, pinned to
    literals so a wrong faucet or share reddens the pin
  - a drawn bout pays both sides, through the loss reason
  - the loss share is exactly `round(win / 3)` in both brackets
  - a repeated loss to the same team decays to 0 and re-arms on the next UTC day
  - a loss does not spend the win award for the rematch, and each counter pays once
  - the daily taper applies to losses but losses never advance it
  - the loss counter round-trips through the save, stays absent when unused (so
    pre-change saves are byte-equal), and sanitizes malformed persisted values
- Parity: the only two goldens that moved are `arena_1v1` and `arena_2v2_wipe`, and
  the only drift in them is the losing side's Honor plus its spent counter. Every
  other scenario is byte-identical, which is the evidence the change is scoped to
  ranked arena results.

## Screenshots / recordings

N/A. No new UI surface: the loss award floats with the same plain Honor float as
every other once-per-match award, and adds one localized chat line
("You gain 8 Honor (Arena bout fought).").

---

## Checklist

### Quality

- [x] **The gate passes.** `node scripts/gate_select.mjs` is green, with decisive
      tests added for the changed behavior.

### Cross-platform

- [x] N/A. No UI layout or input surface changes.

### Localization (i18n)

- [x] **New player-visible strings follow the contributor policy.** One new English
      catalog key (`hudChrome.warfare.reasons.arenaComplete`) in
      `src/ui/i18n.catalog/hud_chrome.ts`, plus the five required non-Latin fills
      under the M16 wordy-copy rule (zh_CN, zh_TW, ja_JP, ko_KR, ru_RU).
- [x] Numbers go through the existing formatters (the Honor float and chat line
      already run the amount through `formatNumber`).
- [x] The sim emits a `HonorReason` enum, not text; it is mapped at the client
      boundary in `src/ui/hud.ts` in this same change and
      `npx vitest run tests/localization_fixes.test.ts` passes.

### Hygiene

- [x] No secrets, credentials, or `.env`, and `ALLOW_DEV_COMMANDS` is untouched.
- [x] No hand-edited generated files: the i18n artifacts were regenerated with
      `npm run i18n:gen` plus `node scripts/i18n_resolved_hash.mjs --write`, and the
      parity goldens with `UPDATE_PARITY=1` in its own commit.
