### PR TITLE
fix(server): destroy static file streams when the client aborts

### DIFF
--- a/server/main.ts
+++ b/server/main.ts
@@ -4,6 +4,7 @@ import './env';
 import * as fs from 'node:fs';
 import * as http from 'node:http';
 import * as path from 'node:path';
+import { pipeline } from 'node:stream';
 import { WebSocketServer } from 'ws';
 import { DEEDS } from '../src/sim/content/deeds';
 import {
@@ -1256,6 +1257,19 @@ const MIME: Record<string, string> = {
   '.webp': 'image/webp',
   '.mp3': 'audio/mpeg',
 };
+// Stream a static file into a response with full teardown: bare pipe() never
+// destroys the SOURCE stream when the response side closes first, so every
+// client-aborted transfer leaked its file descriptor for the life of the
+// process (issue #3562). pipeline() destroys both ends on either side's
+// close. A premature close IS the normal client-abort case, so only real
+// read errors are logged.
+function streamStaticFile(file: string, res: http.ServerResponse): void {
+  pipeline(fs.createReadStream(file), res, (err) => {
+    if (err && (err as NodeJS.ErrnoException).code !== 'ERR_STREAM_PREMATURE_CLOSE') {
+      console.error(`[static] stream failed for ${file}:`, err);
+    }
+  });
+}
 // The admin dashboard is reached via the admin.* subdomain (Caddy proxies it
 // to this same port) or /admin for local dev. The hostname only picks which
 // HTML shell is served, the admin API itself is gated by admin tokens.
@@ -1325,7 +1339,7 @@ function serveStatic(req: http.IncomingMessage, res: http.ServerResponse): void 
     const index = path.join(STATIC_DIR, shell);
     if (fs.existsSync(index)) {
       res.writeHead(200, { 'Content-Type': 'text/html', 'Cache-Control': 'no-cache' });
-      fs.createReadStream(index).pipe(res);
+      streamStaticFile(index, res);
     } else {
       res.writeHead(404);
       res.end('not found (run `npm run build` to serve the client from the game server)');
@@ -1364,7 +1378,7 @@ function serveStatic(req: http.IncomingMessage, res: http.ServerResponse): void 
     res.end(verifiedSfx.bytes);
     return;
   }
-  fs.createReadStream(file).pipe(res);
+  streamStaticFile(file, res);
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/server/static_fd_leak.test.ts
+++ b/tests/server/static_fd_leak.test.ts
@@ -1,0 +1,118 @@
+// Static streams must be destroyed when the client goes away (issue #3562).
+// serveStatic piped fs.createReadStream into the response with bare pipe(),
+// which never destroys the SOURCE stream when the response side closes first:
+// every static request a client aborted mid-transfer left its file descriptor
+// open for the life of the process (~95 fds/hour on prod, with runtime-pack
+// .json the most-duplicated handle). The fix routes both static stream sites
+// through stream.pipeline, whose teardown destroys the read stream on a
+// premature response close.
+//
+// server/main.ts binds fs through a namespace import, so a plain vi.spyOn on
+// the test's own fs object never sees its calls; the capture has to wrap the
+// module itself (pass-through mock, real behavior preserved).
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import * as http from 'node:http';
+import * as net from 'node:net';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+interface CapturedStream {
+  path: unknown;
+  stream: { destroyed: boolean };
+}
+
+const { captured } = vi.hoisted(() => ({ captured: [] as CapturedStream[] }));
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  const wrapped = {
+    ...actual,
+    createReadStream: (...args: Parameters<typeof actual.createReadStream>) => {
+      const stream = actual.createReadStream(...args);
+      captured.push({ path: args[0], stream });
+      return stream;
+    },
+  };
+  return { ...wrapped, default: wrapped };
+});
+
+const packRoot = mkdtempSync(join(tmpdir(), 'woc-static-fd-'));
+mkdirSync(join(packRoot, 'blobs'));
+// Large enough that the response cannot fit in kernel/socket buffers, so the
+// read stream is still mid-flight when the client aborts.
+writeFileSync(join(packRoot, 'runtime-pack.json'), Buffer.alloc(16 * 1024 * 1024, 0x7b));
+
+const savedDatabaseUrl = process.env.DATABASE_URL;
+const savedSfxPackDir = process.env.SFX_PACK_DIR;
+process.env.DATABASE_URL = 'postgres://test:test@127.0.0.1:5433/wocc_static_fd_test';
+process.env.SFX_PACK_DIR = packRoot;
+
+let routeHttpRequest: typeof import('../../server/main').routeHttpRequest;
+
+beforeAll(async () => {
+  ({ routeHttpRequest } = await import('../../server/main'));
+}, 30000);
+
+afterAll(() => {
+  rmSync(packRoot, { recursive: true, force: true });
+  if (savedDatabaseUrl === undefined) delete process.env.DATABASE_URL;
+  else process.env.DATABASE_URL = savedDatabaseUrl;
+  if (savedSfxPackDir === undefined) delete process.env.SFX_PACK_DIR;
+  else process.env.SFX_PACK_DIR = savedSfxPackDir;
+});
+
+async function listen(server: http.Server): Promise<number> {
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => resolve());
+  });
+  const address = server.address();
+  if (address === null || typeof address === 'string') throw new Error('missing test server port');
+  return address.port;
+}
+
+async function close(server: http.Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+const until = async (probe: () => boolean, ms: number): Promise<boolean> => {
+  const deadline = Date.now() + ms;
+  while (Date.now() < deadline) {
+    if (probe()) return true;
+    await new Promise((r) => setTimeout(r, 25));
+  }
+  return probe();
+};
+
+const packStream = (): CapturedStream | undefined =>
+  captured.find((c) => String(c.path).includes('runtime-pack.json'));
+
+describe('static file streams on client abort', () => {
+  it('destroys the read stream when the client disconnects mid-transfer', async () => {
+    const server = http.createServer((req, res) => routeHttpRequest(req, res));
+    const port = await listen(server);
+    try {
+      // Raw socket so the abort is a hard TCP teardown, not a graceful end.
+      const socket = net.connect(port, '127.0.0.1');
+      await new Promise<void>((resolve) => socket.once('connect', () => resolve()));
+      socket.write(
+        'GET /audio/sfx/runtime-pack.json HTTP/1.1\r\nHost: t\r\nConnection: close\r\n\r\n',
+      );
+      // Take the first bytes so the stream is genuinely flowing, then abort.
+      const first = await new Promise<Buffer>((resolve) => socket.once('data', resolve));
+      expect(first.toString('utf8').split('\r\n')[0]).toBe('HTTP/1.1 200 OK');
+      socket.destroy();
+
+      expect(await until(() => packStream() !== undefined, 2000)).toBe(true);
+      // The load-bearing assertion: an aborted response must tear the file
+      // stream down (bare pipe() leaves it open and leaks the descriptor).
+      expect(await until(() => packStream()?.stream.destroyed === true, 3000)).toBe(true);
+    } finally {
+      await close(server);
+    }
+  }, 15000);
+});

--- a/tests/server/static_fd_leak.test.ts
+++ b/tests/server/static_fd_leak.test.ts
@@ -20,7 +20,7 @@ import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
 interface CapturedStream {
   path: unknown;
-  stream: { destroyed: boolean };
+  stream: { destroyed: boolean; closed: boolean };
 }
 
 const { captured } = vi.hoisted(() => ({ captured: [] as CapturedStream[] }));
@@ -44,9 +44,9 @@ mkdirSync(join(packRoot, 'blobs'));
 // read stream is still mid-flight when the client aborts.
 writeFileSync(join(packRoot, 'runtime-pack.json'), Buffer.alloc(16 * 1024 * 1024, 0x7b));
 
-const savedDatabaseUrl = process.env.DATABASE_URL;
+// DATABASE_URL needs no ceremony here: vite.config.ts test.env defaults it
+// for every test file. Only the pack dir override is load-bearing.
 const savedSfxPackDir = process.env.SFX_PACK_DIR;
-process.env.DATABASE_URL = 'postgres://test:test@127.0.0.1:5433/wocc_static_fd_test';
 process.env.SFX_PACK_DIR = packRoot;
 
 let routeHttpRequest: typeof import('../../server/main').routeHttpRequest;
@@ -57,8 +57,6 @@ beforeAll(async () => {
 
 afterAll(() => {
   rmSync(packRoot, { recursive: true, force: true });
-  if (savedDatabaseUrl === undefined) delete process.env.DATABASE_URL;
-  else process.env.DATABASE_URL = savedDatabaseUrl;
   if (savedSfxPackDir === undefined) delete process.env.SFX_PACK_DIR;
   else process.env.SFX_PACK_DIR = savedSfxPackDir;
 });
@@ -110,7 +108,10 @@ describe('static file streams on client abort', () => {
       expect(await until(() => packStream() !== undefined, 2000)).toBe(true);
       // The load-bearing assertion: an aborted response must tear the file
       // stream down (bare pipe() leaves it open and leaks the descriptor).
+      // `closed` pins the descriptor actually being released: `destroyed`
+      // alone would stay true even under a future { autoClose: false }.
       expect(await until(() => packStream()?.stream.destroyed === true, 3000)).toBe(true);
+      expect(packStream()?.stream.closed).toBe(true);
     } finally {
       await close(server);
     }

--- a/tests/server/static_fd_leak.test.ts
+++ b/tests/server/static_fd_leak.test.ts
@@ -111,7 +111,10 @@ describe('static file streams on client abort', () => {
       // `closed` pins the descriptor actually being released: `destroyed`
       // alone would stay true even under a future { autoClose: false }.
       expect(await until(() => packStream()?.stream.destroyed === true, 3000)).toBe(true);
-      expect(packStream()?.stream.closed).toBe(true);
+      // closed flips on the close event after the fd is actually released,
+      // strictly later than destroyed: poll it too or a loaded CI worker can
+      // read inside the gap (measured ~1-4% under drifted observation).
+      expect(await until(() => packStream()?.stream.closed === true, 3000)).toBe(true);
     } finally {
       await close(server);
     }


### PR DESCRIPTION
## Summary

Fixes the prod file descriptor leak (~95 fds per hour for the life of the process, 4,257 open at 34 hours uptime). Both static stream sites in `serveStatic` piped `fs.createReadStream` into the response with bare `pipe()`, which never destroys the source stream when the response side closes first: every static transfer a client aborted mid-flight left its file descriptor open forever. `/proc/<pid>/fd` on prod showed the accumulation directly, with duplicate open handles on `dist` assets (8x `audio/sfx/runtime-pack.json`, 5x `index.html`).

Both sites now stream through a shared `streamStaticFile` helper built on `stream.pipeline`, whose teardown destroys the read stream on a premature response close. A premature close is the normal client-abort case, so only real read errors are logged.

## Related issues

Closes #3562.

## Type of change

- [x] Bug fix

## How was this tested?

- Commands:
  - `npx vitest run tests/server/static_fd_leak.test.ts` (new, red before the fix): serves a 16MB file through the real `routeHttpRequest` on a real socket, hard-destroys the client mid-transfer, and asserts the captured `fs.createReadStream` gets destroyed. `server/main.ts` binds fs through a namespace import, so the capture wraps the module (pass-through mock) rather than spying on the test's own fs object.
  - `npx vitest run tests/server/static_sfx_serving.test.ts` (existing static suite green).
  - `npx tsc --noEmit`, changed-files biome, `node scripts/gate_select.mjs`.
- Manual steps: fd census on the prod process before the fix (`/proc/<pid>/fd` classification) recorded in #3562; prod `process_open_fds` flatness over 24h is the post-deploy acceptance check.

---

## Checklist

### Quality

- [x] **The gate passes.** `node scripts/gate_select.mjs` is green. I added or updated decisive tests for changed behavior and recorded any manual checks above.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files such as `src/render/assets/manifest.generated.ts`. They're regenerated by the build.
