### PR TITLE
fix(loot): give ffa looters the loot instead of the absent party

### DIFF
--- a/src/sim/interaction.ts
+++ b/src/sim/interaction.ts
@@ -133,7 +133,9 @@ export function lootCorpse(
   }
   const mob = ctx.entities.get(mobId);
   if (!mob?.lootable || !mob.loot || corpseHasDecayed(mob.dead, mob.corpseTimer)) return false;
-  // owner-lock lapses LOOT_FFA_DELAY after the corpse became lootable: then anyone may loot.
+  // owner-lock lapses LOOT_FFA_DELAY after the corpse became lootable: then anyone may
+  // loot. The flag is threaded into distribution too, so an outside looter keeps what
+  // they take instead of it being split by the absent tapping party's strategies.
   const ffaUnlocked = honorFfa && lootHasGoneFfa(mob.lootFfaTimer);
   const rights = corpseLootRights(ctx, mob, meta.entityId, ffaUnlocked);
   if (!rights.shared && !rights.personal && !rights.open) {
@@ -146,7 +148,7 @@ export function lootCorpse(
   }
   let didLoot = false;
   if (rights.shared && mob.loot.copper > 0) {
-    distributeLootCopper(ctx, mob, meta);
+    distributeLootCopper(ctx, mob, meta, ffaUnlocked);
     didLoot = true;
   }
   // Capacity gate: an item that doesn't fit the looter's bags STAYS on the
@@ -189,7 +191,7 @@ export function lootCorpse(
         if (!ctx.canAddItem(s.itemId, 1, meta.entityId)) break;
         ctx.addItemInstance(s.itemId, cloneItemInstancePayload(s.instance), meta.entityId);
         s.count--;
-      } else if (awardSharedLootItem(ctx, s.itemId, mob, meta)) {
+      } else if (awardSharedLootItem(ctx, s.itemId, mob, meta, ffaUnlocked)) {
         s.count--;
       } else {
         break;

--- a/src/sim/loot/loot_ffa.ts
+++ b/src/sim/loot/loot_ffa.ts
@@ -43,3 +43,23 @@ export function hasSharedLootRights(
     !!tapperPartyMemberIds?.includes(pid)
   );
 }
+
+/**
+ * Is `pid` part of the group the corpse's loot is owed to: the tapper, their current
+ * party, or the kill-time recipient snapshot?
+ *
+ * The permission counterpart {@link hasSharedLootRights} also says yes to an outsider
+ * once the corpse goes FFA. Party loot strategies bind only this group, so the two
+ * questions must stay separate: distribution asks this one, or an FFA outsider's loot
+ * gets routed to a party that never came back for it.
+ */
+export function isTapGroupMember(
+  pid: number,
+  tappedById: number | null,
+  tapperPartyMemberIds: readonly number[] | null,
+  lootRecipientIds: readonly number[] | null,
+): boolean {
+  return (
+    tappedById === pid || !!tapperPartyMemberIds?.includes(pid) || !!lootRecipientIds?.includes(pid)
+  );
+}

--- a/src/sim/loot/loot_roll.ts
+++ b/src/sim/loot/loot_roll.ts
@@ -53,7 +53,7 @@ import type {
   MasterLootThreshold,
 } from '../types';
 import { dist2d, PARTY_XP_RANGE } from '../types';
-import { LOOT_FFA_DELAY } from './loot_ffa';
+import { isTapGroupMember, LOOT_FFA_DELAY } from './loot_ffa';
 
 // How long (seconds) a need-greed roll stays open before it auto-resolves. Sole
 // users are startNeedGreedRoll + pruneCorpseLoot, so the constant lives with them.
@@ -101,6 +101,26 @@ export interface PendingLootRoll {
 function partyLootStrategiesForMob(ctx: SimContext, mob: Entity): LootStrategies | null {
   if (mob.tappedById === null) return null;
   return ctx.partyOf(mob.tappedById)?.lootStrategies ?? null;
+}
+
+// An FFA corpse opened by someone outside the tapper's group: the rights model handed
+// them the corpse, so distribution must follow it and let them keep what they loot.
+// Without this the tapping party's strategies split the copper and route the items to
+// members who are not there, emptying the corpse and paying the looter nothing.
+function ffaLooterTakesAll(
+  ctx: SimContext,
+  mob: Entity,
+  looter: PlayerMeta,
+  ffaUnlocked: boolean,
+): boolean {
+  if (!ffaUnlocked) return false;
+  const tapperParty = mob.tappedById !== null ? ctx.partyOf(mob.tappedById) : null;
+  return !isTapGroupMember(
+    looter.entityId,
+    mob.tappedById,
+    tapperParty?.members ?? null,
+    mob.lootRecipientIds ?? null,
+  );
 }
 
 export function partyLootCandidatesForMob(ctx: SimContext, mob: Entity): PlayerMeta[] {
@@ -368,10 +388,17 @@ function tryAwardCopperByFairSplit(ctx: SimContext, mob: Entity, copper: number)
   return true;
 }
 
-export function distributeLootCopper(ctx: SimContext, mob: Entity, looter: PlayerMeta): void {
+export function distributeLootCopper(
+  ctx: SimContext,
+  mob: Entity,
+  looter: PlayerMeta,
+  ffaUnlocked = false,
+): void {
   if (!mob.loot || mob.loot.copper <= 0) return;
   const copper = mob.loot.copper;
-  if (!tryAwardCopperByFairSplit(ctx, mob, copper)) awardAllCopperToLooter(ctx, looter, copper);
+  const takesAll = ffaLooterTakesAll(ctx, mob, looter, ffaUnlocked);
+  if (takesAll || !tryAwardCopperByFairSplit(ctx, mob, copper))
+    awardAllCopperToLooter(ctx, looter, copper);
   mob.loot.copper = 0;
 }
 
@@ -486,10 +513,13 @@ export function awardSharedLootItem(
   itemId: string,
   mob: Entity,
   looter: PlayerMeta,
+  ffaUnlocked = false,
 ): boolean {
-  if (startMasterLootRoll(ctx, itemId, mob)) return true;
-  if (startNeedGreedRoll(ctx, itemId, mob)) return true;
-  if (tryAwardItemByRoundRobin(ctx, itemId, mob)) return true;
+  if (!ffaLooterTakesAll(ctx, mob, looter, ffaUnlocked)) {
+    if (startMasterLootRoll(ctx, itemId, mob)) return true;
+    if (startNeedGreedRoll(ctx, itemId, mob)) return true;
+    if (tryAwardItemByRoundRobin(ctx, itemId, mob)) return true;
+  }
   if (!ctx.canAddItem(itemId, 1, looter.entityId)) return false;
   ctx.addItem(itemId, 1, looter.entityId);
   return true;

--- a/tests/loot_ffa.test.ts
+++ b/tests/loot_ffa.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { hasSharedLootRights, LOOT_FFA_DELAY, lootHasGoneFfa } from '../src/sim/loot/loot_ffa';
+import {
+  hasSharedLootRights,
+  isTapGroupMember,
+  LOOT_FFA_DELAY,
+  lootHasGoneFfa,
+} from '../src/sim/loot/loot_ffa';
 
 // Pure unit coverage for the loot free-for-all timeout rule: a tapped corpse the
 // owner has not cleared within LOOT_FFA_DELAY seconds opens to everyone.
@@ -45,6 +50,34 @@ describe('loot FFA timeout', () => {
       const once = hasSharedLootRights(STRANGER, TAPPER, party, false);
       const twice = hasSharedLootRights(STRANGER, TAPPER, party, false);
       expect(once).toEqual(twice);
+    });
+  });
+
+  // Distribution's counterpart to the permission check above: who the loot is owed
+  // to, which an FFA outsider is NOT even though they may open the corpse.
+  describe('isTapGroupMember', () => {
+    const TAPPER = 1;
+    const PARTY_MEMBER = 2;
+    const ABSENT_RECIPIENT = 3;
+    const STRANGER = 9;
+    const party = [TAPPER, PARTY_MEMBER];
+
+    it('counts the tapper, their party, and the kill-time recipients', () => {
+      expect(isTapGroupMember(TAPPER, TAPPER, party, [TAPPER])).toBe(true);
+      expect(isTapGroupMember(PARTY_MEMBER, TAPPER, party, [TAPPER])).toBe(true);
+      expect(isTapGroupMember(ABSENT_RECIPIENT, TAPPER, party, [TAPPER, ABSENT_RECIPIENT])).toBe(
+        true,
+      );
+    });
+
+    it('excludes a stranger even where hasSharedLootRights lets them loot', () => {
+      expect(hasSharedLootRights(STRANGER, TAPPER, party, true)).toBe(true);
+      expect(isTapGroupMember(STRANGER, TAPPER, party, [TAPPER, PARTY_MEMBER])).toBe(false);
+      expect(isTapGroupMember(STRANGER, TAPPER, null, null)).toBe(false);
+    });
+
+    it('excludes everyone from an untapped corpse with no recipients', () => {
+      expect(isTapGroupMember(STRANGER, null, null, null)).toBe(false);
     });
   });
 });

--- a/tests/loot_ffa_sim.test.ts
+++ b/tests/loot_ffa_sim.test.ts
@@ -4,7 +4,7 @@ import { createMob } from '../src/sim/entity';
 import { LOOT_FFA_DELAY } from '../src/sim/loot/loot_ffa';
 import type { PlayerMeta } from '../src/sim/sim';
 import { Sim } from '../src/sim/sim';
-import type { Entity, WorldContent } from '../src/sim/types';
+import type { Entity, LootSlot, WorldContent } from '../src/sim/types';
 
 // End-to-end: a stranger cannot loot a tapped corpse until LOOT_FFA_DELAY seconds
 // after it became lootable; once the owner-lock lapses, the loot goes free-for-all.
@@ -97,4 +97,122 @@ describe('loot goes FFA one minute after a corpse becomes lootable', () => {
     expect(run()).toEqual(run());
     // two full FFA-delay runs: headroom under suite load
   }, 90_000);
+});
+
+// Regression: the FFA rights model and the loot-distribution strategies must agree.
+// A corpse tapped by a PARTIED player and left to lapse used to be drained by the
+// stranger who opened it while the party's own strategies (fair-split / round-robin /
+// need-greed) handed the contents to the absent party, so the looter got nothing.
+
+const COMMON_ITEM = 'worn_sword';
+const PREMIUM_ITEM = 'greyjaw_hide_boots';
+
+function setupPartiedTap(items: LootSlot[] = [{ itemId: COMMON_ITEM, count: 1 }]) {
+  const sim = new Sim({ seed: 7, playerClass: 'warrior', noPlayer: true, world: LOOT_TEST_WORLD });
+  const internals = sim as unknown as SimInternals;
+  const tapper = sim.addPlayer('warrior', 'Tapper');
+  const mate = sim.addPlayer('mage', 'Mate');
+  const stranger = sim.addPlayer('rogue', 'Stranger');
+  sim.partyInvite(mate, tapper);
+  sim.partyAccept(mate);
+  sim.tick();
+
+  for (const pid of [tapper, mate, stranger]) {
+    const e = internals.entities.get(pid)!;
+    e.pos = { x: 0, y: 0, z: 0 };
+    e.prevPos = { x: 0, y: 0, z: 0 };
+  }
+
+  const template = MOBS.forest_wolf;
+  const mob = createMob(9999, template, template.maxLevel, { x: 0, y: 0, z: 0 });
+  mob.dead = true;
+  mob.aiState = 'dead';
+  mob.tappedById = tapper;
+  mob.lootRecipientIds = [tapper, mate];
+  mob.loot = { copper: 50, items };
+  mob.lootable = true;
+  mob.lootFfaTimer = LOOT_FFA_DELAY;
+  mob.corpseTimer = 9999;
+  mob.respawnTimer = 9999;
+  internals.entities.set(mob.id, mob);
+
+  return { sim, internals, tapper, mate, stranger, mob };
+}
+
+function runOutFfaLock(sim: Sim, mob: Entity): void {
+  for (let i = 0; i < 20 * (LOOT_FFA_DELAY + 1) && mob.lootFfaTimer > 0; i++) sim.tick();
+  expect(mob.lootFfaTimer).toBeLessThanOrEqual(0);
+}
+
+describe('an FFA corpse pays the looter, not the absent tapping party', () => {
+  it('gives the stranger the copper and the common item, and the party nothing', () => {
+    const { sim, internals, tapper, mate, stranger, mob } = setupPartiedTap();
+    runOutFfaLock(sim, mob);
+
+    const before = [tapper, mate, stranger].map((pid) => copperOf(internals.players.get(pid)));
+    expect(sim.lootCorpse(mob.id, stranger)).toBe(true);
+
+    expect(copperOf(internals.players.get(stranger)) - before[2]).toBe(50);
+    expect(copperOf(internals.players.get(tapper))).toBe(before[0]);
+    expect(copperOf(internals.players.get(mate))).toBe(before[1]);
+    expect(sim.countItem(COMMON_ITEM, stranger)).toBe(1);
+    expect(sim.countItem(COMMON_ITEM, tapper)).toBe(0);
+    expect(sim.countItem(COMMON_ITEM, mate)).toBe(0);
+    expect(mob.loot?.copper ?? 0).toBe(0);
+    expect(mob.loot?.items.some((s) => s.itemId === COMMON_ITEM && s.count > 0) ?? false).toBe(
+      false,
+    );
+  });
+
+  it('hands a premium drop straight over instead of opening a need/greed roll', () => {
+    const { sim, tapper, mate, stranger, mob } = setupPartiedTap([
+      { itemId: PREMIUM_ITEM, count: 1 },
+    ]);
+    runOutFfaLock(sim, mob);
+    sim.events.length = 0;
+
+    expect(sim.lootCorpse(mob.id, stranger)).toBe(true);
+
+    expect(sim.events.some((e) => e.type === 'lootRoll' || e.type === 'masterLoot')).toBe(false);
+    expect(sim.ctx.pendingLootRolls.size).toBe(0);
+    expect(sim.countItem(PREMIUM_ITEM, stranger)).toBe(1);
+    expect(sim.countItem(PREMIUM_ITEM, tapper)).toBe(0);
+    expect(sim.countItem(PREMIUM_ITEM, mate)).toBe(0);
+  });
+
+  it('still runs the party strategies when the tapper loots before the lock lapses', () => {
+    const { sim, internals, tapper, mate, mob } = setupPartiedTap();
+
+    const before = [tapper, mate].map((pid) => copperOf(internals.players.get(pid)));
+    expect(sim.lootCorpse(mob.id, tapper)).toBe(true);
+
+    // fair-split: 50 copper over the two kill-time recipients.
+    expect(copperOf(internals.players.get(tapper)) - before[0]).toBe(25);
+    expect(copperOf(internals.players.get(mate)) - before[1]).toBe(25);
+    // round-robin: the common item goes to exactly one of them, by the party cursor.
+    expect(sim.countItem(COMMON_ITEM, tapper) + sim.countItem(COMMON_ITEM, mate)).toBe(1);
+  });
+
+  it('still runs the party strategies when a member loots after the lock lapses', () => {
+    const { sim, internals, tapper, mate, mob } = setupPartiedTap();
+    runOutFfaLock(sim, mob);
+
+    const before = [tapper, mate].map((pid) => copperOf(internals.players.get(pid)));
+    expect(sim.lootCorpse(mob.id, mate)).toBe(true);
+
+    expect(copperOf(internals.players.get(tapper)) - before[0]).toBe(25);
+    expect(copperOf(internals.players.get(mate)) - before[1]).toBe(25);
+    expect(sim.countItem(COMMON_ITEM, tapper) + sim.countItem(COMMON_ITEM, mate)).toBe(1);
+  });
+
+  it('still opens a need/greed roll for a premium drop the tapping party loots', () => {
+    const { sim, tapper, mob } = setupPartiedTap([{ itemId: PREMIUM_ITEM, count: 1 }]);
+    runOutFfaLock(sim, mob);
+    sim.events.length = 0;
+
+    expect(sim.lootCorpse(mob.id, tapper)).toBe(true);
+
+    expect(sim.events.some((e) => e.type === 'lootRoll')).toBe(true);
+    expect(sim.ctx.pendingLootRolls.size).toBe(1);
+  });
 });


### PR DESCRIPTION
## Summary

A corpse whose owner lock lapses (LOOT_FFA_DELAY, 60 s) grants loot rights to anyone, but the distribution layer never consulted the actual looter: it resolved loot strategies from the tapper's party and recipients from the kill-time snapshot. With default strategies, a stranger opening an aged-out corpse emptied it while the copper was fair-split to the absent party, common items were round-robined to them, and premium items opened a need/greed roll the looter was not part of. The looter received nothing, with no message, and a party could exploit this by parking on corpses and harvesting whatever a passer-by opened for them.

How the fix works: lootCorpse already computes ffaUnlocked and now threads it into distributeLootCopper and awardSharedLootItem. A new predicate, ffaLooterTakesAll, answers the distribution-side question (who is the loot owed to: the tapper, their current party, or the kill-time recipients) via a pure leaf isTapGroupMember in loot_ffa.ts, the counterpart to the permission-side hasSharedLootRights. When the corpse is FFA-unlocked and the looter is outside the tap group, copper short-circuits to the looter (before the fair-split shuffle, keeping the rng stream clean) and items skip the master-loot, need/greed, and round-robin arms, falling to the existing capacity-gated direct grant. The normal party paths, personal drops, openToAll arm, and walk-by autoloot are untouched.

## Related issues

None found. The issue tracker was swept for this bug before opening the PR; no existing issue describes it.

## Type of change

- [x] Bug fix

## How was this tested?

- Commands:
  - New tests in tests/loot_ffa_sim.test.ts (partied tap fixture, real party invite/accept, real FFA timer): stranger receives copper and items after the lapse while the absent party receives nothing; premium drops open no roll for a stranger; regression guards pin the tapper's own party looting before and after the lapse (fair-split, round-robin, need/greed unchanged). Both bug tests were confirmed red before the fix.
  - New unit tests for isTapGroupMember in tests/loot_ffa.test.ts, including the decisive contrast case where hasSharedLootRights says yes and isTapGroupMember says no for the same stranger.
  - node scripts/gate_select.mjs: PASS, all 12 steps green (i18n gen and freshness, malware scan, changed-files biome, sfx conformance, merged related vitest with the always-run floor, browser regressions, tsc, all builds).
- Manual steps: none needed; the sim tests drive the real lootCorpse path end to end.

## Checklist

### Quality

- [x] The gate passes. node scripts/gate_select.mjs is green and decisive tests were added for the changed behavior.

### Cross-platform

- N/A, no UI change.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or .env committed, and ALLOW_DEV_COMMANDS is not enabled in any production path.
- [x] No generated files were hand-edited.

Generated with [Claude Code](https://claude.com/claude-code)