### PR TITLE
fix(sim): settle physics state on every instance arrival teleport

### DIFF
--- a/src/sim/delves/runs.ts
+++ b/src/sim/delves/runs.ts
@@ -56,6 +56,7 @@ import { aurasSurvivingDeath } from '../resurrection';
 import { Rng } from '../rng';
 import type { PlayerMeta } from '../sim';
 import type { SimContext } from '../sim_context';
+import { settleTeleportArrival } from '../teleport_arrival';
 import {
   DELVE_COMPANION_MAX_RANK,
   DELVE_PLATE_RADIUS,
@@ -410,6 +411,7 @@ export function enterDelve(ctx: SimContext, delveId: string, tierId: string, pid
   p.pos = pos;
   p.prevPos = { ...pos };
   ctx.rebucket(p);
+  settleTeleportArrival(p);
   p.facing = 0;
   p.prevFacing = 0;
   p.targetId = null;
@@ -446,6 +448,7 @@ export function leaveDelve(ctx: SimContext, pid?: number): void {
   p.pos = ctx.groundPos(delve.doorPos.x, delveExitDropZ(delve.doorPos.z, delve.id));
   p.prevPos = { ...p.pos };
   ctx.rebucket(p);
+  settleTeleportArrival(p);
   p.targetId = null;
   p.autoAttack = false;
   ctx.emit({ type: 'log', text: delve.leaveText, color: '#b9f', pid: r.meta.entityId });

--- a/src/sim/displacement.ts
+++ b/src/sim/displacement.ts
@@ -12,6 +12,7 @@
 
 import { cancelProfessionSessionOnDisplacement } from './professions/session_teardown';
 import type { SimContext } from './sim_context';
+import { settleTeleportArrival } from './teleport_arrival';
 import type { Entity } from './types';
 
 export function displacePlayer(
@@ -30,12 +31,6 @@ export function displacePlayer(
   p.facing = landing.facing;
   p.targetId = null;
   p.autoAttack = false;
-  // Land settled: no carried-over jump arc or fall distance from the far
-  // side (a portal pair with an elevation delta would otherwise deal fall
-  // damage on arrival).
-  p.vy = 0;
-  p.jumping = false;
-  p.onGround = true;
-  p.fallStartY = p.pos.y;
+  settleTeleportArrival(p);
   ctx.emit({ type: 'log', text, color: '#b9f', pid: p.id });
 }

--- a/src/sim/instances/dungeons.ts
+++ b/src/sim/instances/dungeons.ts
@@ -30,6 +30,7 @@ import type { InstanceSlot, PlayerMeta } from '../sim';
 import type { SimContext } from '../sim_context';
 import { arenaQueueLeave } from '../social/arena';
 import { resurrectOnInstanceReentry } from '../spirit';
+import { settleTeleportArrival } from '../teleport_arrival';
 import { dropThreat } from '../threat';
 import {
   dist2d,
@@ -429,20 +430,11 @@ export function enterDungeon(
   p.pos = ctx.groundPos(origin.x + dungeon.entry.x, origin.z + dungeon.entry.z);
   p.prevPos = { ...p.pos };
   ctx.rebucket(p);
+  settleTeleportArrival(p);
   p.facing = 0;
   p.prevFacing = 0;
   p.targetId = null;
   p.autoAttack = false;
-  // Land settled: no carried-over jump arc or fall distance from the overworld
-  // side of the door (the same recipe as every other sim teleport, portals.ts
-  // included). Without this, a player who jumps into the door mid-air keeps
-  // its stale overworld fallStartY/onGround=false, and the next vertical pass
-  // computes a bogus drop against the unrelated instance floor height and
-  // deals fall damage that has nothing to do with any real fall.
-  p.vy = 0;
-  p.jumping = false;
-  p.onGround = true;
-  p.fallStartY = p.pos.y;
   inst.emptyFor = 0;
   // Session participation record for this run: awardHeroicMarks pays the mail
   // arm only to locked players who actually walked through the door.
@@ -570,16 +562,9 @@ export function leaveDungeon(ctx: SimContext, pid?: number): boolean {
   p.pos = ctx.groundPos(door.x, door.z);
   p.prevPos = { ...p.pos };
   ctx.rebucket(p);
+  settleTeleportArrival(p);
   p.targetId = null;
   p.autoAttack = false;
-  // Land settled (see the matching comment in enterDungeon above): the exit
-  // side of the door needs the same reset, or leaving mid-air over an
-  // instance's interior geometry carries that fall state back out onto the
-  // overworld door and deals the same bogus fall damage in reverse.
-  p.vy = 0;
-  p.jumping = false;
-  p.onGround = true;
-  p.fallStartY = p.pos.y;
   ctx.emit({ type: 'log', text: dungeon.leaveText, color: '#b9f', pid: r.meta.entityId });
   return true;
 }

--- a/src/sim/social/arena.ts
+++ b/src/sim/social/arena.ts
@@ -36,6 +36,7 @@ import { aurasSurvivingCleanSlate, SICKNESS_AURA_IDS, UNSTUCK_SICKNESS_ID } from
 import type { ArenaMatch, ArenaQueueUnit, ArenaReturnPools, PlayerMeta } from '../sim';
 import type { SimContext } from '../sim_context';
 import { applyResurrectionSickness, applyUnstuckSickness } from '../spirit';
+import { settleTeleportArrival } from '../teleport_arrival';
 import {
   type ArenaCombatant,
   type ArenaFormat,
@@ -1031,6 +1032,7 @@ export function placeInArena(
   e.facing = spawn.facing;
   e.prevFacing = spawn.facing;
   ctx.rebucket(e);
+  settleTeleportArrival(e);
 }
 
 export function placeTeamInArena(

--- a/src/sim/social/battleground.ts
+++ b/src/sim/social/battleground.ts
@@ -44,6 +44,7 @@ import {
 } from '../pvp';
 import type { ArenaReturnPools } from '../sim';
 import type { SimContext } from '../sim_context';
+import { settleTeleportArrival } from '../teleport_arrival';
 import { type Aura, DT, type Entity, type Vec3 } from '../types';
 import { eloDelta, snapshotArenaReturnPools } from './arena';
 import { bgBackfillSeat, pickBgBackfillGroup } from './battleground_backfill';
@@ -1143,6 +1144,7 @@ function placeInBg(
   e.facing = team === 0 ? 0 : Math.PI; // face the field
   e.prevFacing = e.facing;
   ctx.rebucket(e);
+  settleTeleportArrival(e);
   ctx.readyArenaFighter(e, { clearPrep: true });
   // readyArenaFighter revives but does NOT clear the spirit arm: a fighter
   // seated (or re-seated by the form-up hold) must never stay a ghost.

--- a/src/sim/teleport_arrival.ts
+++ b/src/sim/teleport_arrival.ts
@@ -1,0 +1,10 @@
+import type { Entity } from './types';
+
+// Land settled: no carried-over jump arc or fall distance from the far side
+// (otherwise a teleport with an elevation delta can deal fall damage on arrival).
+export function settleTeleportArrival(p: Entity): void {
+  p.vy = 0;
+  p.jumping = false;
+  p.onGround = true;
+  p.fallStartY = p.pos.y;
+}

--- a/tests/parity/golden/delve_death.json
+++ b/tests/parity/golden/delve_death.json
@@ -146,7 +146,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 1008,
-      "state": "06b58c3a",
+      "state": "ad935ba5",
       "events": "d4634cfa",
       "rng": {
         "draws": 1,
@@ -222,7 +222,6 @@
           "detonateTimer": "Infinity",
           "dodgeChance": 0.0715,
           "dualWielding": true,
-          "fallStartY": -1.952555,
           "fiveSecondRule": 99,
           "hp": 93,
           "id": 993,

--- a/tests/teleport_arrival.test.ts
+++ b/tests/teleport_arrival.test.ts
@@ -1,0 +1,107 @@
+// The shared physics-arrival reset every teleport site calls (src/sim/teleport_arrival.ts),
+// extracted from the reset portals.ts already had. Unit-tests the helper directly, then
+// proves it through two real instance-entry paths: a player airborne at the transfer tick
+// must land settled, never taking fall damage from the overworld height it left behind
+// (issue: instance/arena/battleground/delve floors sit at y=0, so a stale fallStartY reads
+// as a 20-50 yd drop on arrival).
+
+import { describe, expect, it } from 'vitest';
+import { BUILTIN_WORLD } from '../src/sim/data';
+import { createPlayer } from '../src/sim/entity';
+import { enterDungeon } from '../src/sim/instances/dungeons';
+import { Sim } from '../src/sim/sim';
+import { settleTeleportArrival } from '../src/sim/teleport_arrival';
+import type { WorldContent } from '../src/sim/types';
+
+const NO_AMBIENT_WORLD: WorldContent = {
+  ...BUILTIN_WORLD,
+  camps: [],
+  npcs: {},
+  groundObjects: [],
+};
+
+describe('settleTeleportArrival', () => {
+  it('zeroes vertical velocity, clears jumping, grounds the entity, and pins fallStartY to the new pos', () => {
+    const p = createPlayer(1, 'warrior', { x: 10, y: 40, z: 10 }, 'Faller');
+    p.vy = -12;
+    p.jumping = true;
+    p.onGround = false;
+    p.fallStartY = 78; // stale overworld height the entity fell from
+
+    settleTeleportArrival(p);
+
+    expect(p.vy).toBe(0);
+    expect(p.jumping).toBe(false);
+    expect(p.onGround).toBe(true);
+    expect(p.fallStartY).toBe(p.pos.y);
+    expect(p.fallStartY).toBe(40);
+  });
+});
+
+describe('instance arrival resets an airborne player (dungeons)', () => {
+  function makeSim(seed = 99) {
+    return new Sim({
+      seed,
+      playerClass: 'warrior',
+      noPlayer: true,
+      world: NO_AMBIENT_WORLD,
+    });
+  }
+
+  it('enterDungeon lands an airborne player settled, with no fall damage on the next tick', () => {
+    const sim = makeSim();
+    const pid = sim.addPlayer('warrior', 'Solo');
+    const p = sim.entities.get(pid)!;
+    p.maxHp = p.hp = 1_000_000;
+    // Mid-jump over the overworld at the exact tick the door trigger fires
+    // (door triggers run in the same tick as movement): a stale fallStartY
+    // this far above the instance floor would be a lethal fall on landing.
+    p.pos.y = 45;
+    p.vy = 3;
+    p.jumping = true;
+    p.onGround = false;
+    p.fallStartY = 45;
+
+    expect(enterDungeon(sim.ctx, 'hollow_crypt', pid)).toBe(true);
+
+    expect(p.onGround).toBe(true);
+    expect(p.jumping).toBe(false);
+    expect(p.vy).toBe(0);
+    expect(p.fallStartY).toBe(p.pos.y);
+
+    const hpBeforeTick = p.hp;
+    sim.tick();
+    expect(p.hp).toBe(hpBeforeTick);
+    expect(p.hp).toBe(1_000_000);
+  });
+});
+
+describe('instance arrival resets an airborne player (delves)', () => {
+  function makeSim(seed = 7) {
+    return new Sim({ seed, playerClass: 'warrior', autoEquip: true, world: NO_AMBIENT_WORLD });
+  }
+
+  it('enterDelve lands an airborne player settled, with no fall damage on the next tick', () => {
+    const sim = makeSim();
+    sim.setPlayerLevel(7); // collapsed_reliquary's minLevel
+    const p = sim.player;
+    p.maxHp = p.hp = 1_000_000;
+    p.pos.y = 50;
+    p.vy = 2;
+    p.jumping = true;
+    p.onGround = false;
+    p.fallStartY = 50;
+
+    sim.enterDelve('collapsed_reliquary', 'normal');
+
+    expect(p.onGround).toBe(true);
+    expect(p.jumping).toBe(false);
+    expect(p.vy).toBe(0);
+    expect(p.fallStartY).toBe(p.pos.y);
+
+    const hpBeforeTick = p.hp;
+    sim.tick();
+    expect(p.hp).toBe(hpBeforeTick);
+    expect(p.hp).toBe(1_000_000);
+  });
+});


### PR DESCRIPTION
## Summary

Arena, battleground, and delve entry/exit teleports repositioned the player without resetting the fall tracker (vy, jumping, onGround, fallStartY). A player airborne at the transfer tick (mid-jump when a queue pop seats them, or jumping into a delve entrance) landed in the instance with fallStartY still holding the overworld height; instance floors sit at y 0 and overworld terrain 20 to 50 yd up, so the first landing computed a drop of that delta, dealing up to 100 percent of max HP at the gates of the content they just entered.

When this fix was first authored the dungeon doors had the same bug, but release/v0.41.0 fixed those two sites independently with an inline copy of the reset block (and its displacePlayer helper settles the portal, ferry, and tutorial teleports). The still-broken sites on this base are placeInArena (covering team and ready-fighter placement), placeInBg, enterDelve, and leaveDelve.

How the fix works: the reset recipe is extracted into a tiny shared module, src/sim/teleport_arrival.ts (settleTeleportArrival), and every arrival site routes through it: displacePlayer, enterDungeon and leaveDungeon (replacing their inline copies, so the block has one home), placeInArena, placeInBg, enterDelve, and leaveDelve, each right after the teleport and rebucket. One parity golden moves: delve_death loses its now-default fallStartY sample. The dungeon_instances golden no longer changes on this base because the base re-recorded it when it fixed the doors itself.

Known follow-up, deliberately out of scope: the instance-to-overworld return teleports (arena return, battleground end, delve module advance) share the shape but cannot produce a positive drop (the stale tracker holds the lower instance height), so they are left for a cleanup pass.

## Related issues

None found for this bug. Adjacent but distinct: issue 3427 covers a deed-tracking exploit around fall-damage death, not the entry teleport.

## Type of change

- [x] Bug fix

## How was this tested?

- Commands:
  - New tests/teleport_arrival.test.ts: unit coverage of the helper, plus integration through the real enterDungeon and enterDelve paths with an airborne player, asserting settled physics and zero HP loss on the next tick. The dungeon case was verified red with the fix reverted (on the original base, where the doors were still broken).
  - After the rebase onto release/v0.41.0: the dungeon and teleport suites (115 tests), the full parity suite (215 passed, golden re-record via UPDATE_PARITY=1), and npx tsc --noEmit.
  - node scripts/gate_select.mjs on the rebased tree: PASS, all 12 steps green.
- Manual steps: none needed.

## Checklist

### Quality

- [x] The gate passes. node scripts/gate_select.mjs is green and decisive tests were added for the changed behavior.

### Cross-platform

- N/A, no UI change.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or .env committed, and ALLOW_DEV_COMMANDS is not enabled in any production path.
- [x] Parity goldens were regenerated via the owning flow (UPDATE_PARITY=1), not hand-edited.

Generated with [Claude Code](https://claude.com/claude-code)
