### PR TITLE
fix(mob): stop evading mobs from acting and telegraph the first pulse

### DIFF
--- a/src/sim/entity.ts
+++ b/src/sim/entity.ts
@@ -775,6 +775,8 @@ export function createMob(id: number, template: MobTemplate, level: number, pos:
   e.swingTimer = 0;
   // Telegraph the first War Stomp: delay it one full interval after engage.
   if (template.stomp) e.stompTimer = template.stomp.every;
+  // Telegraph the first pulse blast the same way: one full interval after engage.
+  if (template.aoePulse) e.pulseTimer = template.aoePulse.every;
   // Telegraph the first Banshee's Wail the same way: one full interval after engage.
   if (template.terrify) e.terrifyTimer = template.terrify.every;
   // Telegraph the first Howling Gale the same way: one full interval after engage.

--- a/src/sim/mob/lifecycle.ts
+++ b/src/sim/mob/lifecycle.ts
@@ -94,6 +94,7 @@ export function respawnMob(ctx: SimContext, mob: Entity): void {
   mob.firedSummons = 0;
   mob.enraged = false;
   mob.healedThisPull = false;
+  mob.pulseTimer = MOBS[mob.templateId]?.aoePulse?.every ?? 0;
   mob.stompTimer = MOBS[mob.templateId]?.stomp?.every ?? 0;
   mob.terrifyTimer = MOBS[mob.templateId]?.terrify?.every ?? 0;
   // The shared spacing lock dies with the life like the timers around it.

--- a/src/sim/mob/locomotion.ts
+++ b/src/sim/mob/locomotion.ts
@@ -390,7 +390,11 @@ export function updateMob(ctx: SimContext, mob: Entity): void {
             (mob.nythraxis.heroicSummonChannelRemaining ?? 0) > 0))
       )
         return;
-    } else {
+    } else if (mob.aiState !== 'evade') {
+      // inCombat deliberately survives startEvadeHome (other systems key on
+      // it), so the kit is gated on the evade state instead: a mob walking home
+      // is damage-immune and untargetable, and must not heal, ward, or enrage
+      // its camp back up while nothing can touch it.
       ctx.updateBossMechanics(mob);
     }
   }

--- a/src/sim/mob/locomotion.ts
+++ b/src/sim/mob/locomotion.ts
@@ -1422,6 +1422,7 @@ export function resetEvadingMob(ctx: SimContext, mob: Entity): void {
   mob.firedSummons = 0;
   mob.enraged = false;
   mob.healedThisPull = false;
+  mob.pulseTimer = MOBS[mob.templateId]?.aoePulse?.every ?? 0;
   mob.stompTimer = MOBS[mob.templateId]?.stomp?.every ?? 0;
   mob.terrifyTimer = MOBS[mob.templateId]?.terrify?.every ?? 0;
   // The shared spacing lock dies with the pull like the timers around it.

--- a/tests/affliction.test.ts
+++ b/tests/affliction.test.ts
@@ -1765,6 +1765,10 @@ describe('Affliction Warlock', () => {
     const bossHp = boss.hp;
     const bossNearby = addTarget(bossSim, 12);
     const bossNearbyHp = bossNearby.hp;
+    // The pinned tier math is the subject here, not resist luck: hit-cap the
+    // cast so the impact draw (still taken, same stream position) cannot land
+    // in the resist band when unrelated mob changes reshuffle the seed.
+    bossSim.player.hitBonus = 1;
     const bossEvents = finishCast(bossSim, 'sentence', boss);
     expect(
       bossEvents

--- a/tests/mob_aoe_pulse_telegraph.test.ts
+++ b/tests/mob_aoe_pulse_telegraph.test.ts
@@ -1,0 +1,98 @@
+// The aoePulse boss mechanic is telegraphed like every one of its siblings
+// (stomp, terrify, aoeSlow, mendAlly, ...): createMob seeds the timer to one
+// full interval so the opening blast never lands the instant melee contact
+// opens, and both pull resets (evade home, respawn) restore that interval.
+// pulseTimer was the one timer missing from all three sites, so every carrier
+// opened with a free AoE, and any leftover negative drift carried into the
+// next pull.
+import { describe, expect, it } from 'vitest';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+import { respawnMob } from '../src/sim/mob/lifecycle';
+import { Sim } from '../src/sim/sim';
+import type { SimContext } from '../src/sim/sim_context';
+import type { Entity, SimEvent } from '../src/sim/types';
+
+const SEED = 42;
+
+// Mogger is the seeded world carrier of the mechanic (Ground Pound).
+const PULSE = MOBS.mogger.aoePulse!;
+
+const ctxOf = (sim: Sim) => (sim as unknown as { ctx: SimContext }).ctx;
+const updateMob = (sim: Sim, mob: Entity) =>
+  (sim as unknown as { updateMob(m: Entity): void }).updateMob(mob);
+
+function makeSim() {
+  return new Sim({ seed: SEED, playerClass: 'warrior', autoEquip: true });
+}
+
+// Spawn a pulsing rare locked in melee on the player, exactly as it stands the
+// instant a pull connects.
+function engagedPulser(sim: Sim, id: number): Entity {
+  const mob = createMob(id, MOBS.mogger, MOBS.mogger.maxLevel, { ...sim.player.pos });
+  mob.spawnPos = { ...sim.player.pos }; // sit on the player: in melee + pulse radius, no leash
+  mob.aiState = 'attack';
+  mob.aggroTargetId = sim.playerId;
+  mob.inCombat = true;
+  (sim as unknown as { addEntity(e: Entity): void }).addEntity(mob);
+  return mob;
+}
+
+const pulseHits = (events: SimEvent[]) =>
+  events.filter((e) => e.type === 'damage' && e.ability === PULSE.name);
+
+describe('aoePulse telegraph', () => {
+  it('Mogger carries the pulse mechanic', () => {
+    expect(PULSE.name).toBe('Ground Pound');
+    expect(PULSE.every).toBe(10);
+  });
+
+  it('is telegraphed: a fresh carrier waits one interval before its first blast', () => {
+    const mob = createMob(900200, MOBS.mogger, MOBS.mogger.maxLevel, { x: 0, y: 0, z: 0 });
+    expect(mob.pulseTimer).toBe(PULSE.every);
+  });
+
+  it('lands no blast on the first melee-contact tick', () => {
+    const sim = makeSim();
+    sim.player.maxHp = 5000;
+    sim.player.hp = 5000;
+    const mob = engagedPulser(sim, 900201);
+    sim.drainEvents();
+    updateMob(sim, mob);
+    expect(pulseHits(sim.drainEvents())).toHaveLength(0);
+    expect(mob.pulseTimer).toBeGreaterThan(0);
+  });
+
+  it('blasts once the seeded interval has elapsed', () => {
+    const sim = makeSim();
+    sim.player.maxHp = 5000;
+    sim.player.hp = 5000;
+    const mob = engagedPulser(sim, 900202);
+    mob.pulseTimer = 0.001; // due now
+    sim.drainEvents();
+    updateMob(sim, mob);
+    expect(pulseHits(sim.drainEvents())).toHaveLength(1);
+    expect(mob.pulseTimer).toBeCloseTo(PULSE.every, 5);
+  });
+
+  // Both pull resets are twins: a timer restored by one and not the other lets
+  // leftover negative drift open the next pull with a free blast.
+  for (const [label, reset] of [
+    ['resetEvadingMob (leashes home)', (sim: Sim, m: Entity) => ctxOf(sim).resetEvadingMob(m)],
+    ['respawnMob (a fresh life)', (sim: Sim, m: Entity) => respawnMob(ctxOf(sim), m)],
+  ] as const) {
+    it(label + ' restores the full interval', () => {
+      const sim = makeSim();
+      const mob = engagedPulser(sim, 900203);
+      mob.pulseTimer = -3.5; // drifted negative behind a held mechanic slot
+      reset(sim, mob);
+      expect(mob.pulseTimer).toBe(PULSE.every);
+    });
+  }
+
+  it('leaves a mob without the mechanic at the untouched default', () => {
+    const mob = createMob(900204, MOBS.forest_wolf, 6, { x: 0, y: 0, z: 0 });
+    expect(MOBS.forest_wolf.aoePulse).toBeUndefined();
+    expect(mob.pulseTimer).toBe(0);
+  });
+});

--- a/tests/mob_evade_support_kit.test.ts
+++ b/tests/mob_evade_support_kit.test.ts
@@ -1,0 +1,111 @@
+// An evading mob is damage-immune (combat/damage.ts) and untargetable for the
+// whole walk home, so its support kit must be silent too: startEvadeHome drops
+// aggro and threat but deliberately leaves inCombat set (other systems key on
+// it), and the boss-mechanic driver keyed on inCombat alone. A leashed
+// Gravecaller Mender therefore kept knitting its camp back to full while
+// nothing could touch it, for as long as the walk lasted (unbounded under the
+// instance-exit hold).
+import { describe, expect, it } from 'vitest';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+import { Sim } from '../src/sim/sim';
+import { type Entity, LEASH_DISTANCE } from '../src/sim/types';
+
+const SEED = 41099;
+const MEND = MOBS.gravecaller_mender.mendAlly!;
+const WOUNDED_FRAC = 0.4;
+
+const addEntity = (sim: Sim, e: Entity) =>
+  (sim as unknown as { addEntity(e: Entity): void }).addEntity(e);
+const updateMob = (sim: Sim, mob: Entity) =>
+  (sim as unknown as { updateMob(m: Entity): void }).updateMob(mob);
+
+function place(sim: Sim, e: Entity, x: number, z: number) {
+  e.pos = sim.groundPos(x, z);
+  e.prevPos = { ...e.pos };
+  sim.grid.update(e);
+}
+
+// Open a real pull: a hit is what seeds threat, and the hate table is what
+// keeps the mob engaged instead of retargeting straight back into evade.
+function pull(sim: Sim, mob: Entity) {
+  sim.ctx.dealDamage(sim.player, mob, 1, false, 'physical', null, 'hit');
+  updateMob(sim, mob);
+  expect(mob.aggroTargetId).toBe(sim.playerId);
+  expect(mob.inCombat).toBe(true);
+}
+
+// A mender pulled off its camp, then dragged past its leash so the next tick
+// sends it home, with a wounded pack-mate at its side (social aggro brings the
+// camp along, so a leashing mender leashes with company in Grave Mending range).
+function leashedMender(sim: Sim) {
+  sim.player.maxHp = 5000;
+  sim.player.hp = 5000; // outlive the mender melee: the kit is what is under test
+  const home = { ...sim.player.pos };
+  const mender = createMob(950001, MOBS.gravecaller_mender, MOBS.gravecaller_mender.maxLevel, home);
+  addEntity(sim, mender);
+  const ally = createMob(950002, MOBS.gravecaller_cultist, MOBS.gravecaller_cultist.maxLevel, home);
+  ally.hp = Math.round(ally.maxHp * WOUNDED_FRAC);
+  addEntity(sim, ally);
+
+  place(sim, sim.player, home.x + 2, home.z);
+  pull(sim, mender);
+
+  const dragX = home.x + LEASH_DISTANCE + 10;
+  place(sim, mender, dragX, home.z);
+  place(sim, ally, dragX, home.z);
+  place(sim, sim.player, dragX + 2, home.z);
+  mender.leashAnchor = null; // measured from spawn: dragged well past the leash
+
+  updateMob(sim, mender);
+  expect(mender.aiState).toBe('evade');
+  return { mender, ally, home };
+}
+
+function walkHome(sim: Sim, mender: Entity, onTick?: () => void) {
+  let ticks = 0;
+  while (mender.aiState === 'evade' && ticks < 20 * 60) {
+    updateMob(sim, mender);
+    onTick?.();
+    ticks++;
+  }
+  expect(ticks).toBeGreaterThan(1); // the walk really happened
+  expect(mender.aiState).toBe('idle'); // arrived home and reset
+  return ticks;
+}
+
+describe('evading mob support kit', () => {
+  it('casts nothing for the whole walk home, with inCombat still set', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior', autoEquip: true });
+    const { mender, ally } = leashedMender(sim);
+    const wounded = ally.hp;
+    mender.mendTimer = 0.001; // due the instant the walk starts
+
+    walkHome(sim, mender, () => {
+      expect(ally.hp).toBe(wounded);
+      // The premise: the evade state is what gates the kit, not inCombat, which
+      // stays set right up to the reset on arrival.
+      if (mender.aiState === 'evade') expect(mender.inCombat).toBe(true);
+    });
+    expect(ally.hp).toBe(wounded);
+  });
+
+  it('mends again once it has reset and been re-engaged', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior', autoEquip: true });
+    const { mender, ally, home } = leashedMender(sim);
+    walkHome(sim, mender);
+    expect(mender.mendTimer).toBe(MEND.every);
+
+    // The camp is whole again: the wounded pack-mate and the next player are
+    // both back at the spawn, so a fresh pull runs the kit as authored.
+    place(sim, ally, home.x, home.z);
+    ally.hp = Math.round(ally.maxHp * WOUNDED_FRAC);
+    place(sim, sim.player, home.x + 2, home.z);
+    pull(sim, mender);
+    const wounded = ally.hp;
+
+    for (let i = 0; i < 20 * MEND.every + 1; i++) updateMob(sim, mender);
+    expect(mender.aiState).not.toBe('evade');
+    expect(ally.hp).toBeGreaterThan(wounded);
+  });
+});

--- a/tests/parity/golden/dungeon_instances.json
+++ b/tests/parity/golden/dungeon_instances.json
@@ -31,7 +31,7 @@
       "tick": 2,
       "time": 0.1,
       "nextId": 1013,
-      "state": "586ca299",
+      "state": "0c38e032",
       "events": "eb5555e6",
       "rng": {
         "draws": 39,
@@ -751,6 +751,7 @@
             "z": -1152.210908
           },
           "potionCooldownUntil": -1,
+          "pulseTimer": 10,
           "spawnPos": {
             "x": 100300,
             "y": 0.6,
@@ -911,7 +912,7 @@
       "tick": 4,
       "time": 0.2,
       "nextId": 1013,
-      "state": "4300622c",
+      "state": "afd47813",
       "events": "94921daa",
       "rng": {
         "draws": 39,
@@ -1636,6 +1637,7 @@
             "z": -1152.421816
           },
           "potionCooldownUntil": -1,
+          "pulseTimer": 10,
           "spawnPos": {
             "x": 100300,
             "y": 0.6,
@@ -1796,7 +1798,7 @@
       "tick": 5,
       "time": 0.25,
       "nextId": 1013,
-      "state": "c0116dcb",
+      "state": "9e536dde",
       "events": "741638a5",
       "rng": {
         "draws": 39,
@@ -1807,7 +1809,7 @@
       "tick": 10,
       "time": 0.5,
       "nextId": 1013,
-      "state": "c250a16e",
+      "state": "5cc814e3",
       "events": "741638a5",
       "rng": {
         "draws": 39,
@@ -1818,7 +1820,7 @@
       "tick": 15,
       "time": 0.75,
       "nextId": 1013,
-      "state": "81664936",
+      "state": "986a4947",
       "events": "741638a5",
       "rng": {
         "draws": 39,

--- a/tests/parity/golden/grix_respawn_window.json
+++ b/tests/parity/golden/grix_respawn_window.json
@@ -28,7 +28,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 999,
-      "state": "1b7e465f",
+      "state": "2c233d24",
       "events": "e1772948",
       "rng": {
         "draws": 8,
@@ -242,6 +242,7 @@
             "z": -56
           },
           "potionCooldownUntil": -1,
+          "pulseTimer": 9,
           "respawnTimer": 1799.057371,
           "spawnPos": {
             "x": -92,
@@ -265,7 +266,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 999,
-      "state": "c6fce0f2",
+      "state": "3f066ddd",
       "events": "bdc5e53a",
       "rng": {
         "draws": 17,
@@ -483,6 +484,7 @@
             "z": -56
           },
           "potionCooldownUntil": -1,
+          "pulseTimer": 9,
           "respawnTimer": 1463.975608,
           "spawnPos": {
             "x": -92,
@@ -507,7 +509,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 999,
-      "state": "c6fce0f2",
+      "state": "3f066ddd",
       "events": "741638a5",
       "rng": {
         "draws": 17,
@@ -725,6 +727,7 @@
             "z": -56
           },
           "potionCooldownUntil": -1,
+          "pulseTimer": 9,
           "respawnTimer": 1463.975608,
           "spawnPos": {
             "x": -92,

--- a/tests/parity/golden/mob_locomotion.json
+++ b/tests/parity/golden/mob_locomotion.json
@@ -11,8 +11,8 @@
     "evade arm arrival -> resetEvadingMob (rng.range(2,8), full-heal, clearThreat, telegraph re-arm)",
     "cowardly flee: maybeFlee at FLEE_HP_THRESHOLD -> flee arm (fleeMoveSpeed run-away)"
   ],
-  "draws": 18,
-  "drawDigest": "9188be02",
+  "draws": 16,
+  "drawDigest": "b3c83c71",
   "frames": [
     {
       "tick": 0,
@@ -684,11 +684,11 @@
       "tick": 0,
       "time": 0,
       "nextId": 1002,
-      "state": "00e43b09",
-      "events": "95fa62d4",
+      "state": "75ec8c93",
+      "events": "9f34cf60",
       "rng": {
-        "draws": 15,
-        "digest": "9507c98f"
+        "draws": 13,
+        "digest": "d051f004"
       },
       "label": "terrify",
       "players": [
@@ -708,7 +708,7 @@
           "cls": "warrior",
           "companionUpgrades": {},
           "counters": {
-            "damageTaken": 207
+            "damageTaken": 183
           },
           "craftSkills": {},
           "deedStats": {
@@ -766,7 +766,7 @@
           "cls": "mage",
           "companionUpgrades": {},
           "counters": {
-            "damageTaken": 65
+            "damageTaken": 44
           },
           "craftSkills": {},
           "deedStats": {
@@ -844,7 +844,7 @@
           "dodgeChance": 0.06,
           "fallStartY": -2,
           "fiveSecondRule": 99,
-          "hp": 999976,
+          "hp": 1000000,
           "id": 997,
           "inCombat": true,
           "kind": "player",
@@ -863,7 +863,7 @@
             "z": -58
           },
           "potionCooldownUntil": -1,
-          "resource": 19.066667,
+          "resource": 16.866667,
           "resourceType": "rage",
           "spawnPos": {
             "x": -94,
@@ -908,7 +908,7 @@
               "remaining": 3,
               "school": "shadow",
               "sourceId": 1001,
-              "value": -0.095652
+              "value": -0.564087
             }
           ],
           "comboUntil": -1,
@@ -917,7 +917,7 @@
           "dodgeChance": 0.056,
           "fallStartY": -2,
           "fiveSecondRule": 99,
-          "hp": 999979,
+          "hp": 1000000,
           "id": 998,
           "inCombat": true,
           "kind": "player",
@@ -1050,6 +1050,7 @@
         {
           "aggroTargetId": 997,
           "aiState": "attack",
+          "combatTimer": 99.05,
           "comboUntil": -1,
           "critChance": 0.05,
           "detonateTimer": "Infinity",
@@ -1074,7 +1075,7 @@
             "z": -58
           },
           "potionCooldownUntil": -1,
-          "pulseTimer": 9,
+          "pulseTimer": 8.95,
           "spawnPos": {
             "x": -94,
             "y": -2,
@@ -1098,11 +1099,11 @@
       "tick": 0,
       "time": 0,
       "nextId": 1003,
-      "state": "c9409e80",
+      "state": "22a876bb",
       "events": "741638a5",
       "rng": {
-        "draws": 17,
-        "digest": "9720b470"
+        "draws": 15,
+        "digest": "9507c98f"
       },
       "label": "idle-wander",
       "players": [
@@ -1122,7 +1123,7 @@
           "cls": "warrior",
           "companionUpgrades": {},
           "counters": {
-            "damageTaken": 207
+            "damageTaken": 183
           },
           "craftSkills": {},
           "deedStats": {
@@ -1180,7 +1181,7 @@
           "cls": "mage",
           "companionUpgrades": {},
           "counters": {
-            "damageTaken": 65
+            "damageTaken": 44
           },
           "craftSkills": {},
           "deedStats": {
@@ -1258,7 +1259,7 @@
           "dodgeChance": 0.06,
           "fallStartY": -2,
           "fiveSecondRule": 99,
-          "hp": 999976,
+          "hp": 1000000,
           "id": 997,
           "inCombat": true,
           "kind": "player",
@@ -1277,7 +1278,7 @@
             "z": -58
           },
           "potionCooldownUntil": -1,
-          "resource": 19.066667,
+          "resource": 16.866667,
           "resourceType": "rage",
           "spawnPos": {
             "x": -94,
@@ -1322,7 +1323,7 @@
               "remaining": 3,
               "school": "shadow",
               "sourceId": 1001,
-              "value": -0.095652
+              "value": -0.564087
             }
           ],
           "comboUntil": -1,
@@ -1331,7 +1332,7 @@
           "dodgeChance": 0.056,
           "fallStartY": -2,
           "fiveSecondRule": 99,
-          "hp": 999979,
+          "hp": 1000000,
           "id": 998,
           "inCombat": true,
           "kind": "player",
@@ -1464,6 +1465,7 @@
         {
           "aggroTargetId": 997,
           "aiState": "attack",
+          "combatTimer": 99.05,
           "comboUntil": -1,
           "critChance": 0.05,
           "detonateTimer": "Infinity",
@@ -1488,7 +1490,7 @@
             "z": -58
           },
           "potionCooldownUntil": -1,
-          "pulseTimer": 9,
+          "pulseTimer": 8.95,
           "spawnPos": {
             "x": -94,
             "y": -2,
@@ -1513,7 +1515,7 @@
           "critChance": 0.05,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.05,
-          "facing": -1.703576,
+          "facing": -1.581433,
           "fallStartY": 6.818369,
           "fiveSecondRule": 99,
           "hostile": true,
@@ -1528,9 +1530,9 @@
           "overpowerUntil": -1,
           "petMode": "defensive",
           "pos": {
-            "x": 299.861232,
-            "y": 6.797488,
-            "z": 299.981465
+            "x": 299.860008,
+            "y": 6.793146,
+            "z": 299.998511
           },
           "potionCooldownUntil": -1,
           "spawnPos": {
@@ -1543,9 +1545,9 @@
           },
           "templateId": "forest_wolf",
           "wanderTarget": {
-            "x": 297.990175,
-            "y": 6.548058,
-            "z": 299.731557
+            "x": 294.606869,
+            "y": 6.16114,
+            "z": 299.942634
           },
           "wanderTimer": 30,
           "weapon": {
@@ -1560,11 +1562,11 @@
       "tick": 0,
       "time": 0,
       "nextId": 1004,
-      "state": "1bc58fdc",
+      "state": "22769988",
       "events": "741638a5",
       "rng": {
-        "draws": 18,
-        "digest": "9188be02"
+        "draws": 16,
+        "digest": "b3c83c71"
       },
       "label": "evade-reset",
       "players": [
@@ -1584,7 +1586,7 @@
           "cls": "warrior",
           "companionUpgrades": {},
           "counters": {
-            "damageTaken": 207
+            "damageTaken": 183
           },
           "craftSkills": {},
           "deedStats": {
@@ -1642,7 +1644,7 @@
           "cls": "mage",
           "companionUpgrades": {},
           "counters": {
-            "damageTaken": 65
+            "damageTaken": 44
           },
           "craftSkills": {},
           "deedStats": {
@@ -1720,7 +1722,7 @@
           "dodgeChance": 0.06,
           "fallStartY": -2,
           "fiveSecondRule": 99,
-          "hp": 999976,
+          "hp": 1000000,
           "id": 997,
           "inCombat": true,
           "kind": "player",
@@ -1739,7 +1741,7 @@
             "z": -58
           },
           "potionCooldownUntil": -1,
-          "resource": 19.066667,
+          "resource": 16.866667,
           "resourceType": "rage",
           "spawnPos": {
             "x": -94,
@@ -1784,7 +1786,7 @@
               "remaining": 3,
               "school": "shadow",
               "sourceId": 1001,
-              "value": -0.095652
+              "value": -0.564087
             }
           ],
           "comboUntil": -1,
@@ -1793,7 +1795,7 @@
           "dodgeChance": 0.056,
           "fallStartY": -2,
           "fiveSecondRule": 99,
-          "hp": 999979,
+          "hp": 1000000,
           "id": 998,
           "inCombat": true,
           "kind": "player",
@@ -1926,6 +1928,7 @@
         {
           "aggroTargetId": 997,
           "aiState": "attack",
+          "combatTimer": 99.05,
           "comboUntil": -1,
           "critChance": 0.05,
           "detonateTimer": "Infinity",
@@ -1950,7 +1953,7 @@
             "z": -58
           },
           "potionCooldownUntil": -1,
-          "pulseTimer": 9,
+          "pulseTimer": 8.95,
           "spawnPos": {
             "x": -94,
             "y": -2,
@@ -1975,7 +1978,7 @@
           "critChance": 0.05,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.05,
-          "facing": -1.703576,
+          "facing": -1.581433,
           "fallStartY": 6.818369,
           "fiveSecondRule": 99,
           "hostile": true,
@@ -1990,9 +1993,9 @@
           "overpowerUntil": -1,
           "petMode": "defensive",
           "pos": {
-            "x": 299.861232,
-            "y": 6.797488,
-            "z": 299.981465
+            "x": 299.860008,
+            "y": 6.793146,
+            "z": 299.998511
           },
           "potionCooldownUntil": -1,
           "spawnPos": {
@@ -2005,9 +2008,9 @@
           },
           "templateId": "forest_wolf",
           "wanderTarget": {
-            "x": 297.990175,
-            "y": 6.548058,
-            "z": 299.731557
+            "x": 294.606869,
+            "y": 6.16114,
+            "z": 299.942634
           },
           "wanderTimer": 30,
           "weapon": {
@@ -2052,7 +2055,7 @@
             "armor": 40
           },
           "templateId": "forest_wolf",
-          "wanderTimer": 5.216553,
+          "wanderTimer": 6.373205,
           "weapon": {
             "max": 12,
             "min": 8,
@@ -2065,11 +2068,11 @@
       "tick": 0,
       "time": 0,
       "nextId": 1005,
-      "state": "6ff6fb8f",
+      "state": "5584a970",
       "events": "313f06ea",
       "rng": {
-        "draws": 18,
-        "digest": "9188be02"
+        "draws": 16,
+        "digest": "b3c83c71"
       },
       "label": "flee-panic",
       "players": [
@@ -2089,7 +2092,7 @@
           "cls": "warrior",
           "companionUpgrades": {},
           "counters": {
-            "damageTaken": 207
+            "damageTaken": 183
           },
           "craftSkills": {},
           "deedStats": {
@@ -2147,7 +2150,7 @@
           "cls": "mage",
           "companionUpgrades": {},
           "counters": {
-            "damageTaken": 65
+            "damageTaken": 44
           },
           "craftSkills": {},
           "deedStats": {
@@ -2244,7 +2247,7 @@
             "z": -58
           },
           "potionCooldownUntil": -1,
-          "resource": 19.066667,
+          "resource": 16.866667,
           "resourceType": "rage",
           "spawnPos": {
             "x": -94,
@@ -2289,7 +2292,7 @@
               "remaining": 3,
               "school": "shadow",
               "sourceId": 1001,
-              "value": -0.095652
+              "value": -0.564087
             }
           ],
           "comboUntil": -1,
@@ -2431,6 +2434,7 @@
         {
           "aggroTargetId": 997,
           "aiState": "attack",
+          "combatTimer": 99.05,
           "comboUntil": -1,
           "critChance": 0.05,
           "detonateTimer": "Infinity",
@@ -2455,7 +2459,7 @@
             "z": -58
           },
           "potionCooldownUntil": -1,
-          "pulseTimer": 9,
+          "pulseTimer": 8.95,
           "spawnPos": {
             "x": -94,
             "y": -2,
@@ -2480,7 +2484,7 @@
           "critChance": 0.05,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.05,
-          "facing": -1.703576,
+          "facing": -1.581433,
           "fallStartY": 6.818369,
           "fiveSecondRule": 99,
           "hostile": true,
@@ -2495,9 +2499,9 @@
           "overpowerUntil": -1,
           "petMode": "defensive",
           "pos": {
-            "x": 299.861232,
-            "y": 6.797488,
-            "z": 299.981465
+            "x": 299.860008,
+            "y": 6.793146,
+            "z": 299.998511
           },
           "potionCooldownUntil": -1,
           "spawnPos": {
@@ -2510,9 +2514,9 @@
           },
           "templateId": "forest_wolf",
           "wanderTarget": {
-            "x": 297.990175,
-            "y": 6.548058,
-            "z": 299.731557
+            "x": 294.606869,
+            "y": 6.16114,
+            "z": 299.942634
           },
           "wanderTimer": 30,
           "weapon": {
@@ -2557,7 +2561,7 @@
             "armor": 40
           },
           "templateId": "forest_wolf",
-          "wanderTimer": 5.216553,
+          "wanderTimer": 6.373205,
           "weapon": {
             "max": 12,
             "min": 8,
@@ -2615,11 +2619,11 @@
       "tick": 0,
       "time": 0,
       "nextId": 1005,
-      "state": "c88b0014",
+      "state": "2bafef5f",
       "events": "741638a5",
       "rng": {
-        "draws": 18,
-        "digest": "9188be02"
+        "draws": 16,
+        "digest": "b3c83c71"
       },
       "label": "flee-run",
       "players": [
@@ -2639,7 +2643,7 @@
           "cls": "warrior",
           "companionUpgrades": {},
           "counters": {
-            "damageTaken": 207
+            "damageTaken": 183
           },
           "craftSkills": {},
           "deedStats": {
@@ -2697,7 +2701,7 @@
           "cls": "mage",
           "companionUpgrades": {},
           "counters": {
-            "damageTaken": 65
+            "damageTaken": 44
           },
           "craftSkills": {},
           "deedStats": {
@@ -2794,7 +2798,7 @@
             "z": -58
           },
           "potionCooldownUntil": -1,
-          "resource": 19.066667,
+          "resource": 16.866667,
           "resourceType": "rage",
           "spawnPos": {
             "x": -94,
@@ -2839,7 +2843,7 @@
               "remaining": 3,
               "school": "shadow",
               "sourceId": 1001,
-              "value": -0.095652
+              "value": -0.564087
             }
           ],
           "comboUntil": -1,
@@ -2981,6 +2985,7 @@
         {
           "aggroTargetId": 997,
           "aiState": "attack",
+          "combatTimer": 99.05,
           "comboUntil": -1,
           "critChance": 0.05,
           "detonateTimer": "Infinity",
@@ -3005,7 +3010,7 @@
             "z": -58
           },
           "potionCooldownUntil": -1,
-          "pulseTimer": 9,
+          "pulseTimer": 8.95,
           "spawnPos": {
             "x": -94,
             "y": -2,
@@ -3030,7 +3035,7 @@
           "critChance": 0.05,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.05,
-          "facing": -1.703576,
+          "facing": -1.581433,
           "fallStartY": 6.818369,
           "fiveSecondRule": 99,
           "hostile": true,
@@ -3045,9 +3050,9 @@
           "overpowerUntil": -1,
           "petMode": "defensive",
           "pos": {
-            "x": 299.861232,
-            "y": 6.797488,
-            "z": 299.981465
+            "x": 299.860008,
+            "y": 6.793146,
+            "z": 299.998511
           },
           "potionCooldownUntil": -1,
           "spawnPos": {
@@ -3060,9 +3065,9 @@
           },
           "templateId": "forest_wolf",
           "wanderTarget": {
-            "x": 297.990175,
-            "y": 6.548058,
-            "z": 299.731557
+            "x": 294.606869,
+            "y": 6.16114,
+            "z": 299.942634
           },
           "wanderTimer": 30,
           "weapon": {
@@ -3107,7 +3112,7 @@
             "armor": 40
           },
           "templateId": "forest_wolf",
-          "wanderTimer": 5.216553,
+          "wanderTimer": 6.373205,
           "weapon": {
             "max": 12,
             "min": 8,
@@ -3166,11 +3171,11 @@
       "tick": 0,
       "time": 0,
       "nextId": 1005,
-      "state": "c88b0014",
+      "state": "2bafef5f",
       "events": "741638a5",
       "rng": {
-        "draws": 18,
-        "digest": "9188be02"
+        "draws": 16,
+        "digest": "b3c83c71"
       },
       "label": "final",
       "players": [
@@ -3190,7 +3195,7 @@
           "cls": "warrior",
           "companionUpgrades": {},
           "counters": {
-            "damageTaken": 207
+            "damageTaken": 183
           },
           "craftSkills": {},
           "deedStats": {
@@ -3248,7 +3253,7 @@
           "cls": "mage",
           "companionUpgrades": {},
           "counters": {
-            "damageTaken": 65
+            "damageTaken": 44
           },
           "craftSkills": {},
           "deedStats": {
@@ -3345,7 +3350,7 @@
             "z": -58
           },
           "potionCooldownUntil": -1,
-          "resource": 19.066667,
+          "resource": 16.866667,
           "resourceType": "rage",
           "spawnPos": {
             "x": -94,
@@ -3390,7 +3395,7 @@
               "remaining": 3,
               "school": "shadow",
               "sourceId": 1001,
-              "value": -0.095652
+              "value": -0.564087
             }
           ],
           "comboUntil": -1,
@@ -3532,6 +3537,7 @@
         {
           "aggroTargetId": 997,
           "aiState": "attack",
+          "combatTimer": 99.05,
           "comboUntil": -1,
           "critChance": 0.05,
           "detonateTimer": "Infinity",
@@ -3556,7 +3562,7 @@
             "z": -58
           },
           "potionCooldownUntil": -1,
-          "pulseTimer": 9,
+          "pulseTimer": 8.95,
           "spawnPos": {
             "x": -94,
             "y": -2,
@@ -3581,7 +3587,7 @@
           "critChance": 0.05,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.05,
-          "facing": -1.703576,
+          "facing": -1.581433,
           "fallStartY": 6.818369,
           "fiveSecondRule": 99,
           "hostile": true,
@@ -3596,9 +3602,9 @@
           "overpowerUntil": -1,
           "petMode": "defensive",
           "pos": {
-            "x": 299.861232,
-            "y": 6.797488,
-            "z": 299.981465
+            "x": 299.860008,
+            "y": 6.793146,
+            "z": 299.998511
           },
           "potionCooldownUntil": -1,
           "spawnPos": {
@@ -3611,9 +3617,9 @@
           },
           "templateId": "forest_wolf",
           "wanderTarget": {
-            "x": 297.990175,
-            "y": 6.548058,
-            "z": 299.731557
+            "x": 294.606869,
+            "y": 6.16114,
+            "z": 299.942634
           },
           "wanderTimer": 30,
           "weapon": {
@@ -3658,7 +3664,7 @@
             "armor": 40
           },
           "templateId": "forest_wolf",
-          "wanderTimer": 5.216553,
+          "wanderTimer": 6.373205,
           "weapon": {
             "max": 12,
             "min": 8,

--- a/tests/parity/golden/mob_swing_affixes.json
+++ b/tests/parity/golden/mob_swing_affixes.json
@@ -10,8 +10,8 @@
     "mobSwing affix cascade: rampage stacking buff_ap (warlord_drogmar self-buff)",
     "friendly-pet mobSwing: mob.hostile=false short-circuits every proc (no debuff on its target)"
   ],
-  "draws": 364,
-  "drawDigest": "0eb4c99a",
+  "draws": 363,
+  "drawDigest": "c0982afc",
   "frames": [
     {
       "tick": 0,
@@ -153,30 +153,30 @@
       "tick": 20,
       "time": 1,
       "nextId": 1004,
-      "state": "ea19114b",
-      "events": "74559051",
+      "state": "5f76fe3c",
+      "events": "3dd3bc64",
       "rng": {
-        "draws": 56,
-        "digest": "7b458e00"
+        "draws": 55,
+        "digest": "56ee185d"
       }
     },
     {
       "tick": 40,
       "time": 2,
       "nextId": 1004,
-      "state": "88043914",
-      "events": "8542d1d1",
+      "state": "df222a94",
+      "events": "1e2c92c1",
       "rng": {
-        "draws": 92,
-        "digest": "4950606f"
+        "draws": 100,
+        "digest": "81fe35c6"
       }
     },
     {
       "tick": 60,
       "time": 3,
       "nextId": 1004,
-      "state": "cda5d94a",
-      "events": "e4985347",
+      "state": "1722eb35",
+      "events": "573c3c0f",
       "rng": {
         "draws": 326,
         "digest": "5baa2bec"
@@ -186,7 +186,7 @@
       "tick": 60,
       "time": 3,
       "nextId": 1004,
-      "state": "d742c4fe",
+      "state": "646ae8fe",
       "events": "741638a5",
       "rng": {
         "draws": 326,
@@ -211,7 +211,7 @@
           "cls": "warrior",
           "companionUpgrades": {},
           "counters": {
-            "damageTaken": 1657
+            "damageTaken": 1378
           },
           "craftSkills": {},
           "deedStats": {
@@ -292,32 +292,23 @@
               "sourceId": 993
             },
             {
-              "duration": 10,
-              "id": "heal_absorb_gravecaller_summoner",
-              "kind": "heal_absorb",
-              "name": "Grave Blight",
-              "remaining": 7.05,
-              "school": "shadow",
-              "sourceId": 1000,
-              "value": 120
-            },
-            {
               "duration": 3,
               "id": "ensnare_webwood_spider",
               "kind": "root",
               "name": "Sticky Web",
-              "remaining": 2,
+              "remaining": 0.5,
               "school": "nature",
               "sourceId": 999
             },
             {
-              "duration": 1,
-              "id": "stun_mogger_lackey",
-              "kind": "stun",
-              "name": "Skullthump",
-              "remaining": 0.5,
-              "school": "physical",
-              "sourceId": 998
+              "duration": 10,
+              "id": "heal_absorb_gravecaller_summoner",
+              "kind": "heal_absorb",
+              "name": "Grave Blight",
+              "remaining": 8.5,
+              "school": "shadow",
+              "sourceId": 1000,
+              "value": 120
             },
             {
               "duration": 10,
@@ -369,7 +360,7 @@
             "z": -21
           },
           "potionCooldownUntil": -1,
-          "resource": 100,
+          "resource": 84.211111,
           "resourceType": "rage",
           "spawnPos": {
             "x": -94,
@@ -395,7 +386,7 @@
         {
           "aggroTargetId": 1002,
           "aiState": "attack",
-          "combatTimer": 0.5,
+          "combatTimer": 0.95,
           "comboUntil": -1,
           "critChance": 0.05,
           "detonateTimer": "Infinity",
@@ -404,7 +395,7 @@
           "fallStartY": -2.838397,
           "fiveSecondRule": 99,
           "hostile": true,
-          "hp": 199989,
+          "hp": 199991,
           "id": 998,
           "inCombat": true,
           "kind": "mob",
@@ -441,7 +432,7 @@
           "threat": [
             [
               1002,
-              11
+              9
             ]
           ],
           "weapon": {
@@ -582,7 +573,7 @@
             "z": -21
           },
           "potionCooldownUntil": -1,
-          "pulseTimer": 9.05,
+          "pulseTimer": 9,
           "spawnPos": {
             "x": -1,
             "y": -2.838397,
@@ -603,7 +594,7 @@
         {
           "aggroTargetId": 998,
           "aiState": "idle",
-          "combatTimer": 0.75,
+          "combatTimer": 0.5,
           "comboUntil": -1,
           "critChance": 0.05,
           "detonateTimer": "Infinity",
@@ -611,7 +602,7 @@
           "facing": 1.570796,
           "fallStartY": -2.838397,
           "fiveSecondRule": 99,
-          "hp": 110,
+          "hp": 77,
           "id": 1002,
           "inCombat": true,
           "kind": "mob",
@@ -648,7 +639,7 @@
         {
           "aggroTargetId": 1002,
           "aiState": "attack",
-          "combatTimer": 0.75,
+          "combatTimer": 0.5,
           "comboUntil": -1,
           "critChance": 0.05,
           "detonateTimer": "Infinity",
@@ -657,7 +648,7 @@
           "fallStartY": -2.838397,
           "fiveSecondRule": 99,
           "hostile": true,
-          "hp": 199941,
+          "hp": 199910,
           "id": 1003,
           "inCombat": true,
           "kind": "mob",
@@ -693,7 +684,7 @@
           "threat": [
             [
               1002,
-              60
+              91
             ]
           ],
           "weapon": {
@@ -708,11 +699,11 @@
       "tick": 64,
       "time": 3.2,
       "nextId": 1004,
-      "state": "27875b13",
+      "state": "17bcc03c",
       "events": "741638a5",
       "rng": {
-        "draws": 364,
-        "digest": "0eb4c99a"
+        "draws": 363,
+        "digest": "c0982afc"
       },
       "label": "final",
       "players": [
@@ -733,7 +724,7 @@
           "cls": "warrior",
           "companionUpgrades": {},
           "counters": {
-            "damageTaken": 1657
+            "damageTaken": 1378
           },
           "craftSkills": {},
           "deedStats": {
@@ -814,32 +805,23 @@
               "sourceId": 993
             },
             {
-              "duration": 10,
-              "id": "heal_absorb_gravecaller_summoner",
-              "kind": "heal_absorb",
-              "name": "Grave Blight",
-              "remaining": 6.85,
-              "school": "shadow",
-              "sourceId": 1000,
-              "value": 120
-            },
-            {
               "duration": 3,
               "id": "ensnare_webwood_spider",
               "kind": "root",
               "name": "Sticky Web",
-              "remaining": 1.8,
+              "remaining": 0.3,
               "school": "nature",
               "sourceId": 999
             },
             {
-              "duration": 1,
-              "id": "stun_mogger_lackey",
-              "kind": "stun",
-              "name": "Skullthump",
-              "remaining": 0.3,
-              "school": "physical",
-              "sourceId": 998
+              "duration": 10,
+              "id": "heal_absorb_gravecaller_summoner",
+              "kind": "heal_absorb",
+              "name": "Grave Blight",
+              "remaining": 8.3,
+              "school": "shadow",
+              "sourceId": 1000,
+              "value": 120
             },
             {
               "duration": 10,
@@ -891,7 +873,7 @@
             "z": -21
           },
           "potionCooldownUntil": -1,
-          "resource": 100,
+          "resource": 84.211111,
           "resourceType": "rage",
           "spawnPos": {
             "x": -94,
@@ -917,7 +899,7 @@
         {
           "aggroTargetId": 1002,
           "aiState": "attack",
-          "combatTimer": 0.7,
+          "combatTimer": 1.15,
           "comboUntil": -1,
           "critChance": 0.05,
           "detonateTimer": "Infinity",
@@ -926,7 +908,7 @@
           "fallStartY": -2.838397,
           "fiveSecondRule": 99,
           "hostile": true,
-          "hp": 199989,
+          "hp": 199991,
           "id": 998,
           "inCombat": true,
           "kind": "mob",
@@ -963,7 +945,7 @@
           "threat": [
             [
               1002,
-              11
+              9
             ]
           ],
           "weapon": {
@@ -1104,7 +1086,7 @@
             "z": -21
           },
           "potionCooldownUntil": -1,
-          "pulseTimer": 8.85,
+          "pulseTimer": 8.8,
           "spawnPos": {
             "x": -1,
             "y": -2.838397,
@@ -1125,7 +1107,7 @@
         {
           "aggroTargetId": 998,
           "aiState": "idle",
-          "combatTimer": 0.95,
+          "combatTimer": 0.7,
           "comboUntil": -1,
           "critChance": 0.05,
           "detonateTimer": "Infinity",
@@ -1133,7 +1115,7 @@
           "facing": 1.570796,
           "fallStartY": -2.838397,
           "fiveSecondRule": 99,
-          "hp": 110,
+          "hp": 77,
           "id": 1002,
           "inCombat": true,
           "kind": "mob",
@@ -1170,7 +1152,7 @@
         {
           "aggroTargetId": 1002,
           "aiState": "attack",
-          "combatTimer": 0.95,
+          "combatTimer": 0.7,
           "comboUntil": -1,
           "critChance": 0.05,
           "detonateTimer": "Infinity",
@@ -1179,7 +1161,7 @@
           "fallStartY": -2.838397,
           "fiveSecondRule": 99,
           "hostile": true,
-          "hp": 199941,
+          "hp": 199910,
           "id": 1003,
           "inCombat": true,
           "kind": "mob",
@@ -1215,7 +1197,7 @@
           "threat": [
             [
               1002,
-              60
+              91
             ]
           ],
           "weapon": {

--- a/tests/rift_rank_tuning.test.ts
+++ b/tests/rift_rank_tuning.test.ts
@@ -1413,7 +1413,8 @@ describe('rift ranks: budget escape and citadel exemption', () => {
     boss.deathZoneStrikeTimer = 999;
     sim.player.pos = { ...boss.pos, z: boss.pos.z - 3 };
     sim.player.prevPos = { ...sim.player.pos };
-    tickAlive(sim, 5); // warm-up: aoePulse fires on first contact and arms the lock
+    boss.pulseTimer = 0.01; // due now: the telegraphed pulse is what arms the lock
+    tickAlive(sim, 5); // warm-up: the due aoePulse fires and arms the lock
     expect(boss.mechanicLockTimer, 'warm-up armed the shared lock').toBeGreaterThan(0);
     boss.deathZoneCastTimer = 0.01; // due now, but the lock is live
     inst.bossDeathZones = [];


### PR DESCRIPTION
## Summary

Two closely related mob-AI defects, one commit each.

First, an evading mob keeps inCombat true until it arrives home (neither evade entry clears it), and the boss-mechanic driver gated on inCombat alone, so a leashed support mob kept firing its whole kit (mend, wards, rally, war cry, enrage) for the entire walk home while damage-immune and untargetable. Reproduced: a leashed Gravecaller Mender healed a wounded camp ally from 10 to 46 HP mid-evade. The fix gates the boss-mechanic driver on the evade state instead of touching inCombat, which other systems key on; the Nythraxis arm is unchanged.

Second, pulseTimer was the only boss-mechanic timer never seeded at spawn nor reset on evade or respawn, so every aoePulse carrier (Mogger, Thunzharr's Thunderclap, the dungeon Shadow Pulse family) landed its opening AoE on the first melee-contact tick instead of one full interval in, the exact telegraph contract its sibling mechanics document. The fix seeds pulseTimer in createMob beside the stomp seed and adds it to both reset sites.

Two fixture consequences, both handled with reasoning in the commits: four parity goldens re-recorded via the sanctioned UPDATE_PARITY flow (diffs confined to the seeded timer and the opening blast no longer landing), and two seeded fixtures repaired against draw reshuffle (rift_rank_tuning arms the pulse it relies on explicitly; the affliction boss Sentence case hit-caps so its pinned tier math cannot land in the resist band, with the draw still taken so the stream position is unchanged).

Note: this branch and the instant-avoidance PR both touch tests/affliction.test.ts; whichever merges second may need a trivial rebase.

## Related issues

None found for these bugs. Adjacent but distinct: issue 2653 covers players exploiting exit portals to drop threat.

## Type of change

- [x] Bug fix

## How was this tested?

- Commands:
  - New tests/mob_evade_support_kit.test.ts: a leashed mender casts nothing for the whole walk home and mends again once reset and re-engaged (red before the fix: ally healed 108 to 146 mid-evade).
  - New tests/mob_aoe_pulse_telegraph.test.ts: pulse seeded at spawn like its siblings, no pulse damage on the first contact tick, and both reset sites restore the full interval (4 of 7 red before the fix).
  - Thirteen mob AI suites, parity after golden regen, architecture, monolith budget all green.
  - node scripts/gate_select.mjs: PASS, all 12 steps green.
- Manual steps: none needed.

## Checklist

### Quality

- [x] The gate passes. node scripts/gate_select.mjs is green and decisive tests were added for the changed behavior.

### Cross-platform

- N/A, no UI change.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or .env committed, and ALLOW_DEV_COMMANDS is not enabled in any production path.
- [x] Parity goldens were regenerated via the owning flow (UPDATE_PARITY=1), not hand-edited.

Generated with [Claude Code](https://claude.com/claude-code)