### PR TITLE
fix(delves): close the Restless Graves portal race and free wedged runs

### DIFF
--- a/docs/prd/delves.md
+++ b/docs/prd/delves.md
@@ -184,7 +184,7 @@ delveDaily: {
 
 | id | name | themes | sim hook |
 |----|------|--------|----------|
-| `restless_graves` | Restless Graves | crypt | Trash may spawn weak undead add after 3s |
+| `restless_graves` | Restless Graves | crypt | Trash spawns a weak undead add 3s after death; pending and risen adds gate the room's exit portal like living trash |
 | `bad_air` | Bad Air | crypt, mine, sewer | Periodic poison aura in marked rooms |
 | `candleblind` | Candleblind | crypt, mine | Reduced `detectRange` in flagged zones |
 | `old_mechanisms` | Old Mechanisms | vault, sewer | Timed door/barrier objects |

--- a/src/sim/delves/runs.ts
+++ b/src/sim/delves/runs.ts
@@ -158,6 +158,13 @@ export function delveOccupancyRadius(run: DelveRun): number {
   return delveModuleZOffsetLayout(run.modules, mi) + span + 40;
 }
 
+/** South edge of the occupancy band, in units south of a run's origin. Module 0
+ *  starts at DELVE_MODULE_Z_START + layout.zMin (about -11, the walkable south
+ *  lip), so 40 leaves ~29u of slack while staying ~100u clear of the neighbor
+ *  slot's rooms (they end 143u south). Pinned from both sides by the two
+ *  south-margin tests in tests/delves.test.ts. */
+export const DELVE_OCCUPANCY_SOUTH_MARGIN = 40;
+
 export function delveRunForEntity(ctx: SimContext, e: Entity): DelveRun | null {
   const byPlayer = delveRunForPlayer(ctx, e.id);
   if (byPlayer) return byPlayer;
@@ -623,16 +630,18 @@ export function updateDelveRuns(ctx: SimContext): void {
     for (const meta of ctx.players.values()) {
       const e = ctx.entities.get(meta.entityId);
       if (!e) continue;
-      // Rooms START at DELVE_MODULE_Z_START + layout.zMin (about -11, so a
-      // player can stand a few units SOUTH of the origin) and extend north up
-      // to ~536u; the neighbor slot's rooms begin 620u away. The old symmetric
-      // +-radius band reached [-536, -143] into the SOUTH neighbor's rooms,
-      // letting busy neighbors pin an abandoned run claimed forever. The -40
-      // south margin covers the walkable south lip with slack while staying
-      // far clear of the neighbor (delveRunForPlayer keeps its symmetric band
-      // on purpose: it is key-gated, so cross-slot binding is unreachable).
+      // Asymmetric band: rooms extend north up to ~536u but only ~11u south
+      // of the origin (see DELVE_OCCUPANCY_SOUTH_MARGIN for the geometry). The
+      // old symmetric +-radius check reached [-536, -143] into the SOUTH
+      // neighbor's rooms (slots sit 620u apart), letting busy neighbors pin an
+      // abandoned run claimed forever. delveRunForPlayer keeps its symmetric
+      // band on purpose: it is key-gated, so cross-slot binding is unreachable.
       const dz = e.pos.z - origin.z;
-      if (Math.abs(e.pos.x - origin.x) < 120 && dz > -40 && dz < delveOccupancyRadius(run)) {
+      if (
+        Math.abs(e.pos.x - origin.x) < 120 &&
+        dz > -DELVE_OCCUPANCY_SOUTH_MARGIN &&
+        dz < delveOccupancyRadius(run)
+      ) {
         occupied = true;
         break;
       }

--- a/src/sim/delves/runs.ts
+++ b/src/sim/delves/runs.ts
@@ -497,6 +497,10 @@ export function spawnDelveModule(ctx: SimContext, run: DelveRun): void {
   run.objectIds = [];
   run.objectState = {};
   run.raiseDeadChannel = null;
+  // Pending Restless Graves spawns are room state: a spawn queued in the old
+  // room must die with it, or it rises there after the advance and joins the
+  // NEW room's mob list, sealing that room's portal forever.
+  run.restlessPending = [];
   run.exitPortalOpen = false;
   run.rewardChestId = null;
   run.surfaceExitId = null;
@@ -614,11 +618,12 @@ export function updateDelveRuns(ctx: SimContext): void {
     let occupied = false;
     for (const meta of ctx.players.values()) {
       const e = ctx.entities.get(meta.entityId);
-      if (
-        e &&
-        Math.abs(e.pos.x - origin.x) < 120 &&
-        Math.abs(e.pos.z - origin.z) < delveOccupancyRadius(run)
-      ) {
+      // Rooms extend only NORTH of the origin (module z offsets are
+      // non-negative), so the band is asymmetric: a symmetric +-radius check
+      // reached ~528u south into the NEIGHBOR slot's rooms (slots sit 620u
+      // apart), letting busy neighbors pin an abandoned run claimed forever.
+      const dz = e ? e.pos.z - origin.z : 0;
+      if (e && Math.abs(e.pos.x - origin.x) < 120 && dz > -40 && dz < delveOccupancyRadius(run)) {
         occupied = true;
         break;
       }
@@ -1014,6 +1019,12 @@ export function tryOpenDelveExitPortal(ctx: SimContext, run: DelveRun): void {
     return e && !e.dead;
   });
   if (liveMobs) return;
+  // Queued Restless Graves spawns count as live: killing the LAST trash in a
+  // room must not open (and latch) the portal inside the 3s grave delay, or the
+  // risen Bonewalkers appear behind an open portal and seal the NEXT room's
+  // gate instead. The tick driver re-checks, so the portal opens normally once
+  // the risen are down.
+  if (run.restlessPending.length > 0) return;
   // Room puzzle gate: every pressure plate in the module must be triggered before
   // the exit opens (Drowned Litany "activate N valves/tablets/candles/ropes"; the
   // Reliquary's plated rooms already require all plates to raise the portcullis, so

--- a/src/sim/delves/runs.ts
+++ b/src/sim/delves/runs.ts
@@ -283,6 +283,10 @@ export function delveRunForPlayer(ctx: SimContext, pid: number): DelveRun | null
   for (const run of ctx.delveRuns) {
     if (run.partyKey !== key) continue;
     const dx = Math.abs(e.pos.x - run.origin.x);
+    // Symmetric band ON PURPOSE, unlike the updateDelveRuns empty sweep's
+    // asymmetric one: this lookup is key-gated (one run per delveId+key, and
+    // delves sit 600u apart in x), so it can never bind a player to a NEIGHBOR
+    // slot's run; the generous band only ever re-finds the caller's own run.
     const dz = Math.abs(e.pos.z - run.origin.z);
     if (dx <= 120 && dz <= delveOccupancyRadius(run)) return run;
   }
@@ -618,12 +622,17 @@ export function updateDelveRuns(ctx: SimContext): void {
     let occupied = false;
     for (const meta of ctx.players.values()) {
       const e = ctx.entities.get(meta.entityId);
-      // Rooms extend only NORTH of the origin (module z offsets are
-      // non-negative), so the band is asymmetric: a symmetric +-radius check
-      // reached ~528u south into the NEIGHBOR slot's rooms (slots sit 620u
-      // apart), letting busy neighbors pin an abandoned run claimed forever.
-      const dz = e ? e.pos.z - origin.z : 0;
-      if (e && Math.abs(e.pos.x - origin.x) < 120 && dz > -40 && dz < delveOccupancyRadius(run)) {
+      if (!e) continue;
+      // Rooms START at DELVE_MODULE_Z_START + layout.zMin (about -11, so a
+      // player can stand a few units SOUTH of the origin) and extend north up
+      // to ~536u; the neighbor slot's rooms begin 620u away. The old symmetric
+      // +-radius band reached [-536, -143] into the SOUTH neighbor's rooms,
+      // letting busy neighbors pin an abandoned run claimed forever. The -40
+      // south margin covers the walkable south lip with slack while staying
+      // far clear of the neighbor (delveRunForPlayer keeps its symmetric band
+      // on purpose: it is key-gated, so cross-slot binding is unreachable).
+      const dz = e.pos.z - origin.z;
+      if (Math.abs(e.pos.x - origin.x) < 120 && dz > -40 && dz < delveOccupancyRadius(run)) {
         occupied = true;
         break;
       }

--- a/tests/delves.test.ts
+++ b/tests/delves.test.ts
@@ -44,7 +44,7 @@ import { solveLockActions } from '../src/sim/lockpick';
 import { PLAYER_BODY_RADIUS } from '../src/sim/pathfind';
 import { Rng } from '../src/sim/rng';
 import { DELVE_IMPLEMENTED_AFFIXES, Sim } from '../src/sim/sim';
-import { type DelveRun, DT, type WorldContent } from '../src/sim/types';
+import { type DelveRun, DT, INSTANCE_EMPTY_TIMEOUT, type WorldContent } from '../src/sim/types';
 import { terrainHeight } from '../src/sim/world';
 
 const DELVE_TEST_WORLD: WorldContent = {
@@ -799,6 +799,108 @@ describe('delve interactables and affixes', () => {
     );
     sim.tick();
     expect(run.restlessPending.length).toBe(0);
+  });
+
+  it('exit portal waits for pending Restless Graves spawns instead of racing them', () => {
+    // Live wedge (prod, 2026-08-17): killing the LAST trash in a room opened the
+    // portal inside the 3s grave delay, so the risen Bonewalkers appeared behind
+    // an already-latched portal and followed the run into the next room's gate.
+    const sim = makeSim();
+    enterReliquary(sim);
+    const run = sim.delveRunForPlayer(sim.playerId)!;
+    run.affixes = ['restless_graves'];
+    run.modules = ['reliquary_bell_niche', 'reliquary_finale'];
+    run.moduleIndex = 0;
+    (sim as any).spawnDelveModule(run);
+    const killAllLiveRunMobs = () => {
+      for (const id of [...run.mobIds]) {
+        const mob = sim.entities.get(id);
+        if (mob && !mob.dead)
+          (sim as any).dealDamage(
+            sim.player,
+            mob,
+            mob.maxHp + 1,
+            false,
+            'physical',
+            null,
+            'hit',
+            true,
+          );
+      }
+    };
+    killAllLiveRunMobs();
+    sim.tick();
+    // The kills queued delayed Bonewalkers; the portal must stay sealed for the
+    // whole pending window even though no live mob exists yet.
+    expect(run.restlessPending.length).toBeGreaterThanOrEqual(1);
+    expect(run.exitPortalOpen).toBe(false);
+    for (let i = 0; i < 20 * 4; i++) sim.tick();
+    // The graves rose: still sealed, now by the live risen.
+    expect(run.restlessPending.length).toBe(0);
+    expect(
+      [...sim.entities.values()].some((e) => e.templateId === 'reliquary_bonewalker' && !e.dead),
+    ).toBe(true);
+    expect(run.exitPortalOpen).toBe(false);
+    // Killing the risen (affix-spawned, so they queue nothing) releases the gate.
+    killAllLiveRunMobs();
+    sim.tick();
+    expect(run.restlessPending.length).toBe(0);
+    expect(run.exitPortalOpen).toBe(true);
+  });
+
+  it('advancing to the next room drops pending Restless Graves spawns with the room', () => {
+    // The pending list is room state: a spawn queued in room N must never rise
+    // after the party advanced (it would land in the OLD room but join the new
+    // room's mob list, sealing that room's portal forever).
+    const sim = makeSim();
+    enterReliquary(sim);
+    const run = sim.delveRunForPlayer(sim.playerId)!;
+    run.affixes = ['restless_graves'];
+    run.modules = ['reliquary_bell_niche', 'reliquary_sunken_ossuary', 'reliquary_finale'];
+    run.moduleIndex = 0;
+    (sim as any).spawnDelveModule(run);
+    const origin = run.origin;
+    // Queue a due spawn exactly as a trash death would, then advance rooms.
+    run.restlessPending.push({
+      at: 0,
+      x: origin.x,
+      z: origin.z + 10,
+      mobId: 'reliquary_bonewalker',
+    });
+    run.moduleIndex = 1;
+    (sim as any).spawnDelveModule(run);
+    expect(run.restlessPending.length).toBe(0);
+    const mobCountAfterAdvance = run.mobIds.length;
+    for (let i = 0; i < 20 * 5; i++) sim.tick();
+    expect(
+      [...sim.entities.values()].some((e) => e.templateId === 'reliquary_bonewalker' && !e.dead),
+    ).toBe(false);
+    expect(run.mobIds.length).toBe(mobCountAfterAdvance);
+  });
+
+  it('a player south of the run origin (the neighbor slot band) does not pin the run occupied', () => {
+    // Rooms extend only NORTH of a run's origin, but the empty-run sweep used a
+    // symmetric +-radius band. With slots 620u apart and a ~528u radius, the
+    // southern half overlapped the neighbor slot's rooms, so busy neighbors
+    // pinned a wedged run claimed forever.
+    const sim = makeSim();
+    enterReliquary(sim);
+    const run = sim.delveRunForPlayer(sim.playerId)!;
+    teleport(sim, run.origin.x, run.origin.z - 400);
+    run.emptyFor = INSTANCE_EMPTY_TIMEOUT - 1;
+    for (let i = 0; i < 21; i++) sim.tick();
+    expect(run.partyKey).toBe(null);
+  });
+
+  it('a player inside the run rooms still pins it occupied', () => {
+    const sim = makeSim();
+    enterReliquary(sim);
+    const run = sim.delveRunForPlayer(sim.playerId)!;
+    teleport(sim, run.origin.x, run.origin.z + 60);
+    run.emptyFor = INSTANCE_EMPTY_TIMEOUT - 1;
+    for (let i = 0; i < 21; i++) sim.tick();
+    expect(run.partyKey).not.toBe(null);
+    expect(run.emptyFor).toBe(0);
   });
 
   it('bad_air affix applies a periodic Bad Air DoT to the party (PRD §6.7)', () => {

--- a/tests/delves.test.ts
+++ b/tests/delves.test.ts
@@ -903,6 +903,32 @@ describe('delve interactables and affixes', () => {
     expect(run.emptyFor).toBe(0);
   });
 
+  it('a player on module 0 south lip (just south of the origin) still pins the run', () => {
+    // Module 0 starts at DELVE_MODULE_Z_START + layout.zMin (about -11), so the
+    // south margin must reach past the walkable lip. This pins the margin from
+    // the inside: shrinking -40 toward 0 frees a run under a standing player.
+    const sim = makeSim();
+    enterReliquary(sim);
+    const run = sim.delveRunForPlayer(sim.playerId)!;
+    teleport(sim, run.origin.x, run.origin.z - 10);
+    run.emptyFor = INSTANCE_EMPTY_TIMEOUT - 1;
+    for (let i = 0; i < 21; i++) sim.tick();
+    expect(run.partyKey).not.toBe(null);
+    expect(run.emptyFor).toBe(0);
+  });
+
+  it('the south margin ends just past the lip, well before the neighbor band', () => {
+    // Pins the margin from the outside: growing -40 back toward the old
+    // symmetric radius re-opens the neighbor-slot pinning bug.
+    const sim = makeSim();
+    enterReliquary(sim);
+    const run = sim.delveRunForPlayer(sim.playerId)!;
+    teleport(sim, run.origin.x, run.origin.z - 45);
+    run.emptyFor = INSTANCE_EMPTY_TIMEOUT - 1;
+    for (let i = 0; i < 21; i++) sim.tick();
+    expect(run.partyKey).toBe(null);
+  });
+
   it('bad_air affix applies a periodic Bad Air DoT to the party (PRD §6.7)', () => {
     const sim = makeSim();
     enterReliquary(sim);


### PR DESCRIPTION
## Summary

Fixes the live production wedge that trapped the character faceless (reported 2026-08-17): a delve run under the Restless Graves affix can become permanently uncompletable, and the broken claim then pins the player because runs are keyed to the durable character key.

Three defects, one module:

1. **Portal race.** Restless Graves queues a Raised Bonewalker 3 seconds after each trash death (`run.restlessPending`). Killing the LAST trash in a room opened and latched the exit portal inside that window, so the risen appeared behind an already-open portal. `tryOpenDelveExitPortal` now counts pending spawns as live; the tick driver re-checks, so the portal opens normally once the risen are down.
2. **Pending spawns survived the room advance.** A spawn queued in room N rose after the party advanced, at room N's coordinates, and joined the new room's `mobIds`, sealing the NEXT room's portal forever (exactly the "adds in the previous room, cannot progress" screenshot from the report). `spawnDelveModule`'s reset now drops the old room's pending list with the room.
3. **Neighbor slots pinned wedged runs claimed.** The empty-run sweep used a symmetric z band (~528u) while slots sit 620u apart and rooms extend only north of the origin, so players in the adjacent slot's rooms kept a wedged run occupied indefinitely (why the player's 20-minute wait never freed it). The band is now asymmetric to match the rooms.

## Type of change

- [x] Bug fix

## How was this tested?

- Commands:
  - `npx vitest run tests/delves.test.ts` (5 new tests: the portal-waits-for-pending race incl. gate release, the cross-room pending drop, the south-band occupancy fix, plus the inside-the-rooms positive control; all reproduce RED on the pre-fix code)
  - `npx vitest run tests/parity tests/architecture.test.ts tests/delves_runs.test.ts`
  - `npx tsc --noEmit`
  - `node scripts/gate_select.mjs` (green)
- Manual steps: none (server-side sim behavior; deterministic tests exercise the real code path)

## Screenshots / recordings

N/A, no UI change.

---

## Checklist

### Quality

- [x] **The gate passes.** `node scripts/gate_select.mjs` is green. I added decisive tests for changed behavior.

### Cross-platform

- ~Tested on desktop and mobile.~ N/A, no UI change.
- ~Accessible.~ N/A.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files.