### PR TITLE
fix(loot): dungeon finale gold rebalance (farm nerfs + heroic finale bases)

### DIFF
--- a/docs/design/dungeon-gold.md
+++ b/docs/design/dungeon-gold.md
@@ -1,0 +1,61 @@
+# Dungeon finale gold
+
+The money a dungeon's final boss drops, on both difficulties. This is the
+design anchor for the values authored on the finale money entries (the
+`LootEntry.heroicCopper` bases live in `src/sim/content/dungeon_difficulty.ts`
+as `HEROIC_FINALE_COPPER` and `NYTHRAXIS_HEROIC_COPPER`); the whole ladder is
+pinned by `tests/heroic_finale_gold.test.ts`.
+
+## The two rules
+
+1. **Normal mode is the anti-farm line.** Normal instances have no lockout
+   and most finales can be skip-pulled, so a finale's normal-mode payout is
+   priced to make repeat pops not worth the clear time: roughly 1g to 2g at
+   the endgame five-mans, less below. History: Korzul (Gravewyrm Sanctum)
+   shipped at a 50000c base (3g to 7g rolled) and Zulgar (Wildheart Basin)
+   at 55000c, an order of magnitude over their sibling bosses, and both
+   became the game's dominant repeat gold farms (the zero-downtime
+   instance-reset exploit itself was closed separately, issue #1600). Both
+   now sit at 15000c.
+2. **Heroic rewards the legitimate clear.** Every heroic dungeon has a
+   per-dungeon daily lockout (`awardHeroicMarks` in
+   `src/sim/instances/dungeons.ts` stamps it on the whole claim), so the
+   heroic finale pays a raised base through `LootEntry.heroicCopper`:
+   five-mans 100000c (10g nominal), the Nythraxis raid 200000c (20g). The
+   loot roller substitutes the heroic base for the normal one on the same
+   single rng draw when the kill carries a live heroic claim.
+
+## The ladder
+
+All money rolls the roller's 0.6x to 1.4x band around the base.
+
+| Dungeon | Finale | Normal base | Heroic base |
+|---|---|---|---|
+| Hollow Crypt | Morthen | 2500c | 100000c |
+| Sunken Bastion | Vael the Mistcaller | 5000c | 100000c |
+| Drowned Temple | Ysolei | 6000c | 100000c |
+| Gravewyrm Sanctum | Korzul the Gravewyrm | 15000c | 100000c |
+| Wildheart Basin | Zulgar, Voice of the Basin | 15000c | 100000c |
+| Nythraxis raid | Nythraxis, Scourge of Thornpeak | 150000c | 200000c |
+
+The heroic base is deliberately flat across the five-mans (they all tune to
+level 22; the clear effort is comparable) rather than a multiple of the
+normal base (which is priced by farmability, not effort).
+
+## The daily ceiling
+
+The lockout is per dungeon, so a group clearing every heroic each day mints
+5 x 100000c + 200000c = 700000c nominal (70g), rolling 42g to 98g, split by
+the party's currency strategy (default looter-takes-all; fair-split shares
+it evenly). That is the intended faucet: bounded, group-wide, and earned
+through the hardest content, versus the old unbounded normal-mode finale
+farming this ladder replaced.
+
+## Changing a value
+
+Edit the content entry (and the shared heroic base constants where they
+apply), update the pinned ladder in `tests/heroic_finale_gold.test.ts` and
+the boss-specific suites (`tests/gravewyrm_boss_gold.test.ts`,
+`tests/wildheart.test.ts`), and update this table in the same change. A new
+heroic dungeon's finale takes a `heroicCopper` on its single money entry, a
+row in the test ladder, and a row here.

--- a/docs/design/master-spec.md
+++ b/docs/design/master-spec.md
@@ -265,7 +265,7 @@ korzul_the_gravewyrm (0,146)  sanctum_drakonid (-5,144) (5,144)
 
 **Boss mechanics summary** (only 2 NEW sim mechanics across the whole expansion, both deterministic, both also used in the Bastion — see §7): summonAdds (Vael, Velkhar), enrage (Korgath, Korzul). aoePulse reused everywhere (Voss, Vael, Drogmar, Korzul). Frontal breath DEFERRED (facing-cone math not worth it).
 
-**Loot:** Korgath → korgaths_chainwraps (50%) + 50s coin. Velkhar → one of three blues (boneguard_breastplate / staff_of_velkhar / shadowmeld_tunic) + 50s. Korzul → one of three EPIC weapons (wyrmfang_greatblade / staff_of_the_gravewyrm / fang_of_korzul, ~1/3 each) + 1.5g coin. Quest blues (q_gravewyrm chest pieces) guarantee every archetype a best-in-slot chest on completion. Trash: 3–3.5s coin/elite + junk.
+**Loot:** Korgath → korgaths_chainwraps (50%) + 50s coin. Velkhar → one of three blues (boneguard_breastplate / staff_of_velkhar / shadowmeld_tunic) + 50s. Korzul → one of three EPIC weapons (wyrmfang_greatblade / staff_of_the_gravewyrm / fang_of_korzul, ~1/3 each) + 1.5g coin. Quest blues (q_gravewyrm chest pieces) guarantee every archetype a best-in-slot chest on completion. Trash: 3 to 3.5s coin/elite + junk.
 
 **XP reality (corrected per judge verdict):** full clear = 18 trash × (140×2×1.43÷5 ≈ 80) + 3 bosses ≈ **1,700 XP/member**. A loot/story event — the level-20 push comes from the lead-up chain, by design.
 

--- a/docs/design/master-spec.md
+++ b/docs/design/master-spec.md
@@ -175,7 +175,7 @@ vael_the_mistcaller (0,98)  tidebound_acolyte (-4,96)  bastion_revenant (4,96)
 | raised_bonewalker | Raised Bonewalker | undead | 18 | (summoned add) | 42/15 | 9/2.2 | 2.2 | no loot; Velkhar's summonAdds target |
 | korgath_the_bound | Korgath the Bound | ogre | 20 | elite, miniboss | 260/36 | 14/2.9 | 2.8 | **enrage** {belowHpPct 0.30, dmgMult 1.5}; copper 5000; korgaths_chainwraps 0.5 |
 | grand_necromancer_velkhar | Grand Necromancer Velkhar | humanoid | 20 | elite, miniboss | 230/33 | 13/2.8 | 2.0 | **summonAdds** {raised_bonewalker, 3, [0.66,0.33]}; copper 5000; boneguard_breastplate 0.33; shadowmeld_tunic 0.33; staff_of_velkhar 0.34 |
-| korzul_the_gravewyrm | Korzul the Gravewyrm | dragonkin | 20 | elite, boss | 420/48 | 15/3.0 | 2.6 | aoePulse {30,42,r14,every8,'Necrotic Shockwave'} + **enrage** {0.30, 1.5}; copper 50000; wyrmfang_greatblade 0.34; staff_of_the_gravewyrm 0.33; fang_of_korzul 0.33 |
+| korzul_the_gravewyrm | Korzul the Gravewyrm | dragonkin | 20 | elite, boss | 420/48 | 15/3.0 | 2.6 | aoePulse {30,42,r14,every8,'Necrotic Shockwave'} + **enrage** {0.30, 1.5}; copper 15000; wyrmfang_greatblade 0.34; staff_of_the_gravewyrm 0.33; fang_of_korzul 0.33 |
 
 ## Camps sketch
 
@@ -265,7 +265,7 @@ korzul_the_gravewyrm (0,146)  sanctum_drakonid (-5,144) (5,144)
 
 **Boss mechanics summary** (only 2 NEW sim mechanics across the whole expansion, both deterministic, both also used in the Bastion — see §7): summonAdds (Vael, Velkhar), enrage (Korgath, Korzul). aoePulse reused everywhere (Voss, Vael, Drogmar, Korzul). Frontal breath DEFERRED (facing-cone math not worth it).
 
-**Loot:** Korgath → korgaths_chainwraps (50%) + 50s coin. Velkhar → one of three blues (boneguard_breastplate / staff_of_velkhar / shadowmeld_tunic) + 50s. Korzul → one of three EPIC weapons (wyrmfang_greatblade / staff_of_the_gravewyrm / fang_of_korzul, ~1/3 each) + 5g coin. Quest blues (q_gravewyrm chest pieces) guarantee every archetype a best-in-slot chest on completion. Trash: 3–3.5s coin/elite + junk.
+**Loot:** Korgath → korgaths_chainwraps (50%) + 50s coin. Velkhar → one of three blues (boneguard_breastplate / staff_of_velkhar / shadowmeld_tunic) + 50s. Korzul → one of three EPIC weapons (wyrmfang_greatblade / staff_of_the_gravewyrm / fang_of_korzul, ~1/3 each) + 1.5g coin. Quest blues (q_gravewyrm chest pieces) guarantee every archetype a best-in-slot chest on completion. Trash: 3–3.5s coin/elite + junk.
 
 **XP reality (corrected per judge verdict):** full clear = 18 trash × (140×2×1.43÷5 ≈ 80) + 3 bosses ≈ **1,700 XP/member**. A loot/story event — the level-20 push comes from the lead-up chain, by design.
 

--- a/src/sim/content/dungeon_difficulty.ts
+++ b/src/sim/content/dungeon_difficulty.ts
@@ -5,6 +5,18 @@ import type { DungeonDifficulty } from '../types';
 // The item record lives in ./items.ts.
 export const HEROIC_MARK_ITEM_ID = 'heroic_mark';
 
+// Heroic finale gold: a heroic-claim kill of a dungeon's final boss pays a
+// raised money base through LootEntry.heroicCopper (the roller substitutes
+// it for the normal copper base on the same single rng draw). Heroic runs
+// sit behind the per-dungeon daily lockout, so this rewards the legitimate
+// clear while the modest normal-mode bases stay the anti-farm line.
+// Five-man finales pay 10g nominal (rolls 6g to 14g); the Nythraxis raid
+// finale pays 20g nominal (rolls 12g to 28g). Full ladder + the daily
+// circuit ceiling: docs/design/dungeon-gold.md; pinned by
+// tests/heroic_finale_gold.test.ts.
+export const HEROIC_FINALE_COPPER = 100000;
+export const NYTHRAXIS_HEROIC_COPPER = 200000;
+
 export interface HeroicDungeonTuning {
   id: string;
   difficulty: Extract<DungeonDifficulty, 'heroic'>;

--- a/src/sim/content/dungeons.ts
+++ b/src/sim/content/dungeons.ts
@@ -512,7 +512,13 @@ export const DUNGEON_MOBS: Record<string, MobTemplate> = {
     },
     enrage: { belowHpPct: 0.3, dmgMult: 1.5, hasteMult: 1.3 },
     loot: [
-      { copper: 50000, chance: 1 },
+      // 15000c base rolls to 9000c to 21000c (the 0.6x to 1.4x loot band):
+      // roughly the 1g to 2g finale payout, a 3x premium over the 5000c the
+      // other Sanctum bosses pay. The old 50000c base paid 3g to 7g per pop
+      // on a lockout-free, skip-pullable finale, the prime repeat gold-farm
+      // target (Zulgar in Wildheart pays 55000c but sits behind
+      // bossChainPull); tests/gravewyrm_boss_gold.test.ts pins the band.
+      { copper: 15000, chance: 1 },
       { itemId: 'boneplate_vest', chance: 0.34, rollGroup: 'korzul_guaranteed_uncommon' },
       { itemId: 'revenant_silk_robe', chance: 0.33, rollGroup: 'korzul_guaranteed_uncommon' },
       { itemId: 'nightwalk_jerkin', chance: 0.33, rollGroup: 'korzul_guaranteed_uncommon' },

--- a/src/sim/content/dungeons.ts
+++ b/src/sim/content/dungeons.ts
@@ -2,6 +2,7 @@
 // lists, and the DungeonDef registry merged by sim/data.ts.
 
 import type { DungeonDef, DungeonSpawn, MobTemplate } from '../types';
+import { HEROIC_FINALE_COPPER, NYTHRAXIS_HEROIC_COPPER } from './dungeon_difficulty';
 
 export const DUNGEON_MOBS: Record<string, MobTemplate> = {
   // ---- The Hollow Crypt (5-player elite instance) ----
@@ -137,7 +138,7 @@ export const DUNGEON_MOBS: Record<string, MobTemplate> = {
     aggroRadius: 16,
     aoePulse: { min: 12, max: 18, radius: 12, every: 10, name: 'Shadow Pulse' },
     loot: [
-      { copper: 2500, chance: 1 },
+      { copper: 2500, heroicCopper: HEROIC_FINALE_COPPER, chance: 1 },
       { itemId: 'cryptbone_greaves', chance: 0.34, rollGroup: 'morthen_guaranteed_uncommon' },
       { itemId: 'quilted_trousers', chance: 0.33, rollGroup: 'morthen_guaranteed_uncommon' },
       { itemId: 'oiled_boots', chance: 0.33, rollGroup: 'morthen_guaranteed_uncommon' },
@@ -294,7 +295,7 @@ export const DUNGEON_MOBS: Record<string, MobTemplate> = {
     aoePulse: { min: 16, max: 24, radius: 12, every: 10, name: 'Mist Surge' },
     summonAdds: { mobId: 'drowned_thrall', count: 2, atHpPct: [0.6, 0.3] },
     loot: [
-      { copper: 5000, chance: 1 },
+      { copper: 5000, heroicCopper: HEROIC_FINALE_COPPER, chance: 1 },
       { itemId: 'trollhide_leggings', chance: 0.34, rollGroup: 'vael_guaranteed_uncommon' },
       { itemId: 'marshstrider_boots', chance: 0.33, rollGroup: 'vael_guaranteed_uncommon' },
       { itemId: 'fenmist_robe', chance: 0.33, rollGroup: 'vael_guaranteed_uncommon' },
@@ -516,9 +517,10 @@ export const DUNGEON_MOBS: Record<string, MobTemplate> = {
       // roughly the 1g to 2g finale payout, a 3x premium over the 5000c the
       // other Sanctum bosses pay. The old 50000c base paid 3g to 7g per pop
       // on a lockout-free, skip-pullable finale, the prime repeat gold-farm
-      // target (Zulgar in Wildheart pays 55000c but sits behind
-      // bossChainPull); tests/gravewyrm_boss_gold.test.ts pins the band.
-      { copper: 15000, chance: 1 },
+      // target (Zulgar in Wildheart took the same nerf). The daily-lockout
+      // heroic clear pays the 10g finale base instead;
+      // tests/gravewyrm_boss_gold.test.ts pins both bands.
+      { copper: 15000, heroicCopper: HEROIC_FINALE_COPPER, chance: 1 },
       { itemId: 'boneplate_vest', chance: 0.34, rollGroup: 'korzul_guaranteed_uncommon' },
       { itemId: 'revenant_silk_robe', chance: 0.33, rollGroup: 'korzul_guaranteed_uncommon' },
       { itemId: 'nightwalk_jerkin', chance: 0.33, rollGroup: 'korzul_guaranteed_uncommon' },
@@ -687,7 +689,7 @@ export const DUNGEON_MOBS: Record<string, MobTemplate> = {
     // existing four groups, with the set-piece chances rebalanced; group 3 is
     // the offhand group and carries two (the caster orb and the hunter quiver).
     loot: [
-      { copper: 150000, chance: 1 },
+      { copper: 150000, heroicCopper: NYTHRAXIS_HEROIC_COPPER, chance: 1 },
       { itemId: 'deathless_heartwood', chance: 0.03, rollGroup: 'nythraxis_drop_1' },
       { itemId: 'bonewrought_greatsword', chance: 0.13, rollGroup: 'nythraxis_drop_1' },
       { itemId: 'crownforged_dreadhelm', chance: 0.14, rollGroup: 'nythraxis_drop_1' },

--- a/src/sim/content/temple.ts
+++ b/src/sim/content/temple.ts
@@ -20,6 +20,7 @@ import type {
   QuestDef,
   ZonePropsDef,
 } from '../types';
+import { HEROIC_FINALE_COPPER } from './dungeon_difficulty';
 
 // Archetype class-locks (match content/items.ts so REWARD_ARCHETYPE hand-offs
 // land on an item the whole group can equip).
@@ -292,7 +293,7 @@ export const TEMPLE_DUNGEON_MOBS: Record<string, MobTemplate> = {
     summonAdds: { mobId: 'moonspawn', count: 2, atHpPct: [0.6, 0.3] },
     enrage: { belowHpPct: 0.3, dmgMult: 1.4, hasteMult: 1.3 },
     loot: [
-      { copper: 6000, chance: 1 },
+      { copper: 6000, heroicCopper: HEROIC_FINALE_COPPER, chance: 1 },
       { itemId: 'ysols_pearl_greaves', chance: 0.5 },
       // exclusive "one of three" blue chests (weights sum to 1.0)
       { itemId: 'moonshroud_breastplate', chance: 0.34, rollGroup: 'ysolei_blue' },

--- a/src/sim/content/wildheart.ts
+++ b/src/sim/content/wildheart.ts
@@ -3,6 +3,7 @@
 // flooded jungle caldera with two routes around a central beast island. Both
 // paths climb into one ritual terrace beneath a colossal jaguar shrine.
 import type { DungeonDef, DungeonSpawn, ItemDef, MobTemplate } from '../types';
+import { HEROIC_FINALE_COPPER } from './dungeon_difficulty';
 
 export const WILDHEART_ITEMS: Record<string, ItemDef> = {
   // Rogue dagger (drops from the Fanglord Beastmaster, the Wildheart Basin
@@ -323,7 +324,12 @@ export const WILDHEART_MOBS: Record<string, MobTemplate> = {
       enrage: 'THE WILD HEART BEATS THROUGH ME!',
     },
     loot: [
-      { copper: 55000, chance: 1 },
+      // 15000c base (rolls 9000c to 21000c, roughly 1g to 2g): the same
+      // gold-farm nerf Korzul took (the old 55000c paid 3.3g to 7.7g per
+      // pop). bossChainPull slows a Zulgar farm but does not stop it. The
+      // daily-lockout heroic clear pays the 10g finale base instead;
+      // tests/heroic_finale_gold.test.ts pins the ladder.
+      { copper: 15000, heroicCopper: HEROIC_FINALE_COPPER, chance: 1 },
       { itemId: 'bone_fragments', chance: 0.8 },
       // Guaranteed uncommon (chances sum to 1.0, exactly one drops): the Korzul
       // korzul_guaranteed_uncommon pattern, one piece per armor class.

--- a/src/sim/loot/loot_roll.ts
+++ b/src/sim/loot/loot_roll.ts
@@ -280,8 +280,17 @@ export function rollLoot(
       continue;
     }
     if (!ctx.rng.chance(entry.chance)) continue;
-    if (entry.copper)
-      copper += ctx.rng.int(Math.ceil(entry.copper * 0.6), Math.ceil(entry.copper * 1.4));
+    if (entry.copper) {
+      // A heroic claim substitutes the raised finale money base (see
+      // LootEntry.heroicCopper): a VALUE swap on the same single int draw at
+      // THIS site, never an extra draw here. (Downstream, the fair-split
+      // remainder loop draws per leftover coin, so a different rolled total
+      // still changes ITS draw count; that was already true of any money
+      // value change.)
+      const moneyBase =
+        heroicClaim && entry.heroicCopper !== undefined ? entry.heroicCopper : entry.copper;
+      copper += ctx.rng.int(Math.ceil(moneyBase * 0.6), Math.ceil(moneyBase * 1.4));
+    }
     if (entry.itemId) items.push({ itemId: heroicItem(entry.itemId), count: 1 });
   }
   // Heroic-only drops: when the mob's claimed instance is heroic and it has a

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -1422,6 +1422,13 @@ export const DEFAULT_PARTY_LOOT_STRATEGIES: LootStrategies = {
 export interface LootEntry {
   itemId?: string;
   copper?: number;
+  // Heroic-claim money base: when the kill carries a live heroic instance
+  // claim, the loot roller substitutes this for `copper` as the roll base
+  // (same 0.6x to 1.4x band on the same single draw). Authored only on
+  // dungeon final bosses via the HEROIC_FINALE_COPPER /
+  // NYTHRAXIS_HEROIC_COPPER bases in content/dungeon_difficulty.ts, and it
+  // always rides a truthy `copper` (the roller's money arm gates on copper).
+  heroicCopper?: number;
   chance: number; // 0..1
   questId?: string; // only drops while this quest is active and not complete
   // Entries sharing a rollGroup are exclusive: one rng draw is partitioned by

--- a/src/ui/dungeon_finder_view.ts
+++ b/src/ui/dungeon_finder_view.ts
@@ -276,7 +276,13 @@ function buildEncounters(activity: FinderActivity): FinderEncounterViewModel[] {
     const loot = (mob.loot ?? []).filter((e) => !e.questId);
     const { groups, singles } = lootGroups(loot);
     let copper = 0;
-    for (const e of loot) if (e.copper) copper += e.copper;
+    // Mirror the roller's money arm: a heroic activity's finale pays the
+    // raised heroicCopper base (same truthy-copper gate), so the preview
+    // must advertise the number the kill actually pays.
+    const heroicFinale = activity.difficulty === 'heroic' && enc.final === true;
+    for (const e of loot)
+      if (e.copper)
+        copper += heroicFinale && e.heroicCopper !== undefined ? e.heroicCopper : e.copper;
     const heroicGroups =
       activity.difficulty === 'heroic' && enc.final
         ? lootGroups(HEROIC_BOSS_LOOT[enc.mobId] ?? []).groups

--- a/tests/dungeon_finder_view.test.ts
+++ b/tests/dungeon_finder_view.test.ts
@@ -130,7 +130,8 @@ describe('dungeon finder view core', () => {
     // below 1 and must NOT claim a guaranteed drop.
     expect(boss?.groups[0].guaranteed).toBe(true);
     expect(boss?.groups[1].guaranteed).toBe(false);
-    expect(boss?.copper).toBeGreaterThan(0);
+    // Normal difficulty previews the normal money base, never the heroic one.
+    expect(boss?.copper).toBe(2500);
     expect(boss?.heroicGroups).toEqual([]);
     // Attunement quest drops never appear in the preview.
     const crypt = live(
@@ -166,6 +167,10 @@ describe('dungeon finder view core', () => {
     expect(boss?.heroicGroups.length).toBe(2);
     expect(boss?.heroicGroups.every((g) => g.guaranteed)).toBe(true);
     expect(view.detail?.heroicMarks).toBe(1);
+    // The heroic finale preview advertises the raised heroicCopper base the
+    // kill actually pays; a non-finale encounter keeps its normal copper.
+    expect(boss?.copper).toBe(100000);
+    expect(view.detail?.encounters.find((e) => e.mobId === 'sexton_marrow')?.copper).toBe(400);
   });
 
   it('maps raid entrances to the Abandoned Crypt door with its zone', () => {

--- a/tests/gravewyrm_boss_gold.test.ts
+++ b/tests/gravewyrm_boss_gold.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest';
+import { DUNGEON_DEFS } from '../src/sim/content/dungeons';
+import { HEROIC_BOSS_LOOT } from '../src/sim/content/heroic_loot';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+import { enterDungeon } from '../src/sim/instances/dungeons';
+import { Sim } from '../src/sim/sim';
+
+// Gravewyrm Sanctum gold-farm fix: Korzul the Gravewyrm paid a guaranteed
+// 50000c base, rolled to 3g to 7g per kill by the loot roller's 0.6x to 1.4x
+// band, 10x the 5000c the other two Sanctum bosses pay, on a lockout-free,
+// skip-pullable finale. (The instance-reset exploit itself was closed by
+// issue #1600, tests/gravewyrm_farm_exploit.test.ts; this pins the payout
+// that still made rate-limited repeat pops the prime farm target.) The base
+// drops to 15000c: a 1.5g nominal payout whose rolled band (9000c to 21000c)
+// is the closest fit to the intended 1g to 2g the fixed variance allows,
+// still a 3x finale premium over the sibling bosses.
+const KORZUL_BASE_COPPER = 15000;
+const SIBLING_BOSS_COPPER = 5000;
+const ROLLED_MIN_COPPER = 9000; // ceil(15000 * 0.6)
+const ROLLED_MAX_COPPER = 21000; // ceil(15000 * 1.4)
+// How close to each band edge the sampled rolls must reach. Over 2000 uniform
+// draws the chance of missing a 100-wide edge window is about 2e-7 per edge,
+// so this cannot flake, while a roller band narrowed by even ~0.7% fails.
+const EDGE_SLACK_COPPER = 100;
+
+// Presence filter for authored money rows. Broader than the roller's own
+// truthiness gate (loot_roll.ts skips a copper: 0 row) ON PURPOSE: the test
+// counts every authored copper field, so it over-reports rather than letting
+// a zero-valued row sit unexamined.
+function copperEntries(loot: { copper?: number; chance: number }[] | undefined) {
+  return (loot ?? []).filter((entry) => entry.copper !== undefined);
+}
+
+// Drives the authoritative roller (Sim.rollLoot) the same way combat death
+// does, so the assertion covers the real payout path, not just the record.
+function rolledKorzulCopper(seed: number, kills: number): number[] {
+  const sim = new Sim({ seed, playerClass: 'warrior', noPlayer: true });
+  const pid = sim.addPlayer('warrior', 'Looter');
+  const meta = (sim as unknown as { players: Map<number, unknown> }).players.get(pid);
+  const template = MOBS.korzul_the_gravewyrm;
+  const amounts: number[] = [];
+  for (let i = 0; i < kills; i++) {
+    const mob = createMob(-1, template, template.maxLevel, { x: 0, y: 0, z: 0 });
+    (sim as unknown as { rollLoot: (m: unknown, meta: unknown) => void }).rollLoot(mob, meta);
+    amounts.push(mob.loot?.copper ?? 0);
+  }
+  return amounts;
+}
+
+// Kills the real spawned Korzul inside a real HEROIC instance through the
+// real death path (dealDamage -> handleDeath -> rollLoot with a live heroic
+// claim), mirroring the rig in tests/heroic_loot_flair.test.ts.
+function heroicKillCopper(seed: number): number {
+  const sim = new Sim({ seed, playerClass: 'warrior', noPlayer: true });
+  const s = sim as unknown as Record<string, any>;
+  const pid = sim.addPlayer('warrior', 'Solo');
+  sim.setDungeonDifficulty('heroic', pid);
+  enterDungeon(s.ctx, 'gravewyrm_sanctum', pid);
+  const inst = (s.instances as any[]).find(
+    (i) => i.dungeonId === 'gravewyrm_sanctum' && i.difficulty === 'heroic' && i.partyKey !== null,
+  );
+  const korzul = inst.mobIds
+    .map((id: number) => s.entities.get(id))
+    .find((e: any) => e?.templateId === 'korzul_the_gravewyrm');
+  const p = s.entities.get(pid);
+  p.pos = { x: korzul.pos.x + 1, y: korzul.pos.y, z: korzul.pos.z };
+  p.prevPos = { ...p.pos };
+  s.rebucket(p);
+  s.dealDamage(p, korzul, korzul.hp + 100, false, 'physical', null, 'hit');
+  return korzul.loot?.copper ?? 0;
+}
+
+describe('Gravewyrm Sanctum end-boss gold (farm fix)', () => {
+  it('pins Korzul to exactly one guaranteed money entry at the 15000c base', () => {
+    // The roller ACCUMULATES copper across matching entries, so the count is
+    // load-bearing: a second entry would reintroduce the payout with the
+    // per-entry pin still green.
+    const money = copperEntries(MOBS.korzul_the_gravewyrm.loot);
+    expect(money).toHaveLength(1);
+    expect(money[0].copper).toBe(KORZUL_BASE_COPPER);
+    expect(money[0].chance).toBe(1);
+  });
+
+  it('keeps the heroic append table free of money entries', () => {
+    // Heroic Korzul pays through the same base money entry: the heroic
+    // append loop handles itemId rows only and IGNORES a copper field, so a
+    // copper row here would silently pay nothing while burning a chance
+    // draw. This pins that no one authors one; the only live payout vector
+    // is the base table's single money entry, pinned above.
+    expect(copperEntries(HEROIC_BOSS_LOOT.korzul_the_gravewyrm)).toHaveLength(0);
+  });
+
+  it('keeps Korzul the only Sanctum money outlier (whole spawn list derived)', () => {
+    // The two named mid-bosses hold the 5000c line (the 3x premium, not the
+    // old 10x), pinned as literals.
+    expect(copperEntries(MOBS.korgath_the_bound.loot)[0]?.copper).toBe(SIBLING_BOSS_COPPER);
+    expect(copperEntries(MOBS.grand_necromancer_velkhar.loot)[0]?.copper).toBe(SIBLING_BOSS_COPPER);
+    // Then the ceiling is derived over EVERY mob the Sanctum spawns
+    // (summoned adds included), not a hand-picked id pair, so a future mob
+    // authored above the mid-boss line fails here instead of silently
+    // re-opening the farm this change closes. (Only the finale carries
+    // boss: true, so a flag-filtered roster would cover one mob.)
+    const mobIds = new Set(DUNGEON_DEFS.gravewyrm_sanctum.spawns.map((spawn) => spawn.mobId));
+    for (const id of [...mobIds]) {
+      const summoned = MOBS[id].summonAdds?.mobId;
+      if (summoned) mobIds.add(summoned);
+    }
+    expect(mobIds.has('korzul_the_gravewyrm')).toBe(true);
+    expect(mobIds.size).toBeGreaterThanOrEqual(5);
+    for (const id of mobIds) {
+      if (id === 'korzul_the_gravewyrm') continue;
+      for (const entry of copperEntries(MOBS[id].loot)) {
+        expect(entry.copper, id).toBeLessThanOrEqual(SIBLING_BOSS_COPPER);
+      }
+    }
+  });
+
+  it('every rolled payout lands inside the 9000c to 21000c band, edges reached', () => {
+    const amounts = rolledKorzulCopper(1234, 2000);
+    for (const copper of amounts) {
+      expect(copper).toBeGreaterThanOrEqual(ROLLED_MIN_COPPER);
+      expect(copper).toBeLessThanOrEqual(ROLLED_MAX_COPPER);
+    }
+    // Both band edges are approached within EDGE_SLACK_COPPER, so a roller
+    // variance narrowed past ~0.7% fails rather than passing inside a wider
+    // pin, and the spread really is a distribution, not two extremes.
+    expect(Math.min(...amounts)).toBeLessThan(ROLLED_MIN_COPPER + EDGE_SLACK_COPPER);
+    expect(Math.max(...amounts)).toBeGreaterThan(ROLLED_MAX_COPPER - EDGE_SLACK_COPPER);
+    expect(new Set(amounts).size).toBeGreaterThan(1000);
+  });
+
+  it('heroic Korzul pays the same band through the real heroic death path', () => {
+    // The heroic claim path shares the base money entry: no multiplier, no
+    // heroic copper append. Under the old 50000c base every heroic kill paid
+    // at least 30000c, so a single sample outside the band is decisive.
+    for (let seed = 1; seed <= 8; seed++) {
+      const copper = heroicKillCopper(seed);
+      expect(copper, `seed ${seed}`).toBeGreaterThanOrEqual(ROLLED_MIN_COPPER);
+      expect(copper, `seed ${seed}`).toBeLessThanOrEqual(ROLLED_MAX_COPPER);
+    }
+  });
+});

--- a/tests/gravewyrm_boss_gold.test.ts
+++ b/tests/gravewyrm_boss_gold.test.ts
@@ -5,6 +5,7 @@ import { MOBS } from '../src/sim/data';
 import { createMob } from '../src/sim/entity';
 import { enterDungeon } from '../src/sim/instances/dungeons';
 import { Sim } from '../src/sim/sim';
+import type { LootEntry } from '../src/sim/types';
 
 // Gravewyrm Sanctum gold-farm fix: Korzul the Gravewyrm paid a guaranteed
 // 50000c base, rolled to 3g to 7g per kill by the loot roller's 0.6x to 1.4x
@@ -16,9 +17,12 @@ import { Sim } from '../src/sim/sim';
 // is the closest fit to the intended 1g to 2g the fixed variance allows,
 // still a 3x finale premium over the sibling bosses.
 const KORZUL_BASE_COPPER = 15000;
+const KORZUL_HEROIC_COPPER = 100000; // the shared 10g heroic finale base
 const SIBLING_BOSS_COPPER = 5000;
 const ROLLED_MIN_COPPER = 9000; // ceil(15000 * 0.6)
 const ROLLED_MAX_COPPER = 21000; // ceil(15000 * 1.4)
+const HEROIC_ROLLED_MIN_COPPER = 60000; // ceil(100000 * 0.6)
+const HEROIC_ROLLED_MAX_COPPER = 140000; // ceil(100000 * 1.4)
 // How close to each band edge the sampled rolls must reach. Over 2000 uniform
 // draws the chance of missing a 100-wide edge window is about 2e-7 per edge,
 // so this cannot flake, while a roller band narrowed by even ~0.7% fails.
@@ -28,7 +32,7 @@ const EDGE_SLACK_COPPER = 100;
 // truthiness gate (loot_roll.ts skips a copper: 0 row) ON PURPOSE: the test
 // counts every authored copper field, so it over-reports rather than letting
 // a zero-valued row sit unexamined.
-function copperEntries(loot: { copper?: number; chance: number }[] | undefined) {
+function copperEntries(loot: LootEntry[] | undefined) {
   return (loot ?? []).filter((entry) => entry.copper !== undefined);
 }
 
@@ -79,6 +83,7 @@ describe('Gravewyrm Sanctum end-boss gold (farm fix)', () => {
     const money = copperEntries(MOBS.korzul_the_gravewyrm.loot);
     expect(money).toHaveLength(1);
     expect(money[0].copper).toBe(KORZUL_BASE_COPPER);
+    expect(money[0].heroicCopper).toBe(KORZUL_HEROIC_COPPER);
     expect(money[0].chance).toBe(1);
   });
 
@@ -130,14 +135,16 @@ describe('Gravewyrm Sanctum end-boss gold (farm fix)', () => {
     expect(new Set(amounts).size).toBeGreaterThan(1000);
   });
 
-  it('heroic Korzul pays the same band through the real heroic death path', () => {
-    // The heroic claim path shares the base money entry: no multiplier, no
-    // heroic copper append. Under the old 50000c base every heroic kill paid
-    // at least 30000c, so a single sample outside the band is decisive.
+  it('heroic Korzul pays the 10g finale band through the real heroic death path', () => {
+    // The daily-lockout heroic clear substitutes the 100000c finale base on
+    // the same money entry (LootEntry.heroicCopper): every heroic kill pays
+    // 60000c to 140000c. Both the normal band (9000c to 21000c) and the old
+    // 50000c base (30000c to 70000c) are disjoint from parts of this band,
+    // and no sample may fall outside it.
     for (let seed = 1; seed <= 8; seed++) {
       const copper = heroicKillCopper(seed);
-      expect(copper, `seed ${seed}`).toBeGreaterThanOrEqual(ROLLED_MIN_COPPER);
-      expect(copper, `seed ${seed}`).toBeLessThanOrEqual(ROLLED_MAX_COPPER);
+      expect(copper, `seed ${seed}`).toBeGreaterThanOrEqual(HEROIC_ROLLED_MIN_COPPER);
+      expect(copper, `seed ${seed}`).toBeLessThanOrEqual(HEROIC_ROLLED_MAX_COPPER);
     }
   });
 });

--- a/tests/gravewyrm_farm_exploit.test.ts
+++ b/tests/gravewyrm_farm_exploit.test.ts
@@ -11,6 +11,8 @@
 //
 // These tests reproduce each link of the chain and prove it is broken, and pin
 // that legitimate arena bouts and dungeon resets are unaffected.
+// The PAYOUT side of the same farm (Korzul's per-kill gold) is pinned
+// separately in tests/gravewyrm_boss_gold.test.ts.
 
 import { describe, expect, it } from 'vitest';
 import { DUNGEON_X_THRESHOLD } from '../src/sim/data';

--- a/tests/heroic_finale_gold.test.ts
+++ b/tests/heroic_finale_gold.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it } from 'vitest';
+import { HEROIC_DUNGEON_TUNING } from '../src/sim/content/dungeon_difficulty';
+import { HEROIC_BOSS_LOOT } from '../src/sim/content/heroic_loot';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+import { enterDungeon } from '../src/sim/instances/dungeons';
+import { Sim } from '../src/sim/sim';
+import type { LootEntry, MobTemplate } from '../src/sim/types';
+
+// Heroic finale gold (LootEntry.heroicCopper; bases in
+// src/sim/content/dungeon_difficulty.ts, ladder doc in
+// docs/design/dungeon-gold.md): a heroic-claim kill of a dungeon's final
+// boss substitutes a raised money base on the SAME single rng draw.
+// Five-man finales pay 10g nominal (100000c, rolls 60000c to 140000c); the
+// Nythraxis raid finale pays 20g (200000c, rolls 120000c to 280000c).
+// Normal-mode kills keep the modest per-dungeon bases: heroic sits behind
+// the per-dungeon daily lockout, so the raise rewards the legitimate clear
+// without re-opening the repeat farms the normal-mode nerfs closed
+// (tests/gravewyrm_boss_gold.test.ts).
+const FIVE_MAN_HEROIC_COPPER = 100000;
+const RAID_HEROIC_COPPER = 200000;
+const HEROIC_ROLL_MIN = 60000; // ceil(100000 * 0.6)
+const HEROIC_ROLL_MAX = 140000; // ceil(100000 * 1.4)
+const RAID_ROLL_MIN = 120000; // ceil(200000 * 0.6)
+const RAID_ROLL_MAX = 280000; // ceil(200000 * 1.4)
+const NORMAL_ROLL_MIN = 9000; // ceil(15000 * 0.6)
+const NORMAL_ROLL_MAX = 21000; // ceil(15000 * 1.4)
+// The full normal-mode finale money ladder, pinned so a single-boss retune
+// (up or down) is a deliberate edit here, not a drive-by.
+const NORMAL_FINALE_COPPER: Record<string, number> = {
+  hollow_crypt: 2500,
+  sunken_bastion: 5000,
+  drowned_temple: 6000,
+  gravewyrm_sanctum: 15000,
+  wildheart_basin: 15000,
+  nythraxis_boss_arena: 150000,
+};
+
+function copperEntries(loot: LootEntry[] | undefined) {
+  return (loot ?? []).filter((entry) => entry.copper !== undefined);
+}
+
+function heroicBandFor(dungeonId: string): { min: number; max: number } {
+  return dungeonId === 'nythraxis_boss_arena'
+    ? { min: RAID_ROLL_MIN, max: RAID_ROLL_MAX }
+    : { min: HEROIC_ROLL_MIN, max: HEROIC_ROLL_MAX };
+}
+
+// Kills the real spawned finale boss inside a real instance through the real
+// death path (dealDamage -> handleDeath -> rollLoot with a live claim), the
+// tests/heroic_loot_flair.test.ts rig.
+function instanceKillCopper(
+  dungeonId: string,
+  bossTemplateId: string,
+  seed: number,
+  difficulty: 'normal' | 'heroic',
+): number {
+  const sim = new Sim({ seed, playerClass: 'warrior', noPlayer: true });
+  const s = sim as unknown as Record<string, any>;
+  const pid = sim.addPlayer('warrior', 'Solo');
+  if (difficulty === 'heroic') sim.setDungeonDifficulty('heroic', pid);
+  enterDungeon(s.ctx, dungeonId, pid);
+  const inst = (s.instances as any[]).find(
+    (i) => i.dungeonId === dungeonId && i.difficulty === difficulty && i.partyKey !== null,
+  );
+  const boss = inst.mobIds
+    .map((id: number) => s.entities.get(id))
+    .find((e: any) => e?.templateId === bossTemplateId);
+  const p = s.entities.get(pid);
+  p.pos = { x: boss.pos.x + 1, y: boss.pos.y, z: boss.pos.z };
+  p.prevPos = { ...p.pos };
+  s.rebucket(p);
+  s.dealDamage(p, boss, boss.hp + 100, false, 'physical', null, 'hit');
+  return boss.loot?.copper ?? 0;
+}
+
+// Drives the roller directly, optionally under a SYNTHETIC heroic claim (a
+// minimal instance record covering the mob id: the same three fields the
+// roller's heroicClaim predicate reads). Returns the rolled copper plus one
+// post-roll rng draw as a stream-position probe.
+function rollWithClaim(
+  template: MobTemplate,
+  heroic: boolean,
+  seed: number,
+): { copper: number; probe: number } {
+  const sim = new Sim({ seed, playerClass: 'warrior', noPlayer: true });
+  const s = sim as unknown as Record<string, any>;
+  const pid = sim.addPlayer('warrior', 'Looter');
+  const meta = s.players.get(pid);
+  const mob = createMob(-1, template, template.maxLevel, { x: 0, y: 0, z: 0 });
+  if (heroic) {
+    (s.instances as any[]).push({
+      dungeonId: 'synthetic_probe',
+      difficulty: 'heroic',
+      partyKey: 'probe',
+      mobIds: [mob.id],
+    });
+  }
+  s.rollLoot(mob, meta);
+  return { copper: mob.loot?.copper ?? 0, probe: s.ctx.rng.next() };
+}
+
+describe('heroic finale gold policy', () => {
+  it('every heroic dungeon finale carries the heroic money base, raid at 20g', () => {
+    const tunings = Object.values(HEROIC_DUNGEON_TUNING);
+    // Vacuity floor: the live registry holds the five 5-mans plus the raid.
+    expect(tunings.length).toBeGreaterThanOrEqual(6);
+    for (const tuning of tunings) {
+      const money = copperEntries(MOBS[tuning.finalBossId].loot);
+      expect(money, tuning.id).toHaveLength(1);
+      expect(money[0].chance, tuning.id).toBe(1);
+      expect(money[0].copper, tuning.id).toBe(NORMAL_FINALE_COPPER[tuning.id]);
+      // The roller's money arm gates on a truthy copper, so a heroicCopper
+      // riding a zero base would silently pay nothing on heroic.
+      expect(money[0].copper, tuning.id).toBeGreaterThan(0);
+      const expectedHeroic =
+        tuning.id === 'nythraxis_boss_arena' ? RAID_HEROIC_COPPER : FIVE_MAN_HEROIC_COPPER;
+      expect(money[0].heroicCopper, tuning.id).toBe(expectedHeroic);
+    }
+    // The ladder table covers exactly the live registry (a new heroic
+    // dungeon must take a deliberate row here).
+    expect(Object.keys(NORMAL_FINALE_COPPER).sort()).toEqual(tunings.map((t) => t.id).sort());
+  });
+
+  it('no mob outside the heroic finale set carries the heroic money base', () => {
+    const finaleBossIds = new Set(
+      Object.values(HEROIC_DUNGEON_TUNING).map((tuning) => tuning.finalBossId),
+    );
+    const carriers = Object.values(MOBS)
+      .filter((mob) => (mob.loot ?? []).some((entry) => entry.heroicCopper !== undefined))
+      .map((mob) => mob.id)
+      .sort();
+    expect(carriers).toEqual([...finaleBossIds].sort());
+  });
+
+  it('no heroic append table anywhere carries money entries', () => {
+    // The heroic append loop handles itemId rows only and IGNORES a copper
+    // field, so a copper row in any HEROIC_BOSS_LOOT table would silently
+    // pay nothing while burning a chance draw.
+    const tables = Object.entries(HEROIC_BOSS_LOOT);
+    expect(tables.length).toBeGreaterThanOrEqual(6);
+    for (const [bossId, rows] of tables) {
+      expect(copperEntries(rows), bossId).toHaveLength(0);
+    }
+  });
+
+  it('every finale rolls its heroic band under a live heroic claim', () => {
+    // Covers all six finales through the roller, the 20g raid value
+    // included, via the synthetic-claim rig (the real-rig kills below prove
+    // the claim plumbing end to end for one dungeon per difficulty).
+    for (const tuning of Object.values(HEROIC_DUNGEON_TUNING)) {
+      const { min, max } = heroicBandFor(tuning.id);
+      for (let seed = 1; seed <= 3; seed++) {
+        const { copper } = rollWithClaim(MOBS[tuning.finalBossId], true, seed * 101);
+        expect(copper, `${tuning.id} seed ${seed}`).toBeGreaterThanOrEqual(min);
+        expect(copper, `${tuning.id} seed ${seed}`).toBeLessThanOrEqual(max);
+      }
+    }
+  });
+
+  it('the heroic substitution keeps the rng stream position identical', () => {
+    // Same seed, same synthetic template (registered into MOBS because the
+    // roller resolves the table by templateId, and absent from
+    // HEROIC_BOSS_LOOT so the heroic-only item append cannot add draws),
+    // rolled once without and once with a heroic claim: the payouts land in
+    // different bands but the post-roll rng probe must match exactly,
+    // proving the substitution is a value swap and never an extra draw.
+    const template: MobTemplate = {
+      ...MOBS.sanctum_boneguard,
+      id: 'synthetic_gold_probe',
+      loot: [{ copper: 1000, heroicCopper: 5000, chance: 1 }],
+    };
+    (MOBS as Record<string, MobTemplate>).synthetic_gold_probe = template;
+    try {
+      const normal = rollWithClaim(template, false, 424242);
+      const heroic = rollWithClaim(template, true, 424242);
+      expect(normal.copper).toBeGreaterThanOrEqual(600);
+      expect(normal.copper).toBeLessThanOrEqual(1400);
+      expect(heroic.copper).toBeGreaterThanOrEqual(3000);
+      expect(heroic.copper).toBeLessThanOrEqual(7000);
+      expect(heroic.probe).toBe(normal.probe);
+    } finally {
+      delete (MOBS as Record<string, MobTemplate>).synthetic_gold_probe;
+    }
+  });
+
+  it('heroic Zulgar pays the 10g finale band through the real heroic death path', () => {
+    for (let seed = 1; seed <= 6; seed++) {
+      const copper = instanceKillCopper('wildheart_basin', 'wildheart_high_priest', seed, 'heroic');
+      expect(copper, `seed ${seed}`).toBeGreaterThanOrEqual(HEROIC_ROLL_MIN);
+      expect(copper, `seed ${seed}`).toBeLessThanOrEqual(HEROIC_ROLL_MAX);
+    }
+  });
+
+  it('a live NORMAL instance claim still pays the normal base', () => {
+    // Pins the difficulty clause of the claim predicate: a refactor that
+    // widened heroicClaim to ANY live claim would pay the heroic base here.
+    for (let seed = 1; seed <= 4; seed++) {
+      const copper = instanceKillCopper('wildheart_basin', 'wildheart_high_priest', seed, 'normal');
+      expect(copper, `seed ${seed}`).toBeGreaterThanOrEqual(NORMAL_ROLL_MIN);
+      expect(copper, `seed ${seed}`).toBeLessThanOrEqual(NORMAL_ROLL_MAX);
+    }
+  });
+
+  it('normal-mode Zulgar ignores the heroic base (the farm nerf holds)', () => {
+    // A bare mob outside any instance carries no claim at all, so the roller
+    // must use the 15000c normal base: every payout inside 9000c to 21000c.
+    // Under the old 55000c base every roll paid at least 33000c.
+    const sim = new Sim({ seed: 77, playerClass: 'warrior', noPlayer: true });
+    const pid = sim.addPlayer('warrior', 'Looter');
+    const meta = (sim as unknown as { players: Map<number, unknown> }).players.get(pid);
+    const template = MOBS.wildheart_high_priest;
+    for (let i = 0; i < 500; i++) {
+      const mob = createMob(-1, template, template.maxLevel, { x: 0, y: 0, z: 0 });
+      (sim as unknown as { rollLoot: (m: unknown, meta: unknown) => void }).rollLoot(mob, meta);
+      const copper = mob.loot?.copper ?? 0;
+      expect(copper).toBeGreaterThanOrEqual(NORMAL_ROLL_MIN);
+      expect(copper).toBeLessThanOrEqual(NORMAL_ROLL_MAX);
+    }
+  });
+});

--- a/tests/wildheart.test.ts
+++ b/tests/wildheart.test.ts
@@ -418,7 +418,7 @@ describe('Wildheart Basin Tier-2 loot pass', () => {
       0.06, 0.06, 0.06,
     ]);
     expect(groupSum('wildheart_bonus')).toBeCloseTo(0.18, 9);
-    expect(loot.some((e) => e.copper === 55000 && e.chance === 1)).toBe(true);
+    expect(loot.some((e) => e.copper === 15000 && e.chance === 1)).toBe(true);
     expect(loot.some((e) => e.itemId === 'bone_fragments' && e.chance === 0.8)).toBe(true);
   });
 


### PR DESCRIPTION
## Summary

Closes the dungeon-finale gold farms and gives heroics a real gold reward, in two commits:

1. **fix(content): cut Korzul's gold drop to close the Sanctum gold farm.** Korzul the Gravewyrm paid a guaranteed 50000c base, rolled to 3g to 7g per kill by the loot roller's 0.6x to 1.4x band, 10x the 5000c the other two Sanctum bosses pay, on a lockout-free, skip-pullable finale. The base drops to 15000c (9000c to 21000c rolled, roughly the intended 1g to 2g). The zero-downtime instance-reset exploit was closed separately by #1600; this closes the payout that kept rate-limited repeat pops profitable.
2. **feat(loot): heroic finale gold bases and the Zulgar farm nerf.** New `LootEntry.heroicCopper`: when a kill carries a live heroic instance claim, the roller substitutes the raised base for the normal one on the SAME single rng draw, so draw count and order are unchanged (pinned by an rng stream-position test) and the parity goldens are untouched. All five 5-man heroic finales pay 100000c nominal (10g, rolls 6g to 14g); the heroic Nythraxis raid finale pays 200000c (20g, rolls 12g to 28g). Zulgar (Wildheart Basin) takes the same normal-mode nerf Korzul did, 55000c down to 15000c. The Dungeon Finder loot preview now advertises the heroic base on heroic finales instead of the normal one.

Design anchor: `docs/design/dungeon-gold.md` records the full ladder, the pricing rules, and the daily ceiling (heroic lockouts are per dungeon, so a full heroic circuit mints 70g nominal per day, 42g to 98g rolled). `docs/design/master-spec.md` updated for Korzul's new value.

## Type of change

- [x] Feature: new functionality
- [x] Bug fix

## How was this tested?

- Commands: `GATE_SELECT_BASE=origin/release/v0.38.3 node scripts/gate_select.mjs` (31784 of 31879 tests passed; the only reds across two runs were 20s/90s timeouts in filesystem-heavy suites, `sfx_export_core`, `ci_shard_partition`, `ci_workflow`, unrelated to this diff and green when run solo: local machine contention). Full `tests/parity` (212 tests), `tests/architecture.test.ts`, and the targeted suites (`heroic_finale_gold`, `gravewyrm_boss_gold`, `wildheart`, `dungeon_finder_view`, `heroic_loot_flair`, `loot_roll`, `loot_drops`, `progression`, `dungeons`, `dungeon_difficulty`, `gravewyrm_normal_tuning`, `heroic_difficulty_floors`) all green; `npx tsc --noEmit` clean; biome clean on changed files; `wiki:content` regen produced no diff.
- Test design: new `tests/heroic_finale_gold.test.ts` pins the whole normal-mode finale money ladder, the exact heroicCopper carrier set (equality against `HEROIC_DUNGEON_TUNING` finales), every `HEROIC_BOSS_LOOT` table as money-free, all six finales' heroic bands through the roller, the rng stream position (same seed, normal vs heroic claim, identical post-roll cursor), plus real `enterDungeon` kills through `dealDamage -> handleDeath -> rollLoot` on heroic AND normal claims. `tests/gravewyrm_boss_gold.test.ts` pins Korzul's single money entry, a whole-spawn-list outlier ceiling, and the rolled band with edge-reach assertions over 2000 seeded kills.

## Screenshots / recordings

N/A: the only UI-visible change is the Dungeon Finder gold preview number on heroic finales, pinned by `tests/dungeon_finder_view.test.ts`.

## Checklist

### Quality
- [x] **The gate passes** (see above: two flaky timeout reds in unrelated filesystem-heavy suites, each green solo; everything in this change's blast radius green).

### Cross-platform
- N/A (no new UI surface; the finder preview reuses the existing money formatter and layout).

### Localization (i18n)
- [x] N/A. This PR adds no player-visible strings (money renders through the existing `formatMoney` path).

### Hygiene
- [x] No secrets, no generated-file hand-edits, no `ALLOW_DEV_COMMANDS`.