### PR TITLE
fix(client): treat battleground enemies and enemy-owned pets as attackable

### DIFF
--- a/src/game/interactions.ts
+++ b/src/game/interactions.ts
@@ -20,6 +20,7 @@ export interface PickInteractionWorld {
   entities: IWorld['entities'];
   duelInfo?: IWorld['duelInfo'];
   arenaInfo?: IWorld['arenaInfo'];
+  bgInfo?: IWorld['bgInfo'];
   // Local party roster for the corpse rights check; optional so party-less
   // fixtures stay valid.
   partyInfo?: IWorld['partyInfo'];
@@ -48,8 +49,25 @@ export function isAttackHoverTarget(e: Entity | undefined): boolean {
   return hoverCursorKind(e, -1, new Set()) === 'attack';
 }
 
+/**
+ * The entity ids the local player may attack in PvP right now: an active duel
+ * opponent, every active-arena enemy (plus the enemy Yumi cat), every
+ * opposing-team fighter of a live Thornhollow Fields match, and the PETS those
+ * enemies own. The one client mirror of the sim's `isHostileTo` PvP arms, so
+ * every attack affordance reading it (hover cursor, click marker, attack-move,
+ * attack-nearest, pad auto-target) agrees with what the server will accept.
+ *
+ * Enemy pets ride the set by ENTITY id because `isAttackableEntity` reads a mob
+ * as attackable only when wild-hostile or listed here, and an owned pet carries
+ * `hostile:false` for life (it is the sim that resolves a pet to its owner's
+ * hostility). Without this arm an enemy warlock's demon showed the friendly
+ * cursor, a gold click marker and the friendly-pet tooltip, and no mouse or pad
+ * affordance would engage it, in every PvP mode. `entities` is optional only so
+ * the lighter fixtures stay valid; every live caller hands the world's map.
+ */
 export function activePvpOpponentIds(
-  world: Pick<PickInteractionWorld, 'player' | 'playerId' | 'duelInfo' | 'arenaInfo'>,
+  world: Pick<PickInteractionWorld, 'player' | 'playerId' | 'duelInfo' | 'arenaInfo' | 'bgInfo'> &
+    Partial<Pick<PickInteractionWorld, 'entities'>>,
   ids = new Set<number>(),
 ): Set<number> {
   ids.clear();
@@ -66,6 +84,22 @@ export function activePvpOpponentIds(
     // own cat stays out of the set, matching the sim hostility rule).
     const yumi = match.yumi;
     if (yumi) ids.add(yumi.team === 'A' ? yumi.yumiB.entityId : yumi.yumiA.entityId);
+  }
+  // Thornhollow Fields: the opposing TEAM is hostile for the whole live match
+  // (the countdown and the ended hold are combat-off, so neither lists anyone).
+  const bg = world.bgInfo?.match;
+  if (bg?.state === 'active') {
+    for (const row of bg.players) {
+      if (row.team !== bg.myTeam && row.pid !== selfId) ids.add(row.pid);
+    }
+  }
+  // Enemy-owned pets, resolved AFTER every player arm above so the owner set is
+  // complete. Iterating the map allocates nothing, which the per-frame hover
+  // caller relies on.
+  if (ids.size > 0 && world.entities) {
+    for (const e of world.entities.values()) {
+      if (e.kind === 'mob' && e.ownerId !== null && ids.has(e.ownerId)) ids.add(e.id);
+    }
   }
   return ids;
 }

--- a/tests/interactions.test.ts
+++ b/tests/interactions.test.ts
@@ -10,6 +10,7 @@ import {
   shouldApproachPickedEntity,
 } from '../src/game/interactions';
 import { type Entity, INTERACT_RANGE } from '../src/sim/types';
+import type { BgInfo, BgMatchInfo, BgPlayerInfo } from '../src/world_api/battleground';
 
 function stubEntity(partial: Partial<Entity> & Pick<Entity, 'id' | 'kind'>): Entity {
   return {
@@ -297,6 +298,126 @@ describe('activePvpOpponentIds', () => {
     });
 
     expect(ids.size).toBe(0);
+  });
+
+  // Thornhollow Fields (5v5 CTF). The sim's isHostileTo treats the opposing
+  // TEAM as hostile for the whole live match and resolves an owned pet to its
+  // owner, so every attack affordance this set drives (hover cursor, click
+  // marker, attack-move, attack-nearest, pad auto-target) must agree: an
+  // enemy fighter and an enemy warlock's demon are attackable, a teammate and
+  // a teammate's pet are not.
+  const bgRow = (pid: number, team: number): BgPlayerInfo => ({
+    pid,
+    name: `P${pid}`,
+    cls: 'warlock',
+    team,
+    carrying: false,
+    dead: false,
+    kills: 0,
+    deaths: 0,
+    captures: 0,
+    assists: 0,
+  });
+  const bgInfoWith = (match: BgMatchInfo | null): BgInfo => ({
+    rating: 0,
+    wins: 0,
+    losses: 0,
+    draws: 0,
+    captures: 0,
+    queued: false,
+    queueSize: 0,
+    queuedParty: 0,
+    firstWinBonusReady: false,
+    proposal: null,
+    requeueIn: 0,
+    match,
+    ladder: [],
+  });
+  const bgMatch: BgMatchInfo = {
+    state: 'active',
+    myTeam: 0,
+    capsToWin: 3,
+    scores: [0, 0],
+    flags: [
+      { state: 'home', carrierPid: null, carrierName: null, carrierTeam: null },
+      { state: 'home', carrierPid: null, carrierName: null, carrierTeam: null },
+    ],
+    players: [bgRow(1, 0), bgRow(5, 0), bgRow(6, 1), bgRow(7, 1)],
+    countdown: 0,
+    timeLeft: 600,
+    waveIn: [10, 10],
+    respawnIn: 0,
+    winner: null,
+  };
+
+  it('includes every opposing-team fighter of an active battleground match, never a teammate', () => {
+    const player = stubEntity({ id: 1, kind: 'player' });
+    const ids = activePvpOpponentIds({ playerId: 1, player, bgInfo: bgInfoWith(bgMatch) });
+    expect([...ids].sort()).toEqual([6, 7]);
+  });
+
+  it('ignores a battleground match that is not active (countdown / ended) or absent', () => {
+    const player = stubEntity({ id: 1, kind: 'player' });
+    expect(
+      activePvpOpponentIds({
+        playerId: 1,
+        player,
+        bgInfo: bgInfoWith({ ...bgMatch, state: 'countdown' }),
+      }).size,
+    ).toBe(0);
+    expect(
+      activePvpOpponentIds({
+        playerId: 1,
+        player,
+        bgInfo: bgInfoWith({ ...bgMatch, state: 'ended' }),
+      }).size,
+    ).toBe(0);
+    expect(activePvpOpponentIds({ playerId: 1, player, bgInfo: bgInfoWith(null) }).size).toBe(0);
+  });
+
+  it('includes an enemy-owned pet (the sim resolves a pet to its owner), never an ally pet', () => {
+    const player = stubEntity({ id: 1, kind: 'player' });
+    const enemyDemon = stubEntity({ id: 60, kind: 'mob', ownerId: 6, hostile: false });
+    const allyDemon = stubEntity({ id: 50, kind: 'mob', ownerId: 5, hostile: false });
+    const ownDemon = stubEntity({ id: 10, kind: 'mob', ownerId: 1, hostile: false });
+    const wildWolf = stubEntity({ id: 70, kind: 'mob', ownerId: null, hostile: true });
+    const entities = new Map<number, Entity>([
+      [1, player],
+      [60, enemyDemon],
+      [50, allyDemon],
+      [10, ownDemon],
+      [70, wildWolf],
+    ]);
+    const ids = activePvpOpponentIds({
+      playerId: 1,
+      player,
+      entities,
+      bgInfo: bgInfoWith(bgMatch),
+    });
+    expect([...ids].sort((a, b) => a - b)).toEqual([6, 7, 60]);
+    // The same verdict every consumer reads:
+    expect(isAttackableEntity(enemyDemon, 1, ids)).toBe(true);
+    expect(isAttackableEntity(allyDemon, 1, ids)).toBe(false);
+    expect(isAttackableEntity(ownDemon, 1, ids)).toBe(false);
+    expect(isAttackableEntity(wildWolf, 1, ids)).toBe(true); // wild-hostile, as before
+    expect(hoverCursorKind(enemyDemon, 1, new Set(), ids)).toBe('attack');
+    expect(hoverCursorKind(allyDemon, 1, new Set(), ids)).toBe('default');
+  });
+
+  it('includes a duel / arena opponent pet too (same owner resolution)', () => {
+    const player = stubEntity({ id: 1, kind: 'player' });
+    const rivalPet = stubEntity({ id: 20, kind: 'mob', ownerId: 2, hostile: false });
+    const entities = new Map<number, Entity>([
+      [1, player],
+      [20, rivalPet],
+    ]);
+    const ids = activePvpOpponentIds({
+      playerId: 1,
+      player,
+      entities,
+      duelInfo: { otherPid: 2, otherName: 'Duelist', state: 'active' },
+    });
+    expect([...ids].sort((a, b) => a - b)).toEqual([2, 20]);
   });
 });
 


### PR DESCRIPTION
## Summary

Inside Thornhollow Fields, enemy players' pets (e.g. a warlock's demon) read as **friendly** on the client: friendly hover cursor, gold click marker, green friendly-pet tooltip, and none of the mouse/pad attack affordances would target or engage them, so they felt unkillable. In a battleground the enemy *players* themselves also fell out of the client's attackable set.

**Root cause (client, not sim).** The sim is correct: `isHostileTo` resolves an owned mob to its owner and the owner goes through the Thornhollow arm, so the server accepts attacks on an enemy demon (reproduced in a scratch sim test: live 5v5, enemy emberkin, cross-team mage Fireball lands 363→334 and auto-attack engages with no error).

The client's single mirror of that rule is `activePvpOpponentIds` in `src/game/interactions.ts`. It listed an active duel opponent and active-arena enemies (plus the enemy Yumi cat) and nothing else:

1. **No battleground arm**, so a live match listed nobody. Same family as #3559 (`isPvpHostileTarget` had the identical gap).
2. **No pets.** `isAttackableEntity` reads a mob as attackable only when `e.hostile || set.has(e.id)`; an owned pet carries `hostile:false` for life and was never listed by entity id. So enemy pets were non-attackable on the client in *every* PvP mode, not just battlegrounds.

That set feeds every attack affordance: hover cursor and mob tooltip (`main.ts` hover path), click-marker colour, attack-move and chase-to-melee engage, attack-nearest, and the gamepad auto-target (`pad_target_pick.ts`).

**Fix at the shared level.** `activePvpOpponentIds` gains the battleground arm (active match, opposing team) and, after all player arms, folds in every mob whose `ownerId` is a listed enemy. `isAttackableEntity` and all seven consumers are untouched and now agree with the sim. The extra pass iterates the entity map without allocating, which the per-frame hover caller relies on (covered by `client_frame_allocations.test.ts`). `entities` is optional on the parameter only so the existing lightweight fixtures stay valid; every live caller passes the world.

No sim change, no player-visible strings, no parity-covered code touched. Complements #3559 (engage-on-cast in battlegrounds); the two are independent.

## Related issues

Follow-up from the battleground auto-attack report behind #3559; no issue number supplied.

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change

## How was this tested?

Test-first reproduction in `tests/interactions.test.ts`: four new cases (battleground fighters listed / teammates not; countdown, ended and absent match list nobody; enemy-owned pet listed and attackable while ally/own pets and a wild-hostile mob keep their verdicts; duel-opponent pet listed). Three failed on the unfixed head, all pass after.

- Commands (worktree on `fix/bg-enemy-pets` off `origin/release/v0.40.0`, tip `fd705304e`):
  - `npx vitest run tests/interactions.test.ts` → 3 failed / 54 passed before, 57 passed after
  - `npx vitest run tests/interactions.test.ts tests/click_move.test.ts tests/client_frame_allocations.test.ts tests/pad_target_pick.test.ts tests/pad_mouse_cursor.test.ts tests/pet_reaction.test.ts tests/pick_resolution.test.ts tests/battleground.test.ts tests/battleground_hud.test.ts tests/duel.test.ts tests/arena.test.ts tests/arena_pet_return.test.ts tests/attack_on_ability.test.ts tests/hud_ tests/parity` → 861 passed, 5 skipped. One `battleground.test.ts` case (a repo-wide `grep -rl` shelled from the test) hit its 60 s timeout under parallel load and passes when run alone; unrelated to this change.
  - `npx tsc --noEmit -p tsconfig.json` → clean
  - `npx biome check src/game/interactions.ts tests/interactions.test.ts` → no errors (3 pre-existing `noExplicitAny` warnings in untouched fixtures)
- Manual steps: none. `node scripts/gate_select.mjs` cannot resolve a base on this Windows machine, so the affected suites were run directly.

## Checklist

### Quality

- [x] **The gate passes.** Affected suites, typecheck and biome are green as listed above; decisive tests added for the changed behaviour.

### Cross-platform

- ~Tested on desktop and mobile.~ N/A, no UI surface changed (cursor/marker/tooltip now take the existing hostile branch).
- ~Accessible.~ N/A.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
