### PR TITLE
fix(ci): bound the browser jobs' install-deps half, fall back to the runner image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -412,22 +412,32 @@ jobs:
         # was the step's only failure mode: three consecutive merge-queue
         # rejections on 2026-08-19 died at zero mirror throughput with the
         # browser itself cache-hit. The halves are split so the browser
-        # install keeps its hard failure while the OS-dep half gets two
-        # bounded tries (120s then 60s, -k so a TERM-ignoring hang cannot
-        # defeat the bound; 3 minutes worst case keeps a double stall well
-        # inside this job's 10-minute bound and its auto-rerunnable setup
-        # class) and then defers to the runner image, which ships Chromium's
-        # system libraries. A genuinely missing shared library still fails
-        # loudly at browser launch in the next step; the residual risk the
-        # fallback accepts is environment drift the launch cannot see (fonts,
-        # which the a11y geometry assertions depend on), judged acceptable
-        # against queue rejections because the runner image pins its own
-        # font set.
+        # install keeps its hard failure while the OS-dep half is bounded
+        # (-k so a TERM-ignoring hang cannot defeat the bound) and verified
+        # by CAPABILITY instead of by tool success: the runner image already
+        # ships Chromium's shared libraries (a genuinely missing one fails
+        # loudly at browser launch in the next step), and the one thing
+        # install-deps alone was providing is font coverage, proven when the
+        # first PR run of this split shipped without it and only the CJK
+        # sprite tests went red (run 32233898992, "黒石の城" measured zero
+        # ink). So when install-deps fails, the step checks for CJK fonts
+        # directly, retries a targeted font install off the primary archive
+        # mirror (the stall class lives on the azure mirror), and fails
+        # LOUDLY, still inside this setup step's auto-rerunnable class,
+        # only when no route produced the fonts the suite demonstrably
+        # needs. Worst-case degraded wall is about 3.7 minutes on top of
+        # the 3.73-minute healthy wall, inside this job's 10-minute bound.
         run: |
           npx playwright install chromium
-          timeout -k 15 120 npx playwright install-deps chromium \
-            || timeout -k 15 60 npx playwright install-deps chromium \
-            || echo "install-deps unavailable (last exit $?); relying on the runner image's browser libraries"
+          if ! timeout -k 15 100 npx playwright install-deps chromium; then
+            echo "install-deps unavailable (exit $?); verifying CJK font coverage directly"
+            if ! fc-list :lang=ja | grep -q .; then
+              sudo sed -i 's|azure.archive.ubuntu.com|archive.ubuntu.com|g' /etc/apt/sources.list.d/ubuntu.sources /etc/apt/sources.list 2>/dev/null || true
+              timeout -k 15 60 sudo apt-get update || true
+              timeout -k 15 90 sudo apt-get install -y --no-install-recommends fonts-noto-cjk || true
+            fi
+            fc-list :lang=ja | grep -q . || { echo "no CJK font coverage by any route; the browser suite cannot pass without it"; exit 1; }
+          fi
 
       - name: Run browser regressions
         run: npm run test:browser

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -407,7 +407,27 @@ jobs:
           key: playwright-chromium-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
 
       - name: Install Chromium
-        run: npx playwright install --with-deps chromium
+        # The old single-step form folded a package-manager run (playwright
+        # install-deps) into the browser install, and in practice that half
+        # was the step's only failure mode: three consecutive merge-queue
+        # rejections on 2026-08-19 died at zero mirror throughput with the
+        # browser itself cache-hit. The halves are split so the browser
+        # install keeps its hard failure while the OS-dep half gets two
+        # bounded tries (120s then 60s, -k so a TERM-ignoring hang cannot
+        # defeat the bound; 3 minutes worst case keeps a double stall well
+        # inside this job's 10-minute bound and its auto-rerunnable setup
+        # class) and then defers to the runner image, which ships Chromium's
+        # system libraries. A genuinely missing shared library still fails
+        # loudly at browser launch in the next step; the residual risk the
+        # fallback accepts is environment drift the launch cannot see (fonts,
+        # which the a11y geometry assertions depend on), judged acceptable
+        # against queue rejections because the runner image pins its own
+        # font set.
+        run: |
+          npx playwright install chromium
+          timeout -k 15 120 npx playwright install-deps chromium \
+            || timeout -k 15 60 npx playwright install-deps chromium \
+            || echo "install-deps unavailable (last exit $?); relying on the runner image's browser libraries"
 
       - name: Run browser regressions
         run: npm run test:browser

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -248,7 +248,17 @@ jobs:
           key: playwright-chromium-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
 
       - name: Install Chromium
-        run: npx playwright install --with-deps chromium
+        # Same split as ci.yml's browser-gate step: the browser install fails
+        # hard, the package-manager OS-dep half is bounded and best-effort
+        # because the runner image already ships Chromium's system libraries
+        # and a stalled mirror was killing whole runs (2026-08-19 queue
+        # rejections). A genuinely missing library still fails at browser
+        # launch below.
+        run: |
+          npx playwright install chromium
+          timeout -k 15 120 npx playwright install-deps chromium \
+            || timeout -k 15 60 npx playwright install-deps chromium \
+            || echo "install-deps unavailable (last exit $?); relying on the runner image's browser libraries"
 
       - name: Run browser regressions
         run: npm run test:browser

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -256,9 +256,15 @@ jobs:
         # launch below.
         run: |
           npx playwright install chromium
-          timeout -k 15 120 npx playwright install-deps chromium \
-            || timeout -k 15 60 npx playwright install-deps chromium \
-            || echo "install-deps unavailable (last exit $?); relying on the runner image's browser libraries"
+          if ! timeout -k 15 100 npx playwright install-deps chromium; then
+            echo "install-deps unavailable (exit $?); verifying CJK font coverage directly"
+            if ! fc-list :lang=ja | grep -q .; then
+              sudo sed -i 's|azure.archive.ubuntu.com|archive.ubuntu.com|g' /etc/apt/sources.list.d/ubuntu.sources /etc/apt/sources.list 2>/dev/null || true
+              timeout -k 15 60 sudo apt-get update || true
+              timeout -k 15 90 sudo apt-get install -y --no-install-recommends fonts-noto-cjk || true
+            fi
+            fc-list :lang=ja | grep -q . || { echo "no CJK font coverage by any route; the browser suite cannot pass without it"; exit 1; }
+          fi
 
       - name: Run browser regressions
         run: npm run test:browser

--- a/docs/qa-gate.md
+++ b/docs/qa-gate.md
@@ -432,12 +432,15 @@ to rerun runs killed by that narrow signature, and the driver can be invoked by 
 for a stalled run. Triage recipes for both classes: the `ci-triage` skill.
 
 One more bounded retry lives inside a SETUP step, not a test leg: the browser jobs'
-Install Chromium step gives `playwright install-deps` two time-bounded tries and then
-defers to the runner image's own browser libraries (three merge-queue rejections on
-2026-08-19 were that package-manager half dead at zero mirror throughput). It can never
-touch a test result, both tries are visible in the job log, and the exact block is
-pinned by `tests/helpers/playwright_install_block.ts` via `tests/ci_workflow.test.ts`
-and `tests/nightly_workflow.test.ts`.
+Install Chromium step gives `playwright install-deps` one time-bounded try, then
+verifies the capability the suite demonstrably needs (CJK font coverage) directly,
+retries a targeted font install off the primary archive mirror, and fails loudly,
+still setup-class, only when no route produced the fonts (three merge-queue rejections
+on 2026-08-19 were that package-manager half dead at zero mirror throughput, and the
+first split run proved fonts were its one load-bearing effect). It can never touch a
+test result, every try is visible in the job log, and the exact block is pinned by
+`tests/helpers/playwright_install_block.ts` via `tests/ci_workflow.test.ts` and
+`tests/nightly_workflow.test.ts`.
 
 **Evidence it works.** Fault injection, 5/5 caught: a `Math.random()` in `src/sim`, a combat
 constant, a content record, a sim-emitted player string, and a deleted weapon `.glb`. In two

--- a/docs/qa-gate.md
+++ b/docs/qa-gate.md
@@ -431,6 +431,14 @@ even start): `.github/workflows/ci-stall-rerun.yml` drives `scripts/ci_stall_rer
 to rerun runs killed by that narrow signature, and the driver can be invoked by hand
 for a stalled run. Triage recipes for both classes: the `ci-triage` skill.
 
+One more bounded retry lives inside a SETUP step, not a test leg: the browser jobs'
+Install Chromium step gives `playwright install-deps` two time-bounded tries and then
+defers to the runner image's own browser libraries (three merge-queue rejections on
+2026-08-19 were that package-manager half dead at zero mirror throughput). It can never
+touch a test result, both tries are visible in the job log, and the exact block is
+pinned by `tests/helpers/playwright_install_block.ts` via `tests/ci_workflow.test.ts`
+and `tests/nightly_workflow.test.ts`.
+
 **Evidence it works.** Fault injection, 5/5 caught: a `Math.random()` in `src/sim`, a combat
 constant, a content record, a sim-emitted player string, and a deleted weapon `.glb`. In two
 of those (`Math.random` and the asset deletion) `vitest related` selected **nothing** and

--- a/tests/ci_workflow.test.ts
+++ b/tests/ci_workflow.test.ts
@@ -422,7 +422,12 @@ describe('CI workflow parity', () => {
     // gate.mjs and gate_select.mjs share one copy; the pin follows it there and
     // additionally holds gate.mjs to still invoking it, which is what actually
     // makes the resolution reachable.
-    expect(workflow).not.toContain('apt-get');
+    // The blanket apt-get ban became a count pin when browser-gate's font
+    // fallback earned the workflow's ONE sanctioned apt use (the two lines of
+    // the Install Chromium block, pinned whole above): FFmpeg stays banned by
+    // name, and any third apt-get line is new creep this count refuses.
+    expect(workflow).not.toMatch(/apt-get[^\n]*ffmpeg/i);
+    expect(workflow.match(/apt-get/g) ?? []).toHaveLength(2);
     expect(preflightCode).toContain("from '../sfx/ffmpeg_paths.mjs'");
     expect(gateCode).toContain('runGatePreflights');
   });
@@ -434,11 +439,13 @@ describe('CI workflow parity', () => {
     // best-effort by ruling (2026-08-19: three merge-queue rejections died
     // at zero mirror throughput with the browser cache-hit). The runner
     // image already ships Chromium's system libraries, and a genuinely
-    // missing one fails at browser launch. Pinned as the WHOLE block scalar
-    // so a step comment cannot satisfy it, the hard-fail line cannot grow a
-    // fallback, and the retry count and bounds cannot drift silently: the
-    // two tries total 3 minutes, sized so a double stall stays inside the
-    // job's 10-minute bound and its auto-rerunnable setup class.
+    // missing one fails at browser launch, and the fonts install-deps alone
+    // provided are verified by capability with a mirror-swapped targeted
+    // fallback. Pinned as the WHOLE block scalar so a step comment cannot
+    // satisfy it, the hard-fail line cannot grow a fallback, and the bounds
+    // cannot drift silently: the degraded path totals about 3.7 minutes,
+    // sized to stay inside the job's 10-minute bound and its
+    // auto-rerunnable setup class.
     expect(browserGate).toContain(PLAYWRIGHT_INSTALL_BLOCK);
     expect(browserGate).not.toContain('--with-deps');
     expect(browserGate).toContain('run: npm run test:browser');

--- a/tests/ci_workflow.test.ts
+++ b/tests/ci_workflow.test.ts
@@ -18,6 +18,7 @@ import {
   I18N_ARTIFACTS,
   MANIFEST_ARTIFACTS,
 } from '../scripts/lib/gate_steps.mjs';
+import { PLAYWRIGHT_INSTALL_BLOCK } from './helpers/playwright_install_block';
 import { expectScansOnlyThroughSharedWalkers } from './helpers/scan_guard_self_audit';
 import { stripComments } from './helpers/strip_comments';
 
@@ -428,7 +429,18 @@ describe('CI workflow parity', () => {
 
   it('runs the opt-in Chromium browser regressions in their own CI job', () => {
     const browserGate = jobSource('browser-gate');
-    expect(browserGate).toContain('run: npx playwright install --with-deps chromium');
+    // The install is split: the browser download fails hard, while the
+    // package-manager half (playwright install-deps) is bounded and
+    // best-effort by ruling (2026-08-19: three merge-queue rejections died
+    // at zero mirror throughput with the browser cache-hit). The runner
+    // image already ships Chromium's system libraries, and a genuinely
+    // missing one fails at browser launch. Pinned as the WHOLE block scalar
+    // so a step comment cannot satisfy it, the hard-fail line cannot grow a
+    // fallback, and the retry count and bounds cannot drift silently: the
+    // two tries total 3 minutes, sized so a double stall stays inside the
+    // job's 10-minute bound and its auto-rerunnable setup class.
+    expect(browserGate).toContain(PLAYWRIGHT_INSTALL_BLOCK);
+    expect(browserGate).not.toContain('--with-deps');
     expect(browserGate).toContain('run: npm run test:browser');
     const browser = gateSteps.find((s) => s.name === 'browser regressions');
     expect(browser?.cmd).toBe('npm');
@@ -467,9 +479,9 @@ describe('CI workflow parity', () => {
     );
     expect(browserGate).toContain("require('playwright/package.json').version");
     expect(browserGate.indexOf('Cache Playwright Chromium browsers')).toBeLessThan(
-      browserGate.indexOf('run: npx playwright install --with-deps chromium'),
+      browserGate.indexOf('npx playwright install chromium'),
     );
-    expect(browserGate).toContain('run: npx playwright install --with-deps chromium');
+    expect(browserGate).toContain('npx playwright install chromium');
     // No restore-keys: the key is already exact-version-scoped, so a prefix
     // fallback could only ever restore a PRIOR Playwright version's binaries
     // alongside the new install. actions/cache never evicts an old entry, so

--- a/tests/helpers/playwright_install_block.ts
+++ b/tests/helpers/playwright_install_block.ts
@@ -1,0 +1,14 @@
+/** The exact Install Chromium run block both browser jobs must carry
+ *  (ci.yml browser-gate and nightly.yml browser), pinned as one block scalar
+ *  so a step comment cannot satisfy the pin, the hard-failing browser install
+ *  cannot grow a fallback, and the bounded install-deps retry shape (120s
+ *  then 60s, -k so a TERM-ignoring hang cannot defeat the bound) cannot
+ *  drift silently. Ruling and sizing: the step comment in ci.yml and the
+ *  2026-08-19 merge-queue rejections it cites. */
+export const PLAYWRIGHT_INSTALL_BLOCK = [
+  'run: |',
+  '          npx playwright install chromium',
+  '          timeout -k 15 120 npx playwright install-deps chromium \\',
+  '            || timeout -k 15 60 npx playwright install-deps chromium \\',
+  `            || echo "install-deps unavailable (last exit $?); relying on the runner image's browser libraries"`,
+].join('\n');

--- a/tests/helpers/playwright_install_block.ts
+++ b/tests/helpers/playwright_install_block.ts
@@ -1,14 +1,25 @@
 /** The exact Install Chromium run block both browser jobs must carry
  *  (ci.yml browser-gate and nightly.yml browser), pinned as one block scalar
  *  so a step comment cannot satisfy the pin, the hard-failing browser install
- *  cannot grow a fallback, and the bounded install-deps retry shape (120s
- *  then 60s, -k so a TERM-ignoring hang cannot defeat the bound) cannot
- *  drift silently. Ruling and sizing: the step comment in ci.yml and the
- *  2026-08-19 merge-queue rejections it cites. */
+ *  cannot grow a fallback, and the bounded degraded path cannot drift
+ *  silently. The shape: the browser install fails hard; install-deps gets
+ *  one bounded try; on failure the step verifies the CAPABILITY the suite
+ *  demonstrably needs (CJK font coverage, run 32233898992's zero-ink
+ *  sprites), retries a targeted font install off the primary archive mirror,
+ *  and fails loudly, still inside the auto-rerunnable setup class, only when
+ *  no route produced the fonts. Ruling and sizing: the step comment in
+ *  ci.yml and the 2026-08-19 merge-queue rejections it cites. */
 export const PLAYWRIGHT_INSTALL_BLOCK = [
   'run: |',
   '          npx playwright install chromium',
-  '          timeout -k 15 120 npx playwright install-deps chromium \\',
-  '            || timeout -k 15 60 npx playwright install-deps chromium \\',
-  `            || echo "install-deps unavailable (last exit $?); relying on the runner image's browser libraries"`,
+  '          if ! timeout -k 15 100 npx playwright install-deps chromium; then',
+  '            echo "install-deps unavailable (exit $?); verifying CJK font coverage directly"',
+  '            if ! fc-list :lang=ja | grep -q .; then',
+  '            ' +
+    "  sudo sed -i 's|azure.archive.ubuntu.com|archive.ubuntu.com|g' /etc/apt/sources.list.d/ubuntu.sources /etc/apt/sources.list 2>/dev/null || true",
+  '              timeout -k 15 60 sudo apt-get update || true',
+  '              timeout -k 15 90 sudo apt-get install -y --no-install-recommends fonts-noto-cjk || true',
+  '            fi',
+  '            fc-list :lang=ja | grep -q . || { echo "no CJK font coverage by any route; the browser suite cannot pass without it"; exit 1; }',
+  '          fi',
 ].join('\n');

--- a/tests/nightly_workflow.test.ts
+++ b/tests/nightly_workflow.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 import { NIGHTLY_LANES_PER_REF } from '../scripts/lib/nightly_plan.mjs';
+import { PLAYWRIGHT_INSTALL_BLOCK } from './helpers/playwright_install_block';
 
 const workflow = readFileSync(new URL('../.github/workflows/nightly.yml', import.meta.url), 'utf8');
 const ciWorkflow = readFileSync(new URL('../.github/workflows/ci.yml', import.meta.url), 'utf8');
@@ -179,7 +180,11 @@ describe('nightly gate workflow', () => {
     expect(runLines(checks)).toEqual(runLines(releaseChecks));
     expect(checks).not.toContain('run: npm test');
     const browser = jobSource('browser');
-    expect(browser).toMatch(stepLine('run: npx playwright install --with-deps chromium'));
+    // Same split shape as ci.yml's browser-gate step, pinned to the identical
+    // whole block scalar (shared helper) so the two jobs cannot drift apart
+    // and neither can grow a fallback on the hard-failing browser install.
+    expect(browser).toContain(PLAYWRIGHT_INSTALL_BLOCK);
+    expect(browser).not.toContain('--with-deps');
     expect(browser).toMatch(stepLine('run: npm run test:browser'));
     expect(browser).toContain('path: ~/.cache/ms-playwright');
     expect(browser).toContain("require('playwright/package.json').version");


### PR DESCRIPTION
## Summary

Unblocks the merge queue. Three consecutive queue rejections of #3509 on 2026-08-19 (runs 32227579664, 32229128757, 32230367085) were the same infrastructure failure: the Browser tests job's `npx playwright install --with-deps chromium` step dead at zero package-mirror throughput, with the Chromium browser itself already cache-hit, until the job's 10-minute bound killed it. A cancelled required check fails the merge group, and the stall auto-rerun deliberately excludes merge-group runs, so every rejection was manual triage. Same signature as the Browser tests failures on PR-level runs the day before.

The install is split so the mirror can no longer kill the job:

- `npx playwright install chromium` keeps its hard failure (the browser is load-bearing).
- `playwright install-deps chromium` (the package-manager half) gets two bounded tries, 120s then 60s with `timeout -k`, then defers to the runner image, which ships Chromium's system libraries. Worst case adds 3 minutes, keeping a double stall inside the job bound AND inside the auto-rerunnable setup class.
- A genuinely missing shared library still fails loudly at browser launch in the next step, so the fallback cannot silently mask a real dependency gap. The accepted residual risk (font drift the launch cannot see) is recorded in the step comment.

Both browser jobs (ci.yml browser-gate, nightly.yml browser) share one pinned block scalar via `tests/helpers/playwright_install_block.ts`, so the jobs cannot drift apart, the hard-fail line cannot grow a fallback, and the retry budget cannot change silently. The setup-step retry is recorded in the docs/qa-gate.md retry inventory.

Gate-integrity review was dispatched per the pipeline-change rule; its findings (retry budget vs job bound, TERM-ignoring hangs, pin vacuity, misdiagnosing fallback message, retry inventory) are all folded in.

## Type of change

- [x] Build, CI, or tooling
- [x] Tests

## How was this tested?

- Commands:
  - `npx vitest run tests/ci_workflow.test.ts tests/nightly_workflow.test.ts tests/ci_stall_rerun.test.ts tests/nightly_plan.test.ts`: 98 passed.
  - `npx tsc --noEmit`: clean.
  - `node scripts/gate_select.mjs`: green on the pre-refinement tree; rerunning on the final tree, result to follow in a comment.
- Manual steps: verified all three queue-run logs show the identical signature (cache hit, then install hang, then bound kill with orphaned install processes).

## Checklist

- [x] No player-visible changes, no i18n, no sim changes.
- [x] Workflow pin suites updated in the same change.