### PR TITLE
fix(combat): make channel pushback cost the ticks it removes

### DIFF
--- a/src/sim/combat/casting_lifecycle.ts
+++ b/src/sim/combat/casting_lifecycle.ts
@@ -523,13 +523,11 @@ export function updateCasting(ctx: SimContext, p: Entity, meta: PlayerMeta): voi
       // end advance separately, so floating-point drift can leave the final
       // tick a hair short exactly when they coincide, silently dropping the
       // last missile (the Arcane Missiles 5-barrage bug). A tick still
-      // meaningfully in the future was not lost to drift: pushbackCast's
-      // channel-fraction branch shortens castRemaining without rescheduling
-      // channelTickTimer, so a big enough pushback can end the channel before
-      // a later tick's timer ever comes due. Classic-era pushback trims the
-      // trailing tick count along with the time, so that tick is dropped too,
-      // never forced out as a same-instant completion burst. Inert for
-      // duration-based channels, whose channelTicksLeft is 0.
+      // meaningfully in the future was not lost to drift: a pushback-shortened
+      // channel already gave up the boundaries it no longer reaches (see
+      // pushbackCast), and anything still orphaned here is dropped rather than
+      // forced out as a same-instant completion burst. Inert for duration-based
+      // channels, whose channelTicksLeft is 0.
       while (p.channelTicksLeft > 0 && p.channelTickTimer <= CAST_COMPLETE_EPS) {
         p.channelTicksLeft -= 1;
         p.channelTickTimer += p.channelTickEvery;
@@ -751,6 +749,14 @@ export function pushbackCast(p: Entity): void {
       0,
       p.castRemaining - p.castTotal * CHANNEL_PUSHBACK_FRACTION * factor,
     );
+    // The shortened channel keeps only the ticks whose boundaries still fit: the
+    // next lands in channelTickTimer, the rest one channelTickEvery apart.
+    if (p.channelTicksLeft > 0 && p.channelTickEvery > 0) {
+      const roomAfterNextTick = p.castRemaining - p.channelTickTimer + CAST_COMPLETE_EPS;
+      const stillFit =
+        roomAfterNextTick < 0 ? 0 : Math.floor(roomAfterNextTick / p.channelTickEvery) + 1;
+      p.channelTicksLeft = Math.min(p.channelTicksLeft, stillFit);
+    }
   } else {
     p.castRemaining += CAST_PUSHBACK_SEC * factor;
     p.castTotal += CAST_PUSHBACK_SEC * factor;

--- a/tests/combat_casting_lifecycle.test.ts
+++ b/tests/combat_casting_lifecycle.test.ts
@@ -547,7 +547,9 @@ describe('casting_lifecycle: pushbackCast', () => {
     pushbackCast(p);
     pushbackCast(p);
     expect(p.castRemaining).toBe(0);
-    expect(p.channelTicksLeft).toBe(2); // pushback itself never touches the tick count
+    // Pushback gives up the boundaries the shortened channel can no longer
+    // reach, so both owed ticks are already surrendered before completion.
+    expect(p.channelTicksLeft).toBe(0);
 
     let maxFiredInOneUpdate = 0;
     let updates = 0;
@@ -655,6 +657,107 @@ describe('casting_lifecycle: pushbackCast', () => {
     expect(p.castingAbility).toBeNull();
     expect(sim.ctx.pendingProjectiles).toHaveLength(0); // every tick dropped, none forced
     expect(p.channelTicksLeft).toBe(0);
+  });
+
+  it('drops the fixed-count ticks a shortened channel no longer reaches', () => {
+    const { sim, p } = makeSim('warlock', 12);
+    spawnTarget(sim, p);
+    castAbility(sim.ctx, 'drain_life', p.id);
+    // Consume runs 3s over 3 ticks with the first pulse front-loaded to one DT,
+    // so its tick boundaries sit at 0.05s, 1.05s and 2.05s.
+    expect(p.channelTicksLeft).toBe(3);
+    pushbackCast(p); // 3.00s to 2.25s: every boundary still fits
+    expect(p.channelTicksLeft).toBe(3);
+    pushbackCast(p); // 2.25s to 1.50s: the 2.05s boundary no longer fits
+    expect(p.channelTicksLeft).toBe(2);
+  });
+});
+
+// A fixed-count channel tick queues exactly one bolt (Aether Darts, Consume), and
+// driving updateCasting alone never advances the projectile queue, so the queue
+// length is a running count of the ticks fired.
+function runChannelTicks(
+  sim: AnySim,
+  p: AnyEntity,
+  meta: any,
+  pushbackOnTicks: number[],
+): number[] {
+  const firedPerTick: number[] = [];
+  let queued = sim.ctx.pendingProjectiles.length;
+  for (let i = 0; p.castingAbility && i < 400; i++) {
+    if (pushbackOnTicks.includes(i)) pushbackCast(p);
+    updateCasting(sim.ctx, p, meta);
+    const now = sim.ctx.pendingProjectiles.length;
+    firedPerTick.push(now - queued);
+    queued = now;
+  }
+  return firedPerTick;
+}
+
+function totalFired(perTick: number[]): number {
+  return perTick.reduce((a, b) => a + b, 0);
+}
+
+describe('casting_lifecycle: channel pushback costs the ticks it removes', () => {
+  // Aether Darts: 3s over 3 ticks with no front-load, so its boundaries land at
+  // 1s, 2s and 3s and the last one coincides with the channel's own end.
+  function aetherDartsCaster() {
+    const { sim, p, meta } = makeSim('mage', 20);
+    expect(sim.setSpec('arcane')).toBe(true);
+    spawnTarget(sim, p, 12);
+    castAbility(sim.ctx, 'arcane_missiles', p.id);
+    expect(p.channeling).toBe(true);
+    expect(p.channelTicksLeft).toBe(3);
+    return { sim, p, meta };
+  }
+
+  it('lands every authored tick, one per boundary, when nothing pushes back', () => {
+    const { sim, p, meta } = aetherDartsCaster();
+    const perTick = runChannelTicks(sim, p, meta, []);
+    expect(totalFired(perTick)).toBe(3);
+    expect(Math.max(...perTick)).toBe(1); // never two missiles inside one sim tick
+    // The final boundary coincides with the channel's end, so the drift-recovery
+    // flush is what delivers it: it must still land.
+    expect(perTick[perTick.length - 1]).toBe(1);
+  });
+
+  it('loses the tail ticks that no longer fit after two pushbacks', () => {
+    const { sim, p, meta } = aetherDartsCaster();
+    const perTick = runChannelTicks(sim, p, meta, [0, 1]);
+    expect(totalFired(perTick)).toBeLessThan(3); // the shortened channel costs ticks
+    expect(totalFired(perTick)).toBeGreaterThan(0);
+    expect(Math.max(...perTick)).toBe(1); // the end flush never dumps the rest of the barrage
+  });
+
+  it('never fires more ticks than the channel authored, however often it is hit', () => {
+    const { sim, p, meta } = aetherDartsCaster();
+    const everyTick = Array.from({ length: 60 }, (_, i) => i);
+    const perTick = runChannelTicks(sim, p, meta, everyTick);
+    expect(totalFired(perTick)).toBeLessThan(3);
+    expect(Math.max(...perTick, 0)).toBeLessThanOrEqual(1);
+  });
+
+  it('costs a pushed Consume real drain damage and self-heal', () => {
+    const runDrain = (pushbackOnTicks: number[]) => {
+      const { sim, p, meta } = makeSim('warlock', 12);
+      const mob = spawnTarget(sim, p);
+      p.hp = 1; // room for every self-heal to land unclamped
+      const mobHp0 = mob.hp;
+      castAbility(sim.ctx, 'drain_life', p.id);
+      const perTick = runChannelTicks(sim, p, meta, pushbackOnTicks);
+      for (let i = 0; i < 200 && sim.ctx.pendingProjectiles.length > 0; i++)
+        advancePendingProjectiles(sim.ctx);
+      return { perTick, simTicks: perTick.length, healed: p.hp - 1, dealt: mobHp0 - mob.hp };
+    };
+
+    const clean = runDrain([]);
+    const pushed = runDrain([0, 1]);
+    expect(totalFired(clean.perTick)).toBe(3);
+    expect(pushed.simTicks).toBeLessThan(clean.simTicks); // pushback did shorten it
+    expect(totalFired(pushed.perTick)).toBeLessThan(3); // and it cost pulses
+    expect(Math.max(...pushed.perTick)).toBe(1); // never a whole drain in one sim tick
+    expect(pushed.dealt).toBeLessThan(clean.dealt);
+    expect(pushed.healed).toBeLessThan(clean.healed);
   });
 });
 


### PR DESCRIPTION
## Summary

Channel pushback (CHANNEL_PUSHBACK_FRACTION, the classic 25 percent shave per hit) shortened castRemaining but never touched channelTicksLeft, so the schedule kept promising every authored tick. When this fix was first authored the end-of-channel flush was also an unbounded while loop that dumped every unreached tick in a single 50 ms sim tick; release/v0.41.0 fixed that half independently by gating the flush on due ticks, so the payload burst is already gone on this base.

What remains broken without this PR: the owed tick count stays stale for the whole shortened channel, and that is observable. A pushback-shortened Consume ends while channelTicksLeft is still positive, so isFinalConsumePulse never becomes true on its real final pulse and the completion doom bonus is silently skipped; the schedule also keeps promising ticks it will never deliver.

How the fix works: pushbackCast's channel arm now recomputes channelTicksLeft after shaving castRemaining, keeping only ticks whose boundaries still fit the remaining time (the next boundary sits at channelTickTimer, the rest one channelTickEvery apart; the shared CAST_COMPLETE_EPS tolerance is load-bearing so an unpushed channel never loses a tick to float drift, and min never lets a pushback raise the count). The base's due-tick completion gate is kept verbatim. An unpushed fixed-count channel still lands exactly its authored ticks including the drift case; a pushed one surrenders the tail at pushback time, so the real final pulse reads as final.

## Related issues

None found for this bug. Adjacent but distinct: issue 3400 covered stale channel state after death mid-channel, a different trigger already fixed on that path.

## Type of change

- [x] Bug fix

## How was this tested?

- Commands:
  - Four new tests plus one extended in tests/combat_casting_lifecycle.test.ts, counting real fires per sim tick: an unpushed 3-tick channel lands exactly 3 with the last-tick drift case protected; a pushed channel fires strictly fewer and never more than one tick per sim tick; total never exceeds the authored count under repeated pushback; a pushed Consume deals strictly less damage and self-heal than an untouched one. A new case pins the trim itself: the second pushback drops exactly the boundary that no longer fits.
  - One base assertion was re-pinned: the base test expected channelTicksLeft to stay 2 after repeated pushback (pushback never touches the count), which is precisely the behavior this PR changes; it now expects 0 with the rationale in a comment.
  - After the rebase onto release/v0.41.0: tests/combat_casting_lifecycle.test.ts 50/50, the full parity suite (215 passed), npx tsc --noEmit, and vitest related over casting_lifecycle.ts (18124 tests passed).
- Manual steps: none needed.

## Checklist

### Quality

- [x] The gate passes. node scripts/gate_select.mjs is green and decisive tests were added for the changed behavior.

### Cross-platform

- N/A, no UI change.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or .env committed, and ALLOW_DEV_COMMANDS is not enabled in any production path.
- [x] No generated files were hand-edited.

Generated with [Claude Code](https://claude.com/claude-code)
