### PR TITLE
fix(sim): keep the Nythraxis arena wardstones visible off the Bastion quest

### DIFF
--- a/src/sim/content/dungeons.ts
+++ b/src/sim/content/dungeons.ts
@@ -920,10 +920,19 @@ export const DUNGEON_DEFS: Record<string, DungeonDef> = {
       // Three soul wardstones in a wide forward triangle in front of the boss
       // (spawn 0,96), well clear of his body so all three read distinctly and
       // raiders must split to channel them. Kept within the encounter's
-      // wardstone search radius (see nythraxisWardstones in sim.ts).
-      { itemId: 'bastion_ward_stone', name: 'Left Wardstone', x: -40, z: 79 },
-      { itemId: 'bastion_ward_stone', name: 'Right Wardstone', x: 40, z: 79 },
-      { itemId: 'bastion_ward_stone', name: 'Threshold Wardstone', x: 0, z: 63 },
+      // wardstone search radius (see nythraxisWardstones in sim.ts). The item id
+      // doubles as the Sunken Bastion quest pickup, so without interactOnly the
+      // quest-collectable display gate hides them from every raider who is not on
+      // that zone 2 quest.
+      { itemId: 'bastion_ward_stone', name: 'Left Wardstone', x: -40, z: 79, interactOnly: true },
+      { itemId: 'bastion_ward_stone', name: 'Right Wardstone', x: 40, z: 79, interactOnly: true },
+      {
+        itemId: 'bastion_ward_stone',
+        name: 'Threshold Wardstone',
+        x: 0,
+        z: 63,
+        interactOnly: true,
+      },
     ],
     interior: 'nythraxis',
     tombDressing: 'coffins',

--- a/src/sim/quest_gated_entity.ts
+++ b/src/sim/quest_gated_entity.ts
@@ -12,9 +12,13 @@
 //   and the pickup deny stays the authority. Objects that are merely INTERACTED with
 //   (bells, huts, wardstones) stay visible: they are scenery in their own right, which
 //   is why the arm keys on a `collect` objective for that exact itemId, not on the
-//   item carrying a questId.
+//   item carrying a questId. An INSTANCE may reuse a collectable's item id for an
+//   interact-only mechanic (the Nythraxis arena wardstones are the Sunken Bastion ward
+//   stone); its dungeon declares those objects `interactOnly`, and the arm reads that
+//   off the instance the object stands in, so the raid keeps its wards while the zone
+//   2 pickup stays a gated collectable.
 // Pure: no DOM, no rng, no clock.
-import { ITEMS, MOBS, QUESTS } from './data';
+import { dungeonAt, ITEMS, MOBS, QUESTS } from './data';
 import type { Entity, QuestProgress } from './types';
 
 /** Active or ready: the two states in which a quest's own entities are shown, and the
@@ -37,6 +41,15 @@ function collectQuestForObject(entity: Entity): string | null {
   return collected ? questId : null;
 }
 
+/** Whether the instance this object stands in declares its item an interact-only
+ *  mechanic (`DungeonObjectSpawn.interactOnly`). Overworld objects have no dungeon and
+ *  are never exempt this way. */
+function isInteractOnlyInstanceObject(entity: Entity): boolean {
+  const dungeon = dungeonAt(entity.pos.x);
+  if (!dungeon?.objects) return false;
+  return dungeon.objects.some((o) => o.interactOnly === true && o.itemId === entity.objectItemId);
+}
+
 /** The GROUND OBJECT arm on its own. Separate from the general predicate because the
  *  two arms want different treatment in the scene graph: a gated mob keeps its body
  *  (inert scenery), while a gated collectable is never built at all, so the renderer
@@ -47,7 +60,8 @@ export function isQuestGatedGroundObjectHidden(
 ): boolean {
   if (entity.kind !== 'object') return false;
   const questId = collectQuestForObject(entity);
-  return questId !== null && !onQuest(questLog, questId);
+  if (questId === null || onQuest(questLog, questId)) return false;
+  return !isInteractOnlyInstanceObject(entity);
 }
 
 export function isQuestGatedEntityHidden(

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -3412,6 +3412,13 @@ export interface DungeonObjectSpawn {
   z: number;
   templateId?: 'dungeon_door' | 'dungeon_exit';
   dungeonId?: string;
+  /**
+   * This object is an encounter mechanic players INTERACT with, never a pickup, even
+   * though its item id is a quest collectable elsewhere in the world (the Nythraxis
+   * arena wardstones reuse the Sunken Bastion ward stone). The quest-collectable
+   * display gate (quest_gated_entity.ts) never hides a flagged object.
+   */
+  interactOnly?: boolean;
 }
 
 export interface DungeonDef {

--- a/tests/nythraxis_wardstone_quest_gate.test.ts
+++ b/tests/nythraxis_wardstone_quest_gate.test.ts
@@ -1,0 +1,120 @@
+// The Nythraxis arena wardstones share their item id with the overworld "Sunken
+// Bastion" quest ward stone (`bastion_ward_stone`, collected for q_bastion_door). The
+// ground-object quest gate (src/sim/quest_gated_entity.ts) hides a collectable whose
+// quest is not on the viewer's log, which is right for the zone 2 pickup and wrong for
+// the raid: the arena wards are an interact-only encounter mechanic (the Deathless Rage
+// channel), and a raider who finished the Bastion quest long ago lost every one of them
+// (no model, no minimap mark, no interact) and could no longer counter the cast.
+//
+// The dungeon declares such objects `interactOnly`; the gate reads that off the
+// instance the object stands in and never hides them.
+
+import { describe, expect, it } from 'vitest';
+import { BUILTIN_WORLD, DUNGEONS, ITEMS, instanceOrigin, QUESTS } from '../src/sim/data';
+import { isQuestGatedGroundObjectHidden } from '../src/sim/quest_gated_entity';
+import { Sim } from '../src/sim/sim';
+import { dist2d, type Entity, type WorldContent } from '../src/sim/types';
+
+const WARD_ITEM_ID = 'bastion_ward_stone';
+const BASTION_QUEST_ID = 'q_bastion_door';
+
+const RAID_TEST_WORLD: WorldContent = { ...BUILTIN_WORLD, camps: [], npcs: {}, groundObjects: [] };
+
+function makeWorld() {
+  return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true, world: RAID_TEST_WORLD });
+}
+
+function enterRaid(sim: Sim, pid: number) {
+  sim.players.get(pid)!.questsDone.add('q_nythraxis_bound_guardian');
+  while ((sim.partyOf(pid)?.members.length ?? 1) < 5) {
+    const fill = sim.addPlayer('priest', `RaidFill${sim.players.size}`);
+    sim.partyInvite(fill, pid);
+    sim.partyAccept(fill);
+  }
+  sim.convertPartyToRaid(pid);
+  sim.enterDungeon('nythraxis_boss_arena', pid);
+  const p = sim.entities.get(pid)!;
+  return instanceOrigin(DUNGEONS.nythraxis_boss_arena.index, sim.instanceSlotAt(p.pos)!);
+}
+
+function arenaWards(sim: Sim, origin: { x: number; z: number }): Entity[] {
+  return [...sim.entities.values()].filter(
+    (e) =>
+      e.kind === 'object' &&
+      e.objectItemId === WARD_ITEM_ID &&
+      dist2d(e.pos, { x: origin.x, y: 0, z: origin.z }) < 140,
+  );
+}
+
+describe('Nythraxis arena wardstones vs the quest-collectable display gate', () => {
+  it('pins the premise: the ward item is a collect target of the Bastion quest', () => {
+    // If this ever changes the arena wards no longer need the exemption, and the
+    // dungeon flag becomes dead data worth removing.
+    expect(ITEMS[WARD_ITEM_ID]?.questId).toBe(BASTION_QUEST_ID);
+    expect(
+      QUESTS[BASTION_QUEST_ID].objectives.some(
+        (o) => o.type === 'collect' && o.itemId === WARD_ITEM_ID,
+      ),
+    ).toBe(true);
+  });
+
+  it('declares every arena wardstone interact-only in the dungeon content', () => {
+    const wards = (DUNGEONS.nythraxis_boss_arena.objects ?? []).filter(
+      (o) => o.itemId === WARD_ITEM_ID,
+    );
+    expect(wards).toHaveLength(3);
+    for (const ward of wards) expect(ward.interactOnly).toBe(true);
+  });
+
+  it('shows all three arena wards to a raider who has never taken the Bastion quest', () => {
+    const sim = makeWorld();
+    const pid = sim.addPlayer('warrior', 'Raider');
+    const origin = enterRaid(sim, pid);
+    const wards = arenaWards(sim, origin);
+    expect(wards).toHaveLength(3);
+    const questLog = sim.players.get(pid)!.questLog;
+    expect(questLog.has(BASTION_QUEST_ID)).toBe(false);
+    for (const ward of wards) expect(isQuestGatedGroundObjectHidden(ward, questLog)).toBe(false);
+  });
+
+  it('shows all three arena wards to a raider who turned the Bastion quest in', () => {
+    const sim = makeWorld();
+    const pid = sim.addPlayer('warrior', 'Raider');
+    const origin = enterRaid(sim, pid);
+    const questLog = sim.players.get(pid)!.questLog;
+    questLog.set(BASTION_QUEST_ID, { questId: BASTION_QUEST_ID, counts: [1], state: 'done' });
+    for (const ward of arenaWards(sim, origin)) {
+      expect(isQuestGatedGroundObjectHidden(ward, questLog)).toBe(false);
+    }
+  });
+
+  it('still hides the overworld Bastion ward stone from a player who is not on the quest', () => {
+    // The zone 2 pickup keeps the collectable behaviour: same item id, no exemption.
+    const sim = new Sim({ seed: 42, playerClass: 'warrior', playerName: 'Gate' });
+    const overworld = [...sim.entities.values()].filter(
+      (e) => e.kind === 'object' && e.objectItemId === WARD_ITEM_ID,
+    );
+    expect(overworld.length).toBeGreaterThan(0);
+    for (const stone of overworld) {
+      expect(isQuestGatedGroundObjectHidden(stone, sim.questLog)).toBe(true);
+    }
+    sim.questLog.set(BASTION_QUEST_ID, { questId: BASTION_QUEST_ID, counts: [0], state: 'active' });
+    for (const stone of overworld) {
+      expect(isQuestGatedGroundObjectHidden(stone, sim.questLog)).toBe(false);
+    }
+  });
+
+  it('keeps the crypt relics gated: only objects the dungeon flags are exempt', () => {
+    // The attunement crypt places real collectables (the keystones and diary of
+    // q_nythraxis_sealed_crypt) through the same dungeon objects list; they carry no
+    // flag and stay hidden off-quest.
+    const crypt = DUNGEONS.nythraxis_crypt.objects ?? [];
+    const relics = crypt.filter((o) => {
+      const questId = ITEMS[o.itemId]?.questId;
+      const quest = questId ? QUESTS[questId] : undefined;
+      return !!quest && quest.objectives.some((q) => q.type === 'collect' && q.itemId === o.itemId);
+    });
+    expect(relics.length).toBeGreaterThan(0);
+    for (const relic of relics) expect(relic.interactOnly).toBeUndefined();
+  });
+});

--- a/tests/quest_gated_ground_object.test.ts
+++ b/tests/quest_gated_ground_object.test.ts
@@ -31,8 +31,16 @@ const SCENERY_IDS = [...new Set(GROUND_OBJECTS.map((d) => d.itemId))].filter(
   (id) => !isCollectTarget(id),
 );
 
+// An OVERWORLD object (x = 0 sits in no instance band): the arm consults the dungeon a
+// collectable stands in for the interact-only exemption, so a fixture needs a position
+// like every live entity. The instance arm is tests/nythraxis_wardstone_quest_gate.ts.
 const objectEntity = (itemId: string | null): Entity =>
-  ({ kind: 'object', templateId: `ground_${itemId}`, objectItemId: itemId }) as unknown as Entity;
+  ({
+    kind: 'object',
+    templateId: `ground_${itemId}`,
+    objectItemId: itemId,
+    pos: { x: 0, y: 0, z: 0 },
+  }) as unknown as Entity;
 
 const log = (questId: string, state: QuestProgress['state']): Map<string, QuestProgress> =>
   new Map([[questId, { questId, counts: [0, 0], state }]]);

--- a/tests/quest_object_gate_core.test.ts
+++ b/tests/quest_object_gate_core.test.ts
@@ -8,11 +8,14 @@ import { makeQuestObjectGate } from '../src/render/quest_object_gate_core';
 import { ITEMS } from '../src/sim/data';
 import type { Entity, QuestProgress } from '../src/sim/types';
 
+// An overworld position (x = 0 is in no instance band): the sim rule consults the
+// dungeon a collectable stands in for the interact-only exemption.
 const crate = (): Entity =>
   ({
     kind: 'object',
     templateId: 'ground_supply_crate',
     objectItemId: 'supply_crate',
+    pos: { x: 0, y: 0, z: 0 },
   }) as unknown as Entity;
 
 const questId = (): string => {


### PR DESCRIPTION
## Summary

Hotfix: the three Nythraxis arena wardstones have been invisible to most raiders since
the quest-collectable display gate landed (`fac8741026`, "only spawn quest collectables
while their quest is active"). Without them the raid cannot channel against Deathless
Rage, and the cast wipes the group.

The wards reuse the Sunken Bastion quest item (`bastion_ward_stone`, a `collect`
objective of `q_bastion_door` in zone 2). The gate hides any collectable whose quest is
not active or ready on the viewer's log, so a raider who finished (or never took) that
zone 2 quest lost the wards entirely: no model, no minimap mark, no interact target. Only
a player mid-way through the Bastion quest still saw them, which is why it went unnoticed
in a quick check.

Fix, kept to the intent the gate's own header already states ("wardstones stay visible"):

- `DungeonObjectSpawn.interactOnly`: a dungeon can declare that one of its placed objects
  is an interact-only mechanic even though its item id is a collectable elsewhere.
- The three arena wardstones in `src/sim/content/dungeons.ts` carry the flag.
- `isQuestGatedGroundObjectHidden` (`src/sim/quest_gated_entity.ts`) resolves the
  instance an object stands in via `dungeonAt(pos.x)` and never hides a flagged one.
  Overworld objects have no dungeon, so the zone 2 pickup keeps its collectable
  behaviour, and the crypt relics (real collectables placed by the attunement crypt)
  stay gated because they carry no flag.

No wire change (the client already mirrors `pos` and `objectItemId`), no rng, no new
item, no i18n. `dungeonAt` is a pure function of x already exported from `sim/data`.

Two existing test fixtures (`tests/quest_gated_ground_object.test.ts`,
`tests/quest_object_gate_core.test.ts`) built synthetic objects without a `pos`; they
now carry an overworld position, like every live entity does.

## Type of change

- [x] Bug fix

## How was this tested?

- Commands:
  - `npx vitest run tests/nythraxis_wardstone_quest_gate.test.ts` (new; red before the
    fix on a real raid instance: three wards, `isQuestGatedGroundObjectHidden` true with
    an empty quest log and with `q_bastion_door` done; green after; also pins that the
    overworld ward stone stays gated and the crypt relics carry no flag)
  - `npx vitest run tests/quest_gated_ground_object.test.ts tests/mirefen_dedupe_objectives.test.ts tests/nythraxis_raid_unit.test.ts tests/nythraxis_encounter.test.ts tests/bastion_ward_stone.test.ts tests/dungeons.test.ts tests/architecture.test.ts`
  - `npx tsc --noEmit`
  - `GATE_SELECT_BASE=upstream/main node scripts/gate_select.mjs`
- Manual steps: enter the Nythraxis arena as a raid on a character that has turned in
  The Sunken Bastion; the three wardstones render, appear on the minimap, and take the
  interact key.

## Checklist

### Quality

- [x] **The gate passes.**

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files.
