### PR TITLE
fix(pvp): apply diminishing returns to player stuns

### DIFF
--- a/docs/design/pvp-crowd-control-dr.md
+++ b/docs/design/pvp-crowd-control-dr.md
@@ -1,0 +1,104 @@
+# PvP crowd-control diminishing returns
+
+Owner module: `src/sim/stun_dr.ts` (the category classifier, the ladder
+constants, and the two resolvers `crowdControlDurationAfterDr` /
+`diminishedCrowdControlDuration`). Every PLAYER-sourced crowd-control
+application funnels through `diminishedCrowdControlDuration`; the effect arms
+in `src/sim/combat/effect_dispatch.ts` are the consumers. Pinned by
+`tests/stun_dr.test.ts`, the duel-path tests in `tests/pvp_safety.test.ts`,
+and `tests/warfare_set_bonuses.test.ts` (the item-set reduction layer).
+
+## The rule
+
+Diminishing returns apply only when a hostile player CCs another player.
+The hostile-pair set is whatever `isHostileTo` reports, which today means
+duels, ranked arena, Thornhollow battlegrounds, Fiesta, Yumi, Vale Cup, and
+the jail brawl; there is no open-world PvP mode. PvE is untouched in both
+directions: a player stunning a mob always lands the full authored duration,
+and boss immunity is the separate `ccImmune` template flag. PET-sourced
+crowd control is also exempt on purpose (the funnel gates on the SOURCE
+being a player): this keeps the WARFARE 4-piece wording, "crowd control
+cast on you by hostile players", exactly true (see `docs/design/warfare.md`).
+
+The reset constants are per family (`PVP_STUN_DR_RESET`, `PVP_ROOT_DR_RESET`,
+both 18 seconds today; polymorph and fear run 60 second windows).
+
+Within one category, successive applications on the same target walk the
+classic ladder: 100 percent, 50 percent, 25 percent, then immune (the fourth
+application applies nothing). The window is `PVP_STUN_DR_RESET` (18 seconds)
+measured from the most recent landed application; each landed application
+refreshes it, a resisted cast does not advance or refresh anything, an
+immune-stage attempt neither advances nor refreshes, and once the window
+lapses the ladder starts fresh. The stamp is taken when the effect is
+APPLIED, not when it fades: a 4 second stun's ladder is already 14 seconds
+into its window when the stun ends. Polymorph and fear ride their own
+schedules (staged absolute durations and duration-scaled multipliers; see
+the constants in `stun_dr.ts`).
+
+## Stun categories
+
+Stuns are split into independent buckets, classified by
+`stunDrCategory(abilityId)`:
+
+- `openerStun`: the from-Duskveil openers, Gut Punch (`cheap_shot`) and
+  Pounce.
+- `controlledStun`: deliberate on-demand stuns behind real cooldowns: Low
+  Blow (`kidney_shot`), Sundering Gavel (`hammer_of_justice`), Bash, Charge,
+  Bear Charge, Faultline, Sun God's Verdict, Storm Bolt, Deadfrost
+  (`deep_freeze`), Abyssal Rift.
+- `randomStun`: the safe default for anything unregistered (proc-style
+  stuns). The Vale Cup Shoulder stays here DELIBERATELY: repeated tumbles
+  on one ball carrier ladder out (1.2, 0.6, 0.3, immune) by authored intent
+  (the sport-abilities comment in `src/sim/content/vale_cup.ts` predates
+  this system going live and asked for exactly that), and it must never
+  share a bucket with real combat stuns.
+
+The split is load-bearing: an opener never diminishes the follow-up
+controlled stun, so the sanctioned rogue flow (full Gut Punch into full Low
+Blow) survives. Only repeated same-bucket stuns shrink and then go immune.
+A NEW stun ability must be added to the right set in `stun_dr.ts` in the same
+change; an unregistered id still diminishes (in `randomStun`) but will not
+share a bucket with the abilities it should.
+
+## Why this shape (the WoW reference)
+
+The reference game ran this exact system for two decades, and our shape maps
+onto its history deliberately:
+
+- The 100/50/25/immune ladder is verbatim from the original system (WoW
+  patch 1.4.0) and held unchanged from vanilla through The War Within.
+- The category split mirrors the WotLK 3.1 structure: a dedicated Cheap
+  Shot plus Pounce opener pair, a broad controlled-stun category, and a
+  random proc-stun category. Vanilla arranged the buckets differently
+  (Kidney Shot alone in its own category, Cheap Shot with the controlled
+  stuns) but delivered the same gameplay property in the opposite
+  direction: in every pre-Cataclysm era the opener and the follow-up
+  finisher stun did NOT share a bucket. Cataclysm merged them and killed
+  the double-full-stun opener; we deliberately keep the classic-era feel.
+- The reset window uses the Warlords semantics (a fixed 18 seconds from the
+  most recent application, refreshed per application) rather than the
+  classic rule (15 to 20 seconds after the effect ENDS, randomized on the
+  server heartbeat). The fixed window is deterministic, which matters here:
+  the classic randomized reset would put an rng draw on every CC
+  application and shift the shared draw order.
+- One deliberate divergence: WoW applies stun DR in PvE too (stuns are the
+  one category that diminishes against mobs). We keep PvE undiminished on
+  purpose: repeated stuns on trash are a core part of how melee kits feel
+  in dungeons here, boss immunity is already handled by `ccImmune`, and
+  applying a ladder to mobs would shift PvE balance and every parity golden
+  for no stated problem.
+
+## History
+
+The first ship of the ladder exempted player stuns entirely (the reasoning:
+short flat durations behind real cooldowns). Live PvP disproved the premise:
+Gut Punch has no cooldown and the Cheap Trick talent row removes its
+Duskveil requirement, so a rogue could hold a player in an unbounded stun
+chain (Gut Punch every 6 seconds of energy, Low Blow and Dirt Toss plugging
+the gaps). The 2026-08 PvP feedback round surfaced it, and the exemption was
+removed: stuns now walk the same ladder as roots and lockouts. For the
+record, the reference game never shipped a permanent no-stealth Cheap Shot
+in any era; the closest analogs were time-boxed windows behind cooldowns
+(Shadow Dance: 6 seconds on a 1 minute cooldown; Subterfuge: 3 seconds
+after stealth breaks). Whether Cheap Trick itself should be reworked is a
+separate balance decision from this system.

--- a/src/sim/combat/effect_dispatch.ts
+++ b/src/sim/combat/effect_dispatch.ts
@@ -3219,7 +3219,7 @@ export function runEffects(
               const duration = ctx.diminishedCrowdControlDuration(
                 p,
                 m,
-                'controlledStun',
+                stunDrCategory(ability.id),
                 eff.duration,
               );
               if (duration !== null) {

--- a/src/sim/combat/hunter_trap.ts
+++ b/src/sim/combat/hunter_trap.ts
@@ -7,6 +7,7 @@
 
 import type { GroundAoE } from '../entity_roster';
 import type { SimContext } from '../sim_context';
+import { stunDrCategory } from '../stun_dr';
 import type { Entity } from '../types';
 import { DT, dist2d } from '../types';
 import { hunterBindingPayload, onHunterTrapTriggered } from './hunter_shared';
@@ -192,11 +193,12 @@ export function tickHunterTrap(ctx: SimContext, effect: GroundAoE): void {
       }
       onHunterTrapTriggered(ctx, source, effect.pos);
     } else {
-      // The legacy Rime Snare retains its controlled-stun behavior.
+      // The legacy Rime Snare retains its controlled-stun behavior: frost_trap
+      // is registered in CONTROLLED_STUNS, so the classifier resolves it there.
       const duration = ctx.diminishedCrowdControlDuration(
         source,
         target,
-        'controlledStun',
+        stunDrCategory(trap.abilityId),
         trap.freezeDuration,
       );
       if (duration !== null) {

--- a/src/sim/stun_dr.ts
+++ b/src/sim/stun_dr.ts
@@ -20,6 +20,10 @@ const CONTROLLED_STUNS = new Set([
   'bear_charge',
   'faultline',
   'sun_gods_verdict',
+  'storm_bolt',
+  'deep_freeze',
+  'abyssal_rift',
+  'frost_trap',
 ]);
 
 export function stunDrCategory(abilityId: string): CrowdControlDrCategory {
@@ -36,9 +40,9 @@ export function isStunDrCategory(category: CrowdControlDrCategory): boolean {
 
 // PvP-only diminishing-returns tuning for the resolvers below: the reset
 // window per category (how long until a fresh application starts the ladder
-// over), the shared 100/50/25/immune multiplier ladder that root and lockout
-// walk, the fixed staged durations for polymorph, and the fear multipliers that
-// scale each ability's authored duration.
+// over), the shared 100/50/25/immune multiplier ladder that root, lockout, and
+// the three stun buckets walk, the fixed staged durations for polymorph, and
+// the fear multipliers that scale each ability's authored duration.
 const PVP_ROOT_DR_RESET = 18; // seconds before a repeated PvP root is fresh again
 const PVP_STUN_DR_RESET = 18; // stuns share the root-style 100/50/25/immune scheme
 const PVP_POLYMORPH_DR_RESET = 60;
@@ -61,17 +65,21 @@ const PVP_FEAR_DR_MULTIPLIERS = [1, 0.5, 0.25, 0.125] as const;
  * The PvP diminishing-returns ladder for one crowd-control category: full
  * duration outside hostile player-versus-player combat, a fixed staged
  * schedule for polymorph, the duration-scaled fear ladder, the shared
- * 100/50/25/immune multiplier ladder for root/lockout, and null once that
+ * 100/50/25/immune multiplier ladder for root/lockout/stun, and null once that
  * ladder is exhausted (DR-immune, apply nothing). `now` and `isHostileTo` are
  * passed in rather than read off a host: this keeps the resolver a leaf module
  * with no `SimContext` dependency, so a Vitest can import and exercise it
  * directly. It is NOT a pure function of its arguments: three of its exits
  * write the new DR stage to `target.ccDr`.
  *
- * Balance pass (maintainer): player stuns are exempt from PvP diminishing
- * returns. They operate differently from fear: short flat durations behind
- * real cooldowns, so the ladder only made banked stuns (Twin Gavels) feel
- * broken. Fear, polymorph, root, and school lockouts keep their ladders.
+ * Balance pass (maintainer, 2026-08): player stuns walk the classic-era ladder
+ * like every other category, per stun bucket, on the PVP_STUN_DR_RESET window.
+ * An earlier pass exempted stuns outright (short flat durations behind real
+ * cooldowns), but live PvP disproved the premise: Gut Punch has no cooldown,
+ * and once the Cheap Trick row removes its stealth gate a rogue chains it into
+ * Low Blow indefinitely. The category split above still protects the
+ * sanctioned opener flow (a Gut Punch opener never diminishes the following
+ * Low Blow); only repeated same-bucket stuns shrink and then go immune.
  */
 export function crowdControlDurationAfterDr(
   now: number,
@@ -84,7 +92,6 @@ export function crowdControlDurationAfterDr(
   if (source.kind !== 'player' || target.kind !== 'player' || !isHostileTo(source, target)) {
     return duration;
   }
-  if (isStunDrCategory(category)) return duration;
   const existing = target.ccDr.get(category);
   const stage = existing && existing.resetAt > now ? existing.stage : 0;
   const reset =
@@ -116,14 +123,12 @@ export function crowdControlDurationAfterDr(
  * reduction on top of it.
  *
  * The two are layered rather than fused because they are separate mechanisms.
- * The ladder has five distinct exits inside its hostile branch and they do not
- * all want the same treatment: stuns take an early return that exempts them
- * from the ladder (see the balance-pass comment on `crowdControlDurationAfterDr`)
- * but NOT from the set reduction, and a DR-immune target returns null, which
- * means "apply nothing" and must pass through untouched rather than being
- * multiplied. Applying the reduction at the generic ladder exit alone would
- * silently miss stuns, which is the category the bonus most exists for, so it
- * is applied here once, over whatever the ladder decided.
+ * The ladder has several distinct exits inside its hostile branch (the staged
+ * polymorph schedule, the fear multipliers, the shared root/lockout/stun
+ * ladder) and a DR-immune target returns null, which means "apply nothing" and
+ * must pass through untouched rather than being multiplied. Applying the
+ * reduction here once, over whatever the ladder decided, keeps every exit
+ * covered without threading it through each arm.
  *
  * The player/hostile gate is duplicated from the inner function on purpose: it
  * is three cheap reads, it leaves the ladder's shape byte-identical to what

--- a/tests/charge_parallel_recharge.test.ts
+++ b/tests/charge_parallel_recharge.test.ts
@@ -9,8 +9,8 @@ import { EMPTY_TEST_WORLD } from './sim_shared';
 // waited a WHOLE extra cooldown behind the first. Charge-limited abilities now
 // run one recharge timer PER SPENT CHARGE in parallel: each charge comes back
 // its own cooldown after the moment IT was spent, not queued behind its twin.
-// Also pinned here: player stuns are exempt from PvP diminishing returns
-// (fear/polymorph/root keep theirs).
+// Also pinned here: player stuns walk the PvP diminishing-returns ladder
+// through the Sim delegate (so a banked second charge lands diminished).
 
 function setup(): { sim: Sim; p: Entity; mob: Entity } {
   const sim = new Sim({
@@ -68,7 +68,7 @@ describe('parallel per-charge recharge (Double Sentence)', () => {
     expect(p.abilityCharges?.hammer_of_justice?.charges).toBe(2);
   });
 
-  it('player stuns are exempt from PvP diminishing returns', () => {
+  it('player stuns walk the PvP diminishing-returns ladder through the Sim delegate', () => {
     const sim = new Sim({
       seed: 7,
       playerClass: 'paladin',
@@ -89,10 +89,12 @@ describe('parallel per-charge recharge (Double Sentence)', () => {
     const hostile = anySim.isHostileTo.bind(sim);
     (sim as unknown as { isHostileTo(a: Entity, b: Entity): boolean }).isHostileTo = (a, b) =>
       (a.id === source.id && b.id === 999) || hostile(a, b);
-    // Repeated stuns keep FULL duration (no 1/2, 1/4, immune ladder).
-    for (let i = 0; i < 4; i++) {
-      expect(anySim.diminishedCrowdControlDuration(source, target, 'controlledStun', 3)).toBe(3);
-    }
+    // Repeated same-bucket stuns diminish (full, 1/2, 1/4, then immune), so a
+    // banked second Sundering Gavel charge lands at half length, not full.
+    expect(anySim.diminishedCrowdControlDuration(source, target, 'controlledStun', 3)).toBe(3);
+    expect(anySim.diminishedCrowdControlDuration(source, target, 'controlledStun', 3)).toBe(1.5);
+    expect(anySim.diminishedCrowdControlDuration(source, target, 'controlledStun', 3)).toBe(0.75);
+    expect(anySim.diminishedCrowdControlDuration(source, target, 'controlledStun', 3)).toBeNull();
     // Fear keeps its ladder: the second application is shorter than the first.
     const first = anySim.diminishedCrowdControlDuration(source, target, 'fear', 8);
     const second = anySim.diminishedCrowdControlDuration(source, target, 'fear', 8);

--- a/tests/pvp_safety.test.ts
+++ b/tests/pvp_safety.test.ts
@@ -316,7 +316,7 @@ describe('PvP control abilities in active duels', () => {
     expect(castFear()).toBe(8);
   }, 90_000);
 
-  it('duel stuns land at full duration on every repeat (stun DR exemption)', () => {
+  it('duel stuns walk the 100/50/25/immune ladder (PvP stun DR)', () => {
     const { sim, aPid, b } = startDuel('paladin', 'warrior', 20);
 
     // Sundering Gavel is a 3s instant stun. As with Fear, a
@@ -337,13 +337,24 @@ describe('PvP control abilities in active duels', () => {
       return dur;
     };
 
-    // Balance pass (maintainer): player stuns are EXEMPT from PvP diminishing
-    // returns (they are short flat durations behind real cooldowns); every
-    // repeat lands at full duration. Fear/polymorph/root keep their ladders.
+    // Player stuns diminish within their category like roots and lockouts:
+    // full, half, quarter, then immune.
     expect(castStun()).toBe(3);
-    expect(castStun()).toBe(3);
-    expect(castStun()).toBe(3);
-    expect(castStun()).toBe(3);
+    expect(castStun()).toBe(1.5);
+    expect(castStun()).toBe(0.75);
+
+    // Fourth application: DR-immune. A single real cast applies no stun aura,
+    // and the decisive pin is the DR state itself: the chain sits at stage 3
+    // (immune), which is what bounds a repeated same-category chain in PvP.
+    b.auras = b.auras.filter((aura) => aura.id !== 'hammer_of_justice_stun');
+    const pala = sim.entities.get(aPid)!;
+    pala.gcdRemaining = 0;
+    pala.resource = pala.maxResource;
+    pala.cooldowns.delete('hammer_of_justice');
+    sim.castAbility('hammer_of_justice', aPid);
+    finishCast(sim, aPid);
+    expect(b.auras.some((aura) => aura.id === 'hammer_of_justice_stun')).toBe(false);
+    expect(b.ccDr.get('controlledStun')?.stage).toBe(3);
   });
 
   it('keeps opener and controlled stuns on independent DR chains (#1004)', () => {
@@ -372,11 +383,11 @@ describe('PvP control abilities in active duels', () => {
       return dur;
     };
 
-    // The controlled stun is unaffected by the spent opener chain, and with
-    // the stun-DR exemption every repeat stays full length.
+    // The controlled stun is unaffected by the spent opener chain: it lands at
+    // full duration, then diminishes only within its own controlled bucket.
     expect(castStun()).toBe(3);
-    expect(castStun()).toBe(3);
-    expect(castStun()).toBe(3);
+    expect(castStun()).toBe(1.5);
+    expect(castStun()).toBe(0.75);
   });
 
   it('does not diminish PvE stuns: a stun on a mob keeps full duration on repeat', () => {

--- a/tests/stun_dr.test.ts
+++ b/tests/stun_dr.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { MOBS } from '../src/sim/data';
+import { ABILITIES, MOBS } from '../src/sim/data';
 import { createMob, createPlayer } from '../src/sim/entity';
 import {
   crowdControlDurationAfterDr,
@@ -21,6 +21,49 @@ describe('stun DR categories (#1004)', () => {
     expect(stunDrCategory('bash')).toBe('controlledStun');
     expect(stunDrCategory('charge')).toBe('controlledStun');
     expect(stunDrCategory('bear_charge')).toBe('controlledStun');
+    expect(stunDrCategory('storm_bolt')).toBe('controlledStun');
+    expect(stunDrCategory('deep_freeze')).toBe('controlledStun');
+    expect(stunDrCategory('abyssal_rift')).toBe('controlledStun');
+    expect(stunDrCategory('frost_trap')).toBe('controlledStun');
+  });
+
+  it('every authored stun-bearing ability carries a deliberate DR bucket', () => {
+    // Bucket assignment is load-bearing since the stun exemption was removed:
+    // an unregistered stun still diminishes, but in the randomStun catch-all,
+    // cut off from the abilities it should share a chain with. This sweep is
+    // how storm_bolt / deep_freeze / abyssal_rift drift gets caught.
+    const RANDOM_BY_DESIGN = new Set([
+      // The Vale Cup Shoulder deliberately rides the randomStun default:
+      // repeated tumbles on one carrier ladder out by authored intent, and it
+      // must never share a bucket with real combat stuns.
+      'sport_shoulder',
+    ]);
+    const stunIds: string[] = [];
+    for (const [id, def] of Object.entries(ABILITIES)) {
+      const effectLists = [def.effects ?? [], ...(def.ranks ?? []).map((r) => r.effects ?? [])];
+      const carriesStun = effectLists.some((effects) =>
+        effects.some((eff) => {
+          const rec = eff as unknown as Record<string, unknown>;
+          return (
+            eff.type === 'stun' ||
+            eff.type === 'finisherStun' ||
+            (eff.type === 'aoeRoot' && rec.stun === true) ||
+            (typeof rec.stunSec === 'number' && rec.stunSec > 0)
+          );
+        }),
+      );
+      if (carriesStun) stunIds.push(id);
+    }
+    // Vacuity floor: the sweep must actually be seeing the live stun roster.
+    expect(stunIds.length).toBeGreaterThanOrEqual(10);
+    const unregistered = stunIds.filter(
+      (id) => !RANDOM_BY_DESIGN.has(id) && stunDrCategory(id) === 'randomStun',
+    );
+    expect(unregistered).toEqual([]);
+    for (const id of RANDOM_BY_DESIGN) {
+      expect(stunIds).toContain(id);
+      expect(stunDrCategory(id)).toBe('randomStun');
+    }
   });
 
   it('keeps opener and controlled stuns in independent buckets', () => {
@@ -127,13 +170,66 @@ describe('crowdControlDurationAfterDr / diminishedCrowdControlDuration', () => {
     expect(crowdControlDurationAfterDr(0, hostile, source, target, 'fear', 4)).toBe(0.5);
   });
 
-  it('leaves stun categories (openerStun/controlledStun/randomStun) undiminished', () => {
+  it('walks the 100/50/25/immune ladder for every hostile PvP stun category', () => {
     const stunCategories: CrowdControlDrCategory[] = ['openerStun', 'controlledStun', 'randomStun'];
     for (const category of stunCategories) {
       const { source, target } = players();
-      for (let i = 0; i < 5; i++) {
-        expect(crowdControlDurationAfterDr(0, hostile, source, target, category, 3)).toBe(3);
-      }
+      expect(crowdControlDurationAfterDr(0, hostile, source, target, category, 4)).toBe(4);
+      expect(crowdControlDurationAfterDr(0, hostile, source, target, category, 4)).toBe(2);
+      expect(crowdControlDurationAfterDr(0, hostile, source, target, category, 4)).toBe(1);
+      expect(crowdControlDurationAfterDr(0, hostile, source, target, category, 4)).toBeNull();
+    }
+  });
+
+  it('keeps the stun buckets independent: an exhausted opener chain leaves controlled stuns fresh', () => {
+    const { source, target } = players();
+    expect(crowdControlDurationAfterDr(0, hostile, source, target, 'openerStun', 4)).toBe(4);
+    expect(crowdControlDurationAfterDr(0, hostile, source, target, 'openerStun', 4)).toBe(2);
+    expect(crowdControlDurationAfterDr(0, hostile, source, target, 'openerStun', 4)).toBe(1);
+    expect(crowdControlDurationAfterDr(0, hostile, source, target, 'openerStun', 4)).toBeNull();
+    // The classic opener/controlled split: a spent Gut Punch chain must not have
+    // touched the Low Blow bucket, so the controlled stun still lands full.
+    expect(crowdControlDurationAfterDr(0, hostile, source, target, 'controlledStun', 6)).toBe(6);
+    expect(crowdControlDurationAfterDr(0, hostile, source, target, 'controlledStun', 6)).toBe(3);
+  });
+
+  it('an immune-window attempt applies nothing and does not refresh the reset window', () => {
+    const { source, target } = players();
+    expect(crowdControlDurationAfterDr(0, hostile, source, target, 'controlledStun', 6)).toBe(6);
+    expect(crowdControlDurationAfterDr(2, hostile, source, target, 'controlledStun', 6)).toBe(3);
+    expect(crowdControlDurationAfterDr(4, hostile, source, target, 'controlledStun', 6)).toBe(1.5);
+    const stampedReset = target.ccDr.get('controlledStun')!.resetAt;
+    // Immune: the attempts apply nothing AND leave the stamp untouched, so an
+    // attacker spamming into immunity cannot hold the target immune-locked.
+    expect(crowdControlDurationAfterDr(6, hostile, source, target, 'controlledStun', 6)).toBeNull();
+    expect(
+      crowdControlDurationAfterDr(10, hostile, source, target, 'controlledStun', 6),
+    ).toBeNull();
+    expect(target.ccDr.get('controlledStun')!.resetAt).toBe(stampedReset);
+    // Fresh 18s after the last LANDED application (t=4), not the last attempt.
+    expect(crowdControlDurationAfterDr(23, hostile, source, target, 'controlledStun', 6)).toBe(6);
+  });
+
+  it('a stun chain starts fresh once the PVP_STUN_DR_RESET window has passed', () => {
+    const { source, target } = players();
+    expect(crowdControlDurationAfterDr(0, hostile, source, target, 'controlledStun', 6)).toBe(6);
+    expect(crowdControlDurationAfterDr(0, hostile, source, target, 'controlledStun', 6)).toBe(3);
+    // PVP_STUN_DR_RESET is 18s from the last application: well past it, the
+    // ladder restarts at full duration.
+    expect(crowdControlDurationAfterDr(100, hostile, source, target, 'controlledStun', 6)).toBe(6);
+  });
+
+  it('leaves stuns undiminished for PvE and non-hostile pairs', () => {
+    const source = players().source;
+    const target = mob();
+    for (let i = 0; i < 5; i++) {
+      expect(crowdControlDurationAfterDr(0, hostile, source, target, 'controlledStun', 3)).toBe(3);
+    }
+    const pair = players();
+    for (let i = 0; i < 5; i++) {
+      expect(
+        crowdControlDurationAfterDr(0, friendly, pair.source, pair.target, 'controlledStun', 3),
+      ).toBe(3);
     }
   });
 

--- a/tests/warfare_set_bonuses.test.ts
+++ b/tests/warfare_set_bonuses.test.ts
@@ -231,10 +231,10 @@ describe('the crowd-control duration hook', () => {
     const { sim, source, target } = duelists();
     // Baseline first with no reduction, then the same category again from a clean
     // DR state. Comparing against the measured baseline rather than restating the
-    // ladder's own formula is what makes this decisive per category: stuns take an
-    // early return that exempts them from the ladder but NOT from this reduction,
-    // and an implementation applying the cut at the generic exit alone passes a
-    // root-only test while silently missing them.
+    // ladder's own formula is what makes this decisive per category: every
+    // category must take the reduction on top of whatever its ladder arm decided,
+    // and an implementation applying the cut at only one exit passes a root-only
+    // test while silently missing the others.
     target.ccDurationReduction = 0;
     const baseline = cc(sim, source, target, category, 6);
     expect(baseline).not.toBeNull();


### PR DESCRIPTION
## Summary

Removes the stun exemption from the PvP crowd-control diminishing-returns funnel (src/sim/stun_dr.ts), so player stuns now walk the classic 100/50/25/immune ladder per bucket on the 18 second reset window, like roots and lockouts already do. Motivated by the PvP feedback round (2026-08-18): with the Cheap Trick row removing Gut Punch's Duskveil gate, a rogue can hold a player in an unbounded stun chain (Gut Punch is 60 energy on no cooldown, energy regen is 20 per 2s, Low Blow and Dirt Toss plug the gaps). Players report 20 to 30 second locks and the mechanics support calling it indefinite.

What changes in practice: the worst case rogue lock drops from unbounded to roughly 13 seconds (Gut Punch 4s, Low Blow 6s, Gut Punch 2s then 1s, then opener-immune), followed by a real gap. The sanctioned opener flow survives: Gut Punch and Low Blow sit in separate buckets (openerStun vs controlledStun), so the opener never diminishes the follow-up finisher.

Also in this change:
- Registers the drifted stuns that were never categorized while buckets were inert: storm_bolt, deep_freeze, abyssal_rift, frost_trap all join CONTROLLED_STUNS.
- Routes the two call sites that passed a literal 'controlledStun' (the aoeRoot stun arm, the hunter trap freeze) through stunDrCategory so future re-bucketing cannot silently miss them.
- Adds a content sweep test that fails on any future stun ability shipped without a deliberate bucket (the Vale Cup Shoulder is allow-listed as randomStun by authored intent).
- New design doc docs/design/pvp-crowd-control-dr.md recording the system, the per-era WoW reference behind each choice, and the deliberate divergences.

## WoW reference (verified against classic-era sources)

The ladder (100/50/25/immune) is verbatim WoW patch 1.4.0 and held for two decades. Our opener/controlled split mirrors the WotLK 3.1 structure (Cheap Shot plus Pounce as a dedicated opener pair) and preserves the property every pre-Cataclysm era had: the opener and the finisher stun never shared a bucket. The reset window uses the Warlords semantics (fixed 18s from the most recent landed application) rather than the classic randomized 15 to 20s after effect end, because the classic rule would put an rng draw on every CC application and shift the shared stream. Deliberate divergences, both documented: PvE stuns do not diminish here (WoW diminishes stuns on mobs too), and pet-sourced CC stays exempt (keeps the WARFARE 4-piece wording exactly true.)

Note for the Cheap Trick discussion: WoW never shipped a permanent no-stealth Cheap Shot in any era; the closest analogs were time-boxed windows behind cooldowns (Shadow Dance 6s on a 1 minute cooldown, Subterfuge 3s). Whether Cheap Trick should be reworked is a separate balance decision this PR deliberately does not make.

## Type of change

- [x] Bug fix (balance defect surfaced by live PvP)
- [x] Documentation
- [x] Tests

## How was this tested?

- Commands: npx vitest run tests/stun_dr.test.ts tests/pvp_safety.test.ts tests/charge_parallel_recharge.test.ts tests/warfare_set_bonuses.test.ts tests/hunter_trap.test.ts tests/vale_cup.test.ts (71 passed); npx vitest run tests/parity (green, no golden re-mint needed: the funnel draws no rng and PvE paths are untouched); npx vitest run tests/architecture.test.ts tests/localization_fixes.test.ts; npx tsc --noEmit; changed-files biome clean.
- Test-first: the ladder pins were rewritten red against the exemption before the code change.
- New coverage: per-bucket ladder walk, cross-bucket independence, the immune-attempts-never-refresh-the-window branch, the 18s reset restart, PvE and friendly-pair exemption pins, DR-immune state assertion through a real duel cast, and the content registration sweep.
- Reviewed by the architecture-reviewer and qa-checklist agents; all blocking findings fixed (the registration sweep and the immune-window test exist because of them).
- Local note: two attempts at a full local gate_select run were externally killed mid-vitest on this machine; every individual gate step has passed locally (the one full run that completed failed only on a since-fixed biome format diff plus a standalone-verified scan flake). CI is the arbiter here.

## Known follow-ups (deliberately out of scope)

- A DR-immune stun gives the caster no feedback (no immune line) and skips enterCombat; this matches how the root/fear/polymorph immune arms already behave, so a fix should cover all categories at once.
- An application refused by Ice Block or an unbreakable-control conflict still advances the ladder (pre-existing for every category; WoW does not advance DR on immune applications).
- The parity scenario set has no hostile-player stun chain, so the parity green proves no PvE drift, not PvP draw-order stability; a duel stun scenario would close that.


