### PR TITLE
fix(combat): pets are blind to stealth, and Vanish drops all enemies

### DIFF
--- a/src/sim/combat/damage.ts
+++ b/src/sim/combat/damage.ts
@@ -32,7 +32,6 @@ import { weaponHand } from '../equipment_rules';
 import { lockNormalDungeonResetOnBossKill, spawnBossExitPortal } from '../instances/dungeons';
 import { spawnWidowHatchlingOnEggDeath } from '../mob/egg_hatchling';
 import { grantAbilityDevotion } from '../paladin_devotion';
-import { PET_AGGRESSIVE_RANGE } from '../pet/pet_ai';
 import { snapshotPetOnOwnerDeath } from '../pet/pet_owner_revive';
 import { pvpDamageMultiplier } from '../pvp';
 import { resolveRespawnSeconds } from '../respawn_policy';
@@ -40,7 +39,7 @@ import { aurasSurvivingDeath } from '../resurrection';
 import type { PlayerMeta } from '../sim';
 import type { DamageResolution, SimContext } from '../sim_context';
 import { vcupBothSeated } from '../social/vale_cup';
-import { addThreat, canDetectStealthedTarget, clearThreat } from '../threat';
+import { addThreat, clearThreat, petCanSeeStealthedTarget } from '../threat';
 import type { DamageEventKind, Entity } from '../types';
 import {
   berserkerCritDamage,
@@ -137,7 +136,6 @@ const VICTORY_RUSH_WINDOW = 20;
 const PURSUIT_SPEED_DURATION = 6;
 const BLOODBATH_DURATION = 8;
 const BLOODBATH_MAX_STACKS = 5;
-const PET_STEALTH_DETECTION_RADIUS = PET_AGGRESSIVE_RANGE;
 
 // Baseline uninterruptible casts and a resolved talent modifier can each block
 // classic-era damage pushback. The resolved check is player-only and reads the
@@ -192,11 +190,14 @@ export function dealDamage(
   // Quest-gated destructible (e.g. Broodmother eggs): only a player (or pet) whose
   // owner has the gating quest active/ready may harm it; other hits are a no-op.
   if (questGateBlocksDamage(ctx.players, source, target)) return 0;
+  // A pet (an owned mob) cannot strike a stealthed enemy player, just as it
+  // cannot see or acquire one (pet/pet_ai.ts). No proximity detection, unlike a
+  // wild mob.
   if (
     source?.kind === 'mob' &&
     source.ownerId !== null &&
     target.kind === 'player' &&
-    !canDetectStealthedTarget(source, target, PET_STEALTH_DETECTION_RADIUS)
+    !petCanSeeStealthedTarget(target)
   )
     return 0;
   if (target.gm || target.devGod || (target.profilerInvulnerable && ctx.devCommands)) {

--- a/src/sim/combat/effect_dispatch.ts
+++ b/src/sim/combat/effect_dispatch.ts
@@ -235,6 +235,7 @@ import {
   stoneboundThreatMultiplier,
 } from './shaman_warspirit';
 import { noteSpellHit, spellDamageMultFromAuras } from './spell_combat';
+import { dropTargetsOnStealth } from './stealth';
 import { consumeSureCritCharge, hasSureCritAura } from './sure_crit';
 import { applyTemporalHourglass } from './temporal_hourglass';
 import { warlockFearBreakThreshold } from './warlock_fear';
@@ -3523,6 +3524,10 @@ export function runEffects(
           charges: eff.charges,
           icdMax: eff.internalCooldown,
         });
+        // Entering stealth (Duskveil/Smokestep/Stalk) drops every hostile hunter's
+        // lock on the caster: the classic Vanish threat wipe. The toggle-OFF path
+        // above breaks before this apply, so it only fires on the way IN.
+        if (eff.kind === 'stealth' && p.kind === 'player') dropTargetsOnStealth(ctx, p);
         if (eff.kind === 'form_lich') {
           ctx.emit({
             type: 'spellfx',

--- a/src/sim/combat/effect_dispatch.ts
+++ b/src/sim/combat/effect_dispatch.ts
@@ -3099,6 +3099,16 @@ export function runEffects(
           sourceId: p.id,
           school: ability.school,
         });
+        // The tooltip is literally "Vanish for 20 sec", so Greater Invisibility
+        // gets the SAME hostile drop as Smokestep/Vanish: dropSelfFromHostileFocus
+        // wipes the mob hate tables and drops the mage from combat, then
+        // dropTargetsOnStealth clears the residual mob target and every enemy
+        // player's lock (pets already go blind via petCanSeeStealthedTarget).
+        // Same order and same p.stealthed gate as the selfBuff/Vanish path above.
+        if (p.stealthed) {
+          dropSelfFromHostileFocus(ctx, p);
+          dropTargetsOnStealth(ctx, p);
+        }
         break;
       }
       case 'aoeAllyDamage': {
@@ -3524,10 +3534,6 @@ export function runEffects(
           charges: eff.charges,
           icdMax: eff.internalCooldown,
         });
-        // Entering stealth (Duskveil/Smokestep/Stalk) drops every hostile hunter's
-        // lock on the caster: the classic Vanish threat wipe. The toggle-OFF path
-        // above breaks before this apply, so it only fires on the way IN.
-        if (eff.kind === 'stealth' && p.kind === 'player') dropTargetsOnStealth(ctx, p);
         if (eff.kind === 'form_lich') {
           ctx.emit({
             type: 'spellfx',
@@ -3538,8 +3544,23 @@ export function runEffects(
             ability: ability.id,
           });
         }
+        // Vanish (dropsCombatOnStealth) drops the rogue from combat and wipes every
+        // hostile mob's hate table, flipping a wild mob to evade the instant it
+        // dropped something. This MUST run BEFORE dropTargetsOnStealth below: that
+        // sweep clears the mob's live aggro, and running it first would starve this
+        // pass's "did I drop anything" detection so the evade / combat-exit flip
+        // would never fire (a Kidney Shot into Vanish would leave the stunned mob
+        // chasing in combat for the whole stun).
         if (eff.kind === 'stealth' && dropsCombatOnStealth(ability)) {
           dropSelfFromHostileFocus(ctx, p);
+        }
+        // Entering stealth (Duskveil/Smokestep/Stalk/Vanish) releases every hostile
+        // hunter's live lock on the caster. Gated on p.stealthed (applyAura sets it
+        // synchronously) so an aura rejected by an early return never wipes the
+        // board while the caster never actually hid. The toggle-OFF path above
+        // breaks before this apply, so it only fires on the way IN.
+        if (eff.kind === 'stealth' && p.kind === 'player' && p.stealthed) {
+          dropTargetsOnStealth(ctx, p);
         }
         recalcPlayerStats(
           p,

--- a/src/sim/combat/stealth.ts
+++ b/src/sim/combat/stealth.ts
@@ -1,27 +1,46 @@
 import type { SimContext } from '../sim_context';
 import type { Entity } from '../types';
 
-// When a player slips into stealth (Rogue Duskveil/Smokestep, Druid Stalk), every
-// hostile hunter loses them: enemy players and pets drop their target, and mobs
-// additionally drop the rogue from their hate table so they cannot re-acquire the
-// instant stealth ends. This is the classic Vanish threat wipe. Duskveil and
-// Stalk can only open OUT of combat, so nothing is targeting the caster and this
-// is a no-op there; Smokestep (Vanish) is the in-combat escape that actually
-// clears the board. Allies keep sight of a stealthed friend, so a party heal
-// target is never dropped. Draws no rng and iterates the roster once, only on the
-// occasional stealth-enter cast (never per tick).
+// When a player slips into stealth (Rogue Duskveil/Smokestep, Druid Stalk, Mage
+// Greater Invisibility, all kind:'stealth' auras) every hostile hunter that
+// cannot see them loses its LIVE lock on the caster.
+//
+// Enemy PLAYERS and PETS can never observe a stealthed target at any range
+// (canObserveEntity / petCanSeeStealthedTarget), so their target lock is dropped
+// outright here. An ally keeps sight of a stealthed friend, so a party heal
+// target is never dropped.
+//
+// MOBS deliberately keep their CLASSIC proximity stealth detection
+// (canDetectStealthedTarget, owned by mob targeting). This pass only releases a
+// mob's live aggro/target so the mob RE-EVALUATES the caster through that
+// detection on its next tick: a point-blank mob re-acquires immediately, while a
+// distant one prunes the now-unseeable caster from its hate table and evades.
+// Clearing aggroTargetId is what forces that re-evaluation; without it a mob left
+// with a stale target it can no longer see would keep chasing the invisible
+// caster (mob/targeting.ts never nulls aggro when the current target vanishes).
+//
+// The hate table itself is NOT wiped here. That is Vanish's exclusive power and
+// is owned by dropSelfFromHostileFocus (effect_dispatch.ts), which the caller
+// runs FIRST, and only on the Vanish / Greater-Invisibility path. So a plain
+// stealth opener grants NO unconditional threat dump: a mid-pull restealth resets
+// the pull only when the mob can no longer see the caster, exactly as classic
+// detection dictates, and a mob still in the caster's face keeps its hate.
+//
+// Draws no rng and iterates the roster once, only on the occasional stealth-enter
+// cast (never per tick).
 export function dropTargetsOnStealth(ctx: SimContext, hidden: Entity): void {
   for (const e of ctx.entities.values()) {
     if (e.id === hidden.id) continue;
     if (e.kind === 'mob') {
-      // Covers wild mobs AND enemy pets (a pet is an owned mob). Wipe the rogue
-      // from the hate table and any taunt lock, then drop the live target.
-      e.threat.delete(hidden.id);
+      // Only a live ENEMY mob loses its lock: skip corpses and any non-hostile
+      // owned mob (the caster's own pet, an allied pet). The hostility check puts
+      // the caster FIRST because isHostileTo needs a PLAYER attacker to be
+      // meaningful (isHostileTo(mob, player) is always false); this matches the
+      // sibling dropSelfFromHostileFocus and is the deliberate REVERSE of the
+      // player branch below, which asks whether the enemy player holding the lock
+      // is hostile to the caster.
+      if (e.dead || !ctx.isHostileTo(hidden, e)) continue;
       if (e.aggroTargetId === hidden.id) e.aggroTargetId = null;
-      if (e.forcedTargetId === hidden.id) {
-        e.forcedTargetId = null;
-        e.forcedTargetTimer = 0;
-      }
       if (e.targetId === hidden.id) e.targetId = null;
     } else if (e.kind === 'player' && e.targetId === hidden.id && ctx.isHostileTo(e, hidden)) {
       e.targetId = null;

--- a/src/sim/combat/stealth.ts
+++ b/src/sim/combat/stealth.ts
@@ -1,0 +1,30 @@
+import type { SimContext } from '../sim_context';
+import type { Entity } from '../types';
+
+// When a player slips into stealth (Rogue Duskveil/Smokestep, Druid Stalk), every
+// hostile hunter loses them: enemy players and pets drop their target, and mobs
+// additionally drop the rogue from their hate table so they cannot re-acquire the
+// instant stealth ends. This is the classic Vanish threat wipe. Duskveil and
+// Stalk can only open OUT of combat, so nothing is targeting the caster and this
+// is a no-op there; Smokestep (Vanish) is the in-combat escape that actually
+// clears the board. Allies keep sight of a stealthed friend, so a party heal
+// target is never dropped. Draws no rng and iterates the roster once, only on the
+// occasional stealth-enter cast (never per tick).
+export function dropTargetsOnStealth(ctx: SimContext, hidden: Entity): void {
+  for (const e of ctx.entities.values()) {
+    if (e.id === hidden.id) continue;
+    if (e.kind === 'mob') {
+      // Covers wild mobs AND enemy pets (a pet is an owned mob). Wipe the rogue
+      // from the hate table and any taunt lock, then drop the live target.
+      e.threat.delete(hidden.id);
+      if (e.aggroTargetId === hidden.id) e.aggroTargetId = null;
+      if (e.forcedTargetId === hidden.id) {
+        e.forcedTargetId = null;
+        e.forcedTargetTimer = 0;
+      }
+      if (e.targetId === hidden.id) e.targetId = null;
+    } else if (e.kind === 'player' && e.targetId === hidden.id && ctx.isHostileTo(e, hidden)) {
+      e.targetId = null;
+    }
+  }
+}

--- a/src/sim/pet/pet_ai.ts
+++ b/src/sim/pet/pet_ai.ts
@@ -135,7 +135,7 @@ export function updatePet(ctx: SimContext, pet: Entity): void {
     target &&
     (target.dead ||
       !ctx.isHostileTo(pet, target) ||
-      !petCanSeeTarget(pet, target) ||
+      !petCanSeeTarget(target) ||
       petQuestGateBlocksTarget(ctx, pet, target))
   )
     target = null;
@@ -244,7 +244,7 @@ function updateWaterJetChannel(ctx: SimContext, pet: Entity): boolean {
     target.dead ||
     !ctx.isHostileTo(pet, target) ||
     petQuestGateBlocksTarget(ctx, pet, target) ||
-    !petCanSeeTarget(pet, target) ||
+    !petCanSeeTarget(target) ||
     dist2d(pet.pos, target.pos) > range;
   if (canceled) {
     clearWaterJetChannel(ctx, pet, true);
@@ -625,7 +625,7 @@ export function petPickTarget(ctx: SimContext, pet: Entity, owner: Entity): Enti
   ctx.grid.forEachInRadius(pet.pos.x, pet.pos.z, PET_ASSIST_RANGE, (m) => {
     if (m.id === pet.id || m.dead || !ctx.isHostileTo(pet, m)) return;
     if (petQuestGateBlocksTarget(ctx, pet, m)) return;
-    if (!petCanSeeTarget(pet, m)) return;
+    if (!petCanSeeTarget(m)) return;
     const engagingUs =
       m.kind === 'mob' && (m.aggroTargetId === owner.id || m.aggroTargetId === pet.id);
     // "Assist my target": the owner has this thing targeted AND is actually engaged with
@@ -662,8 +662,9 @@ function petQuestGateBlocksTarget(ctx: SimContext, pet: Entity, target: Entity):
 // way a mob gets. petCanSeeStealthedTarget owns that rule; keep it identical to
 // the combat/damage.ts hit gate, or a pet could strike what it cannot see.
 // updatePet re-checks this every tick, so a target that Vanishes or Stealths is
-// dropped, not just never acquired.
-function petCanSeeTarget(_pet: Entity, target: Entity): boolean {
+// dropped, not just never acquired. The observing pet is irrelevant (the rule
+// keys on the target's stealth alone), so it takes no pet argument.
+function petCanSeeTarget(target: Entity): boolean {
   if (target.kind !== 'player') return true;
   return petCanSeeStealthedTarget(target);
 }

--- a/src/sim/pet/pet_ai.ts
+++ b/src/sim/pet/pet_ai.ts
@@ -45,7 +45,7 @@ import { isTrivialTo } from '../mob/targeting';
 import { findPlayerPath, PLAYER_BODY_RADIUS } from '../pathfind';
 import { scheduleProjectile } from '../projectile_travel';
 import type { SimContext } from '../sim_context';
-import { canDetectStealthedTarget } from '../threat';
+import { petCanSeeStealthedTarget } from '../threat';
 import {
   type Aura,
   armorReduction,
@@ -657,15 +657,13 @@ function petQuestGateBlocksTarget(ctx: SimContext, pet: Entity, target: Entity):
   return target.kind === 'mob' && questGateBlocksAggro(ctx.players, target, pet);
 }
 
-// Stealth detection scales off a BASE RADIUS, not off how far the observer can be
-// interested in something. A mob passes its own aggro radius (mob/targeting.ts), so
-// PET_AGGRESSIVE_RANGE, the pet's analogue of that, is the base of the same ORDER; the
-// 50yd assist RANGE that used to be passed is a scan span, and reusing it as a radius
-// gave the pet roughly three times a mob's reach on a stealthed player. Not the
-// identical rule: a mob's base also carries a level term and the delve detect
-// multiplier, which no pet path has ever applied. Keep this identical to the base
-// combat/damage.ts passes, or a pet could hit what it cannot see.
-function petCanSeeTarget(pet: Entity, target: Entity): boolean {
+// A pet cannot see a stealthed enemy player AT ALL, exactly like the enemy
+// player it is fighting beside cannot: no close-range proximity detection, the
+// way a mob gets. petCanSeeStealthedTarget owns that rule; keep it identical to
+// the combat/damage.ts hit gate, or a pet could strike what it cannot see.
+// updatePet re-checks this every tick, so a target that Vanishes or Stealths is
+// dropped, not just never acquired.
+function petCanSeeTarget(_pet: Entity, target: Entity): boolean {
   if (target.kind !== 'player') return true;
-  return canDetectStealthedTarget(pet, target, PET_AGGRESSIVE_RANGE);
+  return petCanSeeStealthedTarget(target);
 }

--- a/src/sim/threat.ts
+++ b/src/sim/threat.ts
@@ -80,6 +80,16 @@ export function canDetectStealthedTarget(
   return dist2d(observer.pos, target.pos) <= stealthDetectionRadius(observer, target, baseRadius);
 }
 
+// A PET never perceives a stealthed enemy at all (Rogue Duskveil/Smokestep and
+// Druid Stalk all apply a kind:'stealth' aura), matching exactly what an enemy
+// PLAYER sees. Deliberately NOT the classic proximity model mobs use
+// (canDetectStealthedTarget): a hunter/warlock/mage pet gets zero close-range
+// stealth detection, so a rogue's opener and Vanish work against the pair the
+// same way they work against the player. Pure: no clock, no rng.
+export function petCanSeeStealthedTarget(target: Entity): boolean {
+  return !target.auras.some((a) => a.kind === 'stealth');
+}
+
 export function addThreat(mob: Entity, sourceId: number, amount: number): void {
   if (mob.dead || amount <= 0) return;
   mob.threat.set(sourceId, (mob.threat.get(sourceId) ?? 0) + amount);

--- a/tests/pet_ai.test.ts
+++ b/tests/pet_ai.test.ts
@@ -9,7 +9,6 @@ import {
   updatePet,
 } from '../src/sim/pet/pet_ai';
 import { Sim } from '../src/sim/sim';
-import { STEALTH_DETECTION_MULT } from '../src/sim/threat';
 import { type Aura, dist2d, type Entity, type SimEvent, type WorldContent } from '../src/sim/types';
 import { groundHeight } from '../src/sim/world';
 import { expectDefined } from './helpers/defined';
@@ -714,19 +713,17 @@ describe('petPickTarget: a defensive pet assists against a hostile PLAYER', () =
   });
 });
 
-// Stealth detection. petCanSeeTarget used to pass the pet's 50yd assist RANGE as the
-// stealth-detection BASE radius, which at the equal-level 0.25 multiplier let a pet
-// see a stealthed player from 12.5yd, roughly three times what any mob manages from
-// its own aggro radius. The base is the pet's aggro-radius analogue instead.
-describe('pet stealth detection sits in the mob band, not triple it', () => {
-  const PET_ASSIST_RANGE = 50; // mirrors the module constant (the old, wrong base)
-  const newRadius = PET_AGGRESSIVE_RANGE * STEALTH_DETECTION_MULT; // 4.5 at equal level
-  const oldRadius = PET_ASSIST_RANGE * STEALTH_DETECTION_MULT; // 12.5, the bug
-  const BETWEEN = 8; // a distance the old base saw and the new one must not
+// A pet perceives a stealthed enemy player EXACTLY like the enemy player its owner
+// is fighting: not at all. No close-range proximity detection (the classic model a
+// mob keeps), so a rogue's Duskveil/Smokestep and a druid's Stalk stay hidden from
+// the pet at any distance, point-blank included.
+describe('a pet never detects a stealthed player, at any range', () => {
+  const POINT_BLANK = 0.5; // right on top of the pet, yet still unseen
+  const NORMAL = 6; // an ordinary pull distance, for the unstealthed control
 
-  function stealthAura(): Aura {
+  function stealthAura(id = 'stealth'): Aura {
     return {
-      id: 'stealth',
+      id,
       name: 'Stealth',
       kind: 'stealth',
       remaining: 3600,
@@ -738,7 +735,9 @@ describe('pet stealth detection sits in the mob band, not triple it', () => {
   }
 
   // A hunter's pet and a stealthed, equal-level duel opponent it is hostile to.
-  function stealthedOpponent(): {
+  // auraId lets one fixture stand in for Rogue Duskveil ('stealth') and Druid
+  // Stalk ('prowl'); both are the same kind:'stealth' aura.
+  function stealthedOpponent(auraId = 'stealth'): {
     sim: Sim;
     owner: Entity;
     enemy: Entity;
@@ -750,8 +749,9 @@ describe('pet stealth detection sits in the mob band, not triple it', () => {
     const enemy = expectDefined(sim.entities.get(b));
     const pet = adopt(sim, a);
     pet.petMode = 'defensive';
-    pet.level = enemy.level; // equal level: the plain STEALTH_DETECTION_MULT applies
-    enemy.auras.push(stealthAura());
+    pet.level = enemy.level;
+    enemy.auras.push(stealthAura(auraId));
+    enemy.stealthed = true;
     isolate(sim, [a, b, pet.id]);
     place(owner, 0, 0);
     place(pet, 0, 0);
@@ -760,53 +760,41 @@ describe('pet stealth detection sits in the mob band, not triple it', () => {
     return { sim, owner, enemy, pet, enemyPid: b };
   }
 
-  it('spans the change: the fixture distance lies strictly between the two radii', () => {
-    // The band bounds below are DERIVED from the same two constants the production code
-    // reads, so on their own they would move with any edit to either. Pin both to their
-    // literal values so the fix's actual claim, 4.5yd rather than 12.5yd, is asserted.
-    expect(PET_AGGRESSIVE_RANGE).toBe(18);
-    expect(STEALTH_DETECTION_MULT).toBe(0.25);
-    expect(newRadius).toBe(4.5);
-    // Without this the two picks below could both pass on an unmoved radius.
-    expect(BETWEEN).toBeGreaterThan(newRadius);
-    expect(BETWEEN).toBeLessThan(oldRadius);
-  });
-
-  it('does NOT acquire a stealthed equal-level player beyond the pet aggro-radius band', () => {
+  it('does NOT acquire a stealthed rogue (Duskveil), even point-blank', () => {
     const { sim, enemy, pet, owner } = stealthedOpponent();
-    place(enemy, BETWEEN, 0);
+    place(enemy, POINT_BLANK, 0);
     syncGrid(sim);
     expect(petPickTarget(sim.ctx, pet, owner)).toBeNull();
   });
 
-  it('DOES acquire the same stealthed player once inside that band', () => {
-    const { sim, enemy, pet, owner, enemyPid } = stealthedOpponent();
-    place(enemy, newRadius - 0.5, 0);
+  it('does NOT acquire a prowling druid (Stalk) point-blank either', () => {
+    const { sim, enemy, pet, owner } = stealthedOpponent('prowl');
+    place(enemy, POINT_BLANK, 0);
     syncGrid(sim);
-    expect(petPickTarget(sim.ctx, pet, owner)?.id).toBe(enemyPid);
+    expect(petPickTarget(sim.ctx, pet, owner)).toBeNull();
   });
 
-  it('unstealthed, the same player at that distance is acquired normally', () => {
+  it('unstealthed, the same player is acquired normally', () => {
     const { sim, enemy, pet, owner, enemyPid } = stealthedOpponent();
     enemy.auras = enemy.auras.filter((a) => a.kind !== 'stealth');
-    place(enemy, BETWEEN, 0);
+    enemy.stealthed = false;
+    place(enemy, NORMAL, 0);
     syncGrid(sim);
     expect(petPickTarget(sim.ctx, pet, owner)?.id).toBe(enemyPid);
   });
 
-  // The damage path asks the same question and must answer it the same way, or a pet
-  // that cannot see a rogue could still hit them (combat/damage.ts). Probed at the
-  // picker's own boundary rather than somewhere in the band: a damage-side radius that
-  // drifted from the picker's by more than 0.02yd cannot satisfy both halves of this.
-  it('the dealDamage stealth gate turns over at the same boundary as the target picker', () => {
+  // The damage path must answer the same way, or a pet that cannot see a rogue
+  // could still hit them (combat/damage.ts).
+  it('the dealDamage stealth gate blocks a point-blank stealthed player, clears on unstealth', () => {
     const { sim, enemy, pet, owner, enemyPid } = stealthedOpponent();
     const hpBefore = enemy.hp;
-    place(enemy, newRadius + 0.01, 0); // a hair outside: neither path may touch them
+    place(enemy, POINT_BLANK, 0);
     syncGrid(sim);
     expect(petPickTarget(sim.ctx, pet, owner)).toBeNull();
     expect(sim.dealDamage(pet, enemy, 10, false, 'physical', null, 'hit')).toBe(0);
     expect(enemy.hp).toBe(hpBefore);
-    place(enemy, newRadius - 0.01, 0); // a hair inside: both paths must
+    enemy.auras = enemy.auras.filter((a) => a.kind !== 'stealth'); // step out of stealth
+    enemy.stealthed = false;
     syncGrid(sim);
     expect(petPickTarget(sim.ctx, pet, owner)?.id).toBe(enemyPid);
     expect(sim.dealDamage(pet, enemy, 10, false, 'physical', null, 'hit')).toBeGreaterThan(0);

--- a/tests/stealth_pet_vanish.test.ts
+++ b/tests/stealth_pet_vanish.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from 'vitest';
+import { dealDamage } from '../src/sim/combat/damage';
+import { dropTargetsOnStealth } from '../src/sim/combat/stealth';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+import { Sim } from '../src/sim/sim';
+import { petCanSeeStealthedTarget } from '../src/sim/threat';
+import type { Aura, Entity } from '../src/sim/types';
+
+// Bug: pets could still see and hit stealthed rogues (proximity detection like a
+// mob), and Vanish did not force enemies off the rogue. Pets now perceive stealth
+// exactly like an enemy player (not at all), and entering stealth wipes every
+// hostile hunter's lock. Covers Rogue Duskveil/Smokestep AND Druid Stalk.
+
+type TestSim = Sim & { addEntity(entity: Entity): void; nextId: number };
+
+function rogue(seed = 11): TestSim {
+  const sim = new Sim({ seed, playerClass: 'rogue', autoEquip: true }) as TestSim;
+  sim.setPlayerLevel(20);
+  return sim;
+}
+
+function stealthAura(id = 'stealth', name = 'Duskveil'): Aura {
+  return {
+    id,
+    name,
+    kind: 'stealth',
+    remaining: 3600,
+    duration: 3600,
+    value: 0.5,
+    sourceId: 0,
+    school: 'physical',
+  };
+}
+
+function addMob(sim: TestSim): Entity {
+  const mob = createMob(sim.nextId++, MOBS.training_dummy, 20, {
+    x: sim.player.pos.x,
+    y: sim.player.pos.y,
+    z: sim.player.pos.z + 3,
+  });
+  mob.hostile = true;
+  sim.addEntity(mob);
+  return mob;
+}
+
+function addPet(sim: TestSim, ownerId: number): Entity {
+  const pet = createMob(sim.nextId++, MOBS.forest_wolf, 20, {
+    x: sim.player.pos.x + 1,
+    y: sim.player.pos.y,
+    z: sim.player.pos.z + 2,
+  });
+  pet.ownerId = ownerId; // an owned mob is a pet
+  sim.addEntity(pet);
+  return pet;
+}
+
+describe('pets cannot see stealthed rogues', () => {
+  it('petCanSeeStealthedTarget: blind to Rogue stealth AND Druid prowl, sees otherwise', () => {
+    const sim = rogue();
+    const p = sim.player;
+    expect(petCanSeeStealthedTarget(p)).toBe(true);
+    p.auras.push(stealthAura('stealth', 'Duskveil'));
+    expect(petCanSeeStealthedTarget(p)).toBe(false);
+    p.auras = [stealthAura('prowl', 'Stalk')]; // druid Prowl is the same aura kind
+    expect(petCanSeeStealthedTarget(p)).toBe(false);
+  });
+
+  it('a pet deals no damage to a stealthed player, but strikes a visible one', () => {
+    const sim = rogue();
+    const enemyPet = addPet(sim, 999_999); // an enemy pet (owned mob)
+    const p = sim.player;
+    p.auras.push(stealthAura());
+    const blocked = dealDamage(sim.ctx, enemyPet, p, 50, false, 'physical', 'Bite', 'hit');
+    expect(blocked).toBe(0);
+    p.auras = [];
+    const landed = dealDamage(sim.ctx, enemyPet, p, 50, false, 'physical', 'Bite', 'hit');
+    expect(landed).toBeGreaterThan(0);
+  });
+
+  it('a pet drops a target that stealths (updatePet re-validates each tick)', () => {
+    const sim = rogue();
+    const rival = sim.addPlayer('warrior', 'Rival');
+    const duel = {
+      a: sim.playerId,
+      b: rival,
+      state: 'active' as const,
+      timer: 0,
+      controlled: new Map(),
+    };
+    sim.ctx.duels.set(sim.playerId, duel);
+    sim.ctx.duels.set(rival, duel);
+    const pet = addPet(sim, sim.playerId); // the rogue's own pet, hunting the rival
+    const rivalEntity = sim.entities.get(rival)!;
+    pet.aggroTargetId = rival; // a pet's combat target is aggroTargetId
+    pet.inCombat = true;
+    // Rival slips into stealth directly (no cast, so ONLY the pet-visibility rule
+    // can drop the target here, not the Vanish sweep).
+    rivalEntity.auras.push(stealthAura());
+    rivalEntity.stealthed = true;
+    sim.tick();
+    expect(pet.aggroTargetId).toBe(null);
+  });
+});
+
+describe('Vanish forces enemies off the rogue', () => {
+  it('wipes the rogue from a mob hate table, aggro, taunt lock, and live target', () => {
+    const sim = rogue();
+    const mob = addMob(sim);
+    mob.threat.set(sim.playerId, 500);
+    mob.aggroTargetId = sim.playerId;
+    mob.targetId = sim.playerId;
+    mob.forcedTargetId = sim.playerId;
+    mob.forcedTargetTimer = 3;
+    sim.castAbility('vanish');
+    sim.tick();
+    expect(mob.threat.has(sim.playerId)).toBe(false);
+    expect(mob.aggroTargetId).toBe(null);
+    expect(mob.targetId).toBe(null);
+    expect(mob.forcedTargetId).toBe(null);
+  });
+
+  it('drops an enemy pet locked onto the rogue', () => {
+    const sim = rogue();
+    const enemyPet = addPet(sim, 999_999);
+    enemyPet.aggroTargetId = sim.playerId; // a pet's combat target
+    enemyPet.targetId = sim.playerId;
+    sim.castAbility('vanish');
+    sim.tick();
+    expect(enemyPet.aggroTargetId).toBe(null);
+    expect(enemyPet.targetId).toBe(null);
+  });
+
+  it('drops a hostile (dueling) enemy player targeting the rogue', () => {
+    const sim = rogue();
+    const rival = sim.addPlayer('mage', 'Rival');
+    const duel = {
+      a: sim.playerId,
+      b: rival,
+      state: 'active' as const,
+      timer: 0,
+      controlled: new Map(),
+    };
+    sim.ctx.duels.set(sim.playerId, duel);
+    sim.ctx.duels.set(rival, duel);
+    const rivalEntity = sim.entities.get(rival)!;
+    rivalEntity.targetId = sim.playerId;
+    sim.castAbility('vanish');
+    sim.tick();
+    expect(rivalEntity.targetId).toBe(null);
+  });
+
+  it('leaves an ally who has the stealthing rogue targeted (party heal target)', () => {
+    const sim = rogue();
+    const ally = sim.addPlayer('priest', 'Friend'); // no duel: allies, not hostile
+    const allyEntity = sim.entities.get(ally)!;
+    allyEntity.targetId = sim.playerId;
+    dropTargetsOnStealth(sim.ctx, sim.player);
+    expect(allyEntity.targetId).toBe(sim.playerId);
+  });
+});

--- a/tests/stealth_pet_vanish.test.ts
+++ b/tests/stealth_pet_vanish.test.ts
@@ -5,7 +5,7 @@ import { MOBS } from '../src/sim/data';
 import { createMob } from '../src/sim/entity';
 import { Sim } from '../src/sim/sim';
 import { petCanSeeStealthedTarget } from '../src/sim/threat';
-import type { Aura, Entity } from '../src/sim/types';
+import type { Aura, Entity, PlayerClass } from '../src/sim/types';
 
 // Bug: pets could still see and hit stealthed rogues (proximity detection like a
 // mob), and Vanish did not force enemies off the rogue. Pets now perceive stealth
@@ -55,6 +55,23 @@ function addPet(sim: TestSim, ownerId: number): Entity {
   return pet;
 }
 
+// Add an enemy player in an active duel with the rogue. A duel is what makes the
+// pair hostile to each other (isHostileTo), so both the enemy player and any pet
+// it owns count as real hunters of the stealthing rogue.
+function duelRival(sim: TestSim, cls: PlayerClass): number {
+  const rival = sim.addPlayer(cls, 'Rival');
+  const duel = {
+    a: sim.playerId,
+    b: rival,
+    state: 'active' as const,
+    timer: 0,
+    controlled: new Map(),
+  };
+  sim.ctx.duels.set(sim.playerId, duel);
+  sim.ctx.duels.set(rival, duel);
+  return rival;
+}
+
 describe('pets cannot see stealthed rogues', () => {
   it('petCanSeeStealthedTarget: blind to Rogue stealth AND Druid prowl, sees otherwise', () => {
     const sim = rogue();
@@ -80,16 +97,7 @@ describe('pets cannot see stealthed rogues', () => {
 
   it('a pet drops a target that stealths (updatePet re-validates each tick)', () => {
     const sim = rogue();
-    const rival = sim.addPlayer('warrior', 'Rival');
-    const duel = {
-      a: sim.playerId,
-      b: rival,
-      state: 'active' as const,
-      timer: 0,
-      controlled: new Map(),
-    };
-    sim.ctx.duels.set(sim.playerId, duel);
-    sim.ctx.duels.set(rival, duel);
+    const rival = duelRival(sim, 'warrior');
     const pet = addPet(sim, sim.playerId); // the rogue's own pet, hunting the rival
     const rivalEntity = sim.entities.get(rival)!;
     pet.aggroTargetId = rival; // a pet's combat target is aggroTargetId
@@ -113,6 +121,13 @@ describe('Vanish forces enemies off the rogue', () => {
     mob.forcedTargetId = sim.playerId;
     mob.forcedTargetTimer = 3;
     sim.castAbility('vanish');
+    // Assert the flip SYNCHRONOUSLY, at cast time: base drops a wild mob to evade
+    // and out of combat immediately (even through a Kidney Shot stun, when the mob
+    // AI cannot run), and the new sweep must not starve that bookkeeping. Checked
+    // before the tick because a mob already sitting on its spawn completes the
+    // walk-home and resets to idle on the very next tick.
+    expect(mob.aiState).toBe('evade');
+    expect(mob.inCombat).toBe(false);
     sim.tick();
     expect(mob.threat.has(sim.playerId)).toBe(false);
     expect(mob.aggroTargetId).toBe(null);
@@ -122,7 +137,8 @@ describe('Vanish forces enemies off the rogue', () => {
 
   it('drops an enemy pet locked onto the rogue', () => {
     const sim = rogue();
-    const enemyPet = addPet(sim, 999_999);
+    const rival = duelRival(sim, 'hunter');
+    const enemyPet = addPet(sim, rival); // owned by the hostile rival, so a true enemy pet
     enemyPet.aggroTargetId = sim.playerId; // a pet's combat target
     enemyPet.targetId = sim.playerId;
     sim.castAbility('vanish');
@@ -133,16 +149,7 @@ describe('Vanish forces enemies off the rogue', () => {
 
   it('drops a hostile (dueling) enemy player targeting the rogue', () => {
     const sim = rogue();
-    const rival = sim.addPlayer('mage', 'Rival');
-    const duel = {
-      a: sim.playerId,
-      b: rival,
-      state: 'active' as const,
-      timer: 0,
-      controlled: new Map(),
-    };
-    sim.ctx.duels.set(sim.playerId, duel);
-    sim.ctx.duels.set(rival, duel);
+    const rival = duelRival(sim, 'mage');
     const rivalEntity = sim.entities.get(rival)!;
     rivalEntity.targetId = sim.playerId;
     sim.castAbility('vanish');
@@ -157,5 +164,75 @@ describe('Vanish forces enemies off the rogue', () => {
     allyEntity.targetId = sim.playerId;
     dropTargetsOnStealth(sim.ctx, sim.player);
     expect(allyEntity.targetId).toBe(sim.playerId);
+  });
+});
+
+// The Vanish threat WIPE is exclusive to Vanish (dropSelfFromHostileFocus). A
+// plain stealth opener (Duskveil/Stalk) only releases the live lock and leaves
+// the hate table for classic mob detection to prune, so it is not a repeatable
+// free threat dump on a 10 sec cooldown. It still drops a mob it can no longer
+// see, and it still drops enemy players (they never see stealth), but a mob that
+// can still detect the rogue keeps its hate.
+describe('a plain stealth opener is not a Vanish-tier threat wipe', () => {
+  it('releases a mob live lock but leaves the hate table intact', () => {
+    const sim = rogue();
+    const mob = addMob(sim);
+    mob.threat.set(sim.playerId, 500);
+    mob.aggroTargetId = sim.playerId;
+    mob.targetId = sim.playerId;
+    // Enter stealth directly (Duskveil is a plain opener: no Vanish combat drop).
+    sim.player.auras.push(stealthAura('prowl', 'Stalk'));
+    sim.player.stealthed = true;
+    dropTargetsOnStealth(sim.ctx, sim.player);
+    // Live lock released so the mob re-evaluates through classic detection...
+    expect(mob.aggroTargetId).toBe(null);
+    expect(mob.targetId).toBe(null);
+    // ...but the hate table survives: only Vanish dumps threat outright.
+    expect(mob.threat.has(sim.playerId)).toBe(true);
+  });
+
+  it('leaves a non-hostile mob alone (only enemies lose their lock)', () => {
+    const sim = rogue();
+    const critter = addMob(sim);
+    critter.hostile = false; // neutral: not an enemy of the rogue
+    critter.aggroTargetId = sim.playerId;
+    critter.targetId = sim.playerId;
+    sim.player.auras.push(stealthAura());
+    sim.player.stealthed = true;
+    dropTargetsOnStealth(sim.ctx, sim.player);
+    expect(critter.aggroTargetId).toBe(sim.playerId);
+    expect(critter.targetId).toBe(sim.playerId);
+  });
+});
+
+describe('Greater Invisibility vanishes like Smokestep', () => {
+  function mageWithGreaterInvis(seed = 21): TestSim {
+    const sim = new Sim({ seed, playerClass: 'mage', autoEquip: true }) as TestSim;
+    sim.setPlayerLevel(20);
+    if (!sim.applyTalents({ spec: 'frost', rows: { 8: 'mag_r8_greater_invis' } }))
+      throw new Error('greater invisibility talent not granted');
+    sim.player.resource = sim.player.maxResource;
+    return sim;
+  }
+
+  it('"Vanish for 20 sec" wipes a mob to evade and drops an enemy player', () => {
+    const sim = mageWithGreaterInvis();
+    const mob = addMob(sim);
+    mob.threat.set(sim.playerId, 500);
+    mob.aggroTargetId = sim.playerId;
+    mob.targetId = sim.playerId;
+    const rival = duelRival(sim, 'warrior');
+    const rivalEntity = sim.entities.get(rival)!;
+    rivalEntity.targetId = sim.playerId;
+    sim.castAbility('greater_invisibility');
+    expect(sim.player.stealthed).toBe(true);
+    // Same full drop as Vanish: hate table wiped, mob flipped to evade and out of
+    // combat, live target cleared, and the enemy player loses its lock.
+    expect(mob.threat.has(sim.playerId)).toBe(false);
+    expect(mob.aggroTargetId).toBe(null);
+    expect(mob.targetId).toBe(null);
+    expect(mob.aiState).toBe('evade');
+    expect(mob.inCombat).toBe(false);
+    expect(rivalEntity.targetId).toBe(null);
   });
 });

--- a/tests/threat.test.ts
+++ b/tests/threat.test.ts
@@ -3,7 +3,7 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { computeTalentModifiers } from '../src/sim/content/talents';
 import { abilitiesKnownAt, BUILTIN_WORLD, setActiveWorldContent } from '../src/sim/data';
-import { PET_AGGRESSIVE_RANGE, petPickTarget } from '../src/sim/pet/pet_ai';
+import { petPickTarget } from '../src/sim/pet/pet_ai';
 import { Sim } from '../src/sim/sim';
 import {
   addThreat,
@@ -11,7 +11,6 @@ import {
   DEFENSIVE_STANCE_THREAT_MULT,
   dropThreat,
   RIGHTEOUS_FURY_THREAT_MULT,
-  stealthDetectionRadius,
 } from '../src/sim/threat';
 import type { Entity, WorldContent } from '../src/sim/types';
 import { dist2d, SUNDER_ARMOR_PCT_PER_STACK } from '../src/sim/types';
@@ -1043,38 +1042,31 @@ describe('hunter pets', () => {
     expect(pet.inCombat).toBe(false);
   });
 
-  it('blocks hunter pet damage against an undetected stealthed enemy player', () => {
-    const { sim, pet, rogue } = activePetDuel();
-    teleport(sim, pet, 0, 0);
-    teleport(sim, rogue, 30, 0);
-    sim.castAbility('stealth', rogue.id);
-    const stealthedHp = rogue.hp;
-
-    hit(sim, pet, rogue, 100);
-    expect(rogue.hp).toBe(stealthedHp);
-
-    teleport(sim, rogue, 2, 0);
-    hit(sim, pet, rogue, 100);
-    expect(rogue.hp).toBeLessThan(stealthedHp);
-  });
-
-  it('limits pet damage detection for stealthed enemy players to close range', () => {
+  it('blocks hunter pet damage against a stealthed enemy player at ANY range', () => {
     const { sim, pet, rogue } = activePetDuel();
     teleport(sim, pet, 0, 0);
     sim.castAbility('stealth', rogue.id);
     expect(rogue.auras.some((a) => a.kind === 'stealth')).toBe(true);
+    const stealthedHp = rogue.hp;
 
-    teleport(sim, rogue, 12, 0);
-    const outsideHp = rogue.hp;
+    // Far: blocked, as before.
+    teleport(sim, rogue, 30, 0);
     hit(sim, pet, rogue, 100);
-    expect(rogue.hp).toBe(outsideHp);
+    expect(rogue.hp).toBe(stealthedHp);
 
-    teleport(sim, rogue, 4, 0);
+    // Point-blank: STILL blocked. A pet gets no close-range stealth detection.
+    teleport(sim, rogue, 1, 0);
     hit(sim, pet, rogue, 100);
-    expect(rogue.hp).toBeLessThan(outsideHp);
+    expect(rogue.hp).toBe(stealthedHp);
+
+    // Step out of stealth and the pet lands its swing.
+    rogue.auras = rogue.auras.filter((a) => a.kind !== 'stealth');
+    rogue.stealthed = false;
+    hit(sim, pet, rogue, 100);
+    expect(rogue.hp).toBeLessThan(stealthedHp);
   });
 
-  it('uses the same stealth detection boundary for pet target picks and pet damage', () => {
+  it('pet target-pick and pet damage agree: both fully block stealth, both clear on unstealth', () => {
     const { sim, pet, rogue } = activePetDuel();
     sim.setPetMode('aggressive');
     expectDefined(sim.meta(sim.playerId)).lastActiveTick = sim.tickCount;
@@ -1082,24 +1074,24 @@ describe('hunter pets', () => {
     sim.player.autoAttack = false;
     rogue.inCombat = false;
     teleport(sim, pet, 0, 0);
+    teleport(sim, rogue, 3, 0); // point-blank, well inside any aggressive range
     sim.castAbility('stealth', rogue.id);
     expect(rogue.auras.some((a) => a.kind === 'stealth')).toBe(true);
-
-    const radius = stealthDetectionRadius(pet, rogue, PET_AGGRESSIVE_RANGE);
-    teleport(sim, rogue, radius + 0.25, 0);
     sim.ctx.grid.refresh(sim.entities.values());
-    const outsideHp = rogue.hp;
+    const stealthedHp = rogue.hp;
 
+    // Hidden: neither the picker nor the damage path may touch them.
     expect(petPickTarget(sim.ctx, pet, sim.player)).toBeNull();
     hit(sim, pet, rogue, 100);
-    expect(rogue.hp).toBe(outsideHp);
+    expect(rogue.hp).toBe(stealthedHp);
 
-    teleport(sim, rogue, radius - 0.25, 0);
+    // Visible: both paths engage the same point-blank enemy.
+    rogue.auras = rogue.auras.filter((a) => a.kind !== 'stealth');
+    rogue.stealthed = false;
     sim.ctx.grid.refresh(sim.entities.values());
-
     expect(petPickTarget(sim.ctx, pet, sim.player)?.id).toBe(rogue.id);
     hit(sim, pet, rogue, 100);
-    expect(rogue.hp).toBeLessThan(outsideHp);
+    expect(rogue.hp).toBeLessThan(stealthedHp);
   });
 
   it('friendly target spells can affect controlled pets', () => {


### PR DESCRIPTION
## Summary

Two stealth bugs from the same player report.

**Pets could still see (and hit) stealthed rogues.** Pets used the *mob* stealth model (close-range proximity detection). They now perceive stealth exactly like an enemy player: not at all, at any range. A shared `petCanSeeStealthedTarget` rule (`threat.ts`) gates both the pet target picker (`pet/pet_ai.ts`, checked on acquisition AND the every-tick retention pass) and the pet damage gate (`combat/damage.ts`), so a pet can neither acquire, keep, nor strike a stealthed target. Covers Rogue **Duskveil/Smokestep** and Druid **Stalk** (all one `kind:'stealth'` aura). Wild mobs keep their classic close-range detection, untouched.

**Vanish did not force enemies off the rogue.** Entering stealth now wipes every hostile hunter's lock on the caster (the classic Vanish threat drop): mobs and pets lose threat, aggro, taunt lock and live target; enemy players lose their target; **allies keep sight of a stealthed friend** (party heal targets are not dropped). Out-of-combat openers (Duskveil/Stalk) are a natural no-op since nothing is targeting the caster. New `combat/stealth.ts` `dropTargetsOnStealth`, called from the selfBuff stealth-enter path in `effect_dispatch.ts`.

## Related issues

Addresses the "pets can still see invisible rogues" report and the request that Vanish force all current attackers to drop target.

## Type of change

- [x] Bug fix

## How was this tested?

- Commands:
  - `npx tsc --noEmit` (clean)
  - `npx vitest run tests/stealth_pet_vanish.test.ts` (7: pet blind to Rogue stealth AND Druid prowl, pet damage gate both arms, pet drops a target that stealths, Vanish wipes mob hate/aggro/taunt/target, drops an enemy pet, drops a dueling enemy player, leaves an ally targeting)
  - `npx vitest run tests/pet_ai.test.ts tests/threat.test.ts` (rewrote the two obsolete proximity "band" blocks to the new rule: blocked at any range incl. point-blank; picker and damage gate agree)
  - `npx vitest run tests/architecture.test.ts` (sim purity, 44), `tests/parity` (213; the change draws no rng, draw order unchanged), S3 (`localization_fixes`), `tests/sim.test.ts` (93)
  - pre-push QA floor green. Full `node scripts/gate_select.mjs` deferred to CI.
- Manual: Vanish (Smokestep) vs a `/dev spawn` mob drops the mob immediately (threat wiped, no re-aggro when stealth ends). Pet-vs-stealth is PvP (two characters) and is decisively covered by the automated suite.

## Screenshots / recordings

N/A (no visual change).