### PR TITLE
fix(warlock): allow late party joins at Soulwell

### DIFF
--- a/src/sim/soulwell.ts
+++ b/src/sim/soulwell.ts
@@ -113,7 +113,9 @@ export function interactSoulwell(ctx: SimContext, object: Entity, actorId: numbe
   }
 
   const state = object.soulwell;
-  if (!state.eligiblePlayerIds.includes(actorId)) {
+  const ownerParty = ctx.partyOf(state.ownerId);
+  const isCurrentGroupMember = ownerParty?.members.includes(actorId) ?? false;
+  if (!state.eligiblePlayerIds.includes(actorId) && !isCurrentGroupMember) {
     ctx.error(actorId, 'That ally is not in your group.');
     return true;
   }

--- a/tests/soulwell.test.ts
+++ b/tests/soulwell.test.ts
@@ -132,6 +132,17 @@ describe('Warlock Soulwell', () => {
     expect(sim.countItem(SOUL_STONE_ITEM_ID, strangerId)).toBe(0);
   });
 
+  it('lets a player who joins the group after summoning use the active well', () => {
+    const { sim, owner, ownerId, strangerId } = world();
+    const well = summon(sim, owner);
+
+    sim.partyInvite(strangerId, ownerId);
+    sim.partyAccept(strangerId);
+
+    expect(sim.pickUpObject(well.id, strangerId)).toBe(true);
+    expect(sim.countItem(SOUL_STONE_ITEM_ID, strangerId)).toBe(3);
+  });
+
   it('keeps the summoned group roster eligible after the owner disconnects', () => {
     const { sim, owner, ownerId, allyId } = world();
     const well = summon(sim, owner);


### PR DESCRIPTION
## Summary

- Allow a player who joins the owner's party after Soulwell summoning to use the active well.
- Preserve the summon-time eligible roster, including its existing owner-disconnect behavior.
- Add a regression test through the real party invite, accept, and Soulwell interaction flow.

## Type of change

- [x] Bug fix
- [x] Tests

## How was this tested?

- node_modules\.bin\vitest.cmd run tests\soulwell.test.ts - 12/12 passed.
- node_modules\.bin\vitest.cmd run tests\architecture.test.ts - 44/44 passed.
- node_modules\.bin\tsc.cmd --noEmit - passed.
- Pre-push QA floor - 85 passed, 3 skipped; typecheck, guard tests, lint, and copy rules green.
- node scripts/gate_select.mjs reached the selective Vitest floor but is not fully green on Windows: 9 unrelated infrastructure failures require POSIX grep/npx, stable CI fixtures, or successful temporary-directory cleanup. The changed Soulwell and architecture suites remained green.
- Manual steps: N/A.

---

## Checklist

### Quality

- [x] Added a decisive regression test for the changed behavior.
- [ ] Full selective gate is green locally; see the documented Windows-only unrelated failures above.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or .env committed, and ALLOW_DEV_COMMANDS is not enabled in any production path.
- [x] I did not hand-edit generated files.