### PR TITLE
fix(render): keep the self-motion predictor smooth across a long render frame (cherry-pick of #3445)

### DIFF
--- a/docs/online-movement-latency.md
+++ b/docs/online-movement-latency.md
@@ -32,14 +32,19 @@ here so the survey is not read as the as-built spec:
   simple blend the survey sketched: the authoritative pose is compared against
   the display's own pose one measured echo ago (history ring), with the gain
   bounded by the delay so the loop cannot ring, and the leash clamping the pose
-  only. See the header of `src/render/self_motion.ts`.
+  only. See the header of `src/render/self_motion.ts`. A long render frame is
+  the one sanctioned exception to both halves: it freezes the anchor and then
+  delivers a burst, so the leash lends the block's own ground (bounded by
+  `BLOCK_EPISODE_MAX_MS`) and the servo sits out the resume sweep, pinned by
+  `describe('long render frames')` in `tests/self_motion.test.ts`.
 - **The extrapolation cap landed at 350 ms**, not the surveyed 150 to 200:
   below the real RTT the display rides the leash and steering feels gluey.
 - **The rule amendment has three parts**, not two (`src/net/CLAUDE.md`):
   outcome prediction still banned; display-layer pose extrapolation sanctioned
   under four constraints (applies to `src/render/self_motion.ts`); the heading
   reclassified as client-authoritative input, to which the "never sent"
-  constraint deliberately does not apply.
+  constraint deliberately does not apply. Constraints (a) and (b) carry the
+  long-frame exception recorded above and in `src/net/CLAUDE.md`.
 - Also shipped: the adaptive render lead (`src/game/self_alpha_lead.ts`), the
   shared kernel (`src/sim/player_motion.ts`, bit-for-bit parity-tested), and
   hysteresis fixes for pre-existing animation flicker the smoother display made

--- a/src/game/self_motion_frame_buffer.ts
+++ b/src/game/self_motion_frame_buffer.ts
@@ -8,6 +8,8 @@ export interface BufferedSelfMotionFrame {
   jitterMs: number;
   alpha: number;
   frameDt: number;
+  snapAgeMs: number;
+  snapIntervalMs: number;
 }
 
 export class SelfMotionFrameBuffer {
@@ -21,6 +23,8 @@ export class SelfMotionFrameBuffer {
     jitterMs: number,
     alpha: number,
     frameDt: number,
+    snapAgeMs: number,
+    snapIntervalMs: number,
   ): BufferedSelfMotionFrame {
     if (this.frame === null) {
       this.frame = {
@@ -31,6 +35,8 @@ export class SelfMotionFrameBuffer {
         jitterMs,
         alpha,
         frameDt,
+        snapAgeMs,
+        snapIntervalMs,
       };
     } else {
       this.frame.enabled = enabled;
@@ -40,6 +46,8 @@ export class SelfMotionFrameBuffer {
       this.frame.jitterMs = jitterMs;
       this.frame.alpha = alpha;
       this.frame.frameDt = frameDt;
+      this.frame.snapAgeMs = snapAgeMs;
+      this.frame.snapIntervalMs = snapIntervalMs;
     }
     return this.frame;
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -4635,8 +4635,8 @@ async function startGame(
     }
     perfNetworkStats.connected = net.connected;
     perfNetworkStats.snapInterval = Math.round(net.snapInterval);
-    perfNetworkStats.lastSnapAge =
-      net.lastSnapAt > 0 ? Math.round(performance.now() - net.lastSnapAt) : -1;
+    const cameraLastSnapAge = net.lastSnapAt > 0 ? performance.now() - net.lastSnapAt : -1;
+    perfNetworkStats.lastSnapAge = Math.round(cameraLastSnapAge);
     perfNetworkStats.alpha = Math.round(alpha * 100) / 100;
     perf.setNetwork(perfNetworkStats);
     // Always-on net-pipeline counters (net_pipeline_stats.ts): fold the
@@ -4674,8 +4674,9 @@ async function startGame(
           onlineJitterMs,
           alpha,
           frameDt,
+          Math.max(0, cameraLastSnapAge),
+          net.snapInterval,
         );
-    const cameraLastSnapAge = net.lastSnapAt > 0 ? performance.now() - net.lastSnapAt : -1;
     traceStart = perf.startTrace();
     try {
       updateCamera(frameDt, kbFacing ?? interpServerFacing);

--- a/src/net/CLAUDE.md
+++ b/src/net/CLAUDE.md
@@ -210,7 +210,14 @@ failure, kept as stable English that `main.ts` re-localizes.
   (targeting, range checks, quest triggers, and interest all use authoritative
   positions), and (d) never affects what is sent to the server. Widening any of
   those four constraints is a maintainer decision, see
-  `docs/online-movement-latency.md`.
+  `docs/online-movement-latency.md`. One amendment is already in force, for the
+  long render frame: when a frame outlasts the mirror's snapshot interval the
+  browser applies the snapshots it swallowed in one burst, so for that block
+  episode (a) the leash budget may exceed the latency cap by the ground the
+  frozen anchor did not cover, bounded by `BLOCK_EPISODE_MAX_MS` of run speed,
+  and (b) the blend toward the server pose is held for the settle window that
+  the burst sweep needs. Both live in `src/render/self_motion.ts` and are
+  pinned by `describe('long render frames')` in `tests/self_motion.test.ts`.
 - **The heading is NOT predicted, it is client-authoritative input.** The facing
   channel (`input.facing`, applied outright by the server, corpse-guard only)
   has always been client-driven for mouselook; `src/game/keyboard_turn_facing.ts`

--- a/src/render/self_motion.ts
+++ b/src/render/self_motion.ts
@@ -17,6 +17,27 @@
 //  2. Bounded: the horizontal error from the authoritative pose is leashed to
 //     what the player could legitimately cover in the latency cap; a server
 //     teleport (or any gap over the renderer's 6 yd snap rule) resets outright.
+//     One exception, and only one, the BLOCK EPISODE. A render frame longer
+//     than a snapshot interval blocks the main thread, and the snapshots that
+//     arrived meanwhile land in one burst. The browser orders that burst
+//     either way, and both orderings break the display:
+//       - burst applied after the frame: the anchor is frozen inside the frame
+//         (alpha caps at 1), so the leash, sized for a fresh anchor, clips the
+//         kernel's correct multi-step advance;
+//       - burst applied before the frame's step: the anchor is fresh, but
+//         ClientWorld has just re-anchored prevPos at the DRAWN pose with pos
+//         several ticks ahead, so at alpha ~0 it sits behind the display by
+//         more than the budget and the leash clips just the same; the display
+//         then stalls while the anchor sweeps under it.
+//     Neither is divergence: it is the local block seen from here, and the
+//     kernel ran the same movement math the server ran. So an ISOLATED long
+//     frame opens an episode where the block is trusted: the servo sits out
+//     the burst sweep and the leash lends the lead the kernel took, drained
+//     back afterwards. The episode is bounded (BLOCK_EPISODE_MAX_MS) and
+//     isolation excludes steady low fps, where every frame is long and nothing
+//     is hitching. A NETWORK gap looks the same from here but earns neither:
+//     freezing the display on the leash is the right answer when nothing local
+//     explains the stale anchor.
 //  3. Invisible to logic: the output feeds only the renderer's
 //     selfRenderPosition (mesh + camera). It never writes into ClientWorld
 //     mirrored state, IWorld reads, or the input stream.
@@ -66,6 +87,19 @@ export const SELF_MOTION_DEADBAND_YD = 0.05;
 // Same teleport rule the renderer's self smoother uses (6 yd).
 export const SELF_MOTION_SNAP_DIST_SQ = 6 * 6;
 const MAX_FRAME_DT = 0.25; // matches the main-loop frame clamp
+// The block episode (see the header): how long a hitch may keep lending leash
+// room. It must outlast the browser's post-block catch-up frames with room to
+// spare, and it must END, because a real network stall starting right after a
+// hitch is indistinguishable from here and must fall back to the leash freeze
+// rather than run the display away. 500 ms is the top of the broadcast-gap
+// regime the stall arms in tests/self_motion.test.ts pin, so past it the
+// network answer is the right one.
+export const BLOCK_EPISODE_MAX_MS = 500;
+// Settle window after a block, in snapshot intervals: see servoHoldMs below.
+const SERVO_SETTLE_INTERVALS = 2;
+// The mirror's interval EWMA can arrive degenerate (a fresh or reset
+// ClientWorld); floor it the way every other consumer does (online.ts alpha).
+const MIN_SNAP_INTERVAL_MS = 20;
 const LEASH_SLACK_YD = 0.05;
 // Pose-history ring: enough to look SELF_MOTION_CAP_MAX_MS into the past with
 // headroom even on high-refresh displays (128 entries covers 267 ms at 480 fps
@@ -84,6 +118,10 @@ export interface SelfMotionFrame {
   /** The frame's snapshot alpha (same value handed to renderer.sync). */
   alpha: number;
   frameDt: number;
+  /** Wall-clock ms since the last snapshot was APPLIED to the mirror (0 when none yet). */
+  snapAgeMs: number;
+  /** The mirror's adaptive inter-snapshot interval in ms (ClientWorld.snapInterval). */
+  snapIntervalMs: number;
 }
 
 export interface Vec3Like {
@@ -165,6 +203,15 @@ export class SelfMotionPredictor {
   private lastGhost = false;
   private acc = 0;
   private timeMs = 0;
+  // Long-frame block bookkeeping: the leash room the frozen anchor owes the
+  // display, the post-burst settle window the servo sits out, and what is left
+  // of the local-block episode a long frame opened (step()).
+  private staleAllowanceYd = 0;
+  private servoHoldMs = 0;
+  private blockEpisodeMs = 0;
+  private prevFrameDtMs = 0;
+  // Lending capacity earned while the anchor is blocked, in yards of run.
+  private episodeCapYd = 0;
   // Ring of end-of-frame display poses, for the "where was the prediction one
   // latency cap ago" comparison. Preallocated; hist* index HISTORY_SIZE slots.
   private histCount = 0;
@@ -209,6 +256,11 @@ export class SelfMotionPredictor {
     this.histCount = 0;
     this.histHead = 0;
     this.leadMs = 0;
+    this.staleAllowanceYd = 0;
+    this.servoHoldMs = 0;
+    this.blockEpisodeMs = 0;
+    this.prevFrameDtMs = 0;
+    this.episodeCapYd = 0;
   }
 
   private recordHistory(x: number, y: number, z: number): void {
@@ -308,6 +360,11 @@ export class SelfMotionPredictor {
       };
       this.actor = actor;
       this.acc = 0;
+      this.staleAllowanceYd = 0;
+      this.servoHoldMs = 0;
+      this.blockEpisodeMs = 0;
+      this.prevFrameDtMs = 0;
+      this.episodeCapYd = 0;
       // The old display trajectory is meaningless relative to the new anchor
       // (teleport / life-state flip); comparing against it would fling the pose.
       this.histCount = 0;
@@ -381,6 +438,53 @@ export class SelfMotionPredictor {
     }
     const frac = this.acc / DT;
 
+    const runSpeed = RUN_SPEED * moveSpeedMult(actor, 0);
+    // The local block episode (rationale: the header's Bounded exception).
+    // An ISOLATED long frame is the trigger, staleness not required: in the
+    // deliver-before ordering there is no staleness to see. Isolation is what
+    // keeps steady low fps out, where nothing is hitching and the servo must
+    // keep correcting every frame.
+    const snapIntervalMs = Math.max(MIN_SNAP_INTERVAL_MS, frame.snapIntervalMs);
+    const staleMs = Math.max(0, Math.max(0, frame.snapAgeMs) - snapIntervalMs);
+    const frameDtMs = dt * 1000;
+    const hitchFrame = frameDtMs > snapIntervalMs && this.prevFrameDtMs <= snapIntervalMs;
+    this.prevFrameDtMs = frameDtMs;
+    // The episode outlives the frame that opened it: the browser can run
+    // several short catch-up frames before it drains the socket, and judging
+    // those on their own length would put the stall back a few frames later.
+    if (hitchFrame) {
+      this.blockEpisodeMs = BLOCK_EPISODE_MAX_MS;
+      this.episodeCapYd = 0;
+    } else if (this.blockEpisodeMs > 0)
+      this.blockEpisodeMs = staleMs > 0 ? Math.max(0, this.blockEpisodeMs - frameDtMs) : 0;
+    const blockedFrame = hitchFrame || this.blockEpisodeMs > 0;
+    if (blockedFrame) {
+      // Two snapshot intervals, counted down only once the snapshots flow
+      // again: one for the burst sweep itself, and one more because the sweep
+      // starts from the DRAWN pose (ClientWorld re-anchors prevPos there), so
+      // the first anchor the servo can trust as an independent reading is one
+      // interval past the sweep. Resuming inside that window reads the sweep
+      // as divergence, which is the rush half of the original artifact.
+      this.servoHoldMs = SERVO_SETTLE_INTERVALS * snapIntervalMs;
+    } else {
+      this.servoHoldMs = Math.max(0, this.servoHoldMs - frameDtMs);
+    }
+    // A stale anchor the display has already been lent room against is not a
+    // reference: correcting toward it would drag the pose off the position the
+    // block's own kernel steps put it at (and the next burst confirms), then
+    // make it rush back. Freeze instead, which is the plain leash behavior.
+    // Two intervals, not one: at 60 fps the newest snapshot routinely ages a
+    // frame past the interval, and treating that phase noise as a frozen
+    // anchor would suspend the servo for as long as any loan is outstanding.
+    const staleWithLoan = staleMs > snapIntervalMs && this.staleAllowanceYd > 0;
+    // The settle window belongs to the burst that ends the block, so hold it
+    // full while the anchor is frozen: draining it during the freeze would
+    // leave the servo facing the resume sweep with no cover, reading it as
+    // divergence and hauling the display back off the pose the burst is about
+    // to confirm.
+    if (staleWithLoan) this.servoHoldMs = SERVO_SETTLE_INTERVALS * snapIntervalMs;
+    const servoActive = !blockedFrame && !staleWithLoan && this.servoHoldMs <= 0;
+
     // Divergence correction: the authoritative anchor shows where the server
     // had the player ~capMs ago, so compare it against where the LOCAL display
     // was capMs ago. During agreed motion (steady run, start, stop, jump arc)
@@ -392,7 +496,7 @@ export class SelfMotionPredictor {
     const capMs = clamp(latencyMs, SELF_MOTION_CAP_MIN_MS, SELF_MOTION_CAP_MAX_MS);
     const measureMs = clamp(latencyMs, SELF_MOTION_CAP_MIN_MS, SELF_MOTION_MEASURE_MAX_MS);
     const past = this.sampleHistory(this.timeMs - measureMs);
-    if (past) {
+    if (past && servoActive) {
       // The blend dt is clamped tighter than the frame clamp: at load-hitch
       // frame times (100-250ms at world entry, or on weak hardware) an
       // unclamped exponential eats ~95% of the error in ONE frame, turning
@@ -424,10 +528,38 @@ export class SelfMotionPredictor {
     // budget is the honest upper bound; only corrections consume the slack).
     // Vertical is exempt (a jump apex must not be leash-clipped; gravity
     // bounds it).
-    const budget = (RUN_SPEED * moveSpeedMult(actor, 0) * capMs) / 1000 + LEASH_SLACK_YD;
+    const baseBudget = (runSpeed * capMs) / 1000 + LEASH_SLACK_YD;
     const ex = actor.pos.x - ax;
     const ez = actor.pos.z - az;
     const elen = Math.hypot(ex, ez);
+    if (blockedFrame) {
+      // Lend at RUN SPEED IN WALL CLOCK, and only what THIS episode has
+      // earned. Wall clock rather than a tick per frame because the fixed-step
+      // accumulator lands a whole 50 ms step inside a 10 ms catch-up frame and
+      // clipping THAT is the stall again. Per episode rather than cumulative
+      // because otherwise a machine hitching every few frames ratchets the
+      // boundary outward at every hitch and, against a server that never
+      // confirms the motion, walks the display to the 6 yd re-adopt.
+      this.episodeCapYd += runSpeed * dt;
+      this.staleAllowanceYd = Math.max(
+        this.staleAllowanceYd,
+        Math.min(elen - baseBudget, this.episodeCapYd),
+      );
+    } else {
+      // The allowance drains at run speed once the snapshots flow again, but
+      // never below the lead currently in use: draining THROUGH the live lead
+      // would clamp the display back at run speed, the same stall this fix
+      // removes, one beat later. Shrinking the lead is the servo's job, and
+      // the allowance follows it down (it only ever grows while blocked).
+      this.staleAllowanceYd = Math.max(
+        0,
+        Math.min(
+          this.staleAllowanceYd,
+          Math.max(elen - baseBudget, this.staleAllowanceYd - runSpeed * dt),
+        ),
+      );
+    }
+    const budget = baseBudget + this.staleAllowanceYd;
     if (elen > budget) {
       // Clamp pos ONLY (unlike the correction blend above): prevPos keeps the
       // last displayed point, so the sub-frame interpolation glides onto the
@@ -442,7 +574,6 @@ export class SelfMotionPredictor {
     this.out.y = actor.prevPos.y + (actor.pos.y - actor.prevPos.y) * frac;
     this.out.z = actor.prevPos.z + (actor.pos.z - actor.prevPos.z) * frac;
     this.recordHistory(this.out.x, this.out.y, this.out.z);
-    const runSpeed = RUN_SPEED * moveSpeedMult(actor, 0);
     this.leadMs =
       runSpeed > 0 ? (Math.hypot(this.out.x - ax, this.out.z - az) / runSpeed) * 1000 : 0;
     return this.out;

--- a/tests/paladin_valkyrs_calling.test.ts
+++ b/tests/paladin_valkyrs_calling.test.ts
@@ -334,6 +334,8 @@ describe("Paladin Retribution: Valkyr's Calling", () => {
       jitterMs: 0,
       alpha: 1,
       frameDt: 1 / 60,
+      snapAgeMs: 0,
+      snapIntervalMs: 50,
     };
 
     expect(predictor.step(sim.player, frame)).not.toBeNull();

--- a/tests/self_motion.test.ts
+++ b/tests/self_motion.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  BLOCK_EPISODE_MAX_MS,
   hasAuthoritativeSelfPositionDiscontinuity,
   SELF_MOTION_CAP_MAX_MS,
   SELF_MOTION_CAP_MIN_MS,
@@ -7,6 +8,7 @@ import {
   type SelfMotionFrame,
   SelfMotionPredictor,
   updateSelfRenderFallback,
+  type Vec3Like,
 } from '../src/render/self_motion';
 import { Sim } from '../src/sim/sim';
 import { type Entity, type MoveInput, RUN_SPEED } from '../src/sim/types';
@@ -77,11 +79,36 @@ class Lab {
   // between the last delivery and the resume delivery n plus 1 intervals.
   skipDeliveries = 0;
 
+  // Snapshots produced during a frame, held back until the frame's tail: a
+  // long render frame blocks the main thread, so the socket is only drained
+  // AFTER the frame the messages arrived in (see the long-frame lane below).
+  private pending: { x: number; y: number; z: number }[] = [];
+  private readonly deliverAfter: boolean;
+  private readonly deliveryMs: number;
+  private readonly serverDeaf: boolean;
+  /** While true the frame tail keeps the queue: a scripted delivery burst. */
+  holdSnapshots = false;
+
   constructor(
     readonly lagMs: number,
     readonly frameMs = FRAME_MS,
-    opts: { start?: { x: number; z: number }; facing?: number } = {},
+    opts: {
+      start?: { x: number; z: number };
+      facing?: number;
+      /** Drain the socket in the frame's TAIL instead of before the step. */
+      deliverAfter?: boolean;
+      /** Wall-clock spacing of deliveries, which is what the mirror's EWMA
+       *  measures. Above the 50 ms tick cadence it models a coalescing link:
+       *  the server still ticks at 20 Hz, the snapshots arrive in pairs. */
+      deliveryMs?: number;
+      /** The server never receives the local intent: worst-case divergence,
+       *  the display predicting a run the authority never performs. */
+      serverDeaf?: boolean;
+    } = {},
   ) {
+    this.deliverAfter = opts.deliverAfter ?? false;
+    this.deliveryMs = opts.deliveryMs ?? SNAP_MS;
+    this.serverDeaf = opts.serverDeaf ?? false;
     this.srv = new Sim({
       seed: SEED,
       playerClass: 'warrior',
@@ -107,6 +134,7 @@ class Lab {
 
   // What the server has received by time t (inputs travel lagMs).
   private serverInputAt(tMs: number): MoveInput {
+    if (this.serverDeaf) return this.inputLog[0].input;
     let eff = this.inputLog[0].input;
     for (const e of this.inputLog) {
       if (e.atMs + this.lagMs <= tMs) eff = e.input;
@@ -114,9 +142,13 @@ class Lab {
     return eff;
   }
 
-  frame(): FrameResult {
-    this.nowMs += this.frameMs;
-    this.sinceTickMs += this.frameMs;
+  /** `drainFirst` models the other browser ordering: the socket is drained
+   *  just BEFORE the rAF callback, so the long frame's step already sees the
+   *  burst (fresh anchor, prevPos re-anchored at the drawn pose). */
+  frame(frameMsOverride?: number, drainFirst = false): FrameResult {
+    const frameMs = frameMsOverride ?? this.frameMs;
+    this.nowMs += frameMs;
+    this.sinceTickMs += frameMs;
     let delivered = false;
     while (this.sinceTickMs >= SNAP_MS) {
       this.sinceTickMs -= SNAP_MS;
@@ -128,6 +160,10 @@ class Lab {
         this.skipDeliveries--;
         continue;
       }
+      if (this.deliverAfter) {
+        this.pending.push({ ...this.srv.player.pos });
+        continue;
+      }
       // the 20 Hz snapshot: prev pose = last wire pose, pose = fresh server pose
       this.self.prevPos = { ...this.self.pos };
       this.self.pos = { ...this.srv.player.pos };
@@ -136,7 +172,15 @@ class Lab {
       this.lastSnapMs = this.nowMs;
       delivered = true;
     }
-    const alpha = Math.min(1.25, (this.nowMs - this.lastSnapMs) / SNAP_MS);
+    // At the default cadence every produced tick is delivered as it appears;
+    // a coalescing link (deliveryMs above the tick spacing) holds them back.
+    const dueForDelivery =
+      this.deliveryMs <= SNAP_MS || this.nowMs - this.lastSnapMs >= this.deliveryMs;
+    if (drainFirst && this.pending.length > 0 && !this.holdSnapshots && dueForDelivery) {
+      this.drainPending();
+      delivered = true;
+    }
+    const alpha = Math.min(1.25, (this.nowMs - this.lastSnapMs) / this.deliveryMs);
     const frame: SelfMotionFrame = {
       enabled: this.enabled,
       moveInput: this.localInput,
@@ -144,7 +188,9 @@ class Lab {
       echoMs: this.lagMs,
       jitterMs: 0,
       alpha,
-      frameDt: this.frameMs / 1000,
+      frameDt: frameMs / 1000,
+      snapAgeMs: this.lastSnapMs > 0 ? this.nowMs - this.lastSnapMs : 0,
+      snapIntervalMs: this.deliveryMs,
     };
     const out = this.predictor.step(this.self, frame);
     const a = {
@@ -158,7 +204,32 @@ class Lab {
       y: this.self.prevPos.y + (this.self.pos.y - this.self.prevPos.y) * leashAlpha,
       z: this.self.prevPos.z + (this.self.pos.z - this.self.prevPos.z) * leashAlpha,
     };
+    if (this.pending.length > 0 && !this.holdSnapshots && dueForDelivery) {
+      this.drainPending();
+      delivered = true;
+    }
     return { pose: out ? { ...out } : null, a, ac, delivered };
+  }
+
+  // ClientWorld.applyWire re-anchors prevPos at the pose the renderer last
+  // DREW (contAlpha, capped 1.25), not at the previous server pose, so a burst
+  // of queued snapshots leaves prevPos at the drawn pose and pos at the newest
+  // tick: the anchor then sweeps several ticks over one snapshot interval.
+  private drainPending(): void {
+    for (const pos of this.pending) {
+      const contAlpha =
+        this.lastSnapMs > 0 ? Math.min(1.25, (this.nowMs - this.lastSnapMs) / this.deliveryMs) : 1;
+      this.self.prevPos = {
+        x: this.self.prevPos.x + (this.self.pos.x - this.self.prevPos.x) * contAlpha,
+        y: this.self.prevPos.y + (this.self.pos.y - this.self.prevPos.y) * contAlpha,
+        z: this.self.prevPos.z + (this.self.pos.z - this.self.prevPos.z) * contAlpha,
+      };
+      this.self.pos = { ...pos };
+      this.self.dead = this.srv.player.dead;
+      this.self.ghost = this.srv.player.ghost;
+      this.lastSnapMs = this.nowMs;
+    }
+    this.pending = [];
   }
 
   budget(): number {
@@ -211,6 +282,8 @@ describe('SelfMotionPredictor', () => {
       jitterMs: 0,
       alpha: 1,
       frameDt: 0.05,
+      snapAgeMs: 0,
+      snapIntervalMs: SNAP_MS,
     };
     const predictive = new SelfMotionPredictor(SEED);
     const ordinary = new SelfMotionPredictor(SEED);
@@ -495,6 +568,11 @@ describe('SelfMotionPredictor', () => {
       controlMeanLead: number;
       worstLateral: number;
       serverLateral: number;
+      /** Most negative per-frame step over the WHOLE run, not just the resume
+       *  window: the sub-tick interpolation must never run backward, including
+       *  on a frame where the leash clips more than the kernel step it just
+       *  took (which is what the prevPos collapse in step() prevents). */
+      worstStep: number;
     }
 
     function runStall(gapMs: number): StallTrace {
@@ -508,6 +586,7 @@ describe('SelfMotionPredictor', () => {
       let lastZ = Number.NaN;
       let worstLateral = 0;
       let serverLateral = 0;
+      let worstStep = 0;
       const errOf = (r: FrameResult): number => {
         if (!r.pose) throw new Error('predictor disabled unexpectedly');
         return Math.hypot(r.pose.x - r.ac.x, r.pose.z - r.ac.z);
@@ -517,6 +596,7 @@ describe('SelfMotionPredictor', () => {
         worstLateral = Math.max(worstLateral, Math.abs(r.pose.x));
         serverLateral = Math.max(serverLateral, Math.abs(lab.srv.player.pos.x));
         const step = r.pose.z - lastZ;
+        if (!Number.isNaN(step)) worstStep = Math.min(worstStep, step);
         lastZ = r.pose.z;
         return step;
       };
@@ -582,6 +662,7 @@ describe('SelfMotionPredictor', () => {
         controlMeanLead,
         worstLateral,
         serverLateral,
+        worstStep,
       };
     }
 
@@ -633,6 +714,9 @@ describe('SelfMotionPredictor', () => {
         // assert is a real claim about the predictor and not about terrain.
         expect(run.serverLateral).toBeLessThanOrEqual(1e-9);
         expect(run.worstLateral).toBeLessThanOrEqual(1e-9);
+        // g: not one backward frame anywhere in the run, stall and recovery
+        // included, not just the resume window sampled above
+        expect(run.worstStep).toBeGreaterThanOrEqual(-0.03);
       },
     );
 
@@ -664,7 +748,488 @@ describe('SelfMotionPredictor', () => {
         expect(err, `recovery frame ${i}`).toBeLessThanOrEqual(run.budget + 1e-6);
       });
       expect(run.worstLateral).toBeLessThanOrEqual(1e-9);
+      // The resume sweep here clips MORE than the kernel step the frame took,
+      // which leaves prevPos ahead of the clamped pos; without the collapse in
+      // step() the sub-tick interpolation walks the display backward on that
+      // frame. Measured at about -0.05 yd with the collapse removed.
+      expect(run.worstStep).toBeGreaterThanOrEqual(-0.03);
     });
+  });
+
+  // A long render frame (a shader link, a GC pause, a texture decode) blocks
+  // the main thread, so the snapshots that arrive DURING it are only applied
+  // after it: inside the frame the anchor is frozen, and right after it a
+  // burst of queued snapshots re-anchors prevPos at the drawn pose and sweeps
+  // the anchor several ticks across one snapshot interval. The display must
+  // keep running at its steady speed through both halves: the kernel is
+  // trusted while the anchor is stale (long frame) and while the burst sweep
+  // settles, or the avatar stalls inside the long frame and rushes after it.
+  describe('long render frames', () => {
+    const SPEED_MIN = 5.0; // yd/s: RUN_SPEED is 7
+    const SPEED_MAX = 9.0;
+    const AFTER_FRAMES = 12;
+    const WARMUP_FRAMES = 120; // 2 s, settled on the steady lead
+    const HOLD_FRAMES = 9; // ~150 ms: three snapshots queue up
+    const BURST_FRAMES = 30; // the burst arm repays a real network gap, see below
+    // Long enough to outlast BLOCK_EPISODE_MAX_MS with frames to spare, so the
+    // cap expiring is observable inside the gap rather than at its edge.
+    const GAP_MS = 700;
+    // The sweep replays the whole gap over one snapshot interval, and the
+    // leash then walks its 4.7 yd loan back to the honest budget, which costs
+    // one short re-phasing trim around the fortieth frame. Long enough that
+    // the tail is settled run speed again.
+    const GAP_RECOVERY_FRAMES = 60;
+
+    interface Step {
+      label: string;
+      dtMs: number;
+      /** Horizontal display speed over this frame, yd/s. */
+      speed: number;
+      /** Signed advance along the run direction (+z), yd. */
+      forward: number;
+      /** Horizontal distance to the leash's own anchor (alpha capped at 1). */
+      err: number;
+    }
+
+    const trace = (steps: Step[]): string =>
+      `\n${steps
+        .map(
+          (s) =>
+            `  ${s.label.padStart(6)} dt=${s.dtMs.toFixed(1).padStart(6)}ms ` +
+            `v=${s.speed.toFixed(2).padStart(6)} yd/s fwd=${s.forward.toFixed(3)} ` +
+            `err=${s.err.toFixed(3)}`,
+        )
+        .join('\n')}`;
+
+    // The collider-free open-field lane (same reason as the stall lane above:
+    // the authored town wall would clamp the server and hide the artifact).
+    function warmLab(lagMs: number): Lab {
+      const lab = new Lab(lagMs, FRAME_MS, { start: { x: 0, z: -1000 }, deliverAfter: true });
+      lab.setInput(mi({ forward: true }));
+      for (let i = 0; i < WARMUP_FRAMES; i++) lab.frame();
+      return lab;
+    }
+
+    // Runs `count` frames of `dtMs` and returns one Step per frame, each
+    // measured against the pose the previous frame drew.
+    function recorder(
+      lab: Lab,
+    ): (label: string, dtMs: number, count?: number, drainFirst?: boolean) => Step[] {
+      let prev = { x: Number.NaN, z: Number.NaN };
+      return (label, dtMs, count = 1, drainFirst = false): Step[] => {
+        const out: Step[] = [];
+        for (let i = 0; i < count; i++) {
+          const r = lab.frame(dtMs, drainFirst);
+          if (!r.pose) throw new Error('predictor disabled unexpectedly');
+          const pose = { x: r.pose.x, z: r.pose.z };
+          if (!Number.isNaN(prev.x)) {
+            out.push({
+              label: count > 1 ? `${label}${i + 1}` : label,
+              dtMs,
+              speed: Math.hypot(pose.x - prev.x, pose.z - prev.z) / (dtMs / 1000),
+              forward: pose.z - prev.z,
+              err: Math.hypot(pose.x - r.ac.x, pose.z - r.ac.z),
+            });
+          }
+          prev = pose;
+        }
+        return out;
+      };
+    }
+
+    function runLongFrame(lagMs: number, longMs: number): Step[] {
+      const lab = warmLab(lagMs);
+      const record = recorder(lab);
+      record('warm', FRAME_MS); // seeds the previous pose, produces no step
+      return [...record('long', longMs), ...record('+', FRAME_MS, AFTER_FRAMES)];
+    }
+
+    // The real-browser ordering, measured with injected blocks: after the long
+    // frame Chrome runs several SHORT catch-up frames (8 to 17 ms) before it
+    // drains the socket, so the anchor stays frozen for 4 to 6 more frames and
+    // the queued snapshots land as one burst only then.
+    function runWithheldBurst(
+      lagMs: number,
+      longMs: number,
+      heldFrames: number,
+      heldMs: number,
+    ): Step[] {
+      const lab = warmLab(lagMs);
+      const record = recorder(lab);
+      record('warm', FRAME_MS);
+      lab.holdSnapshots = true;
+      const blocked = [...record('long', longMs), ...record('held', heldMs, heldFrames)];
+      lab.holdSnapshots = false;
+      // the next frame's tail drains the whole queue at once
+      return [...blocked, ...record('+', FRAME_MS, AFTER_FRAMES + 1)];
+    }
+
+    // The other browser ordering, also measured: the socket is drained just
+    // before the long frame's rAF callback, so the anchor is FRESH but
+    // ClientWorld has re-anchored prevPos at the drawn pose with pos several
+    // ticks ahead. Nothing looks stale, and the leash clips the frame's own
+    // multi-step advance unless the hitch itself is recognised.
+    function runDeliverBefore(lagMs: number, longMs: number): Step[] {
+      const lab = warmLab(lagMs);
+      const record = recorder(lab);
+      record('warm', FRAME_MS);
+      const long = record('long', longMs, 1, true);
+      return [...long, ...record('+', FRAME_MS, AFTER_FRAMES)];
+    }
+
+    function runBurst(lagMs: number): Step[] {
+      const lab = warmLab(lagMs);
+      const record = recorder(lab);
+      record('warm', FRAME_MS);
+      lab.holdSnapshots = true;
+      record('hold', FRAME_MS, HOLD_FRAMES);
+      lab.holdSnapshots = false;
+      const burst = record('burst', FRAME_MS); // its tail applies all three at once
+      return [...burst, ...record('+', FRAME_MS, BURST_FRAMES)];
+    }
+
+    const expectSteadyBand = (steps: Step[], maxSpeed = SPEED_MAX): void => {
+      const report = trace(steps);
+      for (const step of steps) {
+        expect(step.speed, `${step.label}${report}`).toBeGreaterThanOrEqual(SPEED_MIN);
+        expect(step.speed, `${step.label}${report}`).toBeLessThanOrEqual(maxSpeed);
+        expect(step.forward, `${step.label}${report}`).toBeGreaterThanOrEqual(0);
+      }
+    };
+
+    // The 250 ms rows carry a wider ceiling for a cause outside this fix: 250
+    // ms IS the main-loop frame clamp, so the kernel accumulator drops the
+    // remainder it was already holding and the display owes the server up to
+    // one tick of ground. The servo repays that at a bounded rate over the
+    // following frames (observed peak 9.67 yd/s); the artifact this test pins
+    // against ran at 13.8 and stalled to 1.3 first.
+    it.each([
+      [40, 100, SPEED_MAX],
+      [40, 156, SPEED_MAX],
+      [40, 250, 10.0],
+      [120, 100, SPEED_MAX],
+      [120, 156, SPEED_MAX],
+      [120, 250, 10.0],
+    ])(
+      'holds the steady display speed across a %ims-echo, %ims render frame',
+      (lagMs, longMs, maxSpeed) => {
+        expectSteadyBand(runLongFrame(lagMs, longMs), maxSpeed);
+      },
+    );
+
+    it.each([
+      [40, 100, 4, 10],
+      [40, 156, 4, 10],
+      [120, 100, 4, 10],
+      [120, 156, 4, 10],
+      [40, 100, 6, FRAME_MS],
+      [40, 156, 6, FRAME_MS],
+      [120, 100, 6, FRAME_MS],
+      [120, 156, 6, FRAME_MS],
+    ])(
+      'holds the steady display speed at %ims echo across a %ims frame plus %i withheld frames of %ims',
+      (lagMs, longMs, heldFrames, heldMs) => {
+        expectSteadyBand(runWithheldBurst(lagMs, longMs, heldFrames, heldMs));
+      },
+    );
+
+    it.each([
+      [40, 100],
+      [40, 156],
+      [120, 100],
+      [120, 156],
+    ])(
+      'holds the steady display speed at %ims echo across a %ims frame whose burst lands first',
+      (lagMs, longMs) => {
+        expectSteadyBand(runDeliverBefore(lagMs, longMs));
+      },
+    );
+
+    // The isolation term in the hitch trigger, pinned from the regime it
+    // protects: at a steady 8 fps nothing is hitching, no episode may open,
+    // and the servo must keep correcting every frame. Sibling of 'keeps
+    // corrections gentle under load-hitch frame times', which pins the same
+    // regime from the smoothness side.
+    it('keeps the divergence servo alive at steady low fps', () => {
+      const lab = new Lab(100, 125, { start: { x: 0, z: -1000 } });
+      lab.setInput(mi({ forward: true }));
+      for (let i = 0; i < 20; i++) lab.frame();
+      lab.srv.player.pos.x += 1; // a server-side sidestep, well under the 6 yd snap
+      const errs: number[] = [];
+      for (let i = 0; i < 8; i++) {
+        const r = lab.frame();
+        if (!r.pose) throw new Error('predictor disabled unexpectedly');
+        errs.push(Math.abs(r.pose.x - r.ac.x));
+      }
+      const report = `\n  lateral error by frame: ${errs.map((e) => e.toFixed(3)).join(' ')}`;
+      // Strictly closing every frame is the decisive part: a held servo would
+      // park the error on the leash boundary (0.75 yd here) instead. The rate
+      // is the module's own bound, not this test's choice: at a 100 ms echo the
+      // blend runs at min(12, 500/measureMs) with its dt capped at 1/30, about
+      // 15% of the gap per frame, so a 1 yd sidestep is two thirds gone by the
+      // sixth frame and under 0.15 yd by the eighth.
+      errs.forEach((err, i) => {
+        if (i > 0) expect(err, `frame ${i}${report}`).toBeLessThan(errs[i - 1]);
+      });
+      expect(errs[5], report).toBeLessThan(0.25);
+      expect(errs[7], report).toBeLessThan(0.15);
+    });
+
+    // The declared worst case, and the one the broadcast-stall arms cannot
+    // reach: an isolated hitch opens an episode and THEN the network gaps for
+    // half a second, so the lending mechanism meets a genuine stall already
+    // switched on. The episode cap is what bounds it.
+    it.each([
+      [40, 156],
+      [120, 156],
+    ])(
+      'caps the episode when a %ims-echo hitch of %ims is followed by a 500 ms gap',
+      (lagMs, longMs) => {
+        const lab = warmLab(lagMs);
+        const record = recorder(lab);
+        record('warm', FRAME_MS);
+        lab.holdSnapshots = true;
+        const gapFrames = Math.round(GAP_MS / FRAME_MS);
+        const blocked = [...record('long', longMs), ...record('gap', FRAME_MS, gapFrames)];
+        lab.holdSnapshots = false;
+        // A 700 ms gap needs a longer tail than the short-burst arms: the
+        // resume sweep is the whole gap replayed over one snapshot interval.
+        const post = record('+', FRAME_MS, GAP_RECOVERY_FRAMES);
+        const report = trace([...blocked, ...post]);
+        // a: the lending is bounded by the episode cap, stated from the
+        // constants: the plain leash budget plus what one capped episode plus
+        // its opening frame can cover at run speed.
+        const bound = lab.budget() + (RUN_SPEED * (BLOCK_EPISODE_MAX_MS + longMs)) / 1000;
+        for (const step of [...blocked, ...post]) {
+          expect(step.err, `${step.label}${report}`).toBeLessThanOrEqual(bound);
+        }
+        // b: the cap expires INSIDE the gap and the display drops back onto
+        // the plain leash freeze: the error stops growing and the display
+        // stops advancing while the anchor stays frozen. With no cap the
+        // lending would run for the whole gap and both would keep going.
+        const frozen = blocked.slice(-6);
+        const errs = frozen.map((step) => step.err);
+        expect(Math.max(...errs) - Math.min(...errs), report).toBeLessThan(0.02);
+        for (const step of frozen) {
+          expect(step.speed, `frozen ${step.label}${report}`).toBeLessThan(1);
+        }
+        // c: the burst re-contains it on the stall arms' own terms
+        for (const step of post) {
+          expect(step.forward, `${step.label}${report}`).toBeGreaterThanOrEqual(-0.03);
+        }
+        expectSteadyBand(post.slice(-8));
+      },
+    );
+
+    // The loan is temporary, pinned where it matters: a plain broadcast gap
+    // arriving later must be contained by the PLAIN leash, not by whatever
+    // room the earlier hitch was lent. A loan that never drained would ride
+    // straight through this.
+    it.each([[40], [120]])(
+      'drains the loan so a later broadcast gap is contained by the plain leash at %ims echo',
+      (lagMs) => {
+        const lab = warmLab(lagMs);
+        const record = recorder(lab);
+        record('warm', FRAME_MS);
+        record('long', 156);
+        record('settle', FRAME_MS, 60); // 1 s of ordinary frames: the loan drains
+        lab.holdSnapshots = true; // now a network gap, with no hitch of its own
+        const stall = record('stall', FRAME_MS, Math.round(250 / FRAME_MS));
+        const report = trace(stall);
+        for (const step of stall) {
+          expect(step.err, `${step.label}${report}`).toBeLessThanOrEqual(lab.budget() + 1e-6);
+        }
+        // and the gap really does drive the display into that boundary
+        expect(Math.max(...stall.map((step) => step.err)), report).toBeGreaterThan(
+          lab.budget() * 0.8,
+        );
+      },
+    );
+
+    // The trigger is RELATIVE to the mirror's measured interval, not to a
+    // hardcoded 50 ms. On a coalescing link that delivers every 70 ms, a 60 ms
+    // frame is an ordinary frame (shorter than the interval, nothing was
+    // swallowed) and must be left to the plain leash, while a 90 ms one is a
+    // hitch and gets its episode.
+    const COALESCED_MS = 70;
+    function runCoalesced(lagMs: number, longMs: number): Step[] {
+      const lab = new Lab(lagMs, FRAME_MS, {
+        start: { x: 0, z: -1000 },
+        deliverAfter: true,
+        deliveryMs: COALESCED_MS,
+      });
+      lab.setInput(mi({ forward: true }));
+      for (let i = 0; i < WARMUP_FRAMES; i++) lab.frame();
+      const record = recorder(lab);
+      record('warm', FRAME_MS);
+      return [...record('long', longMs), ...record('+', FRAME_MS, AFTER_FRAMES)];
+    }
+
+    it.each([[40], [120]])(
+      'treats a 90 ms frame as a hitch when the interval is 70 ms at %ims echo',
+      (lagMs) => {
+        const steps = runCoalesced(lagMs, 90);
+        const report = trace(steps);
+        // the frame's own ground, less the fixed-step accumulator's phase (the
+        // kernel lands whole 50 ms ticks, so a 90 ms frame carries one or two)
+        expect(steps[0].forward, `long${report}`).toBeGreaterThan(0.9 * RUN_SPEED * 0.09);
+        expectSteadyBand(steps);
+      },
+    );
+
+    // The other half of the same claim, and the one a fixed 50 ms threshold
+    // would get wrong: under the measured interval nothing was swallowed, so
+    // the frame is ordinary and the servo must NOT be held. Read through a
+    // server-side sidestep injected just before the frame in question: the
+    // ordinary frame keeps closing it, the hitch defers it for the settle
+    // window. A 50 ms threshold defers both, a 100 ms one defers neither.
+    it('scales the hitch trigger to the measured interval, not to a fixed 50 ms', () => {
+      const lateralErrs = (longMs: number): number[] => {
+        const lab = new Lab(40, FRAME_MS, {
+          start: { x: 0, z: -1000 },
+          deliverAfter: true,
+          deliveryMs: COALESCED_MS,
+        });
+        lab.setInput(mi({ forward: true }));
+        for (let i = 0; i < WARMUP_FRAMES; i++) lab.frame();
+        // Under the plain leash budget on purpose: inside it only the servo
+        // can close the gap, so this reads the servo and not the clamp.
+        lab.srv.player.pos.x += 0.35;
+        lab.frame(longMs);
+        const errs: number[] = [];
+        for (let i = 0; i < 6; i++) {
+          const r = lab.frame();
+          if (!r.pose) throw new Error('predictor disabled unexpectedly');
+          errs.push(Math.abs(r.pose.x - r.ac.x));
+        }
+        return errs;
+      };
+      const ordinary = lateralErrs(60);
+      const hitch = lateralErrs(90);
+      const report =
+        `\n  60 ms frame: ${ordinary.map((e) => e.toFixed(3)).join(' ')}` +
+        `\n  90 ms frame: ${hitch.map((e) => e.toFixed(3)).join(' ')}`;
+      // the ordinary frame leaves the servo running, so the divergence turns
+      // around inside the window; the hitch defers it through its settle
+      // window, where it is still opening
+      expect(ordinary[5], report).toBeLessThan(ordinary[4]);
+      expect(ordinary[5], report).toBeLessThan(0.5);
+      expect(hitch[5], report).toBeGreaterThan(hitch[4]);
+    });
+
+    // Recurrence bound. A machine hitching every few frames must not be able
+    // to keep the servo held forever: measured against a server that never
+    // receives the intent (the display predicts a run the authority never
+    // performs), the display has to stay on the leash instead of walking out
+    // to the 6 yd re-adopt. SERVO_REFRACTORY_INTERVALS is what bounds it.
+    it('bounds the display against a diverging server through repeated hitches', () => {
+      const lab = new Lab(100, FRAME_MS, {
+        start: { x: 0, z: -1000 },
+        deliverAfter: true,
+        serverDeaf: true,
+      });
+      lab.setInput(mi({ forward: true }));
+      const record = recorder(lab);
+      record('warm', FRAME_MS);
+      const hitching: Step[] = [];
+      for (let cycle = 0; cycle < 15; cycle++) {
+        hitching.push(...record('run', FRAME_MS, 5), ...record('hitch', 120));
+      }
+      const settling = record('calm', FRAME_MS, 60);
+      const report = trace([...hitching, ...settling]);
+      const peak = Math.max(...hitching.map((step) => step.err));
+      expect(peak, `peak${report}`).toBeLessThan(2.5);
+      expect(peak, `peak${report}`).toBeLessThan(Math.sqrt(SELF_MOTION_SNAP_DIST_SQ));
+      // and once the hitching stops the servo closes it back onto the leash
+      expect(settling[settling.length - 1].err, `settled${report}`).toBeLessThan(
+        lab.budget() + 1e-6,
+      );
+    });
+
+    // Defensive inputs: ClientWorld hands over its live EWMA and last-apply
+    // age, and a fresh or reset mirror can present 0 or a negative sentinel.
+    // The core floors both, so the two frame shapes must be indistinguishable.
+    it('treats a degenerate interval and a negative snapshot age as the floored pair', () => {
+      const sim = new Sim({
+        seed: SEED,
+        playerClass: 'warrior',
+        autoEquip: true,
+        world: EMPTY_TEST_WORLD,
+      });
+      sim.setPlayerLevel(60);
+      teleport(sim, 0, -1000);
+      sim.player.facing = 0;
+      const mirror = (): Entity => ({
+        ...sim.player,
+        pos: { ...sim.player.pos },
+        prevPos: { ...sim.player.prevPos },
+      });
+      const sentinel = { self: mirror(), predictor: new SelfMotionPredictor(SEED) };
+      const floored = { self: mirror(), predictor: new SelfMotionPredictor(SEED) };
+      const step = (
+        arm: { self: Entity; predictor: SelfMotionPredictor },
+        frameDt: number,
+        snapAgeMs: number,
+        snapIntervalMs: number,
+      ): Vec3Like => {
+        const out = arm.predictor.step(arm.self, {
+          enabled: true,
+          moveInput: mi({ forward: true }),
+          displayFacing: 0,
+          echoMs: 100,
+          jitterMs: 0,
+          alpha: 1,
+          frameDt,
+          snapAgeMs,
+          snapIntervalMs,
+        });
+        if (!out) throw new Error('predictor disabled unexpectedly');
+        expect(Number.isFinite(out.x) && Number.isFinite(out.y) && Number.isFinite(out.z)).toBe(
+          true,
+        );
+        return { ...out };
+      };
+      const pair = (frameDt: number, ageMs: number): { a: Vec3Like; b: Vec3Like } => ({
+        a: step(sentinel, frameDt, ageMs < 0 ? -1 : ageMs, 0),
+        b: step(floored, frameDt, Math.max(0, ageMs), 20),
+      });
+      for (let i = 0; i < 30; i++) pair(FRAME_MS / 1000, -1);
+      const before = pair(FRAME_MS / 1000, -1);
+      const hitch = pair(0.156, -1); // the isolated long frame
+      const after = pair(FRAME_MS / 1000, 300); // ...and a stale frame behind it
+      expect(hitch.a).toEqual(hitch.b);
+      expect(after.a).toEqual(after.b);
+      // the episode still opened despite the sentinel: full kernel ground, not
+      // the base-budget clamp, and the frame after it keeps advancing
+      expect(hitch.a.z - before.a.z).toBeGreaterThan(0.9);
+      expect(after.a.z).toBeGreaterThan(hitch.a.z);
+    });
+
+    // The boundary of the fix, pinned from the other side. A delivery burst
+    // with no long frame is a NETWORK gap: nothing local explains the stale
+    // anchor, so it stays in the broadcast-stall regime above (the display
+    // freezes on the leash, then the resume sweep repays the gap). The
+    // staleness allowance must not leak into it, or the leash containment the
+    // stall arms pin would quietly stop holding.
+    it.each([
+      [40, 15.5],
+      [120, 12.0],
+    ])(
+      'leaves a delivery burst with no long frame frozen on the leash at %ims echo',
+      (lagMs, peakYdS) => {
+        const steps = runBurst(lagMs);
+        const report = trace(steps);
+        // the freeze itself: the frame whose tail applies the burst still steps
+        // against the frozen anchor, so it shows the leash, not the kernel
+        expect(steps[0].speed, `frozen${report}`).toBeLessThan(2);
+        // the repayment: forward, bounded, and back on the steady band by the end
+        for (const step of steps) {
+          expect(step.forward, `${step.label}${report}`).toBeGreaterThanOrEqual(-0.03);
+          expect(step.speed, `${step.label}${report}`).toBeLessThanOrEqual(peakYdS);
+        }
+        expectSteadyBand(steps.slice(-8));
+      },
+    );
   });
 
   it('starts the jump arc locally without waiting for the server', () => {

--- a/tests/self_motion_frame_buffer.test.ts
+++ b/tests/self_motion_frame_buffer.test.ts
@@ -18,9 +18,9 @@ describe('self motion frame buffer', () => {
   it('updates one stable frame object in place', () => {
     const buffer = new SelfMotionFrameBuffer();
     const firstMove = moveInput(true);
-    const first = buffer.write(true, firstMove, 1, 80, 4, 0.5, 1 / 60);
+    const first = buffer.write(true, firstMove, 1, 80, 4, 0.5, 1 / 60, 12, 50);
     const secondMove = moveInput(false);
-    const second = buffer.write(false, secondMove, 2, 120, 8, 0.75, 1 / 30);
+    const second = buffer.write(false, secondMove, 2, 120, 8, 0.75, 1 / 30, 31, 52);
 
     expect(second).toBe(first);
     expect(second).toEqual({
@@ -31,6 +31,8 @@ describe('self motion frame buffer', () => {
       jitterMs: 8,
       alpha: 0.75,
       frameDt: 1 / 30,
+      snapAgeMs: 31,
+      snapIntervalMs: 52,
     });
   });
 });


### PR DESCRIPTION
## Summary

Cherry-pick of #3445 (`31ac4324c350a95e06c9d480e736089ffc145959`, by @madmatah) onto the
`release/v0.38.3` hotfix line. The diff is byte-identical to the commit on #3445: the
cherry-pick applied with no conflicts, and every file it touches
(`src/render/self_motion.ts`, `src/game/self_motion_frame_buffer.ts`, `src/main.ts`,
`src/net/CLAUDE.md`, `docs/online-movement-latency.md`, and the three test files) is
identical between `release/v0.39.0` and `release/v0.38.3`. The 11 hotfix commits that
`release/v0.38.3` carries on top of `release/v0.39.0` touch a disjoint set of files
(Fenbridge/Eastbrook GLB assets and their pins, `post_output_grade.ts`, the Nythraxis
wardstone quest gate), so there is no interaction with the self-motion path.

The original change, in short: online, the local avatar stalled and then lurched around
every long render frame. The browser applies the WebSocket snapshots queued during a
main-thread block only afterwards, so the predictor's authoritative anchor is FROZEN
during the frame and then SWEEPS several ticks in one snapshot interval. The horizontal
leash clamped the kernel's correct multi-step advance against that stale anchor, `prevPos`
ended up ahead of the clamped `pos` (so sub-tick interpolation ran backward or stalled),
and the wall-clock divergence servo read the post-burst sweep as a divergence and rushed
the display.

`SelfMotionPredictor.step` now recognises an ISOLATED long frame (longer than one snapshot
interval, after a normal one) as a block episode: the leash lends the ground the frozen
anchor could not cover (capacity earned on the wall clock, bounded by
`BLOCK_EPISODE_MAX_MS = 500` and by the lead the kernel actually took), and the divergence
servo sits out the burst sweep (`SERVO_SETTLE_INTERVALS = 2`). A RUN of long frames is
steady low fps and opens nothing, so that regime keeps its servo behaviour byte for byte.
`SelfMotionFrame` gains `snapAgeMs` and `snapIntervalMs` to carry the signal;
`SelfMotionFrameBuffer` and the one `src/main.ts` call site pass them.

Full problem statement, the per-frame capture data, and the stated known limits are on
#3445; nothing was re-litigated here.

**Contract widening, called out.** #3445 amends the `src/net/CLAUDE.md` four-constraints
contract: constraints (a) bounded by the latency cap and (b) always blending toward the
server pose now carry one sanctioned long-frame exception. Per `src/net/CLAUDE.md` that
widening is a maintainer decision, and it is accepted here. #3445 itself is still open
against `release/v0.39.0`; this PR lands the same fix on the v0.38.3 hotfix line at the
author's request.

## Related issues

Cherry-pick of #3445 (open against `release/v0.39.0`).

## Type of change

- [x] Bug fix
- [x] Tests

## How was this tested?

- Commands, run in a clean worktree off `origin/release/v0.38.3`:
  - `git cherry-pick -x 31ac4324c3` (clean, no conflicts); the resulting diff is byte
    identical to the #3445 commit.
  - `npx tsc --noEmit` (clean).
  - `npx vitest run tests/self_motion.test.ts tests/self_motion_frame_buffer.test.ts
    tests/paladin_valkyrs_calling.test.ts tests/monolith_budget.test.ts
    tests/architecture.test.ts` (121 passed).
- Manual steps: none re-run here. The real-client captures (injected 120 ms main-thread
  blocks, natural play) are recorded on #3445 and were not repeated for the cherry-pick,
  since the code is identical.

**The local `gate_select` run is NOT green, and CI is the authority for this PR.** Three
full runs on this box red with a DIFFERENT set of files each time (7, then 3, then 9), and
every single failure is a wall-clock `Test timed out` / `Hook timed out`, never an
assertion. The union spans `ci_workflow`, `ci_shard_plan`, `ci_shard_partition`,
`gate_select_plan`, `guide`, `language_fanout_registry`, `professions_admin_restore`,
`release_i18n_tier_coverage`, `scripts_windows_paths`, `server/http/metrics_gate` and
`sfx_export_core`: whole-repo file-scan suites, none of them on the self-motion path. The
machine is sitting at load 30+ on 12 cores from other worktrees, which is the exact failure
mode `scripts/lib/gate_workers.mjs` documents in its header (several gates each sizing
their pool as if they owned the host). `GATE_WORKER_TIER=low` did not rescue it, because
the timeouts are wall-clock and the contention is external. The same files passed in 12 to
64 s earlier in the session when load was lower. The upstream #3445 gate run against
`release/v0.39.0` was green on the identical diff.

## Screenshots / recordings

N/A (motion, no UI change).

---

## Checklist

### Quality

- [ ] **The gate passes.** Not verified locally: see the note under "How was this tested?".
      `tsc` and the change's own suites are green; the full `gate_select` run could not be
      trusted on this box (wall-clock timeouts under external load, a different file set
      every run). Deferring to CI. Tests come with the cherry-picked commit
      (`describe('long render frames')` in `tests/self_motion.test.ts`; 24 of the file's
      53 cases fail on the pre-fix predictor).

### Cross-platform

- [x] Tested on desktop (on #3445).
- ~Accessible.~ N/A

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled
      in any production path.
- [x] I didn't hand-edit generated files.
