### PR TITLE
fix(hud): engage auto-attack on a hostile cast at a battleground enemy

### DIFF
--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -7138,7 +7138,7 @@ export class Hud {
             abilityStartsAutoAttack(resolved.effects) &&
             hasAutoAttackTarget(
               target,
-              isPvpHostileTarget(tid, this.sim.duelInfo, this.sim.arenaInfo),
+              isPvpHostileTarget(tid, this.sim.duelInfo, this.sim.arenaInfo, this.sim.bgInfo),
             )
           ) {
             // A TIMED cast must not engage yet: startAutoAttack aggros the target
@@ -13933,7 +13933,12 @@ export class Hud {
             if (ev.success) {
               const castTid = sim.player.targetId;
               const castTarget = castTid !== null ? (sim.entities.get(castTid) ?? null) : null;
-              const castPvpHostile = isPvpHostileTarget(castTid, sim.duelInfo, sim.arenaInfo);
+              const castPvpHostile = isPvpHostileTarget(
+                castTid,
+                sim.duelInfo,
+                sim.arenaInfo,
+                sim.bgInfo,
+              );
               if (hasAutoAttackTarget(castTarget, castPvpHostile)) this.sim.startAutoAttack();
             }
           }

--- a/src/ui/hud/action_bar/attack_on_ability.ts
+++ b/src/ui/hud/action_bar/attack_on_ability.ts
@@ -5,6 +5,7 @@
 // sim import), so a Vitest drives them directly; the HUD gates on the player's setting.
 
 import type { AbilityEffect, Entity } from '../../../sim/types';
+import type { BgInfo } from '../../../world_api/battleground';
 import type { ArenaInfo, DuelInfo } from '../../../world_api/duel_arena';
 
 // Auto-attack classification of EVERY AbilityEffect type. Because this is a Record over
@@ -213,11 +214,15 @@ export function hasAutoAttackTarget(
 }
 
 /**
- * Whether a player target is PvP-hostile right now: an active duel opponent, or an
- * active-arena opponent/enemy. Mirrors the private `isHostilePlayer` the renderer
+ * Whether a player target is PvP-hostile right now: an active duel opponent, an
+ * active-arena opponent/enemy, or an opposing-team fighter in a live Thornhollow
+ * Fields battleground match. Mirrors the private `isHostilePlayer` the renderer
  * already computes for nameplate coloring (`src/render/renderer.ts`), so the "Auto-Attack
  * on Ability Use" QoL setting recognizes the same PvP-hostile state instead of gating on
- * the mob-only `hostile` flag, which a player target never carries.
+ * the mob-only `hostile` flag, which a player target never carries. The battleground
+ * arm is the one the renderer grew and this gate did not: a hostile cast at a
+ * battleground enemy then never engaged the white swing, while the identical cast in a
+ * duel or arena did.
  *
  * Deliberately narrower than the sim's `isHostileTo`: it does not cover the jail brawl,
  * the warden arm, an enemy player's PET (resolved through `pvpController`), or the Vale
@@ -229,9 +234,17 @@ export function isPvpHostileTarget(
   targetId: number | null | undefined,
   duelInfo: DuelInfo | null | undefined,
   arenaInfo: ArenaInfo | null | undefined,
+  bgInfo?: BgInfo | null,
 ): boolean {
   if (targetId === null || targetId === undefined) return false;
   if (duelInfo?.state === 'active' && duelInfo.otherPid === targetId) return true;
+  // Thornhollow Fields: the opposing TEAM is hostile for the whole live match
+  // (the countdown and the ended hold are combat-off, so neither engages).
+  const bg = bgInfo?.match;
+  if (bg?.state === 'active') {
+    const row = bg.players.find((p) => p.pid === targetId);
+    if (row && row.team !== bg.myTeam) return true;
+  }
   const match = arenaInfo?.match;
   return (
     !!match &&

--- a/tests/attack_on_ability.test.ts
+++ b/tests/attack_on_ability.test.ts
@@ -7,6 +7,7 @@ import {
   hasAutoAttackTarget,
   isPvpHostileTarget,
 } from '../src/ui/hud/action_bar/attack_on_ability';
+import type { BgInfo, BgMatchInfo } from '../src/world_api/battleground';
 import type { ArenaInfo, DuelInfo } from '../src/world_api/duel_arena';
 
 // Resolve a real ability's rank-1 effects by id, so the test pins behavior against
@@ -206,7 +207,106 @@ describe('isPvpHostileTarget (the duel/arena PvP gate, #2451)', () => {
     const arena: ArenaInfo = arenaInfoWith(null);
     expect(isPvpHostileTarget(OTHER_PID, null, arena)).toBe(false);
   });
+
+  // Thornhollow Fields (5v5 CTF). The renderer's nameplate predicate
+  // (`isHostilePlayer`, src/render/renderer.ts) already paints the opposing
+  // TEAM hostile for the whole live match; this gate must agree, or the
+  // "Auto-Attack on Ability Use" QoL never engages a white swing on a
+  // battleground cast while the same cast in a duel/arena does.
+  const bgMatch: BgMatchInfo = {
+    state: 'active',
+    myTeam: 0,
+    capsToWin: 3,
+    scores: [0, 0],
+    flags: [
+      { state: 'home', carrierPid: null, carrierName: null, carrierTeam: null },
+      { state: 'home', carrierPid: null, carrierName: null, carrierTeam: null },
+    ],
+    players: [bgRow(1, 0), bgRow(OTHER_PID, 1), bgRow(7, 1)],
+    countdown: 0,
+    timeLeft: 600,
+    waveIn: [10, 10],
+    respawnIn: 0,
+    winner: null,
+  };
+
+  it('is true for an opposing-team fighter in an active battleground match', () => {
+    expect(isPvpHostileTarget(OTHER_PID, null, null, bgInfoWith(bgMatch))).toBe(true);
+    expect(isPvpHostileTarget(7, null, null, bgInfoWith(bgMatch))).toBe(true);
+  });
+
+  it('is false for a teammate in an active battleground match', () => {
+    expect(isPvpHostileTarget(1, null, null, bgInfoWith(bgMatch))).toBe(false);
+  });
+
+  it('is false for a pid not on the battleground roster', () => {
+    expect(isPvpHostileTarget(999, null, null, bgInfoWith(bgMatch))).toBe(false);
+  });
+
+  it('is false while the battleground match is not active (countdown/ended)', () => {
+    expect(
+      isPvpHostileTarget(OTHER_PID, null, null, bgInfoWith({ ...bgMatch, state: 'countdown' })),
+    ).toBe(false);
+    expect(
+      isPvpHostileTarget(OTHER_PID, null, null, bgInfoWith({ ...bgMatch, state: 'ended' })),
+    ).toBe(false);
+  });
+
+  it('is false with no battleground match (queued only) or no bgInfo at all', () => {
+    expect(isPvpHostileTarget(OTHER_PID, null, null, bgInfoWith(null))).toBe(false);
+    expect(isPvpHostileTarget(OTHER_PID, null, null, null)).toBe(false);
+    expect(isPvpHostileTarget(OTHER_PID, null, null, undefined)).toBe(false);
+  });
+
+  it('engages a white swing on a hostile cast at a battleground enemy exactly as in a duel', () => {
+    // Both HUD engage sites (the instant press and the deferred castStop)
+    // compute hasAutoAttackTarget(target, isPvpHostileTarget(...)). A player
+    // target never carries the mob-only `hostile` flag, so the PvP verdict is
+    // the whole gate: the duel arm already passed, the battleground arm did not.
+    const enemy = { id: OTHER_PID, kind: 'player', dead: false, hostile: false } as Entity;
+    const duel = { state: 'active', otherPid: OTHER_PID } as DuelInfo;
+    const inDuel = hasAutoAttackTarget(enemy, isPvpHostileTarget(OTHER_PID, duel, null, null));
+    const inBg = hasAutoAttackTarget(
+      enemy,
+      isPvpHostileTarget(OTHER_PID, null, null, bgInfoWith(bgMatch)),
+    );
+    expect(inDuel).toBe(true);
+    expect(inBg).toBe(true);
+  });
 });
+
+function bgRow(pid: number, team: number): BgMatchInfo['players'][number] {
+  return {
+    pid,
+    name: `P${pid}`,
+    cls: 'warrior',
+    team,
+    carrying: false,
+    dead: false,
+    kills: 0,
+    deaths: 0,
+    captures: 0,
+    assists: 0,
+  };
+}
+
+function bgInfoWith(match: BgMatchInfo | null): BgInfo {
+  return {
+    rating: 0,
+    wins: 0,
+    losses: 0,
+    draws: 0,
+    captures: 0,
+    queued: false,
+    queueSize: 0,
+    queuedParty: 0,
+    firstWinBonusReady: false,
+    proposal: null,
+    requeueIn: 0,
+    match,
+    ladder: [],
+  };
+}
 
 function arenaInfoWith(match: ArenaInfo['match']): ArenaInfo {
   return {


### PR DESCRIPTION
## Summary

Casting a hostile spell at an enemy player inside Thornhollow Fields (5v5 CTF) never started auto-attack, while the same cast in the open world, a duel, or an arena did. Melee and hybrid casters lost their white damage on every battleground engagement until they pressed Attack separately.

**Root cause (not in the sim).** The "attack on cast" behaviour is the client-side *Auto-Attack on Ability Use* setting, implemented in the HUD, not in `src/sim`. I confirmed this test-first: a scratch sim test that lands an open-world Fireball on a hostile wolf and reads `player.autoAttack` gets `false`. The sim's only cast→engage coupling is the on-next-swing (Heroic Strike) path in `casting_lifecycle.ts`, which is not context-gated at all. So there is no open-world-vs-battleground divergence in the sim; the divergence is in the client predicate.

The HUD engage (both the instant press in `castSlot` and the deferred engage on a successful `castStop`) gates on `hasAutoAttackTarget(target, isPvpHostileTarget(tid, duelInfo, arenaInfo))` in `src/ui/hud/action_bar/attack_on_ability.ts`. A player target never carries the mob-only `hostile` flag, so that PvP verdict is the whole gate for PvP targets. `isPvpHostileTarget` documents itself as mirroring the renderer's nameplate predicate `isHostilePlayer` (`src/render/renderer.ts`), but the renderer grew a Thornhollow Fields arm ("the opposing TEAM is hostile for the whole live match") and this predicate never did: it only recognised an active duel opponent and an active arena opponent/enemy. Battleground enemies therefore read as non-hostile and the engage was silently skipped.

**Fix at the shared level.** Add the battleground arm to `isPvpHostileTarget` (the single funnel both HUD engage sites already use) and pass `bgInfo` through at both sites. No second copy of the engage logic; the predicate matches the renderer's arm exactly (active match only, opposing team only; countdown and the ended hold stay combat-off).

**Duels.** Checked: duels already route through the same predicate's `duelInfo` arm and engage correctly, so they do not share this bug. No sim change, no player-visible strings, no parity-covered code touched.

## Related issues

Fixes the battleground cast-does-not-engage-auto-attack report (no issue number supplied).

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change

## How was this tested?

Test-first reproduction:

1. Scratch sim probe (not committed): open-world Fireball at a hostile `forest_wolf`, drained via `sim.tick()` until the bolt landed (`mob.hp` dropped) → `player.autoAttack === false`. Proves the engage is not a sim behaviour, so a sim-level open-world vs battleground pair cannot show the divergence.
2. Added battleground cases to `tests/attack_on_ability.test.ts` before the fix: opposing-team fighter in an active match → expected hostile; teammate / off-roster pid / countdown / ended / queued-only → not hostile; and a paired duel-vs-battleground assertion through `hasAutoAttackTarget`. On the unfixed head the two "should engage" assertions failed and every duel/arena case passed. After the fix all 33 pass.

- Commands (worktree on `fix/bg-cast-autoattack` off `origin/release/v0.40.0`, tip `fd705304e`):
  - `npx vitest run tests/attack_on_ability.test.ts` → 2 failed / 31 passed before, 33 passed after
  - `npx vitest run tests/attack_on_ability.test.ts tests/options_view.test.ts tests/combat_auto_attack.test.ts tests/combat_casting_lifecycle.test.ts tests/battleground.test.ts tests/battleground_hud.test.ts tests/battleground_wire.test.ts tests/duel.test.ts tests/duel_module.test.ts tests/arena.test.ts tests/honor.test.ts tests/parity` → 22 files passed, 1 skipped; 715 tests passed, 68 skipped (parity goldens included; sim untouched)
  - `npx vitest run tests/hud_` → 10 files, 187 passed, 4 skipped
  - `npx tsc --noEmit -p tsconfig.json` → clean
  - `npx biome check src/ui/hud/action_bar/attack_on_ability.ts src/ui/hud.ts tests/attack_on_ability.test.ts` → clean
- Manual steps: none (no UI surface changed; the setting, toasts and HUD are untouched). `node scripts/gate_select.mjs` cannot resolve a base on this Windows machine (known `^{commit}` / cmd.exe issue), so the affected suites above were run directly.

## Checklist

### Quality

- [x] **The gate passes.** Affected suites, typecheck and biome are green as listed above; decisive tests added for the changed behaviour.

### Cross-platform

- ~Tested on desktop and mobile.~ N/A, no UI change.
- ~Accessible.~ N/A, no UI change.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
