### PR TITLE
fix(warlock): show Litany damage in tooltip

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -7344,7 +7344,7 @@ function renderClassDetails(
             // A combo-point bleed finisher (rupture, rip): `total` alone is the
             // damage at zero combo points, a state the caster can never reach.
             // Render base plus per-combo-point, the same composition the
-            // finisherDamage arm above and abilityEffectText in the HUD use.
+            // finisherDamage arm above and the shared abilityEffectText formatter use.
             dmgText = t('abilityUi.tooltip.finisherDamage', {
               base: formatClassDetailNumber(secondaryEffect.total),
               perCombo: formatClassDetailNumber(secondaryEffect.perCombo),

--- a/src/ui/ability_damage.ts
+++ b/src/ui/ability_damage.ts
@@ -7,7 +7,7 @@
 // This only changes the NUMBERS spliced into the description placeholders ($d
 // damage, $o over-time total, $b buff value, $t duration), never adds a string,
 // so it needs no new i18n keys. It also owns the placeholder EFFECT PICKERS
-// (which effect each placeholder reads), so hud.ts and the tooltip-consistency
+// (which effect each placeholder reads), so ability_description.ts and the tooltip-consistency
 // guard test share one definition and cannot drift. Unit-tested in
 // tests/ability_damage.test.ts; hud.ts is the thin consumer.
 import type { ResolvedAbility } from '../sim/sim';
@@ -118,6 +118,10 @@ export function abilityDamageBonus(
       return Math.round(scaling.rangedPower * eff.rangedPowerCoeff * (eff.damageMult ?? 1));
     case 'hunterStampede':
       return Math.round(scaling.rangedPower * eff.rangedPowerCoeff);
+    case 'afflictionLitany':
+      // Litany is a flat, rank-resolved pulse. It gains Hexcraft's ability
+      // modifier during resolution but has no Spell Power coefficient.
+      return 0;
     default:
       return 0;
   }
@@ -153,7 +157,8 @@ export function abilityPrimaryEffect(res: ResolvedAbility): AbilityEffect | unde
       eff.type === 'faerieFire' ||
       eff.type === 'lifeTap' ||
       eff.type === 'hunterBloodhook' ||
-      eff.type === 'hunterStampede',
+      eff.type === 'hunterStampede' ||
+      eff.type === 'afflictionLitany',
   );
 }
 

--- a/src/ui/ability_description.ts
+++ b/src/ui/ability_description.ts
@@ -10,19 +10,145 @@
 
 import type { ResolvedAbility } from '../sim/sim';
 import {
+  type AbilityEffect,
+  FAERIE_FIRE_ARMOR_PCT,
+  SUNDER_ARMOR_PCT_PER_STACK,
+} from '../sim/types';
+import {
   type AbilityScaling,
   abilityBuffValue,
   abilityDamageBonus,
   abilityDurationValue,
   abilityOverTimeEffect,
+  abilityPrimaryEffect,
+  abilitySecondaryEffect,
   abilityTemporalHourglassValues,
 } from './ability_damage';
+import type { AuraEffectInput } from './aura_effect';
 import { type AbilitySpecNoteField, tEntity, tEntityOptional } from './entity_i18n';
 import { formatNumber, type InterpolationValues, t } from './i18n';
 
 /** The tooltip's number format for every ability figure (damage, seconds, costs). */
 export function formatAbilityNumber(value: number): string {
   return formatNumber(value, { maximumFractionDigits: 1 });
+}
+
+// Builds the {damage} value for an ability tooltip. The selected effect is
+// rank- and talent-resolved before this formatter sees it, so custom flat
+// effects such as Litany display Hexcraft's modifier without inventing a
+// second damage path in the HUD coordinator.
+export function abilityEffectText(res: ResolvedAbility, scaling?: AbilityScaling): string {
+  const suffix = (eff: AbilityEffect) => {
+    const bonus = scaling ? abilityDamageBonus(res, eff, scaling) : 0;
+    return bonus > 0
+      ? ` ${t('hudChrome.abilityScaling.bonus', { value: formatAbilityNumber(bonus) })}`
+      : '';
+  };
+  const primary = abilityPrimaryEffect(res);
+  if (primary) {
+    switch (primary.type) {
+      case 'directDamage':
+      case 'aoeDamage':
+      case 'aoeHeal':
+      case 'chainHeal':
+      case 'aoeRoot':
+      case 'chainDamage':
+      case 'groundAoE':
+      case 'drainTick':
+      case 'valkyrsCalling':
+      case 'hunterStampede':
+        return abilityAmountRange(primary.min, primary.max) + suffix(primary);
+      case 'heal':
+        return primary.casterMaxHpPct === undefined
+          ? abilityAmountRange(primary.min, primary.max) + suffix(primary)
+          : formatAbilityNumber(primary.casterMaxHpPct * 100);
+      case 'repositionToAim':
+        return primary.landingAoe
+          ? abilityAmountRange(primary.landingAoe.min, primary.landingAoe.max)
+          : '';
+      case 'consumeAura':
+        if (primary.deal) {
+          return abilityAmountRange(primary.deal.min, primary.deal.max) + suffix(primary);
+        }
+        if (primary.heal) {
+          return abilityAmountRange(primary.heal.min, primary.heal.max) + suffix(primary);
+        }
+        return '';
+      case 'weaponDamage':
+      case 'weaponStrike':
+        return formatAbilityNumber(primary.bonus);
+      case 'sunder':
+        return formatAbilityNumber(
+          SUNDER_ARMOR_PCT_PER_STACK *
+            (primary.full || primary.perCombo ? primary.maxStacks : 1) *
+            100,
+        );
+      case 'faerieFire':
+        return formatAbilityNumber(FAERIE_FIRE_ARMOR_PCT * 100);
+      case 'lifeTap':
+        return formatAbilityNumber(primary.hp);
+      case 'finisherDamage':
+        return (
+          t('abilityUi.tooltip.finisherDamage', {
+            base: formatAbilityNumber(primary.base),
+            perCombo: formatAbilityNumber(primary.perCombo),
+          }) + suffix(primary)
+        );
+      case 'hunterBloodhook':
+        return (
+          formatAbilityNumber(primary.bleedTotal * (primary.damageMult ?? 1)) + suffix(primary)
+        );
+      case 'afflictionLitany':
+        return formatAbilityNumber(primary.damage);
+    }
+  }
+
+  const secondary = abilitySecondaryEffect(res);
+  if (!secondary) return '';
+  switch (secondary.type) {
+    case 'dot':
+      if (secondary.perCombo !== undefined) {
+        return (
+          t('abilityUi.tooltip.finisherDamage', {
+            base: formatAbilityNumber(secondary.total),
+            perCombo: formatAbilityNumber(secondary.perCombo),
+          }) + suffix(secondary)
+        );
+      }
+      return formatAbilityNumber(secondary.total) + suffix(secondary);
+    case 'hot':
+      return formatAbilityNumber(secondary.total) + suffix(secondary);
+    case 'absorb':
+      return secondary.casterMaxHpPct === undefined
+        ? formatAbilityNumber(secondary.amount) + suffix(secondary)
+        : formatAbilityNumber(secondary.casterMaxHpPct * 100);
+    case 'imbue':
+      return formatAbilityNumber(secondary.bonus);
+    default:
+      return '';
+  }
+}
+
+function abilityAmountRange(min: number, max: number): string {
+  if (min === max) return formatAbilityNumber(min);
+  return t('abilityUi.tooltip.damageRange', {
+    min: formatAbilityNumber(min),
+    max: formatAbilityNumber(max),
+  });
+}
+
+/** Maps custom ability effects onto the same localized, resolved effect lines
+ *  their active auras use. The HUD renders this beside the static ability prose,
+ *  so every locale receives the live rank and talent values without duplicating
+ *  interpolation tokens across translated ability descriptions. */
+export function abilityEffectAuraInput(effect: AbilityEffect): AuraEffectInput | null {
+  if (effect.type !== 'afflictionLitany') return null;
+  return {
+    kind: 'affliction_litany',
+    value: effect.damage,
+    value2: effect.radius,
+    value3: effect.maxTargets,
+  };
 }
 
 // Builds the `$o` over-time string (a hybrid's dot/hot TOTAL) the same way

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -111,7 +111,6 @@ import type {
   SkinCatalog,
 } from '../sim/types';
 import {
-  type AbilityEffect,
   ALL_CLASSES,
   type AuraKind,
   CONSUME_DURATION,
@@ -121,7 +120,6 @@ import {
   dist2d,
   ENCHANT_CAST_ID,
   type Entity,
-  FAERIE_FIRE_ARMOR_PCT,
   FISHING_CAST_ID,
   GATHER_CAST_ID,
   type ItemDef,
@@ -131,7 +129,6 @@ import {
   MILESTONES,
   SALVAGE_CAST_ID,
   type SimEvent,
-  SUNDER_ARMOR_PCT_PER_STACK,
   TICK_RATE,
   TOOL_RECHARGE_CAST_ID,
   virtualLevel,
@@ -149,13 +146,13 @@ import {
   type OverheadEmoteId,
   type PartyInfo,
 } from '../world_api';
+import type { AbilityScaling } from './ability_damage';
 import {
-  type AbilityScaling,
-  abilityDamageBonus,
-  abilityPrimaryEffect,
-  abilitySecondaryEffect,
-} from './ability_damage';
-import { abilityDisplayDescription, formatAbilityNumber } from './ability_description';
+  abilityDisplayDescription,
+  abilityEffectAuraInput,
+  abilityEffectText,
+  formatAbilityNumber,
+} from './ability_description';
 import { abilityDisplayName, abilityDisplayNameFromSource } from './ability_display_name';
 import { ArenaWindow } from './arena_window';
 import { auraDisplayNameForHud, auraDisplayNameFromSource } from './aura_display_name';
@@ -6581,7 +6578,10 @@ export class Hud {
     // Aspect of the Hawk / Fortitude via buffPct) - which the static description can't.
     for (const eff of res.effects) {
       if (res.def.tooltipOmitEffectLines) break;
-      if (eff.type === 'selfBuff' || eff.type === 'buffTarget') {
+      const resolvedAuraEffect = abilityEffectAuraInput(eff);
+      if (resolvedAuraEffect) {
+        html += this.auraEffectTooltipHtml(resolvedAuraEffect);
+      } else if (eff.type === 'selfBuff' || eff.type === 'buffTarget') {
         // Pass the ability id so the effect line can resolve its damage school
         // (the {school} placeholder in the thorns/dot/absorb summaries).
         html += this.auraEffectTooltipHtml({
@@ -19308,114 +19308,6 @@ export function abilityRequirementLines(
       default:
         return t('abilityUi.tooltip.selfOnly');
     }
-  });
-}
-
-// Builds the `$d` damage string for an ability tooltip. When `scaling` (the live
-// character's Spell Power / Ranged AP / Attack Power) is given, the BASE damage is
-// shown with the scaling contribution called out as a "(+N)" suffix, e.g.
-// "66 to 74 (+29)", so a caster sees both the base and exactly what their Spell
-// Power adds, and watches it climb as gear changes.
-export function abilityEffectText(res: ResolvedAbility, scaling?: AbilityScaling): string {
-  // " (+N)" callout for the scaling contribution (Spell Power / Attack Power),
-  // omitted when there is none. Punctuation + formatted number only (no words).
-  const suffix = (eff: AbilityEffect) => {
-    const b = scaling ? abilityDamageBonus(res, eff, scaling) : 0;
-    return b > 0
-      ? ` ${t('hudChrome.abilityScaling.bonus', { value: formatAbilityNumber(b) })}`
-      : '';
-  };
-  // The pickers live in ability_damage.ts so the consistency guard test shares
-  // them; this function only formats the picked effect.
-  const primary = abilityPrimaryEffect(res);
-  if (primary) {
-    switch (primary.type) {
-      case 'directDamage':
-      case 'aoeDamage':
-      case 'aoeHeal':
-      case 'chainHeal':
-      case 'aoeRoot':
-      case 'chainDamage':
-      case 'groundAoE':
-      case 'drainTick':
-      case 'valkyrsCalling':
-        return abilityAmountRange(primary.min, primary.max) + suffix(primary);
-      case 'hunterStampede':
-        return abilityAmountRange(primary.min, primary.max) + suffix(primary);
-      case 'heal':
-        return primary.casterMaxHpPct === undefined
-          ? abilityAmountRange(primary.min, primary.max) + suffix(primary)
-          : formatAbilityNumber(primary.casterMaxHpPct * 100);
-      case 'repositionToAim':
-        return primary.landingAoe
-          ? abilityAmountRange(primary.landingAoe.min, primary.landingAoe.max)
-          : '';
-      case 'consumeAura':
-        if (primary.deal) {
-          return abilityAmountRange(primary.deal.min, primary.deal.max) + suffix(primary);
-        }
-        if (primary.heal) {
-          return abilityAmountRange(primary.heal.min, primary.heal.max) + suffix(primary);
-        }
-        return '';
-      case 'weaponDamage':
-      case 'weaponStrike':
-        return formatAbilityNumber(primary.bonus);
-      case 'sunder':
-        return formatAbilityNumber(
-          SUNDER_ARMOR_PCT_PER_STACK *
-            (primary.full || primary.perCombo ? primary.maxStacks : 1) *
-            100,
-        );
-      case 'faerieFire':
-        return formatAbilityNumber(FAERIE_FIRE_ARMOR_PCT * 100);
-      case 'lifeTap':
-        return formatAbilityNumber(primary.hp);
-      case 'finisherDamage':
-        return (
-          t('abilityUi.tooltip.finisherDamage', {
-            base: formatAbilityNumber(primary.base),
-            perCombo: formatAbilityNumber(primary.perCombo),
-          }) + suffix(primary)
-        );
-      case 'hunterBloodhook':
-        return (
-          formatAbilityNumber(primary.bleedTotal * (primary.damageMult ?? 1)) + suffix(primary)
-        );
-    }
-  }
-
-  const secondary = abilitySecondaryEffect(res);
-  if (!secondary) return '';
-  switch (secondary.type) {
-    case 'dot':
-      if (secondary.perCombo !== undefined) {
-        return (
-          t('abilityUi.tooltip.finisherDamage', {
-            base: formatAbilityNumber(secondary.total),
-            perCombo: formatAbilityNumber(secondary.perCombo),
-          }) + suffix(secondary)
-        );
-      }
-      return formatAbilityNumber(secondary.total) + suffix(secondary);
-    case 'hot':
-      return formatAbilityNumber(secondary.total) + suffix(secondary);
-    case 'absorb':
-      return secondary.casterMaxHpPct === undefined
-        ? formatAbilityNumber(secondary.amount) + suffix(secondary)
-        : formatAbilityNumber(secondary.casterMaxHpPct * 100);
-    case 'imbue':
-      return formatAbilityNumber(secondary.bonus);
-    default:
-      return '';
-  }
-}
-
-function abilityAmountRange(min: number, max: number): string {
-  if (min === max) return formatAbilityNumber(min);
-  return t('abilityUi.tooltip.damageRange', {
-    min: formatAbilityNumber(min),
-    max: formatAbilityNumber(max),
   });
 }
 

--- a/tests/ability_damage.test.ts
+++ b/tests/ability_damage.test.ts
@@ -22,7 +22,8 @@ import {
   abilityDamageBonus,
   abilityTemporalHourglassValues,
 } from '../src/ui/ability_damage';
-import { abilityEffectText } from '../src/ui/hud';
+import { abilityEffectAuraInput, abilityEffectText } from '../src/ui/ability_description';
+import { auraEffectDescriptor } from '../src/ui/aura_effect';
 
 function known(cls: Parameters<typeof abilitiesKnownAt>[0], id: string, mods?: TalentModifiers) {
   const ability = abilitiesKnownAt(cls, MAX_LEVEL, mods).find((k) => k.def.id === id);
@@ -50,12 +51,55 @@ const DESTRUCTION_MODS = computeTalentModifiers('warlock', {
   ...emptyAllocation(),
   spec: 'destruction',
 } as never);
+const AFFLICTION_MODS = computeTalentModifiers('warlock', {
+  ...emptyAllocation(),
+  spec: 'affliction',
+} as never);
 const PROT_MODS = computeTalentModifiers('warrior', {
   ...emptyAllocation(),
   spec: 'prot',
 } as never);
 
 describe('abilityDamageBonus (tooltip scaling mirrors combat)', () => {
+  it('shows Hexcraft-resolved Litany of Guilt damage at every rank', () => {
+    for (const [level, expectedDamage] of [
+      [8, 6],
+      [11, 10],
+      [20, 15],
+    ] as const) {
+      const litany = abilitiesKnownAt('warlock', level, AFFLICTION_MODS).find(
+        (ability) => ability.def.id === 'litany_of_guilt',
+      );
+      expect(litany, `missing Litany of Guilt at level ${level}`).toBeDefined();
+      if (!litany) continue;
+      const effect = litany.effects.find((candidate) => candidate.type === 'afflictionLitany');
+      if (effect?.type !== 'afflictionLitany') throw new Error('missing Litany damage effect');
+
+      expect(effect.damage).toBe(expectedDamage);
+      const damageText = abilityEffectText(litany, {
+        spellPower: 500,
+        rangedPower: 700,
+        attackPower: 900,
+      });
+      expect(damageText).toBe(String(expectedDamage));
+      const auraInput = abilityEffectAuraInput(effect);
+      expect(auraInput).toEqual({
+        kind: 'affliction_litany',
+        value: expectedDamage,
+        value2: effect.radius,
+        value3: effect.maxTargets,
+      });
+      expect(auraInput && auraEffectDescriptor(auraInput)).toEqual({
+        key: 'hudChrome.auraEffect.afflictionLitany',
+        nums: {
+          damage: expectedDamage,
+          targets: effect.maxTargets,
+          radius: effect.radius,
+        },
+      });
+    }
+  });
+
   it('renders Direhowl from its percentage damage reduction, not the retired AP amount', () => {
     expect(abilityBuffValue(known('warrior', 'demoralizing_shout', PROT_MODS))).toBe(20);
   });

--- a/tests/litany_tooltip.test.ts
+++ b/tests/litany_tooltip.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { abilitiesKnownAt } from '../src/sim/content/classes';
+import { computeTalentModifiers, emptyAllocation } from '../src/sim/content/talents';
+import { type ResolvedAbility, Sim } from '../src/sim/sim';
+import { Hud } from '../src/ui/hud';
+import { ensureLocaleLoaded, setLanguage } from '../src/ui/i18n';
+import { EMPTY_TEST_WORLD } from './sim_shared';
+
+interface AbilityTooltipHarness {
+  sim: Sim;
+  abilityTooltip(res: ResolvedAbility): string;
+}
+
+function tooltipHarness(): AbilityTooltipHarness {
+  const hud = Object.create(Hud.prototype) as unknown as AbilityTooltipHarness;
+  hud.sim = new Sim({
+    seed: 42,
+    playerClass: 'warlock',
+    autoEquip: false,
+    world: EMPTY_TEST_WORLD,
+  });
+  hud.sim.setPlayerLevel(20);
+  expect(hud.sim.setSpec('affliction')).toBe(true);
+  return hud;
+}
+
+function afflictionAbility(id: string): ResolvedAbility {
+  const mods = computeTalentModifiers('warlock', {
+    ...emptyAllocation(),
+    spec: 'affliction',
+  } as never);
+  const ability = abilitiesKnownAt('warlock', 20, mods).find((known) => known.def.id === id);
+  if (!ability) throw new Error(`missing Affliction ability ${id}`);
+  return ability;
+}
+
+afterEach(() => setLanguage('en'));
+
+describe('Litany of Guilt ability tooltip', () => {
+  it('renders its resolved damage in the localized HUD effect line', async () => {
+    await ensureLocaleLoaded('es');
+    setLanguage('es');
+    const html = tooltipHarness().abilityTooltip(afflictionAbility('litany_of_guilt'));
+
+    expect(html).toContain(
+      '<div class="tt-effect">Obtener Condena inflige 15 de daño de las Sombras a hasta 4 enemigos en 8 m, una vez por segundo</div>',
+    );
+  });
+
+  it('does not add the Litany effect line to unrelated Affliction abilities', () => {
+    const html = tooltipHarness().abilityTooltip(afflictionAbility('evil_eye'));
+
+    expect(html).not.toContain('hudChrome.auraEffect.afflictionLitany');
+    expect(html).not.toContain('Condemnation gains deal');
+  });
+});

--- a/tests/mage_barrier_tooltip.test.ts
+++ b/tests/mage_barrier_tooltip.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { abilitiesKnownAt } from '../src/sim/content/classes';
 import { emptyModifiers } from '../src/sim/content/talents';
-import { abilityEffectText } from '../src/ui/hud';
+import { abilityEffectText } from '../src/ui/ability_description';
 
 describe('mage personal barrier tooltip', () => {
   it('shows the rank base and the live Spell Power contribution', () => {

--- a/tests/owned_class_approved_followups.test.ts
+++ b/tests/owned_class_approved_followups.test.ts
@@ -12,7 +12,7 @@ import { MOBS } from '../src/sim/data';
 import { createMob } from '../src/sim/entity';
 import { Sim } from '../src/sim/sim';
 import type { Entity, PlayerClass, SimEvent } from '../src/sim/types';
-import { abilityEffectText } from '../src/ui/hud';
+import { abilityEffectText } from '../src/ui/ability_description';
 
 type TestSim = Sim & {
   addEntity(entity: Entity): void;

--- a/tests/paladin_percentage_tooltip.test.ts
+++ b/tests/paladin_percentage_tooltip.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { defaultBuild } from '../src/sim/content/talents';
 import { grantDevotion } from '../src/sim/paladin_devotion';
 import { Sim } from '../src/sim/sim';
-import { abilityEffectText } from '../src/ui/hud';
+import { abilityEffectText } from '../src/ui/ability_description';
 
 function tooltipValue(sim: Sim, abilityId: string): string {
   const ability = sim.resolvedAbility(abilityId);

--- a/tests/rupture_rip_tooltip.test.ts
+++ b/tests/rupture_rip_tooltip.test.ts
@@ -16,7 +16,7 @@
 import { describe, expect, it } from 'vitest';
 import { ABILITIES, abilitiesKnownAt } from '../src/sim/content/classes';
 import { emptyModifiers } from '../src/sim/content/talents';
-import { abilityEffectText } from '../src/ui/hud';
+import { abilityEffectText } from '../src/ui/ability_description';
 
 const NO_SCALING = { spellPower: 0, rangedPower: 0, attackPower: 0 };
 


### PR DESCRIPTION
## Summary

- Show Litany of Guilt's Hexcraft-resolved damage in its ability tooltip at every rank (6/10/15).
- Reuse the existing localized Affliction aura-effect line so damage, targets, and radius render in every locale without adding translation placeholders.
- Keep Litany flat (no Spell Power/AP scaling) and leave combat balance unchanged.
- Move the pure ability-effect formatter out of the HUD coordinator and preserve existing tooltip consumers.

## Type of change

- [x] Bug fix
- [x] Refactor or performance (no behavior change outside the fix)
- [x] Tests

## How was this tested?

- Commands:
  - `pnpm exec vitest run tests/ability_damage.test.ts tests/litany_tooltip.test.ts tests/ability_tooltip_consistency.test.ts tests/mage_barrier_tooltip.test.ts tests/owned_class_approved_followups.test.ts tests/paladin_percentage_tooltip.test.ts tests/rupture_rip_tooltip.test.ts` — 38/38 passed.
  - `pnpm exec vitest run tests/architecture.test.ts tests/localization_fixes.test.ts tests/i18n_completeness.test.ts tests/i18n_t_behavior.test.ts` — 106 passed, 4 skipped.
  - `pnpm exec tsc --noEmit` — passed.
  - `pnpm run test:browser` — 129/129 passed.
  - `pnpm run build:bundle` — passed.
  - `pnpm run security:gate` — passed (0 high findings).
  - Pre-push QA floor — passed; 85 tests passed, 3 skipped, and `ci:changed` checked all 10 changed files.
  - `pnpm run gate` — did not pass: the full Vitest step ended with repeated `ECONNREFUSED` connections to `localhost:3000`. The browser suite passed immediately when rerun in isolation.
- Manual steps: Not run; the integration test exercises the real HUD tooltip renderer and pins the Spanish output (`15` damage, `4` targets, `8 m`).

## Screenshots / recordings

Not captured. This changes tooltip content only and does not change CSS or layout.

---

## Checklist

### Quality

- [ ] **The gate passes.** The focused suites, typecheck, browser tests, build, security gate, and pre-push floor pass; the full gate note is documented above.

### Cross-platform

- [ ] **Tested on desktop and mobile.** No manual viewport pass was performed.
- [x] **Accessible.** No interaction, focus, ARIA, motion, or input behavior changed.

### Localization (i18n)

- [x] Numbers go through the existing locale-aware effect formatter.
- [x] N/A. This PR adds no player-visible strings and reuses the existing localized Litany effect key.

### Hygiene

- [x] No secrets, credentials, or `.env` files committed.
- [x] Generated files were regenerated by repository commands and remain unchanged.