### PR TITLE
fix(ui): Space over a bag row jumps the mount instead of dismounting

### DIFF
--- a/src/ui/bags_window.ts
+++ b/src/ui/bags_window.ts
@@ -82,6 +82,7 @@ import {
 } from './item_instance_glyph_mark';
 import { knownItemDef } from './known_item';
 import type { PainterHostPresentation } from './painter_host';
+import { BAG_ITEM_ROW_ATTR } from './panel_key_guard';
 import {
   installPromptDialog as installModalPromptDialog,
   type PromptDialogHandle,
@@ -112,6 +113,25 @@ const BAG_PROMPT_SELECTOR = '.discard-item-prompt, .sell-quantity-prompt, .bank-
 // prompt in #prompt-stack (promptModalOpen() would keep gating game keys on it).
 export function dismissBagPrompts(): void {
   for (const p of document.querySelectorAll(BAG_PROMPT_SELECTOR)) p.remove();
+}
+
+// An item row runs a GAME action (use / summon / equip / sell / deposit), so it
+// must never be the thing Space activates: Space is Jump. The row rebuild
+// re-seats focus by data-focus-key, so summoning a mount from bags leaves the
+// reins row focused, and the browser's native Space activation then re-used the
+// reins, which, on the mount you are already riding, dismounts you (see
+// src/sim/mounts.ts). Every hop threw the rider.
+//
+// Cancelling the default kills that synthesised click, and NOT stopping
+// propagation is the other half: the press still reaches Input's window keydown,
+// so the mount jumps. Enter is untouched, so keyboard players keep the row's
+// native activation: the same split the action bar draws (hud.ts), which
+// swallows Space on a slot for exactly this reason.
+function guardItemRowSpace(row: HTMLElement): void {
+  row.setAttribute(BAG_ITEM_ROW_ATTR, '');
+  row.addEventListener('keydown', (e) => {
+    if (e.key === ' ' || e.key === 'Spacebar' || e.code === 'Space') e.preventDefault();
+  });
 }
 
 // The unranked quality fallback as a CSS custom property. The shared
@@ -864,6 +884,7 @@ export class BagsWindow {
       // unknown-cell builder keeps the two families from colliding on a
       // shared miss value.
       row.dataset.focusKey = `bag:${s.itemId}:${this.stackOrdinal(world.inventory, s)}`;
+      guardItemRowSpace(row);
       this.bindBagCellDrop(row, cell);
       const qColor = QUALITY_COLOR[bagQualityKey(item)] ?? QUALITY_DEFAULT_COLOR;
       const itemName = itemDisplayName(item);
@@ -1155,6 +1176,7 @@ export class BagsWindow {
     row.dataset.focusKey = `bagu:${s.itemId}:${
       cell ?? this.stackOrdinal(this.deps.world().inventory, s)
     }`;
+    guardItemRowSpace(row);
     row.style.setProperty('--bag-slot-quality', QUALITY_DEFAULT_COLOR);
     // The known cell's ladder gives trade, mail-attach, market-sell, and
     // vendor precedence over the deposit; those four all need a def, so on

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -587,6 +587,7 @@ import {
 } from './painter_host';
 import { PaladinDevotionPainter } from './paladin_devotion_painter';
 import { createPaladinDevotionView } from './paladin_devotion_view';
+import { panelKeyGuardStops } from './panel_key_guard';
 import { PartyBelowTargetPainter } from './party_below_target_painter';
 import { loadPartyCollapsed, savePartyCollapsed } from './party_collapse';
 import type { PartyRowAuraDeps } from './party_frame_row';
@@ -2764,13 +2765,10 @@ export class Hud {
       }
       this.toggleReliquaryTrackerCollapsed();
     });
-    // The delve board, lockpick panel, map window, and the bank + bags cluster are
-    // non-modal overlays, so canUseGameKeys() stays true and the global jump (Space)
-    // / chat (Enter) binds would otherwise hijack those keys on a focused panel
-    // button (the map's Quests toggle, a bank grid cell, and each close button
-    // included). Stop propagation (but NOT the default, so the button's native
-    // activation still fires) when a panel button has focus, mirroring the
-    // quest-tracker guard above.
+    // Non-modal overlays: keep the global jump (Space) / chat (Enter) binds off
+    // a focused panel button, mirroring the quest-tracker guard above. The rule
+    // itself (including the bag item row that Space must still pass through to
+    // reach the jump) lives in panel_key_guard.ts.
     for (const panelId of [
       '#delve-board',
       '#lockpick-panel',
@@ -2783,8 +2781,7 @@ export class Hud {
       '#professions-window',
     ]) {
       $(panelId).addEventListener('keydown', (e) => {
-        if ((e.target as HTMLElement).tagName !== 'BUTTON') return;
-        if (e.key === 'Enter' || e.key === ' ' || e.code === 'Space') e.stopPropagation();
+        if (panelKeyGuardStops(e.target as HTMLElement, e.key, e.code)) e.stopPropagation();
       });
     }
     $('#mm-map').addEventListener('click', () => this.toggleMap());

--- a/src/ui/panel_key_guard.ts
+++ b/src/ui/panel_key_guard.ts
@@ -1,0 +1,34 @@
+// The non-modal panel key guard, as a pure decision.
+//
+// The delve board, lockpick panel, map window, and the bank + bags cluster are
+// non-modal overlays, so canUseGameKeys() stays true over them and the global
+// jump (Space) / chat (Enter) binds would otherwise hijack those keys on a
+// focused panel button (the map's Quests toggle, a bank grid cell, and each
+// close button included). The Hud's guard stops propagation, but NOT the
+// default, so the button's native activation still fires.
+//
+// The one exception is a bag ITEM row. That button runs a GAME action (use /
+// summon / equip / sell / deposit), so Space over it must stay Jump:
+//
+//   - It has already cancelled the default itself (bags_window.ts
+//     guardItemRowSpace), so there is no native activation left to protect the
+//     jump bind from. That matters because the bags rebuild re-seats focus by
+//     data-focus-key: summon a mount from your bags and the reins row is still
+//     focused, so the browser's synthesised Space click re-used the reins,
+//     which on the mount you are already riding dismounts you (src/sim/
+//     mounts.ts). Every attempt to hop threw the rider instead.
+//   - Swallowing Space here would leave that same rider unable to jump at all
+//     while their bags are open, which is the other half of the same bug.
+//
+// Enter is never let through: keyboard players keep the row's native activation.
+
+/** Marks a bag item row: the one panel button Space must pass through. */
+export const BAG_ITEM_ROW_ATTR = 'data-bag-item-row';
+
+/** True when a key over `target` is a panel activation the game must not also see. */
+export function panelKeyGuardStops(target: HTMLElement, key: string, code: string): boolean {
+  if (target.tagName !== 'BUTTON') return false;
+  const isSpace = key === ' ' || key === 'Spacebar' || code === 'Space';
+  if (isSpace) return !target.hasAttribute(BAG_ITEM_ROW_ATTR);
+  return key === 'Enter';
+}

--- a/tests/bags_window_space_jump.test.ts
+++ b/tests/bags_window_space_jump.test.ts
@@ -1,0 +1,183 @@
+// @vitest-environment happy-dom
+//
+// Space over a focused bag row must reach the game as a JUMP, never activate
+// the row. The bug: summoning a mount from bags leaves that reins row focused
+// (the focus-restore ladder re-seats it across the rebuild), so the next
+// Space natively activated the button, re-used the reins, and "clicking the
+// reins you are already riding dismounts" (src/sim/mounts.ts). The rider was
+// thrown every single time they tried to hop.
+//
+// Two halves of the contract, both asserted here:
+//   - the row cancels the default, so the browser never synthesises its click
+//   - the row does NOT stop propagation, so Input's window keydown still jumps
+// Enter is untouched: keyboard players still activate a row with it.
+
+import { describe, expect, it, vi } from 'vitest';
+import type { InvSlot } from '../src/sim/types';
+import { BagsWindow, type BagsWindowDeps } from '../src/ui/bags_window';
+import { ItemDragState } from '../src/ui/item_drag_state';
+import { panelKeyGuardStops } from '../src/ui/panel_key_guard';
+import type { IWorld } from '../src/world_api';
+
+const REINS = 'reins_valorsteed';
+
+function harness(inventory: InvSlot[]): {
+  root: HTMLElement;
+  w: BagsWindow;
+  useItem: ReturnType<typeof vi.fn>;
+} {
+  const useItem = vi.fn();
+  const world = {
+    inventory,
+    bags: [null, null, null, null],
+    bagCapacity: 16,
+    copper: 0,
+    useItem,
+  } as unknown as IWorld;
+  const root = document.createElement('div');
+  document.body.appendChild(root);
+  const noop = (): void => {};
+  const deps: BagsWindowDeps = {
+    itemIcon: () => '<span class="item-icon"></span>',
+    moneyHtml: () => '',
+    itemTooltip: () => '',
+    attachTooltip: noop,
+    root: () => root,
+    world: () => world,
+    wocBalanceHtml: () => '',
+    claudiumLauncherHtml: () => '',
+    openClaudium: noop,
+    openWallet: noop,
+    hideTooltip: noop,
+    consumePeek: () => false,
+    cancelPetFeed: noop,
+    captureFocus: () => null,
+    restoreFocus: noop,
+    renderCharIfOpen: noop,
+    vendorOpen: () => false,
+    tradeOpen: () => false,
+    isMarketSell: () => false,
+    isMailAttach: () => false,
+    isBankOpen: () => false,
+    isPersonalBankTab: () => false,
+    pendingPetFeed: () => false,
+    closeVendor: noop,
+    closeBank: noop,
+    onClosed: noop,
+    addItemToTrade: noop,
+    stageMarketSell: noop,
+    stageMailParcel: noop,
+    insertItemChatLink: noop,
+    showError: noop,
+    setPendingPetFeed: noop,
+    resetPetBarSig: noop,
+    isHotbarItemId: () => false,
+    useGatherTool: () => false,
+    setDragAction: noop,
+    clearActionDropTargets: noop,
+    dragState: new ItemDragState(),
+    isTouchHud: () => false,
+    markEquipDropTargets: noop,
+    dropOnEquipSlot: noop,
+    isGuildBankTab: () => false,
+    dropOnActionSlot: noop,
+    dropOnActionRingSlot: noop,
+    openItemActionMenu: noop,
+  };
+  const w = new BagsWindow(deps);
+  w.render();
+  return { root, w, useItem };
+}
+
+function reinsRow(root: HTMLElement): HTMLElement {
+  const rows = [...root.querySelectorAll<HTMLElement>('[data-focus-key]')];
+  const row = rows.find((n) => n.dataset.focusKey === `bag:${REINS}:0`);
+  expect(row, 'missing the reins row').toBeTruthy();
+  return row as HTMLElement;
+}
+
+/** Dispatch a real bubbling keydown from `row` and report what the game saw. */
+function pressKey(row: HTMLElement, key: string, code: string) {
+  let reachedWindow = false;
+  const onWindow = (): void => {
+    reachedWindow = true;
+  };
+  window.addEventListener('keydown', onWindow);
+  const ev = new KeyboardEvent('keydown', { key, code, bubbles: true, cancelable: true });
+  row.dispatchEvent(ev);
+  window.removeEventListener('keydown', onWindow);
+  return { reachedWindow, defaultPrevented: ev.defaultPrevented };
+}
+
+describe('space over a focused bag row', () => {
+  it('cancels the row activation so the reins are not re-used', () => {
+    const { root, useItem } = harness([{ itemId: REINS, count: 1 }]);
+    const row = reinsRow(root);
+    row.focus();
+    expect(document.activeElement, 'the row holds focus, as after a summon').toBe(row);
+
+    const seen = pressKey(row, ' ', 'Space');
+    expect(seen.defaultPrevented, 'Space must not natively activate the row').toBe(true);
+    expect(useItem, 'Space must never re-use the reins').not.toHaveBeenCalled();
+  });
+
+  it('still lets Space reach the game so the mount jumps', () => {
+    const { root } = harness([{ itemId: REINS, count: 1 }]);
+    const row = reinsRow(root);
+    row.focus();
+
+    const seen = pressKey(row, ' ', 'Space');
+    expect(seen.reachedWindow, "Space must bubble to Input's window keydown to jump").toBe(true);
+  });
+
+  it('leaves Enter activation alone for keyboard players', () => {
+    const { root } = harness([{ itemId: REINS, count: 1 }]);
+    const row = reinsRow(root);
+    row.focus();
+
+    const seen = pressKey(row, 'Enter', 'Enter');
+    expect(seen.defaultPrevented, 'Enter still activates the row natively').toBe(false);
+  });
+
+  it('marks the row so the HUD panel guard can let Space past', () => {
+    const { root } = harness([{ itemId: REINS, count: 1 }]);
+    expect(reinsRow(root).hasAttribute('data-bag-item-row')).toBe(true);
+  });
+
+  // The two halves composed: the real row guard under the real #bags panel
+  // guard the Hud installs. Without the bag-row exemption the panel swallowed
+  // the press here and the rider could not hop with their bags open.
+  it('survives the HUD #bags panel guard and still reaches the game', () => {
+    const { root, useItem } = harness([{ itemId: REINS, count: 1 }]);
+    const panel = document.createElement('div');
+    panel.append(root);
+    document.body.append(panel);
+    // Byte-for-byte the listener hud.ts installs on each non-modal panel.
+    panel.addEventListener('keydown', (e) => {
+      if (panelKeyGuardStops(e.target as HTMLElement, e.key, e.code)) e.stopPropagation();
+    });
+
+    const row = reinsRow(root);
+    row.focus();
+    const seen = pressKey(row, ' ', 'Space');
+
+    expect(seen.reachedWindow, 'the panel guard must let a bag row Space through').toBe(true);
+    expect(seen.defaultPrevented, 'and it must still be a cancelled activation').toBe(true);
+    expect(useItem, 'the reins must never be re-used').not.toHaveBeenCalled();
+  });
+
+  it('the same panel guard still swallows Space on an ordinary panel button', () => {
+    const panel = document.createElement('div');
+    const close = document.createElement('button');
+    panel.append(close);
+    document.body.append(panel);
+    panel.addEventListener('keydown', (e) => {
+      if (panelKeyGuardStops(e.target as HTMLElement, e.key, e.code)) e.stopPropagation();
+    });
+
+    close.focus();
+    expect(pressKey(close, ' ', 'Space').reachedWindow, 'close button keeps the old guard').toBe(
+      false,
+    );
+  });
+});

--- a/tests/deeds_window.test.ts
+++ b/tests/deeds_window.test.ts
@@ -13,6 +13,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { audio } from '../src/game/audio';
 import { deedName } from '../src/ui/deed_i18n';
 import { Hud } from '../src/ui/hud';
+import { panelKeyGuardStops } from '../src/ui/panel_key_guard';
 
 // This file runs under jsdom (for the keyboard-guard behavioral test below),
 // where import.meta.url is an http URL that readFileSync rejects; resolve the
@@ -875,6 +876,8 @@ describe('chrome keys and CSS floors', () => {
 });
 
 describe('non-modal Enter/Space activation guard (WCAG 2.1.1)', () => {
+  const buttonEl = (): HTMLElement => document.createElement('button');
+
   it('adds the Book of Deeds window to the guard array, keeping the shared guard body', () => {
     // The Book is a non-modal overlay, so canUseGameKeys() stays true while a
     // Book button has focus: without the guard, Space jumps the character and
@@ -884,14 +887,21 @@ describe('non-modal Enter/Space activation guard (WCAG 2.1.1)', () => {
     expect(start).toBeGreaterThan(0);
     const guardArray = hud.slice(start, hud.indexOf(']', start));
     expect(guardArray).toContain("'#deeds-window'");
-    // The shared guard body the behavioral test below faithfully copies: it
-    // stopPropagation's Enter/Space only when a BUTTON has focus and NEVER
+    // The guard body: it stopPropagation's on the shared decision and NEVER
     // preventDefault's (native activation survives). Scope the preventDefault
     // absence to the guard region so an unrelated hud handler cannot mask a drift.
     const guardRegion = hud.slice(start, hud.indexOf("$('#mm-map')", start));
-    expect(guardRegion).toContain("(e.target as HTMLElement).tagName !== 'BUTTON'");
+    expect(guardRegion).toContain('panelKeyGuardStops(');
     expect(guardRegion).toContain('e.stopPropagation()');
     expect(guardRegion).not.toContain('preventDefault');
+    // The decision itself moved to the pure src/ui/panel_key_guard.ts, so the
+    // "only a focused BUTTON, only Enter/Space" rule is pinned there instead of
+    // in the hud string. The behavioral test below calls the real function, so
+    // it cannot drift from hud.ts the way a hand-copied body could.
+    expect(panelKeyGuardStops(buttonEl(), 'Enter', 'Enter')).toBe(true);
+    expect(panelKeyGuardStops(buttonEl(), ' ', 'Space')).toBe(true);
+    expect(panelKeyGuardStops(document.createElement('div'), ' ', 'Space')).toBe(false);
+    expect(panelKeyGuardStops(buttonEl(), 'w', 'KeyW')).toBe(false);
   });
 
   it('stops Enter/Space from the game binds on a focused Book button, preserving native activation', () => {
@@ -901,11 +911,11 @@ describe('non-modal Enter/Space activation guard (WCAG 2.1.1)', () => {
     document.body.innerHTML = '<div id="deeds-window"><button data-close></button></div>';
     const root = document.getElementById('deeds-window') as HTMLElement;
     const btn = root.querySelector('button') as HTMLButtonElement;
-    // The listener hud.ts installs on each guarded panel root (survives the
-    // painter's innerHTML rebuilds because it lives on the root).
+    // The listener hud.ts installs on each guarded panel root, byte for byte
+    // (survives the painter's innerHTML rebuilds because it lives on the root).
+    // It calls the real shared decision, so this copy cannot drift from hud.ts.
     root.addEventListener('keydown', (e) => {
-      if ((e.target as HTMLElement).tagName !== 'BUTTON') return;
-      if (e.key === 'Enter' || e.key === ' ' || e.code === 'Space') e.stopPropagation();
+      if (panelKeyGuardStops(e.target as HTMLElement, e.key, e.code)) e.stopPropagation();
     });
     const windowSpy = vi.fn();
     window.addEventListener('keydown', windowSpy);

--- a/tests/mount_jump.test.ts
+++ b/tests/mount_jump.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import { BUILTIN_WORLD } from '../src/sim/data';
+import { Sim } from '../src/sim/sim';
+import type { WorldContent } from '../src/sim/types';
+import { terrainHeight } from '../src/sim/world';
+
+const SEED = 42;
+const WORLD: WorldContent = { ...BUILTIN_WORLD, camps: [], npcs: {}, groundObjects: [] };
+
+function mountedSim(): Sim {
+  const sim = new Sim({ seed: SEED, playerClass: 'warrior', autoEquip: true, world: WORLD });
+  sim.setPlayerLevel(60);
+  const p = sim.player;
+  p.pos.x = 0;
+  p.pos.z = 0;
+  p.pos.y = terrainHeight(0, 0, SEED);
+  p.prevPos = { ...p.pos };
+  p.fallStartY = p.pos.y;
+  p.onGround = true;
+  p.vx = 0;
+  p.vy = 0;
+  p.vz = 0;
+  // Own the reins, so the ride survives the ownership re-validation stagger.
+  sim.addItem('reins_valorsteed', 1, p.id);
+  p.mountKey = 'valorsteed';
+  return sim;
+}
+
+/** Ticks until the ride ends, or -1 if it survived `ticks`. */
+function ticksUntilDismount(sim: Sim, ticks: number): number {
+  for (let i = 0; i < ticks; i++) {
+    sim.tick();
+    if (sim.player.mountKey !== 'valorsteed') return i;
+  }
+  return -1;
+}
+
+describe('space while mounted', () => {
+  it('control: standing still keeps the ride', () => {
+    const sim = mountedSim();
+    expect(ticksUntilDismount(sim, 140), 'dismount tick standing still').toBe(-1);
+  });
+
+  it('control: running keeps the ride', () => {
+    const sim = mountedSim();
+    const meta = sim.players.get(sim.player.id);
+    if (!meta) throw new Error('missing meta');
+    meta.moveInput.forward = true;
+    expect(ticksUntilDismount(sim, 140), 'dismount tick while running').toBe(-1);
+  });
+
+  it('jumps the mount instead of dismounting', () => {
+    const sim = mountedSim();
+    const p = sim.player;
+    const meta = sim.players.get(p.id);
+    if (!meta) throw new Error('missing meta');
+
+    sim.tick();
+    expect(p.mountKey, 'still mounted before the jump').toBe('valorsteed');
+
+    meta.moveInput.jump = true;
+    sim.tick();
+    // eslint-disable-next-line no-console
+    console.log(
+      `jump edge: mountKey=${JSON.stringify(p.mountKey)} vy=${p.vy} onGround=${p.onGround} jumping=${p.jumping}`,
+    );
+    expect(p.vy, 'jump velocity applied').toBeGreaterThan(0);
+    expect(p.mountKey, 'mount survives the jump edge').toBe('valorsteed');
+
+    meta.moveInput.jump = false;
+    const at = ticksUntilDismount(sim, 140);
+    // eslint-disable-next-line no-console
+    console.log(`dismount tick after the jump: ${at} (-1 = survived)`);
+    expect(at, 'mount survives the whole arc and the landing').toBe(-1);
+  });
+});

--- a/tests/panel_key_guard.test.ts
+++ b/tests/panel_key_guard.test.ts
@@ -1,0 +1,41 @@
+// @vitest-environment happy-dom
+//
+// The non-modal panel key guard: which activations the Hud swallows before the
+// global jump / chat binds see them, and the one it must not.
+
+import { describe, expect, it } from 'vitest';
+import { BAG_ITEM_ROW_ATTR, panelKeyGuardStops } from '../src/ui/panel_key_guard';
+
+function el(tag: string, bagItemRow = false): HTMLElement {
+  const node = document.createElement(tag);
+  if (bagItemRow) node.setAttribute(BAG_ITEM_ROW_ATTR, '');
+  return node;
+}
+
+describe('panelKeyGuardStops', () => {
+  it('swallows Enter and Space on an ordinary panel button', () => {
+    const button = el('button');
+    expect(panelKeyGuardStops(button, ' ', 'Space')).toBe(true);
+    expect(panelKeyGuardStops(button, 'Spacebar', 'Spacebar')).toBe(true);
+    expect(panelKeyGuardStops(button, 'Enter', 'Enter')).toBe(true);
+  });
+
+  it('lets Space past a bag item row so the jump still fires', () => {
+    expect(panelKeyGuardStops(el('button', true), ' ', 'Space')).toBe(false);
+    expect(panelKeyGuardStops(el('button', true), 'Spacebar', 'Spacebar')).toBe(false);
+  });
+
+  it('still swallows Enter on a bag item row, which activates it', () => {
+    expect(panelKeyGuardStops(el('button', true), 'Enter', 'Enter')).toBe(true);
+  });
+
+  it('ignores anything that is not a button', () => {
+    expect(panelKeyGuardStops(el('div'), ' ', 'Space')).toBe(false);
+    expect(panelKeyGuardStops(el('input'), 'Enter', 'Enter')).toBe(false);
+  });
+
+  it('ignores other keys', () => {
+    expect(panelKeyGuardStops(el('button'), 'w', 'KeyW')).toBe(false);
+    expect(panelKeyGuardStops(el('button'), 'Escape', 'Escape')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Pressing **Space to jump would dismount you instead**, reliably, whenever you had summoned your mount from your bags and left the bags window open.

The chain is entirely in the UI; the sim was never at fault:

1. You click the reins in your bags. The browser focuses that `<button>`.
2. `useItem` summons the mount and the bags window rebuilds. Its focus-restore ladder re-seats focus by `data-focus-key`, so the **same reins row comes back focused**.
3. You press Space to hop.
4. `Hud`'s non-modal panel guard sees a `BUTTON` inside `#bags` and calls `stopPropagation()` — deliberately *not* `preventDefault()`, so the button's native activation survives for keyboard players.
5. `Input`'s window-level `keydown` therefore never runs: no `preventDefault()` on Space, and no jump latch.
6. The browser synthesises the focused button's `click`. That re-uses the reins — and clicking the reins you are already riding dismounts you (`src/sim/mounts.ts`).

So the rider was thrown on every attempt to jump, and could not jump at all with bags open.

## The fix

Two halves, both needed:

- **`bags_window.ts`** — an item row now cancels the default on Space, killing the synthesised click, and deliberately does **not** stop propagation.
- **`panel_key_guard.ts`** (new, pure) — the panel guard exempts bag item rows for Space, so the press reaches `Input` and jumps. Swallowing it there would leave the same rider unable to jump at all, which is the other half of the same bug.

Enter is untouched, so keyboard players keep the row's native activation, and every other panel button (Close, the map's Quests toggle, a bank cell) behaves exactly as today. This is the same split the action bar already draws for its slots, which `preventDefault` + `stopPropagation` Space on a focused slot for precisely this reason.

The guard decision landed in a new pure module rather than growing `hud.ts`, which is at its line-count ratchet.

## Type of change

- [x] Bug fix
- [x] Tests

## How was this tested?

- Commands: `npm run check:ts` (clean), `npx @biomejs/biome ci --changed` (clean), `npm run test:browser` (**20 files / 131 tests pass**), and the surrounding suites — `bags_window`, `bags_window_focus_restore`, `bags_window_use_routing`, `bags_window_unknown_cell`, `input`, `monolith_budget` (**190 tests pass**).
- New tests:
  - `tests/bags_window_space_jump.test.ts` drives the real `BagsWindow`. It pins that Space over a focused reins row is default-prevented and calls `useItem` zero times, that it still reaches the window handler so the jump fires, that Enter is untouched, and — composing both halves — that the real `#bags` panel guard lets it through while still swallowing Space on an ordinary panel button.
  - `tests/panel_key_guard.test.ts` covers the extracted decision directly.
  - `tests/mount_jump.test.ts` pins that the sim was never the problem: a mounted player given `jump` gets `JUMP_VELOCITY * MOUNT_JUMP_MULT` and keeps `mountKey` through the whole arc and the landing, with standing and running controls.
- Manual: booted offline, opened bags with a bag row focused, and confirmed in the live page that a Space keydown arrives at the window handler with `defaultPrevented` true and fires no click, while Space on the bags Close button is still swallowed.

## Screenshots / recordings

N/A — no visual change; this is keyboard routing.
