### PR TITLE
fix(docker): carry the vitest sharding sequencer into the image build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -21,6 +21,13 @@ scripts/*
 !scripts/rift_forge_rollback_migration.ts
 !scripts/build_sitemap.mjs
 !scripts/browserslist_targets.mjs
+# vite.config.ts imports the vitest sharding sequencer at module scope, so
+# loading the config for a production `vite build` needs it and its two
+# dependencies present. tests/dockerignore_context.test.ts derives this set
+# from the config's own imports and fails if any of it stops reaching the image.
+!scripts/ci_balanced_sequencer.mjs
+!scripts/ci_shard_partition.mjs
+!scripts/ci_shard_weights.generated.json
 !scripts/check_backdrop_survival.mjs
 !scripts/prod_cpu_game_helper.mjs
 !scripts/prod_cpu_profile_client.mjs

--- a/scripts/lib/dockerignore_context.d.mts
+++ b/scripts/lib/dockerignore_context.d.mts
@@ -1,0 +1,5 @@
+export declare function isIgnoredByDockerignore(dockerignore: string, path: string): boolean;
+export declare function collectLocalImportClosure(
+  entry: string,
+  readFile: (path: string) => string | null | undefined,
+): string[];

--- a/scripts/lib/dockerignore_context.mjs
+++ b/scripts/lib/dockerignore_context.mjs
@@ -1,0 +1,101 @@
+// Does the image build context still carry everything vite.config.ts imports?
+//
+// The Dockerfile copies the repo through .dockerignore, which excludes
+// `scripts/*` wholesale and then allowlists individual files. vite.config.ts
+// imports several of those at module scope, so a `vite build` inside the image
+// FAILS TO LOAD ITS OWN CONFIG the moment someone adds an import whose target
+// is not on the allowlist. That has now shipped twice (build_bundle_pregen.mjs,
+// then the ci_balanced_sequencer.mjs chain), because CI builds with the whole
+// repo present and never exercises the .dockerignore filter.
+//
+// These two helpers are the machine-checkable half of that contract:
+// collectLocalImportClosure walks what the config actually imports, and
+// isIgnoredByDockerignore answers whether the filter would drop it. Both are
+// pure so tests/dockerignore_context.test.ts can drive them off fixtures as
+// well as off the real repo.
+
+// One .dockerignore pattern as an anchored RegExp.
+//
+// Docker's matcher is Go filepath.Match plus `**`, evaluated against a
+// context-relative, slash-separated path. A pattern that matches a DIRECTORY
+// also excludes everything beneath it, which is why every pattern here is
+// suffixed with an optional `/...` tail: that tail is what makes the real
+// `scripts/*` line exclude `scripts/lib/foo.mjs`, and it is exactly why the
+// `!scripts/lib/` line below it has to exist at all.
+function patternToRegExp(pattern) {
+  const trimmed = pattern.replace(/^\.\//, '').replace(/\/+$/, '');
+  let source = '';
+  for (let i = 0; i < trimmed.length; i++) {
+    const char = trimmed[i];
+    if (char === '*') {
+      if (trimmed[i + 1] === '*') {
+        i++;
+        if (trimmed[i + 1] === '/') {
+          i++;
+          source += '(?:.*/)?';
+        } else {
+          source += '.*';
+        }
+      } else {
+        source += '[^/]*';
+      }
+      continue;
+    }
+    if (char === '?') {
+      source += '[^/]';
+      continue;
+    }
+    source += char.replace(/[.+^${}()|[\]\\]/g, '\\$&');
+  }
+  return new RegExp(`^${source}(?:/.*)?$`);
+}
+
+/** Would .dockerignore drop `path` from the build context? Last match wins, and
+ *  a `!` line un-drops it, which is how the allowlist under `scripts/*` works. */
+export function isIgnoredByDockerignore(dockerignore, path) {
+  let ignored = false;
+  for (const rawLine of String(dockerignore).split('\n')) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) continue;
+    const negated = line.startsWith('!');
+    const body = (negated ? line.slice(1) : line).trim();
+    if (!body) continue;
+    if (patternToRegExp(body).test(path)) ignored = !negated;
+  }
+  return ignored;
+}
+
+// Relative specifiers only: a bare specifier is a package resolved from
+// node_modules, which the image installs itself and .dockerignore never filters.
+const LOCAL_SPECIFIER = /(?:from\s*|import\s*\(\s*)['"](\.[^'"]+)['"]/g;
+
+function resolveRelative(fromPath, specifier) {
+  const segments = fromPath.split('/').slice(0, -1);
+  for (const part of specifier.split('/')) {
+    if (part === '.' || part === '') continue;
+    if (part === '..') segments.pop();
+    else segments.push(part);
+  }
+  return segments.join('/');
+}
+
+/** Every repo-relative file reachable from `entry` through relative imports,
+ *  entry included. `readFile` returns null for a path that is not a readable
+ *  source file, which ends that branch of the walk. */
+export function collectLocalImportClosure(entry, readFile) {
+  const seen = new Set();
+  const closure = [];
+  const pending = [entry];
+  while (pending.length > 0) {
+    const path = pending.pop();
+    if (seen.has(path)) continue;
+    seen.add(path);
+    const source = readFile(path);
+    if (source === null || source === undefined) continue;
+    closure.push(path);
+    for (const match of String(source).matchAll(LOCAL_SPECIFIER)) {
+      pending.push(resolveRelative(path, match[1]));
+    }
+  }
+  return closure;
+}

--- a/tests/dockerignore_context.test.ts
+++ b/tests/dockerignore_context.test.ts
@@ -1,0 +1,142 @@
+// The image build context has to carry everything vite.config.ts imports.
+//
+// .dockerignore excludes `scripts/*` and allowlists individual files under it.
+// vite.config.ts imports several of those at module scope, so an import whose
+// target is not allowlisted does not fail at review or in CI (both run with the
+// whole repo present); it fails inside `docker compose build` with
+// "failed to load config from /app/vite.config.ts", which is the LAST step
+// before a deploy and the first one nobody watches.
+//
+// It has shipped twice: PR #3353 (build_bundle_pregen.mjs) and then the
+// ci_balanced_sequencer.mjs chain in v0.38.0, which broke every environment's
+// image build until this guard landed. The string pins elsewhere in the suite
+// (`expect(dockerignore).toContain('!scripts/build_bot.mjs')`) cannot catch it,
+// because a new import has no pin until someone remembers to write one. This
+// test derives the set from the config's own imports instead.
+
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import {
+  collectLocalImportClosure,
+  isIgnoredByDockerignore,
+} from '../scripts/lib/dockerignore_context.mjs';
+
+const repoRoot = new URL('../', import.meta.url);
+
+function readRepoFile(path: string): string | null {
+  try {
+    return readFileSync(new URL(path, repoRoot), 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+const dockerignore = readRepoFile('.dockerignore') ?? '';
+
+describe('vite.config.ts survives the image build context', () => {
+  it('reaches the image with every file it imports', () => {
+    const closure = collectLocalImportClosure('vite.config.ts', readRepoFile);
+    const dropped = closure.filter((path) => isIgnoredByDockerignore(dockerignore, path));
+    // Named, not just counted: the failure message has to say which file to
+    // allowlist, since the docker error only names vite.config.ts itself.
+    expect(dropped).toEqual([]);
+  });
+
+  it('walks past the entry into transitive imports', () => {
+    // The v0.38.0 break was two hops deep (vite.config.ts imports the
+    // sequencer, which imports the partitioner, which imports the weights
+    // JSON), so a walk that stopped at direct imports would have missed it.
+    const closure = collectLocalImportClosure('vite.config.ts', readRepoFile);
+    expect(closure).toContain('scripts/ci_balanced_sequencer.mjs');
+    expect(closure).toContain('scripts/ci_shard_partition.mjs');
+    expect(closure).toContain('scripts/ci_shard_weights.generated.json');
+  });
+});
+
+describe('isIgnoredByDockerignore', () => {
+  const rules = [
+    'scripts/*',
+    '!scripts/build_server.mjs',
+    '!scripts/i18n_*.mjs',
+    '!scripts/lib/',
+    '!scripts/sfx/**',
+  ].join('\n');
+
+  it('drops a file under a wildcard-excluded directory', () => {
+    expect(isIgnoredByDockerignore(rules, 'scripts/ci_shard_partition.mjs')).toBe(true);
+  });
+
+  it('keeps a file the allowlist names outright', () => {
+    expect(isIgnoredByDockerignore(rules, 'scripts/build_server.mjs')).toBe(false);
+  });
+
+  it('keeps a file matched by an allowlisted glob, and only that glob', () => {
+    expect(isIgnoredByDockerignore(rules, 'scripts/i18n_modulepreload.mjs')).toBe(false);
+    expect(isIgnoredByDockerignore(rules, 'scripts/sfx_gain.mjs')).toBe(true);
+  });
+
+  it('carries a directory allowlist down to its contents', () => {
+    expect(isIgnoredByDockerignore(rules, 'scripts/lib/ci_shard_plan.mjs')).toBe(false);
+    expect(isIgnoredByDockerignore(rules, 'scripts/sfx/pack/tone.mjs')).toBe(false);
+  });
+
+  it('excludes a directory subtree, which is why the lib allowlist is needed', () => {
+    // `scripts/*` alone would take scripts/lib with it. If this ever reports
+    // false, the directory-tail semantics are gone and every allowlist line
+    // under a directory pattern is silently doing nothing.
+    expect(isIgnoredByDockerignore('scripts/*', 'scripts/lib/ci_shard_plan.mjs')).toBe(true);
+  });
+
+  it('leaves an unmatched path in the context', () => {
+    expect(isIgnoredByDockerignore(rules, 'src/main.ts')).toBe(false);
+  });
+
+  it('ignores comments and blank lines', () => {
+    expect(isIgnoredByDockerignore('# scripts/*\n\n', 'scripts/anything.mjs')).toBe(false);
+  });
+
+  it('lets the last matching rule win in both directions', () => {
+    expect(isIgnoredByDockerignore('scripts/*\n!scripts/a.mjs', 'scripts/a.mjs')).toBe(false);
+    expect(isIgnoredByDockerignore('!scripts/a.mjs\nscripts/*', 'scripts/a.mjs')).toBe(true);
+  });
+});
+
+describe('collectLocalImportClosure', () => {
+  const files: Record<string, string> = {
+    'entry.ts':
+      "import { a } from './one.mjs';\nimport data from './data.json' with { type: 'json' };",
+    'one.mjs': "import { b } from './nested/two.mjs';\nimport 'vitest/node';",
+    'nested/two.mjs': "import { c } from '../one.mjs';",
+    'data.json': '{}',
+  };
+  const read = (path: string) => files[path] ?? null;
+
+  it('returns the entry plus everything reachable from it', () => {
+    expect(collectLocalImportClosure('entry.ts', read).sort()).toEqual([
+      'data.json',
+      'entry.ts',
+      'nested/two.mjs',
+      'one.mjs',
+    ]);
+  });
+
+  it('resolves parent traversal rather than emitting a bogus path', () => {
+    expect(collectLocalImportClosure('nested/two.mjs', read).sort()).toEqual([
+      'nested/two.mjs',
+      'one.mjs',
+    ]);
+  });
+
+  it('terminates on an import cycle', () => {
+    // one.mjs and nested/two.mjs import each other.
+    expect(collectLocalImportClosure('one.mjs', read)).toHaveLength(2);
+  });
+
+  it('skips bare package specifiers, which the image installs itself', () => {
+    expect(collectLocalImportClosure('one.mjs', read)).not.toContain('vitest/node');
+  });
+
+  it('drops a path that does not resolve to a readable file', () => {
+    expect(collectLocalImportClosure('entry.ts', () => null)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

**v0.38.0 cannot build a Docker image, so it cannot deploy to any environment.** The dev
deploy of `main` failed on this today, and prod would fail identically on its next run.

`vite.config.ts:10` imports `./scripts/ci_balanced_sequencer.mjs` at module scope (it supplies
the vitest `sequence.sequencer`). `.dockerignore` excludes `scripts/*` behind a hand-maintained
allowlist, and the sequencer never joined it, so `pnpm run build` inside the image dies loading
its own config:

```
failed to load config from /app/vite.config.ts
[UNRESOLVED_IMPORT] Could not resolve './scripts/ci_balanced_sequencer.mjs' in vite.config.ts
```

The import arrived with `#3396` (measured-weight LPT sharding). Three files are missing from the
build context, which is the whole transitive closure and nothing more:

- `scripts/ci_balanced_sequencer.mjs`
- `scripts/ci_shard_partition.mjs`
- `scripts/ci_shard_weights.generated.json` (113.8 KB)

This PR allowlists those three, and adds the guard that makes the class of bug fail at review
instead of at deploy.

### Why a guard, not just three lines

This is the second time the allowlist has rotted in a week. `#3353` was the identical failure for
`build_bundle_pregen.mjs`. It keeps happening because:

- CI builds with the whole repo present and never exercises the `.dockerignore` filter, so the
  break is invisible until `docker compose build` runs on a deploy host.
- The existing coverage is per-file string pins (`expect(dockerignore).toContain('!scripts/build_bot.mjs')`),
  which a newly added import has no reason to ever acquire.
- The docker error names only `vite.config.ts`, never the file that is actually missing.

`tests/dockerignore_context.test.ts` walks `vite.config.ts`'s own transitive relative imports and
fails on any the filter would drop, listing them by name. It is derived, so it needs no
maintenance when an import is added, and it would have caught both this break and `#3353`.

The two helpers live in `scripts/lib/dockerignore_context.mjs` as a pure core (a `.dockerignore`
matcher and an import-closure walker), matching the `diagnostics_capture_guard.mjs` convention in
the same directory, so the test drives them off fixtures as well as off the real repo.

### Known follow-up, deliberately not in this PR

`BalancedSequencer` is used only inside the `test:` block, so a **test-only** import is what
breaks the **production** image build. The cleaner fix is for `vite.config.ts` to stop importing
test-only code at module scope, but that is a change to a load-bearing config file and does not
belong in a hotfix that unblocks deploys. The guard above holds the line either way.

## Related issues

Follows `#3353` (same failure class). The import came from `#3396`.

## Type of change

- [x] Bug fix
- [x] Tests
- [x] Build, CI, or tooling

## How was this tested?

- Commands:
  - `npx vitest run tests/dockerignore_context.test.ts`: 15 tests pass.
  - **Decisiveness check:** with the `.dockerignore` hunk reverted to `main`'s version, the guard
    fails and names all three files (`expected [ …(3) ] to deeply equal []`). It is not a vacuous
    pin.
  - `npx vitest run tests/diagnostics_capture_guard.test.ts tests/deploy_discord_bot.test.ts tests/ci_shard_partition.test.ts`:
    the neighbouring dockerignore and shard suites still pass (56 tests total with the new file).
  - `npx tsc --noEmit`: clean.
  - `npx @biomejs/biome check` on the four changed files: clean.
- Manual steps:
  - Root cause was confirmed against the real failure: the dev deploy
    (`ansible-playbook playbooks/deploy_eastbrook_game.yml -e target_host=world-of-claudecraft-dev`)
    failed at "Build game stack before restart countdown" with the unresolved-import error above.
  - The playbook builds before stopping the game, so dev stayed live and healthy on its previous
    build throughout, with no DB or migration activity.

## Screenshots / recordings

N/A, no player-visible surface.

---

## Checklist

### Quality

- [x] **The gate passes.** Targeted suites, typecheck, and lint are green, and the new guard is
      verified to fail without the fix.

### Cross-platform

- [x] N/A. Build-context configuration and a Node-only test.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any
      production path.
- [x] No hand-edited generated files.
