### PR TITLE
fix(render): key delve interior builds by z-position, not moduleId

### DIFF
--- a/docs/screenshots/eastbrook-vale-rebuild/polish/metadata/after-desktop-ultra.json
+++ b/docs/screenshots/eastbrook-vale-rebuild/polish/metadata/after-desktop-ultra.json
@@ -11,7 +11,7 @@
     "mode": "composite-sha256",
     "algorithm": "sha256",
     "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-    "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+    "fingerprint": "f2c08dc012f05502a6a230a2c6d695918d32cb7c90aae03343bfc9e05ce2fe78",
     "components": {
       "townAsset": {
         "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -40,7 +40,7 @@
         },
         "renderer": {
           "path": "src/render/renderer.ts",
-          "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+          "sha256": "ea8c1576b056296e3970e5af616a0f694d15f35dba87d4ed24e50ffe0e194f50"
         },
         "entityViewPolicy": {
           "path": "src/render/entity_view_policy_core.ts",
@@ -89,7 +89,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "f2c08dc012f05502a6a230a2c6d695918d32cb7c90aae03343bfc9e05ce2fe78",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -118,7 +118,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "ea8c1576b056296e3970e5af616a0f694d15f35dba87d4ed24e50ffe0e194f50"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -1385,7 +1385,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "f2c08dc012f05502a6a230a2c6d695918d32cb7c90aae03343bfc9e05ce2fe78",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -1414,7 +1414,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "ea8c1576b056296e3970e5af616a0f694d15f35dba87d4ed24e50ffe0e194f50"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -2681,7 +2681,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "f2c08dc012f05502a6a230a2c6d695918d32cb7c90aae03343bfc9e05ce2fe78",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -2710,7 +2710,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "ea8c1576b056296e3970e5af616a0f694d15f35dba87d4ed24e50ffe0e194f50"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -3977,7 +3977,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "f2c08dc012f05502a6a230a2c6d695918d32cb7c90aae03343bfc9e05ce2fe78",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -4006,7 +4006,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "ea8c1576b056296e3970e5af616a0f694d15f35dba87d4ed24e50ffe0e194f50"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -5273,7 +5273,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "f2c08dc012f05502a6a230a2c6d695918d32cb7c90aae03343bfc9e05ce2fe78",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -5302,7 +5302,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "ea8c1576b056296e3970e5af616a0f694d15f35dba87d4ed24e50ffe0e194f50"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -6569,7 +6569,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "f2c08dc012f05502a6a230a2c6d695918d32cb7c90aae03343bfc9e05ce2fe78",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -6598,7 +6598,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "ea8c1576b056296e3970e5af616a0f694d15f35dba87d4ed24e50ffe0e194f50"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -7865,7 +7865,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "f2c08dc012f05502a6a230a2c6d695918d32cb7c90aae03343bfc9e05ce2fe78",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -7894,7 +7894,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "ea8c1576b056296e3970e5af616a0f694d15f35dba87d4ed24e50ffe0e194f50"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -9161,7 +9161,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "f2c08dc012f05502a6a230a2c6d695918d32cb7c90aae03343bfc9e05ce2fe78",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -9190,7 +9190,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "ea8c1576b056296e3970e5af616a0f694d15f35dba87d4ed24e50ffe0e194f50"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -10457,7 +10457,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "f2c08dc012f05502a6a230a2c6d695918d32cb7c90aae03343bfc9e05ce2fe78",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -10486,7 +10486,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "ea8c1576b056296e3970e5af616a0f694d15f35dba87d4ed24e50ffe0e194f50"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -11753,7 +11753,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "f2c08dc012f05502a6a230a2c6d695918d32cb7c90aae03343bfc9e05ce2fe78",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -11782,7 +11782,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "ea8c1576b056296e3970e5af616a0f694d15f35dba87d4ed24e50ffe0e194f50"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -13049,7 +13049,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "f2c08dc012f05502a6a230a2c6d695918d32cb7c90aae03343bfc9e05ce2fe78",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -13078,7 +13078,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "ea8c1576b056296e3970e5af616a0f694d15f35dba87d4ed24e50ffe0e194f50"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -14345,7 +14345,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "f2c08dc012f05502a6a230a2c6d695918d32cb7c90aae03343bfc9e05ce2fe78",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -14374,7 +14374,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "ea8c1576b056296e3970e5af616a0f694d15f35dba87d4ed24e50ffe0e194f50"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -15641,7 +15641,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "f2c08dc012f05502a6a230a2c6d695918d32cb7c90aae03343bfc9e05ce2fe78",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -15670,7 +15670,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "ea8c1576b056296e3970e5af616a0f694d15f35dba87d4ed24e50ffe0e194f50"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -16937,7 +16937,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "f2c08dc012f05502a6a230a2c6d695918d32cb7c90aae03343bfc9e05ce2fe78",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -16966,7 +16966,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "ea8c1576b056296e3970e5af616a0f694d15f35dba87d4ed24e50ffe0e194f50"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -19198,7 +19198,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "f2c08dc012f05502a6a230a2c6d695918d32cb7c90aae03343bfc9e05ce2fe78",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -19227,7 +19227,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "ea8c1576b056296e3970e5af616a0f694d15f35dba87d4ed24e50ffe0e194f50"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -20494,7 +20494,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "f2c08dc012f05502a6a230a2c6d695918d32cb7c90aae03343bfc9e05ce2fe78",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -20523,7 +20523,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "ea8c1576b056296e3970e5af616a0f694d15f35dba87d4ed24e50ffe0e194f50"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -21790,7 +21790,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "f2c08dc012f05502a6a230a2c6d695918d32cb7c90aae03343bfc9e05ce2fe78",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -21819,7 +21819,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "ea8c1576b056296e3970e5af616a0f694d15f35dba87d4ed24e50ffe0e194f50"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -23086,7 +23086,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "f2c08dc012f05502a6a230a2c6d695918d32cb7c90aae03343bfc9e05ce2fe78",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -23115,7 +23115,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "ea8c1576b056296e3970e5af616a0f694d15f35dba87d4ed24e50ffe0e194f50"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -24382,7 +24382,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "f2c08dc012f05502a6a230a2c6d695918d32cb7c90aae03343bfc9e05ce2fe78",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -24411,7 +24411,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "ea8c1576b056296e3970e5af616a0f694d15f35dba87d4ed24e50ffe0e194f50"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -25678,7 +25678,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "f2c08dc012f05502a6a230a2c6d695918d32cb7c90aae03343bfc9e05ce2fe78",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -25707,7 +25707,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "ea8c1576b056296e3970e5af616a0f694d15f35dba87d4ed24e50ffe0e194f50"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -26974,7 +26974,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "f2c08dc012f05502a6a230a2c6d695918d32cb7c90aae03343bfc9e05ce2fe78",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -27003,7 +27003,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "ea8c1576b056296e3970e5af616a0f694d15f35dba87d4ed24e50ffe0e194f50"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -28323,7 +28323,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "f2c08dc012f05502a6a230a2c6d695918d32cb7c90aae03343bfc9e05ce2fe78",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -28352,7 +28352,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "ea8c1576b056296e3970e5af616a0f694d15f35dba87d4ed24e50ffe0e194f50"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -29619,7 +29619,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "f2c08dc012f05502a6a230a2c6d695918d32cb7c90aae03343bfc9e05ce2fe78",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -29648,7 +29648,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "ea8c1576b056296e3970e5af616a0f694d15f35dba87d4ed24e50ffe0e194f50"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",

--- a/docs/screenshots/eastbrook-vale-rebuild/polish/metadata/after-mobile-low.json
+++ b/docs/screenshots/eastbrook-vale-rebuild/polish/metadata/after-mobile-low.json
@@ -11,7 +11,7 @@
     "mode": "composite-sha256",
     "algorithm": "sha256",
     "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-    "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+    "fingerprint": "f2c08dc012f05502a6a230a2c6d695918d32cb7c90aae03343bfc9e05ce2fe78",
     "components": {
       "townAsset": {
         "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -40,7 +40,7 @@
         },
         "renderer": {
           "path": "src/render/renderer.ts",
-          "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+          "sha256": "ea8c1576b056296e3970e5af616a0f694d15f35dba87d4ed24e50ffe0e194f50"
         },
         "entityViewPolicy": {
           "path": "src/render/entity_view_policy_core.ts",
@@ -89,7 +89,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "f2c08dc012f05502a6a230a2c6d695918d32cb7c90aae03343bfc9e05ce2fe78",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -118,7 +118,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "ea8c1576b056296e3970e5af616a0f694d15f35dba87d4ed24e50ffe0e194f50"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -1368,7 +1368,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "f2c08dc012f05502a6a230a2c6d695918d32cb7c90aae03343bfc9e05ce2fe78",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -1397,7 +1397,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "ea8c1576b056296e3970e5af616a0f694d15f35dba87d4ed24e50ffe0e194f50"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -2647,7 +2647,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "f2c08dc012f05502a6a230a2c6d695918d32cb7c90aae03343bfc9e05ce2fe78",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -2676,7 +2676,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "ea8c1576b056296e3970e5af616a0f694d15f35dba87d4ed24e50ffe0e194f50"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -3926,7 +3926,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "f2c08dc012f05502a6a230a2c6d695918d32cb7c90aae03343bfc9e05ce2fe78",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -3955,7 +3955,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "ea8c1576b056296e3970e5af616a0f694d15f35dba87d4ed24e50ffe0e194f50"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -5205,7 +5205,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "f2c08dc012f05502a6a230a2c6d695918d32cb7c90aae03343bfc9e05ce2fe78",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -5234,7 +5234,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "ea8c1576b056296e3970e5af616a0f694d15f35dba87d4ed24e50ffe0e194f50"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -6484,7 +6484,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "f2c08dc012f05502a6a230a2c6d695918d32cb7c90aae03343bfc9e05ce2fe78",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -6513,7 +6513,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "ea8c1576b056296e3970e5af616a0f694d15f35dba87d4ed24e50ffe0e194f50"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -7763,7 +7763,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "f2c08dc012f05502a6a230a2c6d695918d32cb7c90aae03343bfc9e05ce2fe78",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -7792,7 +7792,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "ea8c1576b056296e3970e5af616a0f694d15f35dba87d4ed24e50ffe0e194f50"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -9042,7 +9042,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "f2c08dc012f05502a6a230a2c6d695918d32cb7c90aae03343bfc9e05ce2fe78",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -9071,7 +9071,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "ea8c1576b056296e3970e5af616a0f694d15f35dba87d4ed24e50ffe0e194f50"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -10321,7 +10321,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "f2c08dc012f05502a6a230a2c6d695918d32cb7c90aae03343bfc9e05ce2fe78",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -10350,7 +10350,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "ea8c1576b056296e3970e5af616a0f694d15f35dba87d4ed24e50ffe0e194f50"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -11600,7 +11600,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "f2c08dc012f05502a6a230a2c6d695918d32cb7c90aae03343bfc9e05ce2fe78",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -11629,7 +11629,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "ea8c1576b056296e3970e5af616a0f694d15f35dba87d4ed24e50ffe0e194f50"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -12879,7 +12879,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "f2c08dc012f05502a6a230a2c6d695918d32cb7c90aae03343bfc9e05ce2fe78",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -12908,7 +12908,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "ea8c1576b056296e3970e5af616a0f694d15f35dba87d4ed24e50ffe0e194f50"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -14158,7 +14158,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "f2c08dc012f05502a6a230a2c6d695918d32cb7c90aae03343bfc9e05ce2fe78",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -14187,7 +14187,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "ea8c1576b056296e3970e5af616a0f694d15f35dba87d4ed24e50ffe0e194f50"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -15437,7 +15437,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "f2c08dc012f05502a6a230a2c6d695918d32cb7c90aae03343bfc9e05ce2fe78",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -15466,7 +15466,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "ea8c1576b056296e3970e5af616a0f694d15f35dba87d4ed24e50ffe0e194f50"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -16716,7 +16716,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "f2c08dc012f05502a6a230a2c6d695918d32cb7c90aae03343bfc9e05ce2fe78",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -16745,7 +16745,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "ea8c1576b056296e3970e5af616a0f694d15f35dba87d4ed24e50ffe0e194f50"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -18960,7 +18960,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "f2c08dc012f05502a6a230a2c6d695918d32cb7c90aae03343bfc9e05ce2fe78",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -18989,7 +18989,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "ea8c1576b056296e3970e5af616a0f694d15f35dba87d4ed24e50ffe0e194f50"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -20239,7 +20239,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "f2c08dc012f05502a6a230a2c6d695918d32cb7c90aae03343bfc9e05ce2fe78",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -20268,7 +20268,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "ea8c1576b056296e3970e5af616a0f694d15f35dba87d4ed24e50ffe0e194f50"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -21518,7 +21518,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "f2c08dc012f05502a6a230a2c6d695918d32cb7c90aae03343bfc9e05ce2fe78",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -21547,7 +21547,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "ea8c1576b056296e3970e5af616a0f694d15f35dba87d4ed24e50ffe0e194f50"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -22797,7 +22797,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "f2c08dc012f05502a6a230a2c6d695918d32cb7c90aae03343bfc9e05ce2fe78",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -22826,7 +22826,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "ea8c1576b056296e3970e5af616a0f694d15f35dba87d4ed24e50ffe0e194f50"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -24076,7 +24076,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "f2c08dc012f05502a6a230a2c6d695918d32cb7c90aae03343bfc9e05ce2fe78",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -24105,7 +24105,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "ea8c1576b056296e3970e5af616a0f694d15f35dba87d4ed24e50ffe0e194f50"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -25355,7 +25355,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "f2c08dc012f05502a6a230a2c6d695918d32cb7c90aae03343bfc9e05ce2fe78",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -25384,7 +25384,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "ea8c1576b056296e3970e5af616a0f694d15f35dba87d4ed24e50ffe0e194f50"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -26634,7 +26634,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "f2c08dc012f05502a6a230a2c6d695918d32cb7c90aae03343bfc9e05ce2fe78",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -26663,7 +26663,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "ea8c1576b056296e3970e5af616a0f694d15f35dba87d4ed24e50ffe0e194f50"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -27966,7 +27966,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "f2c08dc012f05502a6a230a2c6d695918d32cb7c90aae03343bfc9e05ce2fe78",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -27995,7 +27995,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "ea8c1576b056296e3970e5af616a0f694d15f35dba87d4ed24e50ffe0e194f50"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -29245,7 +29245,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "f2c08dc012f05502a6a230a2c6d695918d32cb7c90aae03343bfc9e05ce2fe78",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -29274,7 +29274,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "ea8c1576b056296e3970e5af616a0f694d15f35dba87d4ed24e50ffe0e194f50"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",

--- a/docs/screenshots/eastbrook-vale-rebuild/polish/performance/after-desktop-ultra-town.json
+++ b/docs/screenshots/eastbrook-vale-rebuild/polish/performance/after-desktop-ultra-town.json
@@ -14,7 +14,7 @@
     "mode": "composite-sha256",
     "algorithm": "sha256",
     "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-    "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+    "fingerprint": "f2c08dc012f05502a6a230a2c6d695918d32cb7c90aae03343bfc9e05ce2fe78",
     "components": {
       "townAsset": {
         "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -43,7 +43,7 @@
         },
         "renderer": {
           "path": "src/render/renderer.ts",
-          "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+          "sha256": "ea8c1576b056296e3970e5af616a0f694d15f35dba87d4ed24e50ffe0e194f50"
         },
         "entityViewPolicy": {
           "path": "src/render/entity_view_policy_core.ts",

--- a/docs/screenshots/eastbrook-vale-rebuild/polish/performance/after-mobile-low-town.json
+++ b/docs/screenshots/eastbrook-vale-rebuild/polish/performance/after-mobile-low-town.json
@@ -14,7 +14,7 @@
     "mode": "composite-sha256",
     "algorithm": "sha256",
     "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-    "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+    "fingerprint": "f2c08dc012f05502a6a230a2c6d695918d32cb7c90aae03343bfc9e05ce2fe78",
     "components": {
       "townAsset": {
         "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -43,7 +43,7 @@
         },
         "renderer": {
           "path": "src/render/renderer.ts",
-          "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+          "sha256": "ea8c1576b056296e3970e5af616a0f694d15f35dba87d4ed24e50ffe0e194f50"
         },
         "entityViewPolicy": {
           "path": "src/render/entity_view_policy_core.ts",

--- a/src/render/delve_interior_cache_core.ts
+++ b/src/render/delve_interior_cache_core.ts
@@ -1,0 +1,20 @@
+// Delve interior build-cache decision (pure, Three-free). A delve module's
+// z-stacked position within a slot is reused across runs, but which moduleId
+// occupies that position is re-randomized every run (pickDelveModules), so a
+// build cached by POSITION must be invalidated when the moduleId there
+// changes: otherwise the previous run's walls (built at that position for a
+// different room shape) keep standing while this run's mobs/interactables/
+// boss spawn against the true (current) module's geometry, so they read as
+// spawned outside the walls and the stale geometry never blocks movement
+// where the player actually is.
+export type DelveInteriorBuildAction = 'skip' | 'build' | 'rebuild';
+
+export function delveInteriorBuildAction(
+  cachedModuleId: string | undefined,
+  moduleId: string,
+  pending: boolean,
+): DelveInteriorBuildAction {
+  if (pending) return 'skip';
+  if (cachedModuleId === undefined) return 'build';
+  return cachedModuleId === moduleId ? 'skip' : 'rebuild';
+}

--- a/src/render/delve_interior_tracker.ts
+++ b/src/render/delve_interior_tracker.ts
@@ -31,7 +31,11 @@ export class DelveInteriorTracker {
   ) {}
 
   private schedule(key: string, moduleId: DelveModuleId, ox: number, oz: number): void {
-    const action = delveInteriorBuildAction(this.moduleAt.get(key), moduleId, this.pending.has(key));
+    const action = delveInteriorBuildAction(
+      this.moduleAt.get(key),
+      moduleId,
+      this.pending.has(key),
+    );
     if (action === 'skip') return;
     if (action === 'rebuild') {
       const stale = this.groups.get(key);

--- a/src/render/delve_interior_tracker.ts
+++ b/src/render/delve_interior_tracker.ts
@@ -1,0 +1,73 @@
+// Schedules delve module interior builds and retires stale geometry. Extracted
+// out of renderer.ts (the monolith ratchet) rather than grown there.
+import type * as THREE from 'three';
+import { delveModuleZOffset } from '../sim/data';
+import type { DelveModuleId } from '../sim/delve_layout';
+import { delveInteriorBuildAction } from './delve_interior_cache_core';
+import { buildDelveModule } from './delve_interiors';
+import type { DungeonInteriors } from './dungeon';
+import { ensureDelveInteriorKit } from './interior_kit';
+
+/**
+ * Delve interiors are keyed by z-stacked POSITION (delveId:slot:moduleIndex),
+ * not moduleId: pickDelveModules randomizes which module occupies which
+ * position every run, so the same slot's position can host a different room
+ * shape next run. Tracking per position lets a later run detect that mismatch
+ * and retire the stale geometry instead of leaving it standing (walls in the
+ * wrong place while this run's mobs/puzzle/boss spawn against the true,
+ * current module).
+ */
+export class DelveInteriorTracker {
+  private pending = new Set<string>();
+  private moduleAt = new Map<string, DelveModuleId>();
+  private groups = new Map<string, THREE.Group>();
+
+  constructor(
+    private readonly dungeons: () => DungeonInteriors,
+    private readonly retire: (group: THREE.Group) => void,
+    // Shared with the renderer's other interior kinds (dungeon/arena/rift),
+    // so a build here also marks the shared "has this key been built" cache.
+    private readonly built: Set<string>,
+  ) {}
+
+  private schedule(key: string, moduleId: DelveModuleId, ox: number, oz: number): void {
+    const action = delveInteriorBuildAction(this.moduleAt.get(key), moduleId, this.pending.has(key));
+    if (action === 'skip') return;
+    if (action === 'rebuild') {
+      const stale = this.groups.get(key);
+      if (stale) this.retire(stale);
+      this.groups.delete(key);
+      this.built.delete(key);
+    }
+    this.pending.add(key);
+    void buildDelveModule(this.dungeons(), moduleId, ox, oz)
+      .then((group) => {
+        this.moduleAt.set(key, moduleId);
+        this.groups.set(key, group);
+        this.built.add(key);
+        this.pending.delete(key);
+      })
+      .catch((err) => {
+        this.pending.delete(key);
+        if (import.meta.env?.DEV) {
+          console.warn('Failed to build delve interior:', moduleId, 'at', ox, oz, err);
+        }
+      });
+  }
+
+  /** Build every module in a delve run at its stacked z offset (parallel async). */
+  buildAll(
+    delveId: string,
+    slot: number,
+    origin: { x: number; z: number },
+    modules: readonly DelveModuleId[],
+  ): void {
+    void ensureDelveInteriorKit().catch(() => undefined);
+    for (let mi = 0; mi < modules.length; mi++) {
+      const moduleId = modules[mi];
+      const key = `delve:${delveId}:${slot}:${mi}`;
+      const zOff = delveModuleZOffset(modules, mi);
+      this.schedule(key, moduleId, origin.x, origin.z + zOff);
+    }
+  }
+}

--- a/src/render/delve_interiors.ts
+++ b/src/render/delve_interiors.ts
@@ -29,7 +29,7 @@ export function buildDelveModule(
   moduleId: DelveModuleId,
   ox: number,
   oz: number,
-): Promise<void> {
+) {
   const mod = DELVE_MODULES[moduleId];
   const interior = mod?.interior ?? 'crypt';
   // Pass the module's own layout so visible geometry matches the collision set
@@ -41,13 +41,13 @@ export function buildDelveModule(
   const variant = DELVE_MODULE_VARIANT[moduleId] ?? 'delve_ossuary';
   // Static Blackwater hazard pools (The Drowned Litany) are authored on the module
   // def; the renderer draws a visible pool at each so the sim's damage zone reads.
-  // The built group is only tracked for rift interiors; delves discard it.
-  return dungeons
-    .buildInterior(interior, ox, oz, {
-      layout,
-      variant,
-      hazards: mod?.hazards,
-      moduleId,
-    })
-    .then(() => undefined);
+  // The built group IS returned (the renderer tracks it per z-stacked position: a
+  // slot's position is reused run to run with a DIFFERENT randomized module, so a
+  // stale group there must be retirable, not just discarded).
+  return dungeons.buildInterior(interior, ox, oz, {
+    layout,
+    variant,
+    hazards: mod?.hazards,
+    moduleId,
+  });
 }

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -19,7 +19,6 @@ import {
   defaultDelveModules,
   delveAt,
   delveModuleStackEndRelZ,
-  delveModuleZOffset,
   delveOrigin,
   delveSlotAt,
   dungeonAt,
@@ -220,7 +219,7 @@ import {
   warmDuskGrade,
 } from './day_night_core';
 import { shouldPlayDeedFirework } from './deed_fx_gate';
-import { buildDelveModule } from './delve_interiors';
+import { DelveInteriorTracker } from './delve_interior_tracker';
 import { buildDelveInteractable, syncDelveInteractableVisibility } from './delve_props';
 import { detailHorizonStarved } from './detail_horizon_core';
 import { buildDoorBody, buildRiftGateBody, buildRiftPuzzleProp } from './door_portal';
@@ -332,7 +331,6 @@ import { type IceBlockVisual, syncIceBlockVisual } from './ice_block_visual';
 import { idleSlot } from './idle_queue';
 import { buildImpactSite, type ImpactSiteView, MIREFEN_IMPACT_SITE } from './impact_site';
 import * as encounterPrewarm from './interior_encounter_prewarm_pass';
-import { ensureDelveInteriorKit } from './interior_kit';
 import { applyInteriorLightRig, applyRiftLightRig, type FogSceneState } from './interior_light_rig';
 import { buildJailScene, type JailSceneView } from './jail_scene';
 import { buildJungleFeatures, type JungleFeaturesView } from './jungle_features';
@@ -9329,9 +9327,14 @@ export class Renderer {
   private readonly umbralAnchorMarker = new UmbralAnchorMarker(this.groundSample);
   // The approved Maledict Eye is cosmetic: one local, non-targetable Affliction familiar.
   private readonly afflictionFamiliar = new AfflictionFamiliar();
-  // Delve module interiors build asynchronously; track in-flight keys so a
-  // per-frame ensureDelveInteriorsNear does not re-schedule a build mid-load.
-  private pendingInteriors = new Set<string>();
+  // Delve module interiors build asynchronously; the tracker also retires a
+  // position's stale geometry when a new run puts a different module there
+  // (see delve_interior_tracker.ts).
+  private delveInteriors = new DelveInteriorTracker(
+    () => this.ensureDungeons(),
+    (group) => this.retireInteriorGroup(group),
+    this.builtInteriors,
+  );
   // Re-applied rift fog is keyed by the floor descriptor (seed:floorIndex) so a
   // descent (same 'rift' fogState, different palette) still refreshes the fog.
   private riftFogKey: string | null = null;
@@ -9613,27 +9616,6 @@ export class Renderer {
       : (this.scene.fog as THREE.Fog).far;
   }
 
-  private scheduleDelveModuleBuild(
-    key: string,
-    moduleId: DelveModuleId,
-    ox: number,
-    oz: number,
-  ): void {
-    if (this.builtInteriors.has(key) || this.pendingInteriors.has(key)) return;
-    this.pendingInteriors.add(key);
-    void buildDelveModule(this.ensureDungeons(), moduleId, ox, oz)
-      .then(() => {
-        this.builtInteriors.add(key);
-        this.pendingInteriors.delete(key);
-      })
-      .catch((err) => {
-        this.pendingInteriors.delete(key);
-        if (import.meta.env?.DEV) {
-          console.warn('Failed to build delve interior:', moduleId, 'at', ox, oz, err);
-        }
-      });
-  }
-
   /** Build every module in a delve run at its stacked z offset (parallel async). */
   private buildAllDelveModules(
     delveId: string,
@@ -9641,14 +9623,7 @@ export class Renderer {
     origin: { x: number; z: number },
     modules: readonly DelveModuleId[],
   ): void {
-    void ensureDelveInteriorKit().catch(() => undefined);
-    for (let mi = 0; mi < modules.length; mi++) {
-      const moduleId = modules[mi];
-      const key = `delve:${delveId}:${slot}:${moduleId}`;
-      if (this.builtInteriors.has(key) || this.pendingInteriors.has(key)) continue;
-      const zOff = delveModuleZOffset(modules, mi);
-      this.scheduleDelveModuleBuild(key, moduleId, origin.x, origin.z + zOff);
-    }
+    this.delveInteriors.buildAll(delveId, slot, origin, modules);
   }
 
   /** Prebuild the full module stack when a delve run starts (offline + online). */

--- a/tests/architecture.test.ts
+++ b/tests/architecture.test.ts
@@ -443,6 +443,7 @@ const DOM_GLOBAL_VALUE_ALLOWLIST = new Set([join(repoRoot, 'src/ui/safe_local_st
 // post_bloom_shader_core is the host-agnostic GLSL source patch for the
 // identity tint terms in UnrealBloom's composite shader.
 const RENDER_PURE_CORES = [
+  'src/render/delve_interior_cache_core.ts',
   'src/render/entity_view_policy_core.ts',
   'src/render/quest_object_gate_core.ts',
   'src/render/adaptive_link_budget_core.ts',

--- a/tests/delve_interior_cache_core.test.ts
+++ b/tests/delve_interior_cache_core.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { delveInteriorBuildAction } from '../src/render/delve_interior_cache_core';
+
+describe('delveInteriorBuildAction', () => {
+  it('builds a position that has never been built', () => {
+    expect(delveInteriorBuildAction(undefined, 'litany_ring', false)).toBe('build');
+  });
+
+  it('skips a position mid-build', () => {
+    expect(delveInteriorBuildAction(undefined, 'litany_ring', true)).toBe('skip');
+    expect(delveInteriorBuildAction('litany_ring', 'litany_ring', true)).toBe('skip');
+  });
+
+  it('skips a position already built with the same module (same run, or a re-roll that picked the same room)', () => {
+    expect(delveInteriorBuildAction('litany_ring', 'litany_ring', false)).toBe('skip');
+  });
+
+  it('rebuilds a position whose cached module differs from the current run: a new run randomized a DIFFERENT room into a z-slot a previous run already occupied', () => {
+    expect(delveInteriorBuildAction('litany_ring', 'litany_sluice', false)).toBe('rebuild');
+  });
+});

--- a/tests/eastbrook_polish_artifact_integrity.test.ts
+++ b/tests/eastbrook_polish_artifact_integrity.test.ts
@@ -766,10 +766,12 @@ const ACCEPTED_POLISH_V2_METADATA_PATH = path.join(REPO_ROOT, POLISH_SEAL_PATH);
 // Re-minted for the r185 frozen-camera aim fix: the first-order composite
 // follows renderer.ts, then this seal follows the swept evidence bytes. No
 // capture was retaken.
+// Re-minted again after extracting the delve interior build-cache scheduling
+// into src/render/delve_interior_tracker.ts (renderer.ts moved, no capture retaken).
 const ACCEPTED_POLISH_V2_METADATA_SHA256 =
-  '3fd2ffdb3833ef360657aeeb0ad17039279e5fad08c279dea19fb96522db30b9';
+  '80920e22bd9d4f2224f8b285ea692b1c6fced9c09841ce1db2f0df4cb7bea075';
 const ACCEPTED_POLISH_V2_COMPOSITE_PROVENANCE =
-  '63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495';
+  'f2c08dc012f05502a6a230a2c6d695918d32cb7c90aae03343bfc9e05ce2fe78';
 const ACCEPTED_POLISH_V2_METADATA = readJsonFile<CaptureMetadata>(ACCEPTED_POLISH_V2_METADATA_PATH);
 const ACCEPTED_POLISH_V2_PROVENANCE = ACCEPTED_POLISH_V2_METADATA.polishProvenance;
 const ACCEPTED_POLISH_V2_TOWN_CONTRACT = ACCEPTED_POLISH_V2_METADATA.records[0]?.townContract;
@@ -1772,10 +1774,12 @@ describe('Eastbrook polish performance and contact evidence', () => {
     // Re-minted for the r185 frozen-camera aim fix. The first-order composite
     // follows renderer.ts, then this second-order performance seal follows the
     // swept evidence bytes. No capture was retaken.
+    // Re-minted again after extracting the delve interior build-cache
+    // scheduling into src/render/delve_interior_tracker.ts. No capture retaken.
     expect(
       fingerprint.digest('hex'),
       `the second-order performance digest moved; if every input moved legitimately, re-mint with: ${REMINT_COMMAND} (it recomputes this literal LAST, from the swept files)`,
-    ).toBe('3e5298f95d8f76bff403ab31aa4ce1bbd45f981cb1630f2d40f52839f08340dd');
+    ).toBe('0c39176f1d37c6831dcd7d2cf263cd822e170358f9a599cf301ba4daac9d61c4');
   });
 
   it('binds every historical after record to its accepted source and asset provenance', () => {

--- a/tests/eastbrook_polish_capture_contract.test.ts
+++ b/tests/eastbrook_polish_capture_contract.test.ts
@@ -184,8 +184,10 @@ interface AttributionTargetFixture {
 // Re-minted for the r185 frozen-camera aim fix: updateCamera now aims through
 // lookAtFrozen, so renderer.ts moves and the composite follows its bytes. No
 // capture was retaken.
+// Re-minted after extracting the delve interior build-cache scheduling into
+// src/render/delve_interior_tracker.ts (renderer.ts moved again, no capture retaken).
 const PINNED_POLISH_COMPOSITE_FINGERPRINT =
-  '63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495';
+  'f2c08dc012f05502a6a230a2c6d695918d32cb7c90aae03343bfc9e05ce2fe78';
 
 function validPolishAttributionTargets(): AttributionTargetFixture[] {
   return [

--- a/tests/monolith_budget.test.ts
+++ b/tests/monolith_budget.test.ts
@@ -80,7 +80,12 @@ const MONOLITHS: MonolithRow[] = [
     // Lowered again by the castle branch's interior_light_rig.ts extraction;
     // after merging main the merged file lands below both prior pins, so the
     // ceiling is the exact merged count.
-    ceiling: 13689,
+    // Merging release/v0.39.0 again: this branch also extracted the delve
+    // interior build-cache scheduling (the position-keyed rebuild/retire
+    // decision plus the async build loop) into
+    // src/render/delve_interior_tracker.ts, and the merged file lands between
+    // the two pins, so the ceiling is the exact merged count.
+    ceiling: 13664,
     seam: 'a new src/render/<thing>.ts module the renderer calls (src/render/CLAUDE.md)',
   },
   {


### PR DESCRIPTION
<!--
Thanks for contributing to World of ClaudeCraft!
-->

## Summary

Fixes a delve collision/geometry bug: entering a delve could let a player walk
through walls, with floor buttons, enemies, the boss, and the puzzle all
appearing "outside" the room, blocking the delve from completing normally.

Root cause: the client renderer's delve-interior build cache
(`Renderer.scheduleDelveModuleBuild`) was keyed by
`delve:<delveId>:<slot>:<moduleId>`. `pickDelveModules` re-randomizes which
module occupies which z-stacked position on **every** run, but a delve slot
and its module roster are reused across runs. Once a moduleId's geometry had
been built anywhere in a slot, the cache treated any later position that also
picked that moduleId as already built and skipped rebuilding it there. The
result: a *previous* run's walls (built at a *different* z-offset) stayed
standing, or no walls at all were built at the position the *current* run
actually occupies, while mobs/interactables/the boss spawn correctly
(server-authoritative) against the true, current module. Collision itself was
never wrong (the server enforces walls independent of the client), but the
visible geometry drifted out from under it, reading as "walked through walls"
and "everything is outside the room."

```mermaid
sequenceDiagram
    participant S as Server (Sim)
    participant R as Renderer (client)
    participant C as builtInteriors cache

    Note over S: Run A in slot 0<br/>pickDelveModules -> [litany_ring, litany_sluice, ..., apse]
    S->>R: delveRun { modules: [ring, sluice, ...] }
    R->>C: key = delve:drowned_litany:0:litany_ring (built at zOff=8)
    Note over C: cache marks "litany_ring" done, ANY position

    Note over S: Run B in slot 0 (same char/slot, re-entered)<br/>pickDelveModules -> [litany_sluice, litany_ring, ..., apse]
    S->>R: delveRun { modules: [sluice, ring, ...] }
    R->>C: key = delve:drowned_litany:0:litany_ring (now at zOff=134)
    C-->>R: "already built" (bug: cache hit on moduleId, ignores position)
    Note over R: walls stay standing at zOff=8 (stale room A)<br/>mobs/puzzle/boss spawn at zOff=134 (true room B, no walls there)
```

**Fix:** key the cache by z-stacked **position** instead
(`delve:<delveId>:<slot>:<moduleIndex>`), and retire the stale geometry group
when the moduleId cached at a position no longer matches the current run's
moduleId there (mirroring the existing rift-floor stale-retirement pattern).
The position-vs-module decision is a small pure function
(`delve_interior_cache_core.ts`) with its own unit tests; the scheduling and
retirement logic moved into `delve_interior_tracker.ts` to keep
`renderer.ts` (a named monolith-ratchet file) from growing, per its
extraction rule.

## Related issues

Reported in-session: "Delves Bugged: entered the delves and you could walk
through walls. The floor buttons and such were outside walls and so were some
enemies. Last boss was outside and so was the puzzle. Can't finish the delve
(it let me finish eventually, outside the delve)." Character `BigDamage`,
macOS build.

## Type of change

- [x] Bug fix
- [x] Tests

## How was this tested?

- Commands:
  - `npx vitest run tests/delve_interior_cache_core.test.ts tests/delve_render.test.ts tests/delve_colliders.test.ts tests/delves.test.ts tests/delves_runs.test.ts tests/architecture.test.ts tests/monolith_budget.test.ts` (all green)
  - `npx tsc --noEmit` (no new errors)
  - `node scripts/gate_select.mjs` (12/12 steps green)
- Manual steps: none beyond the automated suite; the bug requires two live delve
  runs of the same slot inside one client session to reproduce visually (the
  cache is per page-load), which isn't practical to script reliably here, so
  this PR relies on the new unit test for the extracted cache-decision core
  plus the full delve regression suite instead of a captured screenshot.

## Screenshots / recordings

N/A: this is a geometry-cache correctness fix (procedural room walls/props),
not a UI/HUD/content change, and reliably capturing the drifted-geometry
bug on camera requires two full delve playthroughs of the same instance slot
in one continuous session (the stale cache lives for the page's lifetime), which
isn't something I could script safely and deterministically in this pass. Happy
to add a capture if a maintainer has a faster repro in mind.

---

## Checklist

### Quality

- [x] **The gate passes.** `node scripts/gate_select.mjs` is green. Added a unit
      test for the extracted decision core (`delve_interior_cache_core.ts`); the
      existing delve/render/architecture/monolith-budget suites all cover the
      touched surface and stay green.

### Cross-platform

- [x] N/A: client-renderer-only fix; `src/sim/` (the shared, three-host core)
      is untouched. No `IWorld`/wire changes.

### Content

- [x] N/A: no new game content.

### Determinism / server authority

- [x] N/A: server-side collision was already correct; only the client's visible
      geometry cache changed.
