### PR TITLE
fix(render): gate the streamed world decor on shader compile

### DIFF
--- a/docs/screenshots/eastbrook-vale-rebuild/polish/metadata/after-desktop-ultra.json
+++ b/docs/screenshots/eastbrook-vale-rebuild/polish/metadata/after-desktop-ultra.json
@@ -11,7 +11,7 @@
     "mode": "composite-sha256",
     "algorithm": "sha256",
     "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-    "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+    "fingerprint": "7fedc8aa9a58301b1a0f4ecf242000e3a4e61db768d1e0ac6e7a6b731fd512a2",
     "components": {
       "townAsset": {
         "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -28,7 +28,7 @@
       "runtimeRender": {
         "town": {
           "path": "src/render/eastbrook_town.ts",
-          "sha256": "3cdc80f793321655645c24131b0f05d33f241b4f6229c70d3070427c0e96a3d6"
+          "sha256": "5758a0edab78eb377dfda547c139e0418112ea4a51452c61eb4424cbac09d61f"
         },
         "mailbox": {
           "path": "src/render/mailbox.ts",
@@ -40,7 +40,7 @@
         },
         "renderer": {
           "path": "src/render/renderer.ts",
-          "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+          "sha256": "1fe60f4bf43aa1195c3e0a1a21017f9f42bb265093e0aba7f76d5701d8548660"
         },
         "entityViewPolicy": {
           "path": "src/render/entity_view_policy_core.ts",
@@ -48,7 +48,7 @@
         },
         "viewPriorityPolicy": {
           "path": "src/render/prewarm_policy.ts",
-          "sha256": "6004edc3e7ab4c0205cb0fd554825bac34b1a1a7e269a83dc47e3c09126869ae"
+          "sha256": "c6e1331e61aa3fbe6d01ec051f17591295f7f72cb872d7ad9fe1353c4dcd81be"
         }
       },
       "mailbox": {
@@ -89,7 +89,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "7fedc8aa9a58301b1a0f4ecf242000e3a4e61db768d1e0ac6e7a6b731fd512a2",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -106,7 +106,7 @@
           "runtimeRender": {
             "town": {
               "path": "src/render/eastbrook_town.ts",
-              "sha256": "3cdc80f793321655645c24131b0f05d33f241b4f6229c70d3070427c0e96a3d6"
+              "sha256": "5758a0edab78eb377dfda547c139e0418112ea4a51452c61eb4424cbac09d61f"
             },
             "mailbox": {
               "path": "src/render/mailbox.ts",
@@ -118,7 +118,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "1fe60f4bf43aa1195c3e0a1a21017f9f42bb265093e0aba7f76d5701d8548660"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -126,7 +126,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "6004edc3e7ab4c0205cb0fd554825bac34b1a1a7e269a83dc47e3c09126869ae"
+              "sha256": "c6e1331e61aa3fbe6d01ec051f17591295f7f72cb872d7ad9fe1353c4dcd81be"
             }
           },
           "mailbox": {
@@ -1385,7 +1385,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "7fedc8aa9a58301b1a0f4ecf242000e3a4e61db768d1e0ac6e7a6b731fd512a2",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -1402,7 +1402,7 @@
           "runtimeRender": {
             "town": {
               "path": "src/render/eastbrook_town.ts",
-              "sha256": "3cdc80f793321655645c24131b0f05d33f241b4f6229c70d3070427c0e96a3d6"
+              "sha256": "5758a0edab78eb377dfda547c139e0418112ea4a51452c61eb4424cbac09d61f"
             },
             "mailbox": {
               "path": "src/render/mailbox.ts",
@@ -1414,7 +1414,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "1fe60f4bf43aa1195c3e0a1a21017f9f42bb265093e0aba7f76d5701d8548660"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -1422,7 +1422,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "6004edc3e7ab4c0205cb0fd554825bac34b1a1a7e269a83dc47e3c09126869ae"
+              "sha256": "c6e1331e61aa3fbe6d01ec051f17591295f7f72cb872d7ad9fe1353c4dcd81be"
             }
           },
           "mailbox": {
@@ -2681,7 +2681,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "7fedc8aa9a58301b1a0f4ecf242000e3a4e61db768d1e0ac6e7a6b731fd512a2",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -2698,7 +2698,7 @@
           "runtimeRender": {
             "town": {
               "path": "src/render/eastbrook_town.ts",
-              "sha256": "3cdc80f793321655645c24131b0f05d33f241b4f6229c70d3070427c0e96a3d6"
+              "sha256": "5758a0edab78eb377dfda547c139e0418112ea4a51452c61eb4424cbac09d61f"
             },
             "mailbox": {
               "path": "src/render/mailbox.ts",
@@ -2710,7 +2710,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "1fe60f4bf43aa1195c3e0a1a21017f9f42bb265093e0aba7f76d5701d8548660"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -2718,7 +2718,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "6004edc3e7ab4c0205cb0fd554825bac34b1a1a7e269a83dc47e3c09126869ae"
+              "sha256": "c6e1331e61aa3fbe6d01ec051f17591295f7f72cb872d7ad9fe1353c4dcd81be"
             }
           },
           "mailbox": {
@@ -3977,7 +3977,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "7fedc8aa9a58301b1a0f4ecf242000e3a4e61db768d1e0ac6e7a6b731fd512a2",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -3994,7 +3994,7 @@
           "runtimeRender": {
             "town": {
               "path": "src/render/eastbrook_town.ts",
-              "sha256": "3cdc80f793321655645c24131b0f05d33f241b4f6229c70d3070427c0e96a3d6"
+              "sha256": "5758a0edab78eb377dfda547c139e0418112ea4a51452c61eb4424cbac09d61f"
             },
             "mailbox": {
               "path": "src/render/mailbox.ts",
@@ -4006,7 +4006,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "1fe60f4bf43aa1195c3e0a1a21017f9f42bb265093e0aba7f76d5701d8548660"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -4014,7 +4014,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "6004edc3e7ab4c0205cb0fd554825bac34b1a1a7e269a83dc47e3c09126869ae"
+              "sha256": "c6e1331e61aa3fbe6d01ec051f17591295f7f72cb872d7ad9fe1353c4dcd81be"
             }
           },
           "mailbox": {
@@ -5273,7 +5273,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "7fedc8aa9a58301b1a0f4ecf242000e3a4e61db768d1e0ac6e7a6b731fd512a2",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -5290,7 +5290,7 @@
           "runtimeRender": {
             "town": {
               "path": "src/render/eastbrook_town.ts",
-              "sha256": "3cdc80f793321655645c24131b0f05d33f241b4f6229c70d3070427c0e96a3d6"
+              "sha256": "5758a0edab78eb377dfda547c139e0418112ea4a51452c61eb4424cbac09d61f"
             },
             "mailbox": {
               "path": "src/render/mailbox.ts",
@@ -5302,7 +5302,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "1fe60f4bf43aa1195c3e0a1a21017f9f42bb265093e0aba7f76d5701d8548660"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -5310,7 +5310,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "6004edc3e7ab4c0205cb0fd554825bac34b1a1a7e269a83dc47e3c09126869ae"
+              "sha256": "c6e1331e61aa3fbe6d01ec051f17591295f7f72cb872d7ad9fe1353c4dcd81be"
             }
           },
           "mailbox": {
@@ -6569,7 +6569,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "7fedc8aa9a58301b1a0f4ecf242000e3a4e61db768d1e0ac6e7a6b731fd512a2",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -6586,7 +6586,7 @@
           "runtimeRender": {
             "town": {
               "path": "src/render/eastbrook_town.ts",
-              "sha256": "3cdc80f793321655645c24131b0f05d33f241b4f6229c70d3070427c0e96a3d6"
+              "sha256": "5758a0edab78eb377dfda547c139e0418112ea4a51452c61eb4424cbac09d61f"
             },
             "mailbox": {
               "path": "src/render/mailbox.ts",
@@ -6598,7 +6598,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "1fe60f4bf43aa1195c3e0a1a21017f9f42bb265093e0aba7f76d5701d8548660"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -6606,7 +6606,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "6004edc3e7ab4c0205cb0fd554825bac34b1a1a7e269a83dc47e3c09126869ae"
+              "sha256": "c6e1331e61aa3fbe6d01ec051f17591295f7f72cb872d7ad9fe1353c4dcd81be"
             }
           },
           "mailbox": {
@@ -7865,7 +7865,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "7fedc8aa9a58301b1a0f4ecf242000e3a4e61db768d1e0ac6e7a6b731fd512a2",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -7882,7 +7882,7 @@
           "runtimeRender": {
             "town": {
               "path": "src/render/eastbrook_town.ts",
-              "sha256": "3cdc80f793321655645c24131b0f05d33f241b4f6229c70d3070427c0e96a3d6"
+              "sha256": "5758a0edab78eb377dfda547c139e0418112ea4a51452c61eb4424cbac09d61f"
             },
             "mailbox": {
               "path": "src/render/mailbox.ts",
@@ -7894,7 +7894,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "1fe60f4bf43aa1195c3e0a1a21017f9f42bb265093e0aba7f76d5701d8548660"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -7902,7 +7902,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "6004edc3e7ab4c0205cb0fd554825bac34b1a1a7e269a83dc47e3c09126869ae"
+              "sha256": "c6e1331e61aa3fbe6d01ec051f17591295f7f72cb872d7ad9fe1353c4dcd81be"
             }
           },
           "mailbox": {
@@ -9161,7 +9161,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "7fedc8aa9a58301b1a0f4ecf242000e3a4e61db768d1e0ac6e7a6b731fd512a2",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -9178,7 +9178,7 @@
           "runtimeRender": {
             "town": {
               "path": "src/render/eastbrook_town.ts",
-              "sha256": "3cdc80f793321655645c24131b0f05d33f241b4f6229c70d3070427c0e96a3d6"
+              "sha256": "5758a0edab78eb377dfda547c139e0418112ea4a51452c61eb4424cbac09d61f"
             },
             "mailbox": {
               "path": "src/render/mailbox.ts",
@@ -9190,7 +9190,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "1fe60f4bf43aa1195c3e0a1a21017f9f42bb265093e0aba7f76d5701d8548660"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -9198,7 +9198,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "6004edc3e7ab4c0205cb0fd554825bac34b1a1a7e269a83dc47e3c09126869ae"
+              "sha256": "c6e1331e61aa3fbe6d01ec051f17591295f7f72cb872d7ad9fe1353c4dcd81be"
             }
           },
           "mailbox": {
@@ -10457,7 +10457,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "7fedc8aa9a58301b1a0f4ecf242000e3a4e61db768d1e0ac6e7a6b731fd512a2",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -10474,7 +10474,7 @@
           "runtimeRender": {
             "town": {
               "path": "src/render/eastbrook_town.ts",
-              "sha256": "3cdc80f793321655645c24131b0f05d33f241b4f6229c70d3070427c0e96a3d6"
+              "sha256": "5758a0edab78eb377dfda547c139e0418112ea4a51452c61eb4424cbac09d61f"
             },
             "mailbox": {
               "path": "src/render/mailbox.ts",
@@ -10486,7 +10486,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "1fe60f4bf43aa1195c3e0a1a21017f9f42bb265093e0aba7f76d5701d8548660"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -10494,7 +10494,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "6004edc3e7ab4c0205cb0fd554825bac34b1a1a7e269a83dc47e3c09126869ae"
+              "sha256": "c6e1331e61aa3fbe6d01ec051f17591295f7f72cb872d7ad9fe1353c4dcd81be"
             }
           },
           "mailbox": {
@@ -11753,7 +11753,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "7fedc8aa9a58301b1a0f4ecf242000e3a4e61db768d1e0ac6e7a6b731fd512a2",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -11770,7 +11770,7 @@
           "runtimeRender": {
             "town": {
               "path": "src/render/eastbrook_town.ts",
-              "sha256": "3cdc80f793321655645c24131b0f05d33f241b4f6229c70d3070427c0e96a3d6"
+              "sha256": "5758a0edab78eb377dfda547c139e0418112ea4a51452c61eb4424cbac09d61f"
             },
             "mailbox": {
               "path": "src/render/mailbox.ts",
@@ -11782,7 +11782,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "1fe60f4bf43aa1195c3e0a1a21017f9f42bb265093e0aba7f76d5701d8548660"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -11790,7 +11790,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "6004edc3e7ab4c0205cb0fd554825bac34b1a1a7e269a83dc47e3c09126869ae"
+              "sha256": "c6e1331e61aa3fbe6d01ec051f17591295f7f72cb872d7ad9fe1353c4dcd81be"
             }
           },
           "mailbox": {
@@ -13049,7 +13049,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "7fedc8aa9a58301b1a0f4ecf242000e3a4e61db768d1e0ac6e7a6b731fd512a2",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -13066,7 +13066,7 @@
           "runtimeRender": {
             "town": {
               "path": "src/render/eastbrook_town.ts",
-              "sha256": "3cdc80f793321655645c24131b0f05d33f241b4f6229c70d3070427c0e96a3d6"
+              "sha256": "5758a0edab78eb377dfda547c139e0418112ea4a51452c61eb4424cbac09d61f"
             },
             "mailbox": {
               "path": "src/render/mailbox.ts",
@@ -13078,7 +13078,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "1fe60f4bf43aa1195c3e0a1a21017f9f42bb265093e0aba7f76d5701d8548660"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -13086,7 +13086,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "6004edc3e7ab4c0205cb0fd554825bac34b1a1a7e269a83dc47e3c09126869ae"
+              "sha256": "c6e1331e61aa3fbe6d01ec051f17591295f7f72cb872d7ad9fe1353c4dcd81be"
             }
           },
           "mailbox": {
@@ -14345,7 +14345,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "7fedc8aa9a58301b1a0f4ecf242000e3a4e61db768d1e0ac6e7a6b731fd512a2",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -14362,7 +14362,7 @@
           "runtimeRender": {
             "town": {
               "path": "src/render/eastbrook_town.ts",
-              "sha256": "3cdc80f793321655645c24131b0f05d33f241b4f6229c70d3070427c0e96a3d6"
+              "sha256": "5758a0edab78eb377dfda547c139e0418112ea4a51452c61eb4424cbac09d61f"
             },
             "mailbox": {
               "path": "src/render/mailbox.ts",
@@ -14374,7 +14374,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "1fe60f4bf43aa1195c3e0a1a21017f9f42bb265093e0aba7f76d5701d8548660"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -14382,7 +14382,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "6004edc3e7ab4c0205cb0fd554825bac34b1a1a7e269a83dc47e3c09126869ae"
+              "sha256": "c6e1331e61aa3fbe6d01ec051f17591295f7f72cb872d7ad9fe1353c4dcd81be"
             }
           },
           "mailbox": {
@@ -15641,7 +15641,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "7fedc8aa9a58301b1a0f4ecf242000e3a4e61db768d1e0ac6e7a6b731fd512a2",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -15658,7 +15658,7 @@
           "runtimeRender": {
             "town": {
               "path": "src/render/eastbrook_town.ts",
-              "sha256": "3cdc80f793321655645c24131b0f05d33f241b4f6229c70d3070427c0e96a3d6"
+              "sha256": "5758a0edab78eb377dfda547c139e0418112ea4a51452c61eb4424cbac09d61f"
             },
             "mailbox": {
               "path": "src/render/mailbox.ts",
@@ -15670,7 +15670,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "1fe60f4bf43aa1195c3e0a1a21017f9f42bb265093e0aba7f76d5701d8548660"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -15678,7 +15678,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "6004edc3e7ab4c0205cb0fd554825bac34b1a1a7e269a83dc47e3c09126869ae"
+              "sha256": "c6e1331e61aa3fbe6d01ec051f17591295f7f72cb872d7ad9fe1353c4dcd81be"
             }
           },
           "mailbox": {
@@ -16937,7 +16937,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "7fedc8aa9a58301b1a0f4ecf242000e3a4e61db768d1e0ac6e7a6b731fd512a2",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -16954,7 +16954,7 @@
           "runtimeRender": {
             "town": {
               "path": "src/render/eastbrook_town.ts",
-              "sha256": "3cdc80f793321655645c24131b0f05d33f241b4f6229c70d3070427c0e96a3d6"
+              "sha256": "5758a0edab78eb377dfda547c139e0418112ea4a51452c61eb4424cbac09d61f"
             },
             "mailbox": {
               "path": "src/render/mailbox.ts",
@@ -16966,7 +16966,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "1fe60f4bf43aa1195c3e0a1a21017f9f42bb265093e0aba7f76d5701d8548660"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -16974,7 +16974,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "6004edc3e7ab4c0205cb0fd554825bac34b1a1a7e269a83dc47e3c09126869ae"
+              "sha256": "c6e1331e61aa3fbe6d01ec051f17591295f7f72cb872d7ad9fe1353c4dcd81be"
             }
           },
           "mailbox": {
@@ -19198,7 +19198,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "7fedc8aa9a58301b1a0f4ecf242000e3a4e61db768d1e0ac6e7a6b731fd512a2",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -19215,7 +19215,7 @@
           "runtimeRender": {
             "town": {
               "path": "src/render/eastbrook_town.ts",
-              "sha256": "3cdc80f793321655645c24131b0f05d33f241b4f6229c70d3070427c0e96a3d6"
+              "sha256": "5758a0edab78eb377dfda547c139e0418112ea4a51452c61eb4424cbac09d61f"
             },
             "mailbox": {
               "path": "src/render/mailbox.ts",
@@ -19227,7 +19227,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "1fe60f4bf43aa1195c3e0a1a21017f9f42bb265093e0aba7f76d5701d8548660"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -19235,7 +19235,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "6004edc3e7ab4c0205cb0fd554825bac34b1a1a7e269a83dc47e3c09126869ae"
+              "sha256": "c6e1331e61aa3fbe6d01ec051f17591295f7f72cb872d7ad9fe1353c4dcd81be"
             }
           },
           "mailbox": {
@@ -20494,7 +20494,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "7fedc8aa9a58301b1a0f4ecf242000e3a4e61db768d1e0ac6e7a6b731fd512a2",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -20511,7 +20511,7 @@
           "runtimeRender": {
             "town": {
               "path": "src/render/eastbrook_town.ts",
-              "sha256": "3cdc80f793321655645c24131b0f05d33f241b4f6229c70d3070427c0e96a3d6"
+              "sha256": "5758a0edab78eb377dfda547c139e0418112ea4a51452c61eb4424cbac09d61f"
             },
             "mailbox": {
               "path": "src/render/mailbox.ts",
@@ -20523,7 +20523,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "1fe60f4bf43aa1195c3e0a1a21017f9f42bb265093e0aba7f76d5701d8548660"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -20531,7 +20531,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "6004edc3e7ab4c0205cb0fd554825bac34b1a1a7e269a83dc47e3c09126869ae"
+              "sha256": "c6e1331e61aa3fbe6d01ec051f17591295f7f72cb872d7ad9fe1353c4dcd81be"
             }
           },
           "mailbox": {
@@ -21790,7 +21790,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "7fedc8aa9a58301b1a0f4ecf242000e3a4e61db768d1e0ac6e7a6b731fd512a2",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -21807,7 +21807,7 @@
           "runtimeRender": {
             "town": {
               "path": "src/render/eastbrook_town.ts",
-              "sha256": "3cdc80f793321655645c24131b0f05d33f241b4f6229c70d3070427c0e96a3d6"
+              "sha256": "5758a0edab78eb377dfda547c139e0418112ea4a51452c61eb4424cbac09d61f"
             },
             "mailbox": {
               "path": "src/render/mailbox.ts",
@@ -21819,7 +21819,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "1fe60f4bf43aa1195c3e0a1a21017f9f42bb265093e0aba7f76d5701d8548660"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -21827,7 +21827,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "6004edc3e7ab4c0205cb0fd554825bac34b1a1a7e269a83dc47e3c09126869ae"
+              "sha256": "c6e1331e61aa3fbe6d01ec051f17591295f7f72cb872d7ad9fe1353c4dcd81be"
             }
           },
           "mailbox": {
@@ -23086,7 +23086,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "7fedc8aa9a58301b1a0f4ecf242000e3a4e61db768d1e0ac6e7a6b731fd512a2",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -23103,7 +23103,7 @@
           "runtimeRender": {
             "town": {
               "path": "src/render/eastbrook_town.ts",
-              "sha256": "3cdc80f793321655645c24131b0f05d33f241b4f6229c70d3070427c0e96a3d6"
+              "sha256": "5758a0edab78eb377dfda547c139e0418112ea4a51452c61eb4424cbac09d61f"
             },
             "mailbox": {
               "path": "src/render/mailbox.ts",
@@ -23115,7 +23115,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "1fe60f4bf43aa1195c3e0a1a21017f9f42bb265093e0aba7f76d5701d8548660"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -23123,7 +23123,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "6004edc3e7ab4c0205cb0fd554825bac34b1a1a7e269a83dc47e3c09126869ae"
+              "sha256": "c6e1331e61aa3fbe6d01ec051f17591295f7f72cb872d7ad9fe1353c4dcd81be"
             }
           },
           "mailbox": {
@@ -24382,7 +24382,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "7fedc8aa9a58301b1a0f4ecf242000e3a4e61db768d1e0ac6e7a6b731fd512a2",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -24399,7 +24399,7 @@
           "runtimeRender": {
             "town": {
               "path": "src/render/eastbrook_town.ts",
-              "sha256": "3cdc80f793321655645c24131b0f05d33f241b4f6229c70d3070427c0e96a3d6"
+              "sha256": "5758a0edab78eb377dfda547c139e0418112ea4a51452c61eb4424cbac09d61f"
             },
             "mailbox": {
               "path": "src/render/mailbox.ts",
@@ -24411,7 +24411,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "1fe60f4bf43aa1195c3e0a1a21017f9f42bb265093e0aba7f76d5701d8548660"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -24419,7 +24419,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "6004edc3e7ab4c0205cb0fd554825bac34b1a1a7e269a83dc47e3c09126869ae"
+              "sha256": "c6e1331e61aa3fbe6d01ec051f17591295f7f72cb872d7ad9fe1353c4dcd81be"
             }
           },
           "mailbox": {
@@ -25678,7 +25678,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "7fedc8aa9a58301b1a0f4ecf242000e3a4e61db768d1e0ac6e7a6b731fd512a2",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -25695,7 +25695,7 @@
           "runtimeRender": {
             "town": {
               "path": "src/render/eastbrook_town.ts",
-              "sha256": "3cdc80f793321655645c24131b0f05d33f241b4f6229c70d3070427c0e96a3d6"
+              "sha256": "5758a0edab78eb377dfda547c139e0418112ea4a51452c61eb4424cbac09d61f"
             },
             "mailbox": {
               "path": "src/render/mailbox.ts",
@@ -25707,7 +25707,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "1fe60f4bf43aa1195c3e0a1a21017f9f42bb265093e0aba7f76d5701d8548660"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -25715,7 +25715,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "6004edc3e7ab4c0205cb0fd554825bac34b1a1a7e269a83dc47e3c09126869ae"
+              "sha256": "c6e1331e61aa3fbe6d01ec051f17591295f7f72cb872d7ad9fe1353c4dcd81be"
             }
           },
           "mailbox": {
@@ -26974,7 +26974,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "7fedc8aa9a58301b1a0f4ecf242000e3a4e61db768d1e0ac6e7a6b731fd512a2",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -26991,7 +26991,7 @@
           "runtimeRender": {
             "town": {
               "path": "src/render/eastbrook_town.ts",
-              "sha256": "3cdc80f793321655645c24131b0f05d33f241b4f6229c70d3070427c0e96a3d6"
+              "sha256": "5758a0edab78eb377dfda547c139e0418112ea4a51452c61eb4424cbac09d61f"
             },
             "mailbox": {
               "path": "src/render/mailbox.ts",
@@ -27003,7 +27003,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "1fe60f4bf43aa1195c3e0a1a21017f9f42bb265093e0aba7f76d5701d8548660"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -27011,7 +27011,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "6004edc3e7ab4c0205cb0fd554825bac34b1a1a7e269a83dc47e3c09126869ae"
+              "sha256": "c6e1331e61aa3fbe6d01ec051f17591295f7f72cb872d7ad9fe1353c4dcd81be"
             }
           },
           "mailbox": {
@@ -28323,7 +28323,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "7fedc8aa9a58301b1a0f4ecf242000e3a4e61db768d1e0ac6e7a6b731fd512a2",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -28340,7 +28340,7 @@
           "runtimeRender": {
             "town": {
               "path": "src/render/eastbrook_town.ts",
-              "sha256": "3cdc80f793321655645c24131b0f05d33f241b4f6229c70d3070427c0e96a3d6"
+              "sha256": "5758a0edab78eb377dfda547c139e0418112ea4a51452c61eb4424cbac09d61f"
             },
             "mailbox": {
               "path": "src/render/mailbox.ts",
@@ -28352,7 +28352,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "1fe60f4bf43aa1195c3e0a1a21017f9f42bb265093e0aba7f76d5701d8548660"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -28360,7 +28360,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "6004edc3e7ab4c0205cb0fd554825bac34b1a1a7e269a83dc47e3c09126869ae"
+              "sha256": "c6e1331e61aa3fbe6d01ec051f17591295f7f72cb872d7ad9fe1353c4dcd81be"
             }
           },
           "mailbox": {
@@ -29619,7 +29619,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "7fedc8aa9a58301b1a0f4ecf242000e3a4e61db768d1e0ac6e7a6b731fd512a2",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -29636,7 +29636,7 @@
           "runtimeRender": {
             "town": {
               "path": "src/render/eastbrook_town.ts",
-              "sha256": "3cdc80f793321655645c24131b0f05d33f241b4f6229c70d3070427c0e96a3d6"
+              "sha256": "5758a0edab78eb377dfda547c139e0418112ea4a51452c61eb4424cbac09d61f"
             },
             "mailbox": {
               "path": "src/render/mailbox.ts",
@@ -29648,7 +29648,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "1fe60f4bf43aa1195c3e0a1a21017f9f42bb265093e0aba7f76d5701d8548660"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -29656,7 +29656,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "6004edc3e7ab4c0205cb0fd554825bac34b1a1a7e269a83dc47e3c09126869ae"
+              "sha256": "c6e1331e61aa3fbe6d01ec051f17591295f7f72cb872d7ad9fe1353c4dcd81be"
             }
           },
           "mailbox": {

--- a/docs/screenshots/eastbrook-vale-rebuild/polish/metadata/after-mobile-low.json
+++ b/docs/screenshots/eastbrook-vale-rebuild/polish/metadata/after-mobile-low.json
@@ -11,7 +11,7 @@
     "mode": "composite-sha256",
     "algorithm": "sha256",
     "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-    "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+    "fingerprint": "7fedc8aa9a58301b1a0f4ecf242000e3a4e61db768d1e0ac6e7a6b731fd512a2",
     "components": {
       "townAsset": {
         "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -28,7 +28,7 @@
       "runtimeRender": {
         "town": {
           "path": "src/render/eastbrook_town.ts",
-          "sha256": "3cdc80f793321655645c24131b0f05d33f241b4f6229c70d3070427c0e96a3d6"
+          "sha256": "5758a0edab78eb377dfda547c139e0418112ea4a51452c61eb4424cbac09d61f"
         },
         "mailbox": {
           "path": "src/render/mailbox.ts",
@@ -40,7 +40,7 @@
         },
         "renderer": {
           "path": "src/render/renderer.ts",
-          "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+          "sha256": "1fe60f4bf43aa1195c3e0a1a21017f9f42bb265093e0aba7f76d5701d8548660"
         },
         "entityViewPolicy": {
           "path": "src/render/entity_view_policy_core.ts",
@@ -48,7 +48,7 @@
         },
         "viewPriorityPolicy": {
           "path": "src/render/prewarm_policy.ts",
-          "sha256": "6004edc3e7ab4c0205cb0fd554825bac34b1a1a7e269a83dc47e3c09126869ae"
+          "sha256": "c6e1331e61aa3fbe6d01ec051f17591295f7f72cb872d7ad9fe1353c4dcd81be"
         }
       },
       "mailbox": {
@@ -89,7 +89,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "7fedc8aa9a58301b1a0f4ecf242000e3a4e61db768d1e0ac6e7a6b731fd512a2",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -106,7 +106,7 @@
           "runtimeRender": {
             "town": {
               "path": "src/render/eastbrook_town.ts",
-              "sha256": "3cdc80f793321655645c24131b0f05d33f241b4f6229c70d3070427c0e96a3d6"
+              "sha256": "5758a0edab78eb377dfda547c139e0418112ea4a51452c61eb4424cbac09d61f"
             },
             "mailbox": {
               "path": "src/render/mailbox.ts",
@@ -118,7 +118,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "1fe60f4bf43aa1195c3e0a1a21017f9f42bb265093e0aba7f76d5701d8548660"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -126,7 +126,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "6004edc3e7ab4c0205cb0fd554825bac34b1a1a7e269a83dc47e3c09126869ae"
+              "sha256": "c6e1331e61aa3fbe6d01ec051f17591295f7f72cb872d7ad9fe1353c4dcd81be"
             }
           },
           "mailbox": {
@@ -1368,7 +1368,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "7fedc8aa9a58301b1a0f4ecf242000e3a4e61db768d1e0ac6e7a6b731fd512a2",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -1385,7 +1385,7 @@
           "runtimeRender": {
             "town": {
               "path": "src/render/eastbrook_town.ts",
-              "sha256": "3cdc80f793321655645c24131b0f05d33f241b4f6229c70d3070427c0e96a3d6"
+              "sha256": "5758a0edab78eb377dfda547c139e0418112ea4a51452c61eb4424cbac09d61f"
             },
             "mailbox": {
               "path": "src/render/mailbox.ts",
@@ -1397,7 +1397,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "1fe60f4bf43aa1195c3e0a1a21017f9f42bb265093e0aba7f76d5701d8548660"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -1405,7 +1405,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "6004edc3e7ab4c0205cb0fd554825bac34b1a1a7e269a83dc47e3c09126869ae"
+              "sha256": "c6e1331e61aa3fbe6d01ec051f17591295f7f72cb872d7ad9fe1353c4dcd81be"
             }
           },
           "mailbox": {
@@ -2647,7 +2647,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "7fedc8aa9a58301b1a0f4ecf242000e3a4e61db768d1e0ac6e7a6b731fd512a2",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -2664,7 +2664,7 @@
           "runtimeRender": {
             "town": {
               "path": "src/render/eastbrook_town.ts",
-              "sha256": "3cdc80f793321655645c24131b0f05d33f241b4f6229c70d3070427c0e96a3d6"
+              "sha256": "5758a0edab78eb377dfda547c139e0418112ea4a51452c61eb4424cbac09d61f"
             },
             "mailbox": {
               "path": "src/render/mailbox.ts",
@@ -2676,7 +2676,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "1fe60f4bf43aa1195c3e0a1a21017f9f42bb265093e0aba7f76d5701d8548660"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -2684,7 +2684,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "6004edc3e7ab4c0205cb0fd554825bac34b1a1a7e269a83dc47e3c09126869ae"
+              "sha256": "c6e1331e61aa3fbe6d01ec051f17591295f7f72cb872d7ad9fe1353c4dcd81be"
             }
           },
           "mailbox": {
@@ -3926,7 +3926,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "7fedc8aa9a58301b1a0f4ecf242000e3a4e61db768d1e0ac6e7a6b731fd512a2",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -3943,7 +3943,7 @@
           "runtimeRender": {
             "town": {
               "path": "src/render/eastbrook_town.ts",
-              "sha256": "3cdc80f793321655645c24131b0f05d33f241b4f6229c70d3070427c0e96a3d6"
+              "sha256": "5758a0edab78eb377dfda547c139e0418112ea4a51452c61eb4424cbac09d61f"
             },
             "mailbox": {
               "path": "src/render/mailbox.ts",
@@ -3955,7 +3955,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "1fe60f4bf43aa1195c3e0a1a21017f9f42bb265093e0aba7f76d5701d8548660"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -3963,7 +3963,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "6004edc3e7ab4c0205cb0fd554825bac34b1a1a7e269a83dc47e3c09126869ae"
+              "sha256": "c6e1331e61aa3fbe6d01ec051f17591295f7f72cb872d7ad9fe1353c4dcd81be"
             }
           },
           "mailbox": {
@@ -5205,7 +5205,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "7fedc8aa9a58301b1a0f4ecf242000e3a4e61db768d1e0ac6e7a6b731fd512a2",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -5222,7 +5222,7 @@
           "runtimeRender": {
             "town": {
               "path": "src/render/eastbrook_town.ts",
-              "sha256": "3cdc80f793321655645c24131b0f05d33f241b4f6229c70d3070427c0e96a3d6"
+              "sha256": "5758a0edab78eb377dfda547c139e0418112ea4a51452c61eb4424cbac09d61f"
             },
             "mailbox": {
               "path": "src/render/mailbox.ts",
@@ -5234,7 +5234,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "1fe60f4bf43aa1195c3e0a1a21017f9f42bb265093e0aba7f76d5701d8548660"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -5242,7 +5242,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "6004edc3e7ab4c0205cb0fd554825bac34b1a1a7e269a83dc47e3c09126869ae"
+              "sha256": "c6e1331e61aa3fbe6d01ec051f17591295f7f72cb872d7ad9fe1353c4dcd81be"
             }
           },
           "mailbox": {
@@ -6484,7 +6484,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "7fedc8aa9a58301b1a0f4ecf242000e3a4e61db768d1e0ac6e7a6b731fd512a2",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -6501,7 +6501,7 @@
           "runtimeRender": {
             "town": {
               "path": "src/render/eastbrook_town.ts",
-              "sha256": "3cdc80f793321655645c24131b0f05d33f241b4f6229c70d3070427c0e96a3d6"
+              "sha256": "5758a0edab78eb377dfda547c139e0418112ea4a51452c61eb4424cbac09d61f"
             },
             "mailbox": {
               "path": "src/render/mailbox.ts",
@@ -6513,7 +6513,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "1fe60f4bf43aa1195c3e0a1a21017f9f42bb265093e0aba7f76d5701d8548660"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -6521,7 +6521,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "6004edc3e7ab4c0205cb0fd554825bac34b1a1a7e269a83dc47e3c09126869ae"
+              "sha256": "c6e1331e61aa3fbe6d01ec051f17591295f7f72cb872d7ad9fe1353c4dcd81be"
             }
           },
           "mailbox": {
@@ -7763,7 +7763,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "7fedc8aa9a58301b1a0f4ecf242000e3a4e61db768d1e0ac6e7a6b731fd512a2",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -7780,7 +7780,7 @@
           "runtimeRender": {
             "town": {
               "path": "src/render/eastbrook_town.ts",
-              "sha256": "3cdc80f793321655645c24131b0f05d33f241b4f6229c70d3070427c0e96a3d6"
+              "sha256": "5758a0edab78eb377dfda547c139e0418112ea4a51452c61eb4424cbac09d61f"
             },
             "mailbox": {
               "path": "src/render/mailbox.ts",
@@ -7792,7 +7792,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "1fe60f4bf43aa1195c3e0a1a21017f9f42bb265093e0aba7f76d5701d8548660"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -7800,7 +7800,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "6004edc3e7ab4c0205cb0fd554825bac34b1a1a7e269a83dc47e3c09126869ae"
+              "sha256": "c6e1331e61aa3fbe6d01ec051f17591295f7f72cb872d7ad9fe1353c4dcd81be"
             }
           },
           "mailbox": {
@@ -9042,7 +9042,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "7fedc8aa9a58301b1a0f4ecf242000e3a4e61db768d1e0ac6e7a6b731fd512a2",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -9059,7 +9059,7 @@
           "runtimeRender": {
             "town": {
               "path": "src/render/eastbrook_town.ts",
-              "sha256": "3cdc80f793321655645c24131b0f05d33f241b4f6229c70d3070427c0e96a3d6"
+              "sha256": "5758a0edab78eb377dfda547c139e0418112ea4a51452c61eb4424cbac09d61f"
             },
             "mailbox": {
               "path": "src/render/mailbox.ts",
@@ -9071,7 +9071,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "1fe60f4bf43aa1195c3e0a1a21017f9f42bb265093e0aba7f76d5701d8548660"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -9079,7 +9079,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "6004edc3e7ab4c0205cb0fd554825bac34b1a1a7e269a83dc47e3c09126869ae"
+              "sha256": "c6e1331e61aa3fbe6d01ec051f17591295f7f72cb872d7ad9fe1353c4dcd81be"
             }
           },
           "mailbox": {
@@ -10321,7 +10321,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "7fedc8aa9a58301b1a0f4ecf242000e3a4e61db768d1e0ac6e7a6b731fd512a2",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -10338,7 +10338,7 @@
           "runtimeRender": {
             "town": {
               "path": "src/render/eastbrook_town.ts",
-              "sha256": "3cdc80f793321655645c24131b0f05d33f241b4f6229c70d3070427c0e96a3d6"
+              "sha256": "5758a0edab78eb377dfda547c139e0418112ea4a51452c61eb4424cbac09d61f"
             },
             "mailbox": {
               "path": "src/render/mailbox.ts",
@@ -10350,7 +10350,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "1fe60f4bf43aa1195c3e0a1a21017f9f42bb265093e0aba7f76d5701d8548660"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -10358,7 +10358,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "6004edc3e7ab4c0205cb0fd554825bac34b1a1a7e269a83dc47e3c09126869ae"
+              "sha256": "c6e1331e61aa3fbe6d01ec051f17591295f7f72cb872d7ad9fe1353c4dcd81be"
             }
           },
           "mailbox": {
@@ -11600,7 +11600,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "7fedc8aa9a58301b1a0f4ecf242000e3a4e61db768d1e0ac6e7a6b731fd512a2",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -11617,7 +11617,7 @@
           "runtimeRender": {
             "town": {
               "path": "src/render/eastbrook_town.ts",
-              "sha256": "3cdc80f793321655645c24131b0f05d33f241b4f6229c70d3070427c0e96a3d6"
+              "sha256": "5758a0edab78eb377dfda547c139e0418112ea4a51452c61eb4424cbac09d61f"
             },
             "mailbox": {
               "path": "src/render/mailbox.ts",
@@ -11629,7 +11629,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "1fe60f4bf43aa1195c3e0a1a21017f9f42bb265093e0aba7f76d5701d8548660"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -11637,7 +11637,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "6004edc3e7ab4c0205cb0fd554825bac34b1a1a7e269a83dc47e3c09126869ae"
+              "sha256": "c6e1331e61aa3fbe6d01ec051f17591295f7f72cb872d7ad9fe1353c4dcd81be"
             }
           },
           "mailbox": {
@@ -12879,7 +12879,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "7fedc8aa9a58301b1a0f4ecf242000e3a4e61db768d1e0ac6e7a6b731fd512a2",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -12896,7 +12896,7 @@
           "runtimeRender": {
             "town": {
               "path": "src/render/eastbrook_town.ts",
-              "sha256": "3cdc80f793321655645c24131b0f05d33f241b4f6229c70d3070427c0e96a3d6"
+              "sha256": "5758a0edab78eb377dfda547c139e0418112ea4a51452c61eb4424cbac09d61f"
             },
             "mailbox": {
               "path": "src/render/mailbox.ts",
@@ -12908,7 +12908,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "1fe60f4bf43aa1195c3e0a1a21017f9f42bb265093e0aba7f76d5701d8548660"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -12916,7 +12916,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "6004edc3e7ab4c0205cb0fd554825bac34b1a1a7e269a83dc47e3c09126869ae"
+              "sha256": "c6e1331e61aa3fbe6d01ec051f17591295f7f72cb872d7ad9fe1353c4dcd81be"
             }
           },
           "mailbox": {
@@ -14158,7 +14158,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "7fedc8aa9a58301b1a0f4ecf242000e3a4e61db768d1e0ac6e7a6b731fd512a2",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -14175,7 +14175,7 @@
           "runtimeRender": {
             "town": {
               "path": "src/render/eastbrook_town.ts",
-              "sha256": "3cdc80f793321655645c24131b0f05d33f241b4f6229c70d3070427c0e96a3d6"
+              "sha256": "5758a0edab78eb377dfda547c139e0418112ea4a51452c61eb4424cbac09d61f"
             },
             "mailbox": {
               "path": "src/render/mailbox.ts",
@@ -14187,7 +14187,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "1fe60f4bf43aa1195c3e0a1a21017f9f42bb265093e0aba7f76d5701d8548660"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -14195,7 +14195,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "6004edc3e7ab4c0205cb0fd554825bac34b1a1a7e269a83dc47e3c09126869ae"
+              "sha256": "c6e1331e61aa3fbe6d01ec051f17591295f7f72cb872d7ad9fe1353c4dcd81be"
             }
           },
           "mailbox": {
@@ -15437,7 +15437,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "7fedc8aa9a58301b1a0f4ecf242000e3a4e61db768d1e0ac6e7a6b731fd512a2",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -15454,7 +15454,7 @@
           "runtimeRender": {
             "town": {
               "path": "src/render/eastbrook_town.ts",
-              "sha256": "3cdc80f793321655645c24131b0f05d33f241b4f6229c70d3070427c0e96a3d6"
+              "sha256": "5758a0edab78eb377dfda547c139e0418112ea4a51452c61eb4424cbac09d61f"
             },
             "mailbox": {
               "path": "src/render/mailbox.ts",
@@ -15466,7 +15466,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "1fe60f4bf43aa1195c3e0a1a21017f9f42bb265093e0aba7f76d5701d8548660"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -15474,7 +15474,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "6004edc3e7ab4c0205cb0fd554825bac34b1a1a7e269a83dc47e3c09126869ae"
+              "sha256": "c6e1331e61aa3fbe6d01ec051f17591295f7f72cb872d7ad9fe1353c4dcd81be"
             }
           },
           "mailbox": {
@@ -16716,7 +16716,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "7fedc8aa9a58301b1a0f4ecf242000e3a4e61db768d1e0ac6e7a6b731fd512a2",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -16733,7 +16733,7 @@
           "runtimeRender": {
             "town": {
               "path": "src/render/eastbrook_town.ts",
-              "sha256": "3cdc80f793321655645c24131b0f05d33f241b4f6229c70d3070427c0e96a3d6"
+              "sha256": "5758a0edab78eb377dfda547c139e0418112ea4a51452c61eb4424cbac09d61f"
             },
             "mailbox": {
               "path": "src/render/mailbox.ts",
@@ -16745,7 +16745,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "1fe60f4bf43aa1195c3e0a1a21017f9f42bb265093e0aba7f76d5701d8548660"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -16753,7 +16753,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "6004edc3e7ab4c0205cb0fd554825bac34b1a1a7e269a83dc47e3c09126869ae"
+              "sha256": "c6e1331e61aa3fbe6d01ec051f17591295f7f72cb872d7ad9fe1353c4dcd81be"
             }
           },
           "mailbox": {
@@ -18960,7 +18960,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "7fedc8aa9a58301b1a0f4ecf242000e3a4e61db768d1e0ac6e7a6b731fd512a2",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -18977,7 +18977,7 @@
           "runtimeRender": {
             "town": {
               "path": "src/render/eastbrook_town.ts",
-              "sha256": "3cdc80f793321655645c24131b0f05d33f241b4f6229c70d3070427c0e96a3d6"
+              "sha256": "5758a0edab78eb377dfda547c139e0418112ea4a51452c61eb4424cbac09d61f"
             },
             "mailbox": {
               "path": "src/render/mailbox.ts",
@@ -18989,7 +18989,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "1fe60f4bf43aa1195c3e0a1a21017f9f42bb265093e0aba7f76d5701d8548660"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -18997,7 +18997,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "6004edc3e7ab4c0205cb0fd554825bac34b1a1a7e269a83dc47e3c09126869ae"
+              "sha256": "c6e1331e61aa3fbe6d01ec051f17591295f7f72cb872d7ad9fe1353c4dcd81be"
             }
           },
           "mailbox": {
@@ -20239,7 +20239,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "7fedc8aa9a58301b1a0f4ecf242000e3a4e61db768d1e0ac6e7a6b731fd512a2",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -20256,7 +20256,7 @@
           "runtimeRender": {
             "town": {
               "path": "src/render/eastbrook_town.ts",
-              "sha256": "3cdc80f793321655645c24131b0f05d33f241b4f6229c70d3070427c0e96a3d6"
+              "sha256": "5758a0edab78eb377dfda547c139e0418112ea4a51452c61eb4424cbac09d61f"
             },
             "mailbox": {
               "path": "src/render/mailbox.ts",
@@ -20268,7 +20268,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "1fe60f4bf43aa1195c3e0a1a21017f9f42bb265093e0aba7f76d5701d8548660"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -20276,7 +20276,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "6004edc3e7ab4c0205cb0fd554825bac34b1a1a7e269a83dc47e3c09126869ae"
+              "sha256": "c6e1331e61aa3fbe6d01ec051f17591295f7f72cb872d7ad9fe1353c4dcd81be"
             }
           },
           "mailbox": {
@@ -21518,7 +21518,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "7fedc8aa9a58301b1a0f4ecf242000e3a4e61db768d1e0ac6e7a6b731fd512a2",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -21535,7 +21535,7 @@
           "runtimeRender": {
             "town": {
               "path": "src/render/eastbrook_town.ts",
-              "sha256": "3cdc80f793321655645c24131b0f05d33f241b4f6229c70d3070427c0e96a3d6"
+              "sha256": "5758a0edab78eb377dfda547c139e0418112ea4a51452c61eb4424cbac09d61f"
             },
             "mailbox": {
               "path": "src/render/mailbox.ts",
@@ -21547,7 +21547,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "1fe60f4bf43aa1195c3e0a1a21017f9f42bb265093e0aba7f76d5701d8548660"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -21555,7 +21555,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "6004edc3e7ab4c0205cb0fd554825bac34b1a1a7e269a83dc47e3c09126869ae"
+              "sha256": "c6e1331e61aa3fbe6d01ec051f17591295f7f72cb872d7ad9fe1353c4dcd81be"
             }
           },
           "mailbox": {
@@ -22797,7 +22797,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "7fedc8aa9a58301b1a0f4ecf242000e3a4e61db768d1e0ac6e7a6b731fd512a2",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -22814,7 +22814,7 @@
           "runtimeRender": {
             "town": {
               "path": "src/render/eastbrook_town.ts",
-              "sha256": "3cdc80f793321655645c24131b0f05d33f241b4f6229c70d3070427c0e96a3d6"
+              "sha256": "5758a0edab78eb377dfda547c139e0418112ea4a51452c61eb4424cbac09d61f"
             },
             "mailbox": {
               "path": "src/render/mailbox.ts",
@@ -22826,7 +22826,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "1fe60f4bf43aa1195c3e0a1a21017f9f42bb265093e0aba7f76d5701d8548660"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -22834,7 +22834,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "6004edc3e7ab4c0205cb0fd554825bac34b1a1a7e269a83dc47e3c09126869ae"
+              "sha256": "c6e1331e61aa3fbe6d01ec051f17591295f7f72cb872d7ad9fe1353c4dcd81be"
             }
           },
           "mailbox": {
@@ -24076,7 +24076,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "7fedc8aa9a58301b1a0f4ecf242000e3a4e61db768d1e0ac6e7a6b731fd512a2",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -24093,7 +24093,7 @@
           "runtimeRender": {
             "town": {
               "path": "src/render/eastbrook_town.ts",
-              "sha256": "3cdc80f793321655645c24131b0f05d33f241b4f6229c70d3070427c0e96a3d6"
+              "sha256": "5758a0edab78eb377dfda547c139e0418112ea4a51452c61eb4424cbac09d61f"
             },
             "mailbox": {
               "path": "src/render/mailbox.ts",
@@ -24105,7 +24105,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "1fe60f4bf43aa1195c3e0a1a21017f9f42bb265093e0aba7f76d5701d8548660"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -24113,7 +24113,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "6004edc3e7ab4c0205cb0fd554825bac34b1a1a7e269a83dc47e3c09126869ae"
+              "sha256": "c6e1331e61aa3fbe6d01ec051f17591295f7f72cb872d7ad9fe1353c4dcd81be"
             }
           },
           "mailbox": {
@@ -25355,7 +25355,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "7fedc8aa9a58301b1a0f4ecf242000e3a4e61db768d1e0ac6e7a6b731fd512a2",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -25372,7 +25372,7 @@
           "runtimeRender": {
             "town": {
               "path": "src/render/eastbrook_town.ts",
-              "sha256": "3cdc80f793321655645c24131b0f05d33f241b4f6229c70d3070427c0e96a3d6"
+              "sha256": "5758a0edab78eb377dfda547c139e0418112ea4a51452c61eb4424cbac09d61f"
             },
             "mailbox": {
               "path": "src/render/mailbox.ts",
@@ -25384,7 +25384,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "1fe60f4bf43aa1195c3e0a1a21017f9f42bb265093e0aba7f76d5701d8548660"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -25392,7 +25392,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "6004edc3e7ab4c0205cb0fd554825bac34b1a1a7e269a83dc47e3c09126869ae"
+              "sha256": "c6e1331e61aa3fbe6d01ec051f17591295f7f72cb872d7ad9fe1353c4dcd81be"
             }
           },
           "mailbox": {
@@ -26634,7 +26634,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "7fedc8aa9a58301b1a0f4ecf242000e3a4e61db768d1e0ac6e7a6b731fd512a2",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -26651,7 +26651,7 @@
           "runtimeRender": {
             "town": {
               "path": "src/render/eastbrook_town.ts",
-              "sha256": "3cdc80f793321655645c24131b0f05d33f241b4f6229c70d3070427c0e96a3d6"
+              "sha256": "5758a0edab78eb377dfda547c139e0418112ea4a51452c61eb4424cbac09d61f"
             },
             "mailbox": {
               "path": "src/render/mailbox.ts",
@@ -26663,7 +26663,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "1fe60f4bf43aa1195c3e0a1a21017f9f42bb265093e0aba7f76d5701d8548660"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -26671,7 +26671,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "6004edc3e7ab4c0205cb0fd554825bac34b1a1a7e269a83dc47e3c09126869ae"
+              "sha256": "c6e1331e61aa3fbe6d01ec051f17591295f7f72cb872d7ad9fe1353c4dcd81be"
             }
           },
           "mailbox": {
@@ -27966,7 +27966,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "7fedc8aa9a58301b1a0f4ecf242000e3a4e61db768d1e0ac6e7a6b731fd512a2",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -27983,7 +27983,7 @@
           "runtimeRender": {
             "town": {
               "path": "src/render/eastbrook_town.ts",
-              "sha256": "3cdc80f793321655645c24131b0f05d33f241b4f6229c70d3070427c0e96a3d6"
+              "sha256": "5758a0edab78eb377dfda547c139e0418112ea4a51452c61eb4424cbac09d61f"
             },
             "mailbox": {
               "path": "src/render/mailbox.ts",
@@ -27995,7 +27995,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "1fe60f4bf43aa1195c3e0a1a21017f9f42bb265093e0aba7f76d5701d8548660"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -28003,7 +28003,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "6004edc3e7ab4c0205cb0fd554825bac34b1a1a7e269a83dc47e3c09126869ae"
+              "sha256": "c6e1331e61aa3fbe6d01ec051f17591295f7f72cb872d7ad9fe1353c4dcd81be"
             }
           },
           "mailbox": {
@@ -29245,7 +29245,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+        "fingerprint": "7fedc8aa9a58301b1a0f4ecf242000e3a4e61db768d1e0ac6e7a6b731fd512a2",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -29262,7 +29262,7 @@
           "runtimeRender": {
             "town": {
               "path": "src/render/eastbrook_town.ts",
-              "sha256": "3cdc80f793321655645c24131b0f05d33f241b4f6229c70d3070427c0e96a3d6"
+              "sha256": "5758a0edab78eb377dfda547c139e0418112ea4a51452c61eb4424cbac09d61f"
             },
             "mailbox": {
               "path": "src/render/mailbox.ts",
@@ -29274,7 +29274,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+              "sha256": "1fe60f4bf43aa1195c3e0a1a21017f9f42bb265093e0aba7f76d5701d8548660"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -29282,7 +29282,7 @@
             },
             "viewPriorityPolicy": {
               "path": "src/render/prewarm_policy.ts",
-              "sha256": "6004edc3e7ab4c0205cb0fd554825bac34b1a1a7e269a83dc47e3c09126869ae"
+              "sha256": "c6e1331e61aa3fbe6d01ec051f17591295f7f72cb872d7ad9fe1353c4dcd81be"
             }
           },
           "mailbox": {

--- a/docs/screenshots/eastbrook-vale-rebuild/polish/performance/after-desktop-ultra-town.json
+++ b/docs/screenshots/eastbrook-vale-rebuild/polish/performance/after-desktop-ultra-town.json
@@ -14,7 +14,7 @@
     "mode": "composite-sha256",
     "algorithm": "sha256",
     "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-    "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+    "fingerprint": "7fedc8aa9a58301b1a0f4ecf242000e3a4e61db768d1e0ac6e7a6b731fd512a2",
     "components": {
       "townAsset": {
         "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -31,7 +31,7 @@
       "runtimeRender": {
         "town": {
           "path": "src/render/eastbrook_town.ts",
-          "sha256": "3cdc80f793321655645c24131b0f05d33f241b4f6229c70d3070427c0e96a3d6"
+          "sha256": "5758a0edab78eb377dfda547c139e0418112ea4a51452c61eb4424cbac09d61f"
         },
         "mailbox": {
           "path": "src/render/mailbox.ts",
@@ -43,7 +43,7 @@
         },
         "renderer": {
           "path": "src/render/renderer.ts",
-          "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+          "sha256": "1fe60f4bf43aa1195c3e0a1a21017f9f42bb265093e0aba7f76d5701d8548660"
         },
         "entityViewPolicy": {
           "path": "src/render/entity_view_policy_core.ts",
@@ -51,7 +51,7 @@
         },
         "viewPriorityPolicy": {
           "path": "src/render/prewarm_policy.ts",
-          "sha256": "6004edc3e7ab4c0205cb0fd554825bac34b1a1a7e269a83dc47e3c09126869ae"
+          "sha256": "c6e1331e61aa3fbe6d01ec051f17591295f7f72cb872d7ad9fe1353c4dcd81be"
         }
       },
       "mailbox": {

--- a/docs/screenshots/eastbrook-vale-rebuild/polish/performance/after-mobile-low-town.json
+++ b/docs/screenshots/eastbrook-vale-rebuild/polish/performance/after-mobile-low-town.json
@@ -14,7 +14,7 @@
     "mode": "composite-sha256",
     "algorithm": "sha256",
     "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-    "fingerprint": "63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495",
+    "fingerprint": "7fedc8aa9a58301b1a0f4ecf242000e3a4e61db768d1e0ac6e7a6b731fd512a2",
     "components": {
       "townAsset": {
         "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -31,7 +31,7 @@
       "runtimeRender": {
         "town": {
           "path": "src/render/eastbrook_town.ts",
-          "sha256": "3cdc80f793321655645c24131b0f05d33f241b4f6229c70d3070427c0e96a3d6"
+          "sha256": "5758a0edab78eb377dfda547c139e0418112ea4a51452c61eb4424cbac09d61f"
         },
         "mailbox": {
           "path": "src/render/mailbox.ts",
@@ -43,7 +43,7 @@
         },
         "renderer": {
           "path": "src/render/renderer.ts",
-          "sha256": "555bec985ca81f6164e28623884e98a54e8c9225c95079990a5755fb66afb99b"
+          "sha256": "1fe60f4bf43aa1195c3e0a1a21017f9f42bb265093e0aba7f76d5701d8548660"
         },
         "entityViewPolicy": {
           "path": "src/render/entity_view_policy_core.ts",
@@ -51,7 +51,7 @@
         },
         "viewPriorityPolicy": {
           "path": "src/render/prewarm_policy.ts",
-          "sha256": "6004edc3e7ab4c0205cb0fd554825bac34b1a1a7e269a83dc47e3c09126869ae"
+          "sha256": "c6e1331e61aa3fbe6d01ec051f17591295f7f72cb872d7ad9fe1353c4dcd81be"
         }
       },
       "mailbox": {

--- a/src/render/eastbrook_town.ts
+++ b/src/render/eastbrook_town.ts
@@ -901,12 +901,14 @@ function buildFromTemplates(
   }
 
   const roofHideTargets: RoofHideTarget[] = [];
+  const buildingGroups: THREE.Object3D[] = [];
   for (const building of EASTBROOK_LAYOUT.buildings) {
     const template = templates.get(building.assetId);
     if (!template) throw new Error(`Eastbrook town template is missing: ${building.assetId}`);
     const built = buildBuilding(building, template, groundAt, atlas);
     group.add(built.group);
     roofHideTargets.push(built.hideTarget);
+    buildingGroups.push(built.group);
   }
   const microBuild = buildMicroBatches(templates, groundAt, atlas);
   const microBatches = microBuild.batches;
@@ -917,6 +919,11 @@ function buildFromTemplates(
   const wallBatches = buildWallBatches(wallTemplate, groundAt, atlas);
   for (const batch of wallBatches) group.add(batch);
   const staticCullTargets: THREE.Object3D[] = [...microBatches, ...wallBatches];
+  // The reveal gate compiles the buildings with the static batches: their
+  // per-building materials are not shared with any batch, so a building
+  // outside the roots linked cold on the frame its own fog cull first showed
+  // it (the Fenbridge shape, same fix).
+  const staticRevealRoots: THREE.Object3D[] = [...staticCullTargets, ...buildingGroups];
   const roofVisibilityPlan = newEastbrookRoofVisibilityPlan();
 
   group.userData.buildingIds = EASTBROOK_LAYOUT.buildings.map((building) => building.id);
@@ -946,7 +953,7 @@ function buildFromTemplates(
       revealGate = gate;
     },
     staticRevealRoots(): readonly THREE.Object3D[] {
-      return staticCullTargets;
+      return staticRevealRoots;
     },
     update(
       camX: number,
@@ -975,6 +982,11 @@ function buildFromTemplates(
       for (let index = 0; index < staticCullTargets.length; index++) {
         staticCullTargets[index].visible = staticVisible;
       }
+      // Buildings keep their own fog cull and roof fade, but their FIRST
+      // reveal rides the same hold as the batches: while the gate compiles
+      // the town they stay hidden, and once revealed the latch above never
+      // consults the gate again (a fog re-entry is a plain cull flip).
+      const buildingsHeld = reveal === 'held';
       for (let index = 0; index < roofHideTargets.length; index++) {
         const target = roofHideTargets[index];
         eastbrookRoofVisibilityPlanInto(
@@ -989,7 +1001,7 @@ function buildFromTemplates(
           eyeZ,
           fogFar,
         );
-        target.group.visible = roofVisibilityPlan.visible;
+        target.group.visible = roofVisibilityPlan.visible && !buildingsHeld;
         if (!roofVisibilityPlan.visible) continue;
         target.hidden = roofVisibilityPlan.hidden;
         if (occluderFadeSettled(target.alpha, target.hidden)) continue;

--- a/src/render/fenbridge_town.ts
+++ b/src/render/fenbridge_town.ts
@@ -1213,12 +1213,14 @@ function buildFromTemplates(
   }
 
   const hideTargets: BuildingHideTarget[] = [];
+  const buildingGroups: THREE.Object3D[] = [];
   for (const building of FENBRIDGE_LAYOUT.buildings) {
     const template = templates.get(building.assetId);
     if (!template) throw new Error(`Fenbridge town template is missing: ${building.assetId}`);
     const built = buildBuilding(building, template, groundAt, textures);
     group.add(built.group);
     hideTargets.push(built.hideTarget);
+    buildingGroups.push(built.group);
   }
 
   const microBatches = buildMicroBatches(templates, groundAt, textures);
@@ -1250,6 +1252,12 @@ function buildFromTemplates(
 
   const repeatedBatches = [...wallBatches, ...gateBatches, ...boardwalkBatches];
   const staticCullTargets: THREE.Object3D[] = [...microBatches, ...repeatedBatches];
+  // The reveal gate compiles the buildings with the static batches: their
+  // per-building materials (the emissive lantern variant above all) are not
+  // shared with any batch, so a building outside the roots linked cold on the
+  // frame its own fog cull first showed it (the prod 220 ms
+  // fenbridgeTownEmissive row).
+  const staticRevealRoots: THREE.Object3D[] = [...staticCullTargets, ...buildingGroups];
   const visibilityPlan = newFenbridgeBuildingVisibilityPlan();
   const setCaptureOverlay = (visible: boolean): void => {
     overlay.visible = visible;
@@ -1297,7 +1305,7 @@ function buildFromTemplates(
       revealGate = gate;
     },
     staticRevealRoots(): readonly THREE.Object3D[] {
-      return staticCullTargets;
+      return staticRevealRoots;
     },
     update(
       camX: number,
@@ -1332,6 +1340,11 @@ function buildFromTemplates(
       for (let index = 0; index < staticCullTargets.length; index++) {
         staticCullTargets[index].visible = staticVisible;
       }
+      // Buildings keep their own fog cull and camera fade, but their FIRST
+      // reveal rides the same hold as the batches: while the gate compiles
+      // the town they stay hidden, and once revealed the latch above never
+      // consults the gate again (a fog re-entry is a plain cull flip).
+      const buildingsHeld = reveal === 'held';
       for (let index = 0; index < hideTargets.length; index++) {
         const target = hideTargets[index];
         fenbridgeBuildingVisibilityPlanInto(
@@ -1346,7 +1359,7 @@ function buildFromTemplates(
           eyeZ,
           fogFar,
         );
-        target.group.visible = visibilityPlan.visible;
+        target.group.visible = visibilityPlan.visible && !buildingsHeld;
         if (!visibilityPlan.visible) continue;
         target.hidden = visibilityPlan.hidden;
         if (occluderFadeSettled(target.alpha, target.hidden)) continue;

--- a/src/render/interior_encounter_prewarm_host.ts
+++ b/src/render/interior_encounter_prewarm_host.ts
@@ -29,5 +29,4 @@ export interface InteriorEncounterPrewarmHost {
   compilePrewarmColorPrograms(root: THREE.Object3D, includeOffscreen: boolean): Promise<void>;
   compileShadowPrograms(root: THREE.Object3D): Promise<void>;
   renderBoundedPrewarmRoot(group: THREE.Group, child: THREE.Object3D): void;
-  collectObjectTextures(root: THREE.Object3D, visibleOnly: boolean): Set<THREE.Texture>;
 }

--- a/src/render/interior_encounter_prewarm_pass.ts
+++ b/src/render/interior_encounter_prewarm_pass.ts
@@ -20,6 +20,7 @@ import {
   vfxWeaponSkinIds,
 } from './interior_encounter_prewarm';
 import type { InteriorEncounterPrewarmHost } from './interior_encounter_prewarm_host';
+import { collectObjectTextures } from './material_texture_slots';
 import { runBackgroundPrewarm } from './prewarm_pass';
 import { setRenderCategory } from './renderer_diagnostics';
 import { WEAPON_VFX } from './weapon_vfx';
@@ -292,14 +293,14 @@ async function compileEncounterPrewarmGroup(
         );
       },
       prepareChildAssets: (child) => {
-        for (const texture of host.collectObjectTextures(child as THREE.Object3D, false)) {
+        for (const texture of collectObjectTextures(child as THREE.Object3D, false)) {
           host.webgl.initTexture(texture);
         }
       },
       warmChildUnits: (groupLike, child) => {
         const childRoot = child as THREE.Object3D;
         const units: { label: string; run: () => void }[] = [];
-        const textures = [...host.collectObjectTextures(childRoot, false)];
+        const textures = [...collectObjectTextures(childRoot, false)];
         for (let i = 0; i < textures.length; i += TEXTURE_BATCH) {
           const batch = textures.slice(i, i + TEXTURE_BATCH);
           units.push({

--- a/src/render/material_texture_slots.ts
+++ b/src/render/material_texture_slots.ts
@@ -1,0 +1,64 @@
+// The named texture slots of three's built-in materials and the collectors
+// that walk them: the shared vocabulary of the renderer's texture prewarm
+// (upload the maps a material will sample before its first draw) and of the
+// boot scene texture collection. Kept beside the material types it reads
+// (renderer_diagnostics.ts) and free of renderer state, so the walk is
+// Node-testable and the two renderer callers share ONE slot list.
+
+import type * as THREE from 'three';
+import type { RenderableDiagnosticObject } from './render_diagnostics';
+import type { TextureBackedMaterial, TextureMaterialKey } from './renderer_diagnostics';
+
+export const MATERIAL_TEXTURE_KEYS: readonly TextureMaterialKey[] = [
+  'map',
+  'alphaMap',
+  'aoMap',
+  'bumpMap',
+  'displacementMap',
+  'emissiveMap',
+  'envMap',
+  'lightMap',
+  'metalnessMap',
+  'normalMap',
+  'roughnessMap',
+  'specularMap',
+  'gradientMap',
+];
+
+/** Every texture bound in one material's named slots (unset slots skipped). */
+export function materialSlotTextures(material: THREE.Material): THREE.Texture[] {
+  const textureMaterial = material as TextureBackedMaterial;
+  const textures: THREE.Texture[] = [];
+  for (const key of MATERIAL_TEXTURE_KEYS) {
+    const texture = textureMaterial[key];
+    if (texture) textures.push(texture);
+  }
+  return textures;
+}
+
+/**
+ * Collect the slot textures of every material under `obj` into `textures`
+ * (deduplicated by the Set). `visibleOnly` walks traverseVisible, so hidden
+ * subtrees are skipped: the boot scene collection deliberately mirrors what
+ * the initial frame will draw.
+ */
+export function collectObjectTextures(
+  obj: THREE.Object3D,
+  visibleOnly: boolean,
+  textures = new Set<THREE.Texture>(),
+): Set<THREE.Texture> {
+  const collect = (child: THREE.Object3D): void => {
+    const renderable = child as RenderableDiagnosticObject;
+    const materials = Array.isArray(renderable.material)
+      ? renderable.material
+      : renderable.material
+        ? [renderable.material]
+        : [];
+    for (const material of materials) {
+      for (const texture of materialSlotTextures(material)) textures.add(texture);
+    }
+  };
+  if (visibleOnly) obj.traverseVisible(collect);
+  else obj.traverse(collect);
+  return textures;
+}

--- a/src/render/prewarm_policy.ts
+++ b/src/render/prewarm_policy.ts
@@ -307,12 +307,16 @@ export function prewarmSubmitShouldStop(
  * `programs.compile-submit` here names the SYNTHETIC dropped entry the
  * deferred-submit hand-off pushes (the manifest entry of that id declares no
  * resumeUnits, so no other resume entry can carry it).
+ * `foliage.materials` IS ambient-scene debt: the species it links stream in
+ * with every step of travel (the distant-only pines and far impostors), not on
+ * a specific event, so its dropped units pay on the debt arm too.
  */
 const PREWARM_DEBT_RESUME_IDS: ReadonlySet<string> = new Set([
   'programs.compile',
   'programs.compile-submit',
   'textures.scene',
   'surface-detail.textures',
+  'foliage.materials',
 ]);
 
 /** True when a dropped entry's resume units are hitch-causing debt. */

--- a/src/render/prop_cull_core.ts
+++ b/src/render/prop_cull_core.ts
@@ -1,0 +1,178 @@
+// Per-object fog cull and first-reveal policy for the merged and instanced
+// prop bands (props.ts cullables). A cullable is one world-spanning merged
+// Mesh or InstancedMesh; its programs are shared with nothing the boot sweep
+// is guaranteed to have compiled (a band entirely past the fog at boot is
+// invisible to the visible-only sweep and to every prewarm group that misses
+// its exact variant), so its FIRST fog reveal on a walking approach linked
+// synchronously inside a live frame (the prod never-compiled world-content
+// rows). The policy below is the props twin of town_reveal_core: the first
+// reveal consults a reveal gate and holds while cold, EXCEPT when the band
+// is already near the camera on that first consult (hearth, teleport:
+// arrivals that ride the loading cover, whose warm pass links what it
+// draws), because sim colliders would otherwise block movement against
+// invisible props; a band the gate already holds stays held until the
+// settle (PROP_CULL_REVEAL_NEAR_FRACTION explains why), down to the reach
+// floor where colliders would be at arm's length (PROP_CULL_REVEAL_REACH).
+// Once revealed, the
+// gate is never consulted again: a fog re-entry is a plain cull flip. The
+// gate itself arms at world entry, not under the curtain (props.ts
+// setBandRevealGate).
+//
+// Pure core contract: no three import, no DOM, no clocks, no randomness.
+// Registered in RENDER_PURE_CORES (tests/architecture.test.ts); tested by
+// tests/prop_cull_core.test.ts.
+
+export interface PropCullBounds {
+  /** True when minX..maxZ is a real bounding box; false when it is the
+   *  bounding sphere's box and the sphere reach decides past it. */
+  hasBox: boolean;
+  minX: number;
+  maxX: number;
+  minZ: number;
+  maxZ: number;
+  cx: number;
+  cz: number;
+  r: number;
+}
+
+export interface PropCullRevealState {
+  /** Reveal-gate key (props.ts mints one per cullable). */
+  key: string;
+  /** Latched once the first reveal was allowed: the gate is consulted only
+   *  until the band's programs are known linked. */
+  revealed: boolean;
+  /** Latched once the gate held the band: from then on only the gate's
+   *  settle reveals it, never the near escape (see propCullReveal). */
+  held: boolean;
+}
+
+/** Structural subset of reveal_gate_core's RevealGateCore, so this core
+ *  stays decoupled from the gate module. */
+export interface PropCullRevealGate {
+  allow(key: string): boolean;
+}
+
+/**
+ * Bands closer than this fraction of the fog far plane reveal immediately on
+ * their FIRST consult, gate or not. A walking approach meets a band at the
+ * fog plane itself (dim, a few frames of hold are invisible); a cover
+ * arrival lands the camera among bands that must exist at once. Half the fog
+ * range keeps everything a player can reach before a compile settles
+ * ungated. The escape never applies to a band the gate already holds: after
+ * an arrival the fog opens over seconds, so a band held at the fog edge
+ * would otherwise cross the near line while its compile is still in flight
+ * and link cold anyway (measured as the raced-pending-link rows right after
+ * an arrival reveal); once held, only the settle reveals it, down to the
+ * reach floor below.
+ */
+export const PROP_CULL_REVEAL_NEAR_FRACTION = 0.5;
+
+/**
+ * The absolute floor of the hold, in yards of box distance: a band this
+ * close to the camera reveals on every consult, held or not, gate or not.
+ * The bands carry colliders (fences, the race arches and jumps, every
+ * decoration footprint), and a hold is time-bounded only by the reveal
+ * gate's watchdog, so a driver whose link takes seconds must never leave a
+ * collider invisible at arm's length: the fairness contract is that decor
+ * may arrive late, never that the player walks into nothing. Same distance
+ * as the far-cell swap (one camera boom plus the largest footprint, see
+ * prop_cell_core.ts PROP_FAR_SWAP_DISTANCE): inside it the props are the
+ * player's immediate surroundings. It also floors the near escape when the
+ * fog is clamped tight (the residency clamp after a cover), where half the
+ * fog would be a few yards.
+ */
+export const PROP_CULL_REVEAL_REACH = 40;
+
+/** The reveal-gate key of the band at `index` (its slot in the view's
+ *  cullable list). The `cull:` prefix keeps the namespace disjoint from the
+ *  far-cell grid keys (`propCellKey`, `<x>:<z>`) on the shared props gate. */
+export function propCullKey(index: number): string {
+  return `cull:${index}`;
+}
+
+/** The compile roots behind one props gate key: a far cell's bake meshes,
+ *  or the one band object behind a cullable key, or nothing for a stranger
+ *  (which the gate then settles at once, the fail-soft arm). */
+export function propRevealRoots<T>(
+  farCells: { get(key: string): { meshes: readonly T[] } | undefined },
+  bands: { get(key: string): { obj: T } | undefined },
+  key: string,
+): readonly T[] {
+  const cell = farCells.get(key);
+  if (cell) return cell.meshes;
+  const band = bands.get(key);
+  return band ? [band.obj] : [];
+}
+
+/** XZ distance squared from the camera to the cullable's box (0 inside). */
+export function propCullBoxDistanceSq(c: PropCullBounds, camX: number, camZ: number): number {
+  const dx = camX < c.minX ? c.minX - camX : camX > c.maxX ? camX - c.maxX : 0;
+  const dz = camZ < c.minZ ? c.minZ - camZ : camZ > c.maxZ ? camZ - c.maxZ : 0;
+  return dx * dx + dz * dz;
+}
+
+/** Whether the band draws inside the fog: box distance for boxed bounds,
+ *  sphere reach for the fallback (`boxDistSq` is the caller's box distance). */
+export function propCullInFog(
+  c: PropCullBounds,
+  boxDistSq: number,
+  camX: number,
+  camZ: number,
+  fogFar: number,
+  fogFarSq: number,
+): boolean {
+  if (boxDistSq < fogFarSq) return true;
+  if (c.hasBox) return false;
+  const centerDx = c.cx - camX;
+  const centerDz = c.cz - camZ;
+  const reach = fogFar + c.r;
+  return centerDx * centerDx + centerDz * centerDz < reach * reach;
+}
+
+/**
+ * 'hidden': the fog cull hides the band this frame. 'held': first reveal
+ * deferred by the gate, the band stays hidden; the caller latches `held`.
+ * 'revealed': the band draws; the caller latches `revealed` so the gate is
+ * never consulted again.
+ */
+export type PropCullReveal = 'hidden' | 'held' | 'revealed';
+
+export function propCullReveal(
+  inFog: boolean,
+  boxDistSq: number,
+  fogFar: number,
+  state: PropCullRevealState,
+  gate: PropCullRevealGate | null | undefined,
+): PropCullReveal {
+  if (!inFog) return 'hidden';
+  if (state.revealed) return 'revealed';
+  if (!gate) return 'revealed';
+  if (boxDistSq <= PROP_CULL_REVEAL_REACH * PROP_CULL_REVEAL_REACH) return 'revealed';
+  const near = fogFar * PROP_CULL_REVEAL_NEAR_FRACTION;
+  if (!state.held && boxDistSq <= near * near) return 'revealed';
+  return gate.allow(state.key) ? 'revealed' : 'held';
+}
+
+/**
+ * Per-frame entry: cull, consult, latch and apply in one pass with no
+ * allocation on the frame path (props.ts adapts its live three objects
+ * structurally). No gate keeps the historical immediate reveal.
+ */
+export function updatePropCullable(
+  c: PropCullBounds & PropCullRevealState & { obj: { visible: boolean } },
+  camX: number,
+  camZ: number,
+  fogFar: number,
+  fogFarSq: number,
+  gate: PropCullRevealGate | null | undefined,
+): void {
+  const boxDistSq = propCullBoxDistanceSq(c, camX, camZ);
+  const inFog = propCullInFog(c, boxDistSq, camX, camZ, fogFar, fogFarSq);
+  const reveal = propCullReveal(inFog, boxDistSq, fogFar, c, gate);
+  if (reveal === 'revealed') {
+    if (!c.revealed) c.revealed = true;
+  } else if (reveal === 'held') {
+    c.held = true;
+  }
+  c.obj.visible = reveal === 'revealed';
+}

--- a/src/render/props.ts
+++ b/src/render/props.ts
@@ -48,6 +48,13 @@ import { cloneMaterialWithHooks } from './material_clone_hooks';
 import { applyOccluderFade, type OccluderFadeMat, occluderFadeMat } from './occluder_fade';
 import { occluderFadeSettled, stepOccluderFade } from './occluder_fade_core';
 import { type PropCellBounds, propCellKey, updatePropCell } from './prop_cell_core';
+import {
+  type PropCullBounds,
+  type PropCullRevealState,
+  propCullKey,
+  propRevealRoots,
+  updatePropCullable,
+} from './prop_cull_core';
 import type { RevealGateCore } from './reveal_gate_core';
 import { applySurfaceDetail, wornFamilyFor } from './worn_stone';
 
@@ -90,15 +97,26 @@ export interface PropsResult {
     reducedMotion?: boolean,
   ): void;
   /**
-   * First-reveal compile gating for the far-cell bakes (hitch-hunt P3a): a
-   * cell's first drawn far swap is held in the pixel-identical near
-   * representation until the gate warms its key. No gate keeps the immediate
-   * flip (tests, renderers without async compile; the editor viewport
-   * composes the real Renderer and is therefore gated too).
+   * First-reveal compile gating (hitch-hunt P3a): a far cell's first drawn
+   * far swap is held in the pixel-identical near representation until the
+   * gate warms the key. No gate keeps the immediate flip (tests, renderers
+   * without async compile; the editor viewport composes the real Renderer
+   * and is therefore gated too).
    */
-  setFarCellRevealGate(gate: RevealGateCore | null): void;
-  /** The compile roots behind a far-cell gate key (that cell's bake meshes). */
-  farCellRevealRoots(key: string): readonly THREE.Object3D[];
+  setRevealGate(gate: RevealGateCore | null): void;
+  /**
+   * The same gate for the merged and instanced BANDS: a band's first fog
+   * reveal on a walking approach is held hidden until the gate warms its key
+   * (prop_cull_core). Armed separately, at world entry: under the curtain
+   * the bands beyond half the fog would otherwise queue their compiles
+   * beside the manifest's near-first units, while the initial frame links
+   * whatever is visible anyway; unarmed, a band keeps the historical
+   * immediate cull and latches as revealed.
+   */
+  setBandRevealGate(gate: RevealGateCore | null): void;
+  /** The compile roots behind a gate key: a far cell's bake meshes, or the
+   *  one band behind a cullable key. */
+  revealRoots(key: string): readonly THREE.Object3D[];
 }
 
 const mergeBandDepth = (): number => (GFX.standardMaterials ? 180 : 90);
@@ -2278,8 +2296,7 @@ export function buildProps(seed: number, delveLabel?: (delveId: string) => strin
       im.computeBoundingSphere();
       im.computeBoundingBox();
       group.add(im);
-      const bounds = cullableBounds(im, im.boundingBox, im.boundingSphere);
-      if (bounds) cullables.push(bounds);
+      pushCullable(cullables, im, im.boundingBox, im.boundingSphere);
     }
   }
 
@@ -2289,8 +2306,7 @@ export function buildProps(seed: number, delveLabel?: (delveId: string) => strin
   for (const p of delvePortals) keep.add(p); // shader-driven void: keep its transparency/renderOrder
   const staticMeshes = mergeStaticMeshes(group, keep);
   for (const sm of staticMeshes) {
-    const bounds = cullableBounds(sm, sm.geometry.boundingBox, sm.geometry.boundingSphere);
-    if (bounds) cullables.push(bounds);
+    pushCullable(cullables, sm, sm.geometry.boundingBox, sm.geometry.boundingSphere);
   }
 
   // Far-cell merged bakes for the hideables (dual representation): identical
@@ -2302,18 +2318,23 @@ export function buildProps(seed: number, delveLabel?: (delveId: string) => strin
   // win matters most on the desktop tiers.
   const farCells = GFX.constrainedMemory ? [] : buildFarPropCells(group, hideables);
   const farCellsByKey = new Map(farCells.map((cell) => [cell.key, cell]));
-  let farCellRevealGate: RevealGateCore | null = null;
+  const cullablesByKey = new Map(cullables.map((cullable) => [cullable.key, cullable]));
+  let revealGate: RevealGateCore | null = null;
+  let bandRevealGate: RevealGateCore | null = null;
 
   return {
     group,
     flames,
     windmillFans,
     fireLights,
-    setFarCellRevealGate(gate: RevealGateCore | null): void {
-      farCellRevealGate = gate;
+    setRevealGate(gate: RevealGateCore | null): void {
+      revealGate = gate;
     },
-    farCellRevealRoots(key: string): readonly THREE.Object3D[] {
-      return farCellsByKey.get(key)?.meshes ?? [];
+    setBandRevealGate(gate: RevealGateCore | null): void {
+      bandRevealGate = gate;
+    },
+    revealRoots(key: string): readonly THREE.Object3D[] {
+      return propRevealRoots<THREE.Object3D>(farCellsByKey, cullablesByKey, key);
     },
     update(
       camX: number,
@@ -2327,16 +2348,17 @@ export function buildProps(seed: number, delveLabel?: (delveId: string) => strin
       reducedMotion = false,
     ): void {
       const fogFarSq = fogFar * fogFar;
+      // Band fog cull (prop_cull_core): a band's first reveal on a walking
+      // approach holds until the gate has linked its programs.
       for (let i = 0; i < cullables.length; i++) {
-        const c = cullables[i];
-        c.obj.visible = cullableVisible(c, camX, camZ, fogFar, fogFarSq);
+        updatePropCullable(cullables[i], camX, camZ, fogFar, fogFarSq, bandRevealGate);
       }
       // Far-cell swap first (prop_cell_core): distant cells draw their merged
       // bake and suppress the members' individual baked meshes; near cells
       // (where the ghost fade can fire) draw the individuals while the bake
       // stays as the shadow-only caster. Pixel-identical both ways.
       for (const cell of farCells) {
-        updatePropCell(cell, camX, camZ, fogFar, undefined, farCellRevealGate);
+        updatePropCell(cell, camX, camZ, fogFar, undefined, revealGate);
       }
       for (let i = 0; i < hideables.length; i++) {
         const h = hideables[i];
@@ -2559,20 +2581,25 @@ function cameraSegmentHitsFootprint(
   return eyeY + (camY - eyeY) * t < h.topY;
 }
 
-interface PropCullable {
+interface PropCullable extends PropCullBounds, PropCullRevealState {
   obj: THREE.Object3D;
-  hasBox: boolean;
-  minX: number;
-  maxX: number;
-  minZ: number;
-  maxZ: number;
-  cx: number;
-  cz: number;
-  r: number;
+}
+
+/** Mints the cullable's reveal-gate key from its slot: stable for the
+ *  view's lifetime, and never colliding with the far-cell grid keys. */
+function pushCullable(
+  cullables: PropCullable[],
+  obj: THREE.Object3D,
+  box: THREE.Box3 | null,
+  sphere: THREE.Sphere | null,
+): void {
+  const bounds = cullableBounds(obj, propCullKey(cullables.length), box, sphere);
+  if (bounds) cullables.push(bounds);
 }
 
 function cullableBounds(
   obj: THREE.Object3D,
+  key: string,
   box: THREE.Box3 | null,
   sphere: THREE.Sphere | null,
 ): PropCullable | undefined {
@@ -2580,6 +2607,9 @@ function cullableBounds(
     const fallback = sphere ?? box.getBoundingSphere(new THREE.Sphere());
     return {
       obj,
+      key,
+      revealed: false,
+      held: false,
       hasBox: true,
       minX: box.min.x,
       maxX: box.max.x,
@@ -2593,6 +2623,9 @@ function cullableBounds(
   if (!sphere) return undefined;
   return {
     obj,
+    key,
+    revealed: false,
+    held: false,
     hasBox: false,
     minX: sphere.center.x - sphere.radius,
     maxX: sphere.center.x + sphere.radius,
@@ -2602,23 +2635,6 @@ function cullableBounds(
     cz: sphere.center.z,
     r: sphere.radius,
   };
-}
-
-function cullableVisible(
-  c: PropCullable,
-  camX: number,
-  camZ: number,
-  fogFar: number,
-  fogFarSq: number,
-): boolean {
-  const dx = camX < c.minX ? c.minX - camX : camX > c.maxX ? camX - c.maxX : 0;
-  const dz = camZ < c.minZ ? c.minZ - camZ : camZ > c.maxZ ? camZ - c.maxZ : 0;
-  if (dx * dx + dz * dz < fogFarSq) return true;
-  if (c.hasBox) return false;
-  const centerDx = c.cx - camX;
-  const centerDz = c.cz - camZ;
-  const reach = fogFar + c.r;
-  return centerDx * centerDx + centerDz * centerDz < reach * reach;
 }
 
 // Far-cell merged bakes for the camera-ghost hideables (dual representation,

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -355,6 +355,7 @@ import {
 } from './mage_barrier_visual';
 import { MageGroundFx } from './mage_ground_fx';
 import { buildMailboxPillar } from './mailbox';
+import { collectObjectTextures, materialSlotTextures } from './material_texture_slots';
 import { buildMobNightGlow, type MobNightGlowView } from './mob_night_glow';
 import { buildMotes, type MotesView } from './motes';
 import { MountBeacon } from './mount_beacon';
@@ -511,7 +512,6 @@ import {
   measureFeatureFootprint,
   setRenderCategory,
   type TextureBackedMaterial,
-  type TextureMaterialKey,
 } from './renderer_diagnostics';
 import {
   beginRendererFrameTelemetry,
@@ -519,6 +519,7 @@ import {
   type RendererWorldPhaseMs,
 } from './renderer_frame_telemetry_core';
 import { createRevealGate } from './reveal_gate';
+import type { RevealGateCore } from './reveal_gate_core';
 import { collectRiftAmbientSources } from './rift_ambience';
 import { buildRiftRankBadge } from './rift_rank';
 import { syncRigMatrixFreeze, unfreezeRigMatrices } from './rig_visibility_freeze';
@@ -1732,9 +1733,12 @@ export class Renderer {
       dt: number,
       reducedMotion?: boolean,
     ): void;
-    setFarCellRevealGate(gate: { allow(key: string): boolean } | null): void;
-    farCellRevealRoots(key: string): readonly THREE.Object3D[];
+    setRevealGate(gate: { allow(key: string): boolean } | null): void;
+    setBandRevealGate(gate: { allow(key: string): boolean } | null): void;
+    revealRoots(key: string): readonly THREE.Object3D[];
   };
+  /** The props reveal gate (far cells at construction, bands at world entry). */
+  private propsRevealGate: RevealGateCore | null = null;
   private eastbrookTownView!: EastbrookTownView;
   private fenbridgeTownView!: FenbridgeTownView;
   private lightRank: RankedPointLight[] = [];
@@ -2603,7 +2607,8 @@ export class Renderer {
 
     // First-reveal compile gates (hitch-hunt P3a): a cull flipping world
     // content visible for the first time holds it one representation back
-    // until its programs are linked off-thread. Without async compile the
+    // (a far cell's near twin, or hidden for a fog band or a town's first
+    // approach) until its programs are linked off-thread. Without async compile the
     // gate itself would be the synchronous stall, so the views stay ungated
     // there and keep their historical immediate reveal. Reveal compiles ride
     // BELOW the live entity gates (VISIBLE_PREWARM, not LIVE_VIEW): a
@@ -2626,9 +2631,10 @@ export class Renderer {
           );
         },
       };
-      this.propsView.setFarCellRevealGate(
-        createRevealGate(revealHost, (key) => this.propsView.farCellRevealRoots(key)),
+      this.propsRevealGate = createRevealGate(revealHost, (key) =>
+        this.propsView.revealRoots(key),
       );
+      this.propsView.setRevealGate(this.propsRevealGate);
       this.eastbrookTownView.setRevealGate(
         createRevealGate(revealHost, () => this.eastbrookTownView.staticRevealRoots()),
       );
@@ -3748,6 +3754,8 @@ export class Renderer {
       // draw (getUniforms queries ACTIVE_UNIFORMS synchronously), which was a
       // measured multi-hundred-ms stall per new biome. compileAsync resolves
       // only once the programs report ready, so the live render never pays it.
+      // Both arms: the colour variant AND the shadow-pass depth variant of the
+      // zone's casters, so the sun pass never links either at first draw.
       if (opts?.pace === 'idle') {
         try {
           await withHiddenPrewarmGroups(featureGroups, async () => {
@@ -3758,7 +3766,10 @@ export class Renderer {
                 // another unit. Submit one object at a time so live work can
                 // jump queued visible-zone prewarm without overlapping it.
                 await this.backgroundGpuWork.run(
-                  () => this.compilePrewarmColorPrograms(obj, false),
+                  () =>
+                    this.compilePrewarmColorPrograms(obj, false).then(() =>
+                      this.compileShadowPrograms(obj),
+                    ),
                   GPU_WORK_PRIORITY.VISIBLE_PREWARM,
                   `zone-prepare-compile:${obj.name || obj.type}`,
                 );
@@ -3881,7 +3892,7 @@ export class Renderer {
               const group = groupLike as THREE.Group;
               const childRoot = child as THREE.Object3D;
               const units: { label: string; run: () => void }[] = [];
-              const textures = [...this.collectObjectTextures(childRoot, false)];
+              const textures = [...collectObjectTextures(childRoot, false)];
               for (let i = 0; i < textures.length; i += PREWARM_TEXTURE_UNIT_BATCH) {
                 const batch = textures.slice(i, i + PREWARM_TEXTURE_UNIT_BATCH);
                 units.push({
@@ -5536,24 +5547,8 @@ export class Renderer {
 
   private prewarmMaterialTextures(material: THREE.Material | THREE.Material[] | undefined): void {
     const mats = Array.isArray(material) ? material : material ? [material] : [];
-    const textureKeys: TextureMaterialKey[] = [
-      'map',
-      'alphaMap',
-      'aoMap',
-      'bumpMap',
-      'displacementMap',
-      'emissiveMap',
-      'envMap',
-      'lightMap',
-      'metalnessMap',
-      'normalMap',
-      'roughnessMap',
-      'specularMap',
-      'gradientMap',
-    ];
     for (const mat of mats) {
-      const textureMat = mat as TextureBackedMaterial;
-      for (const key of textureKeys) this.prewarmTexture(textureMat[key]);
+      for (const texture of materialSlotTextures(mat)) this.prewarmTexture(texture);
       // ShaderMaterials (ability-vfx pools, custom fx) hold their textures in
       // uniforms, invisible to the standard-key walk above.
       const shaderMat = mat as THREE.ShaderMaterial;
@@ -5715,53 +5710,13 @@ export class Renderer {
   // the canvas. Lazily built once and kept: 8x8 RGBA plus depth is negligible.
   private prewarmRenderTarget: THREE.WebGLRenderTarget | null = null;
 
-  private collectObjectTextures(
-    obj: THREE.Object3D,
-    visibleOnly: boolean,
-    textures = new Set<THREE.Texture>(),
-  ): Set<THREE.Texture> {
-    const textureKeys: TextureMaterialKey[] = [
-      'map',
-      'alphaMap',
-      'aoMap',
-      'bumpMap',
-      'displacementMap',
-      'emissiveMap',
-      'envMap',
-      'lightMap',
-      'metalnessMap',
-      'normalMap',
-      'roughnessMap',
-      'specularMap',
-      'gradientMap',
-    ];
-    const collect = (child: THREE.Object3D): void => {
-      const renderable = child as RenderableDiagnosticObject;
-      const materials = Array.isArray(renderable.material)
-        ? renderable.material
-        : renderable.material
-          ? [renderable.material]
-          : [];
-      for (const material of materials) {
-        const textureMaterial = material as TextureBackedMaterial;
-        for (const key of textureKeys) {
-          const texture = textureMaterial[key];
-          if (texture) textures.add(texture);
-        }
-      }
-    };
-    if (visibleOnly) obj.traverseVisible(collect);
-    else obj.traverse(collect);
-    return textures;
-  }
-
   private collectInitialSceneTextures(): THREE.Texture[] {
-    const textures = this.collectObjectTextures(this.scene, true);
+    const textures = collectObjectTextures(this.scene, true);
     // Async shader compilation temporarily hides non-self entity groups. Include
     // those already-created views explicitly so their textures do not all upload
     // during the first live submit when the compile gate restores visibility.
     for (const view of this.views.values()) {
-      this.collectObjectTextures(view.group, false, textures);
+      collectObjectTextures(view.group, false, textures);
     }
     return [...textures];
   }
@@ -6776,6 +6731,35 @@ export class Renderer {
         category: 'props',
         priority: 46,
         required: false,
+        // Droppable, so it MUST resume: without these units a deadline drop
+        // meant the pine casters and far impostors were never linked at all,
+        // and every one of them paid its colour AND shadow link mid-travel.
+        // The ghost-fade-variants shape: stage the group HIDDEN (its meshes
+        // are frustumCulled=false casters, so a visible stage would let the
+        // next live frame link every species synchronously before the compile
+        // units run; compileAsync walks hidden subtrees), then link both arms
+        // (the species cast shadows) one species per unit, so the debt lane's
+        // held tail never parks a live gate behind the whole family.
+        resumeUnits: () => {
+          const group = buildFoliageMaterialPrewarmGroup();
+          group.visible = false;
+          return [
+            {
+              id: 'foliage-materials:group',
+              run: () => {
+                foliagePrewarmGroup = group;
+                this.scene.add(group);
+              },
+            },
+            ...group.children.map((child, index) => ({
+              id: `foliage-materials:compile:${index}`,
+              run: async () => {
+                await this.compilePrewarmColorPrograms(child, false);
+                await this.compileShadowPrograms(child);
+              },
+            })),
+          ];
+        },
         run: () => {
           foliagePrewarmGroup = buildFoliageMaterialPrewarmGroup();
           this.scene.add(foliagePrewarmGroup);
@@ -7609,6 +7593,9 @@ export class Renderer {
     };
     this.lastPrewarmStats = stats;
     this.prewarmedZonePrograms.add(activeZone.id);
+    // World entry: from here every prop band's first fog reveal is gated
+    // (props.ts setBandRevealGate explains why not under the curtain).
+    this.propsView.setBandRevealGate(this.propsRevealGate);
     // Dev-channel diagnostic (pairs with main.ts's "[entry-guard] scene built"): one
     // line naming where the entry-time main-thread budget went, for isolating
     // world-entry process kills on real devices.

--- a/src/render/reveal_gate.ts
+++ b/src/render/reveal_gate.ts
@@ -1,7 +1,8 @@
 // Host adapter over reveal_gate_core: wires a cull's first-reveal hold to the
 // renderer's live compile gate. One gate instance per consumer (the props
-// far-cell swap, each town's static cull), each with its own key namespace
-// and roots provider. The compile itself rides the caller-supplied host, so
+// view, each town's static cull), each with its own roots provider and key
+// namespace (the props gate serves two disjoint ones: the far-cell grid keys
+// and the `cull:` band keys). The compile itself rides the caller-supplied host, so
 // this module owns only the settle plumbing, and its contract is absolute:
 // every requested key MUST settle, whatever the compiles do, or scenery
 // stays hidden forever. Three independent escapes guarantee it: per-root

--- a/src/render/worn_stone.ts
+++ b/src/render/worn_stone.ts
@@ -1007,7 +1007,8 @@ export function reapplySurfaceDetailToClone(clone: THREE.Material): void {
  * Every resolved family detail texture (normal/AO/rough/disp/metal clones),
  * for the renderer's boot-prewarm window. These textures are shader UNIFORMS
  * attached in onBeforeCompile, not material properties, so the scene texture
- * sweep (renderer.ts collectObjectTextures reads map/normalMap/... keys) can
+ * sweep (material_texture_slots.ts collectObjectTextures reads the named map
+ * slots) can
  * never find them: without an explicit prewarm they upload on the first live
  * draw that binds them. The Displacement fields are the heavy case: they only
  * load on the parallax tiers (ultra+), and their first-draw decode+upload was

--- a/tests/architecture.test.ts
+++ b/tests/architecture.test.ts
@@ -537,6 +537,7 @@ const RENDER_PURE_CORES = [
   'src/render/opaque_draw_order_core.ts',
   'src/render/perceptual_lod_core.ts',
   'src/render/prop_cell_core.ts',
+  'src/render/prop_cull_core.ts',
   'src/render/race_line_core.ts',
   'src/render/renderer_frame_telemetry_core.ts',
   'src/render/rift_death_zone_core.ts',

--- a/tests/eastbrook_polish_artifact_integrity.test.ts
+++ b/tests/eastbrook_polish_artifact_integrity.test.ts
@@ -767,9 +767,9 @@ const ACCEPTED_POLISH_V2_METADATA_PATH = path.join(REPO_ROOT, POLISH_SEAL_PATH);
 // follows renderer.ts, then this seal follows the swept evidence bytes. No
 // capture was retaken.
 const ACCEPTED_POLISH_V2_METADATA_SHA256 =
-  '3fd2ffdb3833ef360657aeeb0ad17039279e5fad08c279dea19fb96522db30b9';
+  '372302c1c711e1cad57a43e1d049d12fa9e0b25ca414c422715f11bea32ad729';
 const ACCEPTED_POLISH_V2_COMPOSITE_PROVENANCE =
-  '63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495';
+  '7fedc8aa9a58301b1a0f4ecf242000e3a4e61db768d1e0ac6e7a6b731fd512a2';
 const ACCEPTED_POLISH_V2_METADATA = readJsonFile<CaptureMetadata>(ACCEPTED_POLISH_V2_METADATA_PATH);
 const ACCEPTED_POLISH_V2_PROVENANCE = ACCEPTED_POLISH_V2_METADATA.polishProvenance;
 const ACCEPTED_POLISH_V2_TOWN_CONTRACT = ACCEPTED_POLISH_V2_METADATA.records[0]?.townContract;
@@ -1775,7 +1775,7 @@ describe('Eastbrook polish performance and contact evidence', () => {
     expect(
       fingerprint.digest('hex'),
       `the second-order performance digest moved; if every input moved legitimately, re-mint with: ${REMINT_COMMAND} (it recomputes this literal LAST, from the swept files)`,
-    ).toBe('3e5298f95d8f76bff403ab31aa4ce1bbd45f981cb1630f2d40f52839f08340dd');
+    ).toBe('00adf8ce291b42323fa279528b826f88f8a6ccc33c704a1cbbf10af6158bfd89');
   });
 
   it('binds every historical after record to its accepted source and asset provenance', () => {

--- a/tests/eastbrook_polish_capture_contract.test.ts
+++ b/tests/eastbrook_polish_capture_contract.test.ts
@@ -185,7 +185,7 @@ interface AttributionTargetFixture {
 // lookAtFrozen, so renderer.ts moves and the composite follows its bytes. No
 // capture was retaken.
 const PINNED_POLISH_COMPOSITE_FINGERPRINT =
-  '63eae2164f990137dccffd0df83eb3c048a1c8927d125501b717ea3b27b39495';
+  '7fedc8aa9a58301b1a0f4ecf242000e3a4e61db768d1e0ac6e7a6b731fd512a2';
 
 function validPolishAttributionTargets(): AttributionTargetFixture[] {
   return [

--- a/tests/eastbrook_town_renderer.test.ts
+++ b/tests/eastbrook_town_renderer.test.ts
@@ -26,6 +26,7 @@ import {
   newEastbrookRoofVisibilityPlan,
 } from '../src/render/eastbrook_town_visibility_core';
 import { gfxInternalsForTest } from '../src/render/gfx';
+import { createRevealGateCore } from '../src/render/reveal_gate_core';
 import { vertexColorEmissiveInternalsForTest } from '../src/render/vertex_color_emissive';
 import { BUILDING_TERRAIN_SAMPLE_STEP } from '../src/sim/building_layout';
 import { BUILTIN_WORLD } from '../src/sim/data';
@@ -267,6 +268,58 @@ describe('Eastbrook town renderer', () => {
       }
       expect(foundationBottom, `${building.id} deepest terrain seat`).toBeCloseTo(minimumY, 10);
     }
+  });
+
+  it('holds the buildings with the static batches on a walking approach until the gate settles', () => {
+    const view = eastbrookTownInternalsForTest.buildFromSources(fixtureSources(), () => 0, true);
+    const requested: string[] = [];
+    const gate = createRevealGateCore((key) => requested.push(key));
+    view.setRevealGate(gate);
+    const buildingGroups = EASTBROOK_LAYOUT.buildings.map((building) => {
+      const group = view.group.getObjectByName(`eastbrookBuilding:${building.id}`);
+      if (!group) throw new Error(`renderer fixture lost ${building.id}`);
+      return group;
+    });
+    const micro = view.group.getObjectByName('eastbrookTownMicroOpaqueBatch');
+    if (!micro) throw new Error('renderer fixture lost the micro batch');
+    // The gate compiles the buildings WITH the batches: every building group
+    // is a reveal root, so its unshared materials link before first draw.
+    for (const group of buildingGroups) expect(view.staticRevealRoots()).toContain(group);
+    expect(view.staticRevealRoots()).toContain(micro);
+
+    // Camera outside the town cull radius, town and buildings inside the fog.
+    const cullRadius = EASTBROOK_LAYOUT.wall.radius + EASTBROOK_LAYOUT.wall.maximumSegmentSpan / 2;
+    const approachX = cullRadius + 20;
+    view.update(approachX, 2, 0, approachX - 5, 2, 0, 400, 0.05);
+    expect(requested).toEqual(['eastbrook-town-static']);
+    expect(micro.visible).toBe(false);
+    for (const group of buildingGroups) expect(group.visible).toBe(false);
+
+    // Held frames never re-request; the settle reveals batches and buildings
+    // together, and the latch never consults the gate again.
+    view.update(approachX, 2, 0, approachX - 5, 2, 0, 400, 0.05);
+    expect(requested).toEqual(['eastbrook-town-static']);
+    for (const group of buildingGroups) expect(group.visible).toBe(false);
+    gate.settle('eastbrook-town-static');
+    view.update(approachX, 2, 0, approachX - 5, 2, 0, 400, 0.05);
+    expect(micro.visible).toBe(true);
+    for (const group of buildingGroups) expect(group.visible).toBe(true);
+    view.setRevealGate(createRevealGateCore((key) => requested.push(`again:${key}`)));
+    view.update(approachX, 2, 0, approachX - 5, 2, 0, 400, 0.05);
+    expect(requested).toEqual(['eastbrook-town-static']);
+    for (const group of buildingGroups) expect(group.visible).toBe(true);
+  });
+
+  it('never holds the buildings when the camera is already inside the town', () => {
+    const view = eastbrookTownInternalsForTest.buildFromSources(fixtureSources(), () => 0, true);
+    const requested: string[] = [];
+    view.setRevealGate(createRevealGateCore((key) => requested.push(key)));
+    const bank = EASTBROOK_LAYOUT.buildings[0];
+    const bankGroup = view.group.getObjectByName(`eastbrookBuilding:${bank.id}`);
+    if (!bankGroup) throw new Error('renderer fixture lost the bank');
+    view.update(4, 2, 4, 0, 2, 0, 200, 0.05);
+    expect(requested).toEqual([]);
+    expect(bankGroup.visible).toBe(true);
   });
 
   it('roof-fades only building volumes to 20% and restores them without touching microgeometry', () => {

--- a/tests/fenbridge_town_renderer.test.ts
+++ b/tests/fenbridge_town_renderer.test.ts
@@ -37,6 +37,7 @@ import {
 } from '../src/render/fenbridge_town_visibility_core';
 import { GFX, gfxInternalsForTest } from '../src/render/gfx';
 import { questObjectPreloadInternalsForTest } from '../src/render/quest_objects';
+import { createRevealGateCore } from '../src/render/reveal_gate_core';
 import { BUILTIN_WORLD, setActiveWorldContent } from '../src/sim/data';
 import { FENBRIDGE_LAYOUT, localToWorld } from '../src/sim/fenbridge_layout';
 import { terrainHeight } from '../src/sim/world';
@@ -654,6 +655,62 @@ describe('Fenbridge dedicated town renderer', () => {
         ),
       ).toBe(false);
     }
+  });
+
+  it('holds the buildings with the static batches on a walking approach until the gate settles', () => {
+    setGfx({ standardMaterials: false, dynamicShadows: false, surfaceDetail: false });
+    const view = fenbridgeTownInternalsForTest.buildFromSources(fixtureSources(), () => 0, true);
+    const requested: string[] = [];
+    const gate = createRevealGateCore((key) => requested.push(key));
+    view.setRevealGate(gate);
+    const buildingGroups = FENBRIDGE_LAYOUT.buildings.map((building) => {
+      const group = view.group.getObjectByName(`fenbridgeBuilding:${building.id}`);
+      if (!group) throw new Error(`renderer fixture lost ${building.id}`);
+      return group;
+    });
+    const micro = view.group.getObjectByName('fenbridgeTownMicroOpaqueBatch');
+    if (!micro) throw new Error('renderer fixture lost the micro batch');
+    // The gate compiles the buildings WITH the batches: every building group
+    // (its emissive lantern material included) is a reveal root.
+    for (const group of buildingGroups) expect(view.staticRevealRoots()).toContain(group);
+    expect(view.staticRevealRoots()).toContain(micro);
+
+    // Camera outside the town cull radius, town and buildings inside the fog.
+    const hub = FENBRIDGE_LAYOUT.hub.center;
+    const cullRadius = FENBRIDGE_LAYOUT.hub.radius + FENBRIDGE_LAYOUT.wall.maximumSegmentSpan / 2;
+    const approachX = hub.x + cullRadius + 20;
+    view.update(approachX, 2, hub.z, approachX - 5, 2, hub.z, 400, 0.05);
+    expect(requested).toEqual(['fenbridge-town-static']);
+    expect(micro.visible).toBe(false);
+    for (const group of buildingGroups) expect(group.visible).toBe(false);
+
+    // Held frames never re-request; the settle reveals batches and buildings
+    // together, and the latch never consults the gate again.
+    view.update(approachX, 2, hub.z, approachX - 5, 2, hub.z, 400, 0.05);
+    expect(requested).toEqual(['fenbridge-town-static']);
+    for (const group of buildingGroups) expect(group.visible).toBe(false);
+    gate.settle('fenbridge-town-static');
+    view.update(approachX, 2, hub.z, approachX - 5, 2, hub.z, 400, 0.05);
+    expect(micro.visible).toBe(true);
+    for (const group of buildingGroups) expect(group.visible).toBe(true);
+    view.setRevealGate(createRevealGateCore((key) => requested.push(`again:${key}`)));
+    view.update(approachX, 2, hub.z, approachX - 5, 2, hub.z, 400, 0.05);
+    expect(requested).toEqual(['fenbridge-town-static']);
+    for (const group of buildingGroups) expect(group.visible).toBe(true);
+  });
+
+  it('never holds the buildings when the camera is already inside the town', () => {
+    setGfx({ standardMaterials: false, dynamicShadows: false, surfaceDetail: false });
+    const view = fenbridgeTownInternalsForTest.buildFromSources(fixtureSources(), () => 0, true);
+    const requested: string[] = [];
+    view.setRevealGate(createRevealGateCore((key) => requested.push(key)));
+    const building = FENBRIDGE_LAYOUT.buildings[0];
+    const group = view.group.getObjectByName(`fenbridgeBuilding:${building.id}`);
+    if (!group) throw new Error('renderer fixture lost the first building');
+    const hub = FENBRIDGE_LAYOUT.hub.center;
+    view.update(hub.x + 4, 2, hub.z + 4, hub.x, 2, hub.z, 200, 0.05);
+    expect(requested).toEqual([]);
+    expect(group.visible).toBe(true);
   });
 
   it('fades one intersected building independently and never mutates static batches', () => {

--- a/tests/interior_encounter_prewarm_pass.test.ts
+++ b/tests/interior_encounter_prewarm_pass.test.ts
@@ -14,7 +14,12 @@ import {
 
 type Slot = { source: THREE.Mesh; overlay: THREE.Material };
 
-function fakeVisual(name: string, slots = 2, timeline: string[] = []) {
+function fakeVisual(
+  name: string,
+  slots = 2,
+  timeline: string[] = [],
+  overlayMap: THREE.Texture | null = null,
+) {
   const calls = { prewarmSoulRendSlots: 0 };
   return {
     name,
@@ -23,7 +28,7 @@ function fakeVisual(name: string, slots = 2, timeline: string[] = []) {
       calls.prewarmSoulRendSlots++;
       timeline.push(`slots:${name}`);
       return Array.from({ length: slots }, () => {
-        const overlay = new THREE.MeshBasicMaterial();
+        const overlay = new THREE.MeshBasicMaterial({ map: overlayMap });
         overlay.name = name;
         return {
           source: new THREE.Mesh(new THREE.BufferGeometry(), new THREE.MeshBasicMaterial()),
@@ -46,6 +51,7 @@ function fakeHost(
   timeline: string[] = [],
 ) {
   const compiled: string[] = [];
+  const uploaded: THREE.Texture[] = [];
   const host = {
     shutdownStarted: false,
     views: new Map(views.map((v) => [v.id, { visual: v.visual, ...look() }])),
@@ -67,7 +73,7 @@ function fakeHost(
         return work();
       },
     },
-    webgl: { initTexture: () => {} },
+    webgl: { initTexture: (texture: THREE.Texture) => uploaded.push(texture) },
     prewarmEntity: () => ({ kind: 'player', templateId: 'warrior' }),
     compilePrewarmColorPrograms: async (root: THREE.Object3D) => {
       // Name the BODY this batch belongs to, read off the overlay material the
@@ -80,8 +86,8 @@ function fakeHost(
     },
     compileShadowPrograms: async () => {},
     renderBoundedPrewarmRoot: () => {},
-    collectObjectTextures: () => new Set<THREE.Texture>(),
     compiled,
+    uploaded,
   };
   return host;
 }
@@ -160,6 +166,22 @@ describe('interior encounter prewarm pass (driven)', () => {
     queueLiveSoulRendPrewarm(host, player as never, look({ weaponSkinId: 'ice_fang' }), 'player');
     await drain();
     expect(player.calls.prewarmSoulRendSlots).toBeGreaterThan(0);
+  });
+
+  it('uploads the textures bound on the staged overlays before their bounded render', async () => {
+    // The pass reads the staged proxies' map slots through the shared
+    // material_texture_slots walk (not through the renderer host any more):
+    // an overlay's map must reach webgl.initTexture, and nothing else does.
+    const map = new THREE.Texture();
+    const player = fakeVisual('player', 2, [], map);
+    const host = fakeHost([{ id: 1, kind: 'player', visual: player }]);
+    startInteriorEncounterPrewarm('nythraxis', host);
+    await drain();
+    queueLiveSoulRendPrewarm(host, player as never, look({ weaponSkinId: 'ice_fang' }), 'player');
+    await drain();
+    expect(player.calls.prewarmSoulRendSlots).toBeGreaterThan(0);
+    expect(host.uploaded.length).toBeGreaterThan(0);
+    expect(new Set(host.uploaded)).toEqual(new Set([map]));
   });
 
   it('stops warming live bodies once the host reports leaving the interior', async () => {

--- a/tests/material_texture_slots.test.ts
+++ b/tests/material_texture_slots.test.ts
@@ -1,0 +1,74 @@
+// The material texture-slot walk (material_texture_slots.ts): the one slot
+// list the renderer's texture prewarm and boot scene collection share, and
+// the visible-only contract of the object walk (the boot collection mirrors
+// what the initial frame draws; a live entity view is walked in full).
+
+import * as THREE from 'three';
+import { describe, expect, it } from 'vitest';
+import {
+  collectObjectTextures,
+  MATERIAL_TEXTURE_KEYS,
+  materialSlotTextures,
+} from '../src/render/material_texture_slots';
+
+describe('material texture slots', () => {
+  it('names every built-in map slot once', () => {
+    expect([...MATERIAL_TEXTURE_KEYS].sort()).toEqual(
+      [
+        'alphaMap',
+        'aoMap',
+        'bumpMap',
+        'displacementMap',
+        'emissiveMap',
+        'envMap',
+        'gradientMap',
+        'lightMap',
+        'map',
+        'metalnessMap',
+        'normalMap',
+        'roughnessMap',
+        'specularMap',
+      ].sort(),
+    );
+    expect(new Set(MATERIAL_TEXTURE_KEYS).size).toBe(MATERIAL_TEXTURE_KEYS.length);
+  });
+
+  it('reads only the bound slots of a material', () => {
+    const map = new THREE.Texture();
+    const normalMap = new THREE.Texture();
+    const material = new THREE.MeshStandardMaterial({ map, normalMap });
+    expect(materialSlotTextures(material)).toEqual([map, normalMap]);
+    expect(materialSlotTextures(new THREE.MeshBasicMaterial())).toEqual([]);
+  });
+
+  it('collects across a subtree, deduplicated, and skips hidden subtrees only when asked', () => {
+    const shared = new THREE.Texture();
+    const hiddenOnly = new THREE.Texture();
+    const root = new THREE.Group();
+    const a = new THREE.Mesh(
+      new THREE.BufferGeometry(),
+      new THREE.MeshStandardMaterial({ map: shared }),
+    );
+    const b = new THREE.Mesh(new THREE.BufferGeometry(), [
+      new THREE.MeshStandardMaterial({ map: shared }),
+      new THREE.MeshStandardMaterial({ emissiveMap: hiddenOnly }),
+    ]);
+    const hidden = new THREE.Group();
+    hidden.visible = false;
+    hidden.add(b);
+    root.add(a, hidden);
+
+    expect([...collectObjectTextures(root, true)]).toEqual([shared]);
+    expect(new Set(collectObjectTextures(root, false))).toEqual(new Set([shared, hiddenOnly]));
+    // traverseVisible skips a hidden ROOT too: the boot collection of a
+    // hidden group yields nothing, the full walk still everything.
+    root.visible = false;
+    expect([...collectObjectTextures(root, true)]).toEqual([]);
+    expect(new Set(collectObjectTextures(root, false))).toEqual(new Set([shared, hiddenOnly]));
+    root.visible = true;
+    // An existing set accumulates instead of being replaced.
+    const into = new Set<THREE.Texture>([hiddenOnly]);
+    expect(collectObjectTextures(root, true, into)).toBe(into);
+    expect(into).toEqual(new Set([hiddenOnly, shared]));
+  });
+});

--- a/tests/monolith_budget.test.ts
+++ b/tests/monolith_budget.test.ts
@@ -80,7 +80,10 @@ const MONOLITHS: MonolithRow[] = [
     // Lowered again by the castle branch's interior_light_rig.ts extraction;
     // after merging main the merged file lands below both prior pins, so the
     // ceiling is the exact merged count.
-    ceiling: 13689,
+    // Lowered again after extracting the material texture-slot walk
+    // (material_texture_slots.ts) that two renderer methods each carried a
+    // copy of; the streamed-decor gate wiring rode inside that headroom.
+    ceiling: 13676,
     seam: 'a new src/render/<thing>.ts module the renderer calls (src/render/CLAUDE.md)',
   },
   {

--- a/tests/prewarm_policy.test.ts
+++ b/tests/prewarm_policy.test.ts
@@ -215,12 +215,15 @@ describe('resolvePrewarmPolicy: unconstrained desktop', () => {
   });
 
   it('classifies exactly the link/upload debt entries for BOOT_DEBT resume', () => {
-    // Positive arm: the four debt payers whose unpaid remainder surfaces as
+    // Positive arm: the debt payers whose unpaid remainder surfaces as
     // first-draw stalls in live frames.
     expect(prewarmResumeIsDebt('programs.compile')).toBe(true);
     expect(prewarmResumeIsDebt('programs.compile-submit')).toBe(true);
     expect(prewarmResumeIsDebt('textures.scene')).toBe(true);
     expect(prewarmResumeIsDebt('surface-detail.textures')).toBe(true);
+    // The foliage species stream in with travel (ambient scene, not an
+    // event), so their dropped material units are debt too.
+    expect(prewarmResumeIsDebt('foliage.materials')).toBe(true);
     // Negative arm over REACHABLE inputs: these three entries declare real
     // resumeUnits, so they are the ids a misclassification would actually
     // route to BOOT_DEBT. They stay cosmetic (below the preview lane) by the
@@ -298,7 +301,7 @@ describe('resolvePrewarmPolicy: unconstrained desktop', () => {
       .filter((block) => block.includes('resumeUnits:'))
       .map((block) => /id: '([^']+)'/.exec(block)?.[1])
       .filter((id): id is string => Boolean(id) && manifestIds.has(id as string));
-    expect(resumable.length).toBeGreaterThanOrEqual(5);
+    expect(resumable.length).toBeGreaterThanOrEqual(10);
     for (const id of resumable) {
       expect(
         prewarmResumeIsDebt(id) || COSMETIC_RESUME_IDS.includes(id),
@@ -1239,9 +1242,9 @@ describe('constrained entry view creation ramp', () => {
       collectionStart,
     );
     const collectionMethod = renderer.slice(collectionStart, collectionEnd);
-    expect(collectionMethod).toContain('this.collectObjectTextures(this.scene, true)');
+    expect(collectionMethod).toContain('collectObjectTextures(this.scene, true)');
     expect(collectionMethod).toContain('for (const view of this.views.values())');
-    expect(collectionMethod).toContain('this.collectObjectTextures(view.group, false, textures)');
+    expect(collectionMethod).toContain('collectObjectTextures(view.group, false, textures)');
 
     const methodStart = renderer.indexOf('private async prewarmInitialSceneTexturesBatched(');
     const methodEnd = renderer.indexOf('\n  private renderPrewarmPass(', methodStart);

--- a/tests/prop_cull_core.test.ts
+++ b/tests/prop_cull_core.test.ts
@@ -1,0 +1,230 @@
+// The prop band fog cull and its first-reveal policy (prop_cull_core.ts): the
+// props twin of town_reveal_core. A band's first fog reveal on a walking
+// approach consults the gate and holds while cold; a band already near the
+// camera (login, hearth, teleport) reveals at once; a revealed band never
+// consults again; no gate keeps the historical immediate cull.
+
+import { describe, expect, it } from 'vitest';
+import { PROP_FAR_SWAP_DISTANCE, propCellKey } from '../src/render/prop_cell_core';
+import {
+  PROP_CULL_REVEAL_NEAR_FRACTION,
+  PROP_CULL_REVEAL_REACH,
+  type PropCullBounds,
+  propCullBoxDistanceSq,
+  propCullInFog,
+  propCullKey,
+  propCullReveal,
+  propRevealRoots,
+  updatePropCullable,
+} from '../src/render/prop_cull_core';
+import { createRevealGateCore } from '../src/render/reveal_gate_core';
+
+const box = (minX: number, maxX: number, minZ: number, maxZ: number): PropCullBounds => ({
+  hasBox: true,
+  minX,
+  maxX,
+  minZ,
+  maxZ,
+  cx: (minX + maxX) / 2,
+  cz: (minZ + maxZ) / 2,
+  r: Math.hypot(maxX - minX, maxZ - minZ) / 2,
+});
+
+const sphere = (cx: number, cz: number, r: number): PropCullBounds => ({
+  hasBox: false,
+  minX: cx - r,
+  maxX: cx + r,
+  minZ: cz - r,
+  maxZ: cz + r,
+  cx,
+  cz,
+  r,
+});
+
+function cullable(bounds: PropCullBounds, key = 'cull:0') {
+  return { ...bounds, key, revealed: false, held: false, obj: { visible: true } };
+}
+
+/** The historical props.ts cull, composed the way updatePropCullable does. */
+function inFog(c: PropCullBounds, camX: number, camZ: number, fogFar: number): boolean {
+  return propCullInFog(
+    c,
+    propCullBoxDistanceSq(c, camX, camZ),
+    camX,
+    camZ,
+    fogFar,
+    fogFar * fogFar,
+  );
+}
+
+describe('prop cull fog test', () => {
+  it('culls a boxed band by its box distance and a sphere band by its reach', () => {
+    const band = box(100, 300, -50, 50);
+    // Box distance 20 < fogFar 100.
+    expect(inFog(band, 80, 0, 100)).toBe(true);
+    // Box distance 100 is NOT < 100 (the exact fog boundary is excluded).
+    expect(inFog(band, 0, 0, 100)).toBe(false);
+    // Inside the box: distance 0.
+    expect(propCullBoxDistanceSq(band, 200, 0)).toBe(0);
+    // A sphere band past its box distance still draws while its centre is
+    // within fogFar + r (the historical fallback).
+    const orb = sphere(0, 0, 10);
+    expect(inFog(orb, 105, 0, 100)).toBe(true);
+    expect(inFog(orb, 111, 0, 100)).toBe(false);
+  });
+});
+
+describe('prop cull gate keys and roots', () => {
+  it('mints dense band keys that never collide with the far-cell grid keys', () => {
+    expect([0, 1, 7].map(propCullKey)).toEqual(['cull:0', 'cull:1', 'cull:7']);
+    // Both namespaces share ONE props gate: a far-cell key must never look
+    // like a band key, whatever the cell coordinates.
+    for (const [x, z] of [
+      [0, 0],
+      [-1, -1],
+      [119, 119],
+      [120, -120],
+      [-100000, 100000],
+    ]) {
+      expect(propCellKey(x, z)).not.toMatch(/^cull:/);
+    }
+  });
+
+  it('resolves a far cell to its bake meshes, a band to its one object, a stranger to nothing', () => {
+    const bakeA = { name: 'bake-a' };
+    const bakeB = { name: 'bake-b' };
+    const band = { name: 'band' };
+    const farCells = new Map([['0:1', { meshes: [bakeA, bakeB] }]]);
+    const bands = new Map([['cull:3', { obj: band }]]);
+    expect(propRevealRoots(farCells, bands, '0:1')).toEqual([bakeA, bakeB]);
+    expect(propRevealRoots(farCells, bands, 'cull:3')).toEqual([band]);
+    expect(propRevealRoots(farCells, bands, 'cull:4')).toEqual([]);
+    expect(propRevealRoots(farCells, bands, '9:9')).toEqual([]);
+  });
+});
+
+describe('prop cull first-reveal policy', () => {
+  it('hides a fogged band and never consults the gate for it', () => {
+    let consulted = 0;
+    const gate = { allow: () => (consulted++, true) };
+    const state = { key: 'cull:1', revealed: false, held: false };
+    expect(propCullReveal(false, 500 * 500, 100, state, gate)).toBe('hidden');
+    expect(consulted).toBe(0);
+  });
+
+  it('holds a cold far band, reveals it once the gate warms, then never consults again', () => {
+    const requested: string[] = [];
+    const gate = createRevealGateCore((key) => requested.push(key));
+    const c = cullable(box(150, 350, -50, 50), 'cull:7');
+    // Camera 100 from the box, fogFar 120: inside the fog, beyond the near
+    // fraction (60), so the first reveal rides the gate.
+    updatePropCullable(c, 50, 0, 120, 120 * 120, gate);
+    expect(requested).toEqual(['cull:7']);
+    expect(c.obj.visible).toBe(false);
+    expect(c.revealed).toBe(false);
+    expect(c.held).toBe(true);
+    updatePropCullable(c, 50, 0, 120, 120 * 120, gate);
+    expect(requested).toEqual(['cull:7']);
+    expect(c.obj.visible).toBe(false);
+    gate.settle('cull:7');
+    updatePropCullable(c, 50, 0, 120, 120 * 120, gate);
+    expect(c.obj.visible).toBe(true);
+    expect(c.revealed).toBe(true);
+    // Fog re-entry after the latch: a plain cull flip, no consult.
+    const cold = createRevealGateCore((key) => requested.push(`again:${key}`));
+    updatePropCullable(c, -100, 0, 120, 120 * 120, cold);
+    expect(c.obj.visible).toBe(false);
+    updatePropCullable(c, 50, 0, 120, 120 * 120, cold);
+    expect(c.obj.visible).toBe(true);
+    expect(requested).toEqual(['cull:7']);
+  });
+
+  it('reveals a band already near the camera immediately, gate or not', () => {
+    const requested: string[] = [];
+    const gate = createRevealGateCore((key) => requested.push(key));
+    const near = fogFarNearEdge(120);
+    // Box distance exactly at the near fraction reveals without a consult.
+    const c = cullable(box(near, near + 100, -50, 50), 'cull:2');
+    updatePropCullable(c, 0, 0, 120, 120 * 120, gate);
+    expect(requested).toEqual([]);
+    expect(c.obj.visible).toBe(true);
+    expect(c.revealed).toBe(true);
+    // One unit further out consults.
+    const far = cullable(box(near + 1, near + 100, -50, 50), 'cull:3');
+    updatePropCullable(far, 0, 0, 120, 120 * 120, gate);
+    expect(requested).toEqual(['cull:3']);
+    expect(far.obj.visible).toBe(false);
+  });
+
+  it('keeps holding a held band that crosses the near line while its compile is in flight', () => {
+    // After a cover arrival the fog opens over seconds: a band held at the
+    // fog edge (dist 100, fogFar 120) is inside the near line once fogFar
+    // reaches 300 (near 150). It must stay held until the settle, or it
+    // links cold anyway (the raced-pending-link rows after an arrival).
+    const requested: string[] = [];
+    const gate = createRevealGateCore((key) => requested.push(key));
+    const c = cullable(box(150, 350, -50, 50), 'cull:9');
+    updatePropCullable(c, 50, 0, 120, 120 * 120, gate);
+    expect(c.held).toBe(true);
+    expect(c.obj.visible).toBe(false);
+    updatePropCullable(c, 50, 0, 300, 300 * 300, gate);
+    expect(c.obj.visible).toBe(false);
+    expect(c.revealed).toBe(false);
+    gate.settle('cull:9');
+    updatePropCullable(c, 50, 0, 300, 300 * 300, gate);
+    expect(c.obj.visible).toBe(true);
+    expect(requested).toEqual(['cull:9']);
+  });
+
+  it('reveals a band inside the reach floor on every consult, held or not', () => {
+    // A held band whose compile is still in flight when the player walks up
+    // to it: the colliders it carries must not stay invisible at arm's length,
+    // whatever the gate does.
+    const requested: string[] = [];
+    const gate = createRevealGateCore((key) => requested.push(key));
+    const c = cullable(box(150, 350, -50, 50), 'cull:5');
+    updatePropCullable(c, 50, 0, 120, 120 * 120, gate);
+    expect(c.held).toBe(true);
+    expect(c.obj.visible).toBe(false);
+    // Box distance 41: still held.
+    updatePropCullable(c, 109, 0, 120, 120 * 120, gate);
+    expect(c.obj.visible).toBe(false);
+    // Box distance 40: the reach floor reveals, no settle needed.
+    updatePropCullable(c, 110, 0, 120, 120 * 120, gate);
+    expect(c.obj.visible).toBe(true);
+    expect(c.revealed).toBe(true);
+    expect(requested).toEqual(['cull:5']);
+    // The floor also covers a first consult under a tightly clamped fog,
+    // where half the fog would be a few yards: band at 30 under fogFar 45.
+    const clamped = cullable(box(30, 130, -50, 50), 'cull:6');
+    updatePropCullable(clamped, 0, 0, 45, 45 * 45, gate);
+    expect(clamped.obj.visible).toBe(true);
+    expect(requested).toEqual(['cull:5']);
+  });
+
+  it('keeps the historical immediate cull without a gate', () => {
+    const c = cullable(box(150, 350, -50, 50), 'cull:4');
+    updatePropCullable(c, 50, 0, 120, 120 * 120, null);
+    expect(c.obj.visible).toBe(true);
+    expect(c.revealed).toBe(true);
+    updatePropCullable(c, 50, 0, 120, 120 * 120, undefined);
+    expect(c.obj.visible).toBe(true);
+    updatePropCullable(c, -100, 0, 120, 120 * 120, null);
+    expect(c.obj.visible).toBe(false);
+  });
+
+  it('pins the near fraction to half the fog range and the reach floor to the far-cell swap', () => {
+    // A walking approach meets a band at the fog plane; a cover arrival lands
+    // among bands the player can reach before any compile settles. Half the
+    // fog range keeps the reachable ones ungated (prop_cull_core.ts), and the
+    // absolute floor is one camera boom plus the largest footprint, the same
+    // distance the far cells swap to individuals at.
+    expect(PROP_CULL_REVEAL_NEAR_FRACTION).toBe(0.5);
+    expect(PROP_CULL_REVEAL_REACH).toBe(40);
+    expect(PROP_CULL_REVEAL_REACH).toBe(PROP_FAR_SWAP_DISTANCE);
+  });
+});
+
+function fogFarNearEdge(fogFar: number): number {
+  return fogFar * PROP_CULL_REVEAL_NEAR_FRACTION;
+}

--- a/tests/reveal_gate_wiring.test.ts
+++ b/tests/reveal_gate_wiring.test.ts
@@ -11,6 +11,7 @@
 
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
+import { prewarmResumeIsDebt } from '../src/render/prewarm_policy';
 
 function stripComments(source: string): string {
   return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
@@ -37,46 +38,170 @@ describe('reveal gate wiring (source pins)', () => {
     expect(wiring).toContain('label: `reveal-gate:${target.name || target.type}`,');
     expect(wiring).toContain('this.compilePrewarmColorPrograms(target, false).then(() =>');
     expect(wiring).toContain('this.compileShadowPrograms(target),');
-    expect(wiring).toContain('this.propsView.setFarCellRevealGate(');
-    expect(wiring).toContain(
-      'createRevealGate(revealHost, (key) => this.propsView.farCellRevealRoots(key))',
+    expect(wiring).toContain('this.propsRevealGate = createRevealGate(revealHost, (key) =>');
+    expect(wiring).toContain('this.propsView.revealRoots(key),');
+    expect(wiring).toContain('this.propsView.setRevealGate(this.propsRevealGate);');
+    // The band arm of the props gate arms at WORLD ENTRY (the tail of the
+    // boot prewarm), never in the constructor: armed under the curtain, the
+    // bands beyond half the fog would queue their compiles beside the
+    // manifest's near-first units for content the initial frame links
+    // anyway. The negative scans the WHOLE constructor, bounded on its
+    // declaration and its closing brace, not a character window.
+    const constructorStart = anchor(rendererSource, '\n  constructor(');
+    const constructorEnd = rendererSource.indexOf('\n  }\n', constructorStart);
+    expect(constructorEnd).toBeGreaterThan(constructorStart);
+    const constructorBody = rendererSource.slice(constructorStart, constructorEnd);
+    expect(constructorBody).toContain('this.propsView.setRevealGate(this.propsRevealGate);');
+    expect(constructorBody).not.toContain('setBandRevealGate');
+    const entryTail = rendererSource.slice(
+      anchor(rendererSource, 'this.prewarmedZonePrograms.add(activeZone.id);'),
+      anchor(rendererSource, '[entry-guard] prewarm done:'),
     );
+    expect(entryTail).toContain('this.propsView.setBandRevealGate(this.propsRevealGate);');
     expect(wiring).toContain('this.eastbrookTownView.setRevealGate(');
     expect(wiring).toContain('this.fenbridgeTownView.setRevealGate(');
   });
 
-  it('props threads the gate into the per-frame far-cell update', () => {
+  it('props threads the gate into the per-frame far-cell and band updates', () => {
     const propsSource = read('../src/render/props.ts');
     expect(propsSource).toContain(
-      'updatePropCell(cell, camX, camZ, fogFar, undefined, farCellRevealGate);',
+      'updatePropCell(cell, camX, camZ, fogFar, undefined, revealGate);',
     );
-    // The reveal key IS the map key: if these diverge, farCellRevealRoots
-    // returns [] for every consult and the gate degrades to an immediate
-    // reveal that no behavior test can see.
+    expect(propsSource).toContain(
+      'updatePropCullable(cullables[i], camX, camZ, fogFar, fogFarSq, bandRevealGate);',
+    );
+    expect(propsSource).toContain('setBandRevealGate(gate: RevealGateCore | null): void {');
+    // The reveal key IS the map key: if these diverge, revealRoots returns
+    // [] for every consult and the gate degrades to an immediate reveal that
+    // no behavior test can see. Band keys are minted from the slot at push
+    // time and resolve to the one band object.
     expect(propsSource).toContain('new Map(farCells.map((cell) => [cell.key, cell]))');
     expect(propsSource).toContain('key: cellKey,');
     expect(propsSource).toContain(`mesh.name = \`far-bake:\${cellKey}\`;`);
-    expect(propsSource).toContain('farCellsByKey.get(key)?.meshes ?? []');
+    expect(propsSource).toContain('new Map(cullables.map((cullable) => [cullable.key, cullable]))');
+    expect(propsSource).toContain(
+      'cullableBounds(obj, propCullKey(cullables.length), box, sphere)',
+    );
+    const rootsAt = anchor(propsSource, 'revealRoots(key: string): readonly THREE.Object3D[] {');
+    const roots = propsSource.slice(rootsAt, rootsAt + 200);
+    expect(roots).toContain(
+      'return propRevealRoots<THREE.Object3D>(farCellsByKey, cullablesByKey, key);',
+    );
+    // Every band goes through the ONE gated cull entry: no raw `.obj.visible =`
+    // write anywhere in props.ts (the pre-change loop had exactly one). The
+    // matcher is proven live on a fixture first, so the zero is not vacuous.
+    const rawBandWrite = /\.obj\.visible\s*=/g;
+    expect('c.obj.visible = cullableVisible(c, camX);'.match(rawBandWrite)).toHaveLength(1);
+    expect(propsSource.match(rawBandWrite) ?? []).toHaveLength(0);
   });
 
   it.each([
-    ['eastbrook', '../src/render/eastbrook_town.ts', 'eastbrook-town-static'],
-    ['fenbridge', '../src/render/fenbridge_town.ts', 'fenbridge-town-static'],
-  ])('%s resolves its static cull through the town reveal policy', (_town, path, key) => {
-    const source = read(path);
-    // The policy call must decide the SAME staticVisible the cull loop
-    // applies, in that order: policy, latch, then the visibility writes.
-    const policyAt = anchor(source, 'const reveal = townStaticReveal(');
-    const keyAt = anchor(source, `'${key}',`);
-    const latchAt = anchor(source, "if (reveal === 'revealed') staticRevealed = true;");
-    const applyAt = anchor(source, "const staticVisible = reveal === 'revealed';");
-    const cullAt = anchor(source, 'staticCullTargets[index].visible = staticVisible;');
-    expect(policyAt).toBeLessThan(keyAt);
-    expect(keyAt).toBeLessThan(latchAt);
-    expect(latchAt).toBeLessThan(applyAt);
-    expect(applyAt).toBeLessThan(cullAt);
-    // The roots provider hands the gate the exact batch set the cull flips.
-    expect(source).toContain('staticRevealRoots(): readonly THREE.Object3D[] {');
-    expect(source).toContain('return staticCullTargets;');
+    [
+      'eastbrook',
+      '../src/render/eastbrook_town.ts',
+      'eastbrook-town-static',
+      'target.group.visible = roofVisibilityPlan.visible && !buildingsHeld;',
+    ],
+    [
+      'fenbridge',
+      '../src/render/fenbridge_town.ts',
+      'fenbridge-town-static',
+      'target.group.visible = visibilityPlan.visible && !buildingsHeld;',
+    ],
+  ])(
+    '%s resolves its static cull and its buildings through the town reveal policy',
+    (_town, path, key, buildingWrite) => {
+      const source = read(path);
+      // The policy call must decide the SAME staticVisible the cull loop
+      // applies, in that order: policy, latch, then the visibility writes,
+      // batches first and then the buildings under the same hold.
+      const policyAt = anchor(source, 'const reveal = townStaticReveal(');
+      const keyAt = anchor(source, `'${key}',`);
+      const latchAt = anchor(source, "if (reveal === 'revealed') staticRevealed = true;");
+      const applyAt = anchor(source, "const staticVisible = reveal === 'revealed';");
+      const cullAt = anchor(source, 'staticCullTargets[index].visible = staticVisible;');
+      const heldAt = anchor(source, "const buildingsHeld = reveal === 'held';");
+      const buildingAt = anchor(source, buildingWrite);
+      expect(policyAt).toBeLessThan(keyAt);
+      expect(keyAt).toBeLessThan(latchAt);
+      expect(latchAt).toBeLessThan(applyAt);
+      expect(applyAt).toBeLessThan(cullAt);
+      expect(cullAt).toBeLessThan(heldAt);
+      expect(heldAt).toBeLessThan(buildingAt);
+      // The roots provider hands the gate the batch set the cull flips PLUS
+      // every building group: a building outside the roots links its
+      // unshared materials cold on its own first fog reveal.
+      expect(source).toContain(
+        'const staticRevealRoots: THREE.Object3D[] = [...staticCullTargets, ...buildingGroups];',
+      );
+      expect(source).toContain('buildingGroups.push(built.group);');
+      expect(source).toContain('staticRevealRoots(): readonly THREE.Object3D[] {');
+      expect(source).toContain('return staticRevealRoots;');
+    },
+  );
+
+  it('the boot scene sweep stays visible-only, and the idle zone prepare links both arms', () => {
+    // Measured (iGPU, far login, 2026-08-17): a `traverse` sweep also
+    // collects the entity views hidden behind their live compile gates; their
+    // already-linked programs settle instantly, the adaptive link budget of
+    // the early submit lane reads that as progress and keeps submitting until
+    // the hard deadline (13.8 s instead of stalling after one unit), and the
+    // whole manifest behind it (settle-state, textures, the initial frame)
+    // times out. Hidden decor is the reveal gates' job, not the sweep's.
+    const sweep = rendererSource.slice(
+      anchor(rendererSource, "id: 'scene',"),
+      anchor(rendererSource, 'compileRootDistanceSq(root, this.sim.player.pos.x'),
+    );
+    // The scene unit's collector call, whitespace-agnostic: the visible-only
+    // flag is the literal `true` second argument.
+    expect(sweep).toMatch(
+      /compileRoots\(\s*this\.scene\.children\.filter\(\(root\) => !stagedRoots\.has\(root\)\),\s*true,\s*\)/,
+    );
+    // The background (idle) zone prepare compiles the shadow-pass depth
+    // variant AFTER the colour one, inside the same queue unit.
+    const idle = rendererSource.slice(
+      anchor(rendererSource, "if (opts?.pace === 'idle') {"),
+      anchor(rendererSource, 'for (const mesh of waterMeshes) mesh.visible = true;'),
+    );
+    const idleUnit = idle.slice(
+      anchor(idle, 'await this.backgroundGpuWork.run('),
+      anchor(idle, '`zone-prepare-compile:${obj.name || obj.type}`,'),
+    );
+    const idleColourAt = anchor(
+      idleUnit,
+      'this.compilePrewarmColorPrograms(obj, false).then(() =>',
+    );
+    const idleShadowAt = anchor(idleUnit, 'this.compileShadowPrograms(obj),');
+    expect(idleColourAt).toBeLessThan(idleShadowAt);
+  });
+
+  it('the foliage material prewarm resumes after a deadline drop with both compile arms', () => {
+    const entry = rendererSource.slice(
+      anchor(rendererSource, "id: 'foliage.materials',"),
+      anchor(rendererSource, "id: 'foliage.great-tree-materials',"),
+    );
+    expect(entry).toContain('required: false,');
+    expect(entry).toContain('resumeUnits: () => {');
+    // The resumed group is staged HIDDEN (frustumCulled=false casters would
+    // otherwise link on the next live frame), then linked colour THEN shadow,
+    // one species per unit.
+    const buildAt = anchor(entry, 'const group = buildFoliageMaterialPrewarmGroup();');
+    const hideAt = anchor(entry, 'group.visible = false;');
+    const groupAt = anchor(entry, "id: 'foliage-materials:group',");
+    const compileAt = anchor(entry, 'group.children.map((child, index) => ({');
+    const compileIdAt = anchor(entry, 'id: `foliage-materials:compile:${index}`,');
+    const colourAt = anchor(entry, 'await this.compilePrewarmColorPrograms(child, false);');
+    const shadowAt = anchor(entry, 'await this.compileShadowPrograms(child);');
+    expect(buildAt).toBeLessThan(hideAt);
+    expect(hideAt).toBeLessThan(groupAt);
+    expect(groupAt).toBeLessThan(compileAt);
+    expect(compileAt).toBeLessThan(compileIdAt);
+    expect(compileIdAt).toBeLessThan(colourAt);
+    expect(colourAt).toBeLessThan(shadowAt);
+    // The compile units end before the entry's own run(): both arms belong
+    // to the resume units, not to the boot run.
+    expect(shadowAt).toBeLessThan(anchor(entry, 'run: () => {\n          foliagePrewarmGroup ='));
+    // Ambient-scene debt: its dropped units ride the BOOT_DEBT arm.
+    expect(prewarmResumeIsDebt('foliage.materials')).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

**The problem.** Walking through the open world still hitches on streamed
DECOR: when a town, a prop kit or a foliage species enters the fog range for
the first time, its shader programs are linked synchronously inside the live
frame that first draws it, and a shader link on the main thread is a whole
dropped frame or several. Measured on a live production client with the
in-game GL probe (`?perfTrace=1&perf`, `scripts/profiler/gpu_hitch_probe.mjs`):
one Fenbridge building's emissive lantern material cost 220 ms at its first
draw, plain kit `MeshStandardMaterial`s 85 to 180 ms, a Tripo prop material
146 ms, the pine leaves 49 and 46 ms, and over a 90 s stretch of travel the
GLB world content that had never been submitted to `compileAsync` added up to
about a second of stalls. This is the same class of hitch the shadow arm fix
(#3468) and the far-LOD bake gate (#3473) close for characters, on the decor
side. The first-reveal compile gates of hitch-hunt P3a
(`src/render/reveal_gate.ts`, wired for the props' far-cell bakes and the two
towns' static batches) hold world content hidden until its programs are linked
off-thread, but they left four holes, all verified in code:

1. **Town buildings were outside their own town's gate.** `staticRevealRoots()`
   returned only the micro and repeated batches, and each building group's
   `.visible` was a raw write from its own fog and camera-fade plan. The
   per-building materials (the emissive lantern variant above all) are shared
   with no batch, so a walking approach linked them cold on the frame the
   building's cull first showed it, both in Fenbridge and in Eastbrook.
2. **The props' per-band fog cull was ungated.** Only the far-cell bakes
   consulted `farCellRevealGate`; the merged and instanced bands
   (`c.obj.visible = cullableVisible(...)`) flipped visible cold. A band beyond
   the fog at boot is invisible to the visible-only boot sweep and to every
   prewarm group that misses its exact variant, so its first fog reveal on a
   walk was a synchronous link inside a live frame.
3. **`foliage.materials` was droppable with no `resumeUnits`**: a deadline
   drop meant the pine casters and far impostors were never linked at all.
4. **The background (idle) zone prepare compiled the colour arm only**, never
   `compileShadowPrograms`.

Streetlamps, biome dressing and dungeon interiors already ride
`attachSceneGroupGated`; that pattern is the reference here, nothing new is
invented.

**The fix.**

- Both towns: every building group is now a reveal root beside the batches
  (`staticRevealRoots = [...staticCullTargets, ...buildingGroups]`), and while
  the town's first reveal is `held` the buildings stay hidden with the batches
  (`target.group.visible = plan.visible && !buildingsHeld`). Everything else is
  unchanged: fog re-entries stay plain cull flips, the latch never consults the
  gate again, and a camera already inside the town (login, hearth, teleport)
  reveals immediately as before, so sim colliders never block against
  invisible walls.
- Props: a new pure core, `src/render/prop_cull_core.ts` (registered in
  `RENDER_PURE_CORES`), holds the historical fog cull (moved out of `props.ts`
  verbatim, now Node-testable) plus the first-reveal policy, the props twin of
  `town_reveal_core`: a band's first fog reveal consults the gate and holds
  while cold; a band already NEAR the camera on that first consult (closer than
  `PROP_CULL_REVEAL_NEAR_FRACTION` = half the fog range: hearth and teleport
  arrivals, whose warm pass links what it draws) reveals at once, so nothing
  reachable is ever an invisible collider; a band the gate already holds stays
  held until the settle even if it crosses the near line (after an arrival the
  fog opens over seconds; without that rule a held band crossed the near line
  with its compile still in flight and linked cold anyway, measured as the
  raced rows right after an arrival reveal), down to an absolute floor:
  inside `PROP_CULL_REVEAL_REACH` (40 yd of box distance, the far-cell swap
  distance: one camera boom plus the largest footprint) a band reveals on
  every consult, held or not, because the bands carry colliders (fences, the
  race arches and jumps) and a hold is time-bounded only by the gate's
  watchdog: decor may arrive late, the player never walks into nothing; the
  same floor covers a first consult under the tight residency-clamped fog of
  a cover arrival. Once revealed the gate is never consulted again. Each band
  gets a stable key (`propCullKey(slot)` = `cull:<slot>`, disjoint from the
  far-cell grid keys), the props gate becomes generic (`setRevealGate` /
  `revealRoots(key)` resolve far cells AND bands through the pure
  `propRevealRoots`), and the band arm of the gate arms at WORLD ENTRY
  (`setBandRevealGate`, at the tail of `prewarmInitialScene`), never under the
  curtain: armed at boot, the bands beyond half the fog queued their compiles
  beside the manifest's near-first units for content the initial frame links
  anyway (measured as a later reveal, see below).
- `foliage.materials` gets `resumeUnits` (stage the group HIDDEN, its meshes
  are `frustumCulled = false` casters that a visible stage would let the next
  live frame link synchronously; then link colour AND shadow arms, one species
  per unit so the debt lane's held tail never parks a live gate behind the
  whole family; the `props.ghost-fade-variants` shape) and joins the debt class
  (`PREWARM_DEBT_RESUME_IDS`): the species it links stream in with every step
  of travel, ambient scene, not an event.
- The idle zone prepare compiles `compileShadowPrograms(obj)` after the colour
  arm, inside the same queue unit.

**Riders (announced).**
- `src/render/material_texture_slots.ts`: the material texture-slot list and
  the object texture walk (`collectObjectTextures`, `materialSlotTextures`),
  extracted from `renderer.ts` where two methods each carried a copy of the
  13-slot list; `interior_encounter_prewarm_pass.ts` imports the walk directly
  instead of reaching it through the renderer host cast (the host-contract pin
  in `tests/interior_encounter_prewarm_pass.test.ts` caught the removed member).
  `renderer.ts` sits on an exact-count monolith ceiling, so the gate wiring had
  to ride inside that headroom; the ceiling is lowered to the new count.
- Eastbrook polish provenance re-mint (`renderer.ts` and `eastbrook_town.ts`
  are fingerprinted inputs; the three literals were re-minted with
  `scripts/assets/eastbrook_grand_armoury/remint_polish_provenance.mjs`, no
  capture retaken).

**Tried and reverted, worth knowing.** Making the boot `'scene'` compile sweep
collect with `traverse` instead of `traverseVisible` (so hidden-at-boot decor
is prewarmed under the curtain) is a trap: the walk also collects the entity
views hidden behind their live compile gates; their already-linked programs
settle instantly, the adaptive link budget of the early submit lane
(`programs.compile-submit`) reads that as progress and keeps submitting until
the hard deadline (13.8 s instead of stalling after one unit at 3 s), and the
whole manifest behind it (settle-state, texture uploads, the initial frame)
times out: measured on the iGPU as `programsAfter` 131 instead of 255,
`renderPasses` 0, then 2-3 s of cold links in the first live seconds. Pinned
as a source contract in `tests/reveal_gate_wiring.test.ts` (the sweep stays
visible-only; hidden decor is the reveal gates' job).

**Not in this PR** (other families the same benches surfaced, all
pre-existing and unchanged by this diff): the foliage species that link cold
mid-travel while `foliage:0` sits late in the post-entry debt lane (a lane
ordering / reveal-race question, a follow-up of its own); station and gather-node props
(`stations.ts`, `gather_nodes.ts`) which have no prewarm group and no gate
(frustum-culled at the arrival pass, they link at first sight); the leaping
fish (`tripo_material_f1366419`, the prod 146 ms row is this creature) which
links at its first leap; the town buildings' occlusion fade (`transparent`
flips a second program per material at the first fade).

**Measured** (versioned online bench copied to `tmp/`, Intel iGPU, headless,
`?gfx=ultra`, driver shader cache disabled, 2 runs per leg per scenario,
captures under `tmp/captures/decor/`, gitignored):

- Scenario A, Eastbrook login then walking approach of Fenbridge from the
  Veiled Hollow (0,1100 to 0,620 in 30 yd hops every 3 s): before and after
  are equivalent (boot 13 vs 11 scene units, reveal 40.6 vs 40.9 s, the same
  foliage debt-race rows live); the fog reaches 700 yd here, so every kit
  program is already linked by the Eastbrook boot and the family cannot show.
- Scenario B, login FAR from Eastbrook (a reusable observer parked at 0,1000,
  then the same walk south; the only local way to have the zone1/zone2 kits and
  the Fenbridge buildings unlinked at login): before and after have the SAME
  393-program set, boot prewarm 23.2-23.7 s in both, 208 cold links under the
  curtain in both, 2-3 live rows in both (all pre-existing families); the after
  runs add exactly `fenbridgeTownEmissive:fenbridge_warden_gatehouse` (2/2 runs)
  and the `WornIron` band (1/2), both compiled by the reveal gates when they
  entered the fog around 33 s and never drawn (the camera never looked their
  way): in the baseline these programs do not exist and would link cold at
  first sight, the exact shape of the prod 220 ms row.
- Boot cost of the band gate: armed under the curtain it moved the first
  compile-unit submit from 14.4 s to 16.0 s and the reveal by about 1.5 s
  (bands beyond half the fog competing with the manifest); armed at world
  entry (the shipped form) submit and reveal are back to the baseline. At arm
  time every band already in the fog is latched revealed (it was culled
  ungated under the curtain), so arming fires no burst; a cover arrival still
  consults every band the opening fog uncovers over a few seconds, the same
  accepted shape as the far cells ("a teleport can queue dozens of far cells
  at once", the reveal host comment), at VISIBLE_PREWARM below every live
  entity gate.

Prod remains the judge for this family (same capture kit, 3 min in Fenbridge
and a peaks crowd): the never-compiled world-content rows above should
disappear or shrink to the first-frame reveal residue.

## Related issues

Part of the in-game hitch investigation (the streamed-decor family); follows
#3468 and #3473 (independent of both: this gate's
colour arm was always the right variant; its shadow arm links the right depth
variant once #3468 lands, no change needed here).

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [x] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx vitest run tests/prop_cull_core.test.ts tests/reveal_gate_wiring.test.ts tests/fenbridge_town_renderer.test.ts tests/eastbrook_town_renderer.test.ts tests/prewarm_policy.test.ts tests/interior_encounter_prewarm_pass.test.ts tests/material_texture_slots.test.ts tests/monolith_budget.test.ts tests/architecture.test.ts tests/eastbrook_polish_capture_contract.test.ts tests/eastbrook_polish_artifact_integrity.test.ts`
  - `/qa` (qa-checklist + correctness, test-coverage and frontend-seam reviewers): the findings folded in are the reach floor above, the foliage resume group staged hidden and linked per species, the vacuous negative pin replaced by a bounded matcher with a live positive control, the band key/roots resolution moved into the pure core so it is behaviour-tested (dense keys, disjoint from `propCellKey`, roots per namespace, stranger yields nothing), the towns' occluder fade kept stepping while held (the guard stays on the plan, only the visibility write takes the hold), the interior encounter pass's texture upload asserted with a real bound map, ordering pins for the two compile arms, and the whitespace-coupled sweep pin made a regex.
  - `GATE_SELECT_BASE=upstream/release/v0.39.0 node scripts/gate_select.mjs` (see below)
  - Bench: `tmp/run_decor_leg.sh` (scenario A) and `tmp/run_decor_far_pair.sh`
    (scenario B, park + walk) over `tmp/gpu_hitch_capture.farbake.mjs` (the
    #3473 bench with two tmp-only options: a reusable observer account and no
    entry teleport); analysis with `tmp/decor_segments.mjs` and the program-set
    diff. iGPU via `--angle gl-egl` with `__EGL_VENDOR_LIBRARY_FILENAMES` unset,
    `MESA_SHADER_CACHE_DISABLE=true`.
- Manual steps: none beyond the bench (the served vite module was curl-verified
  before every leg; vite restarted between legs and after every stash).

## Screenshots / recordings

N/A (no visible change: on a walking approach a building or a band pops in a
few frames later; nothing a player acts on is delayed).

---

## Checklist

### Quality

- [x] **The gate passes.** `node scripts/gate_select.mjs` is green (or `npm run gate` for
      the full suite). I added or updated decisive
      tests for changed behavior and recorded any manual checks above.

### Cross-platform

- [x] Tested on desktop
- [ ] ~~Accessible.~~ N/A: no UI change.

### Localization (i18n)

- [ ] ~~New player-visible strings follow the contributor policy.~~
- [ ] ~~Numbers, money, dates, units, and percents go through the i18n formatters.~~
- [ ] ~~Player-facing text emitted from `src/sim/` or `server/` is re-localized.~~
- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.