### PR TITLE
fix(sim): require lethal fall state transition for deed

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -2331,11 +2331,11 @@ export class Sim {
       cancelCast: (p) => this.cancelCast(p),
       standUp: (p) => this.standUp(p),
       dealDamage: (source, target, amount, crit, school, ability, kind, noRage) => {
+        const wasLivingPlayerFall =
+          source === null && ability === 'Falling' && target.kind === 'player' && !target.dead;
         this.dealDamage(source, target, amount, crit, school, ability, kind, noRage);
-        // The one sim-side observer of a lethal fall (hid_fall_death): the
-        // shared pure kernel labels the hit 'Falling' with a null source, and
-        // this wrapper keeps the deed hook out of the kernel both hosts run.
-        if (source === null && ability === 'Falling' && target.kind === 'player' && target.dead) {
+        // Keep the deed observer out of the shared pure movement kernel.
+        if (wasLivingPlayerFall && target.dead) {
           deedsMod.onFallDeathForDeeds(this.ctx, target);
         }
       },

--- a/tests/deeds.test.ts
+++ b/tests/deeds.test.ts
@@ -49,6 +49,18 @@ function deedEvents(evs: SimEvent[]): Extract<SimEvent, { type: 'deedUnlocked' }
   });
 }
 
+function stageFallLanding(e: Entity, drop: number): void {
+  const supportY = e.pos.y;
+  e.pos.y = supportY + 0.01;
+  e.prevPos = { ...e.pos };
+  e.fallStartY = supportY + drop;
+  e.onGround = false;
+  e.jumping = false;
+  e.vx = 0;
+  e.vy = 0;
+  e.vz = 0;
+}
+
 // Seat a live 2v2 Fiesta bout (four solo-queuers, countdown run out) so the
 // fiesta-takedown arm of dealDamage can be driven directly. Mirrors the
 // startFiesta harness in tests/fiesta.test.ts.
@@ -1566,6 +1578,50 @@ describe('bounded sets on load', () => {
 });
 
 describe('site wiring (real modules, not direct bumps)', () => {
+  it('does not award Gravity Always Wins when an already-dead ghost lands', () => {
+    const sim = makeSim();
+    const { meta, e } = primary(sim);
+    e.dead = true;
+    e.hp = 0;
+    sim.releaseSpirit();
+    expect(e.dead).toBe(true);
+    expect(e.ghost).toBe(true);
+
+    stageFallLanding(e, 30);
+    const evs = sim.tick();
+
+    expect(e.onGround).toBe(true);
+    expect(meta.deedsEarned.has('hid_fall_death')).toBe(false);
+    expect(deedEvents(evs).filter((ev) => ev.deedId === 'hid_fall_death')).toHaveLength(0);
+  });
+
+  it('awards Gravity Always Wins when a fall transitions a living player to dead', () => {
+    const sim = makeSim();
+    const { meta, e } = primary(sim);
+    e.hp = 1;
+
+    stageFallLanding(e, 30);
+    const evs = sim.tick();
+
+    expect(e.dead).toBe(true);
+    expect(meta.deedsEarned.has('hid_fall_death')).toBe(true);
+    expect(deedEvents(evs).filter((ev) => ev.deedId === 'hid_fall_death')).toHaveLength(1);
+  });
+
+  it('does not award Gravity Always Wins for a damaging nonlethal fall', () => {
+    const sim = makeSim();
+    const { meta, e } = primary(sim);
+    const hpBefore = e.hp;
+
+    stageFallLanding(e, 13);
+    const evs = sim.tick();
+
+    expect(e.hp).toBeLessThan(hpBefore);
+    expect(e.dead).toBe(false);
+    expect(meta.deedsEarned.has('hid_fall_death')).toBe(false);
+    expect(deedEvents(evs).filter((ev) => ev.deedId === 'hid_fall_death')).toHaveLength(0);
+  });
+
   it('a decided duel bumps duelsWon and duelsLost through endDuel', () => {
     const sim = makeSim();
     const a = sim.playerId;


### PR DESCRIPTION
## Summary

- Snapshot whether a player was living before applying fall damage.
- Award Gravity Always Wins only when that fall changes the player to dead.
- Add real simulation tick coverage for already-dead ghosts, lethal living falls, and nonlethal falls.
- Keep the shared movement kernel unchanged and avoid growth in the sim monolith.

## Related issues

Closes #3427

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change

## How was this tested?

- Commands:
  - npx vitest run tests/deeds.test.ts (117 passed)
  - npx vitest run tests/deeds.test.ts tests/player_motion.test.ts tests/architecture.test.ts tests/monolith_budget.test.ts tests/parity (399 passed, 1 skipped)
  - npm run ci:changed
  - npx tsc --noEmit
  - npm run gate
- Manual steps: N/A

Gate note: The full non-browser gate passed 2,947 test files and 41,310 tests. Local Chromium then failed two unrelated FXAA assertions. The identical failures reproduce at the pristine release base in a repository worktree path, while the same baseline tests pass from /private/tmp.

---

## Checklist

### Quality

- [ ] The full local gate passes without notes.
- [x] Decisive tests cover the changed behavior.

### Cross-platform

- [x] N/A. This changes shared simulation behavior with no UI surface.
- [x] N/A. No accessibility behavior changed.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or environment files are committed.
- [x] No generated files were hand-edited.