### PR TITLE
fix(combat): drain heal absorb shields from periodic healing

### DIFF
--- a/src/sim/combat/auras.ts
+++ b/src/sim/combat/auras.ts
@@ -49,6 +49,7 @@ import { isStunned } from './cc';
 import { regenerateRuinOutOfCombat, tickPyreGuardian } from './destruction';
 import { druidEngineOnBleedTick } from './druid_engines';
 import { applyGreaterInvisibilityAftereffect } from './greater_invisibility';
+import { consumeHealAbsorb } from './heal';
 import {
   detonateOssuaryMark,
   OSSUARY_MARK_ABILITY_ID,
@@ -357,11 +358,16 @@ export function updateAuras(ctx: SimContext, e: Entity): void {
           if (a.leechPct !== undefined) {
             const src = dotSource;
             if (src && !src.dead) {
-              const intended = Math.round(tickDamage * a.leechPct);
-              const healed = Math.min(intended, src.maxHp - src.hp);
+              // A leech is healing the SOURCE receives, so it runs the same
+              // recipient-side pipeline as applyHeal: incoming-heal mult, then
+              // the absorb drain, then the missing-hp clamp.
+              const intended = Math.round(tickDamage * a.leechPct * ctx.healingTakenMult(src));
+              const landing = consumeHealAbsorb(ctx, src, intended);
+              const absorbed = intended - landing;
+              const healed = Math.min(landing, src.maxHp - src.hp);
               if (healed > 0) {
                 src.hp += healed;
-                const overheal = intended - healed;
+                const overheal = landing - healed;
                 ctx.emit({
                   type: 'heal2',
                   sourceId: src.id,
@@ -369,6 +375,7 @@ export function updateAuras(ctx: SimContext, e: Entity): void {
                   amount: healed,
                   crit: false,
                   ability: a.name,
+                  ...(absorbed > 0 ? { absorbed } : {}),
                   ...(overheal > 0 ? { overheal } : {}),
                 });
                 ctx.healingThreat(src, src, healed);
@@ -378,10 +385,12 @@ export function updateAuras(ctx: SimContext, e: Entity): void {
           if (e.dead) return;
         } else if (a.kind === 'hot' && !tickMendingCurrent(ctx, e, a)) {
           const intended = Math.round(a.value * ctx.healingTakenMult(e));
-          const healed = Math.min(intended, e.maxHp - e.hp);
+          const landing = consumeHealAbsorb(ctx, e, intended);
+          const absorbed = intended - landing;
+          const healed = Math.min(landing, e.maxHp - e.hp);
           if (healed > 0) {
             e.hp += healed;
-            const overheal = intended - healed;
+            const overheal = landing - healed;
             ctx.emit({
               type: 'heal2',
               sourceId: a.sourceId,
@@ -391,6 +400,7 @@ export function updateAuras(ctx: SimContext, e: Entity): void {
               ability: a.name,
               hot: true,
               abilityId: a.id,
+              ...(absorbed > 0 ? { absorbed } : {}),
               ...(overheal > 0 ? { overheal } : {}),
             });
             const src = ctx.entities.get(a.sourceId);

--- a/src/sim/combat/temporal_hourglass.ts
+++ b/src/sim/combat/temporal_hourglass.ts
@@ -2,6 +2,7 @@ import { zoneAt } from '../data';
 import type { GroundAoE } from '../entity_roster';
 import type { SimContext } from '../sim_context';
 import { type AbilityEffect, DT, type Entity, type Vec3 } from '../types';
+import { consumeHealAbsorb, healingTakenMult } from './heal';
 
 export const TEMPORAL_HOURGLASS_ID = 'temporal_hourglass';
 
@@ -40,13 +41,19 @@ export function tickTemporalHourglassHealing(
   if (ticks <= 0 || remaining <= 0) return;
 
   const planned = Math.ceil(remaining / ticks);
+  // The stored budget spends the PLANNED share: what the target actually keeps is
+  // then mitigated like any other incoming heal (applyHeal's order, mult then
+  // absorb then the missing-hp clamp).
   aura.temporalHealRemaining = Math.max(0, remaining - planned);
   aura.temporalHealTicksRemaining = ticks - 1;
-  const healed = Math.min(planned, target.maxHp - target.hp);
+  const intended = Math.round(planned * healingTakenMult(ctx, target));
+  const landing = consumeHealAbsorb(ctx, target, intended);
+  const absorbed = intended - landing;
+  const healed = Math.min(landing, target.maxHp - target.hp);
   if (healed <= 0) return;
 
   target.hp += healed;
-  const overheal = planned - healed;
+  const overheal = landing - healed;
   ctx.emit({
     type: 'heal2',
     sourceId: aura.sourceId,
@@ -54,6 +61,7 @@ export function tickTemporalHourglassHealing(
     amount: healed,
     crit: false,
     ability: aura.name,
+    ...(absorbed > 0 ? { absorbed } : {}),
     ...(overheal > 0 ? { overheal } : {}),
   });
   const source = ctx.entities.get(aura.sourceId);

--- a/tests/mob_heal_absorb.test.ts
+++ b/tests/mob_heal_absorb.test.ts
@@ -4,10 +4,11 @@
 // Strike — where Mortal Strike scales every heal down for its whole duration,
 // Grave Blight eats a FIXED pool of healing once, then fades.
 import { describe, expect, it } from 'vitest';
-import { Sim } from '../src/sim/sim';
+import { updateAuras } from '../src/sim/combat/auras';
 import { MOBS } from '../src/sim/data';
 import { createMob } from '../src/sim/entity';
-import type { Entity } from '../src/sim/types';
+import { Sim } from '../src/sim/sim';
+import { type Aura, DT, type Entity } from '../src/sim/types';
 
 function makeSim(playerClass: 'warrior' | 'mage' = 'warrior') {
   return new Sim({ seed: 7, playerClass, autoEquip: true });
@@ -16,7 +17,11 @@ function makeSim(playerClass: 'warrior' | 'mage' = 'warrior') {
 // Spawn a Gravecaller Summoner adjacent to the player, engaged and ready to swing.
 function spawnSummoner(sim: Sim, target: Entity): Entity {
   const template = MOBS['gravecaller_summoner'];
-  const mob = createMob((sim as any).nextId++, template, 12, { x: target.pos.x, y: target.pos.y, z: target.pos.z });
+  const mob = createMob((sim as any).nextId++, template, 12, {
+    x: target.pos.x,
+    y: target.pos.y,
+    z: target.pos.z,
+  });
   mob.hostile = true;
   (sim as any).addEntity(mob);
   return mob;
@@ -29,7 +34,13 @@ function swing(sim: Sim, mob: Entity, target: Entity) {
   const rng = (sim as any).rng;
   const realNext = rng.next.bind(rng);
   let firstRoll = true;
-  rng.next = () => { if (firstRoll) { firstRoll = false; return 0.999; } return realNext(); };
+  rng.next = () => {
+    if (firstRoll) {
+      firstRoll = false;
+      return 0.999;
+    }
+    return realNext();
+  };
   try {
     (sim as any).mobSwing(mob, target);
   } finally {
@@ -40,14 +51,19 @@ function swing(sim: Sim, mob: Entity, target: Entity) {
 describe('mob heal-absorb ("Grave Blight")', () => {
   it('seeds the heal-absorb mechanic on the Gravecaller Summoner', () => {
     expect(MOBS['gravecaller_summoner'].healAbsorb).toEqual({
-      chance: 0.25, amount: 120, duration: 10, name: 'Grave Blight', school: 'shadow',
+      chance: 0.25,
+      amount: 120,
+      duration: 10,
+      name: 'Grave Blight',
+      school: 'shadow',
     });
   });
 
   it('applies a heal_absorb aura on a landed hit when it rolls', () => {
     const sim = makeSim();
     const p = sim.player;
-    p.maxHp = 100000; p.hp = 100000;
+    p.maxHp = 100000;
+    p.hp = 100000;
     const mob = spawnSummoner(sim, p);
     MOBS['gravecaller_summoner'].healAbsorb!.chance = 1; // deterministic for the test
     swing(sim, mob, p);
@@ -63,8 +79,14 @@ describe('mob heal-absorb ("Grave Blight")', () => {
     const sim = makeSim();
     const p = sim.player;
     p.auras.push({
-      id: 'heal_absorb_test', name: 'Grave Blight', kind: 'heal_absorb',
-      remaining: 10, duration: 10, value: 120, sourceId: 999, school: 'shadow',
+      id: 'heal_absorb_test',
+      name: 'Grave Blight',
+      kind: 'heal_absorb',
+      remaining: 10,
+      duration: 10,
+      value: 120,
+      sourceId: 999,
+      school: 'shadow',
     });
     // A 50-point heal is fully eaten; the shield drains to 70 and remains.
     expect((sim as any).consumeHealAbsorb(p, 50)).toBe(0);
@@ -77,11 +99,18 @@ describe('mob heal-absorb ("Grave Blight")', () => {
   it('blocks real healing while a shield is active, then heals normally after it lapses', () => {
     const sim = makeSim();
     const p = sim.player;
-    p.maxHp = 1000; p.hp = 500;
+    p.maxHp = 1000;
+    p.hp = 500;
     // A shield larger than any heal (crit included) absorbs the whole heal.
     p.auras.push({
-      id: 'heal_absorb_test', name: 'Grave Blight', kind: 'heal_absorb',
-      remaining: 10, duration: 10, value: 100000, sourceId: 999, school: 'shadow',
+      id: 'heal_absorb_test',
+      name: 'Grave Blight',
+      kind: 'heal_absorb',
+      remaining: 10,
+      duration: 10,
+      value: 100000,
+      sourceId: 999,
+      school: 'shadow',
     });
     (sim as any).applyHeal(p, p, 200, 'Test Heal');
     expect(p.hp).toBe(500); // fully absorbed
@@ -89,5 +118,168 @@ describe('mob heal-absorb ("Grave Blight")', () => {
     p.auras = p.auras.filter((a) => a.kind !== 'heal_absorb');
     (sim as any).applyHeal(p, p, 200, 'Test Heal');
     expect(p.hp).toBeGreaterThanOrEqual(700);
+  });
+});
+
+// The shield is documented as the sibling of Mortal Wound: a fixed pool of
+// incoming healing it devours before any of it lands. That contract is about
+// healing the target RECEIVES, so the periodic heal paths (HoT ticks, a DoT's
+// leech self-heal, the Temporal Hourglass pool) have to drain it exactly the
+// way applyHeal does, or a Renew ticking through a blight defeats the mechanic.
+function shield(value: number, id = 'heal_absorb_test'): Aura {
+  return {
+    id,
+    name: 'Grave Blight',
+    kind: 'heal_absorb',
+    remaining: 60,
+    duration: 60,
+    value,
+    sourceId: 999,
+    school: 'shadow',
+  };
+}
+
+function primedHot(value: number, id = 'rejuvenation'): Aura {
+  return {
+    id,
+    name: 'Rejuvenation',
+    kind: 'hot',
+    remaining: 60,
+    duration: 60,
+    value,
+    tickInterval: DT,
+    sourceId: -1,
+    school: 'nature',
+  };
+}
+
+function spawnTarget(sim: Sim, maxHp: number): Entity {
+  const mob = createMob((sim as any).nextId++, MOBS['forest_wolf'], 5, { x: 40, y: 0, z: 40 });
+  mob.maxHp = maxHp;
+  mob.hp = maxHp;
+  (sim as any).addEntity(mob);
+  return mob;
+}
+
+describe('heal-absorb vs periodic healing', () => {
+  it('drains the pool from HoT ticks and only lands the excess', () => {
+    const sim = makeSim();
+    const mob = spawnTarget(sim, 1000);
+    mob.hp = 500;
+    mob.auras.push(shield(120), primedHot(100));
+
+    updateAuras(sim.ctx, mob);
+    // The whole tick is devoured: the target stays exactly where it was.
+    expect(mob.hp).toBe(500);
+    expect(mob.auras.find((a) => a.kind === 'heal_absorb')!.value).toBe(20);
+
+    sim.drainEvents();
+    updateAuras(sim.ctx, mob);
+    // 20 left in the pool, so 80 of the 100 lands.
+    expect(mob.hp).toBe(580);
+    const heals = (sim.drainEvents() as any[]).filter((e) => e.type === 'heal2');
+    expect(heals).toHaveLength(1);
+    expect(heals[0]).toMatchObject({
+      hot: true,
+      abilityId: 'rejuvenation',
+      amount: 80,
+      absorbed: 20,
+    });
+  });
+
+  it('drops the pool once HoT ticks empty it, the same way applyHeal does', () => {
+    const sim = makeSim();
+    const mob = spawnTarget(sim, 1000);
+    mob.hp = 500;
+    mob.auras.push(shield(60), primedHot(100));
+
+    updateAuras(sim.ctx, mob);
+    expect(mob.auras.some((a) => a.kind === 'heal_absorb')).toBe(false);
+    expect(mob.hp).toBe(540);
+  });
+
+  it("drains the attacker's own pool on a DoT leech self-heal", () => {
+    const sim = makeSim();
+    const p = sim.player;
+    p.maxHp = 1000;
+    p.hp = 500;
+    p.auras.push(shield(30));
+    const mob = spawnTarget(sim, 100000);
+    mob.auras.push({
+      id: 'leech_dot_test',
+      name: 'Siphon',
+      kind: 'dot',
+      remaining: 60,
+      duration: 60,
+      value: 100,
+      leechPct: 0.5,
+      tickInterval: DT,
+      sourceId: p.id,
+      school: 'shadow',
+    });
+
+    updateAuras(sim.ctx, mob);
+    // 50 leeched, 30 eaten by the attacker's own blight, 20 lands.
+    expect(p.hp).toBe(520);
+    expect(p.auras.some((a) => a.kind === 'heal_absorb')).toBe(false);
+  });
+
+  it('applies both healingTakenMult and heal-absorb to Temporal Hourglass healing', () => {
+    const sim = makeSim();
+    const mob = spawnTarget(sim, 1000);
+    mob.hp = 500;
+    mob.auras.push(
+      shield(30),
+      {
+        id: 'mortal_wound_test',
+        name: 'Maiming Strike',
+        kind: 'mortal_wound',
+        remaining: 60,
+        duration: 60,
+        value: 0.5,
+        sourceId: 999,
+        school: 'physical',
+      },
+      {
+        id: 'temporal_hourglass',
+        name: 'Temporal Hourglass',
+        kind: 'stasis',
+        remaining: 60,
+        duration: 60,
+        value: 1,
+        tickInterval: DT,
+        sourceId: -1,
+        school: 'arcane',
+        temporalHealRemaining: 200,
+        temporalHealTicksRemaining: 2,
+      } as Aura,
+    );
+
+    sim.drainEvents();
+    updateAuras(sim.ctx, mob);
+    // 100 planned, halved to 50 by the Mortal Wound, 30 eaten by the blight.
+    expect(mob.hp).toBe(520);
+    expect(mob.auras.some((a) => a.kind === 'heal_absorb')).toBe(false);
+    const heals = (sim.drainEvents() as any[]).filter((e) => e.type === 'heal2');
+    expect(heals).toHaveLength(1);
+    expect(heals[0]).toMatchObject({ amount: 20, absorbed: 30 });
+    // The pool budget still drains by the PLANNED share, not the landed one.
+    expect(mob.auras.find((a) => a.kind === 'stasis')!.temporalHealRemaining).toBe(100);
+  });
+
+  it('leaves an unshielded HoT tick exactly as it was', () => {
+    const sim = makeSim();
+    const mob = spawnTarget(sim, 1000);
+    mob.hp = 500;
+    mob.auras.push(primedHot(100));
+
+    sim.drainEvents();
+    updateAuras(sim.ctx, mob);
+    expect(mob.hp).toBe(600);
+    const heals = (sim.drainEvents() as any[]).filter((e) => e.type === 'heal2');
+    expect(heals).toHaveLength(1);
+    expect(heals[0]).toMatchObject({ hot: true, abilityId: 'rejuvenation', amount: 100 });
+    expect(heals[0].absorbed).toBeUndefined();
+    expect(heals[0].overheal).toBeUndefined();
   });
 });

--- a/tests/parity/coverage_b.test.ts
+++ b/tests/parity/coverage_b.test.ts
@@ -441,11 +441,21 @@ describe('coverage: each scenario fires its subsystem', () => {
     expect(ev.some((e) => e.type === 'heal2' && e.ability === hotAbility && e.amount > 0)).toBe(
       true,
     );
+    // The HoT arm drains heal-absorb like every other heal, so a blighted
+    // Rejuvenation cannot tick at full value: some tick reports what the shield ate.
+    expect(
+      ev.some((e) => e.type === 'heal2' && e.ability === hotAbility && (e.absorbed ?? 0) > 0),
+    ).toBe(true);
     const ents = entities(rec);
     const tank = ents.find((e) => e.id === rec.notes.tankPid);
-    // consumeHealAbsorb: the small shield depleted + was filtered out; the big survived.
+    // consumeHealAbsorb: the small shield depleted + was filtered out; the big one
+    // survived heal 4 (which landed for nothing, soaking past absorb_small's 200
+    // budget) and the shrunk remainder was then drained away by the HoT ticks.
     expect(tank.auras?.some((a: Ev) => a.id === 'absorb_small')).toBe(false);
-    expect(tank.auras?.some((a: Ev) => a.id === 'absorb_big')).toBe(true);
+    const soaked = ev.find((e) => e.type === 'heal2' && e.ability === 'Healing Wave');
+    expect(soaked!.amount).toBe(0);
+    expect(soaked!.absorbed).toBeGreaterThan(200);
+    expect(tank.auras?.some((a: Ev) => a.id === 'absorb_big')).toBe(false);
     // healingThreat split landed: each aware mob now lists healer ids in its hate table.
     const healerIds = rec.notes.healerIds as number[];
     const m1 = ents.find((e) => e.id === rec.notes.m1Id);

--- a/tests/parity/golden/multi_class_heal.json
+++ b/tests/parity/golden/multi_class_heal.json
@@ -7,9 +7,10 @@
     "applyHeal core: crit branch (rng.chance(spellCrit) draw), overheal clamp, heal2 emit",
     "hexOutputMult outgoing cut (hex on source) + healingTakenMult Mortal-Wound cut (target)",
     "consumeHealAbsorb soak: small shield depletes+filters, big shield survives",
+    "consumeHealAbsorb from HoT ticks: the periodic arm drains the shield too",
     "healingThreat even split across multiple aware mobs (entities.values insertion order)",
     "threatEntryMatchesEntity direct-target + pet-owner branches",
-    "hot aura-tick heal path (healingTakenMult ~3089 + healingThreat ~3101)",
+    "hot aura-tick heal path (healingTakenMult + consumeHealAbsorb + healingThreat)",
     "dealDamage consumers: critVulnBonus (crit-only) + hexOutputMult on a damage hit",
     "multi-class healers: priest/paladin/druid/shaman"
   ],
@@ -1695,8 +1696,8 @@
       "tick": 5,
       "time": 0.25,
       "nextId": 1006,
-      "state": "1767e34f",
-      "events": "0c3c841d",
+      "state": "036acf1c",
+      "events": "c1375a25",
       "rng": {
         "draws": 10,
         "digest": "3c49d817"
@@ -1706,7 +1707,7 @@
       "tick": 8,
       "time": 0.4,
       "nextId": 1006,
-      "state": "b824e442",
+      "state": "8d313a15",
       "events": "0c3c841d",
       "rng": {
         "draws": 10,
@@ -2247,16 +2248,6 @@
               "sourceId": 1001
             },
             {
-              "duration": 60,
-              "id": "absorb_big",
-              "kind": "heal_absorb",
-              "name": "Necrotic",
-              "remaining": 59.6,
-              "school": "physical",
-              "sourceId": 1003,
-              "value": 3700
-            },
-            {
               "duration": 3,
               "id": "hot_tk",
               "kind": "hot",
@@ -2278,7 +2269,7 @@
           "dodgeChance": 0.06,
           "fallStartY": -1.48336,
           "fiveSecondRule": 99.4,
-          "hp": 3200,
+          "hp": 2800,
           "id": 1001,
           "kind": "player",
           "level": 1,
@@ -2339,7 +2330,7 @@
           "overpowerUntil": -1,
           "ownerId": 1001,
           "petMode": "defensive",
-          "petPathCooldown": 0.2,
+          "petPathCooldown": 0.3,
           "pos": {
             "x": 30,
             "y": -1.48336,
@@ -2428,7 +2419,7 @@
             ],
             [
               999,
-              343.5
+              293.5
             ],
             [
               1001,
@@ -2489,7 +2480,7 @@
             ],
             [
               999,
-              237.5
+              187.5
             ],
             [
               1001,
@@ -2556,7 +2547,7 @@
             ],
             [
               999,
-              237.5
+              187.5
             ],
             [
               1002,

--- a/tests/parity/scenarios.ts
+++ b/tests/parity/scenarios.ts
@@ -2557,9 +2557,10 @@ function multiClassHeal(): Scenario {
       'applyHeal core: crit branch (rng.chance(spellCrit) draw), overheal clamp, heal2 emit',
       'hexOutputMult outgoing cut (hex on source) + healingTakenMult Mortal-Wound cut (target)',
       'consumeHealAbsorb soak: small shield depletes+filters, big shield survives',
+      'consumeHealAbsorb from HoT ticks: the periodic arm drains the shield too',
       'healingThreat even split across multiple aware mobs (entities.values insertion order)',
       'threatEntryMatchesEntity direct-target + pet-owner branches',
-      'hot aura-tick heal path (healingTakenMult ~3089 + healingThreat ~3101)',
+      'hot aura-tick heal path (healingTakenMult + consumeHealAbsorb + healingThreat)',
       'dealDamage consumers: critVulnBonus (crit-only) + hexOutputMult on a damage hit',
       'multi-class healers: priest/paladin/druid/shaman',
     ],
@@ -2700,9 +2701,10 @@ function multiClassHeal(): Scenario {
       rec.snapshot('crit-vuln-damage');
 
       // HoT path: a druid Rejuvenation on the tank ticks through the `hot` aura
-      // branch -> healingTakenMult(~3089) + healingThreat(~3101) foreign callers.
-      // (The surviving absorb_big rides along untouched: the hot branch never calls
-      // consumeHealAbsorb, only applyHeal does.)
+      // branch -> healingTakenMult + consumeHealAbsorb + healingThreat. The shield
+      // that survived heal 4 is shrunk to a HoT-sized pool first, so the ticks pin
+      // the whole periodic-absorb arc: eaten, drained to nothing, then landing.
+      (tank.auras.find((a: Aura) => a.id === 'absorb_big') as Aura).value = 400;
       tank.hp = 2000;
       tank.auras.push(
         aura({


### PR DESCRIPTION
## Summary

Heal-absorb shields (Grave Blight from Gravecaller Summoners, Necrotic Blight in rifts) are meant to eat the next chunk of incoming healing, the fixed-pool sibling of Mortal Wound. Direct heals honored them, but every periodic heal path bypassed them: HoT ticks and the DoT leech self-heal wrote hp directly without draining the pool (while still applying healingTakenMult on the same line, showing the absorb half was simply missed), and Temporal Hourglass healing skipped both the pool and healingTakenMult. The counter-play inverted the mechanic: a blighted tank was best healed by Renew or Rejuvenation, which healed at full value and left the shield intact to eat the next direct heal.

How the fix works: all three periodic paths (the hot aura tick and the DoT leechPct self-heal in combat/auras.ts, and tickTemporalHourglassHealing) now run the same recipient-side pipeline applyHeal uses: healingTakenMult, then consumeHealAbsorb, then the missing-hp clamp, reusing the exported consumeHealAbsorb rather than duplicating it. Overheal is measured post-absorb so the two never double-count, and the heal2 events carry the absorbed field exactly as applyHeal's do. The hourglass still spends its stored budget at the planned share; only what the target keeps is mitigated.

The multi_class_heal parity golden was re-recorded (sanctioned UPDATE_PARITY flow) because this is a deliberate behavior change; the golden's rng digest and draw count are unchanged, confirming the fix draws no rng and moves no stream position. The scenario now pins the whole periodic-absorb arc: eaten, drained to nothing, then landing.

## Related issues

None found. The issue tracker was swept for this bug before opening the PR.

## Type of change

- [x] Bug fix

## How was this tested?

- Commands:
  - Five new tests in tests/mob_heal_absorb.test.ts: HoT ticks drain the pool and only the excess lands; the pool fades once emptied by ticks; DoT leech drains the attacker's own pool; hourglass healing respects both healingTakenMult and the pool; HoT ticks without a pool are unchanged. Four were confirmed red before the fix.
  - tests/parity suite green after the golden re-record (212 passed), digest and draw count byte-identical.
  - node scripts/gate_select.mjs: PASS, all 12 steps green.
- Manual steps: none needed; the tests drive the real aura tick paths.

## Checklist

### Quality

- [x] The gate passes. node scripts/gate_select.mjs is green and decisive tests were added for the changed behavior.

### Cross-platform

- N/A, no UI change.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or .env committed, and ALLOW_DEV_COMMANDS is not enabled in any production path.
- [x] Parity goldens were regenerated via the owning flow (UPDATE_PARITY=1), not hand-edited.

Generated with [Claude Code](https://claude.com/claude-code)