### PR TITLE
fix(i18n): correct French ability tooltips

### DIFF
--- a/src/ui/i18n.locales/fr_FR.ts
+++ b/src/ui/i18n.locales/fr_FR.ts
@@ -6479,9 +6479,9 @@ export const fr_FR: Partial<Record<TranslationKey, string>> = {
   'entities.abilities.moonkin_form.name': 'Forme de sélénien',
   'entities.abilities.moonkin_form.description':
     'Adopte la forme de sélénien, renforçant l’incantation jusqu’à ce que vous changiez de nouveau. Lancez à nouveau pour revenir à la forme normale. (signature Équilibre)',
-  'entities.abilities.feral_charge.name': 'Charge farouche',
+  'entities.abilities.feral_charge.name': 'Déferlante primordiale',
   'entities.abilities.feral_charge.description':
-    'Charge un ennemi et l’enracine pendant 1 s. Portée de 8-25 m. (signature Farouche)',
+    "Libère une déferlante primordiale. En Forme de loup, augmente la régénération d'énergie de 100% pendant 10 s. En Forme de Bruin, génère instantanément 50 points de rage. (signature Farouche)",
   'entities.abilities.swiftmend.name': 'Prompte guérison',
   'entities.abilities.crusader_strike.name': 'Frappe du croisé',
   'entities.abilities.crusader_strike.description':
@@ -11438,7 +11438,8 @@ export const fr_FR: Partial<Record<TranslationKey, string>> = {
   'entities.abilities.deterrence.description':
     "Augmente vos chances d'esquiver de 50 points de pourcentage pendant 10 s. (talent de Chasseur)",
   'entities.abilities.earthbind.description': 'Immobilise les ennemis dans un rayon de 4 m autour du point visé pendant 2 s, puis les ralentit de 40% pendant 6 s. (Talent de chaman)',
-  'entities.abilities.evocation.description': 'Restaura mana rápidamente. (talent de mage)',
+  'entities.abilities.evocation.description':
+    'Canalisez pendant 6 s : chaque seconde, vous récupérez 100 points de mana et gagnez 8 points de puissance des sorts. Le bonus se cumule pendant la canalisation et dure 15 s. (talent de Mage)',
   'entities.abilities.frenzied_regeneration.description':
     "Rend 180 points de vie en 10 s. Forme d'ours uniquement. (talent de Druide)",
   'entities.abilities.frost_trap.description':
@@ -11449,7 +11450,7 @@ export const fr_FR: Partial<Record<TranslationKey, string>> = {
   'entities.abilities.howl_of_terror.description':
     "Effraie les ennemis proches pendant un maximum de 3 s. Les dégâts peuvent interrompre l'effet. (talent de Démoniste)",
   'entities.abilities.ice_block.description':
-    'Te encierra en hielo y absorbe una enorme cantidad de daño durante 8 s. (talent de mage)',
+    'Vous enferme dans la glace pendant 8 s, vous immunisant contre tous les dégâts et effets et supprimant tous les effets néfastes. Utilisable lorsque vous êtes étourdi ou métamorphosé. Vous ne pouvez pas agir pendant cet effet. Lancez-le à nouveau pour l’annuler. (Mage)',
   'entities.abilities.inner_focus.description': 'Rend votre prochain sort de prêtre gratuit et ininterruptible. Dure 60 s.',
   'entities.abilities.innervate.description':
     "De la sève vivante afflue en vous pendant 10 s et restaure par vagues 20 points de votre ressource actuelle : mana, rage ou énergie. Changer de forme ne l'interrompt pas. Le sommeil, l'étourdissement ou la stase immobilisent la sève. (talent de Druide)",
@@ -11465,7 +11466,7 @@ export const fr_FR: Partial<Record<TranslationKey, string>> = {
   'entities.abilities.preparation.description':
     'Met fin au temps de recharge de Sprint, Évasion et Disparition. (talent de Voleur)',
   'entities.abilities.presence_of_mind.description':
-    'Hace instantáneo tu siguiente hechizo con tiempo de lanzamiento. Dura 60 s. (talent de mage)',
+    'Votre prochain sort ayant un temps d’incantation devient instantané. Dure 60 s. (talent de Mage)',
   'entities.abilities.psychic_scream.description': "Effraie les ennemis dans un rayon de 8 m pendant 4 s au plus. Les dégâts peuvent briser l'effet.",
   'entities.abilities.shadowstep.description':
     'Vous fait traverser les ombres en direction de votre cible. (talent de Voleur)',

--- a/src/ui/i18n.locales/fr_FR.ts
+++ b/src/ui/i18n.locales/fr_FR.ts
@@ -11450,7 +11450,7 @@ export const fr_FR: Partial<Record<TranslationKey, string>> = {
   'entities.abilities.howl_of_terror.description':
     "Effraie les ennemis proches pendant un maximum de 3 s. Les dégâts peuvent interrompre l'effet. (talent de Démoniste)",
   'entities.abilities.ice_block.description':
-    'Vous enferme dans la glace pendant 8 s, vous immunisant contre tous les dégâts et effets et supprimant tous les effets néfastes. Utilisable lorsque vous êtes étourdi ou métamorphosé. Vous ne pouvez pas agir pendant cet effet. Lancez-le à nouveau pour l’annuler. (Mage)',
+    'Vous enferme dans la glace pendant 8 s, vous immunisant contre tous les dégâts. Supprime les effets néfastes ordinaires déjà actifs et empêche l’application de nouveaux effets de ce type. Certains effets de rencontre ne peuvent être ni supprimés ni empêchés. Utilisable lorsque vous êtes étourdi ou métamorphosé. Vous ne pouvez pas agir tant que vous êtes emprisonné. Relancez la capacité pour l’annuler. (talent de Mage)',
   'entities.abilities.inner_focus.description': 'Rend votre prochain sort de prêtre gratuit et ininterruptible. Dure 60 s.',
   'entities.abilities.innervate.description':
     "De la sève vivante afflue en vous pendant 10 s et restaure par vagues 20 points de votre ressource actuelle : mana, rage ou énergie. Changer de forme ne l'interrompt pas. Le sommeil, l'étourdissement ou la stase immobilisent la sève. (talent de Druide)",

--- a/src/ui/i18n.locales/fr_FR.ts
+++ b/src/ui/i18n.locales/fr_FR.ts
@@ -11450,7 +11450,7 @@ export const fr_FR: Partial<Record<TranslationKey, string>> = {
   'entities.abilities.howl_of_terror.description':
     "Effraie les ennemis proches pendant un maximum de 3 s. Les dégâts peuvent interrompre l'effet. (talent de Démoniste)",
   'entities.abilities.ice_block.description':
-    'Vous enferme dans la glace pendant 8 s, vous immunisant contre tous les dégâts. Supprime les effets néfastes ordinaires déjà actifs et empêche l’application de nouveaux effets de ce type. Certains effets de rencontre ne peuvent être ni supprimés ni empêchés. Utilisable lorsque vous êtes étourdi ou métamorphosé. Vous ne pouvez pas agir tant que vous êtes emprisonné. Relancez la capacité pour l’annuler. (talent de Mage)',
+    'Vous enferme dans la glace pendant 8 s, vous immunisant contre tous les dégâts. Supprime les effets néfastes ordinaires déjà actifs et empêche les nouveaux effets de contrôle ordinaires. Utilisable lorsque vous êtes étourdi ou métamorphosé. Vous ne pouvez pas agir pendant cet effet. Relancez la capacité pour l’annuler. (Mage)',
   'entities.abilities.inner_focus.description': 'Rend votre prochain sort de prêtre gratuit et ininterruptible. Dure 60 s.',
   'entities.abilities.innervate.description':
     "De la sève vivante afflue en vous pendant 10 s et restaure par vagues 20 points de votre ressource actuelle : mana, rage ou énergie. Changer de forme ne l'interrompt pas. Le sommeil, l'étourdissement ou la stase immobilisent la sève. (talent de Druide)",

--- a/src/ui/i18n.resolved.generated/fr_CA.ts
+++ b/src/ui/i18n.resolved.generated/fr_CA.ts
@@ -10614,7 +10614,7 @@ export const fr_CA: EnTranslations = {
       },
       "ice_block": {
         "name": "Cercueil froid",
-        "description": "Vous enferme dans la glace pendant 8 s, vous immunisant contre tous les dégâts. Supprime les effets néfastes ordinaires déjà actifs et empêche l’application de nouveaux effets de ce type. Certains effets de rencontre ne peuvent être ni supprimés ni empêchés. Utilisable lorsque vous êtes étourdi ou métamorphosé. Vous ne pouvez pas agir tant que vous êtes emprisonné. Relancez la capacité pour l’annuler. (talent de Mage)"
+        "description": "Vous enferme dans la glace pendant 8 s, vous immunisant contre tous les dégâts. Supprime les effets néfastes ordinaires déjà actifs et empêche les nouveaux effets de contrôle ordinaires. Utilisable lorsque vous êtes étourdi ou métamorphosé. Vous ne pouvez pas agir pendant cet effet. Relancez la capacité pour l’annuler. (Mage)"
       },
       "inner_focus": {
         "name": "Esprit apaisé",

--- a/src/ui/i18n.resolved.generated/fr_CA.ts
+++ b/src/ui/i18n.resolved.generated/fr_CA.ts
@@ -10614,7 +10614,7 @@ export const fr_CA: EnTranslations = {
       },
       "ice_block": {
         "name": "Cercueil froid",
-        "description": "Vous enferme dans la glace pendant 8 s, vous immunisant contre tous les dégâts et effets et supprimant tous les effets néfastes. Utilisable lorsque vous êtes étourdi ou métamorphosé. Vous ne pouvez pas agir pendant cet effet. Lancez-le à nouveau pour l’annuler. (Mage)"
+        "description": "Vous enferme dans la glace pendant 8 s, vous immunisant contre tous les dégâts. Supprime les effets néfastes ordinaires déjà actifs et empêche l’application de nouveaux effets de ce type. Certains effets de rencontre ne peuvent être ni supprimés ni empêchés. Utilisable lorsque vous êtes étourdi ou métamorphosé. Vous ne pouvez pas agir tant que vous êtes emprisonné. Relancez la capacité pour l’annuler. (talent de Mage)"
       },
       "inner_focus": {
         "name": "Esprit apaisé",

--- a/src/ui/i18n.resolved.generated/fr_CA.ts
+++ b/src/ui/i18n.resolved.generated/fr_CA.ts
@@ -10325,8 +10325,8 @@ export const fr_CA: EnTranslations = {
         "description": "Adopte la forme de sélénien, renforçant l’incantation jusqu’à ce que vous changiez de nouveau. Lancez à nouveau pour revenir à la forme normale. (signature Équilibre)"
       },
       "feral_charge": {
-        "name": "Charge farouche",
-        "description": "Charge un ennemi et l’enracine pendant 1 s. Portée de 8-25 m. (signature Farouche)"
+        "name": "Déferlante primordiale",
+        "description": "Libère une déferlante primordiale. En Forme de loup, augmente la régénération d'énergie de 100% pendant 10 s. En Forme de Bruin, génère instantanément 50 points de rage. (signature Farouche)"
       },
       "swiftmend": {
         "name": "Prompte guérison",
@@ -10582,7 +10582,7 @@ export const fr_CA: EnTranslations = {
       },
       "evocation": {
         "name": "Puits d’éther",
-        "description": "Restaura mana rápidamente. (talent de mage)"
+        "description": "Canalisez pendant 6 s : chaque seconde, vous récupérez 100 points de mana et gagnez 8 points de puissance des sorts. Le bonus se cumule pendant la canalisation et dure 15 s. (talent de Mage)"
       },
       "flurry_of_knives": {
         "name": "Rafale de couteaux",
@@ -10614,7 +10614,7 @@ export const fr_CA: EnTranslations = {
       },
       "ice_block": {
         "name": "Cercueil froid",
-        "description": "Te encierra en hielo y absorbe una enorme cantidad de daño durante 8 s. (talent de mage)"
+        "description": "Vous enferme dans la glace pendant 8 s, vous immunisant contre tous les dégâts et effets et supprimant tous les effets néfastes. Utilisable lorsque vous êtes étourdi ou métamorphosé. Vous ne pouvez pas agir pendant cet effet. Lancez-le à nouveau pour l’annuler. (Mage)"
       },
       "inner_focus": {
         "name": "Esprit apaisé",
@@ -10706,7 +10706,7 @@ export const fr_CA: EnTranslations = {
       },
       "presence_of_mind": {
         "name": "Esprit fulgurant",
-        "description": "Hace instantáneo tu siguiente hechizo con tiempo de lanzamiento. Dura 60 s. (talent de mage)"
+        "description": "Votre prochain sort ayant un temps d’incantation devient instantané. Dure 60 s. (talent de Mage)"
       },
       "psychic_scream": {
         "name": "Cri psychique",

--- a/src/ui/i18n.resolved.generated/fr_FR.ts
+++ b/src/ui/i18n.resolved.generated/fr_FR.ts
@@ -10325,8 +10325,8 @@ export const fr_FR: EnTranslations = {
         "description": "Adopte la forme de sélénien, renforçant l’incantation jusqu’à ce que vous changiez de nouveau. Lancez à nouveau pour revenir à la forme normale. (signature Équilibre)"
       },
       "feral_charge": {
-        "name": "Charge farouche",
-        "description": "Charge un ennemi et l’enracine pendant 1 s. Portée de 8-25 m. (signature Farouche)"
+        "name": "Déferlante primordiale",
+        "description": "Libère une déferlante primordiale. En Forme de loup, augmente la régénération d'énergie de 100% pendant 10 s. En Forme de Bruin, génère instantanément 50 points de rage. (signature Farouche)"
       },
       "swiftmend": {
         "name": "Prompte guérison",
@@ -10582,7 +10582,7 @@ export const fr_FR: EnTranslations = {
       },
       "evocation": {
         "name": "Puits d’éther",
-        "description": "Restaura mana rápidamente. (talent de mage)"
+        "description": "Canalisez pendant 6 s : chaque seconde, vous récupérez 100 points de mana et gagnez 8 points de puissance des sorts. Le bonus se cumule pendant la canalisation et dure 15 s. (talent de Mage)"
       },
       "flurry_of_knives": {
         "name": "Rafale de couteaux",
@@ -10614,7 +10614,7 @@ export const fr_FR: EnTranslations = {
       },
       "ice_block": {
         "name": "Cercueil froid",
-        "description": "Te encierra en hielo y absorbe una enorme cantidad de daño durante 8 s. (talent de mage)"
+        "description": "Vous enferme dans la glace pendant 8 s, vous immunisant contre tous les dégâts et effets et supprimant tous les effets néfastes. Utilisable lorsque vous êtes étourdi ou métamorphosé. Vous ne pouvez pas agir pendant cet effet. Lancez-le à nouveau pour l’annuler. (Mage)"
       },
       "inner_focus": {
         "name": "Esprit apaisé",
@@ -10706,7 +10706,7 @@ export const fr_FR: EnTranslations = {
       },
       "presence_of_mind": {
         "name": "Esprit fulgurant",
-        "description": "Hace instantáneo tu siguiente hechizo con tiempo de lanzamiento. Dura 60 s. (talent de mage)"
+        "description": "Votre prochain sort ayant un temps d’incantation devient instantané. Dure 60 s. (talent de Mage)"
       },
       "psychic_scream": {
         "name": "Cri psychique",

--- a/src/ui/i18n.resolved.generated/fr_FR.ts
+++ b/src/ui/i18n.resolved.generated/fr_FR.ts
@@ -10614,7 +10614,7 @@ export const fr_FR: EnTranslations = {
       },
       "ice_block": {
         "name": "Cercueil froid",
-        "description": "Vous enferme dans la glace pendant 8 s, vous immunisant contre tous les dégâts et effets et supprimant tous les effets néfastes. Utilisable lorsque vous êtes étourdi ou métamorphosé. Vous ne pouvez pas agir pendant cet effet. Lancez-le à nouveau pour l’annuler. (Mage)"
+        "description": "Vous enferme dans la glace pendant 8 s, vous immunisant contre tous les dégâts. Supprime les effets néfastes ordinaires déjà actifs et empêche l’application de nouveaux effets de ce type. Certains effets de rencontre ne peuvent être ni supprimés ni empêchés. Utilisable lorsque vous êtes étourdi ou métamorphosé. Vous ne pouvez pas agir tant que vous êtes emprisonné. Relancez la capacité pour l’annuler. (talent de Mage)"
       },
       "inner_focus": {
         "name": "Esprit apaisé",

--- a/src/ui/i18n.resolved.generated/fr_FR.ts
+++ b/src/ui/i18n.resolved.generated/fr_FR.ts
@@ -10614,7 +10614,7 @@ export const fr_FR: EnTranslations = {
       },
       "ice_block": {
         "name": "Cercueil froid",
-        "description": "Vous enferme dans la glace pendant 8 s, vous immunisant contre tous les dégâts. Supprime les effets néfastes ordinaires déjà actifs et empêche l’application de nouveaux effets de ce type. Certains effets de rencontre ne peuvent être ni supprimés ni empêchés. Utilisable lorsque vous êtes étourdi ou métamorphosé. Vous ne pouvez pas agir tant que vous êtes emprisonné. Relancez la capacité pour l’annuler. (talent de Mage)"
+        "description": "Vous enferme dans la glace pendant 8 s, vous immunisant contre tous les dégâts. Supprime les effets néfastes ordinaires déjà actifs et empêche les nouveaux effets de contrôle ordinaires. Utilisable lorsque vous êtes étourdi ou métamorphosé. Vous ne pouvez pas agir pendant cet effet. Relancez la capacité pour l’annuler. (Mage)"
       },
       "inner_focus": {
         "name": "Esprit apaisé",


### PR DESCRIPTION
## Summary

- Replace Spanish text accidentally present in the French descriptions for Aetherwell, Racing Mind, and Cold Coffin.
- Update the stale Feral Charge translation to match the current Primal Surge mechanics.
- Regenerate the French and French Canadian locale bundles.

The corrected tooltips now describe the live mage and druid mechanics accurately.

## Type of change

- [x] Bug fix

## How was this tested?

- Commands:
  - `pnpm run i18n:gen`
  - `pnpm exec vitest run tests/i18n_completeness.test.ts tests/localization_coverage.test.ts tests/talent_tooltip_accuracy.test.ts`
  - `pnpm exec tsc --noEmit`
- Results:
  - 3 test files passed
  - 87 tests passed, 3 skipped
  - TypeScript check passed
- Manual steps:
  - Opened the local offline client in French.
  - Verified the corrected tooltips for Déferlante primordiale, Puits d’éther, Esprit fulgurant, and Cercueil froid.

The selective gate was also attempted locally. It reached the generated media manifest check, where it stopped because the local copies of two existing Evergarden HDR assets produced different hashes. This is unrelated to the translation diff.

## Screenshots / recordings

The corrected tooltips were verified manually in the local desktop client.

---

## Checklist

### Quality

- [ ] **The gate passes.** The targeted localization tests and TypeScript check pass. The selective gate stopped on the unrelated local HDR manifest mismatch described above.

### Cross-platform

- [ ] **Tested on desktop and mobile.** Desktop browser verified; mobile was not tested.
- [ ] **Accessible.** N/A, this PR changes translation text only.

### Localization (i18n)

- [x] N/A. This PR adds no new player-visible strings; it corrects existing French translations.
- [x] The French and French Canadian generated locale bundles were regenerated with `pnpm run i18n:gen`.

### Hygiene

- [x] No secrets, credentials, or `.env` files are included.
- [x] Generated localization bundles were produced by the repository generator and were not edited manually.