### PR TITLE
fix(battleground): keep the backfill sweep going past a declined match

### DIFF
--- a/src/sim/social/battleground.ts
+++ b/src/sim/social/battleground.ts
@@ -684,7 +684,10 @@ function backfillBgMatches(ctx: SimContext): void {
       eligible.push({ index: i, size: g.pids.length, waited: g.waited });
     });
     const pickedAt = pickBgBackfillGroup(eligible.map((c) => ({ size: c.size, waited: c.waited })));
-    if (pickedAt < 0) return; // no eligible solo waiting: no later match can do better
+    // backfillDeclined is scoped to THIS match, so an empty list here only rules
+    // out this match: a later one that never made this offer can still want the
+    // same solo.
+    if (pickedAt < 0) continue;
     const index = eligible[pickedAt].index;
     const [group] = ctx.bgQueue.splice(index, 1);
     // ASK, never seat. The seat is a teleport into a live rated 5v5 that also

--- a/tests/battleground.test.ts
+++ b/tests/battleground.test.ts
@@ -3638,6 +3638,73 @@ describe('Thornhollow Fields: a queued solo backfills a deserted seat', () => {
     expect(match.teams[0]).toHaveLength(BG_TEAM_SIZE);
   });
 
+  it('keeps sweeping past a match a solo declined, so a second short match still gets offered them', () => {
+    // Review catch: an empty eligible list was read as proof no LATER match
+    // could do better either, which only holds for the four match-independent
+    // filters. backfillDeclined is scoped to the one match that made the offer,
+    // so a solo who turned down match A's seat blanked match A's list on every
+    // following tick, and that used to abort the whole sweep: match B stayed a
+    // fighter short forever even though the same solo was still fair game for it.
+    const sim = makeWorld();
+    const classes = ['warrior', 'mage', 'priest', 'rogue', 'hunter'] as const;
+    const pids: number[] = [];
+    for (let i = 0; i < 20; i++) {
+      const pid = sim.addPlayer(classes[i % 5], `P${i}`);
+      tp(sim, pid, (i % 5) * 2 - 4, -40);
+      must(sim.entities.get(pid), 'entity').level = 20;
+      pids.push(pid);
+    }
+    for (const pid of pids) sim.bgQueueJoin(pid);
+    sim.tick(); // both 5v5 pops land as offers in the same tick
+    acceptAllBgOffers(sim);
+
+    const matches: BgMatch[] = [];
+    const seenMatches = new Set<BgMatch>();
+    for (const m of sim.ctx.bgMatches.values()) {
+      if (seenMatches.has(m)) continue;
+      seenMatches.add(m);
+      matches.push(m);
+    }
+    expect(matches, 'twenty queued solos really seat two concurrent matches').toHaveLength(2);
+    const [matchA, matchB] = matches;
+    toActive(sim, matchA);
+    toActive(sim, matchB);
+
+    // Both matches go a fighter down.
+    bgResolveDesertion(sim.ctx, matchA.teams[0][4]);
+    bgResolveDesertion(sim.ctx, matchB.teams[0][4]);
+    expect(matchA.teams[0]).toHaveLength(BG_TEAM_SIZE - 1);
+    expect(matchB.teams[0]).toHaveLength(BG_TEAM_SIZE - 1);
+
+    // The lone queued solo is offered match A's seat first (the older match)...
+    const solo = sim.addPlayer('warrior', 'Solo');
+    tp(sim, solo, 6, -40);
+    must(sim.entities.get(solo), 'entity').level = 20;
+    sim.bgQueueJoin(solo);
+    sim.tick();
+    const firstOffer = must(bgProposalFor(sim.ctx, solo), 'match A offer');
+    expect(firstOffer.backfill?.match, 'match A is offered first').toBe(matchA);
+    bgRespond(sim.ctx, false, solo); // ...and turns it down.
+
+    // The next tick used to stop dead on match A's now-empty eligible list.
+    sim.tick();
+    const secondOffer = must(bgProposalFor(sim.ctx, solo), 'match B offer after the decline');
+    expect(
+      secondOffer.backfill?.match,
+      'the sweep kept going and match B offered the same solo the seat',
+    ).toBe(matchB);
+
+    acceptBackfillOffer(sim, solo);
+    expect(matchB.teams[0], 'match B got its fifth back').toHaveLength(BG_TEAM_SIZE);
+    expect(matchA.teams[0], 'match A never got a second chance at the decliner').toHaveLength(
+      BG_TEAM_SIZE - 1,
+    );
+    expect(
+      sim.ctx.bgProposals.some((p) => p.backfill?.match === matchA),
+      'match A holds no re-offer to the decliner',
+    ).toBe(false);
+  });
+
   // The leaver already pays (bgResolveDesertion charges rating and an L). This
   // is the other half: the four who stayed get their fifth back rather than
   // playing out a rated 4v5, which at BG_TEAM_SIZE 5 is most of a match.


### PR DESCRIPTION
## Summary

backfillBgMatches iterates every live match, but when one match produced an empty candidate list it aborted the whole sweep with a return, on the stated premise that no later match could do better. Four of the five eligibility filters are indeed global, but backfillDeclined is per-match state: a solo who declined match A's backfill offer (free by design, they keep their queue spot) made match A's list empty on every tick, so a second short match B was never offered anyone for as long as match A lived. B played out 4v5 while a willing fighter sat in the queue.

How the fix works: the empty-candidates case now continues to the next match instead of returning, and the comment states why the per-match decline filter makes the whole-sweep abort wrong. A match that finds no candidate simply stops blocking the ones behind it; the decliner is still never re-offered the seat they turned down.

## Related issues

None found for this bug. Adjacent but distinct: issue 3327 is about CTF queue population, not the backfill sweep.

## Type of change

- [x] Bug fix

## How was this tested?

- Commands:
  - New test in tests/battleground.test.ts: two concurrent matches each a fighter short (real desertions), one queued solo who declines match A's offer through the real declineBgBackfill path; asserts match B then offers and seats that solo, and that match A never re-offers the decliner. Confirmed red before the fix (match B never received a proposal).
  - npx vitest run tests/battleground.test.ts tests/battleground_backfill.test.ts tests/architecture.test.ts green (230 tests).
  - node scripts/gate_select.mjs: PASS, all 12 steps green.
- Manual steps: none needed.

## Checklist

### Quality

- [x] The gate passes. node scripts/gate_select.mjs is green and a decisive test was added for the changed behavior.

### Cross-platform

- N/A, no UI change.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or .env committed, and ALLOW_DEV_COMMANDS is not enabled in any production path.
- [x] No generated files were hand-edited.

Generated with [Claude Code](https://claude.com/claude-code)