### PR TITLE
Release v0.39 follow-up: battleground Unstuck cancellation

### DIFF
--- a/src/sim/unstuck.ts
+++ b/src/sim/unstuck.ts
@@ -74,6 +74,7 @@ export interface PendingUnstuck {
    * which would make a pre-started /unstuck a cheaper alternative to the death loop.
    */
   startedDead: boolean;
+  startedInBattlegroundWallTrap: boolean;
 }
 
 export type CancelledUnstuckEvent = Extract<UnstuckEvent, { phase: 'cancelled' }> & {
@@ -282,6 +283,7 @@ export function requestUnstuck(ctx: SimContext, pid?: number): boolean {
     emitBlocked(ctx, p.id, 'invalid_area');
     return false;
   }
+  const startedInBattlegroundWallTrap = battlegroundWallTrap(ctx, p);
   meta.pendingUnstuck = {
     startedAt: ctx.time,
     endsAt: ctx.time + UNSTUCK_COUNTDOWN_SECONDS,
@@ -290,6 +292,7 @@ export function requestUnstuck(ctx: SimContext, pid?: number): boolean {
     damageTaken: meta.counters.damageTaken,
     lastAnnouncedSecond: UNSTUCK_COUNTDOWN_SECONDS,
     startedDead: p.dead || p.ghost,
+    startedInBattlegroundWallTrap,
   };
   p.cooldowns.set(UNSTUCK_COOLDOWN_ID, UNSTUCK_RETRY_SECONDS);
   ctx.emit({
@@ -313,7 +316,7 @@ function cancelReason(
   if (pending.area.kind === 'battleground' && bgCarryingFlag(ctx, p.id)) return 'state_changed';
   if (
     (hasMoveInput(meta) && !battlegroundWallTrap(ctx, p)) ||
-    (pending.area.kind !== 'battleground' &&
+    (!pending.startedInBattlegroundWallTrap &&
       (Math.hypot(p.pos.x - pending.origin.x, p.pos.z - pending.origin.z) > CANCEL_MOVE_DISTANCE ||
         Math.abs(p.pos.y - pending.origin.y) > CANCEL_VERTICAL_DISTANCE))
   )

--- a/src/sim/unstuck.ts
+++ b/src/sim/unstuck.ts
@@ -13,7 +13,7 @@
 // to 5 minutes), and neither outcome can be reached by an attempt that started on
 // the other side of the life/death line (see cancelReason).
 
-import { resolvePosition } from './colliders';
+import { moverHeight, resolvePosition } from './colliders';
 import { isRooted, isStunned } from './combat/cc';
 import {
   bgOriginAt,
@@ -221,7 +221,15 @@ function isFrozenCorpse(p: Entity): boolean {
 
 function battlegroundWallTrap(ctx: SimContext, p: Entity): boolean {
   if (!ctx.bgMatches.has(p.id) || !isBgPos(p.pos.x)) return false;
-  const resolved = resolvePosition(ctx.cfg.seed, p.pos.x, p.pos.z, PLAYER_BODY_RADIUS);
+  const resolved = resolvePosition(
+    ctx.cfg.seed,
+    p.pos.x,
+    p.pos.z,
+    PLAYER_BODY_RADIUS,
+    false,
+    undefined,
+    moverHeight(p),
+  );
   return Math.hypot(resolved.x - p.pos.x, resolved.z - p.pos.z) > POSITION_EPS;
 }
 

--- a/tests/unstuck.test.ts
+++ b/tests/unstuck.test.ts
@@ -815,6 +815,24 @@ describe('unstuck area identity', () => {
     expect(Math.abs(player.pos.z - (origin.z + plot.z))).toBeLessThanOrEqual(plot.hd);
   });
 
+  it('cancels a normal battleground attempt that drifts during the countdown', () => {
+    const { sim, pid } = activeBattleground();
+    const player = required(sim.entities.get(pid), 'battleground player');
+    const meta = required(sim.meta(pid), 'battleground metadata');
+
+    expect(sim.unstuck(pid)).toBe(true);
+    sim.drainEvents();
+
+    player.pos = sim.groundPos(player.pos.x + 0.75, player.pos.z);
+    player.prevPos = { ...player.pos };
+    sim.ctx.rebucket(player);
+
+    expect(eventsOf(sim.tick())).toContainEqual(
+      expect.objectContaining({ type: 'unstuck', phase: 'cancelled', reason: 'moved', pid }),
+    );
+    expect(meta.pendingUnstuck).toBeNull();
+  });
+
   it('reports content-local positions for dungeon, delve, and procedural rift clones', () => {
     const dungeon = makeWorld();
     dungeon.enterDungeon('hollow_crypt', dungeon.player.id);

--- a/tests/unstuck.test.ts
+++ b/tests/unstuck.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from 'vitest';
-import { BG_GRAVEYARDS, bgFieldPlanWalls } from '../src/sim/battleground_layout';
+import { BG_BASES, BG_GRAVEYARDS, bgFieldPlanWalls } from '../src/sim/battleground_layout';
 import { resolvePosition } from '../src/sim/colliders';
 import {
   BUILTIN_WORLD,
@@ -830,6 +830,36 @@ describe('unstuck area identity', () => {
     expect(eventsOf(sim.tick())).toContainEqual(
       expect.objectContaining({ type: 'unstuck', phase: 'cancelled', reason: 'moved', pid }),
     );
+    expect(meta.pendingUnstuck).toBeNull();
+  });
+
+  it('blocks a moving battleground player on the legal flag stand', () => {
+    const { sim, match, pid } = activeBattleground();
+    const origin = battlegroundOrigin(match.slot);
+    const flag = BG_BASES[0].flag;
+    const player = required(sim.entities.get(pid), 'battleground player');
+    const meta = required(sim.meta(pid), 'battleground metadata');
+
+    player.pos = sim.groundPos(origin.x + flag.x, origin.z + flag.z);
+    player.prevPos = { ...player.pos };
+    player.vx = 0;
+    player.vy = 0;
+    player.vz = 0;
+    player.onGround = true;
+    player.jumping = false;
+    sim.ctx.rebucket(player);
+    meta.moveInput.forward = true;
+
+    const legacy = resolvePosition(sim.cfg.seed, player.pos.x, player.pos.z, PLAYER_BODY_RADIUS);
+    expect(Math.hypot(legacy.x - player.pos.x, legacy.z - player.pos.z)).toBeGreaterThan(1);
+
+    expect(sim.unstuck(pid)).toBe(false);
+    expect(eventsOf(sim.drainEvents())).toContainEqual({
+      type: 'unstuck',
+      phase: 'blocked',
+      reason: 'moving',
+      pid,
+    });
     expect(meta.pendingUnstuck).toBeNull();
   });
 

--- a/tests/unstuck_online.test.ts
+++ b/tests/unstuck_online.test.ts
@@ -85,6 +85,7 @@ function armUnstuck(server: GameServer, session: ClientSession): void {
     damageTaken: meta.counters.damageTaken,
     lastAnnouncedSecond: UNSTUCK_COUNTDOWN_SECONDS,
     startedDead: player.dead || player.ghost,
+    startedInBattlegroundWallTrap: false,
   };
   player.cooldowns.set(UNSTUCK_COOLDOWN_ID, UNSTUCK_RETRY_SECONDS);
 }


### PR DESCRIPTION
Automated OSSBrain v0.39 follow-up for the approved Discord battleground Unstuck report.

This keeps the wall-trap recovery from PR #3474 and tightens its cancellation scope: ordinary battleground Unstuck attempts still cancel if the player drifts during the countdown, while attempts that began in a wall trap keep the intended recovery exemption.

Additional repair in this run: reviewer found that the first follow-up head could classify legal battleground standable geometry as a wall trap because the probe did not use the mover height. The current head fixes that with mover-height-aware resolution and adds flag-stand regression coverage.

Current head:
- `6c6e95c2285f43bb50c7e6da99f5dfe5a1631dd7`

Verification:
- `npx vitest run tests/unstuck.test.ts tests/unstuck_online.test.ts` - 42 tests passed locally.
- `npx @biomejs/biome check src/sim/unstuck.ts tests/unstuck.test.ts` - passed locally.
- `npx tsc --noEmit` - passed locally.
- `node scripts/ci_shard_test.mjs --shard=6/8` - passed locally.
- `node scripts/ci_shard_test.mjs --shard=7/8` - passed locally.
- `npx vitest run tests/legacy_druid_hunter_skill_art.test.ts` - passed locally; this is the unchanged art-pin file that timed out in GitHub shard 7.

GitHub CI status:
- CI run `32151029777` on this head is not green. Classify changes, Browser tests, PR checks, PR long sims A/B, and PR tests shards 1,2,3,4,5,6,8 passed.
- `Lint (changed files)` was cancelled during checkout before Biome ran.
- `PR tests (7)` failed on a 20s timeout in unchanged `tests/legacy_druid_hunter_skill_art.test.ts`.
- The repository's CI stall auto-rerun reactor declined to rerun because shard 7 failed in a test step rather than a setup-stall shape. Manual `gh run rerun 32151029777 --failed` from this environment failed with `Resource not accessible by personal access token`.

Runtime client coverage is still blocked because the shared localhost client serves stale build `d2d1a8ad5c11`; the tester stopped before gameplay rather than testing the wrong build. No game-feel capture was required for this non-feel-sensitive server/sim repair.

OSSBrain will not merge this PR.
