### PR TITLE
fix(sim): honor grounded standable sight elevation

### DIFF
--- a/src/sim/colliders.ts
+++ b/src/sim/colliders.ts
@@ -2487,6 +2487,11 @@ export function pathCrossesFence(
 // conservative default, and MOVEMENT collision is untouched everywhere.
 export const SIGHT_HEIGHT = 1.6;
 
+interface TrustedSightFeet {
+  from?: number;
+  to?: number;
+}
+
 // Does any collider at (x,z) rise above `sightY` (absolute world Y of the
 // sight line at that sample)? Mirrors resolvePosition's zone routing so
 // interiors, delves and the arena keep their wall sets, but tests pure overlap
@@ -2574,6 +2579,7 @@ export function lineOfSightClear(
   r = 0.05,
   delveModules?: readonly string[],
   riftToken = 0,
+  trustedFeet?: TrustedSightFeet,
 ): boolean {
   const dx = to.x - from.x;
   const dz = to.z - from.z;
@@ -2582,23 +2588,14 @@ export function lineOfSightClear(
   // The sight line runs eye-to-eye: lerp the endpoint eye heights per sample so
   // a low prop only blocks when its top actually crosses the line.
   //
-  // Eye height is TERRAIN-DERIVED everywhere except the battleground band, and
-  // that scoping is deliberate. Taking the caller's own `y` is the honest rule
-  // ("what you stand on, you see over"), and the band needs it: its field is
-  // the one instanced region with real sculpted terrain and standable decks,
-  // and its cover was authored against tops measured from the body's real
-  // height. But BOTH live callers pass an Entity.pos, which always carries a
-  // y, so applying it everywhere would silently retune open-world spell line
-  // of sight for every player: a caster standing on a knee-high standable prop
-  // (or mid-jump) would start seeing over cover that blocks them today. That
-  // is a global combat change, not a battleground one, so it stays scoped here
-  // and the open world keeps its historical behavior byte for byte. Widening
-  // it is a deliberate change of its own, with its own tests.
-  const eyeAt = (p: { x: number; y?: number; z: number }): number =>
-    (isBgPos(p.x) ? (p.y ?? groundHeight(p.x, p.z, seed)) : groundHeight(p.x, p.z, seed)) +
+  // Raw caller y remains untrusted outside the battleground. Entity-aware
+  // callers may opt in only after proving the feet rest on authored support.
+  const eyeAt = (p: { x: number; y?: number; z: number }, trustedY?: number): number =>
+    (trustedY ??
+      (isBgPos(p.x) ? (p.y ?? groundHeight(p.x, p.z, seed)) : groundHeight(p.x, p.z, seed))) +
     SIGHT_HEIGHT;
-  const eyeFrom = eyeAt(from);
-  const eyeTo = eyeAt(to);
+  const eyeFrom = eyeAt(from, trustedFeet?.from);
+  const eyeTo = eyeAt(to, trustedFeet?.to);
   const steps = Math.max(2, Math.ceil(d / 0.5));
   if (isDelvePos(from.x)) {
     const delve = delveAt(from.x);

--- a/src/sim/colliders.ts
+++ b/src/sim/colliders.ts
@@ -271,7 +271,7 @@ export function colliderTopAt(c: Collider, x: number, z: number): number {
  */
 export const MANTLE_REACH = 0.9;
 /** Float slack when comparing feet height against a collider top. */
-const MOVE_TOP_EPS = 1e-3;
+export const MOVE_TOP_EPS = 1e-3;
 // How much of the body radius must overlap a standable top before it supports
 // the mover: standing needs the center meaningfully over the prop, while the
 // full collision radius still gates entry, so a jump can graze past a rim
@@ -2487,7 +2487,7 @@ export function pathCrossesFence(
 // conservative default, and MOVEMENT collision is untouched everywhere.
 export const SIGHT_HEIGHT = 1.6;
 
-interface TrustedSightFeet {
+interface SightFeetOverride {
   from?: number;
   to?: number;
 }
@@ -2579,7 +2579,7 @@ export function lineOfSightClear(
   r = 0.05,
   delveModules?: readonly string[],
   riftToken = 0,
-  trustedFeet?: TrustedSightFeet,
+  sightFeet?: SightFeetOverride,
 ): boolean {
   const dx = to.x - from.x;
   const dz = to.z - from.z;
@@ -2588,14 +2588,17 @@ export function lineOfSightClear(
   // The sight line runs eye-to-eye: lerp the endpoint eye heights per sample so
   // a low prop only blocks when its top actually crosses the line.
   //
-  // Raw caller y remains untrusted outside the battleground. Entity-aware
-  // callers may opt in only after proving the feet rest on authored support.
+  // The battleground keeps caller y because its sculpted terrain, standable
+  // decks, and cover were authored against real fighter height. Raw caller y
+  // remains untrusted everywhere else: entity-aware open-world callers may
+  // opt in only after constraining feet height to terrain or authored support,
+  // so a jump cannot lift the sight line above intended cover.
   const eyeAt = (p: { x: number; y?: number; z: number }, trustedY?: number): number =>
     (trustedY ??
       (isBgPos(p.x) ? (p.y ?? groundHeight(p.x, p.z, seed)) : groundHeight(p.x, p.z, seed))) +
     SIGHT_HEIGHT;
-  const eyeFrom = eyeAt(from, trustedFeet?.from);
-  const eyeTo = eyeAt(to, trustedFeet?.to);
+  const eyeFrom = eyeAt(from, sightFeet?.from);
+  const eyeTo = eyeAt(to, sightFeet?.to);
   const steps = Math.max(2, Math.ceil(d / 0.5));
   if (isDelvePos(from.x)) {
     const delve = delveAt(from.x);

--- a/src/sim/combat/resurrection_reach.ts
+++ b/src/sim/combat/resurrection_reach.ts
@@ -8,7 +8,7 @@
 // mid-cast, and finish), the mass-resurrection roster sweep, and the accept-time
 // arrival anchor in resurrection_offer.ts.
 
-import { lineOfSightClear } from '../colliders';
+import { entityToBodyLineOfSightClear } from '../line_of_sight_elevation';
 import type { SimContext } from '../sim_context';
 import { dist2d, type Entity, type Vec3 } from '../types';
 
@@ -36,16 +36,13 @@ export function resurrectionReachError(
 ): ResurrectionReachErrorKind | null {
   const body = resurrectionBodyPos(dead);
   if (dist2d(caster.pos, body) > maxRange + rangeSlack) return 'range';
-  // The third sibling of the lineOfSightClear recipe, beside Sim.hasLineOfSight
-  // (sim.ts) and the pet recovery probe (pet/pet_ai.ts): same probe radius, same
-  // delve-module and rift-token wiring. It cannot reuse the ctx.lineOfSightBlocked
-  // seam because reach measures the CORPSE position, not the entity's (a released
-  // ghost stands at the graveyard), and both ends here are players, so only their
-  // delve runs (never a mob's) can supply interior modules.
+  // Reach measures the CORPSE position, not the entity's (a released ghost
+  // stands at the graveyard), so it uses the entity-to-body elevation arm.
+  // Both ends are players, so only their delve runs can supply interior modules.
   const run = ctx.delveRunForPlayer(caster.id) ?? ctx.delveRunForPlayer(dead.id);
-  const clear = lineOfSightClear(
+  const clear = entityToBodyLineOfSightClear(
     ctx.cfg.seed,
-    caster.pos,
+    caster,
     body,
     0.05,
     run?.modules,

--- a/src/sim/line_of_sight_elevation.ts
+++ b/src/sim/line_of_sight_elevation.ts
@@ -1,0 +1,61 @@
+import { lineOfSightClear, supportHeightAt } from './colliders';
+import { DUNGEON_X_THRESHOLD } from './data';
+import { PLAYER_BODY_RADIUS } from './pathfind';
+import type { Entity, Vec3 } from './types';
+
+// Matches the movement support tolerance: a larger gap is airborne, not footing.
+export const SIGHT_SUPPORT_EPSILON = 1e-3;
+
+function trustedSupportedSightFeet(seed: number, pos: Vec3): number | undefined {
+  if (pos.x > DUNGEON_X_THRESHOLD) return undefined;
+  const support = supportHeightAt(
+    seed,
+    pos.x,
+    pos.z,
+    PLAYER_BODY_RADIUS,
+    pos.y + SIGHT_SUPPORT_EPSILON,
+  );
+  return Math.abs(support - pos.y) <= SIGHT_SUPPORT_EPSILON ? pos.y : undefined;
+}
+
+export function trustedGroundedSightFeet(seed: number, entity: Entity): number | undefined {
+  if (
+    entity.kind !== 'player' ||
+    !entity.onGround ||
+    entity.jumping ||
+    entity.pos.x > DUNGEON_X_THRESHOLD
+  ) {
+    return undefined;
+  }
+  return trustedSupportedSightFeet(seed, entity.pos);
+}
+
+export function entityLineOfSightClear(
+  seed: number,
+  source: Entity,
+  target: Entity,
+  r = 0.05,
+  delveModules?: readonly string[],
+  riftToken = 0,
+): boolean {
+  const trustedFeet = {
+    from: trustedGroundedSightFeet(seed, source),
+    to: trustedGroundedSightFeet(seed, target),
+  };
+  return lineOfSightClear(seed, source.pos, target.pos, r, delveModules, riftToken, trustedFeet);
+}
+
+export function entityToBodyLineOfSightClear(
+  seed: number,
+  source: Entity,
+  body: Vec3,
+  r = 0.05,
+  delveModules?: readonly string[],
+  riftToken = 0,
+): boolean {
+  const trustedFeet = {
+    from: trustedGroundedSightFeet(seed, source),
+    to: trustedSupportedSightFeet(seed, body),
+  };
+  return lineOfSightClear(seed, source.pos, body, r, delveModules, riftToken, trustedFeet);
+}

--- a/src/sim/line_of_sight_elevation.ts
+++ b/src/sim/line_of_sight_elevation.ts
@@ -1,21 +1,36 @@
-import { lineOfSightClear, supportHeightAt } from './colliders';
+import { lineOfSightClear, MOVE_TOP_EPS, supportHeightAt } from './colliders';
 import { DUNGEON_X_THRESHOLD } from './data';
 import { PLAYER_BODY_RADIUS } from './pathfind';
 import type { Entity, Vec3 } from './types';
+import { groundHeight } from './world';
 
-// Matches the movement support tolerance: a larger gap is airborne, not footing.
-export const SIGHT_SUPPORT_EPSILON = 1e-3;
+// Pet recovery deliberately remains on raw collider LOS in pet/pet_ai.ts: it
+// gates only the long-distance teleport heuristic, not a combat decision.
 
-function trustedSupportedSightFeet(seed: number, pos: Vec3): number | undefined {
+interface OpenWorldSightHeights {
+  ground: number;
+  support: number;
+}
+
+function openWorldSightHeights(seed: number, pos: Vec3): OpenWorldSightHeights | undefined {
+  // Every instanced band lies beyond this threshold. Leaving those endpoints
+  // undefined preserves lineOfSightClear's zone policy, including the
+  // battleground's deliberate caller-y behavior.
   if (pos.x > DUNGEON_X_THRESHOLD) return undefined;
-  const support = supportHeightAt(
-    seed,
-    pos.x,
-    pos.z,
-    PLAYER_BODY_RADIUS,
-    pos.y + SIGHT_SUPPORT_EPSILON,
-  );
-  return Math.abs(support - pos.y) <= SIGHT_SUPPORT_EPSILON ? pos.y : undefined;
+  return {
+    ground: groundHeight(pos.x, pos.z, seed),
+    support: supportHeightAt(seed, pos.x, pos.z, PLAYER_BODY_RADIUS, pos.y + MOVE_TOP_EPS),
+  };
+}
+
+function exactSupportedSightFeet(pos: Vec3, support: number): number | undefined {
+  return Math.abs(support - pos.y) <= MOVE_TOP_EPS ? pos.y : undefined;
+}
+
+function boundedSightFeet(pos: Vec3, heights: OpenWorldSightHeights): number {
+  // Airborne movement may retain the authored support beneath the current
+  // footprint, but never contribute raw jump height above that support.
+  return Math.min(pos.y, Math.max(heights.ground, heights.support));
 }
 
 export function trustedGroundedSightFeet(seed: number, entity: Entity): number | undefined {
@@ -27,7 +42,25 @@ export function trustedGroundedSightFeet(seed: number, entity: Entity): number |
   ) {
     return undefined;
   }
-  return trustedSupportedSightFeet(seed, entity.pos);
+  const heights = openWorldSightHeights(seed, entity.pos);
+  return heights ? exactSupportedSightFeet(entity.pos, heights.support) : undefined;
+}
+
+function playerSightFeet(seed: number, entity: Entity): number | undefined {
+  if (entity.kind !== 'player') return undefined;
+  const heights = openWorldSightHeights(seed, entity.pos);
+  if (!heights) return undefined;
+  const trusted =
+    entity.onGround && !entity.jumping
+      ? exactSupportedSightFeet(entity.pos, heights.support)
+      : undefined;
+  return trusted ?? boundedSightFeet(entity.pos, heights);
+}
+
+function bodySightFeet(seed: number, body: Vec3): number | undefined {
+  const heights = openWorldSightHeights(seed, body);
+  if (!heights) return undefined;
+  return exactSupportedSightFeet(body, heights.support) ?? boundedSightFeet(body, heights);
 }
 
 export function entityLineOfSightClear(
@@ -38,11 +71,11 @@ export function entityLineOfSightClear(
   delveModules?: readonly string[],
   riftToken = 0,
 ): boolean {
-  const trustedFeet = {
-    from: trustedGroundedSightFeet(seed, source),
-    to: trustedGroundedSightFeet(seed, target),
+  const sightFeet = {
+    from: playerSightFeet(seed, source),
+    to: playerSightFeet(seed, target),
   };
-  return lineOfSightClear(seed, source.pos, target.pos, r, delveModules, riftToken, trustedFeet);
+  return lineOfSightClear(seed, source.pos, target.pos, r, delveModules, riftToken, sightFeet);
 }
 
 export function entityToBodyLineOfSightClear(
@@ -53,9 +86,9 @@ export function entityToBodyLineOfSightClear(
   delveModules?: readonly string[],
   riftToken = 0,
 ): boolean {
-  const trustedFeet = {
-    from: trustedGroundedSightFeet(seed, source),
-    to: trustedSupportedSightFeet(seed, body),
+  const sightFeet = {
+    from: playerSightFeet(seed, source),
+    to: bodySightFeet(seed, body),
   };
-  return lineOfSightClear(seed, source.pos, body, r, delveModules, riftToken, trustedFeet);
+  return lineOfSightClear(seed, source.pos, body, r, delveModules, riftToken, sightFeet);
 }

--- a/src/sim/line_of_sight_elevation.ts
+++ b/src/sim/line_of_sight_elevation.ts
@@ -23,44 +23,21 @@ function openWorldSightHeights(seed: number, pos: Vec3): OpenWorldSightHeights |
   };
 }
 
-function exactSupportedSightFeet(pos: Vec3, support: number): number | undefined {
-  return Math.abs(support - pos.y) <= MOVE_TOP_EPS ? pos.y : undefined;
-}
-
 function boundedSightFeet(pos: Vec3, heights: OpenWorldSightHeights): number {
-  // Airborne movement may retain the authored support beneath the current
-  // footprint, but never contribute raw jump height above that support.
+  // Open-world endpoints may retain authored support beneath their current
+  // footprint, but never contribute raw airborne height above that support.
   return Math.min(pos.y, Math.max(heights.ground, heights.support));
-}
-
-export function trustedGroundedSightFeet(seed: number, entity: Entity): number | undefined {
-  if (
-    entity.kind !== 'player' ||
-    !entity.onGround ||
-    entity.jumping ||
-    entity.pos.x > DUNGEON_X_THRESHOLD
-  ) {
-    return undefined;
-  }
-  const heights = openWorldSightHeights(seed, entity.pos);
-  return heights ? exactSupportedSightFeet(entity.pos, heights.support) : undefined;
 }
 
 function playerSightFeet(seed: number, entity: Entity): number | undefined {
   if (entity.kind !== 'player') return undefined;
   const heights = openWorldSightHeights(seed, entity.pos);
-  if (!heights) return undefined;
-  const trusted =
-    entity.onGround && !entity.jumping
-      ? exactSupportedSightFeet(entity.pos, heights.support)
-      : undefined;
-  return trusted ?? boundedSightFeet(entity.pos, heights);
+  return heights ? boundedSightFeet(entity.pos, heights) : undefined;
 }
 
 function bodySightFeet(seed: number, body: Vec3): number | undefined {
   const heights = openWorldSightHeights(seed, body);
-  if (!heights) return undefined;
-  return exactSupportedSightFeet(body, heights.support) ?? boundedSightFeet(body, heights);
+  return heights ? boundedSightFeet(body, heights) : undefined;
 }
 
 export function entityLineOfSightClear(

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -36,7 +36,6 @@ import { buildCivicServicePlacements } from './civic_service_placements';
 import { advanceClimb, tryStartClimb } from './climb';
 import {
   allocRiftCollisionToken,
-  lineOfSightClear,
   moverHeight,
   placementFloorHeight,
   resolveMovement,
@@ -286,6 +285,7 @@ import {
   paginateGuildLeaderboard,
   paginateLeaderboard,
 } from './leaderboard_page';
+import { entityLineOfSightClear } from './line_of_sight_elevation';
 import type { Ante, PickAction } from './lockpick';
 // L1: the loot-distribution layer (party-loot strategy, the rollLoot roller, copper
 // split, need-greed roll lifecycle, corpse-loot helpers) moved to ./loot/loot_roll.ts;
@@ -6998,7 +6998,7 @@ export class Sim {
     // The delve-run lookup is O(active runs x mobs per run) and allocates a
     // party key per call, and this method sits on every ranged auto-attack,
     // AoE pulse, and LOS-gated cast. Only a sight line with an endpoint
-    // inside the delve band can ever consume run.modules (lineOfSightClear's
+    // inside the delve band can ever consume run.modules (the collider LOS
     // delve arm keys off from.x), so every other combat sight check skips
     // all four lookups. Mirrors the movement path's isDelvePos guard.
     const inDelve = isDelvePos(source.pos.x) || isDelvePos(target.pos.x);
@@ -7008,10 +7008,10 @@ export class Sim {
         this.delveRunForPlayer(source.id) ??
         this.delveRunForPlayer(target.id))
       : undefined;
-    return lineOfSightClear(
+    return entityLineOfSightClear(
       this.cfg.seed,
-      source.pos,
-      target.pos,
+      source,
+      target,
       0.05,
       run?.modules,
       this.riftCollisionToken,

--- a/tests/line_of_sight_elevation.test.ts
+++ b/tests/line_of_sight_elevation.test.ts
@@ -1,13 +1,15 @@
 import { describe, expect, it } from 'vitest';
-import { colliderInternalsForTest, lineOfSightClear, supportHeightAt } from '../src/sim/colliders';
+import {
+  colliderInternalsForTest,
+  lineOfSightClear,
+  MOVE_TOP_EPS,
+  supportHeightAt,
+} from '../src/sim/colliders';
 import { RESURRECTION_RANGE, resurrectionReachError } from '../src/sim/combat/resurrection_reach';
 import { MOBS } from '../src/sim/data';
 import { EASTBROOK_LAYOUT } from '../src/sim/eastbrook_layout';
 import { createMob } from '../src/sim/entity';
-import {
-  SIGHT_SUPPORT_EPSILON,
-  trustedGroundedSightFeet,
-} from '../src/sim/line_of_sight_elevation';
+import { trustedGroundedSightFeet } from '../src/sim/line_of_sight_elevation';
 import { PLAYER_BODY_RADIUS } from '../src/sim/pathfind';
 import { Sim } from '../src/sim/sim';
 import type { Entity, SimEvent } from '../src/sim/types';
@@ -175,6 +177,58 @@ describe('grounded line-of-sight elevation', () => {
     );
   });
 
+  it('keeps a player visible throughout a jump from the supported canopy', () => {
+    const sim = makeSim('priest');
+    const watcherId = sim.addPlayer('priest', 'Watcher');
+    const hopperId = sim.addPlayer('priest', 'Hopper');
+    const watcher = player(sim, watcherId);
+    const hopper = player(sim, hopperId);
+    const hopperMeta = sim.players.get(hopperId);
+    if (!hopperMeta) throw new Error('missing hopper metadata');
+    const stall = EASTBROOK_LAYOUT.market.stalls[0];
+    const supportedY = canopyHeight();
+
+    place(
+      sim,
+      watcher,
+      {
+        x: stall.position.x,
+        y: groundHeight(stall.position.x, stall.position.z + 8, WORLD_SEED),
+        z: stall.position.z + 8,
+      },
+      true,
+    );
+    placeOnCanopy(sim, hopper);
+    const hasLineOfSight = (source: Entity, target: Entity): boolean =>
+      (
+        sim as unknown as {
+          hasLineOfSight(source: Entity, target: Entity): boolean;
+        }
+      ).hasLineOfSight(source, target);
+
+    expect(hasLineOfSight(watcher, hopper)).toBe(true);
+    hopperMeta.moveInput.jump = true;
+    let airborneTicks = 0;
+    let apexY = supportedY;
+    for (let tick = 0; tick <= 14; tick++) {
+      sim.tick();
+      hopperMeta.moveInput.jump = false;
+      if (!hopper.onGround) airborneTicks++;
+      apexY = Math.max(apexY, hopper.pos.y);
+      expect(hasLineOfSight(watcher, hopper), `watcher lost hopper at jump tick ${tick}`).toBe(
+        true,
+      );
+      expect(hasLineOfSight(hopper, watcher), `hopper lost watcher at jump tick ${tick}`).toBe(
+        true,
+      );
+    }
+
+    expect(airborneTicks).toBeGreaterThan(0);
+    expect(apexY).toBeGreaterThan(supportedY);
+    expect(hopper.pos.y).toBe(supportedY);
+    expect(hopper.onGround).toBe(true);
+  });
+
   it('lets a hostile ranged spell complete from the same supported canopy', () => {
     const sim = makeSim('mage');
     const casterId = sim.addPlayer('mage', 'Caster');
@@ -294,12 +348,12 @@ describe('grounded line-of-sight elevation', () => {
     const probe = player(sim, playerId);
 
     placeOnCanopy(sim, probe);
-    expect(trustedGroundedSightFeet(WORLD_SEED, probe)).toBeCloseTo(canopyHeight());
-    expect(SIGHT_SUPPORT_EPSILON).toBe(1e-3);
+    expect(trustedGroundedSightFeet(WORLD_SEED, probe)).toBe(canopyHeight());
+    expect(MOVE_TOP_EPS).toBe(1e-3);
 
     probe.pos.y = canopyHeight() + 0.0005;
     probe.prevPos = { ...probe.pos };
-    expect(trustedGroundedSightFeet(WORLD_SEED, probe)).toBeCloseTo(probe.pos.y);
+    expect(trustedGroundedSightFeet(WORLD_SEED, probe)).toBe(probe.pos.y);
 
     probe.pos.y = canopyHeight() + 0.0011;
     probe.prevPos = { ...probe.pos };
@@ -307,7 +361,7 @@ describe('grounded line-of-sight elevation', () => {
 
     probe.pos.y = canopyHeight() - 0.0005;
     probe.prevPos = { ...probe.pos };
-    expect(trustedGroundedSightFeet(WORLD_SEED, probe)).toBeCloseTo(probe.pos.y);
+    expect(trustedGroundedSightFeet(WORLD_SEED, probe)).toBe(probe.pos.y);
 
     probe.pos.y = canopyHeight() - 0.0011;
     probe.prevPos = { ...probe.pos };

--- a/tests/line_of_sight_elevation.test.ts
+++ b/tests/line_of_sight_elevation.test.ts
@@ -1,15 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import {
-  colliderInternalsForTest,
-  lineOfSightClear,
-  MOVE_TOP_EPS,
-  supportHeightAt,
-} from '../src/sim/colliders';
+import { colliderInternalsForTest, lineOfSightClear, supportHeightAt } from '../src/sim/colliders';
 import { RESURRECTION_RANGE, resurrectionReachError } from '../src/sim/combat/resurrection_reach';
 import { MOBS } from '../src/sim/data';
 import { EASTBROOK_LAYOUT } from '../src/sim/eastbrook_layout';
 import { createMob } from '../src/sim/entity';
-import { trustedGroundedSightFeet } from '../src/sim/line_of_sight_elevation';
+import { entityLineOfSightClear } from '../src/sim/line_of_sight_elevation';
 import { PLAYER_BODY_RADIUS } from '../src/sim/pathfind';
 import { Sim } from '../src/sim/sim';
 import type { Entity, SimEvent } from '../src/sim/types';
@@ -342,59 +337,28 @@ describe('grounded line-of-sight elevation', () => {
     expect(hunter.swingTimer).toBeGreaterThan(0);
   });
 
-  it('does not trust unsupported or airborne player elevation', () => {
+  it('does not grant canopy support to non-player line-of-sight endpoints', () => {
     const sim = makeSim('priest');
-    const playerId = sim.addPlayer('priest', 'Probe');
-    const probe = player(sim, playerId);
-
-    placeOnCanopy(sim, probe);
-    expect(trustedGroundedSightFeet(WORLD_SEED, probe)).toBe(canopyHeight());
-    expect(MOVE_TOP_EPS).toBe(1e-3);
-
-    probe.pos.y = canopyHeight() + 0.0005;
-    probe.prevPos = { ...probe.pos };
-    expect(trustedGroundedSightFeet(WORLD_SEED, probe)).toBe(probe.pos.y);
-
-    probe.pos.y = canopyHeight() + 0.0011;
-    probe.prevPos = { ...probe.pos };
-    expect(trustedGroundedSightFeet(WORLD_SEED, probe)).toBeUndefined();
-
-    probe.pos.y = canopyHeight() - 0.0005;
-    probe.prevPos = { ...probe.pos };
-    expect(trustedGroundedSightFeet(WORLD_SEED, probe)).toBe(probe.pos.y);
-
-    probe.pos.y = canopyHeight() - 0.0011;
-    probe.prevPos = { ...probe.pos };
-    expect(trustedGroundedSightFeet(WORLD_SEED, probe)).toBeUndefined();
-  });
-
-  it('requires grounded and non-jumping state independently', () => {
-    const sim = makeSim('priest');
-    const playerId = sim.addPlayer('priest', 'Probe');
-    const probe = player(sim, playerId);
-
-    placeOnCanopy(sim, probe);
-    probe.onGround = false;
-    probe.jumping = false;
-    expect(trustedGroundedSightFeet(WORLD_SEED, probe)).toBeUndefined();
-
-    placeOnCanopy(sim, probe);
-    probe.onGround = true;
-    probe.jumping = true;
-    expect(trustedGroundedSightFeet(WORLD_SEED, probe)).toBeUndefined();
-  });
-
-  it('does not trust supported elevation for a grounded non-player', () => {
-    const sim = makeSim('priest');
+    const watcherId = sim.addPlayer('priest', 'Watcher');
+    const watcher = player(sim, watcherId);
     const stall = EASTBROOK_LAYOUT.market.stalls[0];
     const wolf = addWolf(sim, 990_352_303, stall.position.x, stall.position.z);
 
+    place(
+      sim,
+      watcher,
+      {
+        x: stall.position.x,
+        y: groundHeight(stall.position.x, stall.position.z + 8, WORLD_SEED),
+        z: stall.position.z + 8,
+      },
+      true,
+    );
     placeOnCanopy(sim, wolf);
 
     expect(wolf.kind).toBe('mob');
-    expect(wolf.onGround).toBe(true);
-    expect(wolf.jumping).toBe(false);
-    expect(trustedGroundedSightFeet(WORLD_SEED, wolf)).toBeUndefined();
+    expect(entityLineOfSightClear(WORLD_SEED, watcher, wolf)).toBe(false);
+    expect(entityLineOfSightClear(WORLD_SEED, wolf, watcher)).toBe(false);
   });
 
   it('keeps a jumping healer behind ordinary open-world cover blocked', () => {

--- a/tests/line_of_sight_elevation.test.ts
+++ b/tests/line_of_sight_elevation.test.ts
@@ -1,0 +1,384 @@
+import { describe, expect, it } from 'vitest';
+import { colliderInternalsForTest, lineOfSightClear, supportHeightAt } from '../src/sim/colliders';
+import { RESURRECTION_RANGE, resurrectionReachError } from '../src/sim/combat/resurrection_reach';
+import { MOBS } from '../src/sim/data';
+import { EASTBROOK_LAYOUT } from '../src/sim/eastbrook_layout';
+import { createMob } from '../src/sim/entity';
+import {
+  SIGHT_SUPPORT_EPSILON,
+  trustedGroundedSightFeet,
+} from '../src/sim/line_of_sight_elevation';
+import { PLAYER_BODY_RADIUS } from '../src/sim/pathfind';
+import { Sim } from '../src/sim/sim';
+import type { Entity, SimEvent } from '../src/sim/types';
+import { groundHeight } from '../src/sim/world';
+import { WORLD_SEED } from '../src/sim/world_seed';
+
+function player(sim: Sim, id: number): Entity {
+  const entity = sim.entities.get(id);
+  if (!entity) throw new Error(`missing player ${id}`);
+  return entity;
+}
+
+function place(
+  sim: Sim,
+  entity: Entity,
+  pos: { x: number; y: number; z: number },
+  grounded: boolean,
+): void {
+  entity.pos = { ...pos };
+  entity.prevPos = { ...pos };
+  entity.vx = 0;
+  entity.vy = 0;
+  entity.vz = 0;
+  entity.onGround = grounded;
+  entity.jumping = !grounded;
+  entity.fallStartY = pos.y;
+  sim.rebucket(entity);
+}
+
+function tickUntilIdle(sim: Sim, caster: Entity, maxTicks = 80): SimEvent[] {
+  const events: SimEvent[] = [];
+  for (let tick = 0; tick < maxTicks && caster.castingAbility !== null; tick++) {
+    events.push(...sim.tick());
+  }
+  return events;
+}
+
+function makeSim(playerClass: 'hunter' | 'mage' | 'priest', seed = WORLD_SEED): Sim {
+  return new Sim({ seed, playerClass, autoEquip: true, noPlayer: true });
+}
+
+function canopyHeight(): number {
+  const stall = EASTBROOK_LAYOUT.market.stalls[0];
+  return supportHeightAt(
+    WORLD_SEED,
+    stall.position.x,
+    stall.position.z,
+    PLAYER_BODY_RADIUS,
+    groundHeight(stall.position.x, stall.position.z, WORLD_SEED) + stall.height,
+  );
+}
+
+function placeOnCanopy(sim: Sim, entity: Entity): void {
+  const stall = EASTBROOK_LAYOUT.market.stalls[0];
+  place(sim, entity, { x: stall.position.x, y: canopyHeight(), z: stall.position.z }, true);
+}
+
+function addWolf(sim: Sim, id: number, x: number, z: number): Entity {
+  const wolf = createMob(id, MOBS.forest_wolf, 1, {
+    x,
+    y: groundHeight(x, z, sim.cfg.seed),
+    z,
+  });
+  sim.entities.set(wolf.id, wolf);
+  sim.rebucket(wolf);
+  return wolf;
+}
+
+describe('grounded line-of-sight elevation', () => {
+  it('lets Whispered Prayer heal from the supported Eastbrook market canopy', () => {
+    const sim = makeSim('priest');
+    const healerId = sim.addPlayer('priest', 'Healer');
+    const allyId = sim.addPlayer('warrior', 'Ally');
+    const healer = player(sim, healerId);
+    const ally = player(sim, allyId);
+    const stall = EASTBROOK_LAYOUT.market.stalls[0];
+    const terrainY = groundHeight(stall.position.x, stall.position.z, WORLD_SEED);
+    const canopyY = supportHeightAt(
+      WORLD_SEED,
+      stall.position.x,
+      stall.position.z,
+      PLAYER_BODY_RADIUS,
+      terrainY + stall.height,
+    );
+
+    expect(stall.id).toBe('eastbrook_market_stall_world_market');
+    expect(stall.height).toBe(2.7);
+    expect(terrainY).toBeCloseTo(1.5);
+    expect(canopyY).toBeCloseTo(terrainY + stall.height);
+    const stallCollider = colliderInternalsForTest
+      .staticWorldColliders(WORLD_SEED)
+      .find(
+        (collider) =>
+          collider.type === 'obb' &&
+          collider.x === stall.position.x &&
+          collider.z === stall.position.z,
+      );
+    expect(stallCollider).toMatchObject({
+      cameraTopY: canopyY,
+      moveTopY: canopyY,
+      standable: true,
+    });
+
+    place(sim, healer, { x: stall.position.x, y: canopyY, z: stall.position.z }, true);
+    const allyPos = {
+      x: stall.position.x,
+      y: groundHeight(stall.position.x, stall.position.z + 8, WORLD_SEED),
+      z: stall.position.z + 8,
+    };
+    place(sim, ally, allyPos, true);
+    ally.hp = 1;
+    healer.resource = healer.maxResource;
+    healer.gcdRemaining = 0;
+    sim.drainEvents();
+
+    expect(lineOfSightClear(WORLD_SEED, healer.pos, ally.pos)).toBe(false);
+    sim.castAbilityOn('lesser_heal', allyId, healerId);
+    const startEvents = sim.drainEvents();
+
+    expect(startEvents).toContainEqual(
+      expect.objectContaining({ type: 'castStart', entityId: healerId, ability: 'lesser_heal' }),
+    );
+    expect(startEvents).not.toContainEqual(
+      expect.objectContaining({ type: 'error', text: 'Line of sight.' }),
+    );
+
+    const completionEvents = tickUntilIdle(sim, healer);
+    const heal = completionEvents.find(
+      (event) => event.type === 'heal2' && event.sourceId === healerId && event.targetId === allyId,
+    );
+    expect(heal).toMatchObject({ ability: 'Whispered Prayer' });
+    expect(heal?.type === 'heal2' ? heal.amount : 0).toBeGreaterThan(0);
+    expect(ally.hp).toBeGreaterThan(1);
+  });
+
+  it('uses supported elevation for an elevated friendly target too', () => {
+    const sim = makeSim('priest');
+    const healerId = sim.addPlayer('priest', 'Healer');
+    const allyId = sim.addPlayer('warrior', 'Ally');
+    const healer = player(sim, healerId);
+    const ally = player(sim, allyId);
+    const stall = EASTBROOK_LAYOUT.market.stalls[0];
+
+    place(
+      sim,
+      healer,
+      {
+        x: stall.position.x,
+        y: groundHeight(stall.position.x, stall.position.z + 8, WORLD_SEED),
+        z: stall.position.z + 8,
+      },
+      true,
+    );
+    placeOnCanopy(sim, ally);
+    ally.hp = 1;
+
+    sim.castAbilityOn('lesser_heal', allyId, healerId);
+    const events = sim.drainEvents();
+
+    expect(events).toContainEqual(
+      expect.objectContaining({ type: 'castStart', entityId: healerId, ability: 'lesser_heal' }),
+    );
+    expect(events).not.toContainEqual(
+      expect.objectContaining({ type: 'error', text: 'Line of sight.' }),
+    );
+  });
+
+  it('lets a hostile ranged spell complete from the same supported canopy', () => {
+    const sim = makeSim('mage');
+    const casterId = sim.addPlayer('mage', 'Caster');
+    const caster = player(sim, casterId);
+    const stall = EASTBROOK_LAYOUT.market.stalls[0];
+    const wolf = addWolf(sim, 990_352_301, stall.position.x, stall.position.z + 8);
+
+    placeOnCanopy(sim, caster);
+    caster.facing = Math.atan2(wolf.pos.x - caster.pos.x, wolf.pos.z - caster.pos.z);
+    sim.targetEntity(wolf.id, casterId);
+    sim.castAbility('fireball', casterId);
+    const startEvents = sim.drainEvents();
+
+    expect(startEvents).toContainEqual(
+      expect.objectContaining({ type: 'castStart', entityId: casterId, ability: 'fireball' }),
+    );
+    expect(startEvents).not.toContainEqual(
+      expect.objectContaining({ type: 'error', text: 'Line of sight.' }),
+    );
+
+    const completionEvents = tickUntilIdle(sim, caster);
+    expect(completionEvents).toContainEqual(
+      expect.objectContaining({
+        type: 'spellfx',
+        sourceId: casterId,
+        targetId: wolf.id,
+        school: 'fire',
+        fx: 'projectile',
+        ability: 'fireball',
+      }),
+    );
+    expect(completionEvents).not.toContainEqual(
+      expect.objectContaining({ type: 'error', text: 'Line of sight.' }),
+    );
+  });
+
+  it('uses the same supported source elevation for resurrection reach', () => {
+    const sim = makeSim('priest');
+    const casterId = sim.addPlayer('priest', 'Caster');
+    const fallenId = sim.addPlayer('warrior', 'Fallen');
+    const caster = player(sim, casterId);
+    const fallen = player(sim, fallenId);
+    const stall = EASTBROOK_LAYOUT.market.stalls[0];
+
+    placeOnCanopy(sim, caster);
+    place(
+      sim,
+      fallen,
+      {
+        x: stall.position.x,
+        y: groundHeight(stall.position.x, stall.position.z + 8, WORLD_SEED),
+        z: stall.position.z + 8,
+      },
+      true,
+    );
+    fallen.dead = true;
+    fallen.hp = 0;
+    fallen.corpsePos = { ...fallen.pos };
+
+    expect(resurrectionReachError(sim.ctx, caster, fallen, RESURRECTION_RANGE)).toBeNull();
+  });
+
+  it('uses the same supported elevation for an elevated resurrection body', () => {
+    const sim = makeSim('priest');
+    const casterId = sim.addPlayer('priest', 'Caster');
+    const fallenId = sim.addPlayer('warrior', 'Fallen');
+    const caster = player(sim, casterId);
+    const fallen = player(sim, fallenId);
+    const stall = EASTBROOK_LAYOUT.market.stalls[0];
+
+    place(
+      sim,
+      caster,
+      {
+        x: stall.position.x,
+        y: groundHeight(stall.position.x, stall.position.z + 8, WORLD_SEED),
+        z: stall.position.z + 8,
+      },
+      true,
+    );
+    placeOnCanopy(sim, fallen);
+    fallen.dead = true;
+    fallen.hp = 0;
+    fallen.corpsePos = { ...fallen.pos };
+
+    expect(resurrectionReachError(sim.ctx, caster, fallen, RESURRECTION_RANGE)).toBeNull();
+  });
+
+  it('lets ranged auto-attack fire from the same supported canopy', () => {
+    const sim = makeSim('hunter');
+    const hunterId = sim.addPlayer('hunter', 'Hunter');
+    const hunter = player(sim, hunterId);
+    const stall = EASTBROOK_LAYOUT.market.stalls[0];
+    const wolf = addWolf(sim, 990_352_302, stall.position.x, stall.position.z + 8);
+
+    placeOnCanopy(sim, hunter);
+    hunter.facing = Math.atan2(wolf.pos.x - hunter.pos.x, wolf.pos.z - hunter.pos.z);
+    sim.targetEntity(wolf.id, hunterId);
+    sim.startAutoAttack(hunterId);
+    hunter.swingTimer = 0;
+
+    const events = sim.tick();
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: 'spellfx',
+        sourceId: hunterId,
+        targetId: wolf.id,
+        fx: 'projectile',
+      }),
+    );
+    expect(hunter.swingTimer).toBeGreaterThan(0);
+  });
+
+  it('does not trust unsupported or airborne player elevation', () => {
+    const sim = makeSim('priest');
+    const playerId = sim.addPlayer('priest', 'Probe');
+    const probe = player(sim, playerId);
+
+    placeOnCanopy(sim, probe);
+    expect(trustedGroundedSightFeet(WORLD_SEED, probe)).toBeCloseTo(canopyHeight());
+    expect(SIGHT_SUPPORT_EPSILON).toBe(1e-3);
+
+    probe.pos.y = canopyHeight() + 0.0005;
+    probe.prevPos = { ...probe.pos };
+    expect(trustedGroundedSightFeet(WORLD_SEED, probe)).toBeCloseTo(probe.pos.y);
+
+    probe.pos.y = canopyHeight() + 0.0011;
+    probe.prevPos = { ...probe.pos };
+    expect(trustedGroundedSightFeet(WORLD_SEED, probe)).toBeUndefined();
+
+    probe.pos.y = canopyHeight() - 0.0005;
+    probe.prevPos = { ...probe.pos };
+    expect(trustedGroundedSightFeet(WORLD_SEED, probe)).toBeCloseTo(probe.pos.y);
+
+    probe.pos.y = canopyHeight() - 0.0011;
+    probe.prevPos = { ...probe.pos };
+    expect(trustedGroundedSightFeet(WORLD_SEED, probe)).toBeUndefined();
+  });
+
+  it('requires grounded and non-jumping state independently', () => {
+    const sim = makeSim('priest');
+    const playerId = sim.addPlayer('priest', 'Probe');
+    const probe = player(sim, playerId);
+
+    placeOnCanopy(sim, probe);
+    probe.onGround = false;
+    probe.jumping = false;
+    expect(trustedGroundedSightFeet(WORLD_SEED, probe)).toBeUndefined();
+
+    placeOnCanopy(sim, probe);
+    probe.onGround = true;
+    probe.jumping = true;
+    expect(trustedGroundedSightFeet(WORLD_SEED, probe)).toBeUndefined();
+  });
+
+  it('does not trust supported elevation for a grounded non-player', () => {
+    const sim = makeSim('priest');
+    const stall = EASTBROOK_LAYOUT.market.stalls[0];
+    const wolf = addWolf(sim, 990_352_303, stall.position.x, stall.position.z);
+
+    placeOnCanopy(sim, wolf);
+
+    expect(wolf.kind).toBe('mob');
+    expect(wolf.onGround).toBe(true);
+    expect(wolf.jumping).toBe(false);
+    expect(trustedGroundedSightFeet(WORLD_SEED, wolf)).toBeUndefined();
+  });
+
+  it('keeps a jumping healer behind ordinary open-world cover blocked', () => {
+    const seed = 42;
+    const sim = makeSim('priest', seed);
+    const healerId = sim.addPlayer('priest', 'Jumper');
+    const allyId = sim.addPlayer('warrior', 'Ally');
+    const healer = player(sim, healerId);
+    const ally = player(sim, allyId);
+    const from = { x: -186, z: 168 };
+    const to = { x: -168, z: 168 };
+
+    place(sim, healer, { x: from.x, y: groundHeight(from.x, from.z, seed) + 3, z: from.z }, false);
+    place(sim, ally, { x: to.x, y: groundHeight(to.x, to.z, seed), z: to.z }, true);
+    ally.hp = 1;
+    healer.resource = healer.maxResource;
+    healer.gcdRemaining = 0;
+    const resourceBefore = healer.resource;
+
+    expect(lineOfSightClear(seed, healer.pos, ally.pos)).toBe(false);
+    expect(
+      lineOfSightClear(seed, healer.pos, ally.pos, 0.05, undefined, 0, {
+        from: healer.pos.y,
+      }),
+      'the lifted eye would clear this cover if airborne y were trusted',
+    ).toBe(true);
+
+    sim.drainEvents();
+    sim.castAbilityOn('lesser_heal', allyId, healerId);
+    const events = sim.drainEvents();
+
+    expect(healer.castingAbility).toBeNull();
+    expect(events).not.toContainEqual(expect.objectContaining({ type: 'castStart' }));
+    expect(events).toContainEqual(
+      expect.objectContaining({ type: 'error', text: 'Line of sight.' }),
+    );
+    expect(healer.resource).toBe(resourceBefore);
+    expect(healer.gcdRemaining).toBe(0);
+    expect(ally.hp).toBe(1);
+  });
+});

--- a/tests/parity/coverage_c.test.ts
+++ b/tests/parity/coverage_c.test.ts
@@ -664,4 +664,32 @@ describe('coverage: each scenario fires its subsystem', () => {
     const deaths = (rec.allEvents as Ev[]).filter((e) => e.type === 'death');
     expect(deaths.length).toBeGreaterThanOrEqual(2);
   });
+
+  it('supported_elevation_line_of_sight: heals from the stall and denies airborne cover sight', () => {
+    const rec = run('supported_elevation_line_of_sight');
+    const events = rec.allEvents as Ev[];
+    const healerId = rec.notes.healerId as number;
+    const allyId = rec.notes.allyId as number;
+
+    expect(
+      events.some(
+        (event) =>
+          event.type === 'castStart' &&
+          event.entityId === healerId &&
+          event.ability === 'lesser_heal',
+      ),
+    ).toBe(true);
+    expect(
+      events.some(
+        (event) =>
+          event.type === 'heal2' &&
+          event.sourceId === healerId &&
+          event.targetId === allyId &&
+          event.ability === 'Whispered Prayer',
+      ),
+    ).toBe(true);
+    expect(events.some((event) => event.type === 'error' && event.text === 'Line of sight.')).toBe(
+      true,
+    );
+  });
 });

--- a/tests/parity/coverage_c.test.ts
+++ b/tests/parity/coverage_c.test.ts
@@ -665,31 +665,30 @@ describe('coverage: each scenario fires its subsystem', () => {
     expect(deaths.length).toBeGreaterThanOrEqual(2);
   });
 
-  it('supported_elevation_line_of_sight: heals from the stall and denies airborne cover sight', () => {
+  it('supported_elevation_line_of_sight: heals across the stall jump and denies airborne cover sight', () => {
     const rec = run('supported_elevation_line_of_sight');
     const events = rec.allEvents as Ev[];
     const healerId = rec.notes.healerId as number;
     const allyId = rec.notes.allyId as number;
 
-    expect(
-      events.some(
-        (event) =>
-          event.type === 'castStart' &&
-          event.entityId === healerId &&
-          event.ability === 'lesser_heal',
-      ),
-    ).toBe(true);
-    expect(
-      events.some(
-        (event) =>
-          event.type === 'heal2' &&
-          event.sourceId === healerId &&
-          event.targetId === allyId &&
-          event.ability === 'Whispered Prayer',
-      ),
-    ).toBe(true);
-    expect(events.some((event) => event.type === 'error' && event.text === 'Line of sight.')).toBe(
-      true,
+    const starts = events.filter(
+      (event) =>
+        event.type === 'castStart' &&
+        event.entityId === healerId &&
+        event.ability === 'lesser_heal',
     );
+    expect(starts).toHaveLength(2);
+    const heals = events.filter(
+      (event) =>
+        event.type === 'heal2' &&
+        event.sourceId === healerId &&
+        event.targetId === allyId &&
+        event.ability === 'Whispered Prayer',
+    );
+    expect(heals).toHaveLength(2);
+    const lineOfSightErrors = events.filter(
+      (event) => event.type === 'error' && event.text === 'Line of sight.',
+    );
+    expect(lineOfSightErrors).toHaveLength(1);
   });
 });

--- a/tests/parity/golden/supported_elevation_line_of_sight.json
+++ b/tests/parity/golden/supported_elevation_line_of_sight.json
@@ -2,14 +2,15 @@
   "scenario": "supported_elevation_line_of_sight",
   "seed": 20061,
   "sampleEvery": 10,
-  "ticks": 40,
+  "ticks": 81,
   "coverage": [
     "Eastbrook standable canopy supplies grounded player eye elevation for a completed heal",
+    "Eastbrook standable canopy keeps a jumping target visible without granting jump height",
     "airborne player elevation is rejected behind ordinary open-world cover",
     "shared Sim cast entry point and completion LOS recheck"
   ],
-  "draws": 2,
-  "drawDigest": "f56e9f11",
+  "draws": 362,
+  "drawDigest": "156325a6",
   "frames": [
     {
       "tick": 0,
@@ -567,14 +568,561 @@
       ]
     },
     {
-      "tick": 40,
-      "time": 2,
+      "tick": 41,
+      "time": 2.05,
       "nextId": 969,
-      "state": "c67a7528",
+      "state": "33ea5994",
+      "events": "f731da68",
+      "rng": {
+        "draws": 6,
+        "digest": "05c1975a"
+      },
+      "label": "canopy-jump-heal-start",
+      "players": [
+        {
+          "activeLoadout": -1,
+          "archetype": {},
+          "arena2v2Rating": 1500,
+          "arenaRating": 1500,
+          "bags": [
+            null,
+            null,
+            null,
+            null
+          ],
+          "bank": {},
+          "bgRating": 1500,
+          "cls": "priest",
+          "companionUpgrades": {},
+          "counters": {},
+          "craftSkills": {},
+          "deedStats": {
+            "counters": {},
+            "dungeonClears": {},
+            "itemsDiscovered": [
+              "apprentice_robe",
+              "baked_bread",
+              "gnarled_staff",
+              "spring_water"
+            ],
+            "visited": [
+              "poi:eastbrook_vale:eastbrook"
+            ]
+          },
+          "delveClears": {},
+          "delveDaily": {},
+          "entityId": 967,
+          "equipment": {
+            "chest": "apprentice_robe",
+            "mainhand": "gnarled_staff"
+          },
+          "equipmentInstance": {},
+          "gatheringProficiency": {},
+          "heroicDaily": {},
+          "inventory": [
+            {
+              "count": 5,
+              "itemId": "baked_bread"
+            },
+            {
+              "count": 5,
+              "itemId": "spring_water"
+            }
+          ],
+          "mailWelcomed": true,
+          "nodeHarvestReadyAt": {},
+          "recipesGrandfathered": true,
+          "reliquary": {
+            "counts": {},
+            "firstFind": {}
+          },
+          "talents": {
+            "rows": {}
+          },
+          "townFocus": {}
+        },
+        {
+          "activeLoadout": -1,
+          "archetype": {},
+          "arena2v2Rating": 1500,
+          "arenaRating": 1500,
+          "bags": [
+            null,
+            null,
+            null,
+            null
+          ],
+          "bank": {},
+          "bgRating": 1500,
+          "cls": "warrior",
+          "companionUpgrades": {},
+          "counters": {},
+          "craftSkills": {},
+          "deedStats": {
+            "counters": {},
+            "dungeonClears": {},
+            "itemsDiscovered": [
+              "baked_bread",
+              "eastbrook_buckler",
+              "recruit_tunic",
+              "worn_sword"
+            ]
+          },
+          "delveClears": {},
+          "delveDaily": {},
+          "entityId": 968,
+          "equipment": {
+            "chest": "recruit_tunic",
+            "mainhand": "worn_sword",
+            "offhand": "eastbrook_buckler"
+          },
+          "equipmentInstance": {},
+          "gatheringProficiency": {},
+          "heroicDaily": {},
+          "inventory": [
+            {
+              "count": 5,
+              "itemId": "baked_bread"
+            }
+          ],
+          "mailWelcomed": true,
+          "nodeHarvestReadyAt": {},
+          "recipesGrandfathered": true,
+          "reliquary": {
+            "counts": {},
+            "firstFind": {}
+          },
+          "talents": {
+            "rows": {}
+          },
+          "townFocus": {}
+        }
+      ],
+      "entities": [
+        {
+          "aiState": "idle",
+          "attackPower": 10,
+          "castRemaining": 2,
+          "castTargetId": 968,
+          "castTotal": 2,
+          "castingAbility": "lesser_heal",
+          "combatTimer": 101.05,
+          "comboUntil": -1,
+          "critChance": 0.0555,
+          "detonateTimer": "Infinity",
+          "dodgeChance": 0.0555,
+          "fallStartY": 1.499559,
+          "fiveSecondRule": 0.1,
+          "gcdRemaining": 1.5,
+          "hp": 51,
+          "id": 967,
+          "kind": "player",
+          "level": 1,
+          "lootFfaTimer": "Infinity",
+          "maxHp": 51,
+          "maxResource": 175,
+          "moveSpeed": 7,
+          "onGround": true,
+          "overpowerUntil": -1,
+          "petMode": "defensive",
+          "pos": {
+            "x": -5.5,
+            "y": 1.499559,
+            "z": 17.5
+          },
+          "potionCooldownUntil": -1,
+          "resource": 175,
+          "resourceType": "mana",
+          "spawnPos": {
+            "x": 2,
+            "y": 1.5,
+            "z": -2
+          },
+          "spellPower": 12,
+          "stats": {
+            "agi": 11,
+            "armor": 50,
+            "int": 23,
+            "spi": 24,
+            "sta": 13,
+            "str": 10
+          },
+          "templateId": "priest",
+          "weapon": {
+            "max": 6,
+            "min": 3,
+            "speed": 2.9
+          }
+        },
+        {
+          "aiState": "idle",
+          "attackPower": 46,
+          "auras": [
+            {
+              "duration": 3600,
+              "id": "battle_stance",
+              "kind": "battle_stance",
+              "name": "Battle Stance",
+              "remaining": 3597.95,
+              "school": "physical",
+              "sourceId": 968
+            }
+          ],
+          "blockChance": 0.05,
+          "blockValue": 6,
+          "combatTimer": 101.05,
+          "comboUntil": -1,
+          "critChance": 0.06,
+          "detonateTimer": "Infinity",
+          "dodgeChance": 0.06,
+          "fallStartY": 4.46,
+          "fiveSecondRule": 101.05,
+          "hp": 1,
+          "id": 968,
+          "jumping": true,
+          "kind": "player",
+          "level": 1,
+          "lootFfaTimer": "Infinity",
+          "maxHp": 100,
+          "maxResource": 100,
+          "moveSpeed": 7,
+          "offhandItemId": "eastbrook_buckler",
+          "overpowerUntil": -1,
+          "petMode": "defensive",
+          "pos": {
+            "x": -5.5,
+            "y": 4.46,
+            "z": 9.5
+          },
+          "potionCooldownUntil": -1,
+          "resourceType": "rage",
+          "spawnPos": {
+            "x": 2,
+            "y": 1.5,
+            "z": -2
+          },
+          "spellPower": 5,
+          "stats": {
+            "agi": 20,
+            "armor": 144,
+            "int": 10,
+            "spi": 11,
+            "sta": 23,
+            "str": 23
+          },
+          "templateId": "warrior",
+          "weapon": {
+            "max": 5,
+            "min": 2,
+            "speed": 2
+          }
+        }
+      ]
+    },
+    {
+      "tick": 50,
+      "time": 2.5,
+      "nextId": 969,
+      "state": "9035e3d8",
+      "events": "741638a5",
+      "rng": {
+        "draws": 68,
+        "digest": "67de50d8"
+      }
+    },
+    {
+      "tick": 60,
+      "time": 3,
+      "nextId": 969,
+      "state": "82106f12",
+      "events": "741638a5",
+      "rng": {
+        "draws": 158,
+        "digest": "85fd701d"
+      }
+    },
+    {
+      "tick": 70,
+      "time": 3.5,
+      "nextId": 969,
+      "state": "4dd42905",
+      "events": "741638a5",
+      "rng": {
+        "draws": 249,
+        "digest": "2457c444"
+      }
+    },
+    {
+      "tick": 80,
+      "time": 4,
+      "nextId": 969,
+      "state": "e77a3542",
+      "events": "741638a5",
+      "rng": {
+        "draws": 353,
+        "digest": "5f74472b"
+      }
+    },
+    {
+      "tick": 81,
+      "time": 4.05,
+      "nextId": 969,
+      "state": "37f2500f",
+      "events": "6cd16806",
+      "rng": {
+        "draws": 362,
+        "digest": "156325a6"
+      },
+      "label": "canopy-jump-heal-complete",
+      "players": [
+        {
+          "activeLoadout": -1,
+          "archetype": {},
+          "arena2v2Rating": 1500,
+          "arenaRating": 1500,
+          "bags": [
+            null,
+            null,
+            null,
+            null
+          ],
+          "bank": {},
+          "bgRating": 1500,
+          "cls": "priest",
+          "companionUpgrades": {},
+          "counters": {},
+          "craftSkills": {},
+          "deedStats": {
+            "counters": {},
+            "dungeonClears": {},
+            "itemsDiscovered": [
+              "apprentice_robe",
+              "baked_bread",
+              "gnarled_staff",
+              "spring_water"
+            ],
+            "visited": [
+              "poi:eastbrook_vale:eastbrook"
+            ]
+          },
+          "delveClears": {},
+          "delveDaily": {},
+          "entityId": 967,
+          "equipment": {
+            "chest": "apprentice_robe",
+            "mainhand": "gnarled_staff"
+          },
+          "equipmentInstance": {},
+          "gatheringProficiency": {},
+          "heroicDaily": {},
+          "inventory": [
+            {
+              "count": 5,
+              "itemId": "baked_bread"
+            },
+            {
+              "count": 5,
+              "itemId": "spring_water"
+            }
+          ],
+          "mailWelcomed": true,
+          "nodeHarvestReadyAt": {},
+          "recipesGrandfathered": true,
+          "reliquary": {
+            "counts": {},
+            "firstFind": {}
+          },
+          "talents": {
+            "rows": {}
+          },
+          "townFocus": {}
+        },
+        {
+          "activeLoadout": -1,
+          "archetype": {},
+          "arena2v2Rating": 1500,
+          "arenaRating": 1500,
+          "bags": [
+            null,
+            null,
+            null,
+            null
+          ],
+          "bank": {},
+          "bgRating": 1500,
+          "cls": "warrior",
+          "companionUpgrades": {},
+          "counters": {},
+          "craftSkills": {},
+          "deedStats": {
+            "counters": {},
+            "dungeonClears": {},
+            "itemsDiscovered": [
+              "baked_bread",
+              "eastbrook_buckler",
+              "recruit_tunic",
+              "worn_sword"
+            ],
+            "visited": [
+              "poi:eastbrook_vale:eastbrook"
+            ]
+          },
+          "delveClears": {},
+          "delveDaily": {},
+          "entityId": 968,
+          "equipment": {
+            "chest": "recruit_tunic",
+            "mainhand": "worn_sword",
+            "offhand": "eastbrook_buckler"
+          },
+          "equipmentInstance": {},
+          "gatheringProficiency": {},
+          "heroicDaily": {},
+          "inventory": [
+            {
+              "count": 5,
+              "itemId": "baked_bread"
+            }
+          ],
+          "mailWelcomed": true,
+          "nodeHarvestReadyAt": {},
+          "recipesGrandfathered": true,
+          "reliquary": {
+            "counts": {},
+            "firstFind": {}
+          },
+          "talents": {
+            "rows": {}
+          },
+          "townFocus": {}
+        }
+      ],
+      "entities": [
+        {
+          "aiState": "idle",
+          "attackPower": 10,
+          "castTotal": 2,
+          "combatTimer": 103.05,
+          "comboUntil": -1,
+          "critChance": 0.0555,
+          "detonateTimer": "Infinity",
+          "dodgeChance": 0.0555,
+          "fallStartY": 1.499559,
+          "fiveSecondRule": 0.05,
+          "hp": 51,
+          "id": 967,
+          "kind": "player",
+          "level": 1,
+          "lootFfaTimer": "Infinity",
+          "maxHp": 51,
+          "maxResource": 175,
+          "moveSpeed": 7,
+          "onGround": true,
+          "overpowerUntil": -1,
+          "petMode": "defensive",
+          "pos": {
+            "x": -5.5,
+            "y": 1.499559,
+            "z": 17.5
+          },
+          "potionCooldownUntil": -1,
+          "resource": 145,
+          "resourceType": "mana",
+          "spawnPos": {
+            "x": 2,
+            "y": 1.5,
+            "z": -2
+          },
+          "spellPower": 12,
+          "stats": {
+            "agi": 11,
+            "armor": 50,
+            "int": 23,
+            "spi": 24,
+            "sta": 13,
+            "str": 10
+          },
+          "templateId": "priest",
+          "weapon": {
+            "max": 6,
+            "min": 3,
+            "speed": 2.9
+          }
+        },
+        {
+          "aiState": "idle",
+          "attackPower": 46,
+          "auras": [
+            {
+              "duration": 3600,
+              "id": "battle_stance",
+              "kind": "battle_stance",
+              "name": "Battle Stance",
+              "remaining": 3595.95,
+              "school": "physical",
+              "sourceId": 968
+            }
+          ],
+          "blockChance": 0.05,
+          "blockValue": 6,
+          "combatTimer": 103.05,
+          "comboUntil": -1,
+          "critChance": 0.06,
+          "detonateTimer": "Infinity",
+          "dodgeChance": 0.06,
+          "fallStartY": 4.2,
+          "fiveSecondRule": 103.05,
+          "hp": 74,
+          "id": 968,
+          "kind": "player",
+          "level": 1,
+          "lootFfaTimer": "Infinity",
+          "maxHp": 100,
+          "maxResource": 100,
+          "moveSpeed": 7,
+          "offhandItemId": "eastbrook_buckler",
+          "onGround": true,
+          "overpowerUntil": -1,
+          "petMode": "defensive",
+          "pos": {
+            "x": -5.5,
+            "y": 4.2,
+            "z": 9.5
+          },
+          "potionCooldownUntil": -1,
+          "resourceType": "rage",
+          "spawnPos": {
+            "x": 2,
+            "y": 1.5,
+            "z": -2
+          },
+          "spellPower": 5,
+          "stats": {
+            "agi": 20,
+            "armor": 144,
+            "int": 10,
+            "spi": 11,
+            "sta": 23,
+            "str": 23
+          },
+          "templateId": "warrior",
+          "weapon": {
+            "max": 5,
+            "min": 2,
+            "speed": 2
+          }
+        }
+      ]
+    },
+    {
+      "tick": 81,
+      "time": 4.05,
+      "nextId": 969,
+      "state": "6aa5ce31",
       "events": "c53990e9",
       "rng": {
-        "draws": 2,
-        "digest": "f56e9f11"
+        "draws": 362,
+        "digest": "156325a6"
       },
       "label": "airborne-cover-denied",
       "players": [
@@ -665,6 +1213,9 @@
               "eastbrook_buckler",
               "recruit_tunic",
               "worn_sword"
+            ],
+            "visited": [
+              "poi:eastbrook_vale:eastbrook"
             ]
           },
           "delveClears": {},
@@ -702,7 +1253,7 @@
           "aiState": "idle",
           "attackPower": 10,
           "castTotal": 2,
-          "combatTimer": 101,
+          "combatTimer": 103.05,
           "comboUntil": -1,
           "critChance": 0.0555,
           "detonateTimer": "Infinity",
@@ -758,20 +1309,20 @@
               "id": "battle_stance",
               "kind": "battle_stance",
               "name": "Battle Stance",
-              "remaining": 3598,
+              "remaining": 3595.95,
               "school": "physical",
               "sourceId": 968
             }
           ],
           "blockChance": 0.05,
           "blockValue": 6,
-          "combatTimer": 101,
+          "combatTimer": 103.05,
           "comboUntil": -1,
           "critChance": 0.06,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.06,
           "fallStartY": 7.018047,
-          "fiveSecondRule": 101,
+          "fiveSecondRule": 103.05,
           "hp": 1,
           "id": 968,
           "kind": "player",
@@ -815,14 +1366,14 @@
       ]
     },
     {
-      "tick": 40,
-      "time": 2,
+      "tick": 81,
+      "time": 4.05,
       "nextId": 969,
-      "state": "c67a7528",
+      "state": "6aa5ce31",
       "events": "741638a5",
       "rng": {
-        "draws": 2,
-        "digest": "f56e9f11"
+        "draws": 362,
+        "digest": "156325a6"
       },
       "label": "final",
       "players": [
@@ -913,6 +1464,9 @@
               "eastbrook_buckler",
               "recruit_tunic",
               "worn_sword"
+            ],
+            "visited": [
+              "poi:eastbrook_vale:eastbrook"
             ]
           },
           "delveClears": {},
@@ -950,7 +1504,7 @@
           "aiState": "idle",
           "attackPower": 10,
           "castTotal": 2,
-          "combatTimer": 101,
+          "combatTimer": 103.05,
           "comboUntil": -1,
           "critChance": 0.0555,
           "detonateTimer": "Infinity",
@@ -1006,20 +1560,20 @@
               "id": "battle_stance",
               "kind": "battle_stance",
               "name": "Battle Stance",
-              "remaining": 3598,
+              "remaining": 3595.95,
               "school": "physical",
               "sourceId": 968
             }
           ],
           "blockChance": 0.05,
           "blockValue": 6,
-          "combatTimer": 101,
+          "combatTimer": 103.05,
           "comboUntil": -1,
           "critChance": 0.06,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.06,
           "fallStartY": 7.018047,
-          "fiveSecondRule": 101,
+          "fiveSecondRule": 103.05,
           "hp": 1,
           "id": 968,
           "kind": "player",

--- a/tests/parity/golden/supported_elevation_line_of_sight.json
+++ b/tests/parity/golden/supported_elevation_line_of_sight.json
@@ -1,0 +1,1066 @@
+{
+  "scenario": "supported_elevation_line_of_sight",
+  "seed": 20061,
+  "sampleEvery": 10,
+  "ticks": 40,
+  "coverage": [
+    "Eastbrook standable canopy supplies grounded player eye elevation for a completed heal",
+    "airborne player elevation is rejected behind ordinary open-world cover",
+    "shared Sim cast entry point and completion LOS recheck"
+  ],
+  "draws": 2,
+  "drawDigest": "f56e9f11",
+  "frames": [
+    {
+      "tick": 0,
+      "time": 0,
+      "nextId": 967,
+      "state": "5bc471b0",
+      "events": "741638a5",
+      "rng": {
+        "draws": 0,
+        "digest": "811c9dc5"
+      },
+      "label": "init",
+      "players": [],
+      "entities": []
+    },
+    {
+      "tick": 0,
+      "time": 0,
+      "nextId": 969,
+      "state": "2e819f0a",
+      "events": "f731da68",
+      "rng": {
+        "draws": 0,
+        "digest": "811c9dc5"
+      },
+      "label": "supported-heal-start",
+      "players": [
+        {
+          "activeLoadout": -1,
+          "archetype": {},
+          "arena2v2Rating": 1500,
+          "arenaRating": 1500,
+          "bags": [
+            null,
+            null,
+            null,
+            null
+          ],
+          "bank": {},
+          "bgRating": 1500,
+          "cls": "priest",
+          "companionUpgrades": {},
+          "counters": {},
+          "craftSkills": {},
+          "deedStats": {
+            "counters": {},
+            "dungeonClears": {},
+            "itemsDiscovered": [
+              "apprentice_robe",
+              "baked_bread",
+              "gnarled_staff",
+              "spring_water"
+            ]
+          },
+          "delveClears": {},
+          "delveDaily": {},
+          "entityId": 967,
+          "equipment": {
+            "chest": "apprentice_robe",
+            "mainhand": "gnarled_staff"
+          },
+          "equipmentInstance": {},
+          "gatheringProficiency": {},
+          "heroicDaily": {},
+          "inventory": [
+            {
+              "count": 5,
+              "itemId": "baked_bread"
+            },
+            {
+              "count": 5,
+              "itemId": "spring_water"
+            }
+          ],
+          "mailWelcomed": true,
+          "nodeHarvestReadyAt": {},
+          "recipesGrandfathered": true,
+          "reliquary": {
+            "counts": {},
+            "firstFind": {}
+          },
+          "talents": {
+            "rows": {}
+          },
+          "townFocus": {}
+        },
+        {
+          "activeLoadout": -1,
+          "archetype": {},
+          "arena2v2Rating": 1500,
+          "arenaRating": 1500,
+          "bags": [
+            null,
+            null,
+            null,
+            null
+          ],
+          "bank": {},
+          "bgRating": 1500,
+          "cls": "warrior",
+          "companionUpgrades": {},
+          "counters": {},
+          "craftSkills": {},
+          "deedStats": {
+            "counters": {},
+            "dungeonClears": {},
+            "itemsDiscovered": [
+              "baked_bread",
+              "eastbrook_buckler",
+              "recruit_tunic",
+              "worn_sword"
+            ]
+          },
+          "delveClears": {},
+          "delveDaily": {},
+          "entityId": 968,
+          "equipment": {
+            "chest": "recruit_tunic",
+            "mainhand": "worn_sword",
+            "offhand": "eastbrook_buckler"
+          },
+          "equipmentInstance": {},
+          "gatheringProficiency": {},
+          "heroicDaily": {},
+          "inventory": [
+            {
+              "count": 5,
+              "itemId": "baked_bread"
+            }
+          ],
+          "mailWelcomed": true,
+          "nodeHarvestReadyAt": {},
+          "recipesGrandfathered": true,
+          "reliquary": {
+            "counts": {},
+            "firstFind": {}
+          },
+          "talents": {
+            "rows": {}
+          },
+          "townFocus": {}
+        }
+      ],
+      "entities": [
+        {
+          "aiState": "idle",
+          "attackPower": 10,
+          "castRemaining": 2,
+          "castTargetId": 968,
+          "castTotal": 2,
+          "castingAbility": "lesser_heal",
+          "combatTimer": 99,
+          "comboUntil": -1,
+          "critChance": 0.0555,
+          "detonateTimer": "Infinity",
+          "dodgeChance": 0.0555,
+          "fallStartY": 4.2,
+          "fiveSecondRule": 99,
+          "gcdRemaining": 1.5,
+          "hp": 51,
+          "id": 967,
+          "kind": "player",
+          "level": 1,
+          "lootFfaTimer": "Infinity",
+          "maxHp": 51,
+          "maxResource": 175,
+          "moveSpeed": 7,
+          "onGround": true,
+          "overpowerUntil": -1,
+          "petMode": "defensive",
+          "pos": {
+            "x": -5.5,
+            "y": 4.2,
+            "z": 9.5
+          },
+          "potionCooldownUntil": -1,
+          "resource": 175,
+          "resourceType": "mana",
+          "spawnPos": {
+            "x": 2,
+            "y": 1.5,
+            "z": -2
+          },
+          "spellPower": 12,
+          "stats": {
+            "agi": 11,
+            "armor": 50,
+            "int": 23,
+            "spi": 24,
+            "sta": 13,
+            "str": 10
+          },
+          "templateId": "priest",
+          "weapon": {
+            "max": 6,
+            "min": 3,
+            "speed": 2.9
+          }
+        },
+        {
+          "aiState": "idle",
+          "attackPower": 46,
+          "auras": [
+            {
+              "duration": 3600,
+              "id": "battle_stance",
+              "kind": "battle_stance",
+              "name": "Battle Stance",
+              "remaining": 3600,
+              "school": "physical",
+              "sourceId": 968
+            }
+          ],
+          "blockChance": 0.05,
+          "blockValue": 6,
+          "combatTimer": 99,
+          "comboUntil": -1,
+          "critChance": 0.06,
+          "detonateTimer": "Infinity",
+          "dodgeChance": 0.06,
+          "fallStartY": 1.499559,
+          "fiveSecondRule": 99,
+          "hp": 1,
+          "id": 968,
+          "kind": "player",
+          "level": 1,
+          "lootFfaTimer": "Infinity",
+          "maxHp": 100,
+          "maxResource": 100,
+          "moveSpeed": 7,
+          "offhandItemId": "eastbrook_buckler",
+          "onGround": true,
+          "overpowerUntil": -1,
+          "petMode": "defensive",
+          "pos": {
+            "x": -5.5,
+            "y": 1.499559,
+            "z": 17.5
+          },
+          "potionCooldownUntil": -1,
+          "resourceType": "rage",
+          "spawnPos": {
+            "x": 2,
+            "y": 1.5,
+            "z": -2
+          },
+          "spellPower": 5,
+          "stats": {
+            "agi": 20,
+            "armor": 144,
+            "int": 10,
+            "spi": 11,
+            "sta": 23,
+            "str": 23
+          },
+          "templateId": "warrior",
+          "weapon": {
+            "max": 5,
+            "min": 2,
+            "speed": 2
+          }
+        }
+      ]
+    },
+    {
+      "tick": 10,
+      "time": 0.5,
+      "nextId": 969,
+      "state": "d3bde76d",
+      "events": "741638a5",
+      "rng": {
+        "draws": 0,
+        "digest": "811c9dc5"
+      }
+    },
+    {
+      "tick": 20,
+      "time": 1,
+      "nextId": 969,
+      "state": "f8941292",
+      "events": "d595937a",
+      "rng": {
+        "draws": 0,
+        "digest": "811c9dc5"
+      }
+    },
+    {
+      "tick": 30,
+      "time": 1.5,
+      "nextId": 969,
+      "state": "4b0796ed",
+      "events": "741638a5",
+      "rng": {
+        "draws": 0,
+        "digest": "811c9dc5"
+      }
+    },
+    {
+      "tick": 40,
+      "time": 2,
+      "nextId": 969,
+      "state": "07cb34d6",
+      "events": "6cd16806",
+      "rng": {
+        "draws": 2,
+        "digest": "f56e9f11"
+      }
+    },
+    {
+      "tick": 40,
+      "time": 2,
+      "nextId": 969,
+      "state": "07cb34d6",
+      "events": "741638a5",
+      "rng": {
+        "draws": 2,
+        "digest": "f56e9f11"
+      },
+      "label": "supported-heal-complete",
+      "players": [
+        {
+          "activeLoadout": -1,
+          "archetype": {},
+          "arena2v2Rating": 1500,
+          "arenaRating": 1500,
+          "bags": [
+            null,
+            null,
+            null,
+            null
+          ],
+          "bank": {},
+          "bgRating": 1500,
+          "cls": "priest",
+          "companionUpgrades": {},
+          "counters": {},
+          "craftSkills": {},
+          "deedStats": {
+            "counters": {},
+            "dungeonClears": {},
+            "itemsDiscovered": [
+              "apprentice_robe",
+              "baked_bread",
+              "gnarled_staff",
+              "spring_water"
+            ],
+            "visited": [
+              "poi:eastbrook_vale:eastbrook"
+            ]
+          },
+          "delveClears": {},
+          "delveDaily": {},
+          "entityId": 967,
+          "equipment": {
+            "chest": "apprentice_robe",
+            "mainhand": "gnarled_staff"
+          },
+          "equipmentInstance": {},
+          "gatheringProficiency": {},
+          "heroicDaily": {},
+          "inventory": [
+            {
+              "count": 5,
+              "itemId": "baked_bread"
+            },
+            {
+              "count": 5,
+              "itemId": "spring_water"
+            }
+          ],
+          "mailWelcomed": true,
+          "nodeHarvestReadyAt": {},
+          "recipesGrandfathered": true,
+          "reliquary": {
+            "counts": {},
+            "firstFind": {}
+          },
+          "talents": {
+            "rows": {}
+          },
+          "townFocus": {}
+        },
+        {
+          "activeLoadout": -1,
+          "archetype": {},
+          "arena2v2Rating": 1500,
+          "arenaRating": 1500,
+          "bags": [
+            null,
+            null,
+            null,
+            null
+          ],
+          "bank": {},
+          "bgRating": 1500,
+          "cls": "warrior",
+          "companionUpgrades": {},
+          "counters": {},
+          "craftSkills": {},
+          "deedStats": {
+            "counters": {},
+            "dungeonClears": {},
+            "itemsDiscovered": [
+              "baked_bread",
+              "eastbrook_buckler",
+              "recruit_tunic",
+              "worn_sword"
+            ]
+          },
+          "delveClears": {},
+          "delveDaily": {},
+          "entityId": 968,
+          "equipment": {
+            "chest": "recruit_tunic",
+            "mainhand": "worn_sword",
+            "offhand": "eastbrook_buckler"
+          },
+          "equipmentInstance": {},
+          "gatheringProficiency": {},
+          "heroicDaily": {},
+          "inventory": [
+            {
+              "count": 5,
+              "itemId": "baked_bread"
+            }
+          ],
+          "mailWelcomed": true,
+          "nodeHarvestReadyAt": {},
+          "recipesGrandfathered": true,
+          "reliquary": {
+            "counts": {},
+            "firstFind": {}
+          },
+          "talents": {
+            "rows": {}
+          },
+          "townFocus": {}
+        }
+      ],
+      "entities": [
+        {
+          "aiState": "idle",
+          "attackPower": 10,
+          "castTotal": 2,
+          "combatTimer": 101,
+          "comboUntil": -1,
+          "critChance": 0.0555,
+          "detonateTimer": "Infinity",
+          "dodgeChance": 0.0555,
+          "fallStartY": 4.2,
+          "fiveSecondRule": 0.05,
+          "hp": 51,
+          "id": 967,
+          "kind": "player",
+          "level": 1,
+          "lootFfaTimer": "Infinity",
+          "maxHp": 51,
+          "maxResource": 175,
+          "moveSpeed": 7,
+          "onGround": true,
+          "overpowerUntil": -1,
+          "petMode": "defensive",
+          "pos": {
+            "x": -5.5,
+            "y": 4.2,
+            "z": 9.5
+          },
+          "potionCooldownUntil": -1,
+          "resource": 149,
+          "resourceType": "mana",
+          "spawnPos": {
+            "x": 2,
+            "y": 1.5,
+            "z": -2
+          },
+          "spellPower": 12,
+          "stats": {
+            "agi": 11,
+            "armor": 50,
+            "int": 23,
+            "spi": 24,
+            "sta": 13,
+            "str": 10
+          },
+          "templateId": "priest",
+          "weapon": {
+            "max": 6,
+            "min": 3,
+            "speed": 2.9
+          }
+        },
+        {
+          "aiState": "idle",
+          "attackPower": 46,
+          "auras": [
+            {
+              "duration": 3600,
+              "id": "battle_stance",
+              "kind": "battle_stance",
+              "name": "Battle Stance",
+              "remaining": 3598,
+              "school": "physical",
+              "sourceId": 968
+            }
+          ],
+          "blockChance": 0.05,
+          "blockValue": 6,
+          "combatTimer": 101,
+          "comboUntil": -1,
+          "critChance": 0.06,
+          "detonateTimer": "Infinity",
+          "dodgeChance": 0.06,
+          "fallStartY": 1.499559,
+          "fiveSecondRule": 101,
+          "hp": 74,
+          "id": 968,
+          "kind": "player",
+          "level": 1,
+          "lootFfaTimer": "Infinity",
+          "maxHp": 100,
+          "maxResource": 100,
+          "moveSpeed": 7,
+          "offhandItemId": "eastbrook_buckler",
+          "onGround": true,
+          "overpowerUntil": -1,
+          "petMode": "defensive",
+          "pos": {
+            "x": -5.5,
+            "y": 1.499559,
+            "z": 17.5
+          },
+          "potionCooldownUntil": -1,
+          "resourceType": "rage",
+          "spawnPos": {
+            "x": 2,
+            "y": 1.5,
+            "z": -2
+          },
+          "spellPower": 5,
+          "stats": {
+            "agi": 20,
+            "armor": 144,
+            "int": 10,
+            "spi": 11,
+            "sta": 23,
+            "str": 23
+          },
+          "templateId": "warrior",
+          "weapon": {
+            "max": 5,
+            "min": 2,
+            "speed": 2
+          }
+        }
+      ]
+    },
+    {
+      "tick": 40,
+      "time": 2,
+      "nextId": 969,
+      "state": "c67a7528",
+      "events": "c53990e9",
+      "rng": {
+        "draws": 2,
+        "digest": "f56e9f11"
+      },
+      "label": "airborne-cover-denied",
+      "players": [
+        {
+          "activeLoadout": -1,
+          "archetype": {},
+          "arena2v2Rating": 1500,
+          "arenaRating": 1500,
+          "bags": [
+            null,
+            null,
+            null,
+            null
+          ],
+          "bank": {},
+          "bgRating": 1500,
+          "cls": "priest",
+          "companionUpgrades": {},
+          "counters": {},
+          "craftSkills": {},
+          "deedStats": {
+            "counters": {},
+            "dungeonClears": {},
+            "itemsDiscovered": [
+              "apprentice_robe",
+              "baked_bread",
+              "gnarled_staff",
+              "spring_water"
+            ],
+            "visited": [
+              "poi:eastbrook_vale:eastbrook"
+            ]
+          },
+          "delveClears": {},
+          "delveDaily": {},
+          "entityId": 967,
+          "equipment": {
+            "chest": "apprentice_robe",
+            "mainhand": "gnarled_staff"
+          },
+          "equipmentInstance": {},
+          "gatheringProficiency": {},
+          "heroicDaily": {},
+          "inventory": [
+            {
+              "count": 5,
+              "itemId": "baked_bread"
+            },
+            {
+              "count": 5,
+              "itemId": "spring_water"
+            }
+          ],
+          "mailWelcomed": true,
+          "nodeHarvestReadyAt": {},
+          "recipesGrandfathered": true,
+          "reliquary": {
+            "counts": {},
+            "firstFind": {}
+          },
+          "talents": {
+            "rows": {}
+          },
+          "townFocus": {}
+        },
+        {
+          "activeLoadout": -1,
+          "archetype": {},
+          "arena2v2Rating": 1500,
+          "arenaRating": 1500,
+          "bags": [
+            null,
+            null,
+            null,
+            null
+          ],
+          "bank": {},
+          "bgRating": 1500,
+          "cls": "warrior",
+          "companionUpgrades": {},
+          "counters": {},
+          "craftSkills": {},
+          "deedStats": {
+            "counters": {},
+            "dungeonClears": {},
+            "itemsDiscovered": [
+              "baked_bread",
+              "eastbrook_buckler",
+              "recruit_tunic",
+              "worn_sword"
+            ]
+          },
+          "delveClears": {},
+          "delveDaily": {},
+          "entityId": 968,
+          "equipment": {
+            "chest": "recruit_tunic",
+            "mainhand": "worn_sword",
+            "offhand": "eastbrook_buckler"
+          },
+          "equipmentInstance": {},
+          "gatheringProficiency": {},
+          "heroicDaily": {},
+          "inventory": [
+            {
+              "count": 5,
+              "itemId": "baked_bread"
+            }
+          ],
+          "mailWelcomed": true,
+          "nodeHarvestReadyAt": {},
+          "recipesGrandfathered": true,
+          "reliquary": {
+            "counts": {},
+            "firstFind": {}
+          },
+          "talents": {
+            "rows": {}
+          },
+          "townFocus": {}
+        }
+      ],
+      "entities": [
+        {
+          "aiState": "idle",
+          "attackPower": 10,
+          "castTotal": 2,
+          "combatTimer": 101,
+          "comboUntil": -1,
+          "critChance": 0.0555,
+          "detonateTimer": "Infinity",
+          "dodgeChance": 0.0555,
+          "fallStartY": 6.91393,
+          "fiveSecondRule": 0.05,
+          "hp": 51,
+          "id": 967,
+          "jumping": true,
+          "kind": "player",
+          "level": 1,
+          "lootFfaTimer": "Infinity",
+          "maxHp": 51,
+          "maxResource": 175,
+          "moveSpeed": 7,
+          "overpowerUntil": -1,
+          "petMode": "defensive",
+          "pos": {
+            "x": -224,
+            "y": 6.91393,
+            "z": 200
+          },
+          "potionCooldownUntil": -1,
+          "resource": 175,
+          "resourceType": "mana",
+          "spawnPos": {
+            "x": 2,
+            "y": 1.5,
+            "z": -2
+          },
+          "spellPower": 12,
+          "stats": {
+            "agi": 11,
+            "armor": 50,
+            "int": 23,
+            "spi": 24,
+            "sta": 13,
+            "str": 10
+          },
+          "templateId": "priest",
+          "weapon": {
+            "max": 6,
+            "min": 3,
+            "speed": 2.9
+          }
+        },
+        {
+          "aiState": "idle",
+          "attackPower": 46,
+          "auras": [
+            {
+              "duration": 3600,
+              "id": "battle_stance",
+              "kind": "battle_stance",
+              "name": "Battle Stance",
+              "remaining": 3598,
+              "school": "physical",
+              "sourceId": 968
+            }
+          ],
+          "blockChance": 0.05,
+          "blockValue": 6,
+          "combatTimer": 101,
+          "comboUntil": -1,
+          "critChance": 0.06,
+          "detonateTimer": "Infinity",
+          "dodgeChance": 0.06,
+          "fallStartY": 7.018047,
+          "fiveSecondRule": 101,
+          "hp": 1,
+          "id": 968,
+          "kind": "player",
+          "level": 1,
+          "lootFfaTimer": "Infinity",
+          "maxHp": 100,
+          "maxResource": 100,
+          "moveSpeed": 7,
+          "offhandItemId": "eastbrook_buckler",
+          "onGround": true,
+          "overpowerUntil": -1,
+          "petMode": "defensive",
+          "pos": {
+            "x": -224,
+            "y": 7.018047,
+            "z": 224
+          },
+          "potionCooldownUntil": -1,
+          "resourceType": "rage",
+          "spawnPos": {
+            "x": 2,
+            "y": 1.5,
+            "z": -2
+          },
+          "spellPower": 5,
+          "stats": {
+            "agi": 20,
+            "armor": 144,
+            "int": 10,
+            "spi": 11,
+            "sta": 23,
+            "str": 23
+          },
+          "templateId": "warrior",
+          "weapon": {
+            "max": 5,
+            "min": 2,
+            "speed": 2
+          }
+        }
+      ]
+    },
+    {
+      "tick": 40,
+      "time": 2,
+      "nextId": 969,
+      "state": "c67a7528",
+      "events": "741638a5",
+      "rng": {
+        "draws": 2,
+        "digest": "f56e9f11"
+      },
+      "label": "final",
+      "players": [
+        {
+          "activeLoadout": -1,
+          "archetype": {},
+          "arena2v2Rating": 1500,
+          "arenaRating": 1500,
+          "bags": [
+            null,
+            null,
+            null,
+            null
+          ],
+          "bank": {},
+          "bgRating": 1500,
+          "cls": "priest",
+          "companionUpgrades": {},
+          "counters": {},
+          "craftSkills": {},
+          "deedStats": {
+            "counters": {},
+            "dungeonClears": {},
+            "itemsDiscovered": [
+              "apprentice_robe",
+              "baked_bread",
+              "gnarled_staff",
+              "spring_water"
+            ],
+            "visited": [
+              "poi:eastbrook_vale:eastbrook"
+            ]
+          },
+          "delveClears": {},
+          "delveDaily": {},
+          "entityId": 967,
+          "equipment": {
+            "chest": "apprentice_robe",
+            "mainhand": "gnarled_staff"
+          },
+          "equipmentInstance": {},
+          "gatheringProficiency": {},
+          "heroicDaily": {},
+          "inventory": [
+            {
+              "count": 5,
+              "itemId": "baked_bread"
+            },
+            {
+              "count": 5,
+              "itemId": "spring_water"
+            }
+          ],
+          "mailWelcomed": true,
+          "nodeHarvestReadyAt": {},
+          "recipesGrandfathered": true,
+          "reliquary": {
+            "counts": {},
+            "firstFind": {}
+          },
+          "talents": {
+            "rows": {}
+          },
+          "townFocus": {}
+        },
+        {
+          "activeLoadout": -1,
+          "archetype": {},
+          "arena2v2Rating": 1500,
+          "arenaRating": 1500,
+          "bags": [
+            null,
+            null,
+            null,
+            null
+          ],
+          "bank": {},
+          "bgRating": 1500,
+          "cls": "warrior",
+          "companionUpgrades": {},
+          "counters": {},
+          "craftSkills": {},
+          "deedStats": {
+            "counters": {},
+            "dungeonClears": {},
+            "itemsDiscovered": [
+              "baked_bread",
+              "eastbrook_buckler",
+              "recruit_tunic",
+              "worn_sword"
+            ]
+          },
+          "delveClears": {},
+          "delveDaily": {},
+          "entityId": 968,
+          "equipment": {
+            "chest": "recruit_tunic",
+            "mainhand": "worn_sword",
+            "offhand": "eastbrook_buckler"
+          },
+          "equipmentInstance": {},
+          "gatheringProficiency": {},
+          "heroicDaily": {},
+          "inventory": [
+            {
+              "count": 5,
+              "itemId": "baked_bread"
+            }
+          ],
+          "mailWelcomed": true,
+          "nodeHarvestReadyAt": {},
+          "recipesGrandfathered": true,
+          "reliquary": {
+            "counts": {},
+            "firstFind": {}
+          },
+          "talents": {
+            "rows": {}
+          },
+          "townFocus": {}
+        }
+      ],
+      "entities": [
+        {
+          "aiState": "idle",
+          "attackPower": 10,
+          "castTotal": 2,
+          "combatTimer": 101,
+          "comboUntil": -1,
+          "critChance": 0.0555,
+          "detonateTimer": "Infinity",
+          "dodgeChance": 0.0555,
+          "fallStartY": 6.91393,
+          "fiveSecondRule": 0.05,
+          "hp": 51,
+          "id": 967,
+          "jumping": true,
+          "kind": "player",
+          "level": 1,
+          "lootFfaTimer": "Infinity",
+          "maxHp": 51,
+          "maxResource": 175,
+          "moveSpeed": 7,
+          "overpowerUntil": -1,
+          "petMode": "defensive",
+          "pos": {
+            "x": -224,
+            "y": 6.91393,
+            "z": 200
+          },
+          "potionCooldownUntil": -1,
+          "resource": 175,
+          "resourceType": "mana",
+          "spawnPos": {
+            "x": 2,
+            "y": 1.5,
+            "z": -2
+          },
+          "spellPower": 12,
+          "stats": {
+            "agi": 11,
+            "armor": 50,
+            "int": 23,
+            "spi": 24,
+            "sta": 13,
+            "str": 10
+          },
+          "templateId": "priest",
+          "weapon": {
+            "max": 6,
+            "min": 3,
+            "speed": 2.9
+          }
+        },
+        {
+          "aiState": "idle",
+          "attackPower": 46,
+          "auras": [
+            {
+              "duration": 3600,
+              "id": "battle_stance",
+              "kind": "battle_stance",
+              "name": "Battle Stance",
+              "remaining": 3598,
+              "school": "physical",
+              "sourceId": 968
+            }
+          ],
+          "blockChance": 0.05,
+          "blockValue": 6,
+          "combatTimer": 101,
+          "comboUntil": -1,
+          "critChance": 0.06,
+          "detonateTimer": "Infinity",
+          "dodgeChance": 0.06,
+          "fallStartY": 7.018047,
+          "fiveSecondRule": 101,
+          "hp": 1,
+          "id": 968,
+          "kind": "player",
+          "level": 1,
+          "lootFfaTimer": "Infinity",
+          "maxHp": 100,
+          "maxResource": 100,
+          "moveSpeed": 7,
+          "offhandItemId": "eastbrook_buckler",
+          "onGround": true,
+          "overpowerUntil": -1,
+          "petMode": "defensive",
+          "pos": {
+            "x": -224,
+            "y": 7.018047,
+            "z": 224
+          },
+          "potionCooldownUntil": -1,
+          "resourceType": "rage",
+          "spawnPos": {
+            "x": 2,
+            "y": 1.5,
+            "z": -2
+          },
+          "spellPower": 5,
+          "stats": {
+            "agi": 20,
+            "armor": 144,
+            "int": 10,
+            "spi": 11,
+            "sta": 23,
+            "str": 23
+          },
+          "templateId": "warrior",
+          "weapon": {
+            "max": 5,
+            "min": 2,
+            "speed": 2
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/parity/scenarios.ts
+++ b/tests/parity/scenarios.ts
@@ -5843,6 +5843,7 @@ function supportedElevationLineOfSight(): Scenario {
     name: 'supported_elevation_line_of_sight',
     coverage: [
       'Eastbrook standable canopy supplies grounded player eye elevation for a completed heal',
+      'Eastbrook standable canopy keeps a jumping target visible without granting jump height',
       'airborne player elevation is rejected behind ordinary open-world cover',
       'shared Sim cast entry point and completion LOS recheck',
     ],
@@ -5896,6 +5897,29 @@ function supportedElevationLineOfSight(): Scenario {
       rec.snapshot('supported-heal-start');
       rec.tick(40);
       rec.snapshot('supported-heal-complete');
+
+      place(
+        healer,
+        {
+          x: stall.position.x,
+          y: groundHeight(stall.position.x, stall.position.z + 8, WORLD_SEED),
+          z: stall.position.z + 8,
+        },
+        true,
+      );
+      place(ally, { x: stall.position.x, y: canopyY, z: stall.position.z }, true);
+      ally.hp = 1;
+      healer.resource = healer.maxResource;
+      healer.gcdRemaining = 0;
+      const allyMeta = sim.players.get(allyId);
+      if (!allyMeta) throw new Error('missing line-of-sight ally metadata');
+      allyMeta.moveInput.jump = true;
+      rec.tick();
+      allyMeta.moveInput.jump = false;
+      sim.castAbilityOn('lesser_heal', allyId, healerId);
+      rec.snapshot('canopy-jump-heal-start');
+      rec.tick(40);
+      rec.snapshot('canopy-jump-heal-complete');
 
       const from = { x: -224, z: 200 };
       const to = { x: -224, z: 224 };

--- a/tests/parity/scenarios.ts
+++ b/tests/parity/scenarios.ts
@@ -21,6 +21,7 @@
 // mobSwing, spawnDelveModule), never reaching into not-yet-extracted internals
 // in a way the sim itself does not already expose.
 
+import { supportHeightAt } from '../../src/sim/colliders';
 import {
   arenaOrigin,
   DELVES,
@@ -30,11 +31,13 @@ import {
   PROPS,
   QUESTS,
 } from '../../src/sim/data';
+import { EASTBROOK_LAYOUT } from '../../src/sim/eastbrook_layout';
 import { createMob } from '../../src/sim/entity';
 import type { DelayedEvent } from '../../src/sim/entity_roster';
 import { solveLockActions } from '../../src/sim/lockpick';
 import type { PendingLootRoll } from '../../src/sim/loot/loot_roll';
 import { RIFT_MECHANIC_SPACING_SEC } from '../../src/sim/mob/mechanic_spacing';
+import { PLAYER_BODY_RADIUS } from '../../src/sim/pathfind';
 import { startFishing } from '../../src/sim/professions/fishing';
 import { gatherCastDurationSec, gatherNodeById } from '../../src/sim/professions/gathering';
 import { type ArenaMatch, type PlayerMeta, Sim } from '../../src/sim/sim';
@@ -58,7 +61,8 @@ import {
   type SimEvent,
   xpForLevel,
 } from '../../src/sim/types';
-import { terrainHeight } from '../../src/sim/world';
+import { groundHeight, terrainHeight } from '../../src/sim/world';
+import { WORLD_SEED } from '../../src/sim/world_seed';
 import { runCraft } from '../helpers/enchant_family_cast';
 import { OPEN_FIELD } from '../helpers/open_field';
 import type { Recorder, Scenario } from './record';
@@ -5829,6 +5833,94 @@ function catFormAutoSwing(): Scenario {
   };
 }
 
+// The entity-aware open-world LOS policy must use real supported feet while
+// continuing to reject an airborne source whose lifted ray clears ordinary
+// cover. Both arms run in the shipping world seed so the positive arm uses the
+// exact Eastbrook stall and the negative arm stays on the same deterministic
+// collider set.
+function supportedElevationLineOfSight(): Scenario {
+  return {
+    name: 'supported_elevation_line_of_sight',
+    coverage: [
+      'Eastbrook standable canopy supplies grounded player eye elevation for a completed heal',
+      'airborne player elevation is rejected behind ordinary open-world cover',
+      'shared Sim cast entry point and completion LOS recheck',
+    ],
+    sampleEvery: 10,
+    build: () => new Sim({ seed: WORLD_SEED, playerClass: 'priest', noPlayer: true }),
+    drive(rec: Recorder) {
+      const sim = rec.sim;
+      const healerId = sim.addPlayer('priest', 'ElevatedHealer') as number;
+      const allyId = sim.addPlayer('warrior', 'SightAlly') as number;
+      const healer = requireEntity(sim, healerId, 'elevated healer');
+      const ally = requireEntity(sim, allyId, 'line-of-sight ally');
+      const stall = EASTBROOK_LAYOUT.market.stalls[0];
+      const terrainY = groundHeight(stall.position.x, stall.position.z, WORLD_SEED);
+      const canopyY = supportHeightAt(
+        WORLD_SEED,
+        stall.position.x,
+        stall.position.z,
+        PLAYER_BODY_RADIUS,
+        terrainY + stall.height,
+      );
+      const place = (
+        entity: AnyEntity,
+        pos: { x: number; y: number; z: number },
+        grounded: boolean,
+      ): void => {
+        entity.pos = { ...pos };
+        entity.prevPos = { ...pos };
+        entity.vx = 0;
+        entity.vy = 0;
+        entity.vz = 0;
+        entity.onGround = grounded;
+        entity.jumping = !grounded;
+        entity.fallStartY = pos.y;
+        sim.rebucket(entity);
+      };
+
+      place(healer, { x: stall.position.x, y: canopyY, z: stall.position.z }, true);
+      place(
+        ally,
+        {
+          x: stall.position.x,
+          y: groundHeight(stall.position.x, stall.position.z + 8, WORLD_SEED),
+          z: stall.position.z + 8,
+        },
+        true,
+      );
+      ally.hp = 1;
+      healer.resource = healer.maxResource;
+      healer.gcdRemaining = 0;
+      sim.castAbilityOn('lesser_heal', allyId, healerId);
+      rec.snapshot('supported-heal-start');
+      rec.tick(40);
+      rec.snapshot('supported-heal-complete');
+
+      const from = { x: -224, z: 200 };
+      const to = { x: -224, z: 224 };
+      place(
+        healer,
+        {
+          x: from.x,
+          y: groundHeight(from.x, from.z, WORLD_SEED) + 3,
+          z: from.z,
+        },
+        false,
+      );
+      place(ally, { x: to.x, y: groundHeight(to.x, to.z, WORLD_SEED), z: to.z }, true);
+      ally.hp = 1;
+      healer.resource = healer.maxResource;
+      healer.gcdRemaining = 0;
+      sim.castAbilityOn('lesser_heal', allyId, healerId);
+      rec.snapshot('airborne-cover-denied');
+
+      rec.notes.healerId = healerId;
+      rec.notes.allyId = allyId;
+    },
+  };
+}
+
 export const SCENARIOS: Scenario[] = [
   soloWarrior(),
   soloMage(),
@@ -5897,4 +5989,5 @@ export const SCENARIOS: Scenario[] = [
   riftBossFloor(),
   grixRespawnWindow(),
   catFormAutoSwing(),
+  supportedElevationLineOfSight(),
 ];


### PR DESCRIPTION
## Summary

- Allow open-world line of sight to use authored standable support elevation for player and body endpoints.
- Bound airborne endpoints to `min(actual y, max(terrain, authored support))`, so a real jump from the Eastbrook canopy keeps legitimate sight without ever granting raw jump height over ordinary cover.
- Leave the existing battleground caller-height policy and all instanced dungeon, delve, and arena routing unchanged.
- Route healing, hostile casts, ranged auto-attacks, and resurrection reach through the same deterministic elevation policy.
- Add focused regressions using the shipped Eastbrook stall geometry, a real movement-driven canopy jump, ordinary airborne cover, resurrection, auto-attacks, and a dedicated parity golden.
- Keep the elevation seam minimal: player/body endpoints use the bounded support result directly, and the non-player rule is pinned through the public LOS path.

## Related issues

Fixes #3523

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

### Automated simulation and parity coverage

- `npx vitest run tests/line_of_sight_elevation.test.ts tests/parity/coverage_c.test.ts tests/resurrection_reach.test.ts tests/battleground_band.test.ts tests/architecture.test.ts tests/physics_audit_world.test.ts tests/parkour.test.ts tests/arena.test.ts tests/monolith_budget.test.ts`: 253 passed.
- `npx vitest run tests/parity`: 215 passed, 1 skipped (11 files passed, 1 skipped).
- Added independent public-path pins for the shipped Eastbrook stall, healing and hostile casts, ranged auto-attacks, resurrection, a real movement-driven canopy jump across the full 14-tick arc, ordinary airborne cover denial, non-player endpoints in both directions, battleground cover, and parity goldens.
- Canonical selective Vitest phase: 1,893 files passed, 10 skipped; 29,898 tests passed, 91 skipped.

### Static checks, builds, and host smoke

- `npx tsc --noEmit`: passed.
- `npm run ci:changed`: passed with the repository's existing 308 Biome warnings.
- Pre-push QA floor: 85 passed, 3 skipped; typecheck, guards, lint, and copy rules green.
- Artifact freshness, manifest validation, and the deterministic malware scan in the canonical gate: passed.
- `./node_modules/.bin/turbo run check:types build:env build:server build:bot --ui=stream`: all tasks passed.
- `./node_modules/.bin/turbo run build:bundle --ui=stream`: passed.
- Headless NDJSON smoke: info/reset/action dispatch/close passed.
- `git diff --check`: passed; worktree clean after all checks.

### Browser validation

- Desktop Offline, 1440x900: stood a Priest on the shipped Eastbrook market stall, targeted an injured ally, and used the physical `3` key. Whispered Prayer started and completed, healing 1 to 100 with no line-of-sight denial.
- Desktop negative control: lifted the caster behind ordinary open-world cover with airborne movement state. The cast was denied with `Line of sight.`, while HP, mana, GCD, and casting state remained unchanged.
- True touch mobile context, 844x390 landscape: tapped action slot 3. Whispered Prayer started and completed from the stall, healing 1 to 100 with no page errors.
- True touch mobile context, 390x844 portrait: verified the product's intentional `Rotate to Landscape` gate.

### Canonical gate status

`GATE_SELECT_BASE=upstream/release/v0.40.0 GATE_MAX_WORKERS=2 node scripts/gate_select.mjs` passed all 12 steps from exact PR commit `ef894878d42f2415c5ebca536805b6f6262660ff` in a space-free worktree:

- Non-browser: 1,893 files passed, 10 skipped; 29,898 tests passed, 91 skipped.
- Chromium: 28 files passed; 256 tests passed, including both FXAA tests.
- Typechecks and env/server/bot/bundle builds passed.

The earlier two FXAA failures were traced to a path-sensitive Vitest Browser Mode false failure. When the checkout path contained a space, the test's mocked `GFX.fxaa` value was not applied and the assertions failed before reaching their pixel checks. The same PR commit, dependencies, and Chromium passed from a space-free path; the pristine release base showed the same path-dependent behaviour. No LOS or renderer change was involved.

### Readiness and validation

- [x] Reconciled with the current `release/v0.40.0` base. The branch is 0 commits behind and GitHub reports it mergeable.
- [x] Complete a fully green canonical local gate. All 12 steps passed, including 28 browser files and 256 Chromium tests.
- [x] Run automated desktop and true-touch mobile browser validation, including the airborne-cover negative control and portrait rotation gate.
- [x] Complete human gameplay validation. Confirmed complete by the contributor after review of the desktop success, airborne-denial, and true-touch mobile game sessions.
- GitHub CI was not triggered; a maintainer confirmed that a passing local gate is sufficient for this contribution.

---

## Checklist

### Quality

- [x] **The gate passes.** `gate_select.mjs` passed all 12 steps from exact PR commit `ef894878d`, including 1,893 non-browser files / 29,898 tests and 28 Chromium files / 256 tests.

### Cross-platform

- [x] **Tested on desktop and mobile.** Automated Playwright passed desktop and true-touch landscape mobile; portrait correctly presents the rotate-device gate.
- [ ] ~~**Accessible.**~~ N/A. This host-agnostic simulation change makes no UI or interaction changes.

### Localization (i18n)

- [ ] ~~**New player-visible strings follow the contributor policy.**~~ N/A.
- [ ] ~~Numbers, money, dates, units, and percents go through the i18n formatters.~~ N/A.
- [ ] ~~Player-facing text emitted from `src/sim/` or `server/` is re-localized at the client boundary in this same change.~~ N/A.
- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files such as `src/render/assets/manifest.generated.ts`. They're regenerated by the build.
