### PR TITLE
fix(render): show outfit colorway dye on low graphics tier

### DIFF
--- a/docs/design/graphics-settings-fairness.md
+++ b/docs/design/graphics-settings-fairness.md
@@ -76,6 +76,16 @@ COSMETIC (may be tiered down on lower presets):
   low-tier target-frame body throttle (about 10 Hz, target swap bypasses), a redraw-smoothness
   shed this list already sanctions for the portrait.
 
+- The armour DYE of a picked outfit colorway (`src/render/characters/armor_dye.ts`,
+  `outfitDye` in `modular.ts`). The colorway itself is IDENTITY the player chose in the
+  creator, so it may never be dropped outright; what a tier with no shader stage may shed is
+  its FIDELITY. On standard tier and above, `attachArmorDye` remaps the atlas's steel, trim,
+  leather, and cloth zones independently in a fragment shader. On low tier, every rig
+  material rebuilds as flat Lambert with no `onBeforeCompile` hook to run that shader in, so
+  `outfitDyeFallbackHex` (`modular.ts`) stands in with a single, value-normalized multiply
+  toward the colorway's own hue: a rougher, whole-armour approximation of the same colour
+  rather than the atlas's undyed default. Pinned by `tests/tinted_material.test.ts`.
+
 - Edge anti-aliasing, and WHICH edge anti-aliasing a tier gets. High and above run the SMAA
   tail; medium (and any mix that resolves to the grade-only chain) runs the FXAA arm fused
   into `OutputGradePass`; low and the memory-constrained WebKit rungs run none, because they
@@ -213,6 +223,12 @@ silently reopening the bug behind a green core test.
   governor; a source-scan pins that party frames are not tiered.
 - `tests/architecture.test.ts`: `ui_tier_knobs.ts` is a registered UI_PURE_CORE (no governor,
   DOM, or render import).
+- `tests/tinted_material.test.ts`: an active outfit colorway renders as a genuinely different
+  colour on low tier too (never the atlas's undyed default), the low-tier fallback is
+  value-normalized so it cannot crush the whole armour toward black the way a naive multiply
+  of the swatch chip would, a non-armour material (skin) is proven untouched by the fallback,
+  and the standard-tier shader-dyed material's own `.color` is proven unchanged by the fix
+  (the shader still carries the dye there).
 - `tests/professions_graphics_fairness.test.ts`: the professions actionable set (the fishing
   bobber pair, the minimap markers and painter, the node tooltip, the node prop ladder) is
   scanned profile- and governor-free with comment-stripped sources, the tier ladder is

--- a/src/render/characters/CLAUDE.md
+++ b/src/render/characters/CLAUDE.md
@@ -33,6 +33,10 @@ no procedural-rig path here anymore. Reads the world; never mutates the sim.
   `../material_clone_hooks.ts` must re-attach it on every program-preserving
   clone and cannot depend on the whole of `assets.ts` to do it; the spec rides
   `Material.userData.armorDye`, which `clone()` copies while it drops the hook.
+  A sibling key on the same material, `userData.armorDyeFallbackHex`
+  (`assets.ts` `recolored()`), carries a flat, multiply-safe approximation of
+  the same colorway for the low tier, which has no shader stage to run the
+  spec in at all; `buildTintedClone`'s Lambert branch reads it instead.
 - `visual.ts`: `CharacterVisual`, the mixer + `BaseState` machine, LOD/shadow/
   ghost plumbing, one-shot triggers, death/revive edge logic. A transparent
   effect (ghost run, stealth, Shadowform, Moonkin) is a new program per rig

--- a/src/render/characters/armor_dye.ts
+++ b/src/render/characters/armor_dye.ts
@@ -166,7 +166,10 @@ void main() {`,
  * The isMeshStandardMaterial guard mirrors where the factories actually attach
  * the layer (recolored() dyes the standard GLB material, and the standard arm
  * of buildTintedClone re-attaches it): the low tier rebuilds rig materials as
- * Lambert from scratch and so never carries the spec at all.
+ * Lambert from scratch and so never carries the SHADER SPEC at all. Low tier
+ * is not left with no dye, though: recolored() also stashes a flat,
+ * multiply-safe `userData.armorDyeFallbackHex` (assets.ts), which the
+ * Lambert branch of buildTintedClone reads instead.
  */
 export function reapplyArmorDyeToClone(clone: THREE.Material): void {
   if (!(clone as THREE.MeshStandardMaterial).isMeshStandardMaterial) return;

--- a/src/render/characters/assets.ts
+++ b/src/render/characters/assets.ts
@@ -49,6 +49,7 @@ import {
 } from './manifest';
 import { meshProgramShapeKey } from './material_program_shape_core';
 import {
+  armorMaterialSet,
   bandMaterialSpec,
   DEFAULT_LOOK,
   earringMaterialSpec,
@@ -70,6 +71,7 @@ import {
   modularPartNames,
   morphInfluences,
   outfitDye,
+  outfitDyeFallbackHex,
   skinColor,
   stubbleDecals,
   wearsFaceDecal,
@@ -1276,6 +1278,18 @@ function recolored(
       ? (armorDyed(src, dye) as THREE.MeshStandardMaterial)
       : (src.clone() as THREE.MeshStandardMaterial);
   if (hex !== null) mat.color.setHex(hex);
+  // Low tier rebuilds every rig material as flat Lambert from scratch
+  // (buildTintedClone's non-standard branch), which drops onBeforeCompile and
+  // so the shader dye entirely: picking any outfit colorway would otherwise be
+  // a silent no-op on low graphics. Stash a flat, multiply-safe approximation
+  // as inert metadata so that branch can stand in for the dye instead of
+  // showing nothing; this material's own .color stays untouched so the
+  // standard-tier shader path (and this cache entry across a live tier
+  // switch) are unaffected.
+  if (dye !== null) {
+    const dyeSet = armorMaterialSet(src.name);
+    if (dyeSet) mat.userData.armorDyeFallbackHex = outfitDyeFallbackHex(dyeSet, look.app.outfit);
+  }
   // HAIR IS DOUBLE-SIDED. The sculpts ship as the designer anchored them
   // (hairimp.FAITHFUL_SCULPT), and a sculpt is a one-sided open shell: seen
   // from inside, through the gaps between strands, up under a fringe, along
@@ -1987,12 +2001,27 @@ function buildTintedClone(
     if (worn) applySurfaceDetail(mat, worn.family, { strength: worn.strength, objectSpace: true });
   } else {
     if ((src as THREE.MeshBasicMaterial).isMeshBasicMaterial) {
+      // Armour materials are always MeshStandardMaterial (the KayKit atlases),
+      // so armorDyeFallbackHex never applies here; a Basic armour material
+      // would silently lose its outfit colorway on low tier exactly like the
+      // bug this file's dye fallback exists to fix.
       mat = (src as THREE.MeshBasicMaterial).clone();
     } else {
-      // low tier: Lambert with the same texture map (no PBR, no rim)
+      // low tier: Lambert with the same texture map (no PBR, no rim). An
+      // active outfit colorway has no shader here to dye it (see recolored's
+      // armorDyeFallbackHex comment), so a flat, value-normalized multiply
+      // stands in for the zone-selective dye: a rougher result, but visible,
+      // where the alternative was invisible.
+      const armorDyeFallbackHex = (s.userData as { armorDyeFallbackHex?: number })
+        .armorDyeFallbackHex;
       mat = new THREE.MeshLambertMaterial({
         map: s.map ?? null,
-        color: s.color ? s.color.clone() : new THREE.Color(0xffffff),
+        color:
+          armorDyeFallbackHex !== undefined
+            ? new THREE.Color(armorDyeFallbackHex)
+            : s.color
+              ? s.color.clone()
+              : new THREE.Color(0xffffff),
         vertexColors: s.vertexColors,
         transparent: s.transparent,
         opacity: s.opacity,

--- a/src/render/characters/modular.ts
+++ b/src/render/characters/modular.ts
@@ -1617,6 +1617,30 @@ export function outfitSwatchHex(set: ArmorSetId, id: OutfitColorway): number {
   return hslToHex(hue, sat, light);
 }
 
+/** A multiply-safe approximation of a colorway's dye, for a material with no
+ *  shader to run it (the low-tier Lambert rebuild in characters/assets.ts
+ *  buildTintedClone, which drops the onBeforeCompile hook attachArmorDye
+ *  needs). `outfitSwatchHex` is tuned to read as a small swatch CHIP against
+ *  the customizer's dark background, roughly half brightness; used directly
+ *  as a `material.color` multiply factor over a bright atlas texture, that
+ *  same half-brightness crushes the whole armour toward black. Scaling every
+ *  channel so the brightest reads full brightness keeps the swatch's hue and
+ *  relative saturation while multiplying the atlas back toward its own
+ *  brightness instead of away from it. */
+export function outfitDyeFallbackHex(set: ArmorSetId, id: OutfitColorway): number {
+  const hex = outfitSwatchHex(set, id);
+  const r = (hex >> 16) & 0xff;
+  const g = (hex >> 8) & 0xff;
+  const b = hex & 0xff;
+  const max = Math.max(r, g, b);
+  if (max <= 0) return 0xffffff;
+  const scale = 255 / max;
+  const nr = Math.min(255, Math.round(r * scale));
+  const ng = Math.min(255, Math.round(g * scale));
+  const nb = Math.min(255, Math.round(b * scale));
+  return (nr << 16) | (ng << 8) | nb;
+}
+
 /** Gradient stops for a colorway chip. A hue colorway is one flat stop; a
  *  material colorway shows what its rules do to the set's measured steel,
  *  bright-plate and cloth anchors, so the chip is an honest three-material preview. */

--- a/tests/modular_character.test.ts
+++ b/tests/modular_character.test.ts
@@ -51,6 +51,7 @@ import {
   OUTFIT_COLORWAY_IDS,
   OUTFIT_COLORWAYS,
   outfitDye,
+  outfitDyeFallbackHex,
   outfitSwatchHex,
   outfitSwatchHexes,
   randomHairStyles,
@@ -764,6 +765,28 @@ describe('outfit colorways', () => {
     }
     // a hue colorway stays a flat single-stop chip
     expect(outfitSwatchHexes('knight', 'crimson')).toHaveLength(1);
+  });
+
+  it('normalizes the low-tier dye fallback to full brightness on its dominant channel', () => {
+    for (const set of ARMOR_SETS) {
+      for (const id of OUTFIT_COLORWAY_IDS) {
+        const hex = outfitDyeFallbackHex(set, id);
+        const r = (hex >> 16) & 0xff;
+        const g = (hex >> 8) & 0xff;
+        const b = hex & 0xff;
+        // the brightest channel of the swatch's own colour reads at full
+        // strength once scaled up, or the fallback is still crushing the
+        // atlas toward black exactly like the bug it exists to fix
+        expect(Math.max(r, g, b), `${set}/${id}`).toBe(255);
+      }
+    }
+  });
+
+  it('keeps the fallback hue distinct across colorways, like the swatch chip it is derived from', () => {
+    const hexes = OUTFIT_COLORWAY_IDS.map((id) => outfitDyeFallbackHex('mage', id));
+    // classic shares a native hue family with at most one dye target, same
+    // tolerance as the swatch-chip distinctness test above
+    expect(new Set(hexes).size).toBeGreaterThanOrEqual(OUTFIT_COLORWAY_IDS.length - 2);
   });
 });
 

--- a/tests/tinted_material.test.ts
+++ b/tests/tinted_material.test.ts
@@ -2,10 +2,12 @@ import * as THREE from 'three';
 import { describe, expect, it, vi } from 'vitest';
 import {
   applyMaterials,
+  recolorMesh,
   tintedFarMaterials,
   tintedMaterial,
 } from '../src/render/characters/assets';
 import type { VisualDef } from '../src/render/characters/manifest';
+import { type ModularLook, normalizeAppearance } from '../src/render/characters/modular';
 import { gfxInternalsForTest } from '../src/render/gfx';
 import { createWeaponVfx, type WeaponVfxSpec } from '../src/render/weapon_vfx';
 
@@ -14,6 +16,13 @@ vi.mock('../src/render/assets/loader', () => ({
   loadKtx2Texture: vi.fn(() => new Promise(() => undefined)),
   loadTexture: vi.fn(() => new Promise(() => undefined)),
 }));
+
+function luminance(hex: number): number {
+  const r = ((hex >> 16) & 0xff) / 255;
+  const g = ((hex >> 8) & 0xff) / 255;
+  const b = (hex & 0xff) / 255;
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
 
 vi.mock('../src/render/assets/preload', () => ({
   registerPreload: vi.fn(),
@@ -190,6 +199,98 @@ describe('tinted character materials', () => {
     } finally {
       vi.doUnmock('../src/render/assets/loader');
       vi.resetModules();
+    }
+  });
+
+  it('falls back to a flat colour so an outfit colorway still shows on low graphics', () => {
+    // Low tier rebuilds every rig material as Lambert from scratch, which has
+    // no onBeforeCompile and so never runs the armour dye shader (see
+    // recolored's armorDyeFallbackHex comment in assets.ts): without the
+    // fallback this mesh would stay whatever colour the atlas ships, whichever
+    // colorway the player picked. Compares two colorways against the classic
+    // (undyed) baseline rather than pinning an exact hex, so the readability
+    // lift buildTintedClone always applies on low tier (a separate, unrelated
+    // accessibility pass) cannot make this test brittle.
+    const restoreGfx = gfxInternalsForTest.overrideSettings({ standardMaterials: false });
+    try {
+      const lowTierColor = (outfit: 'classic' | 'obsidian' | 'crimson'): number => {
+        const src = new THREE.MeshStandardMaterial({ color: 0xffffff });
+        src.name = 'mage';
+        const mesh = new THREE.Mesh(new THREE.BoxGeometry(1, 1, 1), src);
+        mesh.name = 'Armor_mage_Chest';
+        const root = new THREE.Group();
+        root.add(mesh);
+        const look: ModularLook = { app: normalizeAppearance({ outfit }), worn: {} };
+        recolorMesh(mesh, look);
+        applyMaterials(root, {} as VisualDef, 0xffffff);
+        const finalMat = mesh.material as unknown as THREE.MeshLambertMaterial;
+        expect(finalMat.isMeshLambertMaterial).toBe(true);
+        return finalMat.color.getHex();
+      };
+      const classic = lowTierColor('classic');
+      const obsidian = lowTierColor('obsidian');
+      const crimson = lowTierColor('crimson');
+      // classic never carries a dye (outfitDye returns null for it), so it
+      // stays the atlas's own white multiplier; a real colorway must differ
+      // from that AND from every other colorway.
+      expect(obsidian).not.toBe(classic);
+      expect(crimson).not.toBe(classic);
+      expect(obsidian).not.toBe(crimson);
+      // outfitDyeFallbackHex value-normalizes before it lands here (see its
+      // own comment): a naive multiply of the swatch chip's own half-bright
+      // hex would crush the whole armour toward black, which is nearly as
+      // invisible as the bug this fix exists to solve.
+      expect(luminance(obsidian)).toBeGreaterThan(0.4);
+      expect(luminance(crimson)).toBeGreaterThan(0.4);
+    } finally {
+      restoreGfx();
+    }
+  });
+
+  it('never touches a non-armour material: skin/hair keep their own colour path on low graphics', () => {
+    const restoreGfx = gfxInternalsForTest.overrideSettings({ standardMaterials: false });
+    try {
+      const src = new THREE.MeshStandardMaterial({ color: 0xffffff });
+      src.name = 'mod_skin';
+      const mesh = new THREE.Mesh(new THREE.BoxGeometry(1, 1, 1), src);
+      mesh.name = 'Head';
+      const root = new THREE.Group();
+      root.add(mesh);
+      // An outfit colorway is active, but this mesh is skin, not armour:
+      // outfitDye (and so armorDyeFallbackHex) must never apply to it. Skin's
+      // own hex path is pre-existing behaviour (recolored's `hex !== null`
+      // arm), not this fix; the decisive check here is that the fallback
+      // metadata never leaks onto a mesh outfitDye was never meant to touch.
+      const look: ModularLook = { app: normalizeAppearance({ outfit: 'obsidian' }), worn: {} };
+      recolorMesh(mesh, look);
+      expect((mesh.material as THREE.Material).userData.armorDyeFallbackHex).toBeUndefined();
+      applyMaterials(root, {} as VisualDef, 0xffffff);
+      const finalMat = mesh.material as unknown as THREE.MeshLambertMaterial;
+      expect(finalMat.isMeshLambertMaterial).toBe(true);
+      expect(finalMat.color.getHex()).not.toBe(0xffffff);
+    } finally {
+      restoreGfx();
+    }
+  });
+
+  it('leaves the standard-tier dyed material color untouched (the shader carries the dye, not .color)', () => {
+    const restoreGfx = gfxInternalsForTest.overrideSettings({ standardMaterials: true });
+    try {
+      const src = new THREE.MeshStandardMaterial({ color: 0xffffff });
+      src.name = 'mage';
+      const mesh = new THREE.Mesh(new THREE.BoxGeometry(1, 1, 1), src);
+      mesh.name = 'Armor_mage_Chest';
+      const root = new THREE.Group();
+      root.add(mesh);
+      const look: ModularLook = { app: normalizeAppearance({ outfit: 'obsidian' }), worn: {} };
+      recolorMesh(mesh, look);
+      applyMaterials(root, {} as VisualDef, 0xffffff);
+      const finalMat = mesh.material as THREE.MeshStandardMaterial;
+      expect(finalMat.isMeshStandardMaterial).toBe(true);
+      expect(finalMat.color.getHex()).toBe(0xffffff);
+      expect(finalMat.userData.armorDye).toBeTruthy();
+    } finally {
+      restoreGfx();
     }
   });
 });


### PR DESCRIPTION
## Summary

Picking an outfit colorway in the character creator's STYLE tab (or the
char-select Redesign editor) visibly selects the swatch, but the previewed
character never changes color once the pick lands on the **low graphics
tier**, which is the default for every touch-capable device and any GPU
auto-classified `weak`/`software`. Any colorway, hue or material, is a
silent no-op there.

`recolored()` in `src/render/characters/assets.ts` always attaches the
armor-dye shader hook via `attachArmorDye` (`src/render/characters/armor_dye.ts`),
but `buildTintedClone`'s low-tier branch rebuilds every rig material as flat
`MeshLambertMaterial` from scratch, which has no `onBeforeCompile` stage to
run that shader in. The dye spec is attached, then thrown away.

```mermaid
flowchart TD
    A["Player picks an outfit colorway swatch"] --> B["recolored() in assets.ts"]
    B --> C{"outfitDye returns a dye spec?"}
    C -->|"no, classic"| Z["Source material returned unchanged"]
    C -->|"yes"| D["armorDyed(): clone + attachArmorDye()\nattaches the onBeforeCompile shader hook"]
    D --> E["NEW: stash mat.userData.armorDyeFallbackHex\n= outfitDyeFallbackHex(set, outfit)"]
    E --> F["applyMaterials -> tintedMaterial -> buildTintedClone"]
    F --> G{"GFX.standardMaterials?"}
    G -->|"true, Standard/High tier"| H["MeshStandardMaterial clone\nkeeps onBeforeCompile shader\n-> zone-selective dye renders"]
    G -->|"false, Low tier\n(default for every touch device)"| I["BEFORE: rebuilt as flat\nMeshLambertMaterial from src.color\n-> shader hook silently dropped\n-> colorway invisible"]
    I -.-> J["AFTER: MeshLambertMaterial\ncolor = armorDyeFallbackHex\n-> colorway visible, just flatter"]
```

## Fix

`recolored()` now also stashes a flat, value-normalized approximation of the
colorway as inert `userData.armorDyeFallbackHex` metadata
(`outfitDyeFallbackHex`, new in `src/render/characters/modular.ts`), scaled
so the swatch's dominant channel reads at full brightness instead of
crushing the whole atlas toward black (the swatch chip color is deliberately
dim for the customizer's dark background; used as a raw multiply it would
read as "the armor turned black" for most colorways). `buildTintedClone`'s
Lambert branch reads that fallback instead of the atlas's undyed base color
when present.

Standard-tier rendering is untouched: `.color` on the shader-dyed material
stays the atlas default there (the shader owns the dye), and skin/hair/eye
materials are unaffected (the fallback is only ever set on armor materials
with an active non-`classic` colorway).

Also updates `docs/design/graphics-settings-fairness.md` to record outfit
dye as a COSMETIC (never gameplay-actionable) tier knob that may shed
fidelity but not identity, and the local `src/render/characters/CLAUDE.md`
to document the new `userData` key alongside the existing `armorDye` one.

## Related issues

N/A (found via user report with a screenshot; no existing issue tracked this).

## Type of change

- [x] Bug fix

## How was this tested?

- Commands: `npx tsc --noEmit`, `npx @biomejs/biome check` on changed files,
  `npx vitest run tests/tinted_material.test.ts tests/modular_character.test.ts`,
  and `node scripts/gate_select.mjs` (full 12-step gate, green).
- New tests (`tests/tinted_material.test.ts`): an active outfit colorway
  renders as a genuinely different color on low tier for both a hue and a
  material colorway (never the atlas's undyed default); the fallback is
  luminance-checked so it cannot crush the armor toward black; a non-armor
  material (skin) is proven untouched by the fallback; the standard-tier
  shader-dyed material's own `.color` is proven unchanged by the fix (the
  shader still carries the dye there). Plus two new pure-function tests on
  `outfitDyeFallbackHex` in `tests/modular_character.test.ts` (full-brightness
  normalization, hue distinctness across colorways).
- Manual: I could not capture live before/after screenshots. This sandbox's
  headless Chromium (with SwiftShader software WebGL, confirmed working via
  a raw `WEBGL_debug_renderer_info` probe) never lays out the character
  preview canvas with a non-zero `getBoundingClientRect()`, so the app's own
  visibility-gated render loop (`characterPreviewFrameVisible`) correctly
  never draws a frame there. I confirmed this is an environment limitation,
  not specific to this change: the repo's own pre-existing
  `scripts/creator_share_shot.mjs` (previously used for
  `docs/screenshots/3159-creator-appearance-persistence/`) fails identically
  in this sandbox on an unmodified checkout.

## Screenshots / recordings

Not included — see the manual-testing note above for why, and the
`tests/tinted_material.test.ts` additions for the behavioral proof in place
of a visual capture.

## Checklist

### Quality

- [x] **The gate passes.** `node scripts/gate_select.mjs` is green (12/12
      steps). Decisive tests added for the new behavior.

### Cross-platform

- [ ] Tested on desktop and mobile. (See the manual-testing note; this is
      specifically a low-graphics-tier/touch-default fix, so mobile
      verification would have been the most valuable check and I was not
      able to do it live in this environment.)
- [x] Accessible. No new interactive elements; existing swatch UI unchanged.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed.
- [x] No hand-edited generated files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
