### PR TITLE
balance(sim): soften the Warspirit convergence to a 210 contract point

### DIFF
--- a/src/sim/content/spec_baselines.ts
+++ b/src/sim/content/spec_baselines.ts
@@ -132,13 +132,20 @@ export const SPEC_BASELINES: SpecBaselineTable = {
     enhancement: {
       // v0.28.x stat-identity pass: Enhancement primary is Strength, so its Int
       // stays below Elemental's; melee AP is retained.
-      stats: { int: 2, ap: 24, apPct: 0.05 },
+      // v0.40 210 softening round: the 200 convergence landed Warspirit below
+      // combat rogue and fire mage on live heroic parses, so part of the
+      // baseline revert is given back on the damage-only axes (apPct feeds
+      // only the two Attack Power lines; agiPct would also buy avoidance).
+      // Measured at 24 seeds on the 120 s Nythraxis-armor boss: epic-only
+      // best kit 209.8 to 221.1 at level 20, contract fixture 188.5 to 199.2.
+      // Echo (0.25) and the tooltip-literal knobs stay put on purpose.
+      stats: { int: 2, ap: 24, apPct: 0.15 },
       ability: [
         { ability: 'lightning_bolt', costPct: -0.2 },
         { ability: 'earth_shock', costPct: -0.2 },
         { ability: 'flame_shock', costPct: -0.2 },
         { ability: 'rockbiter_weapon', dmgPct: 0.4 },
-        { ability: 'stormstrike', dmgPct: 0.5 },
+        { ability: 'stormstrike', dmgPct: 0.6 },
       ],
     },
     restoration: {

--- a/tests/owned_class_balance_role_bands.test.ts
+++ b/tests/owned_class_balance_role_bands.test.ts
@@ -35,13 +35,15 @@ describe('owned-class level 20 balance harness (sustained role bands)', () => {
       // 0.83 floor and puts the diet ceiling at 1.11.
       expect(thundercall.dps).toBeGreaterThanOrEqual(vespersSingle.dps * 0.83);
       expect(thundercall.dps).toBeLessThanOrEqual(vespersSingle.dps * band(1.1, 1.11));
-      // Warspirit area/single: re-pinned for the 200 DPS convergence package
-      // (echo 0.25, baseline apPct 0.05, Ancestral Strike 0.5) and the
-      // BiS-anchored fixture loadout. Full actual 1.0321 (5 seeds), diet
-      // actual 1.1073. Same relative margins as the prior pins: full 0.99 to
-      // 1.08, diet 1.05 to 1.15.
-      expect(warspiritArea.dps / warspiritSingle.dps).toBeGreaterThanOrEqual(band(0.99, 1.05));
-      expect(warspiritArea.dps / warspiritSingle.dps).toBeLessThanOrEqual(band(1.08, 1.15));
+      // Warspirit area/single: re-pinned for the 210 softening round (baseline
+      // apPct 0.05 to 0.15, Ancestral Strike 0.5 to 0.6, echo stays 0.25). The
+      // AP raise grows the melee and echo-cleave lines while the Stormcast
+      // bolt share (flat, single-target) stays put, so the ratio climbs; the
+      // two-seed diet window amplifies it. Full actual 1.0859 (5 seeds), diet
+      // actual 1.2173. Same relative margins as the prior pins: full 1.04 to
+      // 1.13, diet 1.15 to 1.26.
+      expect(warspiritArea.dps / warspiritSingle.dps).toBeGreaterThanOrEqual(band(1.04, 1.15));
+      expect(warspiritArea.dps / warspiritSingle.dps).toBeLessThanOrEqual(band(1.13, 1.26));
       // Vespers area/single: full actual 1.4041, diet actual 1.4475; the diet
       // floor rises to 1.29 with the same relative margin.
       expect(vespersArea.dps / vespersSingle.dps).toBeGreaterThanOrEqual(band(1.25, 1.29));
@@ -52,15 +54,14 @@ describe('owned-class level 20 balance harness (sustained role bands)', () => {
       // re-measure: full actual 1.1539 (5 seeds, 120 s boss), diet actual
       // 1.1775 (2 seeds, 60 s boss); same relative margins give 0.95 / 1.22.
       expect(warspiritBoss.dps / vespersBoss.dps).toBeGreaterThanOrEqual(band(0.93, 0.95));
-      // Full-sweep ceiling kept at 1.2 (200 DPS convergence package: full
-      // actual 1.0683, warspirit 187.8 / vespers 175.8 at 120 s on the
-      // BiS-anchored fixture). Diet re-pinned from its own printed actual
-      // 1.3864: the BiS kit front-loads the 60 s diet window (the Primal
-      // Exaltation opener plus the crownforged haste land whole inside it)
-      // while Vespers is still ramping; the prior diet margin gives 1.44.
-      // Re-author both sides of this pair when the owned-class stack
-      // integrates.
-      expect(warspiritBoss.dps / vespersBoss.dps).toBeLessThanOrEqual(band(1.2, 1.44));
+      // Full-sweep ceiling kept at 1.2 (210 softening round: full actual
+      // 1.1091, warspirit 195.0 / vespers 175.8 at 120 s on the BiS-anchored
+      // fixture). Diet re-pinned from its own printed actual 1.4326: the BiS
+      // kit front-loads the 60 s diet window (the Primal Exaltation opener
+      // plus the crownforged haste land whole inside it) while Vespers is
+      // still ramping; the prior diet margin gives 1.49. Re-author both sides
+      // of this pair when the owned-class stack integrates.
+      expect(warspiritBoss.dps / vespersBoss.dps).toBeLessThanOrEqual(band(1.2, 1.49));
       // Full sweep: the grown owned-class matrix ran ~180s under shard load and
       // roughly doubled in the shared lane (run 31288946173 killed it at 240s).
       // Diet: two seeds and the 60 s boss window cut the simulated time 3.2x.

--- a/tests/owned_class_raid_sustain_bands.test.ts
+++ b/tests/owned_class_raid_sustain_bands.test.ts
@@ -42,8 +42,10 @@ describe('owned-class raid-level balance harness (sustain bands)', () => {
         // (seeds 29_930/29_931 roll Warspirit low), so the diet floor is 0.76
         // and ceiling 1.05, the same relative margins at the diet actual.
         expect(warspirit.dps).toBeGreaterThanOrEqual(vespers.dps * band(0.81, 0.76));
-        // Full-sweep ceiling kept at 1.12 (level-22 measured 1.0568 that
-        // round). Re-author the pair when the owned-class stack integrates.
+        // Full-sweep ceiling kept at 1.12 (210 softening round full-sweep
+        // actuals: level-22 1.0851, level-23 1.0860, level-24 1.0216; was
+        // 1.0568 at level 22 the round before). Re-author the pair when the
+        // owned-class stack integrates.
         expect(warspirit.dps).toBeLessThanOrEqual(vespers.dps * band(1.12, 1.05));
         // 200 DPS convergence package re-measure (echo 0.25, baseline apPct
         // 0.05, Ancestral Strike 0.5, BiS-anchored fixture with the Unleash

--- a/tests/parity/golden/shaman_engines.json
+++ b/tests/parity/golden/shaman_engines.json
@@ -32,7 +32,7 @@
       "tick": 20,
       "time": 1,
       "nextId": 972,
-      "state": "92262e0b",
+      "state": "a5a92798",
       "events": "65e06e27",
       "rng": {
         "draws": 0,
@@ -43,7 +43,7 @@
       "tick": 40,
       "time": 2,
       "nextId": 972,
-      "state": "4b7a255f",
+      "state": "c7380710",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -54,7 +54,7 @@
       "tick": 60,
       "time": 3,
       "nextId": 972,
-      "state": "f372ff6a",
+      "state": "00e59aab",
       "events": "5b87c56c",
       "rng": {
         "draws": 154,
@@ -65,7 +65,7 @@
       "tick": 80,
       "time": 4,
       "nextId": 972,
-      "state": "baf82ab9",
+      "state": "90544cd4",
       "events": "741638a5",
       "rng": {
         "draws": 328,
@@ -76,7 +76,7 @@
       "tick": 100,
       "time": 5,
       "nextId": 972,
-      "state": "3ce5f6b9",
+      "state": "29729a74",
       "events": "f7d271f4",
       "rng": {
         "draws": 508,
@@ -87,7 +87,7 @@
       "tick": 100,
       "time": 5,
       "nextId": 972,
-      "state": "3ce5f6b9",
+      "state": "29729a74",
       "events": "741638a5",
       "rng": {
         "draws": 508,
@@ -556,7 +556,7 @@
         },
         {
           "aiState": "idle",
-          "attackPower": 103,
+          "attackPower": 113,
           "combatTimer": 104,
           "comboUntil": -1,
           "critChance": 0.0675,
@@ -774,8 +774,8 @@
       "tick": 120,
       "time": 6,
       "nextId": 972,
-      "state": "3e623546",
-      "events": "cfa9face",
+      "state": "8ad4159e",
+      "events": "757265c6",
       "rng": {
         "draws": 695,
         "digest": "ff70d1e3"
@@ -785,7 +785,7 @@
       "tick": 140,
       "time": 7,
       "nextId": 972,
-      "state": "1a76f4bd",
+      "state": "22314c33",
       "events": "741638a5",
       "rng": {
         "draws": 923,
@@ -796,8 +796,8 @@
       "tick": 160,
       "time": 8,
       "nextId": 972,
-      "state": "a3ee0bea",
-      "events": "2384ceec",
+      "state": "b0a0b63a",
+      "events": "eb264d60",
       "rng": {
         "draws": 1157,
         "digest": "0901d425"
@@ -807,7 +807,7 @@
       "tick": 180,
       "time": 9,
       "nextId": 972,
-      "state": "642c98ce",
+      "state": "68ac523e",
       "events": "741638a5",
       "rng": {
         "draws": 1413,
@@ -818,7 +818,7 @@
       "tick": 182,
       "time": 9.1,
       "nextId": 972,
-      "state": "dce9a2ee",
+      "state": "8c5c6256",
       "events": "741638a5",
       "rng": {
         "draws": 1440,
@@ -941,12 +941,12 @@
           "cls": "shaman",
           "companionUpgrades": {},
           "counters": {
-            "damageDealt": 99
+            "damageDealt": 107
           },
           "craftSkills": {},
           "deedStats": {
             "counters": {
-              "dummyDamage": 99
+              "dummyDamage": 107
             },
             "dungeonClears": {},
             "itemsDiscovered": [
@@ -1291,7 +1291,7 @@
         },
         {
           "aiState": "idle",
-          "attackPower": 103,
+          "attackPower": 113,
           "auras": [
             {
               "duration": 1800,
@@ -1530,7 +1530,7 @@
           "fallStartY": 1.5,
           "fiveSecondRule": 99,
           "hostile": true,
-          "hp": 999675,
+          "hp": 999667,
           "id": 971,
           "inCombat": true,
           "kind": "mob",
@@ -1566,7 +1566,7 @@
             ],
             [
               968,
-              99
+              107
             ]
           ],
           "weapon": {
@@ -1579,8 +1579,8 @@
       "tick": 200,
       "time": 10,
       "nextId": 972,
-      "state": "f65eaa8b",
-      "events": "683b3e8c",
+      "state": "121ae08a",
+      "events": "b266ef57",
       "rng": {
         "draws": 1681,
         "digest": "40b82402"
@@ -1590,7 +1590,7 @@
       "tick": 220,
       "time": 11,
       "nextId": 972,
-      "state": "4f8be03c",
+      "state": "8c887295",
       "events": "741638a5",
       "rng": {
         "draws": 1834,
@@ -1601,7 +1601,7 @@
       "tick": 224,
       "time": 11.2,
       "nextId": 972,
-      "state": "f8335517",
+      "state": "0e301884",
       "events": "741638a5",
       "rng": {
         "draws": 1870,
@@ -1724,12 +1724,12 @@
           "cls": "shaman",
           "companionUpgrades": {},
           "counters": {
-            "damageDealt": 249
+            "damageDealt": 260
           },
           "craftSkills": {},
           "deedStats": {
             "counters": {
-              "dummyDamage": 249
+              "dummyDamage": 260
             },
             "dungeonClears": {},
             "itemsDiscovered": [
@@ -2059,7 +2059,7 @@
         },
         {
           "aiState": "idle",
-          "attackPower": 103,
+          "attackPower": 113,
           "auras": [
             {
               "duration": 1800,
@@ -2333,7 +2333,7 @@
           "fallStartY": 1.5,
           "fiveSecondRule": 99,
           "hostile": true,
-          "hp": 999525,
+          "hp": 999514,
           "id": 971,
           "inCombat": true,
           "kind": "mob",
@@ -2369,7 +2369,7 @@
             ],
             [
               968,
-              511.5
+              527.75
             ]
           ],
           "weapon": {
@@ -2382,7 +2382,7 @@
       "tick": 240,
       "time": 12,
       "nextId": 972,
-      "state": "0aad695b",
+      "state": "0819ba56",
       "events": "7bc4a807",
       "rng": {
         "draws": 1978,
@@ -2393,8 +2393,8 @@
       "tick": 260,
       "time": 13,
       "nextId": 972,
-      "state": "da78a23f",
-      "events": "402c0e9c",
+      "state": "338042d3",
+      "events": "6d3ecab6",
       "rng": {
         "draws": 2123,
         "digest": "b7c4e5fd"
@@ -2404,7 +2404,7 @@
       "tick": 280,
       "time": 14,
       "nextId": 972,
-      "state": "db712d8d",
+      "state": "53fe9f7d",
       "events": "f63acf03",
       "rng": {
         "draws": 2315,
@@ -2415,8 +2415,8 @@
       "tick": 300,
       "time": 15,
       "nextId": 972,
-      "state": "aaa1ae84",
-      "events": "a94a01cb",
+      "state": "ecaa933a",
+      "events": "77166a0f",
       "rng": {
         "draws": 2513,
         "digest": "52a850b9"
@@ -2426,7 +2426,7 @@
       "tick": 306,
       "time": 15.3,
       "nextId": 972,
-      "state": "d17e6005",
+      "state": "6e9f7795",
       "events": "741638a5",
       "rng": {
         "draws": 2568,
@@ -2549,12 +2549,12 @@
           "cls": "shaman",
           "companionUpgrades": {},
           "counters": {
-            "damageDealt": 374
+            "damageDealt": 391
           },
           "craftSkills": {},
           "deedStats": {
             "counters": {
-              "dummyDamage": 374
+              "dummyDamage": 391
             },
             "dungeonClears": {},
             "itemsDiscovered": [
@@ -2884,7 +2884,7 @@
         },
         {
           "aiState": "idle",
-          "attackPower": 103,
+          "attackPower": 113,
           "auras": [
             {
               "duration": 1800,
@@ -3157,7 +3157,7 @@
           "fallStartY": 1.5,
           "fiveSecondRule": 99,
           "hostile": true,
-          "hp": 999400,
+          "hp": 999383,
           "id": 971,
           "inCombat": true,
           "kind": "mob",
@@ -3193,7 +3193,7 @@
             ],
             [
               968,
-              855.25
+              888
             ]
           ],
           "weapon": {
@@ -3206,7 +3206,7 @@
       "tick": 306,
       "time": 15.3,
       "nextId": 972,
-      "state": "d17e6005",
+      "state": "6e9f7795",
       "events": "741638a5",
       "rng": {
         "draws": 2568,
@@ -3329,12 +3329,12 @@
           "cls": "shaman",
           "companionUpgrades": {},
           "counters": {
-            "damageDealt": 374
+            "damageDealt": 391
           },
           "craftSkills": {},
           "deedStats": {
             "counters": {
-              "dummyDamage": 374
+              "dummyDamage": 391
             },
             "dungeonClears": {},
             "itemsDiscovered": [
@@ -3664,7 +3664,7 @@
         },
         {
           "aiState": "idle",
-          "attackPower": 103,
+          "attackPower": 113,
           "auras": [
             {
               "duration": 1800,
@@ -3937,7 +3937,7 @@
           "fallStartY": 1.5,
           "fiveSecondRule": 99,
           "hostile": true,
-          "hp": 999400,
+          "hp": 999383,
           "id": 971,
           "inCombat": true,
           "kind": "mob",
@@ -3973,7 +3973,7 @@
             ],
             [
               968,
-              855.25
+              888
             ]
           ],
           "weapon": {

--- a/tests/spec_baselines.test.ts
+++ b/tests/spec_baselines.test.ts
@@ -109,13 +109,13 @@ const EXPECTED_BASELINES: Record<string, BaselineSnapshot> = {
     },
   },
   'shaman/enhancement': {
-    stats: { int: 2, ap: 24, apPct: 0.05 },
+    stats: { int: 2, ap: 24, apPct: 0.15 },
     abilities: {
       lightning_bolt: { costPct: -0.2 },
       earth_shock: { costPct: -0.2 },
       flame_shock: { costPct: -0.2 },
       rockbiter_weapon: { dmgPct: 0.4 },
-      stormstrike: { dmgPct: 0.5 },
+      stormstrike: { dmgPct: 0.6 },
     },
   },
   'shaman/restoration': {


### PR DESCRIPTION
## Summary

Partial revert of the PR 3581 Enhancement (Warspirit) nerf package, per the owner ruling after the v0.39.x heroic Nythraxis parse review: combat rogue and fire mage sit above the 200 contract on live parses (top boss-only parses 222 and 217), so landing Enhancement exactly on 200 buried it relative to two specs that are themselves due a look. The landing point moves to about 212 on the 3581 epic-only anchor.

Knobs: baseline apPct 0.05 to 0.15 and Ancestral Strike dmgPct 0.5 to 0.6 (both partial reverts toward the pre-3581 values 0.22 and 0.8). Galeheart Echo (0.25), fire Ignition (0.3), and the Bonewrought relabel from PR 3581 are untouched. Echo and Ignition percentages are literal in their tooltips, so holding them keeps this diff free of catalog and i18n changes; the Ancestral Strike tooltip resolves `{damage}` from live values.

Measurements (24 seeds, 120 s Nythraxis-armor boss, on a harness whose run loop reproduces `scripts/owned_class_balance_probe.ts` per-seed to three decimals):

| rig | shipped v0.40.0 | this PR |
|---|---|---|
| epic-only best kit (gravewyrm cleaver MH, stormcallers focus OH, no-shock rotation, Echoing Elements), L20 | 209.8 | 221.1 |
| same rig, L22 heroic profile | 202.0 | 212.7 |
| contract fixture tripwire (the band tests' rig), L20 | 188.5 | 199.2 |
| contract fixture, L22 | 179.6 | 191.7 |

Reviewer note: at the SHIPPED constants this harness already measures the newly shaman-legal crownforged epic kit at 209.8, above the 200.9 epic-only figure PR 3581 recorded; the Bonewrought relabel legalized a stronger epic kit than the original sweep measured. The softening is therefore applied as the measured uplift (+5.4 percent) on the 3581 anchor arithmetic (200.9 to about 212), and the two figures above are the same rig before and after.

Test changes:
- `tests/spec_baselines.test.ts`: mirror snapshot pins for both knobs.
- `tests/owned_class_balance_role_bands.test.ts`: area/single and boss-pair bands re-pinned from printed actuals at the prior relative margins (full 1.0859, diet 1.2173, boss diet 1.4326); the mechanism for the area/single climb is recorded in the comment.
- `tests/owned_class_raid_sustain_bands.test.ts`: comment refreshed with the new full-sweep actuals (L22 1.0851, L23 1.0860, L24 1.0216); every bound holds unchanged, diet and full-sweep arms both re-run green.
- `tests/parity/golden/shaman_engines.json`: re-minted via `UPDATE_PARITY=1`. Value-only: rng draw counts are byte-identical at every checkpoint; state hashes plus the event hashes of damage-carrying ticks move, idle-tick event hashes are unchanged.

## Type of change

- [x] Feature: new functionality (balance retune, numeric knobs only)
- [x] Tests

## How was this tested?

- Commands:
  - `npx vitest run tests/spec_baselines.test.ts tests/shaman_warspirit.test.ts tests/shaman_warspirit_engine.test.ts tests/shaman_stonebound_benchmark.test.ts` (green)
  - `npx vitest run tests/parity` (full suite, green after mint; only `shaman_engines` moved)
  - `npx vitest run tests/owned_class_balance_role_bands.test.ts tests/owned_class_raid_sustain_bands.test.ts` (diet arms, green)
  - `WOC_FULL_BALANCE_SWEEP=1 npx vitest run` over both band files (full arms, green)
  - `npx tsc --noEmit`, changed-files biome (clean)
  - `GATE_SELECT_BASE=origin/release/v0.40.0 node scripts/gate_select.mjs`: green except one known flake, the `tests/sfx_export_core.test.ts` byte-determinism case, which timed out at 90 s under gate worker load and passes solo on the same tree (verified twice); same flake class as recorded in the 3581 round. CI is the arbiter.
- Manual steps: 24-seed Monte Carlo convergence sweep across kit, rotation, and talent variants at level 20 and level 22 (table above).

---

## Checklist

### Quality

- [x] **The gate passes.** `node scripts/gate_select.mjs` green apart from the solo-green sfx flake noted above; decisive pins updated for the changed behavior.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files. The parity golden was re-minted via its sanctioned `UPDATE_PARITY=1` path.
