### PR TITLE
fix(climb): refuse ledge grabs from damaging fall speeds

### DIFF
--- a/src/sim/climb.ts
+++ b/src/sim/climb.ts
@@ -21,7 +21,7 @@ import { MANTLE_REACH, supportHeightAt } from './colliders';
 import { isRooted, isStunned } from './combat/cc';
 import { PLAYER_BODY_RADIUS } from './pathfind';
 import { findLedgeGrab, LEDGE_GRAB_MAX, LEDGE_GRAB_MIN } from './physics/ledge';
-import { GRAVITY, JUMP_VELOCITY } from './player_motion';
+import { FALL_SAFE_DISTANCE, GRAVITY, JUMP_VELOCITY } from './player_motion';
 import { DT, type Entity, type LedgeClimb } from './types';
 import { groundHeight } from './world';
 
@@ -42,6 +42,24 @@ const CLIMB_RISE_PHASE = 0.62;
 const CLIMB_SETTLE_EPS = 1e-3;
 /** A climb only starts while genuinely airborne and not already rising fast. */
 const CLIMB_MAX_RISE_SPEED = 2.5;
+
+/**
+ * The other end of the same gate: a grab zeroes the body's velocity and
+ * `advanceClimb` rebases `fallStartY` on completion, so catching a plunge
+ * erases its fall damage outright. This is the descent speed the sim's 20 Hz
+ * integrator reaches after exactly FALL_SAFE_DISTANCE of free fall, so a fall
+ * that already hurts can never be caught by a ledge on the way past.
+ *
+ * Derived, not hand-tuned: the discrete step (`vy -= GRAVITY * DT`, then
+ * `pos.y += vy * DT`) covers `(v^2 / GRAVITY + v * DT) / 2` yards by the time
+ * it reaches speed `v`, so the safe speed is the positive root of that at
+ * FALL_SAFE_DISTANCE.
+ */
+const CLIMB_FALL_STEP = GRAVITY * DT;
+export const CLIMB_MAX_FALL_SPEED =
+  (Math.sqrt(CLIMB_FALL_STEP * CLIMB_FALL_STEP + 8 * GRAVITY * FALL_SAFE_DISTANCE) -
+    CLIMB_FALL_STEP) /
+  2;
 
 /**
  * The pull-up is for lips ABOVE YOUR HEAD: a ledge lower than this over the
@@ -76,6 +94,9 @@ export function tryStartClimb(p: Entity, seed: number): boolean {
   // arc short and rob the player of the height they just bought. Wait for the
   // apex, which is also when a real climber's hands reach the lip.
   if (p.vy > CLIMB_MAX_RISE_SPEED) return false;
+  // Falling this fast means the fall is already a damaging one; a grab would
+  // zero the velocity and rebase the fall, refunding the damage for free.
+  if (p.vy < -CLIMB_MAX_FALL_SPEED) return false;
   if (isStunned(p) || isRooted(p)) return false;
   const grab = findLedgeGrab(
     { seed, radius: PLAYER_BODY_RADIUS, facing: p.facing, vx: p.vx, vz: p.vz },

--- a/tests/climb.test.ts
+++ b/tests/climb.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, describe, expect, it } from 'vitest';
-import { advanceClimb, CLIMB_MIN_OVERHEAD, climbDuration, tryStartClimb } from '../src/sim/climb';
+import {
+  advanceClimb,
+  CLIMB_MAX_FALL_SPEED,
+  CLIMB_MIN_OVERHEAD,
+  climbDuration,
+  tryStartClimb,
+} from '../src/sim/climb';
 import {
   campCrateShape,
   DOCK_HUT_ROOF_TOP,
@@ -15,10 +21,10 @@ import { BUILTIN_WORLD, setActiveWorldContent } from '../src/sim/data';
 import { PLAYER_BODY_RADIUS } from '../src/sim/pathfind';
 import { MAX_STEP_HEIGHT } from '../src/sim/physics';
 import { findLedgeGrab, LEDGE_GRAB_MAX, LEDGE_GRAB_MIN } from '../src/sim/physics/ledge';
-import { GRAVITY, JUMP_VELOCITY } from '../src/sim/player_motion';
+import { FALL_SAFE_DISTANCE, GRAVITY, JUMP_VELOCITY } from '../src/sim/player_motion';
 import { graveHeight, graveOffset } from '../src/sim/prop_layout';
 import { Sim } from '../src/sim/sim';
-import type { Entity, WorldContent } from '../src/sim/types';
+import { DT, type Entity, type WorldContent } from '../src/sim/types';
 import { groundHeight, terrainHeight, terrainSteepnessAt, WATER_LEVEL } from '../src/sim/world';
 
 // The ledge climb completes the traversal ladder: step over the low, vault the
@@ -558,5 +564,122 @@ describe('the climb onto the town roofs', () => {
     // Walked into the stall and stopped at its rim, never through or onto it.
     expect(p.pos.z).toBeLessThan(sz - 1.6);
     expect(p.pos.y).toBeLessThan(groundHeight(p.pos.x, p.pos.z, SEED) + 0.5);
+  });
+});
+
+describe('a ledge grab never refunds a fall', () => {
+  // The grab zeroes velocity and advanceClimb rebases fallStartY, so a lip
+  // crossed mid-plunge used to swallow every yard of fall behind it. The stall
+  // canopy is the worst case in town: a standable 2.54 top beside open ground.
+  const STALL_DZ = 2.6;
+  const BODY_DX = -2.0; // beside the gable end, clear of its own footprint
+
+  const JUMP_FORWARD = {
+    forward: true,
+    back: false,
+    turnLeft: false,
+    turnRight: false,
+    strafeLeft: false,
+    strafeRight: false,
+    jump: true,
+    dive: false,
+    surface: false,
+  };
+
+  interface Plunge {
+    hpLost: number;
+    grabbed: boolean;
+    landedY: number;
+  }
+
+  // A level 60 warrior, the fixture every Sim-level climb test here drives.
+  function makeWarrior(): Sim {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior', autoEquip: true });
+    sim.setPlayerLevel(60);
+    return sim;
+  }
+
+  function dropBesideStall(dropHeight: number, withStall: boolean): Plunge {
+    const sz = SPOT.z + STALL_DZ;
+    const stall = world({ stalls: [{ x: SPOT.x, z: sz, rot: 0, r: 1.7 }] });
+    setActiveWorldContent(withStall ? stall : world({}));
+    const sim = makeWarrior();
+    const p = sim.player;
+    const bx = SPOT.x + BODY_DX;
+    p.pos.x = bx;
+    p.pos.z = sz;
+    p.pos.y = groundHeight(bx, sz, SEED) + dropHeight;
+    p.prevPos = { ...p.pos };
+    p.facing = Math.PI / 2;
+    p.onGround = false;
+    p.jumping = false;
+    p.vx = 0;
+    p.vy = 0;
+    p.vz = 0;
+    p.climb = null;
+    p.fallStartY = p.pos.y;
+    const hp0 = p.hp;
+    let grabbed = false;
+    for (let i = 0; i < 200 && !p.onGround; i++) {
+      sim.tick();
+      if (p.climb) grabbed = true;
+    }
+    return { hpLost: hp0 - p.hp, grabbed, landedY: p.pos.y };
+  }
+
+  it('refuses a grab at a fall speed that would already deal damage', () => {
+    const drop = 20; // well past FALL_SAFE_DISTANCE
+    const bare = dropBesideStall(drop, false);
+    expect(bare.grabbed).toBe(false);
+    expect(bare.hpLost).toBeGreaterThan(0);
+    const beside = dropBesideStall(drop, true);
+    expect(beside.hpLost).toBe(bare.hpLost);
+    expect(beside.grabbed).toBe(false);
+    expect(beside.landedY).toBeCloseTo(bare.landedY, 6);
+  });
+
+  it('still catches a fall that is short enough to be harmless', () => {
+    const drop = 6; // half the safe distance: the grab is still free
+    const caught = dropBesideStall(drop, true);
+    expect(caught.grabbed).toBe(true);
+    expect(caught.hpLost).toBe(0);
+  });
+
+  it('caps the grab at exactly FALL_SAFE_DISTANCE of free fall', () => {
+    // Replay the sim's own vertical step. The cap has to land on the yard the
+    // damage starts at: lower and a harmless fall loses its grab, higher and a
+    // damaging one keeps buying a refund.
+    let vy = 0;
+    let fallen = 0;
+    for (let i = 0; i < 500 && -vy < CLIMB_MAX_FALL_SPEED - 1e-9; i++) {
+      vy -= GRAVITY * DT;
+      fallen -= vy * DT;
+    }
+    expect(-vy).toBeCloseTo(CLIMB_MAX_FALL_SPEED, 6);
+    expect(fallen).toBeCloseTo(FALL_SAFE_DISTANCE, 6);
+  });
+
+  it('leaves a ground jump at the same canopy climbing as before', () => {
+    const sz = SPOT.z + STALL_DZ;
+    setActiveWorldContent(world({ stalls: [{ x: SPOT.x, z: sz, rot: 0, r: 1.7 }] }));
+    const sim = makeWarrior();
+    const p = sim.player;
+    const meta = sim.players.get(p.id);
+    if (!meta) throw new Error('missing meta');
+    p.pos.x = SPOT.x - 1.55 - 1.4;
+    p.pos.z = sz;
+    p.pos.y = terrainHeight(p.pos.x, p.pos.z, SEED);
+    p.prevPos = { ...p.pos };
+    p.fallStartY = p.pos.y;
+    p.facing = Math.PI / 2;
+    p.onGround = true;
+    let climbed = false;
+    for (let i = 0; i < 120 && !climbed; i++) {
+      Object.assign(meta.moveInput, JUMP_FORWARD);
+      sim.tick();
+      if (p.climb) climbed = true;
+    }
+    expect(climbed).toBe(true);
+    expect(p.hp).toBe(p.maxHp);
   });
 });


### PR DESCRIPTION
## Summary

tryStartClimb gated only on rising speed, so a body plummeting past any standable prop top whose grab band it crossed would grab it; the grab zeroes velocity and advanceClimb rebases fallStartY on completion, so the accumulated fall damage was erased outright. Reproduced empirically: drops of 16, 20, 30, and 39 yd beside the market stall dealt 230, 460, 1036, and lethal damage on bare ground and exactly 0 with the stall in the descent line. Any tower, ridge, or rooftop with a grabbable ledge below it made lethal falls free.

How the fix works: a symmetric descent-speed gate joins the existing rise gate. The new CLIMB_MAX_FALL_SPEED is derived, not hand tuned: it is the speed the sim's semi-implicit Euler integrator (vy minus GRAVITY times DT, then pos.y plus vy times DT) reaches after exactly FALL_SAFE_DISTANCE of free fall, so a fall that already deals damage can never be caught, while short hops and ordinary standing grabs are untouched. The discrete form is used rather than the continuous sqrt(2gh) because the continuous value is loose enough to let a slightly damaging fall through. fallStartY handling for legitimate climbs is unchanged.

## Related issues

None found. The issue tracker was swept for this bug before opening the PR.

## Type of change

- [x] Bug fix

## How was this tested?

- Commands:
  - Four new tests in tests/climb.test.ts: a 20 yd drop past the stall takes the same fall damage as bare ground and does not grab; a 6 yd drop still grabs harmlessly; a both-sides pin of the exact FALL_SAFE_DISTANCE boundary replayed through the sim's own integrator; the ordinary jump-at-a-ledge path still climbs. The first was confirmed red with the gate disabled (expected 0 to be 460, the exact reported symptom).
  - Regression sweep over ten climb and fall adjacent suites, all green.
  - node scripts/gate_select.mjs: PASS, all 12 steps green.
- Manual steps: none needed.

## Checklist

### Quality

- [x] The gate passes. node scripts/gate_select.mjs is green and decisive tests were added for the changed behavior.

### Cross-platform

- N/A, no UI change.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or .env committed, and ALLOW_DEV_COMMANDS is not enabled in any production path.
- [x] No generated files were hand-edited.

Generated with [Claude Code](https://claude.com/claude-code)