### PR TITLE
feat(mail): gate the welcome letter on reaching level 6

### DIFF
--- a/src/sim/combat/damage.ts
+++ b/src/sim/combat/damage.ts
@@ -30,6 +30,7 @@ import { recalcPlayerStats } from '../entity';
 import { DAMAGE_IDLE_DESPAWN_MOB_IDS, DAMAGE_IDLE_DESPAWN_SECONDS } from '../entity_roster';
 import { weaponHand } from '../equipment_rules';
 import { lockNormalDungeonResetOnBossKill, spawnBossExitPortal } from '../instances/dungeons';
+import { maybeSendLevelWelcome } from '../mail/welcome_gate';
 import { spawnWidowHatchlingOnEggDeath } from '../mob/egg_hatchling';
 import { grantAbilityDevotion } from '../paladin_devotion';
 import { PET_AGGRESSIVE_RANGE } from '../pet/pet_ai';
@@ -1810,6 +1811,10 @@ export function grantXp(
   // Dinged to cap mid-grant: clear the leftover from the BAR. It is not lost —
   // the full award was already added to lifetimeXp above (FR-1.4).
   if (p.level >= MAX_LEVEL) meta.xp = 0;
+  // Progression-gated welcome letter: the first ding at or past the gate
+  // books it (a multi-level grant crosses the gate once; the flag makes any
+  // later call a no-op).
+  maybeSendLevelWelcome(ctx, meta, p.level);
 }
 
 // Add to the monotonic lifetime counter, emitting cosmetic virtual-level-up

--- a/src/sim/mail/post_office.ts
+++ b/src/sim/mail/post_office.ts
@@ -18,12 +18,7 @@
 
 import { bagCapacity, canGrantCopies, instancedCountCap } from '../bags';
 import { rekeySigner } from '../character_rename';
-import {
-  HEROIC_MARK_LETTER,
-  type LetterDef,
-  QUEST_LETTERS,
-  WELCOME_LETTER,
-} from '../content/letters';
+import { HEROIC_MARK_LETTER, type LetterDef, QUEST_LETTERS } from '../content/letters';
 import { ITEMS } from '../data';
 import { boundCraftedRecipeIdOnLoad, warnDroppedInstanceKeys } from '../item_instance_load';
 import { itemInstancePayloadsEqual } from '../item_instance_merge';
@@ -690,11 +685,6 @@ export class PostOffice {
       items: (letter.items ?? []).map((s) => ({ ...s })),
       delaySeconds: letter.delaySeconds ?? MAIL_NPC_DELIVERY_SECONDS,
     });
-  }
-
-  // The one-time service letter; the caller flips meta.mailWelcomed.
-  sendWelcome(meta: PlayerMeta): void {
-    this.sendLetter(this.mailKeyFor(meta), meta.name, WELCOME_LETTER, 'system');
   }
 
   // Heroic Marks reward hook (awardHeroicMarks): posts a participant's marks when

--- a/src/sim/mail/welcome_gate.ts
+++ b/src/sim/mail/welcome_gate.ts
@@ -1,0 +1,35 @@
+// The progression gate for the one-time Ravenpost welcome letter (#3560
+// follow-up). The letter used to book at character creation, which minted an
+// immortal letter for every rolled-and-abandoned character; the design rule
+// now is that system letters trigger on progression or attendance, never on
+// account existence. The welcome books the first time a character stands at
+// WELCOME_LETTER_LEVEL or above with the flag unset, whichever path got them
+// there:
+//   - the natural ding (combat/damage.ts grantXp),
+//   - a dev/GM level jump (Sim.setPlayerLevel),
+//   - joining with a restored save already past the gate (Sim.addPlayer):
+//     this is what keeps the letter doubling as the service announcement for
+//     characters saved before mail existed, exactly as the creation-time send
+//     did.
+// Bots never reach the send: addPlayer pre-flips meta.mailWelcomed for them.
+// The flag flips BEFORE the send (the established re-entrancy idiom), and the
+// booking draws no rng, so the gate cannot fork the shared draw stream.
+
+import { WELCOME_LETTER } from '../content/letters';
+import type { PlayerMeta } from '../sim';
+import type { SimContext } from '../sim_context';
+
+export const WELCOME_LETTER_LEVEL = 6;
+
+/** Book the welcome letter if this character just became eligible. Returns
+ *  whether the letter was booked (callers do not branch on it; tests do). */
+export function maybeSendLevelWelcome(
+  ctx: Pick<SimContext, 'mailAuthoredLetter'>,
+  meta: PlayerMeta,
+  level: number,
+): boolean {
+  if (meta.mailWelcomed || level < WELCOME_LETTER_LEVEL) return false;
+  meta.mailWelcomed = true;
+  ctx.mailAuthoredLetter(meta, WELCOME_LETTER);
+  return true;
+}

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -304,6 +304,7 @@ import {
   submitLootRoll as submitLootRollImpl,
 } from './loot/loot_roll';
 import { type MailSave, PostOffice } from './mail/post_office';
+import * as welcomeGate from './mail/welcome_gate';
 import { Market, type MarketListing, type MarketSave } from './market';
 import { defaultMarketQuery, type MarketQuery } from './market_query';
 import { accountCosmeticsWithWornMechChroma } from './mech_chroma_ownership';
@@ -3618,14 +3619,14 @@ export class Sim {
     if (savedState?.pet && petCommands.canRestorePetState(meta, savedState.pet)) {
       this.restorePet(player, savedState.pet);
     }
-    // One-time Ravenpost welcome (doubles as the service announcement for
-    // characters saved before mail existed). Flipped before the send so a
-    // re-entrant save can never double-book the letter. Bots flip WITHOUT the
-    // send: their letters would sit in the shared mail book forever.
-    if (!meta.mailWelcomed) {
-      meta.mailWelcomed = true;
-      if (!opts?.bot) this.postOffice.sendWelcome(meta);
-    }
+    // One-time Ravenpost welcome, gated on progression (level 6): a
+    // rolled-and-abandoned character never mints a letter. Bots pre-flip the
+    // flag WITHOUT ever sending; a restored save already past the gate books
+    // here on join, which keeps the letter doubling as the service
+    // announcement for characters saved before mail existed. Sub-gate
+    // characters get theirs from the ding path (combat/damage.ts grantXp).
+    if (opts?.bot) meta.mailWelcomed = true;
+    welcomeGate.maybeSendLevelWelcome(this.ctx, meta, player.level);
     // Book of Deeds retro-on-join, after the saved state is fully restored:
     // seed the discovery ledger from current holdings, apply the retro
     // fallbacks a predicate cannot express (proof inferences plus the
@@ -5939,6 +5940,8 @@ export class Sim {
     if (r.e.resourceType === 'mana') r.e.resource = r.e.maxResource;
     this.refreshKnownAbilities(r.meta, false);
     this.syncPetLevel(r.e);
+    // A dev/GM jump past the welcome gate books the letter like a live ding.
+    welcomeGate.maybeSendLevelWelcome(this.ctx, r.meta, r.e.level);
     deedsMod.markDeedsDirty(this.ctx, r.meta.entityId); // level/lifetimeXp predicates re-check
   }
 

--- a/tests/guild_letter_online.test.ts
+++ b/tests/guild_letter_online.test.ts
@@ -80,6 +80,10 @@ describe('guild letter over the live GameServer wire (session routing)', () => {
       // Drive the crosser past the threshold on the LIVE server sim (the
       // sweep reads meta.craftSkills; it draws no rng, so no seed hunting).
       const players = (server.sim as unknown as { players: Map<number, PlayerMeta> }).players;
+      // The welcome letter is level-gated (6): level the three humans past it
+      // on the live sim BEFORE any showcase bots stage, so the original
+      // welcome-plus-guild unread shape and the human-vs-bot contrast hold.
+      for (const pid of players.keys()) server.sim.setPlayerLevel(6, pid);
       const meta = players.get(sc.pid);
       if (!meta) throw new Error('no crosser meta');
       meta.craftSkills.weaponcrafting = 13;

--- a/tests/guild_letter_online.test.ts
+++ b/tests/guild_letter_online.test.ts
@@ -74,16 +74,18 @@ describe('guild letter over the live GameServer wire (session routing)', () => {
       const fcOther = fakeWs();
       const fcThird = fakeWs();
       const sc = joinServer(server, fcCross, 81, 'Crosser');
-      joinServer(server, fcOther, 82, 'Watcher');
-      joinServer(server, fcThird, 83, 'Wanderer');
+      const scOther = joinServer(server, fcOther, 82, 'Watcher');
+      const scThird = joinServer(server, fcThird, 83, 'Wanderer');
 
       // Drive the crosser past the threshold on the LIVE server sim (the
       // sweep reads meta.craftSkills; it draws no rng, so no seed hunting).
       const players = (server.sim as unknown as { players: Map<number, PlayerMeta> }).players;
-      // The welcome letter is level-gated (6): level the three humans past it
-      // on the live sim BEFORE any showcase bots stage, so the original
-      // welcome-plus-guild unread shape and the human-vs-bot contrast hold.
-      for (const pid of players.keys()) server.sim.setPlayerLevel(6, pid);
+      // The welcome letter is level-gated (6): level the three named humans
+      // past it on the live sim BEFORE any showcase bots stage, so the
+      // original welcome-plus-guild unread shape and the human-vs-bot
+      // contrast hold. Named pids, not a players.keys() sweep: setPlayerLevel
+      // clamps, so a blanket sweep would demote a seeded above-6 character.
+      for (const s of [sc, scOther, scThird]) server.sim.setPlayerLevel(6, s.pid);
       const meta = players.get(sc.pid);
       if (!meta) throw new Error('no crosser meta');
       meta.craftSkills.weaponcrafting = 13;

--- a/tests/mail.test.ts
+++ b/tests/mail.test.ts
@@ -112,9 +112,13 @@ describe('mailboxes in the world', () => {
 });
 
 describe('the welcome letter', () => {
-  it('greets a new character exactly once, with the enclosed coin', () => {
+  it('greets a new character exactly once, at the level gate, with the enclosed coin', () => {
     const sim = makeWorld();
     const pid = sim.addPlayer('warrior', 'Newbie');
+    // Level-gated (welcome_gate.ts): nothing at creation, the letter on
+    // reaching the gate, and never a second one.
+    expect(sim.mailUnreadFor(pid)).toBe(0);
+    sim.setPlayerLevel(6, pid);
     expect(sim.mailUnreadFor(pid)).toBe(1);
     moveToMailbox(sim, pid);
     const info = sim.mailInfoFor(pid);
@@ -127,6 +131,7 @@ describe('the welcome letter', () => {
   it('is not re-sent to a character whose save says it was already welcomed', () => {
     const sim = makeWorld();
     const pid = sim.addPlayer('warrior', 'Veteran');
+    sim.setPlayerLevel(6, pid); // pass the gate so the save carries the flag
     const state = sim.serializeCharacter(pid);
     expect(state?.mailWelcomed).toBe(true);
     const sim2 = makeWorld();
@@ -140,6 +145,8 @@ describe('sending a letter', () => {
     const sim = makeWorld();
     const alice = sim.addPlayer('warrior', 'Alice');
     const bob = sim.addPlayer('mage', 'Bob');
+    sim.setPlayerLevel(6, alice); // past the welcome gate: the fixture
+    sim.setPlayerLevel(6, bob); // counts assume both welcomes exist
     const aliceMeta = sim.meta(alice);
     if (!aliceMeta) throw new Error('no meta');
     aliceMeta.copper = 10_000;
@@ -175,6 +182,8 @@ describe('sending a letter', () => {
     const sim = makeWorld();
     const alice = sim.addPlayer('warrior', 'Alice');
     const bob = sim.addPlayer('mage', 'Bob');
+    sim.setPlayerLevel(6, alice); // past the welcome gate: the fixture
+    sim.setPlayerLevel(6, bob); // counts assume both welcomes exist
     const aliceMeta = sim.meta(alice);
     if (!aliceMeta) throw new Error('no meta');
     aliceMeta.copper = 100_000;
@@ -656,6 +665,8 @@ describe('persistence and rename', () => {
     const sim = makeWorld();
     const alice = sim.addPlayer('warrior', 'Alice');
     const bob = sim.addPlayer('mage', 'Bob');
+    sim.setPlayerLevel(6, alice); // past the welcome gate: the fixture
+    sim.setPlayerLevel(6, bob); // counts assume both welcomes exist
     const aliceMeta = sim.meta(alice);
     if (!aliceMeta) throw new Error('no meta');
     aliceMeta.copper = 10_000;
@@ -667,6 +678,7 @@ describe('persistence and rename', () => {
     const sim2 = makeWorld();
     sim2.loadMail(JSON.parse(JSON.stringify(save)));
     const bob2 = sim2.addPlayer('mage', 'Bob');
+    sim2.setPlayerLevel(6, bob2); // past the welcome gate in this world too
     // Welcome letter arrives fresh (new character in this world) + the loaded one.
     expect(sim2.mailUnreadFor(bob2)).toBe(2);
     // The already-delivered letter never re-toasts after a load.
@@ -1122,6 +1134,7 @@ describe('purgeMailOwner - deleting a character', () => {
     // The mailbox owner is live here only so the maintained index is observable;
     // the real delete flow is gated on the character being offline.
     const doomed = sim.addPlayer('warrior', 'Doomed', { characterId: DOOMED_ID });
+    sim.setPlayerLevel(6, doomed); // past the welcome gate: the fixture expects the welcome
     const alice = makeSender(sim);
     sim.mailSendResolved({ key: DOOMED_KEY, name: 'Doomed' }, 'Note', 'Just words.', 0, [], alice);
     tickFor(sim, MAIL_DELIVERY_SECONDS + 2);

--- a/tests/mail_bot_welcome.test.ts
+++ b/tests/mail_bot_welcome.test.ts
@@ -1,7 +1,9 @@
 // Bots must never receive mail (issue #3560): every synthetic participant the
 // sim creates (Vale Cup showcase bots, fiesta practice bots, /dev bots) is
-// created with the Ravenpost welcome suppressed, while a real new character
-// still receives exactly one welcome letter. Before this gate existed, every
+// created with the Ravenpost welcome suppressed. The human welcome is
+// level-gated at 6 (tests/mail_welcome_level_gate.test.ts owns that story);
+// here the human is leveled past the gate so every pin keeps the decisive
+// human-gets-mail vs bot-gets-nothing contrast. Before this gate existed, every
 // hourly-ish showcase minted six immortal welcome letters into the shared mail
 // book (134k letters, 85MB of the prod world_state row by 2026-08-22), and the
 // 30s autosave serialized all of it on the main thread.
@@ -23,8 +25,10 @@ function letters(sim: Sim): MailBookLetter[] {
 }
 
 describe('bot players receive no welcome mail', () => {
-  it('a real new character receives exactly one welcome letter', () => {
+  it('a new character books nothing at creation; the gate books it at level 6', () => {
     const sim = makeWorld({ noPlayer: false, playerName: 'Watcher' });
+    expect(letters(sim).length).toBe(0);
+    sim.setPlayerLevel(6);
     const book = letters(sim);
     expect(book.length).toBe(1);
     expect(book[0].letterId).toBe('ravenpost_welcome');
@@ -33,6 +37,7 @@ describe('bot players receive no welcome mail', () => {
 
   it('a 3v3 bot showcase creates zero new letters', () => {
     const sim = makeWorld({ noPlayer: false, playerName: 'Watcher' });
+    sim.setPlayerLevel(6);
     (sim as unknown as { cfg: { valeCupShowcase: boolean } }).cfg.valeCupShowcase = true;
     for (let i = 0; i < 20 * 60 + 2 && !sim.vcup.match; i++) sim.tick();
     // The showcase really staged: six bots are seated.
@@ -56,6 +61,7 @@ describe('bot players receive no welcome mail', () => {
 
   it('a /dev bot spawn creates no letters', () => {
     const sim = makeWorld({ noPlayer: false, playerName: 'Watcher' });
+    sim.setPlayerLevel(6);
     const pid = sim.spawnDevBot('Helper');
     expect(pid).toBeGreaterThan(0);
     const book = letters(sim);
@@ -65,6 +71,7 @@ describe('bot players receive no welcome mail', () => {
 
   it('a fiesta practice set creates no letters for its three bots', () => {
     const sim = makeWorld({ noPlayer: false, playerName: 'Watcher' });
+    sim.setPlayerLevel(6);
     expect(startFiestaPractice(sim)).toBe(true);
     expect(sim.fiestaBotPids.length).toBe(3);
     const book = letters(sim);

--- a/tests/mail_expiry.test.ts
+++ b/tests/mail_expiry.test.ts
@@ -43,6 +43,8 @@ function setupParcel(copper = 500) {
   const sim = makeWorld();
   const alice = sim.addPlayer('warrior', 'Alice');
   const bob = sim.addPlayer('mage', 'Bob');
+  sim.setPlayerLevel(6, alice); // past the welcome gate: fixtures use the letter
+  sim.setPlayerLevel(6, bob);
   const aliceMeta = sim.meta(alice);
   if (!aliceMeta) throw new Error('no meta');
   aliceMeta.copper = 10_000;
@@ -233,6 +235,7 @@ describe('the system and npc exemption', () => {
   it('gives authored parcels no clock at all through the real send paths', () => {
     const sim = makeWorld();
     const pid = sim.addPlayer('warrior', 'Keeper');
+    sim.setPlayerLevel(6, pid); // past the welcome gate: the fixture reads the letter
     const welcome = bookOf(sim).find((m) => m.letterId === WELCOME_LETTER.letterId);
     expect(welcome.kind).toBe('system');
     expect(welcome.copper).toBeGreaterThan(0);
@@ -256,6 +259,7 @@ describe('the system and npc exemption', () => {
   it('the sweep kind filter leaves a non-player parcel alone even past a forced expiry', () => {
     const sim = makeWorld();
     const pid = sim.addPlayer('warrior', 'Keeper');
+    sim.setPlayerLevel(6, pid); // past the welcome gate: the fixture reads the letter
     sim.postOffice.mailHeroicMarks(pid, HEROIC_MARK_ITEM_ID, 3);
     tickFor(sim, 1);
     const marks = bookOf(sim).find((m) => m.letterId === HEROIC_MARK_LETTER.letterId);

--- a/tests/mail_welcome_level_gate.test.ts
+++ b/tests/mail_welcome_level_gate.test.ts
@@ -1,0 +1,104 @@
+// The Ravenpost welcome letter is progression-gated (level 6): a character
+// that never plays never mints a letter, so the shared mail book cannot
+// re-accumulate dead welcome mail the way #3560's bot letters did. The gate
+// has three entry paths (natural ding, dev/GM level jump, join with a
+// restored save already past the gate) and every path books at most once.
+
+import { describe, expect, it, vi } from 'vitest';
+import { WELCOME_LETTER_LEVEL } from '../src/sim/mail/welcome_gate';
+import type { Sim } from '../src/sim/sim';
+import { xpForLevel } from '../src/sim/types';
+import { makeWorld } from './vale_cup_util';
+
+vi.setConfig({ testTimeout: 30000 });
+
+interface MailBookLetter {
+  letterId?: string;
+  recipientName: string;
+}
+
+function welcomes(sim: Sim): MailBookLetter[] {
+  return (sim.serializeMail() as { mail: MailBookLetter[] }).mail.filter(
+    (m) => m.letterId === 'ravenpost_welcome',
+  );
+}
+
+function xpToReach(level: number): number {
+  let total = 0;
+  for (let l = 1; l < level; l++) total += xpForLevel(l);
+  return total;
+}
+
+describe('welcome letter level gate', () => {
+  it('books nothing at character creation', () => {
+    const sim = makeWorld({ noPlayer: false, playerName: 'Fresh' });
+    expect(welcomes(sim).length).toBe(0);
+    expect(sim.players.get(sim.playerId)?.mailWelcomed).toBe(false);
+  });
+
+  it('books nothing below the gate, exactly one at it, and never a second', () => {
+    const sim = makeWorld({ noPlayer: false, playerName: 'Climber' });
+    sim.grantXp(xpToReach(WELCOME_LETTER_LEVEL - 1));
+    expect(sim.entities.get(sim.playerId)?.level).toBe(WELCOME_LETTER_LEVEL - 1);
+    expect(welcomes(sim).length).toBe(0);
+
+    sim.grantXp(xpForLevel(WELCOME_LETTER_LEVEL - 1));
+    expect(sim.entities.get(sim.playerId)?.level).toBe(WELCOME_LETTER_LEVEL);
+    const book = welcomes(sim);
+    expect(book.length).toBe(1);
+    expect(book[0].recipientName).toBe('Climber');
+
+    sim.grantXp(xpForLevel(WELCOME_LETTER_LEVEL));
+    expect(welcomes(sim).length).toBe(1);
+  });
+
+  it('a single multi-level grant across the gate books exactly once', () => {
+    const sim = makeWorld({ noPlayer: false, playerName: 'Rocket' });
+    sim.grantXp(xpToReach(WELCOME_LETTER_LEVEL + 4));
+    expect(sim.entities.get(sim.playerId)?.level).toBe(WELCOME_LETTER_LEVEL + 4);
+    expect(welcomes(sim).length).toBe(1);
+  });
+
+  it('a dev/GM level jump past the gate books it, once', () => {
+    const sim = makeWorld({ noPlayer: false, playerName: 'Jumper' });
+    sim.setPlayerLevel(20);
+    expect(welcomes(sim).length).toBe(1);
+    sim.setPlayerLevel(30);
+    expect(welcomes(sim).length).toBe(1);
+  });
+
+  it('a restored save already past the gate books on join (pre-mail service announcement)', () => {
+    const sim = makeWorld({ noPlayer: false, playerName: 'Oldtimer' });
+    sim.setPlayerLevel(30);
+    const state = sim.serializeCharacter(sim.playerId);
+    if (!state) throw new Error('serializeCharacter returned nothing');
+    // Simulate a save from before mail existed: past the gate, never welcomed.
+    const preMail = { ...state, mailWelcomed: false };
+
+    const restored = makeWorld({});
+    const pid = restored.addPlayer('warrior', 'Oldtimer', { state: preMail });
+    const book = welcomes(restored);
+    expect(book.length).toBe(1);
+    expect(book[0].recipientName).toBe('Oldtimer');
+    expect(restored.players.get(pid)?.mailWelcomed).toBe(true);
+  });
+
+  it('a restored sub-gate save books nothing on join and books on its later ding', () => {
+    const sim = makeWorld({ noPlayer: false, playerName: 'Sprout' });
+    const state = sim.serializeCharacter(sim.playerId);
+    if (!state) throw new Error('serializeCharacter returned nothing');
+
+    const restored = makeWorld({});
+    const pid = restored.addPlayer('warrior', 'Sprout', { state });
+    expect(welcomes(restored).length).toBe(0);
+    restored.setPlayerLevel(WELCOME_LETTER_LEVEL, pid);
+    expect(welcomes(restored).length).toBe(1);
+  });
+
+  it('a bot leveled past the gate never books (the bot pre-flip holds)', () => {
+    const sim = makeWorld({});
+    const pid = sim.addPlayer('mage', 'Botty', { bot: true });
+    sim.setPlayerLevel(20, pid);
+    expect(welcomes(sim).length).toBe(0);
+  });
+});

--- a/tests/mail_welcome_level_gate.test.ts
+++ b/tests/mail_welcome_level_gate.test.ts
@@ -83,7 +83,7 @@ describe('welcome letter level gate', () => {
     expect(restored.players.get(pid)?.mailWelcomed).toBe(true);
   });
 
-  it('a restored sub-gate save books nothing on join and books on its later ding', () => {
+  it('a restored sub-gate save books nothing on join and books when it later crosses the gate', () => {
     const sim = makeWorld({ noPlayer: false, playerName: 'Sprout' });
     const state = sim.serializeCharacter(sim.playerId);
     if (!state) throw new Error('serializeCharacter returned nothing');

--- a/tests/mail_wire_cache.test.ts
+++ b/tests/mail_wire_cache.test.ts
@@ -62,6 +62,7 @@ const bookOf = (sim: Sim): any[] => (sim.postOffice as any).mail;
 
 function makeSender(sim: Sim, name = 'Alice'): number {
   const pid = sim.addPlayer('warrior', name);
+  sim.setPlayerLevel(6, pid); // past the welcome gate: these fixtures use the letter
   const meta = sim.meta(pid);
   if (!meta) throw new Error('no meta');
   meta.copper = 10_000;
@@ -73,6 +74,7 @@ describe('the mail revision signal (mailRevFor)', () => {
   it('is null away from a raven pillar and a number beside one', () => {
     const sim = makeWorld();
     const pid = sim.addPlayer('warrior', 'Postie');
+    sim.setPlayerLevel(6, pid); // past the welcome gate: these fixtures use the letter
     // The town spawn point sits within mail range of its pillar, so walk out
     // of range first: the null arm must be pinned away from every mailbox.
     moveAwayFromMailboxes(sim, pid);
@@ -86,6 +88,7 @@ describe('the mail revision signal (mailRevFor)', () => {
   it('holds steady across idle ticks while nothing changes', () => {
     const sim = makeWorld();
     const pid = sim.addPlayer('warrior', 'Postie');
+    sim.setPlayerLevel(6, pid); // past the welcome gate: these fixtures use the letter
     moveToMailbox(sim, pid);
     // Settle the welcome letter's announce sweep first (announced is a
     // runtime flag, not a view change, and must not advance the revision).
@@ -99,6 +102,7 @@ describe('the mail revision signal (mailRevFor)', () => {
     const sim = makeWorld();
     const alice = makeSender(sim);
     const bob = sim.addPlayer('mage', 'Bob');
+    sim.setPlayerLevel(6, bob); // past the welcome gate: these fixtures use the letter
     tickFor(sim, 2);
 
     // Booking: the sender pays postage, the letter enters the book in flight.
@@ -140,6 +144,7 @@ describe('the mail revision signal (mailRevFor)', () => {
     const sim = makeWorld();
     const alice = makeSender(sim);
     const bob = sim.addPlayer('mage', 'Bob');
+    sim.setPlayerLevel(6, bob); // past the welcome gate: these fixtures use the letter
     sim.mailSendResolved({ key: String(bob), name: 'Bob' }, 'Coin', 'Words.', 40, [], alice);
     tickFor(sim, MAIL_DELIVERY_SECONDS + 2);
     moveToMailbox(sim, bob);
@@ -169,6 +174,7 @@ describe('the mail revision signal (mailRevFor)', () => {
     const sim = makeWorld();
     const alice = makeSender(sim);
     const bob = sim.addPlayer('mage', 'Bob');
+    sim.setPlayerLevel(6, bob); // past the welcome gate: these fixtures use the letter
     sim.mailSendResolved({ key: String(bob), name: 'Bob' }, 'Plain', 'Words.', 0, [], alice);
     sim.mailSendResolved({ key: String(bob), name: 'Bob' }, 'Coin', 'Yours.', 300, [], alice);
     tickFor(sim, MAIL_DELIVERY_SECONDS + 2);
@@ -213,6 +219,7 @@ describe('the mail revision signal (mailRevFor)', () => {
     const sim = makeWorld();
     const alice = makeSender(sim);
     const bob = sim.addPlayer('mage', 'Bob');
+    sim.setPlayerLevel(6, bob); // past the welcome gate: these fixtures use the letter
     sim.addItem('wolf_fang', 1, alice);
     sim.mailSendResolved(
       { key: String(bob), name: 'Bob' },
@@ -271,6 +278,7 @@ describe('the mail revision signal (mailRevFor)', () => {
 
     const sim2 = makeWorld();
     const bob2 = sim2.addPlayer('mage', 'Bob');
+    sim2.setPlayerLevel(6, bob2); // past the welcome gate: these fixtures use the letter
     const rev = rawRev(sim2);
     sim2.loadMail(save);
     expect(rawRev(sim2)).toBeGreaterThan(rev);
@@ -285,6 +293,7 @@ describe('bucketed deliveredFor vs the whole-book scan', () => {
     const sim = makeWorld();
     const alice = makeSender(sim);
     const bob = sim.addPlayer('mage', 'Bob');
+    sim.setPlayerLevel(6, bob); // past the welcome gate: these fixtures use the letter
     const bobMeta = sim.meta(bob);
     if (!bobMeta) throw new Error('no meta');
     // One letter on the stable id key, one legacy letter keyed by display

--- a/tests/mail_wire_cadence.test.ts
+++ b/tests/mail_wire_cadence.test.ts
@@ -75,6 +75,8 @@ function mailboxServer(): { server: GameServer; fc: FakeClient; session: ClientS
   const server = new GameServer();
   const fc = fakeWs();
   const session = joinServer(server, fc, 71, 'Postie');
+  // Past the welcome gate (level 6): the cadence pins count the welcome letter.
+  server.sim.setPlayerLevel(6, session.pid);
   placeAtMailbox(server, session.pid);
   return { server, fc, session };
 }

--- a/tests/parity/golden/affix_mob.json
+++ b/tests/parity/golden/affix_mob.json
@@ -16,7 +16,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 968,
-      "state": "f3a1d8c8",
+      "state": "35f9b8f7",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -69,7 +69,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {

--- a/tests/parity/golden/bank_round_trip.json
+++ b/tests/parity/golden/bank_round_trip.json
@@ -31,7 +31,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 968,
-      "state": "a1714591",
+      "state": "5b9d6eba",
       "events": "7b009995",
       "rng": {
         "draws": 0,
@@ -89,7 +89,6 @@
               "itemId": "wolf_fang"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -172,7 +171,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 968,
-      "state": "74261b3d",
+      "state": "e5e3b11e",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -240,7 +239,6 @@
               "itemId": "wolf_fang"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -323,7 +321,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 968,
-      "state": "c53e7b2b",
+      "state": "45df9808",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -387,7 +385,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -470,7 +467,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 968,
-      "state": "20e834dd",
+      "state": "705a037e",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -538,7 +535,6 @@
               "itemId": "wolf_fang"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -621,7 +617,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 968,
-      "state": "16626443",
+      "state": "57a80060",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -682,7 +678,6 @@
               "itemId": "wolf_fang"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -765,7 +760,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 968,
-      "state": "10c341a1",
+      "state": "03da616a",
       "events": "1eb1adb2",
       "rng": {
         "draws": 0,
@@ -828,7 +823,6 @@
               "itemId": "wolf_fang"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -911,7 +905,7 @@
       "tick": 2,
       "time": 0.1,
       "nextId": 968,
-      "state": "47a56cdf",
+      "state": "ac8a604c",
       "events": "36534ad5",
       "rng": {
         "draws": 0,
@@ -984,7 +978,6 @@
               "itemId": "wolf_fang"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {

--- a/tests/parity/golden/c3_aura_runner.json
+++ b/tests/parity/golden/c3_aura_runner.json
@@ -17,7 +17,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 968,
-      "state": "25cf2924",
+      "state": "ae278f1b",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -75,7 +75,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {

--- a/tests/parity/golden/card_duel.json
+++ b/tests/parity/golden/card_duel.json
@@ -29,7 +29,7 @@
       "tick": 5,
       "time": 0.25,
       "nextId": 969,
-      "state": "a037f703",
+      "state": "593e7f25",
       "events": "84056da1",
       "rng": {
         "draws": 38,
@@ -40,7 +40,7 @@
       "tick": 10,
       "time": 0.5,
       "nextId": 969,
-      "state": "591e80c8",
+      "state": "05c23b4a",
       "events": "741638a5",
       "rng": {
         "draws": 38,
@@ -51,7 +51,7 @@
       "tick": 15,
       "time": 0.75,
       "nextId": 969,
-      "state": "4828d07e",
+      "state": "19ad6bc8",
       "events": "741638a5",
       "rng": {
         "draws": 38,
@@ -62,8 +62,8 @@
       "tick": 20,
       "time": 1,
       "nextId": 969,
-      "state": "ecfc2a31",
-      "events": "d595937a",
+      "state": "34214345",
+      "events": "741638a5",
       "rng": {
         "draws": 38,
         "digest": "ef472e1d"
@@ -73,7 +73,7 @@
       "tick": 25,
       "time": 1.25,
       "nextId": 969,
-      "state": "b4ff4b36",
+      "state": "7baba40a",
       "events": "741638a5",
       "rng": {
         "draws": 38,
@@ -84,7 +84,7 @@
       "tick": 30,
       "time": 1.5,
       "nextId": 969,
-      "state": "7fe657d7",
+      "state": "651ff41b",
       "events": "741638a5",
       "rng": {
         "draws": 38,
@@ -95,7 +95,7 @@
       "tick": 35,
       "time": 1.75,
       "nextId": 969,
-      "state": "69868b5f",
+      "state": "1f1f9663",
       "events": "741638a5",
       "rng": {
         "draws": 38,
@@ -106,7 +106,7 @@
       "tick": 40,
       "time": 2,
       "nextId": 969,
-      "state": "89dd5842",
+      "state": "68c44016",
       "events": "741638a5",
       "rng": {
         "draws": 38,
@@ -117,7 +117,7 @@
       "tick": 41,
       "time": 2.05,
       "nextId": 969,
-      "state": "a8fbb24f",
+      "state": "3c1e7e93",
       "events": "741638a5",
       "rng": {
         "draws": 44,
@@ -172,7 +172,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -234,7 +233,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {

--- a/tests/parity/golden/chat_social.json
+++ b/tests/parity/golden/chat_social.json
@@ -30,7 +30,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 970,
-      "state": "0d8671e1",
+      "state": "1931908e",
       "events": "55dfa04b",
       "rng": {
         "draws": 0,
@@ -84,7 +84,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -145,7 +144,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -200,7 +198,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -391,7 +388,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 970,
-      "state": "0d8671e1",
+      "state": "1931908e",
       "events": "bb251f35",
       "rng": {
         "draws": 0,
@@ -445,7 +442,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -506,7 +502,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -561,7 +556,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -752,7 +746,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 970,
-      "state": "0d8671e1",
+      "state": "1931908e",
       "events": "e4d6de98",
       "rng": {
         "draws": 0,
@@ -806,7 +800,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -867,7 +860,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -922,7 +914,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1113,7 +1104,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 970,
-      "state": "0d8671e1",
+      "state": "1931908e",
       "events": "9d9cd8d1",
       "rng": {
         "draws": 0,
@@ -1167,7 +1158,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1228,7 +1218,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1283,7 +1272,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1474,7 +1462,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 970,
-      "state": "0d8671e1",
+      "state": "1931908e",
       "events": "40b414dd",
       "rng": {
         "draws": 0,
@@ -1528,7 +1516,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1589,7 +1576,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1644,7 +1630,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1835,7 +1820,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 970,
-      "state": "0d8671e1",
+      "state": "1931908e",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -1889,7 +1874,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1950,7 +1934,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -2005,7 +1988,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {

--- a/tests/parity/golden/delve_companion.json
+++ b/tests/parity/golden/delve_companion.json
@@ -16,7 +16,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 968,
-      "state": "f3a1d8c8",
+      "state": "35f9b8f7",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -69,7 +69,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {

--- a/tests/parity/golden/delve_death.json
+++ b/tests/parity/golden/delve_death.json
@@ -15,7 +15,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 968,
-      "state": "fae50bb5",
+      "state": "f3344ed6",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -67,7 +67,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {

--- a/tests/parity/golden/delve_lockpick.json
+++ b/tests/parity/golden/delve_lockpick.json
@@ -16,7 +16,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 968,
-      "state": "fae50bb5",
+      "state": "f3344ed6",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -68,7 +68,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {

--- a/tests/parity/golden/delve_lockpick_tries_exhausted.json
+++ b/tests/parity/golden/delve_lockpick_tries_exhausted.json
@@ -16,7 +16,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 968,
-      "state": "fae50bb5",
+      "state": "f3344ed6",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -68,7 +68,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {

--- a/tests/parity/golden/delve_progression.json
+++ b/tests/parity/golden/delve_progression.json
@@ -16,7 +16,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 968,
-      "state": "f3a1d8c8",
+      "state": "35f9b8f7",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -69,7 +69,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {

--- a/tests/parity/golden/drowned_litany.json
+++ b/tests/parity/golden/drowned_litany.json
@@ -16,7 +16,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 968,
-      "state": "f3a1d8c8",
+      "state": "35f9b8f7",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -69,7 +69,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {

--- a/tests/parity/golden/duel_to_winner.json
+++ b/tests/parity/golden/duel_to_winner.json
@@ -29,8 +29,8 @@
       "tick": 20,
       "time": 1,
       "nextId": 969,
-      "state": "5c8b8057",
-      "events": "056eff0c",
+      "state": "42231567",
+      "events": "80085ba3",
       "rng": {
         "draws": 0,
         "digest": "811c9dc5"
@@ -40,7 +40,7 @@
       "tick": 40,
       "time": 2,
       "nextId": 969,
-      "state": "e77a6504",
+      "state": "ddf1b0c4",
       "events": "25b22570",
       "rng": {
         "draws": 0,
@@ -51,7 +51,7 @@
       "tick": 60,
       "time": 3,
       "nextId": 969,
-      "state": "7862502d",
+      "state": "a998286d",
       "events": "0d47fc3e",
       "rng": {
         "draws": 137,
@@ -62,7 +62,7 @@
       "tick": 61,
       "time": 3.05,
       "nextId": 969,
-      "state": "6ea4acdc",
+      "state": "d8a4f81c",
       "events": "956db475",
       "rng": {
         "draws": 152,
@@ -118,7 +118,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -181,7 +180,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -313,7 +311,7 @@
       "tick": 61,
       "time": 3.05,
       "nextId": 969,
-      "state": "cc824133",
+      "state": "72857831",
       "events": "cc7b7e87",
       "rng": {
         "draws": 152,
@@ -372,7 +370,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -437,7 +434,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -569,7 +565,7 @@
       "tick": 80,
       "time": 4,
       "nextId": 969,
-      "state": "e8538482",
+      "state": "0ccfd65e",
       "events": "d1ad4fa9",
       "rng": {
         "draws": 305,
@@ -580,7 +576,7 @@
       "tick": 100,
       "time": 5,
       "nextId": 969,
-      "state": "c502d9d5",
+      "state": "6988ef41",
       "events": "741638a5",
       "rng": {
         "draws": 520,
@@ -591,7 +587,7 @@
       "tick": 101,
       "time": 5.05,
       "nextId": 969,
-      "state": "6d5db782",
+      "state": "a90d295e",
       "events": "741638a5",
       "rng": {
         "draws": 527,
@@ -656,7 +652,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -728,7 +723,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {

--- a/tests/parity/golden/dungeon_instances.json
+++ b/tests/parity/golden/dungeon_instances.json
@@ -31,7 +31,7 @@
       "tick": 2,
       "time": 0.1,
       "nextId": 983,
-      "state": "783b8cbc",
+      "state": "dedd4e34",
       "events": "669bce9e",
       "rng": {
         "draws": 39,
@@ -91,7 +91,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -159,7 +158,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -912,7 +910,7 @@
       "tick": 4,
       "time": 0.2,
       "nextId": 983,
-      "state": "4eed8b3c",
+      "state": "adf96002",
       "events": "f15855a9",
       "rng": {
         "draws": 42,
@@ -984,7 +982,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1052,7 +1049,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1796,7 +1792,7 @@
       "tick": 5,
       "time": 0.25,
       "nextId": 983,
-      "state": "f6bb6e99",
+      "state": "f076a1d1",
       "events": "5d57ba27",
       "rng": {
         "draws": 42,
@@ -1807,7 +1803,7 @@
       "tick": 10,
       "time": 0.5,
       "nextId": 983,
-      "state": "26f7ee6b",
+      "state": "64d84703",
       "events": "741638a5",
       "rng": {
         "draws": 42,
@@ -1818,7 +1814,7 @@
       "tick": 15,
       "time": 0.75,
       "nextId": 983,
-      "state": "fcf02a05",
+      "state": "99e8cffd",
       "events": "741638a5",
       "rng": {
         "draws": 42,
@@ -1829,8 +1825,8 @@
       "tick": 20,
       "time": 1,
       "nextId": 983,
-      "state": "00259e6d",
-      "events": "d595937a",
+      "state": "39a35065",
+      "events": "741638a5",
       "rng": {
         "draws": 44,
         "digest": "8329963e"
@@ -1840,7 +1836,7 @@
       "tick": 24,
       "time": 1.2,
       "nextId": 983,
-      "state": "1d1b5b1d",
+      "state": "277649d5",
       "events": "741638a5",
       "rng": {
         "draws": 44,
@@ -1912,7 +1908,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1992,7 +1987,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -2115,7 +2109,7 @@
       "tick": 24,
       "time": 1.2,
       "nextId": 983,
-      "state": "1d1b5b1d",
+      "state": "277649d5",
       "events": "741638a5",
       "rng": {
         "draws": 44,
@@ -2187,7 +2181,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -2267,7 +2260,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {

--- a/tests/parity/golden/dungeon_raid_lockout.json
+++ b/tests/parity/golden/dungeon_raid_lockout.json
@@ -28,7 +28,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 972,
-      "state": "88441736",
+      "state": "5c8ea619",
       "events": "3cf88c8c",
       "rng": {
         "draws": 0,
@@ -82,7 +82,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "questsDone": [
             "q_nythraxis_bound_guardian"
@@ -152,7 +151,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -213,7 +211,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -274,7 +271,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -335,7 +331,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -618,7 +613,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 972,
-      "state": "88441736",
+      "state": "5c8ea619",
       "events": "14125c96",
       "rng": {
         "draws": 0,
@@ -672,7 +667,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "questsDone": [
             "q_nythraxis_bound_guardian"
@@ -742,7 +736,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -803,7 +796,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -864,7 +856,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -925,7 +916,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1208,7 +1198,7 @@
       "tick": 1,
       "time": 0.05,
       "nextId": 972,
-      "state": "490cbed6",
+      "state": "4e36d1db",
       "events": "fb38d615",
       "rng": {
         "draws": 0,
@@ -1268,7 +1258,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "questsDone": [
             "q_nythraxis_bound_guardian"
@@ -1345,7 +1334,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1413,7 +1401,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1481,7 +1468,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1549,7 +1535,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {

--- a/tests/parity/golden/entity_roster.json
+++ b/tests/parity/golden/entity_roster.json
@@ -16,7 +16,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 968,
-      "state": "f3a1d8c8",
+      "state": "35f9b8f7",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -69,7 +69,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {

--- a/tests/parity/golden/fiesta.json
+++ b/tests/parity/golden/fiesta.json
@@ -30,8 +30,8 @@
       "tick": 25,
       "time": 1.25,
       "nextId": 971,
-      "state": "09f0e53d",
-      "events": "589c1631",
+      "state": "d08f2d33",
+      "events": "2729ef58",
       "rng": {
         "draws": 0,
         "digest": "811c9dc5"
@@ -41,7 +41,7 @@
       "tick": 50,
       "time": 2.5,
       "nextId": 971,
-      "state": "282c26e2",
+      "state": "cee29878",
       "events": "b585a892",
       "rng": {
         "draws": 66,
@@ -52,7 +52,7 @@
       "tick": 75,
       "time": 3.75,
       "nextId": 971,
-      "state": "1f93f2c8",
+      "state": "7fd5832e",
       "events": "4aac3c56",
       "rng": {
         "draws": 247,
@@ -63,7 +63,7 @@
       "tick": 100,
       "time": 5,
       "nextId": 971,
-      "state": "db64a351",
+      "state": "30e35757",
       "events": "73428f7e",
       "rng": {
         "draws": 485,
@@ -74,7 +74,7 @@
       "tick": 125,
       "time": 6.25,
       "nextId": 971,
-      "state": "e6de3cf8",
+      "state": "caf880a6",
       "events": "959be81b",
       "rng": {
         "draws": 755,
@@ -85,7 +85,7 @@
       "tick": 150,
       "time": 7.5,
       "nextId": 971,
-      "state": "da71c2e5",
+      "state": "f5b670bb",
       "events": "741638a5",
       "rng": {
         "draws": 1038,
@@ -96,7 +96,7 @@
       "tick": 163,
       "time": 8.15,
       "nextId": 971,
-      "state": "248e8972",
+      "state": "e3156848",
       "events": "8e9ed808",
       "rng": {
         "draws": 1176,
@@ -160,7 +160,6 @@
             }
           ],
           "lifetimeHonor": 20,
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -233,7 +232,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -307,7 +305,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -375,7 +372,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {

--- a/tests/parity/golden/fiesta_midcast_kill.json
+++ b/tests/parity/golden/fiesta_midcast_kill.json
@@ -31,8 +31,8 @@
       "tick": 25,
       "time": 1.25,
       "nextId": 971,
-      "state": "09f0e53d",
-      "events": "f6243a75",
+      "state": "d08f2d33",
+      "events": "21d4c724",
       "rng": {
         "draws": 0,
         "digest": "811c9dc5"
@@ -42,7 +42,7 @@
       "tick": 50,
       "time": 2.5,
       "nextId": 971,
-      "state": "282c26e2",
+      "state": "cee29878",
       "events": "b585a892",
       "rng": {
         "draws": 64,
@@ -53,7 +53,7 @@
       "tick": 75,
       "time": 3.75,
       "nextId": 971,
-      "state": "1f93f2c8",
+      "state": "7fd5832e",
       "events": "4aac3c56",
       "rng": {
         "draws": 280,
@@ -64,7 +64,7 @@
       "tick": 100,
       "time": 5,
       "nextId": 971,
-      "state": "db64a351",
+      "state": "30e35757",
       "events": "73428f7e",
       "rng": {
         "draws": 530,
@@ -75,7 +75,7 @@
       "tick": 101,
       "time": 5.05,
       "nextId": 971,
-      "state": "fce07614",
+      "state": "6fa71e0a",
       "events": "6c4069d1",
       "rng": {
         "draws": 542,
@@ -137,7 +137,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -210,7 +209,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -281,7 +279,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -349,7 +346,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -598,7 +594,7 @@
       "tick": 101,
       "time": 5.05,
       "nextId": 971,
-      "state": "23004fe4",
+      "state": "1d945e26",
       "events": "e0f38cb9",
       "rng": {
         "draws": 542,
@@ -660,7 +656,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -733,7 +728,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -804,7 +798,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -872,7 +865,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1119,7 +1111,7 @@
       "tick": 101,
       "time": 5.05,
       "nextId": 971,
-      "state": "3e821ce9",
+      "state": "71bba937",
       "events": "d67c1707",
       "rng": {
         "draws": 542,
@@ -1184,7 +1176,6 @@
             }
           ],
           "lifetimeHonor": 20,
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1257,7 +1248,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1329,7 +1319,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1397,7 +1386,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1644,7 +1632,7 @@
       "tick": 125,
       "time": 6.25,
       "nextId": 971,
-      "state": "806e3485",
+      "state": "00f00793",
       "events": "741638a5",
       "rng": {
         "draws": 788,
@@ -1655,7 +1643,7 @@
       "tick": 142,
       "time": 7.1,
       "nextId": 971,
-      "state": "4575ae48",
+      "state": "087f91ee",
       "events": "741638a5",
       "rng": {
         "draws": 972,
@@ -1720,7 +1708,6 @@
             }
           ],
           "lifetimeHonor": 20,
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1793,7 +1780,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1865,7 +1851,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1933,7 +1918,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {

--- a/tests/parity/golden/fiesta_powerups.json
+++ b/tests/parity/golden/fiesta_powerups.json
@@ -29,7 +29,7 @@
       "tick": 10,
       "time": 0.5,
       "nextId": 971,
-      "state": "d74478b2",
+      "state": "4925e362",
       "events": "a1c02d48",
       "rng": {
         "draws": 0,
@@ -40,8 +40,8 @@
       "tick": 20,
       "time": 1,
       "nextId": 971,
-      "state": "e57c7e4b",
-      "events": "be03fce4",
+      "state": "2c60b363",
+      "events": "741638a5",
       "rng": {
         "draws": 0,
         "digest": "811c9dc5"
@@ -51,7 +51,7 @@
       "tick": 30,
       "time": 1.5,
       "nextId": 971,
-      "state": "a3a0cc73",
+      "state": "4a37740b",
       "events": "45629ea2",
       "rng": {
         "draws": 0,
@@ -62,7 +62,7 @@
       "tick": 40,
       "time": 2,
       "nextId": 971,
-      "state": "6f42d56c",
+      "state": "651d17ac",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -73,7 +73,7 @@
       "tick": 50,
       "time": 2.5,
       "nextId": 971,
-      "state": "47b09416",
+      "state": "1e5b6426",
       "events": "b585a892",
       "rng": {
         "draws": 58,
@@ -84,7 +84,7 @@
       "tick": 60,
       "time": 3,
       "nextId": 971,
-      "state": "ad86b229",
+      "state": "ef248681",
       "events": "741638a5",
       "rng": {
         "draws": 123,
@@ -95,7 +95,7 @@
       "tick": 70,
       "time": 3.5,
       "nextId": 971,
-      "state": "0263f169",
+      "state": "4b63d4c1",
       "events": "4aac3c56",
       "rng": {
         "draws": 204,
@@ -106,7 +106,7 @@
       "tick": 80,
       "time": 4,
       "nextId": 971,
-      "state": "edc6bdc2",
+      "state": "b5dcb5b2",
       "events": "741638a5",
       "rng": {
         "draws": 295,
@@ -117,7 +117,7 @@
       "tick": 90,
       "time": 4.5,
       "nextId": 971,
-      "state": "f1f65344",
+      "state": "8d144524",
       "events": "73428f7e",
       "rng": {
         "draws": 380,
@@ -128,7 +128,7 @@
       "tick": 100,
       "time": 5,
       "nextId": 971,
-      "state": "0ee7127f",
+      "state": "edfc8857",
       "events": "741638a5",
       "rng": {
         "draws": 481,
@@ -139,7 +139,7 @@
       "tick": 110,
       "time": 5.5,
       "nextId": 971,
-      "state": "030e2d77",
+      "state": "e33fe4ef",
       "events": "2cee4c42",
       "rng": {
         "draws": 581,
@@ -150,7 +150,7 @@
       "tick": 120,
       "time": 6,
       "nextId": 971,
-      "state": "01ab6e0c",
+      "state": "ec6c624c",
       "events": "741638a5",
       "rng": {
         "draws": 684,
@@ -161,7 +161,7 @@
       "tick": 130,
       "time": 6.5,
       "nextId": 971,
-      "state": "b813d7aa",
+      "state": "ee2d17da",
       "events": "741638a5",
       "rng": {
         "draws": 788,
@@ -172,7 +172,7 @@
       "tick": 140,
       "time": 7,
       "nextId": 971,
-      "state": "d3b1b6dd",
+      "state": "be7bc585",
       "events": "741638a5",
       "rng": {
         "draws": 914,
@@ -183,7 +183,7 @@
       "tick": 150,
       "time": 7.5,
       "nextId": 971,
-      "state": "49ada1e1",
+      "state": "a1669399",
       "events": "741638a5",
       "rng": {
         "draws": 1052,
@@ -194,7 +194,7 @@
       "tick": 160,
       "time": 8,
       "nextId": 971,
-      "state": "08d3e392",
+      "state": "602916c2",
       "events": "741638a5",
       "rng": {
         "draws": 1180,
@@ -205,7 +205,7 @@
       "tick": 170,
       "time": 8.5,
       "nextId": 971,
-      "state": "d145cc90",
+      "state": "5f97d1e0",
       "events": "741638a5",
       "rng": {
         "draws": 1303,
@@ -216,7 +216,7 @@
       "tick": 180,
       "time": 9,
       "nextId": 971,
-      "state": "43ddea03",
+      "state": "29c1365b",
       "events": "741638a5",
       "rng": {
         "draws": 1418,
@@ -227,7 +227,7 @@
       "tick": 190,
       "time": 9.5,
       "nextId": 971,
-      "state": "eeb0d397",
+      "state": "b8ec078f",
       "events": "741638a5",
       "rng": {
         "draws": 1545,
@@ -238,7 +238,7 @@
       "tick": 200,
       "time": 10,
       "nextId": 971,
-      "state": "1ec032f0",
+      "state": "f23900c0",
       "events": "741638a5",
       "rng": {
         "draws": 1678,
@@ -249,7 +249,7 @@
       "tick": 210,
       "time": 10.5,
       "nextId": 971,
-      "state": "aa2f356d",
+      "state": "13e3a555",
       "events": "741638a5",
       "rng": {
         "draws": 1753,
@@ -260,7 +260,7 @@
       "tick": 220,
       "time": 11,
       "nextId": 971,
-      "state": "d03c0162",
+      "state": "af8db9d2",
       "events": "741638a5",
       "rng": {
         "draws": 1828,
@@ -271,7 +271,7 @@
       "tick": 230,
       "time": 11.5,
       "nextId": 971,
-      "state": "959827fe",
+      "state": "657994ae",
       "events": "741638a5",
       "rng": {
         "draws": 1898,
@@ -282,7 +282,7 @@
       "tick": 240,
       "time": 12,
       "nextId": 971,
-      "state": "31adf455",
+      "state": "48b14edd",
       "events": "741638a5",
       "rng": {
         "draws": 1968,
@@ -293,7 +293,7 @@
       "tick": 250,
       "time": 12.5,
       "nextId": 971,
-      "state": "ae593917",
+      "state": "b7868d0f",
       "events": "741638a5",
       "rng": {
         "draws": 2019,
@@ -304,7 +304,7 @@
       "tick": 260,
       "time": 13,
       "nextId": 971,
-      "state": "3f6aa58c",
+      "state": "f04339cc",
       "events": "741638a5",
       "rng": {
         "draws": 2082,
@@ -315,7 +315,7 @@
       "tick": 270,
       "time": 13.5,
       "nextId": 971,
-      "state": "4ee6a0e0",
+      "state": "7bf7a730",
       "events": "2a66f9d6",
       "rng": {
         "draws": 2161,
@@ -326,7 +326,7 @@
       "tick": 280,
       "time": 14,
       "nextId": 971,
-      "state": "147f1b27",
+      "state": "f2ddd2df",
       "events": "741638a5",
       "rng": {
         "draws": 2238,
@@ -337,7 +337,7 @@
       "tick": 290,
       "time": 14.5,
       "nextId": 971,
-      "state": "b427de41",
+      "state": "f25fdc79",
       "events": "741638a5",
       "rng": {
         "draws": 2326,
@@ -348,7 +348,7 @@
       "tick": 300,
       "time": 15,
       "nextId": 971,
-      "state": "35be9b46",
+      "state": "2833b996",
       "events": "741638a5",
       "rng": {
         "draws": 2417,
@@ -359,7 +359,7 @@
       "tick": 310,
       "time": 15.5,
       "nextId": 971,
-      "state": "6f6c7772",
+      "state": "b2b2bb22",
       "events": "741638a5",
       "rng": {
         "draws": 2523,
@@ -370,7 +370,7 @@
       "tick": 320,
       "time": 16,
       "nextId": 971,
-      "state": "343f0379",
+      "state": "d3acd891",
       "events": "741638a5",
       "rng": {
         "draws": 2628,
@@ -381,7 +381,7 @@
       "tick": 330,
       "time": 16.5,
       "nextId": 971,
-      "state": "88f16c8b",
+      "state": "a27faea3",
       "events": "741638a5",
       "rng": {
         "draws": 2739,
@@ -392,7 +392,7 @@
       "tick": 340,
       "time": 17,
       "nextId": 971,
-      "state": "7feb5a50",
+      "state": "2b075ea0",
       "events": "741638a5",
       "rng": {
         "draws": 2828,
@@ -403,7 +403,7 @@
       "tick": 350,
       "time": 17.5,
       "nextId": 971,
-      "state": "6b0faba4",
+      "state": "c1207f84",
       "events": "741638a5",
       "rng": {
         "draws": 2932,
@@ -414,7 +414,7 @@
       "tick": 360,
       "time": 18,
       "nextId": 971,
-      "state": "1be94d2b",
+      "state": "91d292c3",
       "events": "741638a5",
       "rng": {
         "draws": 3037,
@@ -425,7 +425,7 @@
       "tick": 370,
       "time": 18.5,
       "nextId": 971,
-      "state": "5ba560dd",
+      "state": "0796ef85",
       "events": "741638a5",
       "rng": {
         "draws": 3103,
@@ -436,7 +436,7 @@
       "tick": 380,
       "time": 19,
       "nextId": 971,
-      "state": "2a22409a",
+      "state": "34e06f4a",
       "events": "741638a5",
       "rng": {
         "draws": 3195,
@@ -447,7 +447,7 @@
       "tick": 390,
       "time": 19.5,
       "nextId": 971,
-      "state": "e06894a6",
+      "state": "ea59fef6",
       "events": "741638a5",
       "rng": {
         "draws": 3276,
@@ -458,7 +458,7 @@
       "tick": 400,
       "time": 20,
       "nextId": 971,
-      "state": "14ff69bd",
+      "state": "a02b5e65",
       "events": "741638a5",
       "rng": {
         "draws": 3382,
@@ -469,7 +469,7 @@
       "tick": 410,
       "time": 20.5,
       "nextId": 971,
-      "state": "a4617f22",
+      "state": "d7b49392",
       "events": "741638a5",
       "rng": {
         "draws": 3473,
@@ -480,7 +480,7 @@
       "tick": 420,
       "time": 21,
       "nextId": 971,
-      "state": "9871a875",
+      "state": "3234fb7d",
       "events": "741638a5",
       "rng": {
         "draws": 3548,
@@ -491,7 +491,7 @@
       "tick": 430,
       "time": 21.5,
       "nextId": 971,
-      "state": "35e529fc",
+      "state": "b23a243c",
       "events": "bcba3848",
       "rng": {
         "draws": 3618,
@@ -502,7 +502,7 @@
       "tick": 440,
       "time": 22,
       "nextId": 971,
-      "state": "9fc37738",
+      "state": "c8e586e8",
       "events": "bcba3848",
       "rng": {
         "draws": 3705,
@@ -513,7 +513,7 @@
       "tick": 450,
       "time": 22.5,
       "nextId": 971,
-      "state": "6b62909f",
+      "state": "6d0a7e77",
       "events": "ab8f5845",
       "rng": {
         "draws": 3776,
@@ -524,7 +524,7 @@
       "tick": 460,
       "time": 23,
       "nextId": 971,
-      "state": "eebba7c6",
+      "state": "8adc2616",
       "events": "bcba3848",
       "rng": {
         "draws": 3864,
@@ -535,7 +535,7 @@
       "tick": 470,
       "time": 23.5,
       "nextId": 971,
-      "state": "44459e14",
+      "state": "61a56564",
       "events": "4b3311f9",
       "rng": {
         "draws": 3945,
@@ -546,7 +546,7 @@
       "tick": 480,
       "time": 24,
       "nextId": 971,
-      "state": "1d322f9f",
+      "state": "e9855b77",
       "events": "6a9595a2",
       "rng": {
         "draws": 4025,
@@ -557,7 +557,7 @@
       "tick": 490,
       "time": 24.5,
       "nextId": 971,
-      "state": "4c74c157",
+      "state": "5040fa19",
       "events": "7b25d3cb",
       "rng": {
         "draws": 4110,
@@ -568,7 +568,7 @@
       "tick": 500,
       "time": 25,
       "nextId": 971,
-      "state": "6e025123",
+      "state": "c6d2cbf5",
       "events": "b82428b3",
       "rng": {
         "draws": 4195,
@@ -579,7 +579,7 @@
       "tick": 510,
       "time": 25.5,
       "nextId": 971,
-      "state": "aaa24994",
+      "state": "ff95be16",
       "events": "b82428b3",
       "rng": {
         "draws": 4273,
@@ -590,7 +590,7 @@
       "tick": 520,
       "time": 26,
       "nextId": 971,
-      "state": "b599d37e",
+      "state": "1a91bf58",
       "events": "b82428b3",
       "rng": {
         "draws": 4381,
@@ -601,7 +601,7 @@
       "tick": 530,
       "time": 26.5,
       "nextId": 971,
-      "state": "981b276d",
+      "state": "88eda957",
       "events": "cc8edcd4",
       "rng": {
         "draws": 4451,
@@ -612,7 +612,7 @@
       "tick": 540,
       "time": 27,
       "nextId": 971,
-      "state": "c9117aba",
+      "state": "e0f719c4",
       "events": "5fe1d1b5",
       "rng": {
         "draws": 4543,
@@ -623,7 +623,7 @@
       "tick": 550,
       "time": 27.5,
       "nextId": 971,
-      "state": "c0c06ab4",
+      "state": "0b1b4736",
       "events": "0a6c5a58",
       "rng": {
         "draws": 4629,
@@ -634,7 +634,7 @@
       "tick": 560,
       "time": 28,
       "nextId": 971,
-      "state": "557f49e3",
+      "state": "e18420b5",
       "events": "83df4250",
       "rng": {
         "draws": 4727,
@@ -645,7 +645,7 @@
       "tick": 570,
       "time": 28.5,
       "nextId": 971,
-      "state": "f066ac2f",
+      "state": "71078951",
       "events": "bcba3848",
       "rng": {
         "draws": 4818,
@@ -656,7 +656,7 @@
       "tick": 573,
       "time": 28.65,
       "nextId": 971,
-      "state": "309edacd",
+      "state": "82348bb7",
       "events": "741638a5",
       "rng": {
         "draws": 4855,
@@ -731,7 +731,6 @@
             }
           ],
           "lifetimeHonor": 20,
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -805,7 +804,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -876,7 +874,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -949,7 +946,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {

--- a/tests/parity/golden/frost_proc_orb.json
+++ b/tests/parity/golden/frost_proc_orb.json
@@ -16,7 +16,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 968,
-      "state": "aeaf2d86",
+      "state": "63255509",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -72,7 +72,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {

--- a/tests/parity/golden/g1b_xp_prestige.json
+++ b/tests/parity/golden/g1b_xp_prestige.json
@@ -17,7 +17,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 968,
-      "state": "f3a1d8c8",
+      "state": "35f9b8f7",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -70,7 +70,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -153,8 +152,8 @@
       "tick": 20,
       "time": 1,
       "nextId": 968,
-      "state": "96df1d0f",
-      "events": "7169815f",
+      "state": "e328f652",
+      "events": "b12edcc7",
       "rng": {
         "draws": 0,
         "digest": "811c9dc5"
@@ -164,7 +163,7 @@
       "tick": 40,
       "time": 2,
       "nextId": 968,
-      "state": "4ca5ab44",
+      "state": "002ecb4d",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -175,7 +174,7 @@
       "tick": 60,
       "time": 3,
       "nextId": 968,
-      "state": "15937063",
+      "state": "8f247c40",
       "events": "741638a5",
       "rng": {
         "draws": 149,
@@ -186,7 +185,7 @@
       "tick": 60,
       "time": 3,
       "nextId": 968,
-      "state": "15937063",
+      "state": "8f247c40",
       "events": "741638a5",
       "rng": {
         "draws": 149,
@@ -245,7 +244,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -330,7 +328,7 @@
       "tick": 60,
       "time": 3,
       "nextId": 968,
-      "state": "f9ef06d2",
+      "state": "7ebd0e1f",
       "events": "ac69ce98",
       "rng": {
         "draws": 149,
@@ -392,7 +390,6 @@
             }
           ],
           "lifetimeXp": 160,
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -478,7 +475,7 @@
       "tick": 60,
       "time": 3,
       "nextId": 968,
-      "state": "76dd532d",
+      "state": "2bd15094",
       "events": "20cbdba1",
       "rng": {
         "draws": 149,
@@ -541,7 +538,6 @@
             }
           ],
           "lifetimeXp": 610,
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {

--- a/tests/parity/golden/grix_respawn_window.json
+++ b/tests/parity/golden/grix_respawn_window.json
@@ -28,7 +28,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 969,
-      "state": "dd15db49",
+      "state": "6d3e203a",
       "events": "0b0ecc41",
       "rng": {
         "draws": 8,
@@ -97,7 +97,6 @@
             }
           ],
           "lifetimeXp": 192,
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -262,7 +261,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 969,
-      "state": "cc17a6da",
+      "state": "25ece991",
       "events": "b1195e3d",
       "rng": {
         "draws": 17,
@@ -331,7 +330,6 @@
             }
           ],
           "lifetimeXp": 384,
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -501,7 +499,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 969,
-      "state": "cc17a6da",
+      "state": "25ece991",
       "events": "741638a5",
       "rng": {
         "draws": 17,
@@ -570,7 +568,6 @@
             }
           ],
           "lifetimeXp": 384,
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {

--- a/tests/parity/golden/hit_rating_heroic_geared.json
+++ b/tests/parity/golden/hit_rating_heroic_geared.json
@@ -14,7 +14,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 968,
-      "state": "75c894bb",
+      "state": "0611e738",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -69,7 +69,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {

--- a/tests/parity/golden/hit_rating_heroic_ungeared.json
+++ b/tests/parity/golden/hit_rating_heroic_ungeared.json
@@ -14,7 +14,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 968,
-      "state": "75c894bb",
+      "state": "0611e738",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -69,7 +69,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {

--- a/tests/parity/golden/hunter_pet.json
+++ b/tests/parity/golden/hunter_pet.json
@@ -15,7 +15,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 968,
-      "state": "2deb07bc",
+      "state": "9b0671f3",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -66,7 +66,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {

--- a/tests/parity/golden/idle_mob_distance_culling.json
+++ b/tests/parity/golden/idle_mob_distance_culling.json
@@ -16,7 +16,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 968,
-      "state": "78dd8755",
+      "state": "3ce3b2b6",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -68,7 +68,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -151,7 +150,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 970,
-      "state": "53c01360",
+      "state": "de9c9c0f",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -203,7 +202,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -363,8 +361,8 @@
       "tick": 20,
       "time": 1,
       "nextId": 970,
-      "state": "31f9953d",
-      "events": "155f3705",
+      "state": "63090b1e",
+      "events": "741638a5",
       "rng": {
         "draws": 0,
         "digest": "811c9dc5"
@@ -374,7 +372,7 @@
       "tick": 40,
       "time": 2,
       "nextId": 970,
-      "state": "0c1101f0",
+      "state": "ca4580ff",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -385,7 +383,7 @@
       "tick": 60,
       "time": 3,
       "nextId": 970,
-      "state": "827ba0cb",
+      "state": "9a7e3e68",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -396,7 +394,7 @@
       "tick": 80,
       "time": 4,
       "nextId": 970,
-      "state": "6a8ad132",
+      "state": "2eacea3d",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -407,7 +405,7 @@
       "tick": 80,
       "time": 4,
       "nextId": 970,
-      "state": "6a8ad132",
+      "state": "2eacea3d",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -462,7 +460,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -625,7 +622,7 @@
       "tick": 80,
       "time": 4,
       "nextId": 970,
-      "state": "6a8ad132",
+      "state": "2eacea3d",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -680,7 +677,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {

--- a/tests/parity/golden/inventory_vendor.json
+++ b/tests/parity/golden/inventory_vendor.json
@@ -35,7 +35,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 968,
-      "state": "6e8c0a5c",
+      "state": "a56996d3",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -88,7 +88,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -171,7 +170,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 968,
-      "state": "7b1598eb",
+      "state": "3e105cc8",
       "events": "c3317951",
       "rng": {
         "draws": 0,
@@ -234,7 +233,6 @@
               "itemId": "minor_healing_potion"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -317,7 +315,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 968,
-      "state": "084f040f",
+      "state": "2287f046",
       "events": "49ddbae5",
       "rng": {
         "draws": 0,
@@ -387,7 +385,6 @@
               "itemId": "roadwardens_helm"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -477,7 +474,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 968,
-      "state": "a27c2996",
+      "state": "8af2424b",
       "events": "102514d7",
       "rng": {
         "draws": 0,
@@ -547,7 +544,6 @@
               "itemId": "cryptbone_helm"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -637,7 +633,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 968,
-      "state": "b465e102",
+      "state": "44b1a04f",
       "events": "5f9a5dce",
       "rng": {
         "draws": 0,
@@ -710,7 +706,6 @@
               "itemId": "roadwardens_helm"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -800,7 +795,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 968,
-      "state": "27857612",
+      "state": "ed3fb07f",
       "events": "9bcf50f7",
       "rng": {
         "draws": 0,
@@ -873,7 +868,6 @@
               "itemId": "roadwardens_helm"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -976,7 +970,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 968,
-      "state": "b13101d1",
+      "state": "21459614",
       "events": "40beaa42",
       "rng": {
         "draws": 0,
@@ -1045,7 +1039,6 @@
               "itemId": "roadwardens_helm"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1148,7 +1141,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 968,
-      "state": "02a75f2a",
+      "state": "489a6517",
       "events": "27eb8fbd",
       "rng": {
         "draws": 0,
@@ -1218,7 +1211,6 @@
               "itemId": "roadwardens_helm"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1331,7 +1323,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 968,
-      "state": "782830b9",
+      "state": "9f45d67c",
       "events": "305fdb61",
       "rng": {
         "draws": 0,
@@ -1405,7 +1397,6 @@
               "itemId": "roadwardens_helm"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1518,7 +1509,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 968,
-      "state": "7a31a2fc",
+      "state": "1adca15d",
       "events": "32424d20",
       "rng": {
         "draws": 0,
@@ -1597,7 +1588,6 @@
               "itemId": "wolf_fang"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1710,7 +1700,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 968,
-      "state": "76de62f1",
+      "state": "c326c71a",
       "events": "e0d370bc",
       "rng": {
         "draws": 0,
@@ -1789,7 +1779,6 @@
               "itemId": "wolf_fang"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1908,7 +1897,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 968,
-      "state": "e15af8c4",
+      "state": "2c97f147",
       "events": "670ccbae",
       "rng": {
         "draws": 0,
@@ -1988,7 +1977,6 @@
               "itemId": "wolf_fang"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -2111,7 +2099,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 968,
-      "state": "8a9e48a7",
+      "state": "c3b1479e",
       "events": "f3111079",
       "rng": {
         "draws": 0,
@@ -2191,7 +2179,6 @@
               "itemId": "wolf_fang"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -2310,7 +2297,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 968,
-      "state": "8a9e48a7",
+      "state": "c3b1479e",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -2390,7 +2377,6 @@
               "itemId": "wolf_fang"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {

--- a/tests/parity/golden/l1_loot_distribution.json
+++ b/tests/parity/golden/l1_loot_distribution.json
@@ -30,7 +30,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 971,
-      "state": "d70875b3",
+      "state": "2567517a",
       "events": "ce8a6a17",
       "rng": {
         "draws": 1,
@@ -92,7 +92,6 @@
               "itemId": "worn_sword"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -157,7 +156,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -218,7 +216,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -471,7 +468,7 @@
       "tick": 1,
       "time": 0.05,
       "nextId": 971,
-      "state": "d66aa5f9",
+      "state": "d8e685d8",
       "events": "e8ed6d45",
       "rng": {
         "draws": 3,
@@ -544,7 +541,6 @@
               "itemId": "greyjaw_hide_boots"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -623,7 +619,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -691,7 +686,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -951,7 +945,7 @@
       "tick": 1,
       "time": 0.05,
       "nextId": 971,
-      "state": "26b3a467",
+      "state": "c4ffb906",
       "events": "d311d24a",
       "rng": {
         "draws": 3,
@@ -1024,7 +1018,6 @@
               "itemId": "greyjaw_hide_boots"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1112,7 +1105,6 @@
               "itemId": "greyjaw_hide_boots"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1187,7 +1179,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1431,7 +1422,7 @@
       "tick": 3,
       "time": 0.15,
       "nextId": 971,
-      "state": "5a2730a4",
+      "state": "019b797d",
       "events": "741638a5",
       "rng": {
         "draws": 3,
@@ -1504,7 +1495,6 @@
               "itemId": "greyjaw_hide_boots"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1592,7 +1582,6 @@
               "itemId": "greyjaw_hide_boots"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1667,7 +1656,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {

--- a/tests/parity/golden/market_round_trip.json
+++ b/tests/parity/golden/market_round_trip.json
@@ -32,7 +32,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 969,
-      "state": "7677c853",
+      "state": "e5343a9d",
       "events": "9807a992",
       "rng": {
         "draws": 0,
@@ -89,7 +89,6 @@
               "itemId": "wolf_fang"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -149,7 +148,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -282,7 +280,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 969,
-      "state": "692930fd",
+      "state": "f6cdf357",
       "events": "66ec7450",
       "rng": {
         "draws": 0,
@@ -339,7 +337,6 @@
               "itemId": "wolf_fang"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -399,7 +396,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -532,7 +528,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 969,
-      "state": "692930fd",
+      "state": "f6cdf357",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -589,7 +585,6 @@
               "itemId": "wolf_fang"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -649,7 +644,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -782,7 +776,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 969,
-      "state": "692930fd",
+      "state": "f6cdf357",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -839,7 +833,6 @@
               "itemId": "wolf_fang"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -899,7 +892,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1032,7 +1024,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 969,
-      "state": "6089d882",
+      "state": "6f1b4902",
       "events": "4fadd61f",
       "rng": {
         "draws": 0,
@@ -1089,7 +1081,6 @@
               "itemId": "wolf_fang"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1154,7 +1145,6 @@
               "itemId": "wolf_fang"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1287,7 +1277,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 969,
-      "state": "6089d882",
+      "state": "6f1b4902",
       "events": "e8a22aaf",
       "rng": {
         "draws": 0,
@@ -1344,7 +1334,6 @@
               "itemId": "wolf_fang"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1409,7 +1398,6 @@
               "itemId": "wolf_fang"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1542,8 +1530,8 @@
       "tick": 20,
       "time": 1,
       "nextId": 969,
-      "state": "14543136",
-      "events": "14f0936f",
+      "state": "69fd16b4",
+      "events": "f189e54c",
       "rng": {
         "draws": 0,
         "digest": "811c9dc5"
@@ -1553,7 +1541,7 @@
       "tick": 20,
       "time": 1,
       "nextId": 969,
-      "state": "14543136",
+      "state": "69fd16b4",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -1613,7 +1601,6 @@
               "itemId": "wolf_fang"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1681,7 +1668,6 @@
               "itemId": "wolf_fang"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1814,7 +1800,7 @@
       "tick": 20,
       "time": 1,
       "nextId": 969,
-      "state": "fc141266",
+      "state": "a0bead24",
       "events": "ee79170f",
       "rng": {
         "draws": 0,
@@ -1877,7 +1863,6 @@
               "itemId": "wolf_fang"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1945,7 +1930,6 @@
               "itemId": "wolf_fang"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -2078,7 +2062,7 @@
       "tick": 20,
       "time": 1,
       "nextId": 969,
-      "state": "fc141266",
+      "state": "a0bead24",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -2141,7 +2125,6 @@
               "itemId": "wolf_fang"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -2209,7 +2192,6 @@
               "itemId": "wolf_fang"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {

--- a/tests/parity/golden/master_loot.json
+++ b/tests/parity/golden/master_loot.json
@@ -32,7 +32,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 972,
-      "state": "85f87b7a",
+      "state": "5729467a",
       "events": "231eadda",
       "rng": {
         "draws": 0,
@@ -86,7 +86,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -147,7 +146,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -204,7 +202,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -265,7 +262,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -558,7 +554,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 972,
-      "state": "85f87b7a",
+      "state": "5729467a",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -612,7 +608,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -673,7 +668,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -730,7 +724,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -791,7 +784,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1084,7 +1076,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 972,
-      "state": "9f50db8a",
+      "state": "8bfee21c",
       "events": "75a24d2b",
       "rng": {
         "draws": 0,
@@ -1138,7 +1130,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1204,7 +1195,6 @@
               "itemId": "greyjaw_hide_boots"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1268,7 +1258,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1329,7 +1318,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1622,7 +1610,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 972,
-      "state": "63622836",
+      "state": "d096a826",
       "events": "20f4b915",
       "rng": {
         "draws": 0,
@@ -1676,7 +1664,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1742,7 +1729,6 @@
               "itemId": "greyjaw_hide_boots"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1811,7 +1797,6 @@
               "itemId": "greyjaw_hide_boots"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1879,7 +1864,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -2172,7 +2156,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 972,
-      "state": "63622836",
+      "state": "d096a826",
       "events": "63506797",
       "rng": {
         "draws": 0,
@@ -2226,7 +2210,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -2292,7 +2275,6 @@
               "itemId": "greyjaw_hide_boots"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -2361,7 +2343,6 @@
               "itemId": "greyjaw_hide_boots"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -2429,7 +2410,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -2722,7 +2702,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 972,
-      "state": "ee9e2844",
+      "state": "33078722",
       "events": "fba9c612",
       "rng": {
         "draws": 4,
@@ -2776,7 +2756,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -2842,7 +2821,6 @@
               "itemId": "greyjaw_hide_boots"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -2911,7 +2889,6 @@
               "itemId": "greyjaw_hide_boots"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -2984,7 +2961,6 @@
               "itemId": "greyjaw_hide_boots"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -3284,7 +3260,7 @@
       "tick": 2,
       "time": 0.1,
       "nextId": 972,
-      "state": "e85d0f41",
+      "state": "568395fb",
       "events": "6b65875a",
       "rng": {
         "draws": 4,
@@ -3344,7 +3320,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -3417,7 +3392,6 @@
               "itemId": "greyjaw_hide_boots"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -3493,7 +3467,6 @@
               "itemId": "greyjaw_hide_boots"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -3573,7 +3546,6 @@
               "itemId": "greyjaw_hide_boots"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {

--- a/tests/parity/golden/mob_lifecycle.json
+++ b/tests/parity/golden/mob_lifecycle.json
@@ -31,7 +31,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 972,
-      "state": "d0ec8a93",
+      "state": "65a0460c",
       "events": "879a477a",
       "rng": {
         "draws": 5,
@@ -91,7 +91,6 @@
             }
           ],
           "lifetimeXp": 84,
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -410,7 +409,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 973,
-      "state": "97d088c4",
+      "state": "2a1d4e9d",
       "events": "646f7d55",
       "rng": {
         "draws": 8,
@@ -476,7 +475,6 @@
             }
           ],
           "lifetimeXp": 198,
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -849,7 +847,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 973,
-      "state": "a38c8766",
+      "state": "1f7ae13b",
       "events": "58ee48fb",
       "rng": {
         "draws": 9,
@@ -916,7 +914,6 @@
             }
           ],
           "lifetimeXp": 198,
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1290,7 +1287,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 975,
-      "state": "4b4c7f86",
+      "state": "855e8bf3",
       "events": "1b8677b6",
       "rng": {
         "draws": 15,
@@ -1357,7 +1354,6 @@
             }
           ],
           "lifetimeXp": 282,
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1774,7 +1770,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 976,
-      "state": "6effe537",
+      "state": "e41cb0f6",
       "events": "4b20f211",
       "rng": {
         "draws": 20,
@@ -1845,7 +1841,6 @@
             }
           ],
           "lifetimeXp": 366,
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -2317,7 +2312,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 976,
-      "state": "6effe537",
+      "state": "e41cb0f6",
       "events": "741638a5",
       "rng": {
         "draws": 20,
@@ -2388,7 +2383,6 @@
             }
           ],
           "lifetimeXp": 366,
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {

--- a/tests/parity/golden/mob_locomotion.json
+++ b/tests/parity/golden/mob_locomotion.json
@@ -32,7 +32,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 970,
-      "state": "dcce338d",
+      "state": "dac738e3",
       "events": "97b252ff",
       "rng": {
         "draws": 5,
@@ -86,7 +86,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -147,7 +146,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -326,7 +324,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 971,
-      "state": "fd47ce67",
+      "state": "90c7a339",
       "events": "9b4738df",
       "rng": {
         "draws": 10,
@@ -380,7 +378,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -441,7 +438,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -684,7 +680,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 972,
-      "state": "a7f6181e",
+      "state": "a55ae014",
       "events": "db67a223",
       "rng": {
         "draws": 15,
@@ -738,7 +734,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -799,7 +794,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1098,7 +1092,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 973,
-      "state": "d1421d08",
+      "state": "8adda94e",
       "events": "741638a5",
       "rng": {
         "draws": 17,
@@ -1152,7 +1146,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1213,7 +1206,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1560,7 +1552,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 974,
-      "state": "6f9864e9",
+      "state": "3fc2fc37",
       "events": "741638a5",
       "rng": {
         "draws": 18,
@@ -1614,7 +1606,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1675,7 +1666,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -2065,7 +2055,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 975,
-      "state": "9445890b",
+      "state": "f79e7649",
       "events": "31f7976f",
       "rng": {
         "draws": 18,
@@ -2119,7 +2109,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -2180,7 +2169,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -2615,7 +2603,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 975,
-      "state": "8e7f40e4",
+      "state": "8923ed1a",
       "events": "741638a5",
       "rng": {
         "draws": 18,
@@ -2669,7 +2657,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -2730,7 +2717,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -3166,7 +3152,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 975,
-      "state": "8e7f40e4",
+      "state": "8923ed1a",
       "events": "741638a5",
       "rng": {
         "draws": 18,
@@ -3220,7 +3206,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -3281,7 +3266,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {

--- a/tests/parity/golden/mob_swing_affixes.json
+++ b/tests/parity/golden/mob_swing_affixes.json
@@ -17,7 +17,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 968,
-      "state": "f3a1d8c8",
+      "state": "35f9b8f7",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -70,7 +70,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {

--- a/tests/parity/golden/mob_targeting.json
+++ b/tests/parity/golden/mob_targeting.json
@@ -31,7 +31,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 971,
-      "state": "35b43f5b",
+      "state": "bdd4c504",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -83,7 +83,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -138,7 +137,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -197,7 +195,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -439,7 +436,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 971,
-      "state": "efea05a6",
+      "state": "1a166d55",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -491,7 +488,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -546,7 +542,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -605,7 +600,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -847,7 +841,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 971,
-      "state": "da4b58de",
+      "state": "7ee5b90d",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -899,7 +893,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -954,7 +947,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1013,7 +1005,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1255,7 +1246,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 971,
-      "state": "c923864d",
+      "state": "2ff1618a",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -1307,7 +1298,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1362,7 +1352,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1421,7 +1410,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1663,7 +1651,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 971,
-      "state": "01124add",
+      "state": "3b9c8bba",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -1715,7 +1703,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1770,7 +1757,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1829,7 +1815,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -2073,7 +2058,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 971,
-      "state": "7c08f641",
+      "state": "728d67f6",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -2125,7 +2110,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -2180,7 +2164,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -2239,7 +2222,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -2483,7 +2465,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 971,
-      "state": "7cbc3e84",
+      "state": "65221d17",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -2535,7 +2517,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -2590,7 +2571,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -2649,7 +2629,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -2892,7 +2871,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 971,
-      "state": "e541fd2a",
+      "state": "780094b1",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -2944,7 +2923,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -2999,7 +2977,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -3058,7 +3035,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -3301,7 +3277,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 971,
-      "state": "76066de1",
+      "state": "277b6e56",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -3353,7 +3329,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -3408,7 +3383,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -3467,7 +3441,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -3695,7 +3668,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 971,
-      "state": "76066de1",
+      "state": "277b6e56",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -3747,7 +3720,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -3802,7 +3774,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -3861,7 +3832,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {

--- a/tests/parity/golden/multi_class_frenzy.json
+++ b/tests/parity/golden/multi_class_frenzy.json
@@ -30,7 +30,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 971,
-      "state": "f12539a3",
+      "state": "4f7230d6",
       "events": "f920b281",
       "rng": {
         "draws": 3,
@@ -86,7 +86,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -149,7 +148,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -208,7 +206,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -479,7 +476,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 971,
-      "state": "6ab7a529",
+      "state": "6b263418",
       "events": "833584f3",
       "rng": {
         "draws": 6,
@@ -535,7 +532,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -598,7 +594,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -657,7 +652,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -928,7 +922,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 971,
-      "state": "7de6dc31",
+      "state": "6f70caa8",
       "events": "833584f3",
       "rng": {
         "draws": 9,
@@ -984,7 +978,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1047,7 +1040,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1106,7 +1098,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1377,7 +1368,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 971,
-      "state": "490bd6bf",
+      "state": "cefb7312",
       "events": "833584f3",
       "rng": {
         "draws": 12,
@@ -1433,7 +1424,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1496,7 +1486,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1555,7 +1544,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1826,7 +1814,7 @@
       "tick": 5,
       "time": 0.25,
       "nextId": 971,
-      "state": "b3892772",
+      "state": "e83da543",
       "events": "1ee1131a",
       "rng": {
         "draws": 15,
@@ -1837,7 +1825,7 @@
       "tick": 10,
       "time": 0.5,
       "nextId": 971,
-      "state": "e642fb3a",
+      "state": "f86fd50b",
       "events": "741638a5",
       "rng": {
         "draws": 15,
@@ -1848,7 +1836,7 @@
       "tick": 10,
       "time": 0.5,
       "nextId": 971,
-      "state": "e642fb3a",
+      "state": "f86fd50b",
       "events": "741638a5",
       "rng": {
         "draws": 15,
@@ -1905,7 +1893,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1968,7 +1955,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -2027,7 +2013,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {

--- a/tests/parity/golden/multi_class_heal.json
+++ b/tests/parity/golden/multi_class_heal.json
@@ -34,7 +34,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 976,
-      "state": "26625cc0",
+      "state": "5727b6f1",
       "events": "4647f9a8",
       "rng": {
         "draws": 6,
@@ -89,7 +89,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -150,7 +149,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -209,7 +207,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -268,7 +265,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -324,7 +320,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -853,7 +848,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 976,
-      "state": "26199e97",
+      "state": "2fefc066",
       "events": "cb403efe",
       "rng": {
         "draws": 6,
@@ -908,7 +903,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -969,7 +963,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1033,7 +1026,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1092,7 +1084,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1148,7 +1139,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1695,7 +1685,7 @@
       "tick": 5,
       "time": 0.25,
       "nextId": 976,
-      "state": "17f0b215",
+      "state": "ceaf66f0",
       "events": "3007b80d",
       "rng": {
         "draws": 10,
@@ -1706,7 +1696,7 @@
       "tick": 8,
       "time": 0.4,
       "nextId": 976,
-      "state": "3a615a79",
+      "state": "4cab3d8c",
       "events": "3007b80d",
       "rng": {
         "draws": 10,
@@ -1761,7 +1751,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1822,7 +1811,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1886,7 +1874,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1945,7 +1932,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -2001,7 +1987,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {

--- a/tests/parity/golden/paladin_consecration.json
+++ b/tests/parity/golden/paladin_consecration.json
@@ -15,7 +15,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 968,
-      "state": "25cf2924",
+      "state": "ae278f1b",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -73,7 +73,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {

--- a/tests/parity/golden/party_loot.json
+++ b/tests/parity/golden/party_loot.json
@@ -28,7 +28,7 @@
       "tick": 3,
       "time": 0.15,
       "nextId": 970,
-      "state": "4269fbd5",
+      "state": "bb1caf1b",
       "events": "e9632ef4",
       "rng": {
         "draws": 2,
@@ -88,7 +88,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -161,7 +160,6 @@
               "itemId": "greyjaw_hide_boots"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {

--- a/tests/parity/golden/party_raid.json
+++ b/tests/parity/golden/party_raid.json
@@ -30,7 +30,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 974,
-      "state": "5523dbb9",
+      "state": "d6f9e82c",
       "events": "bf3c2028",
       "rng": {
         "draws": 0,
@@ -84,7 +84,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -145,7 +144,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -202,7 +200,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -258,7 +255,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -319,7 +315,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -380,7 +375,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -436,7 +430,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -846,7 +839,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 974,
-      "state": "5523dbb9",
+      "state": "d6f9e82c",
       "events": "3ccf37eb",
       "rng": {
         "draws": 0,
@@ -900,7 +893,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -961,7 +953,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1018,7 +1009,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1074,7 +1064,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1135,7 +1124,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1196,7 +1184,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1252,7 +1239,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1662,7 +1648,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 974,
-      "state": "bcd0b77f",
+      "state": "3f7b21b4",
       "events": "e798ce5a",
       "rng": {
         "draws": 0,
@@ -1716,7 +1702,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1777,7 +1762,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1834,7 +1818,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1890,7 +1873,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1951,7 +1933,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -2014,7 +1995,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -2072,7 +2052,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -2482,7 +2461,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 974,
-      "state": "bcd0b77f",
+      "state": "3f7b21b4",
       "events": "8abf71ff",
       "rng": {
         "draws": 0,
@@ -2536,7 +2515,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -2597,7 +2575,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -2654,7 +2631,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -2710,7 +2686,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -2771,7 +2746,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -2834,7 +2808,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -2892,7 +2865,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -3302,7 +3274,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 974,
-      "state": "bcd0b77f",
+      "state": "3f7b21b4",
       "events": "6b489d4d",
       "rng": {
         "draws": 0,
@@ -3356,7 +3328,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -3417,7 +3388,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -3474,7 +3444,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -3530,7 +3499,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -3591,7 +3559,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -3654,7 +3621,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -3712,7 +3678,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -4122,7 +4087,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 974,
-      "state": "bcd0b77f",
+      "state": "3f7b21b4",
       "events": "43c3289a",
       "rng": {
         "draws": 0,
@@ -4176,7 +4141,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -4237,7 +4201,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -4294,7 +4257,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -4350,7 +4312,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -4411,7 +4372,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -4474,7 +4434,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -4532,7 +4491,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -4942,7 +4900,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 974,
-      "state": "bcd0b77f",
+      "state": "3f7b21b4",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -4996,7 +4954,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -5057,7 +5014,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -5114,7 +5070,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -5170,7 +5125,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -5231,7 +5185,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -5294,7 +5247,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -5352,7 +5304,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {

--- a/tests/parity/golden/pet_ai.json
+++ b/tests/parity/golden/pet_ai.json
@@ -17,7 +17,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 968,
-      "state": "2deb07bc",
+      "state": "9b0671f3",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -68,7 +68,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {

--- a/tests/parity/golden/pet_commands.json
+++ b/tests/parity/golden/pet_commands.json
@@ -23,7 +23,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 968,
-      "state": "2deb07bc",
+      "state": "9b0671f3",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -74,7 +74,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {

--- a/tests/parity/golden/player_trade.json
+++ b/tests/parity/golden/player_trade.json
@@ -30,7 +30,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 969,
-      "state": "39f81eb5",
+      "state": "b1ed3bbf",
       "events": "9b9b2dcb",
       "rng": {
         "draws": 0,
@@ -88,7 +88,6 @@
               "itemId": "wolf_fang"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -148,7 +147,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -280,7 +278,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 969,
-      "state": "e91b31ed",
+      "state": "a5dbe703",
       "events": "7217b253",
       "rng": {
         "draws": 0,
@@ -340,7 +338,6 @@
               "itemId": "wolf_fang"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -407,7 +404,6 @@
               "itemId": "wolf_fang"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -539,7 +535,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 969,
-      "state": "e91b31ed",
+      "state": "a5dbe703",
       "events": "49585f51",
       "rng": {
         "draws": 0,
@@ -599,7 +595,6 @@
               "itemId": "wolf_fang"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -666,7 +661,6 @@
               "itemId": "wolf_fang"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -798,7 +792,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 969,
-      "state": "e91b31ed",
+      "state": "a5dbe703",
       "events": "5e110716",
       "rng": {
         "draws": 0,
@@ -858,7 +852,6 @@
               "itemId": "wolf_fang"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -925,7 +918,6 @@
               "itemId": "wolf_fang"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1057,7 +1049,7 @@
       "tick": 1,
       "time": 0.05,
       "nextId": 969,
-      "state": "2b8e21c2",
+      "state": "a662df88",
       "events": "98e68da3",
       "rng": {
         "draws": 0,
@@ -1123,7 +1115,6 @@
               "itemId": "wolf_fang"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1197,7 +1188,6 @@
               "itemId": "wolf_fang"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1331,7 +1321,7 @@
       "tick": 1,
       "time": 0.05,
       "nextId": 969,
-      "state": "2b8e21c2",
+      "state": "a662df88",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -1397,7 +1387,6 @@
               "itemId": "wolf_fang"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1471,7 +1460,6 @@
               "itemId": "wolf_fang"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {

--- a/tests/parity/golden/professions_craft.json
+++ b/tests/parity/golden/professions_craft.json
@@ -19,7 +19,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 968,
-      "state": "78dd8755",
+      "state": "3ce3b2b6",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -71,7 +71,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -154,7 +153,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 968,
-      "state": "6bf72748",
+      "state": "6dc07f77",
       "events": "07ce633b",
       "rng": {
         "draws": 0,
@@ -210,7 +209,6 @@
             "reason": "insufficient_materials",
             "recipeId": "recipe_minor_healing_potion"
           },
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -293,7 +291,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 968,
-      "state": "1fd272d8",
+      "state": "3dd87257",
       "events": "a3a70b1c",
       "rng": {
         "draws": 1,
@@ -367,7 +365,6 @@
             "recipeId": "recipe_minor_healing_potion"
           },
           "lifetimeXp": 24,
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -452,7 +449,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 968,
-      "state": "6905eb7f",
+      "state": "e176f782",
       "events": "b8dabfff",
       "rng": {
         "draws": 2,
@@ -572,7 +569,6 @@
             "recipeId": "recipe_eastbrook_ritual_vestments"
           },
           "lifetimeXp": 24,
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -675,7 +671,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 968,
-      "state": "457240aa",
+      "state": "67d26493",
       "events": "a3a70b1c",
       "rng": {
         "draws": 3,
@@ -793,7 +789,6 @@
             "recipeId": "recipe_eastbrook_ritual_vestments"
           },
           "lifetimeXp": 48,
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -896,7 +891,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 968,
-      "state": "8f9e56fe",
+      "state": "8ce4ac1f",
       "events": "0f312f41",
       "rng": {
         "draws": 3,
@@ -1026,7 +1021,6 @@
             "recipeId": "recipe_eastbrook_ritual_vestments"
           },
           "lifetimeXp": 48,
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1134,7 +1128,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 968,
-      "state": "8f9e56fe",
+      "state": "8ce4ac1f",
       "events": "741638a5",
       "rng": {
         "draws": 3,
@@ -1264,7 +1258,6 @@
             "recipeId": "recipe_eastbrook_ritual_vestments"
           },
           "lifetimeXp": 48,
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {

--- a/tests/parity/golden/professions_fishing_session.json
+++ b/tests/parity/golden/professions_fishing_session.json
@@ -18,7 +18,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 968,
-      "state": "f3a1d8c8",
+      "state": "35f9b8f7",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -71,7 +71,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -154,7 +153,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 968,
-      "state": "4d87330c",
+      "state": "0287ebe3",
       "events": "04788513",
       "rng": {
         "draws": 1,
@@ -212,7 +211,6 @@
               "itemId": "simple_fishing_pole"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -300,8 +298,8 @@
       "tick": 91,
       "time": 4.55,
       "nextId": 968,
-      "state": "116b3e5f",
-      "events": "76f2af40",
+      "state": "b24fdb94",
+      "events": "a995e888",
       "rng": {
         "draws": 1,
         "digest": "acd1c827"
@@ -358,7 +356,6 @@
               "itemId": "simple_fishing_pole"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -446,7 +443,7 @@
       "tick": 91,
       "time": 4.55,
       "nextId": 968,
-      "state": "e00bb4eb",
+      "state": "5a27349c",
       "events": "f450bad9",
       "rng": {
         "draws": 2,
@@ -512,7 +509,6 @@
               "itemId": "raw_river_perch"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "pendingGatherGrants": [
             {
@@ -602,7 +598,7 @@
       "tick": 99,
       "time": 4.95,
       "nextId": 968,
-      "state": "09cd77ba",
+      "state": "f0ba4345",
       "events": "42fd0d47",
       "rng": {
         "draws": 3,
@@ -680,7 +676,6 @@
               "itemId": "raw_river_perch"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {

--- a/tests/parity/golden/professions_gather.json
+++ b/tests/parity/golden/professions_gather.json
@@ -21,7 +21,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 968,
-      "state": "f3a1d8c8",
+      "state": "35f9b8f7",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -74,7 +74,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -157,8 +156,8 @@
       "tick": 51,
       "time": 2.55,
       "nextId": 968,
-      "state": "33e3b8b0",
-      "events": "4f19cddf",
+      "state": "4b596715",
+      "events": "6e58772f",
       "rng": {
         "draws": 2,
         "digest": "00a2a78c"
@@ -249,7 +248,6 @@
             }
           ],
           "lifetimeXp": 21,
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {
             "ore_eastbrook_1": 242.5
           },
@@ -337,7 +335,7 @@
       "tick": 104,
       "time": 5.2,
       "nextId": 968,
-      "state": "d6ce4da2",
+      "state": "01912481",
       "events": "bf5fd9a3",
       "rng": {
         "draws": 4,
@@ -448,7 +446,6 @@
             }
           ],
           "lifetimeXp": 42,
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {
             "ore_eastbrook_1": 242.5,
             "wood_eastbrook_1": 245
@@ -537,7 +534,7 @@
       "tick": 500,
       "time": 25,
       "nextId": 968,
-      "state": "b0bba1a9",
+      "state": "03127160",
       "events": "25b740fb",
       "rng": {
         "draws": 18,
@@ -548,7 +545,7 @@
       "tick": 1000,
       "time": 50,
       "nextId": 968,
-      "state": "594792bb",
+      "state": "fcb47a3e",
       "events": "f39a9e1d",
       "rng": {
         "draws": 38,
@@ -559,7 +556,7 @@
       "tick": 1500,
       "time": 75,
       "nextId": 968,
-      "state": "8ab2af95",
+      "state": "73a572d0",
       "events": "f1cbc05a",
       "rng": {
         "draws": 58,
@@ -570,7 +567,7 @@
       "tick": 2000,
       "time": 100,
       "nextId": 968,
-      "state": "e48ffb66",
+      "state": "d0882bcf",
       "events": "73ae91c9",
       "rng": {
         "draws": 78,
@@ -581,7 +578,7 @@
       "tick": 2500,
       "time": 125,
       "nextId": 968,
-      "state": "bc25f8e9",
+      "state": "2f95ccdc",
       "events": "ec3989e3",
       "rng": {
         "draws": 96,
@@ -592,7 +589,7 @@
       "tick": 3000,
       "time": 150,
       "nextId": 968,
-      "state": "26c60cdd",
+      "state": "3933c554",
       "events": "73ae91c9",
       "rng": {
         "draws": 116,
@@ -603,7 +600,7 @@
       "tick": 3500,
       "time": 175,
       "nextId": 968,
-      "state": "23eaf444",
+      "state": "c1e96853",
       "events": "47d8a866",
       "rng": {
         "draws": 136,
@@ -614,7 +611,7 @@
       "tick": 4000,
       "time": 200,
       "nextId": 968,
-      "state": "0a4dde6b",
+      "state": "d42ccc4e",
       "events": "69e5600d",
       "rng": {
         "draws": 156,
@@ -625,7 +622,7 @@
       "tick": 4500,
       "time": 225,
       "nextId": 968,
-      "state": "cebbc64d",
+      "state": "04053ea2",
       "events": "32e1da52",
       "rng": {
         "draws": 176,
@@ -636,7 +633,7 @@
       "tick": 5000,
       "time": 250,
       "nextId": 968,
-      "state": "67ad1358",
+      "state": "0e2d5497",
       "events": "9a5a5373",
       "rng": {
         "draws": 194,
@@ -647,7 +644,7 @@
       "tick": 5206,
       "time": 260.3,
       "nextId": 968,
-      "state": "86f503ac",
+      "state": "1aac1da7",
       "events": "81f16df5",
       "rng": {
         "draws": 204,
@@ -782,7 +779,6 @@
             }
           ],
           "lifetimeXp": 2022,
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {
             "herb_eastbrook_1": 500.25,
             "ore_eastbrook_1": 242.5,
@@ -878,7 +874,7 @@
       "tick": 5208,
       "time": 260.4,
       "nextId": 968,
-      "state": "3294dd0b",
+      "state": "5b57537c",
       "events": "741638a5",
       "rng": {
         "draws": 204,
@@ -1013,7 +1009,6 @@
             }
           ],
           "lifetimeXp": 2022,
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {
             "herb_eastbrook_1": 500.25,
             "ore_eastbrook_1": 242.5,

--- a/tests/parity/golden/professions_gather_fine.json
+++ b/tests/parity/golden/professions_gather_fine.json
@@ -18,7 +18,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 968,
-      "state": "f3a1d8c8",
+      "state": "35f9b8f7",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -71,7 +71,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -154,8 +153,8 @@
       "tick": 51,
       "time": 2.55,
       "nextId": 968,
-      "state": "e8a78289",
-      "events": "0fab9a55",
+      "state": "aa51acea",
+      "events": "1f9b9a1b",
       "rng": {
         "draws": 2,
         "digest": "00a2a78c"
@@ -245,7 +244,6 @@
             }
           ],
           "lifetimeXp": 36,
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {
             "ore_mirefen_t2": 242.1
           },
@@ -333,7 +331,7 @@
       "tick": 104,
       "time": 5.2,
       "nextId": 968,
-      "state": "49eaff14",
+      "state": "50657e39",
       "events": "ee3f94ed",
       "rng": {
         "draws": 4,
@@ -432,7 +430,6 @@
             }
           ],
           "lifetimeXp": 72,
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {
             "ore_mirefen_1": 244.35,
             "ore_mirefen_t2": 242.1
@@ -521,7 +518,7 @@
       "tick": 157,
       "time": 7.85,
       "nextId": 968,
-      "state": "7b8b1a8b",
+      "state": "c29a971c",
       "events": "76f683cf",
       "rng": {
         "draws": 6,
@@ -629,7 +626,6 @@
             }
           ],
           "lifetimeXp": 108,
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {
             "herb_mirefen_t2": 247.8,
             "ore_mirefen_1": 244.35,
@@ -719,7 +715,7 @@
       "tick": 159,
       "time": 7.95,
       "nextId": 968,
-      "state": "8f30dc86",
+      "state": "e1030b0d",
       "events": "741638a5",
       "rng": {
         "draws": 6,
@@ -827,7 +823,6 @@
             }
           ],
           "lifetimeXp": 108,
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {
             "herb_mirefen_t2": 247.8,
             "ore_mirefen_1": 244.35,

--- a/tests/parity/golden/professions_tool_effect_slot.json
+++ b/tests/parity/golden/professions_tool_effect_slot.json
@@ -23,7 +23,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 968,
-      "state": "f3a1d8c8",
+      "state": "35f9b8f7",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -76,7 +76,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -159,7 +158,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 968,
-      "state": "06cfe796",
+      "state": "7d118bf3",
       "events": "ce7e15ee",
       "rng": {
         "draws": 0,
@@ -223,7 +222,6 @@
               "itemId": "mithril_mining_pick"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -315,8 +313,8 @@
       "tick": 51,
       "time": 2.55,
       "nextId": 968,
-      "state": "a17aa159",
-      "events": "20e14929",
+      "state": "13a0762c",
+      "events": "d0936a19",
       "rng": {
         "draws": 2,
         "digest": "00a2a78c"
@@ -402,7 +400,6 @@
             }
           ],
           "lifetimeXp": 36,
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {
             "ore_mirefen_t2": 242.1
           },
@@ -499,7 +496,7 @@
       "tick": 53,
       "time": 2.65,
       "nextId": 968,
-      "state": "b6cd0c70",
+      "state": "24b6b811",
       "events": "fd57698b",
       "rng": {
         "draws": 2,
@@ -586,7 +583,6 @@
             }
           ],
           "lifetimeXp": 36,
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {
             "ore_mirefen_t2": 242.1
           },
@@ -683,7 +679,7 @@
       "tick": 55,
       "time": 2.75,
       "nextId": 968,
-      "state": "b4d03c62",
+      "state": "d0e7d7cb",
       "events": "df46ced7",
       "rng": {
         "draws": 2,
@@ -770,7 +766,6 @@
             }
           ],
           "lifetimeXp": 36,
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {
             "ore_mirefen_t2": 242.1
           },
@@ -867,7 +862,7 @@
       "tick": 106,
       "time": 5.3,
       "nextId": 968,
-      "state": "c65ba38b",
+      "state": "4bdf25f4",
       "events": "ee3f94ed",
       "rng": {
         "draws": 4,
@@ -962,7 +957,6 @@
             }
           ],
           "lifetimeXp": 72,
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {
             "ore_mirefen_1": 244.45,
             "ore_mirefen_t2": 242.1
@@ -1060,7 +1054,7 @@
       "tick": 157,
       "time": 7.85,
       "nextId": 968,
-      "state": "459356d6",
+      "state": "057d2687",
       "events": "071bc787",
       "rng": {
         "draws": 6,
@@ -1162,7 +1156,6 @@
             }
           ],
           "lifetimeXp": 108,
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {
             "ore_mirefen_1": 244.45,
             "ore_mirefen_t2": 242.1,
@@ -1261,7 +1254,7 @@
       "tick": 159,
       "time": 7.95,
       "nextId": 968,
-      "state": "81ba981d",
+      "state": "e4b0b9c4",
       "events": "741638a5",
       "rng": {
         "draws": 6,
@@ -1363,7 +1356,6 @@
             }
           ],
           "lifetimeXp": 108,
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {
             "ore_mirefen_1": 244.45,
             "ore_mirefen_t2": 242.1,

--- a/tests/parity/golden/quest_collect_turnin.json
+++ b/tests/parity/golden/quest_collect_turnin.json
@@ -16,7 +16,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 968,
-      "state": "78dd8755",
+      "state": "3ce3b2b6",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -68,7 +68,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -151,7 +150,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 968,
-      "state": "3d32c973",
+      "state": "c224bec8",
       "events": "a3656d0a",
       "rng": {
         "draws": 0,
@@ -203,7 +202,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "questLog": [
             [
@@ -301,7 +299,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 968,
-      "state": "bfd2f963",
+      "state": "7b4800ea",
       "events": "6ba4e76a",
       "rng": {
         "draws": 0,
@@ -360,7 +358,6 @@
               "itemId": "boar_hide"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "questLog": [
             [
@@ -458,7 +455,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 968,
-      "state": "073fd618",
+      "state": "1f965b1f",
       "events": "6a98d239",
       "rng": {
         "draws": 0,
@@ -517,7 +514,6 @@
               "itemId": "boar_hide"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "questLog": [
             [
@@ -615,7 +611,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 968,
-      "state": "c7e37062",
+      "state": "12a04d5f",
       "events": "960e3146",
       "rng": {
         "draws": 0,
@@ -674,7 +670,6 @@
               "itemId": "boar_hide"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "questLog": [
             [
@@ -772,7 +767,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 968,
-      "state": "663c0c16",
+      "state": "fb3ed605",
       "events": "b2626b99",
       "rng": {
         "draws": 0,
@@ -831,7 +826,6 @@
             }
           ],
           "lifetimeXp": 350,
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "questsDone": [
             "q_boars"
@@ -918,7 +912,7 @@
       "tick": 2,
       "time": 0.1,
       "nextId": 968,
-      "state": "9dc7c312",
+      "state": "162b5929",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -977,7 +971,6 @@
             }
           ],
           "lifetimeXp": 350,
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "questsDone": [
             "q_boars"

--- a/tests/parity/golden/quest_kill_credit.json
+++ b/tests/parity/golden/quest_kill_credit.json
@@ -16,7 +16,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 968,
-      "state": "f3a1d8c8",
+      "state": "35f9b8f7",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -69,7 +69,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {

--- a/tests/parity/golden/quest_link_abandon.json
+++ b/tests/parity/golden/quest_link_abandon.json
@@ -29,7 +29,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 969,
-      "state": "eb48d5ef",
+      "state": "b2a92cf1",
       "events": "257e967c",
       "rng": {
         "draws": 0,
@@ -81,7 +81,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -140,7 +139,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -273,7 +271,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 969,
-      "state": "eb48d5ef",
+      "state": "b2a92cf1",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -325,7 +323,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -384,7 +381,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -517,7 +513,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 969,
-      "state": "e13eff65",
+      "state": "cb72f241",
       "events": "55dfa04b",
       "rng": {
         "draws": 0,
@@ -571,7 +567,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -632,7 +627,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -765,7 +759,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 969,
-      "state": "d9020f75",
+      "state": "a8efcad1",
       "events": "2ed2584a",
       "rng": {
         "draws": 0,
@@ -819,7 +813,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -880,7 +873,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "questLog": [
             [
@@ -1028,7 +1020,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 969,
-      "state": "e13eff65",
+      "state": "cb72f241",
       "events": "fbc04efc",
       "rng": {
         "draws": 0,
@@ -1082,7 +1074,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1143,7 +1134,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1276,7 +1266,7 @@
       "tick": 2,
       "time": 0.1,
       "nextId": 969,
-      "state": "83aa124f",
+      "state": "6c5e8b6f",
       "events": "e935bc38",
       "rng": {
         "draws": 0,
@@ -1336,7 +1326,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1404,7 +1393,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {

--- a/tests/parity/golden/rift_boss_floor.json
+++ b/tests/parity/golden/rift_boss_floor.json
@@ -16,7 +16,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 968,
-      "state": "f3a1d8c8",
+      "state": "35f9b8f7",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -69,7 +69,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {

--- a/tests/parity/golden/solo_mage.json
+++ b/tests/parity/golden/solo_mage.json
@@ -15,7 +15,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 968,
-      "state": "aeaf2d86",
+      "state": "63255509",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -71,7 +71,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {

--- a/tests/parity/golden/solo_rogue.json
+++ b/tests/parity/golden/solo_rogue.json
@@ -15,7 +15,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 968,
-      "state": "fae50bb5",
+      "state": "f3344ed6",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -67,7 +67,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {

--- a/tests/parity/golden/solo_warrior.json
+++ b/tests/parity/golden/solo_warrior.json
@@ -17,7 +17,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 968,
-      "state": "f3a1d8c8",
+      "state": "35f9b8f7",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -70,7 +70,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {

--- a/tests/parity/golden/talents_progression.json
+++ b/tests/parity/golden/talents_progression.json
@@ -17,7 +17,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 968,
-      "state": "f3a1d8c8",
+      "state": "35f9b8f7",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -70,7 +70,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {

--- a/tests/parity/golden/targeting_markers.json
+++ b/tests/parity/golden/targeting_markers.json
@@ -30,7 +30,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 973,
-      "state": "a2ab50fc",
+      "state": "4dcfcbe5",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -82,7 +82,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -141,7 +140,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -200,7 +198,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -494,7 +491,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 973,
-      "state": "2441e1d1",
+      "state": "d9b1a8c4",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -546,7 +543,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -605,7 +601,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -664,7 +659,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -958,7 +952,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 973,
-      "state": "69c32a3a",
+      "state": "56abcfef",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -1010,7 +1004,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1069,7 +1062,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1128,7 +1120,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1422,7 +1413,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 973,
-      "state": "a2ab50fc",
+      "state": "4dcfcbe5",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -1474,7 +1465,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1533,7 +1523,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1592,7 +1581,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1886,7 +1874,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 973,
-      "state": "bf23943c",
+      "state": "8dc7a533",
       "events": "c06d57fd",
       "rng": {
         "draws": 0,
@@ -1940,7 +1928,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -2001,7 +1988,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -2062,7 +2048,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -2356,7 +2341,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 973,
-      "state": "dae42293",
+      "state": "b50a60a8",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -2410,7 +2395,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -2471,7 +2455,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -2532,7 +2515,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -2826,7 +2808,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 973,
-      "state": "bf23943c",
+      "state": "8dc7a533",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -2880,7 +2862,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -2941,7 +2922,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -3002,7 +2982,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -3296,7 +3275,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 973,
-      "state": "bf23943c",
+      "state": "8dc7a533",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -3350,7 +3329,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -3411,7 +3389,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -3472,7 +3449,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -3766,7 +3742,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 973,
-      "state": "bf23943c",
+      "state": "8dc7a533",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -3820,7 +3796,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -3881,7 +3856,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -3942,7 +3916,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -4236,7 +4209,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 973,
-      "state": "bf23943c",
+      "state": "8dc7a533",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -4290,7 +4263,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -4351,7 +4323,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -4412,7 +4383,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -4706,7 +4676,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 973,
-      "state": "b45feb54",
+      "state": "74c78ec1",
       "events": "bab3d652",
       "rng": {
         "draws": 5,
@@ -4767,7 +4737,6 @@
             }
           ],
           "lifetimeXp": 26,
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -4833,7 +4802,6 @@
             }
           ],
           "lifetimeXp": 26,
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -4899,7 +4867,6 @@
             }
           ],
           "lifetimeXp": 26,
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -5240,7 +5207,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 973,
-      "state": "b45feb54",
+      "state": "74c78ec1",
       "events": "741638a5",
       "rng": {
         "draws": 5,
@@ -5301,7 +5268,6 @@
             }
           ],
           "lifetimeXp": 26,
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -5367,7 +5333,6 @@
             }
           ],
           "lifetimeXp": 26,
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -5433,7 +5398,6 @@
             }
           ],
           "lifetimeXp": 26,
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {

--- a/tests/parity/golden/warlock_pet.json
+++ b/tests/parity/golden/warlock_pet.json
@@ -16,7 +16,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 968,
-      "state": "3afc9986",
+      "state": "8df10109",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -72,7 +72,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {

--- a/tests/parity/golden/warrior_row_capstones.json
+++ b/tests/parity/golden/warrior_row_capstones.json
@@ -16,7 +16,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 968,
-      "state": "f3a1d8c8",
+      "state": "35f9b8f7",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -69,7 +69,6 @@
               "itemId": "baked_bread"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -492,7 +491,7 @@
       "tick": 12,
       "time": 0.6,
       "nextId": 971,
-      "state": "3637ef1c",
+      "state": "def48493",
       "events": "a09e4eab",
       "rng": {
         "draws": 7,
@@ -503,7 +502,7 @@
       "tick": 16,
       "time": 0.8,
       "nextId": 971,
-      "state": "57c45294",
+      "state": "9d68d9eb",
       "events": "741638a5",
       "rng": {
         "draws": 7,
@@ -514,8 +513,8 @@
       "tick": 20,
       "time": 1,
       "nextId": 971,
-      "state": "d268d02a",
-      "events": "f8e9b912",
+      "state": "01e144b5",
+      "events": "1dec9df8",
       "rng": {
         "draws": 7,
         "digest": "6fb8517f"
@@ -525,7 +524,7 @@
       "tick": 24,
       "time": 1.2,
       "nextId": 971,
-      "state": "4a28969b",
+      "state": "0127b0d8",
       "events": "741638a5",
       "rng": {
         "draws": 7,
@@ -536,7 +535,7 @@
       "tick": 24,
       "time": 1.2,
       "nextId": 971,
-      "state": "4a28969b",
+      "state": "0127b0d8",
       "events": "741638a5",
       "rng": {
         "draws": 7,
@@ -691,7 +690,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -961,7 +959,7 @@
       "tick": 28,
       "time": 1.4,
       "nextId": 971,
-      "state": "0c8c154b",
+      "state": "fa9c4ae8",
       "events": "741638a5",
       "rng": {
         "draws": 7,
@@ -972,7 +970,7 @@
       "tick": 32,
       "time": 1.6,
       "nextId": 971,
-      "state": "22829f39",
+      "state": "49e5c722",
       "events": "741638a5",
       "rng": {
         "draws": 7,
@@ -983,7 +981,7 @@
       "tick": 32,
       "time": 1.6,
       "nextId": 971,
-      "state": "7690bf58",
+      "state": "0bcdc6e7",
       "events": "94f5dd35",
       "rng": {
         "draws": 10,
@@ -1138,7 +1136,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -1441,7 +1438,7 @@
       "tick": 36,
       "time": 1.8,
       "nextId": 971,
-      "state": "0cf66e87",
+      "state": "0d3f515c",
       "events": "741638a5",
       "rng": {
         "draws": 10,
@@ -1452,7 +1449,7 @@
       "tick": 40,
       "time": 2,
       "nextId": 971,
-      "state": "d1b8e462",
+      "state": "db77020d",
       "events": "741638a5",
       "rng": {
         "draws": 10,
@@ -1463,7 +1460,7 @@
       "tick": 40,
       "time": 2,
       "nextId": 973,
-      "state": "df14a593",
+      "state": "c95df910",
       "events": "9a7ac135",
       "rng": {
         "draws": 19,
@@ -1623,7 +1620,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -2059,7 +2055,7 @@
       "tick": 44,
       "time": 2.2,
       "nextId": 973,
-      "state": "0299b1fc",
+      "state": "9c01d733",
       "events": "117585cf",
       "rng": {
         "draws": 48,
@@ -2070,7 +2066,7 @@
       "tick": 48,
       "time": 2.4,
       "nextId": 973,
-      "state": "bfd6c42e",
+      "state": "57eb0f31",
       "events": "741638a5",
       "rng": {
         "draws": 84,
@@ -2081,7 +2077,7 @@
       "tick": 52,
       "time": 2.6,
       "nextId": 973,
-      "state": "fb57b116",
+      "state": "da034539",
       "events": "63d4e106",
       "rng": {
         "draws": 111,
@@ -2092,7 +2088,7 @@
       "tick": 56,
       "time": 2.8,
       "nextId": 973,
-      "state": "2641e0be",
+      "state": "c03500e1",
       "events": "741638a5",
       "rng": {
         "draws": 135,
@@ -2103,7 +2099,7 @@
       "tick": 60,
       "time": 3,
       "nextId": 973,
-      "state": "80fe66ac",
+      "state": "32c9a343",
       "events": "32a83485",
       "rng": {
         "draws": 164,
@@ -2114,7 +2110,7 @@
       "tick": 64,
       "time": 3.2,
       "nextId": 973,
-      "state": "f5e09580",
+      "state": "843931ef",
       "events": "741638a5",
       "rng": {
         "draws": 209,
@@ -2125,7 +2121,7 @@
       "tick": 68,
       "time": 3.4,
       "nextId": 973,
-      "state": "db108adb",
+      "state": "07b1ef18",
       "events": "741638a5",
       "rng": {
         "draws": 240,
@@ -2136,7 +2132,7 @@
       "tick": 72,
       "time": 3.6,
       "nextId": 973,
-      "state": "05ec46af",
+      "state": "fc963e04",
       "events": "741638a5",
       "rng": {
         "draws": 267,
@@ -2147,7 +2143,7 @@
       "tick": 76,
       "time": 3.8,
       "nextId": 973,
-      "state": "a0c34503",
+      "state": "f9a83820",
       "events": "741638a5",
       "rng": {
         "draws": 297,
@@ -2158,7 +2154,7 @@
       "tick": 80,
       "time": 4,
       "nextId": 973,
-      "state": "fb65f2d1",
+      "state": "986389fa",
       "events": "f6f1dec4",
       "rng": {
         "draws": 332,
@@ -2169,7 +2165,7 @@
       "tick": 84,
       "time": 4.2,
       "nextId": 973,
-      "state": "320b2474",
+      "state": "5802698b",
       "events": "0936ecf5",
       "rng": {
         "draws": 366,
@@ -2180,7 +2176,7 @@
       "tick": 88,
       "time": 4.4,
       "nextId": 973,
-      "state": "53656f24",
+      "state": "825ff51b",
       "events": "741638a5",
       "rng": {
         "draws": 407,
@@ -2191,7 +2187,7 @@
       "tick": 92,
       "time": 4.6,
       "nextId": 973,
-      "state": "12453274",
+      "state": "90d0178b",
       "events": "741638a5",
       "rng": {
         "draws": 458,
@@ -2202,7 +2198,7 @@
       "tick": 96,
       "time": 4.8,
       "nextId": 973,
-      "state": "13333984",
+      "state": "e432353b",
       "events": "741638a5",
       "rng": {
         "draws": 497,
@@ -2213,7 +2209,7 @@
       "tick": 100,
       "time": 5,
       "nextId": 973,
-      "state": "d1ca201f",
+      "state": "c8032454",
       "events": "095f51fb",
       "rng": {
         "draws": 542,
@@ -2224,7 +2220,7 @@
       "tick": 104,
       "time": 5.2,
       "nextId": 973,
-      "state": "b290b7d5",
+      "state": "71b9bb36",
       "events": "741638a5",
       "rng": {
         "draws": 574,
@@ -2235,7 +2231,7 @@
       "tick": 108,
       "time": 5.4,
       "nextId": 973,
-      "state": "34abd532",
+      "state": "a58cae3d",
       "events": "741638a5",
       "rng": {
         "draws": 616,
@@ -2246,7 +2242,7 @@
       "tick": 112,
       "time": 5.6,
       "nextId": 973,
-      "state": "416a56e4",
+      "state": "39f86bdb",
       "events": "9c17d388",
       "rng": {
         "draws": 662,
@@ -2257,7 +2253,7 @@
       "tick": 116,
       "time": 5.8,
       "nextId": 973,
-      "state": "da9cf95f",
+      "state": "fb232694",
       "events": "741638a5",
       "rng": {
         "draws": 713,
@@ -2268,7 +2264,7 @@
       "tick": 120,
       "time": 6,
       "nextId": 973,
-      "state": "be824d22",
+      "state": "049eb4cd",
       "events": "e86b9ddf",
       "rng": {
         "draws": 750,
@@ -2279,7 +2275,7 @@
       "tick": 124,
       "time": 6.2,
       "nextId": 973,
-      "state": "de7704ba",
+      "state": "f07eb465",
       "events": "f8ff7601",
       "rng": {
         "draws": 799,
@@ -2290,7 +2286,7 @@
       "tick": 128,
       "time": 6.4,
       "nextId": 973,
-      "state": "6ab740e7",
+      "state": "8ab2667c",
       "events": "5a9abc04",
       "rng": {
         "draws": 847,
@@ -2301,7 +2297,7 @@
       "tick": 132,
       "time": 6.6,
       "nextId": 973,
-      "state": "f12ada06",
+      "state": "d10d1989",
       "events": "741638a5",
       "rng": {
         "draws": 903,
@@ -2312,7 +2308,7 @@
       "tick": 136,
       "time": 6.8,
       "nextId": 973,
-      "state": "7cfd2fbc",
+      "state": "bb0c19f3",
       "events": "a6398fa3",
       "rng": {
         "draws": 937,
@@ -2323,7 +2319,7 @@
       "tick": 140,
       "time": 7,
       "nextId": 973,
-      "state": "f9a6183f",
+      "state": "94c49834",
       "events": "741638a5",
       "rng": {
         "draws": 980,
@@ -2334,7 +2330,7 @@
       "tick": 140,
       "time": 7,
       "nextId": 973,
-      "state": "f9a6183f",
+      "state": "94c49834",
       "events": "741638a5",
       "rng": {
         "draws": 980,
@@ -2498,7 +2494,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {
@@ -2907,7 +2902,7 @@
       "tick": 144,
       "time": 7.2,
       "nextId": 973,
-      "state": "5cbc65db",
+      "state": "63555a18",
       "events": "9f13f3ac",
       "rng": {
         "draws": 1016,
@@ -2918,7 +2913,7 @@
       "tick": 144,
       "time": 7.2,
       "nextId": 973,
-      "state": "5cbc65db",
+      "state": "63555a18",
       "events": "741638a5",
       "rng": {
         "draws": 1016,
@@ -3084,7 +3079,6 @@
               "itemId": "spring_water"
             }
           ],
-          "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
           "reliquary": {

--- a/tests/professions_mastery_reset.test.ts
+++ b/tests/professions_mastery_reset.test.ts
@@ -369,6 +369,7 @@ describe('the mail-phase notice letter', () => {
   it('a new character gets no reset and no notice (construction path)', () => {
     const sim = makeSim();
     const pid = sim.addPlayer('warrior', 'Fresh');
+    sim.setPlayerLevel(6, pid); // past the welcome gate: the pin counts the welcome
     const meta = metaOf(sim, pid);
     expect(meta.pendingMasteryResetNotice).toBe(false);
     for (let i = 0; i < 40; i++) sim.tick();


### PR DESCRIPTION
## Summary

Moves the one-time Ravenpost welcome letter from character creation to a progression gate: it now books the first time a character reaches **level 6**. A character that is rolled but never played never mints a letter, closing the remaining dead-mail class behind #3560: bots stop under #3566, but every abandoned level-1 character still left an immortal letter in the shared book (~18k of them on prod today, growing with every signup). The design rule this encodes: **system letters trigger on progression or attendance, never on account existence.**

Mechanics (one small module, `src/sim/mail/welcome_gate.ts`, on the `SimContext` seam):

- `maybeSendLevelWelcome(ctx, meta, level)` books at most once, flag-first (the established re-entrancy idiom), through `ctx.mailAuthoredLetter`, which is byte-identical to the removed `PostOffice.sendWelcome` booking. No rng is drawn, so the gate cannot fork the shared draw stream.
- Three entry paths, all covered by tests: the natural ding (`combat/damage.ts` `grantXp`, a multi-level grant crosses once), a dev/GM level jump (`Sim.setPlayerLevel`), and joining with a restored save already past the gate (`Sim.addPlayer`), which preserves the letter's second job as the service announcement for characters saved before mail existed.
- Bots stay pre-flipped at creation (the #3566 `bot` option) and can never book, including when leveled to their roster level.
- Level 6 also matches the existing early-game shape (`q_fenbridge_muster` gates at 6), so the letter lands as new players finish the starting arc, when the mailbox lesson is actually relevant.

Stacked on #3566 (`fix/vale-cup-bot-welcome-mail`): the base branch of this PR is that branch, and this diff is only the gate change. Merge #3566 first; GitHub retargets this PR automatically.

Existing characters are unaffected: everyone already welcomed carries `mailWelcomed: true` in their save. The only behavior change for a live character is a pre-mail-era save below the gate, which now gets its letter at 6 instead of on next join. Player-visible timing note: the new-mail toast and mailbox glow now appear at the level-6 ding rather than at first login (no HUD code changed). Known pre-existing risk class, unchanged by this PR: the letter lives in the mail row and the flag in the character row, so a crash between the ding and the character autosave can double-book (or drop) one cosmetic 50-copper letter.

Parity golden re-mint (own commit, per the harness contract) churns exactly three categories and nothing else: 423 sampled `mailWelcomed: true` lines drop (sub-gate scenario players no longer carry the flag at creation), the rolling `state` hashes that fold them in, and `events` digests in 13 goldens because `WELCOME_LETTER.delaySeconds` is 0, so the first-sweep `mailArrived` no longer fires in sub-gate scenarios. Zero `draws`/`digest` churn anywhere: the rng stream is untouched in all 56 goldens. Fidelity proof: `tests/parity/golden/solo_warrior.json` changes only its init frame (that scenario levels immediately after init, re-booking the same letter at the same `ctx.time`), with every later frame byte-identical.

## Related issues

Closes the standing re-accumulation risk discussed in #3560; complements #3561 (whole-book serialization) and the #3566 purge.

## Type of change

- [x] New feature

## How was this tested?

- Commands:
  - `npx vitest run tests/mail_welcome_level_gate.test.ts` (new): nothing at creation; nothing below the gate, exactly one at it, never a second; a single multi-level grant crosses once; a dev/GM jump books once; a restored save past the gate books on join; a restored sub-gate save books on its later ding; a bot leveled past the gate never books.
  - `npx vitest run tests/mail.test.ts tests/mail_bot_welcome.test.ts tests/mail_wire_cache.test.ts tests/guild_letter_online.test.ts tests/mailbox_view.test.ts tests/localization_fixes.test.ts` (125 tests green): fixtures that used the creation-time welcome now level their characters past the gate, so every original human-gets-mail vs bot-gets-nothing contrast stays decisive.
  - `npx tsc --noEmit`, changed-files biome, `node scripts/gate_select.mjs`.

---

## Checklist

- [x] Tests added/updated for the change
- [x] `node scripts/gate_select.mjs` green locally
- [x] No new dependencies
- [x] Conventional commit with body
