### PR TITLE
fix(account): add Set a Password for Apple/Discord passwordless accounts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -590,6 +590,7 @@ jobs:
           sparse-checkout: |
             /*
             !/docs/screenshots/*/
+            /docs/screenshots/account-set-password/
             /docs/screenshots/admin-cheater-mark/
             /docs/screenshots/admin-guild-bank-panel/
             /docs/screenshots/eastbrook-grand-armoury/
@@ -801,6 +802,7 @@ jobs:
           sparse-checkout: |
             /*
             !/docs/screenshots/*/
+            /docs/screenshots/account-set-password/
             /docs/screenshots/admin-cheater-mark/
             /docs/screenshots/admin-guild-bank-panel/
             /docs/screenshots/eastbrook-grand-armoury/
@@ -894,6 +896,7 @@ jobs:
           sparse-checkout: |
             /*
             !/docs/screenshots/*/
+            /docs/screenshots/account-set-password/
             /docs/screenshots/admin-cheater-mark/
             /docs/screenshots/admin-guild-bank-panel/
             /docs/screenshots/eastbrook-grand-armoury/
@@ -1150,6 +1153,7 @@ jobs:
           sparse-checkout: |
             /*
             !/docs/screenshots/*/
+            /docs/screenshots/account-set-password/
             /docs/screenshots/admin-cheater-mark/
             /docs/screenshots/admin-guild-bank-panel/
             /docs/screenshots/eastbrook-grand-armoury/
@@ -1241,6 +1245,7 @@ jobs:
           sparse-checkout: |
             /*
             !/docs/screenshots/*/
+            /docs/screenshots/account-set-password/
             /docs/screenshots/admin-cheater-mark/
             /docs/screenshots/admin-guild-bank-panel/
             /docs/screenshots/eastbrook-grand-armoury/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -590,7 +590,6 @@ jobs:
           sparse-checkout: |
             /*
             !/docs/screenshots/*/
-            /docs/screenshots/account-set-password/
             /docs/screenshots/admin-cheater-mark/
             /docs/screenshots/admin-guild-bank-panel/
             /docs/screenshots/eastbrook-grand-armoury/
@@ -802,7 +801,6 @@ jobs:
           sparse-checkout: |
             /*
             !/docs/screenshots/*/
-            /docs/screenshots/account-set-password/
             /docs/screenshots/admin-cheater-mark/
             /docs/screenshots/admin-guild-bank-panel/
             /docs/screenshots/eastbrook-grand-armoury/
@@ -896,7 +894,6 @@ jobs:
           sparse-checkout: |
             /*
             !/docs/screenshots/*/
-            /docs/screenshots/account-set-password/
             /docs/screenshots/admin-cheater-mark/
             /docs/screenshots/admin-guild-bank-panel/
             /docs/screenshots/eastbrook-grand-armoury/
@@ -1153,7 +1150,6 @@ jobs:
           sparse-checkout: |
             /*
             !/docs/screenshots/*/
-            /docs/screenshots/account-set-password/
             /docs/screenshots/admin-cheater-mark/
             /docs/screenshots/admin-guild-bank-panel/
             /docs/screenshots/eastbrook-grand-armoury/
@@ -1245,7 +1241,6 @@ jobs:
           sparse-checkout: |
             /*
             !/docs/screenshots/*/
-            /docs/screenshots/account-set-password/
             /docs/screenshots/admin-cheater-mark/
             /docs/screenshots/admin-guild-bank-panel/
             /docs/screenshots/eastbrook-grand-armoury/

--- a/tests/ci_workflow.test.ts
+++ b/tests/ci_workflow.test.ts
@@ -248,6 +248,7 @@ describe('CI workflow parity', () => {
       '          sparse-checkout: |',
       '            /*',
       '            !/docs/screenshots/*/',
+      '            /docs/screenshots/account-set-password/',
       '            /docs/screenshots/admin-cheater-mark/',
       '            /docs/screenshots/admin-guild-bank-panel/',
       '            /docs/screenshots/eastbrook-grand-armoury/',


### PR DESCRIPTION
## Summary

An account created via **Sign in with Apple** (or the equivalent first-time Discord
sign-in) is provisioned with `password_set = false` and a random, owner-unknown
password hash (`server/apple_auth.ts` `provisionAppleAccount`). That account has no
real password to fall back on, and "Continue with Apple" only appears on the native
iOS app (`NATIVE_APP && isNativeIos()` in `src/main.ts`), so a player who created
their account with Sign in with Apple on iPhone has no way to authenticate on Mac,
Windows, or the web: no Apple button there, and no known password.

Password reset (`/api/account/password/forgot` + `/reset`) is the only existing
route to a real password for these accounts, but it depends on the player both
knowing their (auto-generated) username and having a deliverable recovery email on
file, and there was no self-service fallback if either link in that chain breaks. A
`password_set = false` account could only get a real password through the Discord
**unlink** flow's "set a password to keep your account" gate (`server/discord.ts`),
which requires the account to already be Discord-linked in the first place, so it
never helped an Apple-only account trying to add Discord as a first login.

```mermaid
flowchart TD
    A["Sign in with Apple on iPhone"] --> B["Account created<br/>password_set = false<br/>(random, owner-unknown hash)"]
    B --> C{"Open the game on Mac,<br/>Windows, or the web"}
    C -->|"No Apple sign-in button<br/>on this platform"| D["Stuck: no known password"]
    D --> E["Try Forgot Password"]
    E -->|"Needs the auto-generated<br/>username + a deliverable email"| F["Dead end if either breaks"]
    D --> G["NEW: Set a Password<br/>in Account Settings"]
    G -->|"While already signed in<br/>via Apple or Discord"| H["Real password saved<br/>password_set = true"]
    H --> I["Log in with username<br/>+ password on any device"]
    H --> J["Link Discord without<br/>needing the old password"]
```

This PR adds a self-service **"Set a Password"** action to the account portal for
any `password_set = false` account, reachable while the player is still
authenticated (e.g. still signed in on the iPhone via Apple). It does not depend on
email deliverability or on the player knowing an auto-generated username, so it
works even when the reset-email path does not.

### What changed

- **`POST /api/account/password/set-initial`** (`server/account.ts`, mirrors the
  existing `email/set-initial` shape): bearer-scoped, 409s once a real password
  already exists, otherwise validates length and calls the existing
  `updatePasswordHash` primitive, which already flips `password_set` and busts the
  Discord-status cache (no new DB writes needed). Registered in both the
  `RouteDef` table and the legacy dispatch-ladder twin
  (`server/main.ts`), plus the characterization-spine ledgers
  (`tests/server/http/surface_inventory.ts`, `content_type_classification.ts`).
- **`GET /api/account` (whoami)** now reports `passwordSet` so the client knows
  which form to show.
- **Client**: `Api.setInitialPassword()` (`src/net/online.ts`), a pure
  `validateInitialPassword` validator (`src/ui/account_portal.ts`), and a new
  "Set a Password" form in the Account Settings card (`index.html`) that replaces
  "Change Password" for a `passwordSet:false` account, wired in `src/main.ts`.
  English + the five required non-Latin fills (`zh_CN`/`zh_TW`/`ja_JP`/`ko_KR`/`ru_RU`)
  for the new wordy copy (M16).
- Extracted the account-portal DOM painters (`setAccountFieldMsg`,
  `paintTwoFactorStatus`, `paintAccountPortal`) out of `src/main.ts` into a new
  `src/ui/account_portal_dom.ts` sibling module, which paid for the new wiring and
  kept `main.ts` under its monolith line-count ceiling
  (`tests/monolith_budget.test.ts`, lowered in the same change).
- New error code `account.password_already_set` (`server/http/error_codes.ts` +
  the client `apiError.*` catalog), following the existing code-first REST error
  contract.

## Related issues

N/A (reported directly by a player: an account created with Sign in with Apple on
iOS could not be reached from the Mac client, and password reset did not get them
back in).

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [ ] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands: `node scripts/gate_select.mjs` (green, 12/12 steps), `npx tsc --noEmit`,
  `npx vitest run tests/account_server.test.ts tests/account_portal.test.ts
  tests/api_error_code_parity.test.ts tests/server/account.test.ts
  tests/server/http/{completeness,surface_inventory,error_codes,content_type_classification}.test.ts
  tests/architecture.test.ts tests/monolith_budget.test.ts tests/hud_perf_budget.test.ts
  tests/localization_fixes.test.ts tests/i18n_completeness.test.ts` (all green).
- Manual steps: drove the account portal in a headless browser (`scripts/account_set_password_shot.mjs`)
  to confirm the new "Set a Password" section renders correctly in place of "Change
  Password" (screenshots below); added unit tests covering the new handler's 200,
  400 (too short/too long), 409 (already set), and 404 (account gone) branches, plus
  the `passwordSet` field on whoami.

## Screenshots / recordings

Account Settings card, before (an ordinary account) and after (a `passwordSet:false`
account created via Sign in with Apple or Discord):

![before](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/ec92a163d7bdd5fe43b3f7d155f97229c571e90d/docs/screenshots/account-set-password/before-change-password.png)
![after](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/ec92a163d7bdd5fe43b3f7d155f97229c571e90d/docs/screenshots/account-set-password/after-set-password.png)

---

## Checklist

### Quality

- [x] **The gate passes.** `node scripts/gate_select.mjs` is green. Added
      decisive tests for the new handler, the new client validator, and the
      whoami/error-code/route-count pins the new endpoint touches.

### Cross-platform

- [x] **Tested on desktop and mobile.** The new form is a plain stacked
      `account-form` block reusing the existing Change Password markup and
      styling verbatim (same field/label/button classes), so it inherits the
      portal's existing responsive and touch-target behavior; no new layout
      was introduced.
- [x] **Accessible.** Reuses the existing `auth-field`/`auth-label`/`auth-field-msg`
      markup and `aria-live` region verbatim; no new interactive pattern.

### Localization (i18n)

- [x] **New player-visible strings follow the contributor policy.** Added
      English-only catalog entries in `src/ui/i18n.catalog/hud_chrome.ts` and
      `api_error.ts`, plus the five required non-Latin fills for the wordy new
      copy (M16: `zh_CN`, `zh_TW`, `ja_JP`, `ko_KR`, `ru_RU`).
- [ ] Numbers, money, dates, units, and percents go through the i18n formatters. N/A,
      this change adds no such values.
- [x] N/A for the sim/server player-text rule: the new error code follows the
      existing code-first REST contract (server emits a stable code, the client
      catalog supplies the text), not raw English from `server/`.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled anywhere in this change.
- [x] No hand-edited generated files; `src/ui/i18n.resolved.generated/*`,
      `src/ui/i18n.catalog/translation_keys.generated.ts` regenerated via
      `npm run i18n:gen`.

