### PR TITLE
fix(mail): never mail bots and purge the accumulated bot welcome letters

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -19,6 +19,8 @@ scripts/*
 !scripts/old_cragmaw_pelt_migration.ts
 !scripts/migrate_rift_forge_rollback.ts
 !scripts/rift_forge_rollback_migration.ts
+!scripts/migrate_mail_bot_welcome_purge.ts
+!scripts/mail_bot_welcome_purge_migration.ts
 !scripts/build_sitemap.mjs
 !scripts/browserslist_targets.mjs
 # vite.config.ts imports the vitest sharding sequencer at module scope, so

--- a/scripts/build_server.mjs
+++ b/scripts/build_server.mjs
@@ -40,4 +40,14 @@ await esbuild.build({
   alias: { '#bot-detector': usePrivate ? privateImpl : stubImpl },
 });
 
+await esbuild.build({
+  entryPoints: ['scripts/migrate_mail_bot_welcome_purge.ts'],
+  bundle: true,
+  platform: 'node',
+  format: 'cjs',
+  external: ['pg-native'],
+  outfile: 'dist-server/migrate_mail_bot_welcome_purge.cjs',
+  alias: { '#bot-detector': usePrivate ? privateImpl : stubImpl },
+});
+
 console.log(`[build:server] bot detector: ${usePrivate ? 'private' : 'stub (no-op)'}`);

--- a/scripts/mail_bot_welcome_purge_migration.ts
+++ b/scripts/mail_bot_welcome_purge_migration.ts
@@ -12,8 +12,10 @@
 //   - recipientKey is the character id AND recipientName is that character's
 //     current name (renames rekey both through rekeyMailOwner, so a live
 //     character's pair always matches), or
-//   - recipientKey equals a character's name (the legacy name-keyed letters
-//     from before the stable-id key existed).
+//   - recipientKey equals a character's name (belt and braces: mailKeyFor has
+//     been id-based since the mail system shipped, so no such letter should
+//     exist, but an arm that can only KEEP more is the right failure direction
+//     for a destructive script).
 // A bot letter can never satisfy either arm: its key is a transient pid that
 // at best collides with some character's id while carrying a bot roster name.
 // The worst possible false remove is bounded by the letter itself: the welcome
@@ -25,14 +27,24 @@
 // Run with no flags for an all-realm dry run; --realm NAME scopes it. --apply
 // writes, and is a MANUAL deploy-window step with the game server stopped:
 // the server re-persists its in-memory book every 30 seconds, so a purge
-// applied under a live server would be clobbered on the next autosave. The
-// apply path locks character_leases, reaps expired crash orphans, and refuses
-// while any live lease remains for the realm.
+// applied under a live server would be clobbered on the next autosave. Two
+// guards prove the stop, because character leases alone cannot (a lease row
+// exists per character IN WORLD, so an idle-but-running realm holds none while
+// flushPeriodicSaves still rewrites the book every cycle):
+//   1. the mail row's own updated_at must be older than several autosave
+//      cycles, which an idle-but-running server can never satisfy;
+//   2. the UPDATE compare-and-swaps on that same updated_at, so an autosave
+//      racing the run makes the write fail loudly instead of silently losing.
+// The lease lock/reap stays as the secondary guard for the populated case.
 
 import { Pool, type PoolClient } from 'pg';
 
 export const WELCOME_LETTER_ID = 'ravenpost_welcome';
 const MAIL_KEY_PREFIX = 'mail:';
+/** A mail row younger than this refuses --apply: the autosave rewrites the
+ *  book every 30 seconds, so a row this fresh means the realm's server is
+ *  still running (even with zero players in world). Three cycles of margin. */
+export const FRESH_WRITE_WINDOW_SECONDS = 90;
 
 export interface PurgeOptions {
   apply: boolean;
@@ -161,10 +173,11 @@ export async function runMailBotWelcomePurgeMigration(
     throw new Error('DATABASE_URL is required.');
   }
 
+  const scope = realm ? `realm "${realm}"` : 'all realms';
+  const mode = apply ? 'applying' : 'dry run';
   const pool = runtime.createPool(databaseUrl);
   let client: PoolClient | null = null;
   let transactionOpen = false;
-  const report: string[] = [];
 
   try {
     // One pinned client for the whole run: BEGIN/COMMIT on a bare pool are
@@ -182,17 +195,42 @@ export async function runMailBotWelcomePurgeMigration(
       await client.query('DELETE FROM character_leases WHERE expires_at <= now()');
     }
 
-    const mailRows = await client.query<{ key: string; data: MailBookLike }>(
+    const mailRows = await client.query<{
+      key: string;
+      data: MailBookLike;
+      updated_at: string;
+      age_seconds: number;
+    }>(
       realm
-        ? 'SELECT key, data FROM world_state WHERE key = $1 ORDER BY key ASC'
-        : "SELECT key, data FROM world_state WHERE key LIKE 'mail:%' ORDER BY key ASC",
+        ? `SELECT key, data, updated_at::text AS updated_at,
+             EXTRACT(EPOCH FROM now() - updated_at)::float8 AS age_seconds
+           FROM world_state WHERE key = $1 ORDER BY key ASC`
+        : `SELECT key, data, updated_at::text AS updated_at,
+             EXTRACT(EPOCH FROM now() - updated_at)::float8 AS age_seconds
+           FROM world_state WHERE key LIKE 'mail:%' ORDER BY key ASC`,
       realm ? [MAIL_KEY_PREFIX + realm] : [],
     );
+    if (realm && mailRows.rows.length === 0) {
+      throw new Error(
+        `No mail row exists for realm "${realm}": check the spelling (a destructive run must not report empty success).`,
+      );
+    }
 
+    console.log(`Bot welcome letter purge (${scope}, ${mode}):`);
     for (const row of mailRows.rows) {
       const rowRealm = row.key.slice(MAIL_KEY_PREFIX.length);
 
       if (apply) {
+        // Primary stop-proof: a running server rewrites this row every 30s
+        // autosave whether or not anyone is online, so freshness means live.
+        if (row.age_seconds < FRESH_WRITE_WINDOW_SECONDS) {
+          throw new Error(
+            `Realm "${rowRealm}"'s mail row was written ${Math.round(row.age_seconds)}s ago ` +
+              `(fresher than ${FRESH_WRITE_WINDOW_SECONDS}s): its game server is still running. ` +
+              'Stop it before --apply.',
+          );
+        }
+        // Secondary: no character may be in world (lease-fenced).
         const leases = await client.query<{ count: string }>(
           'SELECT count(*)::text AS count FROM character_leases WHERE realm = $1',
           [rowRealm],
@@ -212,16 +250,26 @@ export async function runMailBotWelcomePurgeMigration(
       const before = JSON.stringify(row.data).length;
       const result = purgeBotWelcomeLetters(row.data, characters.rows);
       const after = result.changed ? JSON.stringify(result.value).length : before;
-      report.push(
-        `${row.key}: kept=${result.kept} removed=${result.removed} bytes ${before} -> ${after}`,
+      // Printed as produced, so a throw on a later realm keeps earlier lines.
+      console.log(
+        `  ${row.key}: kept=${result.kept} removed=${result.removed} bytes ${before} -> ${after}`,
       );
       if (!result.changed) continue;
 
       if (apply) {
-        await client.query('UPDATE world_state SET data = $1, updated_at = now() WHERE key = $2', [
-          JSON.stringify(result.value),
-          row.key,
-        ]);
+        // CAS on the exact updated_at we read (text round-trip preserves the
+        // microseconds a JS Date would lose): a concurrent autosave makes
+        // this write miss and the run abort, never silently lose the purge.
+        const updated = await client.query(
+          `UPDATE world_state SET data = $1, updated_at = now()
+           WHERE key = $2 AND updated_at::text = $3`,
+          [JSON.stringify(result.value), row.key, row.updated_at],
+        );
+        if (updated.rowCount !== 1) {
+          throw new Error(
+            `Concurrent write detected on ${row.key} (its game server is running); aborting.`,
+          );
+        }
       }
     }
 
@@ -245,11 +293,9 @@ export async function runMailBotWelcomePurgeMigration(
     await pool.end();
   }
 
-  const scope = realm ? `realm "${realm}"` : 'all realms';
-  const mode = apply ? 'applied' : 'dry run';
-  console.log(`Bot welcome letter purge (${scope}, ${mode}):`);
-  for (const line of report) console.log(`  ${line}`);
-  if (!apply) {
+  if (apply) {
+    console.log('Applied and committed.');
+  } else {
     console.log('Dry run only. Re-run with --apply (game server stopped) to write.');
   }
 }

--- a/scripts/mail_bot_welcome_purge_migration.ts
+++ b/scripts/mail_bot_welcome_purge_migration.ts
@@ -1,0 +1,216 @@
+// Purge the bot-addressed Ravenpost welcome letters from the shared mail book
+// (issue #3560). Vale Cup showcase/backfill bots (plus fiesta and /dev bots)
+// were created through the normal addPlayer path, so every bot got the one-time
+// ravenpost_welcome letter addressed to its transient pid; the bot was reaped
+// at match end but the letter persisted forever. By 2026-08-22 the prod book
+// held 151,548 letters, 134,431 of them bot welcomes (85MB of the 89MB row),
+// and the 30 second autosave serialized all of it on the main thread.
+//
+// The send-side fix (addPlayer's `bot` option) stops new bot letters. This
+// migration removes the accumulated ones: a ravenpost_welcome letter is kept
+// only when its recipient resolves to a real character, meaning either
+//   - recipientKey is the character id AND recipientName is that character's
+//     current name (renames rekey both through rekeyMailOwner, so a live
+//     character's pair always matches), or
+//   - recipientKey equals a character's name (the legacy name-keyed letters
+//     from before the stable-id key existed).
+// A bot letter can never satisfy either arm: its key is a transient pid that
+// at best collides with some character's id while carrying a bot roster name.
+// Like the old-cragmaw migration (and unlike the rift forge rollback), the
+// matching condition cannot legitimately reappear once the send-side fix is
+// deployed, so re-running is safe; no completion marker is needed.
+//
+// Run with no flags for an all-realm dry run; --realm NAME scopes it. --apply
+// writes, and belongs in the deploy window while the game server is stopped:
+// the server re-persists its in-memory book every 30 seconds, so a purge
+// applied under a live server would be clobbered on the next autosave. The
+// apply path refuses while any character lease is still held for the realm.
+
+import { Pool } from 'pg';
+
+export const WELCOME_LETTER_ID = 'ravenpost_welcome';
+const MAIL_KEY_PREFIX = 'mail:';
+
+interface Options {
+  apply: boolean;
+  realm?: string;
+}
+
+export interface MailLetterLike {
+  letterId?: unknown;
+  recipientKey?: unknown;
+  recipientName?: unknown;
+  [key: string]: unknown;
+}
+
+export interface MailBookLike {
+  mail?: unknown;
+  [key: string]: unknown;
+}
+
+export interface CharacterRow {
+  id: number;
+  name: string;
+}
+
+export interface PurgeResult {
+  changed: boolean;
+  value: MailBookLike;
+  kept: number;
+  removed: number;
+}
+
+/** Whether this letter survives the purge (see the header for the contract). */
+export function keepsLetter(
+  letter: MailLetterLike,
+  byId: ReadonlyMap<string, string>,
+  names: ReadonlySet<string>,
+): boolean {
+  if (letter.letterId !== WELCOME_LETTER_ID) return true;
+  const key = typeof letter.recipientKey === 'string' ? letter.recipientKey : '';
+  const name = typeof letter.recipientName === 'string' ? letter.recipientName : '';
+  if (byId.get(key) === name) return true;
+  return names.has(key);
+}
+
+export function purgeBotWelcomeLetters(
+  book: MailBookLike,
+  characters: readonly CharacterRow[],
+): PurgeResult {
+  const mail = Array.isArray(book.mail) ? (book.mail as MailLetterLike[]) : null;
+  if (!mail) return { changed: false, value: book, kept: 0, removed: 0 };
+
+  const byId = new Map<string, string>();
+  const names = new Set<string>();
+  for (const c of characters) {
+    byId.set(String(c.id), c.name);
+    names.add(c.name);
+  }
+
+  const kept = mail.filter((letter) => keepsLetter(letter, byId, names));
+  if (kept.length === mail.length) {
+    return { changed: false, value: book, kept: kept.length, removed: 0 };
+  }
+  return {
+    changed: true,
+    value: { ...book, mail: kept },
+    kept: kept.length,
+    removed: mail.length - kept.length,
+  };
+}
+
+function parseArgs(argv: readonly string[]): Options {
+  let realm: string | undefined;
+  let apply = false;
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--apply') {
+      apply = true;
+      continue;
+    }
+    if (arg === '--realm') {
+      realm = argv[i + 1]?.trim();
+      i += 1;
+      continue;
+    }
+    if (arg.startsWith('--realm=')) {
+      realm = arg.slice('--realm='.length).trim();
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+  return { apply, realm: realm || undefined };
+}
+
+export async function runMailBotWelcomePurgeMigration(argv: readonly string[]): Promise<void> {
+  try {
+    process.loadEnvFile?.();
+  } catch {
+    // .env is optional; production injects DATABASE_URL through Docker Compose.
+  }
+
+  const { apply, realm } = parseArgs(argv);
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    throw new Error('DATABASE_URL is required.');
+  }
+
+  const pool = new Pool({ connectionString: databaseUrl, max: 2 });
+  let committed = false;
+  const report: string[] = [];
+
+  try {
+    await pool.query('BEGIN');
+
+    const mailRows = await pool.query<{ key: string; data: MailBookLike }>(
+      realm
+        ? 'SELECT key, data FROM world_state WHERE key = $1 ORDER BY key ASC'
+        : "SELECT key, data FROM world_state WHERE key LIKE 'mail:%' ORDER BY key ASC",
+      realm ? [MAIL_KEY_PREFIX + realm] : [],
+    );
+
+    for (const row of mailRows.rows) {
+      const rowRealm = row.key.slice(MAIL_KEY_PREFIX.length);
+
+      if (apply) {
+        // A live server re-persists its in-memory book every 30 seconds and
+        // would clobber this purge; refuse while its character leases exist.
+        const leases = await pool.query<{ count: string }>(
+          'SELECT count(*)::text AS count FROM character_leases WHERE realm = $1',
+          [rowRealm],
+        );
+        if (Number(leases.rows[0]?.count ?? 0) > 0) {
+          throw new Error(
+            `Realm "${rowRealm}" still holds character leases: stop its game server before --apply.`,
+          );
+        }
+      }
+
+      const characters = await pool.query<CharacterRow>(
+        'SELECT id, name FROM characters WHERE realm = $1',
+        [rowRealm],
+      );
+
+      const before = JSON.stringify(row.data).length;
+      const result = purgeBotWelcomeLetters(row.data, characters.rows);
+      const after = result.changed ? JSON.stringify(result.value).length : before;
+      report.push(
+        `${row.key}: kept=${result.kept} removed=${result.removed} bytes ${before} -> ${after}`,
+      );
+      if (!result.changed) continue;
+
+      if (apply) {
+        await pool.query('UPDATE world_state SET data = $1, updated_at = now() WHERE key = $2', [
+          JSON.stringify(result.value),
+          row.key,
+        ]);
+      }
+    }
+
+    if (apply) {
+      await pool.query('COMMIT');
+      committed = true;
+    } else {
+      await pool.query('ROLLBACK');
+    }
+  } catch (err) {
+    if (!committed) {
+      try {
+        await pool.query('ROLLBACK');
+      } catch {
+        // Ignore rollback errors after a failed or already closed transaction.
+      }
+    }
+    throw err;
+  } finally {
+    await pool.end();
+  }
+
+  const scope = realm ? `realm "${realm}"` : 'all realms';
+  const mode = apply ? 'applied' : 'dry run';
+  console.log(`Bot welcome letter purge (${scope}, ${mode}):`);
+  for (const line of report) console.log(`  ${line}`);
+  if (!apply) {
+    console.log('Dry run only. Re-run with --apply (game server stopped) to write.');
+  }
+}

--- a/scripts/mail_bot_welcome_purge_migration.ts
+++ b/scripts/mail_bot_welcome_purge_migration.ts
@@ -183,6 +183,7 @@ export async function runMailBotWelcomePurgeMigration(
   const pool = runtime.createPool(databaseUrl);
   let client: PoolClient | null = null;
   let transactionOpen = false;
+  let printedRows = 0;
 
   try {
     // One pinned client for the whole run: BEGIN/COMMIT on a bare pool are
@@ -259,13 +260,18 @@ export async function runMailBotWelcomePurgeMigration(
       const result = purgeBotWelcomeLetters(row.data, characters.rows);
       // One stringify shared by the report and the UPDATE payload: before
       // comes from octet_length in SQL, so the 89MB book that motivated this
-      // migration is never re-serialized just to print a number.
+      // migration is never re-serialized just to print a number. The two
+      // figures use different rulers: before is Postgres's jsonb rendering
+      // (a space after every colon and comma, about 4.5 percent wider), after
+      // is compact JSON.stringify. Close enough for an operator report; not
+      // worth buying back with a second stringify of the full book.
       const serialized = result.changed ? JSON.stringify(result.value) : null;
       const after = serialized === null ? row.bytes : serialized.length;
       // Printed as produced, so a throw on a later realm keeps earlier lines.
       console.log(
         `  ${row.key}: kept=${result.kept} removed=${result.removed} bytes ${row.bytes} -> ${after}`,
       );
+      printedRows += 1;
       if (serialized === null) continue;
 
       if (apply) {
@@ -298,7 +304,7 @@ export async function runMailBotWelcomePurgeMigration(
       } catch {
         // Ignore rollback errors after a failed or already closed transaction.
       }
-      if (apply) {
+      if (apply && printedRows > 0) {
         console.log('Aborted and rolled back: nothing reported above was written.');
       }
     }

--- a/scripts/mail_bot_welcome_purge_migration.ts
+++ b/scripts/mail_bot_welcome_purge_migration.ts
@@ -16,25 +16,40 @@
 //     from before the stable-id key existed).
 // A bot letter can never satisfy either arm: its key is a transient pid that
 // at best collides with some character's id while carrying a bot roster name.
-// Like the old-cragmaw migration (and unlike the rift forge rollback), the
-// matching condition cannot legitimately reappear once the send-side fix is
-// deployed, so re-running is safe; no completion marker is needed.
+// The worst possible false remove is bounded by the letter itself: the welcome
+// carries 50 copper and no items, so no player parcel or escrow is ever at
+// stake. Like the old-cragmaw migration (and unlike the rift forge rollback),
+// the matching condition cannot legitimately reappear once the send-side fix
+// is deployed, so re-running is safe; no completion marker is needed.
 //
 // Run with no flags for an all-realm dry run; --realm NAME scopes it. --apply
-// writes, and belongs in the deploy window while the game server is stopped:
+// writes, and is a MANUAL deploy-window step with the game server stopped:
 // the server re-persists its in-memory book every 30 seconds, so a purge
 // applied under a live server would be clobbered on the next autosave. The
-// apply path refuses while any character lease is still held for the realm.
+// apply path locks character_leases, reaps expired crash orphans, and refuses
+// while any live lease remains for the realm.
 
-import { Pool } from 'pg';
+import { Pool, type PoolClient } from 'pg';
 
 export const WELCOME_LETTER_ID = 'ravenpost_welcome';
 const MAIL_KEY_PREFIX = 'mail:';
 
-interface Options {
+export interface PurgeOptions {
   apply: boolean;
   realm?: string;
 }
+
+export interface MailBotWelcomePurgeRuntime {
+  loadEnvFile(): void;
+  databaseUrl(): string | undefined;
+  createPool(connectionString: string): Pool;
+}
+
+const DEFAULT_RUNTIME: MailBotWelcomePurgeRuntime = {
+  loadEnvFile: () => process.loadEnvFile?.(),
+  databaseUrl: () => process.env.DATABASE_URL,
+  createPool: (connectionString) => new Pool({ connectionString, max: 2 }),
+};
 
 export interface MailLetterLike {
   letterId?: unknown;
@@ -99,7 +114,10 @@ export function purgeBotWelcomeLetters(
   };
 }
 
-function parseArgs(argv: readonly string[]): Options {
+/** A destructive command must never guess: a bare trailing --realm, or one
+ *  whose "value" is actually the next flag, would silently widen the run to
+ *  all realms (or silently swallow --apply), so both throw instead. */
+export function parseArgs(argv: readonly string[]): PurgeOptions {
   let realm: string | undefined;
   let apply = false;
   for (let i = 0; i < argv.length; i += 1) {
@@ -109,40 +127,62 @@ function parseArgs(argv: readonly string[]): Options {
       continue;
     }
     if (arg === '--realm') {
-      realm = argv[i + 1]?.trim();
+      const value = argv[i + 1];
+      if (value === undefined || value.startsWith('--') || !value.trim()) {
+        throw new Error('--realm requires a realm name');
+      }
+      realm = value.trim();
       i += 1;
       continue;
     }
     if (arg.startsWith('--realm=')) {
       realm = arg.slice('--realm='.length).trim();
+      if (!realm) throw new Error('--realm requires a realm name');
       continue;
     }
     throw new Error(`Unknown argument: ${arg}`);
   }
-  return { apply, realm: realm || undefined };
+  return { apply, realm };
 }
 
-export async function runMailBotWelcomePurgeMigration(argv: readonly string[]): Promise<void> {
+export async function runMailBotWelcomePurgeMigration(
+  argv: readonly string[],
+  runtime: MailBotWelcomePurgeRuntime = DEFAULT_RUNTIME,
+): Promise<void> {
+  const { apply, realm } = parseArgs(argv);
+
   try {
-    process.loadEnvFile?.();
+    runtime.loadEnvFile();
   } catch {
     // .env is optional; production injects DATABASE_URL through Docker Compose.
   }
-
-  const { apply, realm } = parseArgs(argv);
-  const databaseUrl = process.env.DATABASE_URL;
+  const databaseUrl = runtime.databaseUrl();
   if (!databaseUrl) {
     throw new Error('DATABASE_URL is required.');
   }
 
-  const pool = new Pool({ connectionString: databaseUrl, max: 2 });
-  let committed = false;
+  const pool = runtime.createPool(databaseUrl);
+  let client: PoolClient | null = null;
+  let transactionOpen = false;
   const report: string[] = [];
 
   try {
-    await pool.query('BEGIN');
+    // One pinned client for the whole run: BEGIN/COMMIT on a bare pool are
+    // independent checkouts that only form a transaction by accident.
+    client = await pool.connect();
+    await client.query('BEGIN');
+    transactionOpen = true;
 
-    const mailRows = await pool.query<{ key: string; data: MailBookLike }>(
+    if (apply) {
+      // A live server re-persists its in-memory book every 30 seconds and
+      // would clobber this purge. The SHARE MODE lock keeps a realm process
+      // from acquiring a lease after the check; reaping expired rows first
+      // keeps a crash orphan from wedging the deploy window forever.
+      await client.query('LOCK TABLE character_leases IN SHARE MODE');
+      await client.query('DELETE FROM character_leases WHERE expires_at <= now()');
+    }
+
+    const mailRows = await client.query<{ key: string; data: MailBookLike }>(
       realm
         ? 'SELECT key, data FROM world_state WHERE key = $1 ORDER BY key ASC'
         : "SELECT key, data FROM world_state WHERE key LIKE 'mail:%' ORDER BY key ASC",
@@ -153,20 +193,18 @@ export async function runMailBotWelcomePurgeMigration(argv: readonly string[]): 
       const rowRealm = row.key.slice(MAIL_KEY_PREFIX.length);
 
       if (apply) {
-        // A live server re-persists its in-memory book every 30 seconds and
-        // would clobber this purge; refuse while its character leases exist.
-        const leases = await pool.query<{ count: string }>(
+        const leases = await client.query<{ count: string }>(
           'SELECT count(*)::text AS count FROM character_leases WHERE realm = $1',
           [rowRealm],
         );
         if (Number(leases.rows[0]?.count ?? 0) > 0) {
           throw new Error(
-            `Realm "${rowRealm}" still holds character leases: stop its game server before --apply.`,
+            `Realm "${rowRealm}" still holds live character leases: stop its game server before --apply.`,
           );
         }
       }
 
-      const characters = await pool.query<CharacterRow>(
+      const characters = await client.query<CharacterRow>(
         'SELECT id, name FROM characters WHERE realm = $1',
         [rowRealm],
       );
@@ -180,7 +218,7 @@ export async function runMailBotWelcomePurgeMigration(argv: readonly string[]): 
       if (!result.changed) continue;
 
       if (apply) {
-        await pool.query('UPDATE world_state SET data = $1, updated_at = now() WHERE key = $2', [
+        await client.query('UPDATE world_state SET data = $1, updated_at = now() WHERE key = $2', [
           JSON.stringify(result.value),
           row.key,
         ]);
@@ -188,21 +226,22 @@ export async function runMailBotWelcomePurgeMigration(argv: readonly string[]): 
     }
 
     if (apply) {
-      await pool.query('COMMIT');
-      committed = true;
+      await client.query('COMMIT');
     } else {
-      await pool.query('ROLLBACK');
+      await client.query('ROLLBACK');
     }
+    transactionOpen = false;
   } catch (err) {
-    if (!committed) {
+    if (client && transactionOpen) {
       try {
-        await pool.query('ROLLBACK');
+        await client.query('ROLLBACK');
       } catch {
         // Ignore rollback errors after a failed or already closed transaction.
       }
     }
     throw err;
   } finally {
+    client?.release();
     await pool.end();
   }
 

--- a/scripts/mail_bot_welcome_purge_migration.ts
+++ b/scripts/mail_bot_welcome_purge_migration.ts
@@ -32,7 +32,12 @@
 // exists per character IN WORLD, so an idle-but-running realm holds none while
 // flushPeriodicSaves still rewrites the book every cycle):
 //   1. the mail row's own updated_at must be older than several autosave
-//      cycles, which an idle-but-running server can never satisfy;
+//      cycles, which an idle-but-running server can never satisfy. Strictly
+//      this proves "no write in the last 90 seconds", not "no process": a
+//      server started moments ago that has not reached its first autosave
+//      slips both guards, so the operator still owns the stop. (A fresh row
+//      right after a successful --apply is the same signal from the other
+//      side: the apply itself stamped updated_at.);
 //   2. the UPDATE compare-and-swaps on that same updated_at, so an autosave
 //      racing the run makes the write fail loudly instead of silently losing.
 // The lease lock/reap stays as the secondary guard for the populated case.
@@ -200,13 +205,16 @@ export async function runMailBotWelcomePurgeMigration(
       data: MailBookLike;
       updated_at: string;
       age_seconds: number;
+      bytes: number;
     }>(
       realm
         ? `SELECT key, data, updated_at::text AS updated_at,
-             EXTRACT(EPOCH FROM now() - updated_at)::float8 AS age_seconds
+             EXTRACT(EPOCH FROM now() - updated_at)::float8 AS age_seconds,
+             octet_length(data::text) AS bytes
            FROM world_state WHERE key = $1 ORDER BY key ASC`
         : `SELECT key, data, updated_at::text AS updated_at,
-             EXTRACT(EPOCH FROM now() - updated_at)::float8 AS age_seconds
+             EXTRACT(EPOCH FROM now() - updated_at)::float8 AS age_seconds,
+             octet_length(data::text) AS bytes
            FROM world_state WHERE key LIKE 'mail:%' ORDER BY key ASC`,
       realm ? [MAIL_KEY_PREFIX + realm] : [],
     );
@@ -227,7 +235,8 @@ export async function runMailBotWelcomePurgeMigration(
           throw new Error(
             `Realm "${rowRealm}"'s mail row was written ${Math.round(row.age_seconds)}s ago ` +
               `(fresher than ${FRESH_WRITE_WINDOW_SECONDS}s): its game server is still running. ` +
-              'Stop it before --apply.',
+              'Stop it before --apply. (A fresh row can also mean an --apply just ' +
+              'committed here: re-running is safe once the window passes.)',
           );
         }
         // Secondary: no character may be in world (lease-fenced).
@@ -247,14 +256,17 @@ export async function runMailBotWelcomePurgeMigration(
         [rowRealm],
       );
 
-      const before = JSON.stringify(row.data).length;
       const result = purgeBotWelcomeLetters(row.data, characters.rows);
-      const after = result.changed ? JSON.stringify(result.value).length : before;
+      // One stringify shared by the report and the UPDATE payload: before
+      // comes from octet_length in SQL, so the 89MB book that motivated this
+      // migration is never re-serialized just to print a number.
+      const serialized = result.changed ? JSON.stringify(result.value) : null;
+      const after = serialized === null ? row.bytes : serialized.length;
       // Printed as produced, so a throw on a later realm keeps earlier lines.
       console.log(
-        `  ${row.key}: kept=${result.kept} removed=${result.removed} bytes ${before} -> ${after}`,
+        `  ${row.key}: kept=${result.kept} removed=${result.removed} bytes ${row.bytes} -> ${after}`,
       );
-      if (!result.changed) continue;
+      if (serialized === null) continue;
 
       if (apply) {
         // CAS on the exact updated_at we read (text round-trip preserves the
@@ -263,7 +275,7 @@ export async function runMailBotWelcomePurgeMigration(
         const updated = await client.query(
           `UPDATE world_state SET data = $1, updated_at = now()
            WHERE key = $2 AND updated_at::text = $3`,
-          [JSON.stringify(result.value), row.key, row.updated_at],
+          [serialized, row.key, row.updated_at],
         );
         if (updated.rowCount !== 1) {
           throw new Error(
@@ -285,6 +297,9 @@ export async function runMailBotWelcomePurgeMigration(
         await client.query('ROLLBACK');
       } catch {
         // Ignore rollback errors after a failed or already closed transaction.
+      }
+      if (apply) {
+        console.log('Aborted and rolled back: nothing reported above was written.');
       }
     }
     throw err;

--- a/scripts/migrate_mail_bot_welcome_purge.ts
+++ b/scripts/migrate_mail_bot_welcome_purge.ts
@@ -1,0 +1,6 @@
+import { runMailBotWelcomePurgeMigration } from './mail_bot_welcome_purge_migration';
+
+runMailBotWelcomePurgeMigration(process.argv.slice(2)).catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/server/community_test_accounts.ts
+++ b/server/community_test_accounts.ts
@@ -46,7 +46,11 @@ function templateStates(): ReadonlyMap<PlayerClass, CharacterState> {
   const sim = new Sim({ seed: TEMPLATE_SEED, playerClass: 'warrior', noPlayer: true });
   const templates = new Map<PlayerClass, CharacterState>();
   for (const cls of ALL_CLASSES) {
-    const pid = sim.addPlayer(cls, `${cls}template`);
+    // bot: this throwaway template Sim's mail book is discarded, but the flag
+    // keeps the no-mail-for-synthetic-players rule uniform across every
+    // non-player addPlayer site (the flip itself is unchanged: templates
+    // already carried mailWelcomed true into cloned characters).
+    const pid = sim.addPlayer(cls, `${cls}template`, { bot: true });
     sim.setPlayerLevel(MAX_LEVEL, pid);
     // Remove starter gear before applying the kit. With live offhands and
     // dual wielding, leaving it equipped can route the intended mainhand into

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3654,7 +3654,7 @@ export class Sim {
     if (!clean) return -1;
     for (const m of this.players.values())
       if (m.name.toLowerCase() === clean.toLowerCase()) return -1;
-    const pid = this.addPlayer('mage', clean);
+    const pid = this.addPlayer('mage', clean, { bot: true });
     const meta = this.players.get(pid);
     if (meta) meta.isDevBot = true;
     const me = this.entities.get(this.primaryId);
@@ -3681,7 +3681,7 @@ export class Sim {
   // A friendly stationary ally bot for the Cascada playtest scenario, dropped at an
   // exact spot (no name-uniqueness gate, so /dev cascade can be re-run). Dev only.
   private spawnScenarioAlly(name: string, x: number, z: number, cls: PlayerClass = 'mage'): number {
-    const id = this.addPlayer(cls, name);
+    const id = this.addPlayer(cls, name, { bot: true });
     const meta = this.players.get(id);
     if (meta) meta.isDevBot = true;
     // Level 20 like the mage: a level-1 ally has so little health that a single Echo

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -2852,6 +2852,11 @@ export class Sim {
       // never re-emits it). Stamped onto the entity so it rides the identity
       // wire (`app`) to every client in view. Opaque to the sim.
       appearance?: Record<string, unknown> | null;
+      // A synthetic participant (Vale Cup showcase/backfill, fiesta practice,
+      // /dev bots): created pre-welcomed so no mail is ever minted for it. Bot
+      // metas are session-only, but their letters would outlive them in the
+      // shared mail book forever (issue #3560).
+      bot?: boolean;
     },
   ): number {
     const savedState = opts?.state
@@ -3615,10 +3620,11 @@ export class Sim {
     }
     // One-time Ravenpost welcome (doubles as the service announcement for
     // characters saved before mail existed). Flipped before the send so a
-    // re-entrant save can never double-book the letter.
+    // re-entrant save can never double-book the letter. Bots flip WITHOUT the
+    // send: their letters would sit in the shared mail book forever.
     if (!meta.mailWelcomed) {
       meta.mailWelcomed = true;
-      this.postOffice.sendWelcome(meta);
+      if (!opts?.bot) this.postOffice.sendWelcome(meta);
     }
     // Book of Deeds retro-on-join, after the saved state is fully restored:
     // seed the discovery ledger from current holdings, apply the retro
@@ -10329,7 +10335,7 @@ export class Sim {
         if (!taken) break;
         name = `${baseName}${n}`;
       }
-      const botPid = this.addPlayer(cls, name);
+      const botPid = this.addPlayer(cls, name, { bot: true });
       const meta = this.players.get(botPid);
       if (meta) meta.isDevBot = true;
       spawnSeq++;

--- a/src/sim/social/fiesta_bots.ts
+++ b/src/sim/social/fiesta_bots.ts
@@ -58,7 +58,7 @@ export function startFiestaPractice(sim: Sim): boolean {
     { cls: 'rogue', name: 'Sneakbot' },
   ];
   for (let i = 0; i < kit.length; i++) {
-    const pid = sim.addPlayer(kit[i].cls, kit[i].name);
+    const pid = sim.addPlayer(kit[i].cls, kit[i].name, { bot: true });
     const botMeta = sim.players.get(pid);
     if (botMeta) botMeta.isFiestaBot = true;
     const e = sim.entities.get(pid);

--- a/src/sim/social/fiesta_bots.ts
+++ b/src/sim/social/fiesta_bots.ts
@@ -19,7 +19,7 @@
 // Three, rng-only) so tests/architecture.test.ts still passes.
 
 import { rangedAutoProfile } from '../combat/form_swing';
-import { arenaOrigin, CLASSES, DUNGEON_X_THRESHOLD } from '../data';
+import { arenaOrigin, DUNGEON_X_THRESHOLD } from '../data';
 import type { PlayerMeta, Sim } from '../sim';
 import {
   angleTo,

--- a/src/sim/social/vale_cup_bots.ts
+++ b/src/sim/social/vale_cup_bots.ts
@@ -25,7 +25,6 @@ import {
   type VcNationId,
 } from '../types';
 import {
-  GOAL_BOX_DEPTH,
   GOAL_HALF_W,
   GOAL_LINE_EAST_X,
   GOAL_LINE_WEST_X,

--- a/src/sim/social/vale_cup_bots.ts
+++ b/src/sim/social/vale_cup_bots.ts
@@ -106,7 +106,7 @@ const VC_BOT_CLASSES = [
 
 function spawnCupBot(sim: Sim, role: SportRole): { pid: number; role: SportRole } {
   const cls = VC_BOT_CLASSES[sim.vcup.botPids.length % VC_BOT_CLASSES.length];
-  const pid = sim.addPlayer(cls, nextBotName(sim));
+  const pid = sim.addPlayer(cls, nextBotName(sim), { bot: true });
   sim.vcup.botPids.push(pid);
   return { pid, role };
 }

--- a/tests/guild_letter_online.test.ts
+++ b/tests/guild_letter_online.test.ts
@@ -114,9 +114,18 @@ describe('guild letter over the live GameServer wire (session routing)', () => {
       // (server/game.ts maybe('mailU', sim.mailUnreadFor(pid))).
       const unreadFor = (pid: number) =>
         (server.sim as unknown as { mailUnreadFor(pid: number): number }).mailUnreadFor(pid);
-      const otherPids = [...players.keys()].filter((pid) => pid !== sc.pid);
+      // The live GameServer keeps valeCupShowcase on, so an idle bot
+      // exhibition stages itself mid-window and its bots land in `players`.
+      // The bystander sweep names the humans; bots carry no mail at all
+      // (issue #3560), which the trailing loop pins on the server path.
+      const botPids = new Set(
+        (server.sim as unknown as { vcup: { botPids: number[] } }).vcup.botPids,
+      );
+      const otherPids = [...players.keys()].filter((pid) => pid !== sc.pid && !botPids.has(pid));
+      expect(otherPids.length).toBe(2);
       expect(unreadFor(sc.pid)).toBe(2);
       for (const pid of otherPids) expect(unreadFor(pid)).toBe(1);
+      for (const pid of botPids) expect(unreadFor(pid)).toBe(0);
 
       // One-shot at the booking level over the server path: a second
       // qualifying pair never re-books (asserted against the PostOffice store

--- a/tests/mail_bot_welcome.test.ts
+++ b/tests/mail_bot_welcome.test.ts
@@ -1,0 +1,52 @@
+// Bots must never receive mail (issue #3560): every synthetic participant the
+// sim creates (Vale Cup showcase bots, fiesta practice bots, /dev bots) is
+// created with the Ravenpost welcome suppressed, while a real new character
+// still receives exactly one welcome letter. Before this gate existed, every
+// hourly-ish showcase minted six immortal welcome letters into the shared mail
+// book (134k letters, 85MB of the prod world_state row by 2026-08-22), and the
+// 30s autosave serialized all of it on the main thread.
+
+import { describe, expect, it, vi } from 'vitest';
+import type { Sim } from '../src/sim/sim';
+import { makeWorld } from './vale_cup_util';
+
+vi.setConfig({ testTimeout: 30000 });
+
+interface MailBookLetter {
+  letterId?: string;
+  recipientName: string;
+}
+
+function letters(sim: Sim): MailBookLetter[] {
+  return (sim.serializeMail() as { mail: MailBookLetter[] }).mail;
+}
+
+describe('bot players receive no welcome mail', () => {
+  it('a real new character receives exactly one welcome letter', () => {
+    const sim = makeWorld({ noPlayer: false, playerName: 'Watcher' });
+    const book = letters(sim);
+    expect(book.length).toBe(1);
+    expect(book[0].letterId).toBe('ravenpost_welcome');
+    expect(book[0].recipientName).toBe('Watcher');
+  });
+
+  it('a 3v3 bot showcase creates zero new letters', () => {
+    const sim = makeWorld({ noPlayer: false, playerName: 'Watcher' });
+    (sim as unknown as { cfg: { valeCupShowcase: boolean } }).cfg.valeCupShowcase = true;
+    for (let i = 0; i < 20 * 60 + 2 && !sim.vcup.match; i++) sim.tick();
+    // The showcase really staged: six bots are seated.
+    expect(sim.vcup.botPids.length).toBe(6);
+    // The book still holds only the human's welcome, nothing addressed to bots.
+    const book = letters(sim);
+    expect(book.length).toBe(1);
+    expect(book[0].recipientName).toBe('Watcher');
+  });
+
+  it('addPlayer with bot: true sends no welcome and marks the meta pre-welcomed', () => {
+    const sim = makeWorld({});
+    const pid = sim.addPlayer('mage', 'Botty', { bot: true });
+    expect(letters(sim).length).toBe(0);
+    // Pre-welcomed, so no later path can ever mint the letter for this meta.
+    expect(sim.players.get(pid)?.mailWelcomed).toBe(true);
+  });
+});

--- a/tests/mail_bot_welcome.test.ts
+++ b/tests/mail_bot_welcome.test.ts
@@ -8,6 +8,7 @@
 
 import { describe, expect, it, vi } from 'vitest';
 import type { Sim } from '../src/sim/sim';
+import { startFiestaPractice } from '../src/sim/social/fiesta_bots';
 import { makeWorld } from './vale_cup_util';
 
 vi.setConfig({ testTimeout: 30000 });
@@ -48,5 +49,26 @@ describe('bot players receive no welcome mail', () => {
     expect(letters(sim).length).toBe(0);
     // Pre-welcomed, so no later path can ever mint the letter for this meta.
     expect(sim.players.get(pid)?.mailWelcomed).toBe(true);
+  });
+
+  // The per-site pins below exist so a refactor of a spawner cannot silently
+  // drop its bot flag: each site is exercised through its own entry point.
+
+  it('a /dev bot spawn creates no letters', () => {
+    const sim = makeWorld({ noPlayer: false, playerName: 'Watcher' });
+    const pid = sim.spawnDevBot('Helper');
+    expect(pid).toBeGreaterThan(0);
+    const book = letters(sim);
+    expect(book.length).toBe(1);
+    expect(book[0].recipientName).toBe('Watcher');
+  });
+
+  it('a fiesta practice set creates no letters for its three bots', () => {
+    const sim = makeWorld({ noPlayer: false, playerName: 'Watcher' });
+    expect(startFiestaPractice(sim)).toBe(true);
+    expect(sim.fiestaBotPids.length).toBe(3);
+    const book = letters(sim);
+    expect(book.length).toBe(1);
+    expect(book[0].recipientName).toBe('Watcher');
   });
 });

--- a/tests/mail_bot_welcome_purge.test.ts
+++ b/tests/mail_bot_welcome_purge.test.ts
@@ -127,7 +127,7 @@ function queryResult(rows: unknown[] = []) {
   return { rows, rowCount: rows.length };
 }
 
-const STALE_ROW = { updated_at: '2026-08-22 01:00:00.123456+00', age_seconds: 3600 };
+const STALE_ROW = { updated_at: '2026-08-22 01:00:00.123456+00', age_seconds: 3600, bytes: 4096 };
 
 function purgeHarness(options: HarnessOptions = {}) {
   const statements: string[] = [];
@@ -209,6 +209,11 @@ describe('runMailBotWelcomePurgeMigration', () => {
     expect(written.mail).toHaveLength(1);
     expect(written.mail[0].recipientName).toBe('PhoneBoy');
     expect(written.nextMailId).toBe(9);
+    // The CAS predicate itself is load-bearing SQL for a destructive prod
+    // script: pin the literal and that $3 is the exact updated_at the SELECT
+    // returned, so dropping either turns this red (proven by mutation).
+    expect(update[0]).toContain('AND updated_at::text = $3');
+    expect((update[1] as string[])[2]).toBe(STALE_ROW.updated_at);
   });
 
   it('apply refuses while the realm holds a live lease and rolls back', async () => {

--- a/tests/mail_bot_welcome_purge.test.ts
+++ b/tests/mail_bot_welcome_purge.test.ts
@@ -118,26 +118,32 @@ describe('parseArgs', () => {
 
 interface HarnessOptions {
   liveLeases?: string;
-  mailRows?: Array<{ key: string; data: unknown }>;
+  mailRows?: Array<{ key: string; data: unknown; updated_at?: string; age_seconds?: number }>;
   characters?: CharacterRow[];
+  updateRowCount?: number;
 }
 
 function queryResult(rows: unknown[] = []) {
   return { rows, rowCount: rows.length };
 }
 
+const STALE_ROW = { updated_at: '2026-08-22 01:00:00.123456+00', age_seconds: 3600 };
+
 function purgeHarness(options: HarnessOptions = {}) {
   const statements: string[] = [];
   const querySpy = vi.fn(async (text: string, _values?: unknown[]) => {
     statements.push(text);
-    if (text.includes('SELECT key, data FROM world_state')) {
-      return queryResult(options.mailRows ?? []);
+    if (text.includes('age_seconds')) {
+      return queryResult((options.mailRows ?? []).map((r) => ({ ...STALE_ROW, ...r })));
     }
     if (text.includes('count(*)') && text.includes('character_leases')) {
       return queryResult([{ count: options.liveLeases ?? '0' }]);
     }
     if (text.includes('SELECT id, name FROM characters')) {
       return queryResult(options.characters ?? []);
+    }
+    if (text.startsWith('UPDATE world_state')) {
+      return { rows: [], rowCount: options.updateRowCount ?? 1 };
     }
     return queryResult();
   });
@@ -207,10 +213,54 @@ describe('runMailBotWelcomePurgeMigration', () => {
 
   it('apply refuses while the realm holds a live lease and rolls back', async () => {
     const h = purgeHarness({ mailRows: [BOT_BOOK], characters: CHARACTERS, liveLeases: '1' });
-    await expect(runMailBotWelcomePurgeMigration(['--apply'], h.runtime)).rejects.toThrow(
-      'still holds live character leases',
-    );
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      await expect(runMailBotWelcomePurgeMigration(['--apply'], h.runtime)).rejects.toThrow(
+        'still holds live character leases',
+      );
+    } finally {
+      log.mockRestore();
+    }
     expect(h.statements.at(-1)).toBe('ROLLBACK');
     expect(h.statements.some((s) => s.startsWith('UPDATE world_state'))).toBe(false);
+  });
+
+  it('apply refuses a mail row fresher than the autosave window (idle server still running)', async () => {
+    // Character leases cannot prove the stop: an idle realm holds zero leases
+    // while flushPeriodicSaves still rewrites the book every 30s. Freshness can.
+    const h = purgeHarness({
+      mailRows: [{ ...BOT_BOOK, age_seconds: 12 }],
+      characters: CHARACTERS,
+    });
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      await expect(runMailBotWelcomePurgeMigration(['--apply'], h.runtime)).rejects.toThrow(
+        'game server is still running',
+      );
+    } finally {
+      log.mockRestore();
+    }
+    expect(h.statements.some((s) => s.startsWith('UPDATE world_state'))).toBe(false);
+    expect(h.statements.at(-1)).toBe('ROLLBACK');
+  });
+
+  it('apply aborts loudly when the CAS write misses (concurrent autosave)', async () => {
+    const h = purgeHarness({ mailRows: [BOT_BOOK], characters: CHARACTERS, updateRowCount: 0 });
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      await expect(runMailBotWelcomePurgeMigration(['--apply'], h.runtime)).rejects.toThrow(
+        'Concurrent write detected',
+      );
+    } finally {
+      log.mockRestore();
+    }
+    expect(h.statements.at(-1)).toBe('ROLLBACK');
+  });
+
+  it('a --realm that matches no mail row throws instead of reporting empty success', async () => {
+    const h = purgeHarness({ mailRows: [] });
+    await expect(
+      runMailBotWelcomePurgeMigration(['--realm', 'Cluademoon'], h.runtime),
+    ).rejects.toThrow('No mail row exists for realm "Cluademoon"');
   });
 });

--- a/tests/mail_bot_welcome_purge.test.ts
+++ b/tests/mail_bot_welcome_purge.test.ts
@@ -1,0 +1,89 @@
+// The bot welcome letter purge (issue #3560): the pure book transform behind
+// scripts/migrate_mail_bot_welcome_purge.ts. A ravenpost_welcome letter
+// survives only when its recipient resolves to a real character, by the
+// (id, current name) pair or the legacy name-key; everything that is not a
+// welcome letter is untouchable regardless of addressee.
+
+import { describe, expect, it } from 'vitest';
+import {
+  type CharacterRow,
+  type MailLetterLike,
+  purgeBotWelcomeLetters,
+  WELCOME_LETTER_ID,
+} from '../scripts/mail_bot_welcome_purge_migration';
+
+const CHARACTERS: CharacterRow[] = [
+  { id: 10774, name: 'PhoneBoy' },
+  { id: 20001, name: 'Old Hobb' },
+];
+
+function welcome(recipientKey: string, recipientName: string): MailLetterLike {
+  return { id: 1, letterId: WELCOME_LETTER_ID, kind: 'system', recipientKey, recipientName };
+}
+
+describe('purgeBotWelcomeLetters', () => {
+  it('removes a welcome letter addressed to a reaped bot pid', () => {
+    const book = { mail: [welcome('987654', 'Reeve Marlow')], nextMailId: 5 };
+    const result = purgeBotWelcomeLetters(book, CHARACTERS);
+    expect(result.changed).toBe(true);
+    expect(result.removed).toBe(1);
+    expect((result.value.mail as unknown[]).length).toBe(0);
+    // The rest of the book shape rides along unchanged.
+    expect(result.value.nextMailId).toBe(5);
+  });
+
+  it('keeps a real character welcome letter (id and current name match)', () => {
+    const book = { mail: [welcome('10774', 'PhoneBoy')] };
+    const result = purgeBotWelcomeLetters(book, CHARACTERS);
+    expect(result.changed).toBe(false);
+    expect(result.kept).toBe(1);
+    expect(result.value).toBe(book);
+  });
+
+  it('removes a bot letter whose pid collides with a real character id', () => {
+    // The bot letter is keyed to character 10774 but carries the bot roster
+    // name, so the pair mismatch identifies it even though the key is live.
+    const book = { mail: [welcome('10774', 'Tally Cooper'), welcome('10774', 'PhoneBoy')] };
+    const result = purgeBotWelcomeLetters(book, CHARACTERS);
+    expect(result.removed).toBe(1);
+    expect((result.value.mail as MailLetterLike[])[0].recipientName).toBe('PhoneBoy');
+  });
+
+  it('keeps a legacy name-keyed welcome letter', () => {
+    const book = { mail: [welcome('PhoneBoy', 'PhoneBoy')] };
+    const result = purgeBotWelcomeLetters(book, CHARACTERS);
+    expect(result.changed).toBe(false);
+    expect(result.kept).toBe(1);
+  });
+
+  it('keeps a welcome letter for a real character who shares a bot roster name', () => {
+    const book = { mail: [welcome('20001', 'Old Hobb')] };
+    const result = purgeBotWelcomeLetters(book, CHARACTERS);
+    expect(result.changed).toBe(false);
+    expect(result.kept).toBe(1);
+  });
+
+  it('never touches non-welcome letters, whoever they are addressed to', () => {
+    const book = {
+      mail: [
+        {
+          id: 2,
+          letterId: 'letter_q_wolves',
+          kind: 'npc',
+          recipientKey: '555',
+          recipientName: 'Gone',
+        },
+        { id: 3, kind: 'player', recipientKey: '987654', recipientName: 'Reeve Marlow' },
+      ],
+    };
+    const result = purgeBotWelcomeLetters(book, CHARACTERS);
+    expect(result.changed).toBe(false);
+    expect(result.kept).toBe(2);
+  });
+
+  it('handles a malformed book without throwing', () => {
+    const result = purgeBotWelcomeLetters({ mail: undefined }, CHARACTERS);
+    expect(result.changed).toBe(false);
+    expect(result.removed).toBe(0);
+  });
+});

--- a/tests/mail_bot_welcome_purge.test.ts
+++ b/tests/mail_bot_welcome_purge.test.ts
@@ -198,7 +198,8 @@ describe('runMailBotWelcomePurgeMigration', () => {
     expect(h.statements.at(-1)).toBe('COMMIT');
     // The written blob keeps the real letter and the book shape.
     const update = h.querySpy.mock.calls.find(([text]) => text.startsWith('UPDATE world_state'));
-    const written = JSON.parse((update?.[1] as string[])[0]);
+    if (!update) throw new Error('no world_state UPDATE was issued');
+    const written = JSON.parse((update[1] as string[])[0]);
     expect(written.mail).toHaveLength(1);
     expect(written.mail[0].recipientName).toBe('PhoneBoy');
     expect(written.nextMailId).toBe(9);

--- a/tests/mail_bot_welcome_purge.test.ts
+++ b/tests/mail_bot_welcome_purge.test.ts
@@ -4,11 +4,15 @@
 // (id, current name) pair or the legacy name-key; everything that is not a
 // welcome letter is untouchable regardless of addressee.
 
-import { describe, expect, it } from 'vitest';
+import type { Pool, PoolClient } from 'pg';
+import { describe, expect, it, vi } from 'vitest';
 import {
   type CharacterRow,
+  type MailBotWelcomePurgeRuntime,
   type MailLetterLike,
+  parseArgs,
   purgeBotWelcomeLetters,
+  runMailBotWelcomePurgeMigration,
   WELCOME_LETTER_ID,
 } from '../scripts/mail_bot_welcome_purge_migration';
 
@@ -85,5 +89,127 @@ describe('purgeBotWelcomeLetters', () => {
     const result = purgeBotWelcomeLetters({ mail: undefined }, CHARACTERS);
     expect(result.changed).toBe(false);
     expect(result.removed).toBe(0);
+  });
+});
+
+describe('parseArgs', () => {
+  it('parses both realm forms and apply', () => {
+    expect(parseArgs([])).toEqual({ apply: false, realm: undefined });
+    expect(parseArgs(['--apply', '--realm', 'Claudemoon'])).toEqual({
+      apply: true,
+      realm: 'Claudemoon',
+    });
+    expect(parseArgs(['--realm=Claudemoon'])).toEqual({ apply: false, realm: 'Claudemoon' });
+  });
+
+  it('throws instead of widening a destructive run on a valueless --realm', () => {
+    // A bare trailing --realm used to silently mean all realms; --realm --apply
+    // used to consume the flag as the realm name and silently disable apply.
+    expect(() => parseArgs(['--apply', '--realm'])).toThrow('--realm requires a realm name');
+    expect(() => parseArgs(['--realm', '--apply'])).toThrow('--realm requires a realm name');
+    expect(() => parseArgs(['--realm='])).toThrow('--realm requires a realm name');
+    expect(() => parseArgs(['--wat'])).toThrow('Unknown argument');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Runner arm: fake pinned-client pool (the rift forge rollback harness idiom).
+// ---------------------------------------------------------------------------
+
+interface HarnessOptions {
+  liveLeases?: string;
+  mailRows?: Array<{ key: string; data: unknown }>;
+  characters?: CharacterRow[];
+}
+
+function queryResult(rows: unknown[] = []) {
+  return { rows, rowCount: rows.length };
+}
+
+function purgeHarness(options: HarnessOptions = {}) {
+  const statements: string[] = [];
+  const querySpy = vi.fn(async (text: string, _values?: unknown[]) => {
+    statements.push(text);
+    if (text.includes('SELECT key, data FROM world_state')) {
+      return queryResult(options.mailRows ?? []);
+    }
+    if (text.includes('count(*)') && text.includes('character_leases')) {
+      return queryResult([{ count: options.liveLeases ?? '0' }]);
+    }
+    if (text.includes('SELECT id, name FROM characters')) {
+      return queryResult(options.characters ?? []);
+    }
+    return queryResult();
+  });
+  const release = vi.fn();
+  const client = {
+    query: querySpy as unknown as PoolClient['query'],
+    release,
+  } as unknown as PoolClient;
+  const poolQuery = vi.fn(() => {
+    throw new Error('runner must not use pool.query: the transaction needs one pinned client');
+  });
+  const pool = {
+    connect: vi.fn(async () => client),
+    end: vi.fn(async () => undefined),
+    query: poolQuery,
+  } as unknown as Pool;
+  const runtime: MailBotWelcomePurgeRuntime = {
+    loadEnvFile: vi.fn(),
+    databaseUrl: () => 'postgres://unit.test/mail',
+    createPool: vi.fn(() => pool),
+  };
+  return { statements, querySpy, release, runtime };
+}
+
+const BOT_BOOK = {
+  key: 'mail:Claudemoon',
+  data: { mail: [welcome('987654', 'Reeve Marlow'), welcome('10774', 'PhoneBoy')], nextMailId: 9 },
+};
+
+describe('runMailBotWelcomePurgeMigration', () => {
+  it('dry run rolls back, takes no lease lock, and never writes', async () => {
+    const h = purgeHarness({ mailRows: [BOT_BOOK], characters: CHARACTERS });
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      await runMailBotWelcomePurgeMigration([], h.runtime);
+    } finally {
+      log.mockRestore();
+    }
+    expect(h.statements[0]).toBe('BEGIN');
+    expect(h.statements.at(-1)).toBe('ROLLBACK');
+    expect(h.statements.some((s) => s.startsWith('UPDATE world_state'))).toBe(false);
+    expect(h.statements.some((s) => s.startsWith('LOCK TABLE'))).toBe(false);
+    expect(h.release).toHaveBeenCalled();
+  });
+
+  it('apply locks leases, reaps expired ones, writes the purged row, and commits', async () => {
+    const h = purgeHarness({ mailRows: [BOT_BOOK], characters: CHARACTERS });
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      await runMailBotWelcomePurgeMigration(['--apply'], h.runtime);
+    } finally {
+      log.mockRestore();
+    }
+    expect(h.statements[0]).toBe('BEGIN');
+    expect(h.statements[1]).toBe('LOCK TABLE character_leases IN SHARE MODE');
+    expect(h.statements[2]).toBe('DELETE FROM character_leases WHERE expires_at <= now()');
+    expect(h.statements.some((s) => s.startsWith('UPDATE world_state'))).toBe(true);
+    expect(h.statements.at(-1)).toBe('COMMIT');
+    // The written blob keeps the real letter and the book shape.
+    const update = h.querySpy.mock.calls.find(([text]) => text.startsWith('UPDATE world_state'));
+    const written = JSON.parse((update?.[1] as string[])[0]);
+    expect(written.mail).toHaveLength(1);
+    expect(written.mail[0].recipientName).toBe('PhoneBoy');
+    expect(written.nextMailId).toBe(9);
+  });
+
+  it('apply refuses while the realm holds a live lease and rolls back', async () => {
+    const h = purgeHarness({ mailRows: [BOT_BOOK], characters: CHARACTERS, liveLeases: '1' });
+    await expect(runMailBotWelcomePurgeMigration(['--apply'], h.runtime)).rejects.toThrow(
+      'still holds live character leases',
+    );
+    expect(h.statements.at(-1)).toBe('ROLLBACK');
+    expect(h.statements.some((s) => s.startsWith('UPDATE world_state'))).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Stops the shared mail book's unbounded growth and cleans up what already accumulated. Every Vale Cup showcase, backfill, and practice bot (plus fiesta and /dev bots) was created through the normal `addPlayer` path, so each one received the one-time Ravenpost welcome letter addressed to its transient pid; the bot is reaped at match end but its letter persists forever. On prod (2026-08-22) the book held 151,548 letters, 134,431 of them bot welcomes (85MB of the 89MB `world_state` mail row), and the 30 second autosave serializes the whole book on the main thread every cycle (~250ms of stringify measured on prod hardware), which is the recurring event-loop stall floor behind the ongoing prod perf degradation.

Two halves:

- `addPlayer` gains a `bot` option that flips `mailWelcomed` without sending, and all six non-player `addPlayer` sites pass it (`vale_cup_bots.ts`, `fiesta_bots.ts`, the three `/dev` spawners `spawnBot`/`spawnDevBot`/`spawnScenarioAlly`, and the community-test template Sim for uniformity). Mail draws no rng, so the shared draw stream is untouched.
- A deploy-time purge migration (`scripts/migrate_mail_bot_welcome_purge.ts`, modeled on the old-cragmaw standing migration with the rift-forge transaction discipline) removes the accumulated bot letters: a `ravenpost_welcome` letter survives only when its recipient resolves to a real character by the (id, current name) pair or the legacy name key, neither of which a bot letter can satisfy (renames stay consistent because `rekeyMailOwner` rekeys both fields). The worst possible false remove is the welcome letter itself (50 copper, no items), so no player parcel or escrow is ever at stake. The whole run holds one pinned client transaction. Apply proves the game server is actually stopped with two guards (review finding: leases alone cannot, since an idle realm holds zero leases while the autosave still rewrites the book every 30s): it refuses while the mail row's own `updated_at` is fresher than three autosave cycles, and the `UPDATE` compare-and-swaps on that same `updated_at` so a racing autosave fails the run loudly instead of silently absorbing the purge. The `character_leases` SHARE lock + expired-orphan reap stays as the secondary guard for the populated case.

**Operator note: the purge is a manual deploy-window step, not automatic.** The build ships `dist-server/migrate_mail_bot_welcome_purge.cjs`; run it by hand with the game server stopped: dry run first (no flags), then `--apply`. A live server re-persists its in-memory book every 30 seconds and would clobber a DB-only purge, which is what the freshness and CAS guards enforce.

## Related issues

Closes #3560. Reduces the blast radius of #3561 (the whole-book serialization architecture), which stays open.

## Type of change

- [x] Bug fix

## How was this tested?

- Commands:
  - `npx vitest run tests/mail_bot_welcome.test.ts` (new, red before the fix): a 3v3 bot showcase creates zero letters, a real character still gets exactly one welcome, `bot: true` marks the meta pre-welcomed.
  - `npx vitest run tests/mail_bot_welcome_purge.test.ts` (new): purge keeps real welcomes by pair and legacy name key, removes bot letters including pid-collision cases, never touches non-welcome letters; the runner arm is covered through an injected pool harness (dry run rolls back, apply locks/reaps/writes/commits on one pinned client, a live lease refuses, a fresh mail row refuses, a missed CAS aborts, a valueless or non-matching `--realm` throws).
  - `npx vitest run tests/vale_cup_bots.test.ts tests/mail.test.ts` (existing suites green).
  - `tests/guild_letter_online.test.ts` updated: its every-player-but-the-crosser unread sweep silently included the live server's showcase bots and only passed because bots used to receive welcome letters; it now names the two human bystanders and pins zero letters on every bot.
  - `npx tsc --noEmit`, changed-files biome, `node scripts/gate_select.mjs`.
- Manual steps: mail blob composition and stringify cost measured against the live prod database during the investigation (see #3560).

---

## Checklist

### Quality

- [x] **The gate passes.** `node scripts/gate_select.mjs` is green. I added or updated decisive tests for changed behavior and recorded any manual checks above.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files such as `src/render/assets/manifest.generated.ts`. They're regenerated by the build.
