### PR TITLE
fix(sim): clear persistent Paladin auras on party leave

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -10493,11 +10493,15 @@ export class Sim {
     duelMod.updateDuels(this.ctx);
   }
 
-  private clearAurasFromSource(target: Entity, sourceId: number): void {
+  private clearAurasFromSource(
+    target: Entity,
+    sourceId: number,
+    shouldClear?: (aura: Aura) => boolean,
+  ): void {
     let statsDirty = false;
     for (let i = target.auras.length - 1; i >= 0; i--) {
       const a = target.auras[i];
-      if (a.sourceId !== sourceId) continue;
+      if (a.sourceId !== sourceId || (shouldClear && !shouldClear(a))) continue;
       target.auras.splice(i, 1);
       this.emit({ type: 'aura', targetId: target.id, name: a.name, gained: false });
       if (a.kind.startsWith('buff') || a.kind.startsWith('form')) statsDirty = true;

--- a/src/sim/sim_context.ts
+++ b/src/sim/sim_context.ts
@@ -441,7 +441,11 @@ export interface SimContextCallbacks {
   // hasPendingSocialInvite are core; the five fiesta* hooks are A3-owned), plus the
   // arena bodies EXPOSED for the Fiesta slice (A3): readyArenaFighter / resetForArena
   // / isArenaTeamWiped / arenaIsDown / arenaAllPids (arenaTeamOf already above).
-  clearAurasFromSource(target: Entity, sourceId: number): void;
+  clearAurasFromSource(
+    target: Entity,
+    sourceId: number,
+    shouldClear?: (aura: Aura) => boolean,
+  ): void;
   entityInDungeon(e: Entity, dungeonId: string): boolean;
   hasPendingSocialInvite(targetPid: number): boolean;
   createFiestaState(): FiestaState;

--- a/src/sim/social/party.ts
+++ b/src/sim/social/party.ts
@@ -16,11 +16,12 @@
 // render/ui/game/net, no Math.random/Date.now), so it runs unchanged in Node, the
 // browser, and the headless RL env (enforced by tests/architecture.test.ts).
 
+import { ABILITIES } from '../content/classes';
 import { revokeMasterLooterAuthority } from '../loot/loot_roll';
 import { effectiveMasterLooter } from '../loot_master';
 import type { Party } from '../sim';
 import type { SimContext } from '../sim_context';
-import { DEFAULT_PARTY_LOOT_STRATEGIES } from '../types';
+import { type Aura, DEFAULT_PARTY_LOOT_STRATEGIES } from '../types';
 
 // Group caps (classic 5-player party, 10-player raid as 2 subgroups of 5). Moved
 // from sim.ts with the code that reads them; do NOT inline new numbers.
@@ -34,6 +35,9 @@ const RAID_MIN = 5;
 // wire bound too, which is the intent.
 export const RAID_MAX = 10;
 const RAID_GROUP_MAX = 5;
+function isPersistentPaladinAura(aura: Aura): boolean {
+  return aura.permanent === true && ABILITIES[aura.id]?.class === 'paladin';
+}
 
 // One indivisible Dungeon Finder unit as the formation seam receives it: a
 // whole existing party (partyId set, roster snapshot included) or one solo
@@ -547,6 +551,12 @@ export class PartyMachine {
     party.members = party.members.filter((m) => m !== pid);
     party.raidGroups.delete(pid);
     this.partyByPid.delete(pid);
+    // Paladin auras are tied to the party relationship. Keep the caster's own
+    // aura intact, but remove paladin auras from the remaining members.
+    for (const mPid of party.members) {
+      const member = this.ctx.resolve(mPid)?.e;
+      if (member) this.ctx.clearAurasFromSource(member, pid, isPersistentPaladinAura);
+    }
     // Drop the leaver from any in-flight ready check so the remaining members can
     // still early-finalize once everyone left has answered (their pending slot
     // would otherwise block it for the full timeout).

--- a/tests/party_machine.test.ts
+++ b/tests/party_machine.test.ts
@@ -14,8 +14,9 @@ import type { Entity, SimEvent } from '../src/sim/types';
 type Invite = { fromPid: number; expires: number };
 
 // A minimal SimContext that supplies only what PartyMachine reads: resolve/players/
-// error/emit/time + the trade/duel invite maps + readyChecks + dropPartyMarkers. The
-// rest of the seam is irrelevant to the party machine and left unimplemented.
+// error/emit/time + the trade/duel invite maps + readyChecks + dropPartyMarkers +
+// aura cleanup. The rest of the seam is irrelevant to the party machine and left
+// unimplemented.
 function makeCtx() {
   const players = new Map<number, PlayerMeta>();
   const tradeInvites = new Map<number, Invite>();
@@ -59,6 +60,7 @@ function makeCtx() {
     emit(ev: SimEvent) {
       events.push(ev);
     },
+    clearAurasFromSource() {},
     dropPartyMarkers(partyId: number) {
       droppedMarkers.push(partyId);
     },

--- a/tests/social.test.ts
+++ b/tests/social.test.ts
@@ -82,6 +82,30 @@ describe('parties', () => {
     expect(sim.partyOf(b)).toBe(null);
   });
 
+  it('removes persistent paladin auras but keeps 30-minute devotion buffs when the caster leaves', () => {
+    for (const persistentAura of ['devotion_ward', 'retribution_aura'] as const) {
+      const sim = makeWorld();
+      const paladin = sim.addPlayer('paladin', 'Paladin');
+      const member = sim.addPlayer('warrior', 'Member');
+      sim.setPlayerLevel(16, paladin);
+      sim.partyInvite(member, paladin);
+      sim.partyAccept(member);
+
+      const paladinEntity = sim.entities.get(paladin);
+      if (!paladinEntity) throw new Error('missing paladin entity');
+      sim.castAbility(persistentAura, paladin);
+      paladinEntity.gcdRemaining = 0;
+      sim.castAbility('dawn_devotion', paladin);
+      expect(sim.entities.get(member)?.auras.find((a) => a.id === persistentAura)).toBeDefined();
+      expect(sim.entities.get(member)?.auras.find((a) => a.id === 'dawn_devotion')).toBeDefined();
+
+      sim.partyLeave(paladin);
+
+      expect(sim.entities.get(member)?.auras.find((a) => a.id === persistentAura)).toBeUndefined();
+      expect(sim.entities.get(member)?.auras.find((a) => a.id === 'dawn_devotion')).toBeDefined();
+    }
+  });
+
   it('does not replace a pending party invite', () => {
     const sim = makeWorld();
     const a = sim.addPlayer('warrior', 'Aleph');


### PR DESCRIPTION
## Summary\n\n- Clear source-owned permanent Paladin auras from remaining party members when the caster leaves.\n- Cover current Bastion Devotion (devotion_ward) and Requital Aura (etribution_aura).\n- Preserve ordinary 30-minute Devotion buffs such as Dawn Devotion (dawn_devotion).\n\n## Related issues\n\nN/A\n\n## Type of change\n\n- [x] Bug fix\n- [x] Tests\n\n## How was this tested?\n\n- 
pm.cmd exec -- vitest run tests/social.test.ts tests/party_machine.test.ts tests/paladin_retribution_aura.test.ts tests/architecture.test.ts\n- 
ode_modules\\.bin\\tsc.cmd --noEmit\n- 
pm.cmd run ci:changed\n- 
ode scripts/gate_select.mjs was attempted; artifact checks passed, but the global floor exposed unrelated Windows and external-service failures (grep/
px unavailable, stale CI fixture expectations, and localhost:3000 unavailable).\n- Push preflight passed its QA floor.\n\n## Checklist\n\n- [x] Decisive regression tests added.\n- [x] No player-visible strings or UI changes.\n- [x] No generated files changed.\n