### PR TITLE
fix(sim): make lockout auras non-removable by any player counter

### DIFF
--- a/src/sim/aura_classify.ts
+++ b/src/sim/aura_classify.ts
@@ -56,17 +56,43 @@ export function isDebuffAura(kind: AuraKind, value: number): boolean {
   return DEBUFF_AURA_KINDS.has(kind) || (kind.startsWith('buff_') && value < 0);
 }
 
+// A lockout the sim owns: the aura's PRESENCE is the cooldown. Internal cooldowns,
+// proc windows, and rolling-window accumulators gate their own re-arm on a bare
+// presence check, and the `sated` / `cauterize_fatigue` comments above say outright
+// that the debuff IS the lockout. Letting a player take one off (right-click
+// cancel, cleanse, a friendly dispel, or an enemy's offensive dispel or
+// Spellsteal) hands someone a free cooldown reset. `internal_cd` renders on the
+// buff bar so the player can watch it tick down; `sated` and `cauterize_fatigue`
+// stay in DEBUFF_AURA_KINDS so they keep rendering red.
+export const LOCKOUT_AURA_KINDS: ReadonlySet<AuraKind> = new Set<AuraKind>([
+  'internal_cd',
+  'sated',
+  'cauterize_fatigue',
+]);
+
+// Two auras wear the internal_cd kind without being lockouts (nothing re-arms on
+// their presence), so they keep the normal removal rules:
+//  - Divine Ascension: a player-owned resource state surfaced as an aura for HUD
+//    clarity. Its voluntary right-click cancel deliberately ends the state
+//    (Sim.cancelAura zeroes the charges); dispel and Spellsteal still refuse it
+//    by id in isDispellableAura below.
+//  - Stoneward: a real ally-carried healing ward, so purge and Spellsteal remain
+//    legitimate counterplay and its carrier may right-click it off.
+const NON_LOCKOUT_AURA_IDS: ReadonlySet<string> = new Set(['divine_ascension', 'shaman_stoneward']);
+
 // The one rule for "may a player counter take this aura off at all", ahead of any
-// question of school or polarity. Two aura classes answer no: encounter-authored
-// unbreakable control (the script owns its release) and `undispellable` penalties
-// (the recovery sicknesses, which only their own timer clears). Every removal path a
-// player can drive routes through here so the answer cannot drift between them: the
-// dispel executor and its requiresDispellable cast gate (isDispellableAura below),
-// the cleanseSelf executor (combat/effect_dispatch.ts), and the right-click buff
+// question of school or polarity. Three aura classes answer no: encounter-authored
+// unbreakable control (the script owns its release), `undispellable` penalties
+// (the recovery sicknesses, which only their own timer clears), and sim-owned
+// lockouts (LOCKOUT_AURA_KINDS above). Every removal path a player can drive
+// routes through here so the answer cannot drift between them: the dispel
+// executor and its requiresDispellable cast gate (isDispellableAura below), the
+// cleanseSelf executor (combat/effect_dispatch.ts), and the right-click buff
 // cancel (combat/aura_cancel.ts).
 export function isPlayerRemovableAura(
-  aura: Pick<Aura, 'kind' | 'unbreakableControl' | 'undispellable'>,
+  aura: Pick<Aura, 'kind' | 'unbreakableControl' | 'undispellable'> & Partial<Pick<Aura, 'id'>>,
 ): boolean {
+  if (LOCKOUT_AURA_KINDS.has(aura.kind) && !NON_LOCKOUT_AURA_IDS.has(aura.id ?? '')) return false;
   return !isUnbreakableControlAura(aura) && aura.undispellable !== true;
 }
 

--- a/src/sim/moderation/cheater_mark.ts
+++ b/src/sim/moderation/cheater_mark.ts
@@ -105,10 +105,12 @@ export function cheaterMarkAfterPlayed(
  *    applySickness in ../spirit.ts): a penalty a dispel, a cleanse, or a
  *    right-click could shed is not a penalty.
  *  - the PHYSICAL school, which isDispellableAura (../aura_classify.ts) refuses
- *    outright, whatever the flag says. This is what the repo's other inert
- *    markers ride ('flag_carried', 'internal_cd'), and it is the reason the
- *    mark is not on 'shadow': a shadow-school debuff protected by one boolean
- *    is one careless edit away from being a warlock's Voidfeast snack.
+ *    outright, whatever the flag says. The 'flag_carried' marker rides it for
+ *    the same reason ('internal_cd' instead earned a kind-level guard,
+ *    LOCKOUT_AURA_KINDS, because its sites span every school), and it is the
+ *    reason the mark is not on 'shadow': a shadow-school debuff protected by
+ *    one boolean is one careless edit away from being a warlock's Voidfeast
+ *    snack.
  * Only its own timer, an operator lift, or the served sanction clears it.
  */
 export function cheaterMarkAura(mark: CheaterMark, entityId: number): Aura {

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -563,10 +563,12 @@ export type AuraKind =
   // OUTCOME is overridden to true (combat/fire_mage.ts fireGuaranteedCrit; the
   // roll is still drawn). Guaranteed crits build Hot Streak like any other.
   | 'combustion'
-  // Inert timer marker: NO combat reader keys on this kind, so it is pure
-  // visible state (an internal cooldown or a capped-window accumulator the
-  // player can watch tick). Kept apart per user by the aura id (Temporal
-  // Rift's 20s ICD, Overflowing Power's 30s shave window).
+  // Inert timer marker: no combat reader keys on this kind, but the removal
+  // rule does (aura_classify.ts LOCKOUT_AURA_KINDS): its presence IS the
+  // cooldown, so no player counter (cancel, cleanse, dispel, Spellsteal) may
+  // take it off. Otherwise pure visible state (an internal cooldown or a
+  // capped-window accumulator the player can watch tick), kept apart per user
+  // by the aura id (Temporal Rift's 20s ICD, Overflowing Power's 30s window).
   | 'internal_cd'
   // Thornhollow Fields: "you are carrying the enemy flag" (social/battleground.ts).
   // Deliberately its own kind rather than a borrowed inert marker, because the

--- a/tests/aura_cancel.test.ts
+++ b/tests/aura_cancel.test.ts
@@ -76,6 +76,14 @@ describe('isDebuffAura', () => {
 
     expect(isCancelableAura(scriptedStasis)).toBe(false);
   });
+
+  it('never exposes an internal_cd lockout as player-cancelable', () => {
+    // A proc gate re-arms on the lockout aura's presence, so cancelling it
+    // would be a free cooldown reset. Not a debuff either: it stays on the
+    // buff bar so the player can watch it tick down.
+    expect(isCancelableAura(aura('hunter_guise_mastery_icd', 'internal_cd'))).toBe(false);
+    expect(isDebuffAura(aura('hunter_guise_mastery_icd', 'internal_cd'))).toBe(false);
+  });
 });
 
 describe('auraAffectsStats', () => {
@@ -106,6 +114,20 @@ describe('removeCancelableAura', () => {
     const auras = [aura('hemorrhage_bleed_vuln', 'bleed_vuln', 0.4)];
     expect(removeCancelableAura(auras, 'hemorrhage_bleed_vuln')).toBeNull();
     expect(auras).toHaveLength(1);
+  });
+
+  it('refuses to cancel an internal_cd lockout but still removes an ordinary buff', () => {
+    const auras = [aura('hunter_guise_mastery_icd', 'internal_cd'), aura('might', 'buff_ap', 50)];
+    expect(removeCancelableAura(auras, 'hunter_guise_mastery_icd')).toBeNull();
+    expect(auras).toHaveLength(2);
+    expect(removeCancelableAura(auras, 'might')?.id).toBe('might');
+    expect(auras.map((a) => a.id)).toEqual(['hunter_guise_mastery_icd']);
+  });
+
+  it('still removes Divine Ascension, the one voluntarily cancelable internal_cd', () => {
+    const auras = [aura('divine_ascension', 'internal_cd')];
+    expect(removeCancelableAura(auras, 'divine_ascension')?.id).toBe('divine_ascension');
+    expect(auras).toHaveLength(0);
   });
 
   it('returns null when nothing matches', () => {

--- a/tests/aura_classify.test.ts
+++ b/tests/aura_classify.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { isDebuffAura, isDispellableAura } from '../src/sim/aura_classify';
+import { isDebuffAura, isDispellableAura, isPlayerRemovableAura } from '../src/sim/aura_classify';
 import type { Aura, AuraKind } from '../src/sim/types';
 
 // Every harmful kind the HUD and /targetbuffs treat as a debuff. Keeping this
@@ -112,5 +112,68 @@ describe('isDispellableAura', () => {
     };
     expect(isDispellableAura(ascension, true)).toBe(false);
     expect(isDispellableAura(ascension, false)).toBe(false);
+  });
+});
+
+// Sim-owned lockout kinds. The aura's PRESENCE is the cooldown, so any
+// player-driven removal (right-click cancel, cleanse, a friendly dispel, an
+// enemy's offensive dispel or Spellsteal) is a free cooldown reset. Pinned here
+// so no kind can drift back into the removable set.
+const LOCKOUT: AuraKind[] = ['internal_cd', 'sated', 'cauterize_fatigue'];
+
+const ALL_SCHOOLS: Aura['school'][] = [
+  'physical',
+  'fire',
+  'frost',
+  'arcane',
+  'shadow',
+  'holy',
+  'nature',
+];
+
+describe('lockout kinds (internal cooldowns)', () => {
+  it('no player counter may remove a lockout at all', () => {
+    for (const kind of LOCKOUT) {
+      expect(isPlayerRemovableAura({ kind })).toBe(false);
+      expect(isPlayerRemovableAura({ id: 'hunter_guise_mastery_icd', kind })).toBe(false);
+    }
+  });
+
+  it('refuses dispel and Spellsteal for a lockout at every school and both polarities', () => {
+    for (const kind of LOCKOUT) {
+      for (const school of ALL_SCHOOLS) {
+        for (const offensive of [true, false]) {
+          expect(isDispellableAura({ kind, value: 1, school }, offensive)).toBe(false);
+          expect(isDispellableAura({ kind, value: 0, school }, offensive)).toBe(false);
+        }
+      }
+    }
+  });
+
+  it('keeps an internal_cd off the debuff bar (renders as a watchable buff icon)', () => {
+    expect(isDebuffAura('internal_cd', 1)).toBe(false);
+    expect(isDebuffAura('internal_cd', 0)).toBe(false);
+  });
+
+  it('keeps sated and cauterize_fatigue on the debuff bar (they render red)', () => {
+    expect(isDebuffAura('sated', 0)).toBe(true);
+    expect(isDebuffAura('cauterize_fatigue', 0)).toBe(true);
+  });
+
+  it('keeps Divine Ascension voluntarily cancelable (a resource state, not a lockout)', () => {
+    // An internal_cd aura a player may remove: right-click cancel ends the
+    // ascension and Sim.cancelAura zeroes its charges. Dispel and Spellsteal
+    // still refuse it by id (pinned in the isDispellableAura suite above).
+    expect(isPlayerRemovableAura({ id: 'divine_ascension', kind: 'internal_cd' })).toBe(true);
+  });
+
+  it('keeps Stoneward purgeable and stealable (a ward, not a lockout)', () => {
+    // Stoneward is a real ally-carried healing ward that wears the internal_cd
+    // kind; nothing re-arms on its presence, so purge and Spellsteal remain
+    // legitimate counterplay and its carrier may right-click it off.
+    const stoneward = { id: 'shaman_stoneward', kind: 'internal_cd' as const };
+    expect(isPlayerRemovableAura(stoneward)).toBe(true);
+    expect(isDispellableAura({ ...stoneward, value: 0, school: 'nature' }, true)).toBe(true);
+    expect(isDispellableAura({ ...stoneward, value: 0, school: 'nature' }, false)).toBe(false);
   });
 });

--- a/tests/cheater_mark.test.ts
+++ b/tests/cheater_mark.test.ts
@@ -222,9 +222,10 @@ describe('cheaterMarkAura', () => {
   });
 
   test('rides the physical school, so a dispel is refused even without the flag', () => {
-    // Two independent guards, pinned independently. The repo's other inert
-    // markers (flag_carried, internal_cd) ride physical for exactly this reason:
-    // one boolean is one careless edit away from making the tag dispel food.
+    // Two independent guards, pinned independently. The flag_carried marker
+    // rides physical for exactly this reason (internal_cd instead has the
+    // kind-level LOCKOUT_AURA_KINDS guard): one boolean is one careless edit
+    // away from making the tag dispel food.
     expect(aura.school).toBe('physical');
     const flagDropped = { ...aura, undispellable: undefined };
     expect(isDispellableAura(flagDropped, false)).toBe(false);

--- a/tests/hunter_talents.test.ts
+++ b/tests/hunter_talents.test.ts
@@ -270,6 +270,25 @@ describe('Hunter v0.29 choice-row mechanics', () => {
     );
   });
 
+  it('Guise Mastery lockout survives a right-click cancel (no free proc reset)', () => {
+    // The internal cooldown rides an aura and the proc gate is a presence
+    // check, so a cancelable lockout would let the hunter re-proc at will.
+    const sim = hunter('marksmanship', { 14: 'hun_r14_guise_mastery' }, 2935);
+    sim.castAbility('aspect_of_the_hawk');
+    const hasIcd = () => sim.player.auras.some((entry) => entry.id === 'hunter_guise_mastery_icd');
+    expect(hasIcd()).toBe(true);
+
+    sim.cancelAura('hunter_guise_mastery_icd');
+    expect(hasIcd()).toBe(true);
+
+    // Swap guise again well inside the 20 second lockout: the swap itself
+    // succeeds (positive control) but grants no second rider.
+    advance(sim, 2);
+    sim.castAbility('aspect_of_the_monkey');
+    expect(sim.player.auras.some((entry) => entry.id === 'aspect_of_the_monkey')).toBe(true);
+    expect(sim.player.auras.some((entry) => entry.id === 'hunter_guise_marten')).toBe(false);
+  });
+
   it('Shell and Fang trades mitigation for attacks during Shellskin', () => {
     const sim = hunter('marksmanship', { 17: 'hun_r17_shell_and_fang' }, 2934);
     const target = addMob(sim, 20);


### PR DESCRIPTION
## Summary

Closes the internal-cooldown classification gap from the internal report "Player-cancelable internal cooldowns": the aura kind `internal_cd` was absent from every classification list, so all 25+ lockout auras across 6 classes classified as helpful buffs. A player could right-click their own proc lockout off the buff bar and re-arm the proc immediately (the worked example: Guise Mastery's 20 second shared cooldown, bypassable at will), and an enemy's offensive dispel or Spellsteal could strip, and steal-copy, any non-physical-school lockout.

The fix lands at the documented chokepoint, `isPlayerRemovableAura` in `src/sim/aura_classify.ts`, which every player-driven removal path routes through (right-click cancel, cleanse, the dispel executor, and its `requiresDispellable` cast gate). A new `LOCKOUT_AURA_KINDS` set makes lockout auras non-removable by any player counter, closing all four paths in one edit. The Spellsteal copy is closed by the same edit, since the steal only fires after the dispel predicate passes.

Two deviations from the report's literal one-liner, both forced by existing pinned behavior or by preserving non-lockout gameplay:

- `divine_ascension` is exempted by id. It is a player-owned resource state wearing the `internal_cd` kind for HUD clarity, and its voluntary right-click cancel (which zeroes the charges in `Sim.cancelAura`) is pinned by `tests/paladin_core_abilities.test.ts`. Dispel and Spellsteal still refuse it by id, as before.
- `shaman_stoneward` is exempted by id. Stoneward is a real ally-carried healing ward (6 charges, heals on hit) that wears the `internal_cd` kind; nothing re-arms on its presence, so purging or stealing it is legitimate counterplay, and blanket-protecting it would be a silent PvP balance change. Pinned in `tests/aura_classify.test.ts`.

One extension beyond the report's scope, same exploit class at the same chokepoint: `sated` and `cauterize_fatigue` are debuff-kind lockouts (their own comments say the debuff IS the cooldown), and a friendly dispel, or the mage's own Ice Block cleanse, could strip them, re-enabling a second Bloodlust or a second Cauterize save inside the 5 minute window. Both kinds join `LOCKOUT_AURA_KINDS`. They stay in `DEBUFF_AURA_KINDS` so their rendering is unchanged.

## Review decisions to confirm

Accepted deltas of the kind-level rule, flagged here rather than silently shipped:

- Ready-state procs riding `internal_cd` (`heating_up`, `shaman_thunder_charges`, `stormsurge_ready`, warlock `reflection_ready`, hunter `stampede_ready`, and similar) are no longer purgeable off an enemy. The report's recommended comment covers "proc windows" explicitly, and hidden proc states were not dispellable in the classic era, so this reads as intended; it is still a PvP-visible change.
- Purge asymmetry inside state clusters: for example Thundercall's `primal_mastery` markers are now protected while the sibling `next_cast_instant` empowerment is still purgeable, so a purge can take half a cluster. Pre-existing kinds, unchanged here; called out in case the empowerment kinds should join the guard later.
- Lockout icons keep rendering on the buff bar (deliberate, so the player can watch the cooldown tick down; pinned) but no longer respond to right-click. No visual styling changes, so no screenshots.

Cancellation still emits the same bare fade event, indistinguishable from expiry; the report's suggested removal-reason audit trail is deliberately left as a separate change.

## Related issues

Internal report: internal_cd aura classification gap (docs/pdf circulated 2026-08; no GitHub issue).

## Type of change

- [x] Bug fix
- [x] Tests

## How was this tested?

- Commands:
  - All new pins written failing first against the unfixed code (5 assertions across 3 files reproduced the exploit; the `sated`/`cauterize_fatigue` and Stoneward pins reproduced their arms the same way), then green after the fix.
  - `npx vitest run` over the 19 suites touching the cancel/dispel/cleanse paths and their consumers (aura_classify, aura_cancel, hunter_talents, paladin_core_abilities, auras_view, aura_icon_view, battleground incl. the flag-drop interception, sickness_undispellable, cheater_mark, cauterize, temporal_acceleration, shaman/rogue talents, party_frames, world_api_parity, and more): 852 tests passed.
  - `npx tsc --noEmit` clean; changed-files biome clean.
  - `node scripts/gate_select.mjs` green.
  - A fresh read-only sim-domain review agent audited the diff for coverage: determinism/rng draw order untouched (parity golden traces unchanged), sim purity intact, three-host parity confirmed (client `ClientWorld.cancelAura` is a pure command send with no optimistic removal; wire sends `id` and `kind` unconditionally; the RL env exposes no cancel action), battleground flag drop unaffected (`flag_carried` is its own kind, intercepted upstream).
- Manual steps: none required; no rendering or styling changes.

## New tests

- `tests/aura_classify.test.ts`: pinned lockout list (`internal_cd`, `sated`, `cauterize_fatigue`) is not player-removable and not dispellable at all 7 schools, both polarities, values 0 and 1; `internal_cd` stays off the debuff bar; `sated`/`cauterize_fatigue` stay red; the Divine Ascension and Stoneward exemptions are pinned.
- `tests/aura_cancel.test.ts`: `removeCancelableAura` returns null for an `internal_cd` lockout and leaves the array intact while still removing an ordinary buff; Divine Ascension remains removable at this layer.
- `tests/hunter_talents.test.ts`: end to end on the real path: proc Guise Mastery, `sim.cancelAura` the lockout, re-swap guise inside 20 seconds (with a positive control that the swap itself succeeded), assert no second proc.

---

## Checklist

### Quality

- [x] **The gate passes.** `node scripts/gate_select.mjs` is green. I added decisive tests for changed behavior and recorded the manual checks above.

### Cross-platform

- ~Tested on desktop and mobile.~ N/A: no UI layout or styling change; the only client-visible difference is that right-clicking a lockout icon no longer removes it, enforced server-side by the same shared predicate.
- ~Accessible.~ N/A: no UI added or edited.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings (the changed emit paths reuse existing aura names).

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files.
