### PR TITLE
fix(sim): stop feared players pinning on battleground geometry

### DIFF
--- a/src/sim/combat/fear_steering.ts
+++ b/src/sim/combat/fear_steering.ts
@@ -1,26 +1,31 @@
 // Feared-PLAYER wall guard. Fear runs a player on one fixed heading for its whole
-// duration, so a heading pointed at a wall marches them into it. This steers that
-// heading away: probe FEAR_WALL_LOOKAHEAD yards ahead and, if blocked, turn to the
-// most open heading. Deterministic (probes the collider set via
-// ctx.resolveMovePoint, which is seed-deterministic and applies the player's own
-// mover height; draws no rng), so the parity draw order is untouched. The caller
-// (Sim.updateFearMovement) applies it to players only, so feared-mob movement, and
-// the parity draw order with it, stays byte-identical.
+// duration, so a heading pointed at a wall marches them into it. Two arms keep the
+// run off the geometry, and they are deliberately different sensors:
+//
+//  1. steerFearFromWalls PREDICTS. It probes FEAR_WALL_LOOKAHEAD yards ahead against
+//     the collider set and makes a corrective turn before the body reaches the wall,
+//     which is what keeps the run looking like a panicked veer rather than a bounce.
+//  2. fleeAlongOpenHeading MEASURES. It runs the step, reads how far the body
+//     actually got, and turns until one delivers. It is the backstop for everything
+//     the collider probe cannot see, and it owns the big turns (see its own header).
+//
+// Both are deterministic and draw no rng, so the parity draw order is untouched. The
+// caller (Sim.updateFearMovement) applies them to players only, so feared-mob
+// movement, and the parity draw order with it, stays byte-identical.
 import { PLAYER_BODY_RADIUS } from '../pathfind';
 import type { SimContext } from '../sim_context';
-import type { Entity } from '../types';
+import { DT, type Entity } from '../types';
 
 export const FEAR_WALL_LOOKAHEAD = 2; // yards ahead to watch for a wall (turn late, near the wall)
 const FEAR_WALL_PROBE_STEP = 1; // radius-0.5 probe discs are tangent at a 1yd step, so no gap along the ray
-const FEAR_TURN_FAN = [
-  Math.PI / 4,
-  -Math.PI / 4,
-  Math.PI / 2,
-  -Math.PI / 2,
-  (3 * Math.PI) / 4,
-  -(3 * Math.PI) / 4,
-  Math.PI,
-]; // headings to try (smallest turn first, ties broken by fan order) when blocked ahead
+// Headings to try (smallest turn first, ties broken by fan order) when blocked ahead.
+// Corrective turns only, a quarter or a half. A PREDICTED wall is not evidence enough
+// for a three-quarter turn or an about-face: in a shallow dead end the most open probe
+// direction is simply back the way the run came, and taking it every tick bounces the
+// body between the two ends for the whole fear, which is the same complaint as a pin.
+// A big turn has to be earned by a MEASURED stall (fleeAlongOpenHeading below), whose
+// fan does carry the reversal.
+const FEAR_TURN_FAN = [Math.PI / 4, -Math.PI / 4, Math.PI / 2, -Math.PI / 2];
 
 // Yards the entity can travel straight along `heading` before a wall, capped at
 // FEAR_WALL_LOOKAHEAD. Mover-aware via ctx.resolveMovePoint, so a low prop the
@@ -54,4 +59,134 @@ export function steerFearFromWalls(ctx: SimContext, e: Entity, heading: number):
     }
   }
   return best;
+}
+
+// ---------------------------------------------------------------------------
+// Stall escape: the same job as the probe above, but read from the OUTCOME.
+//
+// steerFearFromWalls predicts a wall from the collider set alone, and that model
+// is narrower than the mover it is standing in for: moveToward also refuses an
+// uphill step onto ground steeper than the climb limit (true across the whole
+// Thornhollow band, which is authored relief, see world.ts nearSteepWalls), a
+// step across a garden hedge, and a landlocked step under the waterline. None of
+// those show up in a resolveMovePoint probe, so the guard reads "open", never
+// turns, and the run pins anyway. The probe is also 1yd-grained, so it accepts a
+// 1yd pocket as an improvement and then has nothing left to try once every
+// direction reads blocked (its documented no-jitter fallback).
+//
+// So measure the step the flee ACTUALLY covered and turn off a heading that is
+// not delivering. Whatever refused the step (collider, relief, hedge, waterline,
+// delve clamp) shows up the same way, which is the point: this arm has no model
+// of the world to keep in sync with the mover. Deterministic and rng-free.
+
+const FEAR_FLEE_LOOKAHEAD = 10; // yards ahead the flee destination is placed
+
+// Fraction of the step the flee speed asked for that a tick has to cover before
+// the run counts as moving. A heading that merely SLIDES along a wall still
+// covers a full step (moveToward's own slide fan takes the body sideways at
+// speed), so a half-step bar separates a wall-hugging run, which is fine and is
+// what fear is supposed to look like, from a body pinned against the geometry.
+export const FEAR_STALL_STEP_FRACTION = 0.5;
+
+// Headings tried when the step stalls: the current one first, then symmetric
+// turns of growing size so a stalled body takes the shortest way out, ending at
+// a straight reversal, which is open by construction because the player just ran
+// from there. A full sweep, so a sealed corner always has an answer.
+export const FEAR_ESCAPE_FAN = [
+  0,
+  Math.PI / 6,
+  -Math.PI / 6,
+  Math.PI / 3,
+  -Math.PI / 3,
+  Math.PI / 2,
+  -Math.PI / 2,
+  (2 * Math.PI) / 3,
+  -(2 * Math.PI) / 3,
+  (5 * Math.PI) / 6,
+  -(5 * Math.PI) / 6,
+  Math.PI,
+];
+
+/** One tick's worth of flee movement, injected so the search stays host-agnostic
+ *  and a test can drive it with a synthetic map instead of a live Sim. */
+export interface FearFleeStepper {
+  /** Run one flee step along `heading`, leave the body at the stepped position,
+   *  and return the yards it covered measured from where this tick started. */
+  step(heading: number): number;
+  /** Put the body back where this tick started, so the next candidate is tried
+   *  from the same place. */
+  rewind(): void;
+}
+
+/** Wrap to (-PI, PI]. The chosen heading is written back to the aura every tick
+ *  and shipped raw on every snapshot, so it is kept bounded rather than left to
+ *  accumulate a turn per tick for the length of the fear. */
+export function wrapHeading(heading: number): number {
+  // Exact for a heading already in range: the modulo below would perturb it by an ulp,
+  // and an unchanged heading has to compare equal so a steady run reads as steady.
+  if (heading > -Math.PI && heading <= Math.PI) return heading;
+  const turns = (((heading + Math.PI) % (2 * Math.PI)) + 2 * Math.PI) % (2 * Math.PI);
+  return turns === 0 ? Math.PI : turns - Math.PI;
+}
+
+/**
+ * Step the flee along `heading`, and if that step stalls, turn until one does not.
+ * Returns the heading actually committed to (wrapped), which the caller remembers
+ * on the aura so the run holds its new course instead of re-testing the blocked
+ * one next tick. The body is left at the stepped position.
+ *
+ * Common case (open ground) costs exactly one step and returns immediately; only
+ * a body that is genuinely not moving pays for the fan.
+ */
+export function fleeAlongOpenHeading(
+  heading: number,
+  intendedStep: number,
+  stepper: FearFleeStepper,
+): number {
+  const bar = intendedStep * FEAR_STALL_STEP_FRACTION;
+  let bestOff = 0;
+  let bestMoved = -1;
+  for (const off of FEAR_ESCAPE_FAN) {
+    const moved = stepper.step(heading + off);
+    if (moved >= bar) return wrapHeading(heading + off);
+    if (moved > bestMoved) {
+      bestMoved = moved;
+      bestOff = off;
+    }
+    stepper.rewind();
+  }
+  // Sealed on every heading: still take the ground the best candidate gives, so the
+  // body is never frozen outright, but KEEP the heading. Committing to whichever
+  // offset happened to win a sealed tick makes the next tick pick the opposite one,
+  // and a boxed-in body jitters in place instead of holding a course; this is the
+  // same no-jitter contract steerFearFromWalls keeps for its own sealed case.
+  stepper.step(heading + bestOff);
+  return wrapHeading(heading);
+}
+
+/** The live-Sim stepper: move, measure, and rewind through the seam. */
+export function fearFleeStepper(ctx: SimContext, e: Entity, speed: number): FearFleeStepper {
+  const start = { x: e.pos.x, y: e.pos.y, z: e.pos.z, facing: e.facing };
+  return {
+    step(heading: number): number {
+      const dest = ctx.groundPos(
+        e.pos.x + Math.sin(heading) * FEAR_FLEE_LOOKAHEAD,
+        e.pos.z + Math.cos(heading) * FEAR_FLEE_LOOKAHEAD,
+      );
+      ctx.moveToward(e, dest, speed);
+      return Math.hypot(e.pos.x - start.x, e.pos.z - start.z);
+    },
+    rewind(): void {
+      e.pos.x = start.x;
+      e.pos.y = start.y;
+      e.pos.z = start.z;
+      e.facing = start.facing;
+    },
+  };
+}
+
+/** Sim entry point: run this tick's feared step and return the heading it took. */
+export function fleeFearStep(ctx: SimContext, e: Entity, heading: number): number {
+  const speed = ctx.fleeMoveSpeed(e);
+  return fleeAlongOpenHeading(heading, speed * DT, fearFleeStepper(ctx, e, speed));
 }

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -88,7 +88,7 @@ import {
 import { damageTakenWithin } from './combat/damage_history';
 import { druidEngineCombatState } from './combat/druid_engines';
 import { runEffects as runEffectsImpl } from './combat/effect_dispatch';
-import { steerFearFromWalls } from './combat/fear_steering';
+import { fleeFearStep, steerFearFromWalls } from './combat/fear_steering';
 import { applyIgnite } from './combat/fire_mage';
 import { frostMageChannelPulse } from './combat/frost_mage';
 import { type FrozenOrbState, tickFrozenOrbs } from './combat/frozen_orb';
@@ -6436,15 +6436,15 @@ export class Sim {
     const aura = this.fearAura(e);
     if (!aura || e.auras.some((a) => a.kind === 'root') || hasUnbreakableMovementLock(e, aura))
       return false;
-    let angle = Number.isFinite(aura.value) ? aura.value : e.facing;
-    // Player-only wall guard (combat/fear_steering.ts): redirect the flee heading
-    // away from a wall it is about to run into, and remember the new heading on the
-    // aura so it holds until the next wall. Feared mobs keep their untouched
-    // movement (and the parity draw order with it), matching the vertical snap's
-    // player-only scoping.
+    const angle = Number.isFinite(aura.value) ? aura.value : e.facing;
+    // Player-only wall guard (combat/fear_steering.ts): steer the flee heading off a
+    // wall it is about to run into, then run the step and turn again if it stalled,
+    // so relief, a hedge or the waterline cannot pin the run either. The committed
+    // heading is remembered on the aura so it holds until the next wall. Feared mobs
+    // keep their untouched movement (and the parity draw order with it).
     if (e.kind === 'player') {
-      angle = steerFearFromWalls(this.ctx, e, angle);
-      aura.value = angle;
+      aura.value = fleeFearStep(this.ctx, e, steerFearFromWalls(this.ctx, e, angle));
+      return true;
     }
     const dest = this.groundPos(e.pos.x + Math.sin(angle) * 10, e.pos.z + Math.cos(angle) * 10);
     this.moveToward(e, dest, this.fleeMoveSpeed(e));

--- a/tests/fear_stall_escape.test.ts
+++ b/tests/fear_stall_escape.test.ts
@@ -1,0 +1,303 @@
+import { describe, expect, it } from 'vitest';
+import {
+  FEAR_ESCAPE_FAN,
+  FEAR_STALL_STEP_FRACTION,
+  type FearFleeStepper,
+  fleeAlongOpenHeading,
+  wrapHeading,
+} from '../src/sim/combat/fear_steering';
+import { battlegroundOrigin } from '../src/sim/data';
+import { Sim } from '../src/sim/sim';
+import { DT } from '../src/sim/types';
+import { WORLD_SEED } from '../src/sim/world_seed';
+
+// A feared player runs one heading for the whole fear. The predictive wall guard
+// (steerFearFromWalls) turns that heading off a wall it can SEE in the collider set,
+// but the mover refuses steps for reasons a collider probe never sees: authored
+// relief steeper than the climb limit (all of Thornhollow), a garden hedge, the
+// waterline. Where the probe and the mover disagreed the run pinned anyway, which is
+// the "feared into the decor" report from the 5v5 battleground.
+//
+// fleeAlongOpenHeading closes the loop on the OUTCOME: run the step, measure what it
+// covered, and turn until one delivers. Whatever refused the step shows up the same
+// way, so this arm has no world model to keep in sync with the mover.
+
+const STEP = 1; // one yard of intended travel, so the stall bar is FEAR_STALL_STEP_FRACTION
+const BAR = STEP * FEAR_STALL_STEP_FRACTION;
+
+/** Synthetic mover: a step along `heading` covers a full step when the heading is one
+ *  of `open`, and nothing otherwise. Records the call order so the search's shape is
+ *  observable without a live Sim. */
+function fakeStepper(open: number[], tol = 1e-9) {
+  const steps: number[] = [];
+  const rewinds: number[] = [];
+  let at = 0;
+  const stepper: FearFleeStepper = {
+    step(heading: number): number {
+      steps.push(heading);
+      at = open.some((o) => Math.abs(wrapHeading(heading - o)) <= tol) ? STEP : 0;
+      return at;
+    },
+    rewind(): void {
+      rewinds.push(steps.length);
+      at = 0;
+    },
+  };
+  return { stepper, steps, rewinds, moved: () => at };
+}
+
+describe('fear stall escape (pure core)', () => {
+  it('keeps a heading that delivers, and pays for exactly one step', () => {
+    const f = fakeStepper([0.7]);
+    expect(fleeAlongOpenHeading(0.7, STEP, f.stepper)).toBe(0.7);
+    expect(f.steps).toEqual([0.7]); // no fan walked on the open-ground path
+    expect(f.rewinds).toEqual([]); // and the body is left where the step put it
+  });
+
+  it('turns to the first fan heading that actually moves the body', () => {
+    // Straight ahead is refused; a third of a turn to the left is open.
+    const f = fakeStepper([0.7 + Math.PI / 3]);
+    const chosen = fleeAlongOpenHeading(0.7, STEP, f.stepper);
+    expect(chosen).toBeCloseTo(wrapHeading(0.7 + Math.PI / 3), 10);
+    expect(f.moved()).toBe(STEP); // committed step, not a rewound probe
+    // Smallest turns first, and every refused candidate is rewound before the next.
+    expect(f.steps).toEqual([0.7, 0.7 + Math.PI / 6, 0.7 - Math.PI / 6, 0.7 + Math.PI / 3]);
+    expect(f.rewinds).toEqual([1, 2, 3]);
+  });
+
+  it('reverses when only the way back is open (a dead end still empties)', () => {
+    const f = fakeStepper([wrapHeading(0.7 + Math.PI)]);
+    expect(fleeAlongOpenHeading(0.7, STEP, f.stepper)).toBeCloseTo(wrapHeading(0.7 + Math.PI), 10);
+    expect(f.moved()).toBe(STEP);
+  });
+
+  it('a step under the stall bar does not count as delivered', () => {
+    const steps: number[] = [];
+    const stepper: FearFleeStepper = {
+      step(h: number): number {
+        steps.push(h);
+        return BAR - 1e-9; // every heading gives a sub-bar nudge: sealed
+      },
+      rewind(): void {},
+    };
+    expect(fleeAlongOpenHeading(0.4, STEP, stepper)).toBe(wrapHeading(0.4));
+    expect(steps).toHaveLength(FEAR_ESCAPE_FAN.length + 1); // whole fan, then the fallback
+  });
+
+  it('a step exactly on the bar counts as delivered', () => {
+    const steps: number[] = [];
+    const stepper: FearFleeStepper = {
+      step(h: number): number {
+        steps.push(h);
+        return BAR;
+      },
+      rewind(): void {},
+    };
+    expect(fleeAlongOpenHeading(0.4, STEP, stepper)).toBe(0.4);
+    expect(steps).toEqual([0.4]);
+  });
+
+  it('sealed on every heading: keeps the heading, but still takes the best step', () => {
+    // Nothing is open; one fan candidate gives more ground than the rest.
+    const best = -Math.PI / 6;
+    const steps: number[] = [];
+    let lastMoved = -1;
+    const stepper: FearFleeStepper = {
+      step(h: number): number {
+        steps.push(h);
+        lastMoved = Math.abs(wrapHeading(h - (0.4 + best))) < 1e-9 ? BAR / 2 : BAR / 10;
+        return lastMoved;
+      },
+      rewind(): void {},
+    };
+    // The heading is UNCHANGED: committing to whichever offset won a sealed tick makes
+    // the next tick pick the opposite one, and the body jitters instead of holding.
+    expect(fleeAlongOpenHeading(0.4, STEP, stepper)).toBe(wrapHeading(0.4));
+    expect(steps[steps.length - 1]).toBeCloseTo(0.4 + best, 10); // best-effort step ran last
+    expect(lastMoved).toBe(BAR / 2); // and it is the best candidate's, not a frozen zero
+  });
+
+  it('a zero intended step (fully snared) returns immediately without walking the fan', () => {
+    const f = fakeStepper([]);
+    expect(fleeAlongOpenHeading(1.1, 0, f.stepper)).toBe(1.1);
+    expect(f.steps).toEqual([1.1]);
+  });
+
+  it('the committed heading is always wrapped to (-PI, PI]', () => {
+    for (const off of FEAR_ESCAPE_FAN) {
+      const f = fakeStepper([wrapHeading(3.0 + off)]);
+      const chosen = fleeAlongOpenHeading(3.0, STEP, f.stepper);
+      expect(chosen).toBeGreaterThan(-Math.PI);
+      expect(chosen).toBeLessThanOrEqual(Math.PI);
+    }
+  });
+
+  it('the fan starts straight ahead, is symmetric, and carries a full reversal', () => {
+    expect(FEAR_ESCAPE_FAN[0]).toBe(0);
+    expect(FEAR_ESCAPE_FAN).toContain(Math.PI);
+    for (const off of FEAR_ESCAPE_FAN) {
+      if (off === 0 || off === Math.PI) continue;
+      expect(FEAR_ESCAPE_FAN).toContain(-off);
+    }
+    // Non-decreasing turn size, so the shortest way out is always tried first.
+    const sizes = FEAR_ESCAPE_FAN.map(Math.abs);
+    for (let i = 1; i < sizes.length; i++) expect(sizes[i]).toBeGreaterThanOrEqual(sizes[i - 1]);
+  });
+});
+
+describe('wrapHeading', () => {
+  it('bounds a heading to (-PI, PI] without changing its direction', () => {
+    const cases: [number, number][] = [
+      [0, 0],
+      [Math.PI, Math.PI],
+      [-Math.PI, Math.PI],
+      [Math.PI / 2, Math.PI / 2],
+      [-Math.PI / 2, -Math.PI / 2],
+      [3 * Math.PI, Math.PI],
+      [2 * Math.PI, 0],
+      [-3 * Math.PI, Math.PI],
+    ];
+    for (const [raw, want] of cases) expect(wrapHeading(raw)).toBeCloseTo(want, 12);
+    // A many-turn accumulation lands on the same unit vector as the raw angle.
+    const raw = 0.7 + 40 * Math.PI;
+    expect(Math.sin(wrapHeading(raw))).toBeCloseTo(Math.sin(raw), 10);
+    expect(Math.cos(wrapHeading(raw))).toBeCloseTo(Math.cos(raw), 10);
+  });
+});
+
+// The Thornhollow battleground field, where the report comes from: an authored relief
+// map inside a walled rectangle. These field-local spots each FROZE a feared player
+// outright on release/v0.40.0 (under a twentieth of a yard of travel over three
+// seconds of fear) because the mover refused every step the collider probe called
+// open. Found by sweeping every playable yard of the field against sixteen headings.
+const FROZEN_SPOTS: { x: number; z: number; heading: number; what: string }[] = [
+  { x: 30, z: -26, heading: 0, what: 'chamber cover' },
+  { x: 7, z: -39, heading: -(3 * Math.PI) / 8, what: 'heart ruin approach' },
+  { x: 7, z: -38, heading: (5 * Math.PI) / 8, what: 'heart ruin approach, mirrored' },
+  { x: -24, z: -47, heading: Math.PI / 2, what: 'curtain wall pocket' },
+  { x: -21, z: -54, heading: -Math.PI / 8, what: 'gatehouse corner' },
+];
+
+type FearHooks = {
+  updateFearMovement(e: unknown): boolean;
+  fleeMoveSpeed(e: unknown): number;
+};
+
+function fearedInBattleground(localX: number, localZ: number, heading: number) {
+  const sim = new Sim({ seed: WORLD_SEED, playerClass: 'warrior', autoEquip: true });
+  sim.setPlayerLevel(20);
+  const origin = battlegroundOrigin(0);
+  const p = sim.player;
+  const x = origin.x + localX;
+  const z = origin.z + localZ;
+  p.pos = { x, y: sim.groundPos(x, z).y, z };
+  p.prevPos = { ...p.pos };
+  sim.rebucket(p);
+  p.auras.push({
+    id: 'fear_incap',
+    name: 'Fear',
+    kind: 'incapacitate',
+    remaining: 60,
+    duration: 60,
+    value: heading,
+    sourceId: 0,
+    school: 'shadow',
+  });
+  return { sim, p, hooks: sim as unknown as FearHooks, from: { x, z } };
+}
+
+/** Yards of ground actually covered over `ticks` of fear (path length, not net
+ *  displacement): the number that separates a body that RUNS from one pinned in place. */
+function fleePathLength(sim: Sim, ticks: number): number {
+  const hooks = sim as unknown as FearHooks;
+  const p = sim.player;
+  let path = 0;
+  let px = p.pos.x;
+  let pz = p.pos.z;
+  for (let i = 0; i < ticks; i++) {
+    hooks.updateFearMovement(p);
+    path += Math.hypot(p.pos.x - px, p.pos.z - pz);
+    px = p.pos.x;
+    pz = p.pos.z;
+  }
+  return path;
+}
+
+describe('feared players are never pinned in the battleground (regression)', () => {
+  for (const spot of FROZEN_SPOTS) {
+    it(`runs instead of freezing at ${spot.x},${spot.z} (${spot.what})`, () => {
+      const { sim, p, hooks } = fearedInBattleground(spot.x, spot.z, spot.heading);
+      const ticks = 60; // three seconds of fear
+      const unobstructed = hooks.fleeMoveSpeed(p) * DT * ticks;
+      expect(unobstructed).toBeGreaterThan(0); // the fixture is not vacuously slow
+      // The bar is a conservative fraction of the ground an unobstructed flee covers,
+      // so a wall-hugging run clears it and a pinned body cannot.
+      expect(fleePathLength(sim, ticks)).toBeGreaterThan(unobstructed * 0.5);
+    });
+  }
+
+  // Two cells of the field sit inside a prop's baked collision (a thicket) where the
+  // mover refuses EVERY heading, not just the feared one. Geometry that sealed cannot
+  // be opened from the movement code, and re-picking a heading there would only make
+  // the body jitter. What the escape guarantees is the part that is in reach: the body
+  // is no longer frozen outright, and it holds one heading while it is boxed in.
+  it('a sealed thicket pocket is no longer a hard freeze, and does not jitter', () => {
+    const { sim, p, hooks } = fearedInBattleground(-4, 34, 0);
+    const path = fleePathLength(sim, 60);
+    expect(path).toBeGreaterThan(1); // release/v0.40.0 covered 0.05 yards here
+    const held = p.auras.find((a) => a.id === 'fear_incap')?.value;
+    for (let i = 0; i < 40; i++) {
+      hooks.updateFearMovement(p);
+      expect(p.auras.find((a) => a.id === 'fear_incap')?.value).toBe(held); // one course
+    }
+  });
+
+  it('the flee heading stays bounded for the whole fear', () => {
+    const { sim, p, hooks } = fearedInBattleground(-24, -47, Math.PI / 2);
+    for (let i = 0; i < 200; i++) {
+      hooks.updateFearMovement(p);
+      const value = p.auras.find((a) => a.id === 'fear_incap')?.value;
+      expect(Number.isFinite(value)).toBe(true);
+      expect(Math.abs(value ?? 0)).toBeLessThanOrEqual(Math.PI);
+    }
+    expect(sim.player).toBe(p);
+  });
+
+  it('is deterministic: the same seed and spot replay identically', () => {
+    const run = (): number[] => {
+      const { p, hooks } = fearedInBattleground(7, -39, -(3 * Math.PI) / 8);
+      const out: number[] = [];
+      for (let i = 0; i < 40; i++) {
+        hooks.updateFearMovement(p);
+        out.push(p.pos.x, p.pos.z, p.auras.find((a) => a.id === 'fear_incap')?.value ?? 0);
+      }
+      return out;
+    };
+    const first = run();
+    expect(first).toEqual(run());
+    expect(first.some((v, i) => i % 3 === 0 && v !== first[0])).toBe(true); // it moved
+  });
+
+  it('draws no rng: the shared stream is untouched by a feared step', () => {
+    // The stall escape retries a blocked step up to a full fan per tick, so a single
+    // stray draw in that loop would fork the world between the three hosts.
+    const { sim } = fearedInBattleground(-24, -47, Math.PI / 2);
+    let draws = 0;
+    sim.rng.setObserver(() => {
+      draws++;
+    });
+    const path = fleePathLength(sim, 60);
+    sim.rng.setObserver(null);
+    expect(path).toBeGreaterThan(1); // the fan really ran, so the count is not vacuous
+    expect(draws).toBe(0);
+  });
+
+  it('open ground keeps the heading it was feared on', () => {
+    const { sim, p } = fearedInBattleground(20, 0, 0);
+    const from = { x: p.pos.x, z: p.pos.z };
+    fleePathLength(sim, 20);
+    expect(p.auras.find((a) => a.id === 'fear_incap')?.value).toBe(0);
+    expect(p.pos.z - from.z).toBeGreaterThan(1); // ran the way the fear pointed
+    expect(Math.abs(p.pos.x - from.x)).toBeLessThan(0.5); // and straight, not veering
+  });
+});


### PR DESCRIPTION
## Summary

In the 5v5 battleground, a feared player often ended up stuck in the decor near a
wall or the edge of the map, frozen in place for the whole fear with no way out
(Unstuck is blocked in combat and in a competitive match).

The feared-player wall guard added in `src/sim/combat/fear_steering.ts` already
steers the flee heading off a wall, but it predicts that wall by probing the
**collider set** alone. The mover refuses steps for three things that probe cannot
see:

- ground steeper than the climb limit, and `nearSteepWalls` returns `true` for the
  whole Thornhollow band because the field is authored relief rather than a flat
  instance floor,
- a garden hedge crossing,
- a landlocked step under the waterline.

Wherever the probe said "open" and `moveToward` said "no", the guard never turned
and the run pinned anyway. The probe is also 1 yard grained, so it accepts a 1 yard
pocket as an improvement and then has nothing left to try.

This change adds a second arm to the same module that reads the **outcome** instead
of predicting it: run the flee step, measure the ground it actually covered, and
turn until one delivers. Whatever refused the step (collider, relief, hedge,
waterline, delve clamp) shows up the same way, which is the point, since this arm
has no world model that can drift from the mover.

It also caps the predictive arm to corrective turns (a quarter or a half). Its
three-quarter turn and about-face were the second half of the report: in a shallow
dead end the most open probe direction is simply back the way the run came, so the
body bounced between the two ends for the whole fear and got nowhere. A big turn is
now earned by a measured stall, and that arm's fan still carries the full reversal.

### Measured effect

Sweeping every playable yard of the Thornhollow field against 16 fear headings
(359,984 position and heading pairs), comparing this branch against its
`release/v0.40.0` base:

| | before | after |
|---|---:|---:|
| bodies frozen for the whole fear (under 1yd of travel in 3s) | 60 | **0** |
| spots frozen from every one of the 16 headings | 2 | **0** |
| net displacement under 1yd after 3s | 305 | 178 |
| spots net-stuck from every heading | 4 | 2 |

The reported bug, a body that does not move at all, is gone everywhere on the map.

**What this does not fix, stated plainly:** two cells of the field sit inside a
prop's baked collision (a thicket) where the mover refuses *every* heading, not just
the feared one. Movement code cannot open sealed geometry, and re-picking a heading
there would only make the body jitter. Those two are no longer a hard freeze (0.05
to 1.3 yards of travel) and now hold one course instead of jittering, which is what
`tests/fear_stall_escape.test.ts` pins for them. Actually opening those pockets is a
map authoring change, not a movement change, and is out of scope here.

### Notes for the reviewer

- **Determinism.** Neither arm draws rng. The escape retries a blocked step up to a
  full fan per tick, so a stray draw there would fork the world across the three
  hosts; the test asserts zero draws through the `Rng.setObserver` seam rather than
  by eyeballing the code, and `tests/parity` is green.
- **Player only.** The mob arm of `updateFearMovement` is untouched, so feared-mob
  movement and the rng draw order with it stay byte identical. This keeps the
  scoping the existing guard already had.
- **`sim.ts` is net zero lines.** Its `monolith_budget` ceiling (12570) had zero
  headroom, so the coordinator edit is a swap, not growth: all new logic is in the
  module behind `SimContext`, reached through `ctx.moveToward` / `ctx.groundPos` /
  `ctx.fleeMoveSpeed`.
- **`wrapHeading` returns an in-range heading exactly**, by an early return rather
  than through the modulo, so an unchanged heading still compares equal and a steady
  run reads as steady. The aura's `value` is rewritten every tick and shipped raw on
  every snapshot, which is why it is kept bounded.
- The pure core takes its stepper as an injected interface, so
  `tests/fear_stall_escape.test.ts` drives the whole search with a synthetic map
  (call order, rewinds, the stall bar, the sealed fallback) without a live `Sim`,
  alongside live-`Sim` regression cases at five spots that each froze on the base.

## Related issues

N/A. Reported in play, no tracking issue filed.

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [ ] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npm run gate` (the full merge bar). **Red on my machine, exit 1, and none of it
    is from this change.** Full detail under "Gate honesty" below.
  - `npx vitest run tests/fear_stall_escape.test.ts` (new, 20 cases)
  - `npx vitest run tests/fear_wall_guard.test.ts tests/fear_standable_support.test.ts tests/mob_dread.test.ts tests/mob_terrify.test.ts tests/warlock_fear.test.ts tests/fear_break_chance.test.ts`
  - `npx vitest run tests/parity tests/sim.test.ts tests/player_motion.test.ts tests/parkour.test.ts tests/battleground.test.ts tests/unstuck.test.ts`
  - `npx vitest run tests/architecture.test.ts tests/monolith_budget.test.ts tests/sim_context.test.ts tests/localization_fixes.test.ts`
  - `npx tsc --noEmit`
  - `npx @biomejs/biome check --write` on the three changed files only
- Manual steps:
  - Wrote a throwaway harness that walks every playable yard of the Thornhollow
    field against 16 fear headings and runs the real `updateFearMovement` for three
    seconds per sample, recording path length (did the body move at all) separately
    from net displacement (did it get anywhere). Ran it against this branch and
    against a clean `release/v0.40.0` working tree to produce the table above. The
    harness was not committed; the five spots it found that froze outright are
    committed as the regression fixtures in `tests/fear_stall_escape.test.ts`.
  - Confirmed each of those five fixtures covers 0.00 to 0.05 yards on the base
    branch and clears half of an unobstructed flee's distance on this one.

### Gate honesty

`npm run gate` exits 1 for me, on a Windows dev box, with 54 files and 191 tests red.
I am not going to claim a green gate I did not get, so here is exactly what I did to
separate my change from the machine.

I detached to the untouched base (`1ff69563c3`, the tip of `release/v0.40.0`) and ran
the identical failing set at the same worker count:

| | count |
|---|---:|
| red suites in my gate run | 49 |
| failing identically on the untouched base | **46** |
| red only under full-suite parallel load, green in isolation on this branch | **3** |
| attributable to this diff | **0** |

The 46 are environment, not code. They are entirely asset, SFX, icon-converter,
eastbrook/fenbridge, CLI, CI-tooling, deploy-watchdog (failing on `ECONNREFUSED :3000`)
and HTTP-characterization suites. The gate names its own root cause, "missing required
SFX audio tooling: ffmpeg, ffprobe", but both bundled binaries are present and run fine
(`ffmpeg -version` and `ffprobe -version` each exit 0), so the probe for them is what is
broken here, not the dependency. That is a known family of Windows spawn issues in the
gate scripts on this machine and predates this branch.

The 3 (`chronomancy_balance_targets`, `language_fanout_registry`, `nythraxis_matrix`)
all pass on this branch when run on their own; they are heavy-sim load flakes under
parallel workers, not regressions.

Worth noting separately, because it is the check that would actually catch a mistake
here: **`tests/parity` is green**. It is the golden-trace plus rng-draw-order gate that
goes red on any unexpected sim behavior change, which is precisely the risk class of a
movement edit. So are `architecture` (sim purity and determinism), `monolith_budget`,
`sim_context`, `localization_fixes`, both existing fear suites, and the 20 new cases.

A reviewer should treat Linux CI as the real signal on the suites above.

## Screenshots / recordings

N/A. Not a visual change: the repo's own capture classifier
(`scripts/pr_shot_targets.mjs`, which is what `scripts/pr_screenshots.mjs` uses to
decide what to shoot) reports `isVisual: false` for this diff, so per that script's
header the change captures no frames and needs no screenshot section.

---

## Checklist

Tick the items that apply to your change. It's fine to leave the rest unchecked
or strike them through (`~like this~`) when they don't.

### Quality

- [ ] **The gate passes.** Not claimed: `npm run gate` is red on my Windows box for
      pre-existing environment reasons. I proved every red suite against the untouched
      base and none is attributable to this diff (see "Gate honesty" above), and the
      change-relevant suites, `tests/parity` included, are green. I added decisive tests
      for the changed behavior and recorded the manual checks above.

### Cross-platform

- [ ] N/A. **Tested on desktop and mobile.** Verified on a desktop and on a
      phone-sized viewport in both portrait and landscape. Touch targets stay at
      least 40x40px and inputs at least 16px font (see `src/ui/CLAUDE.md`).
      This change is `src/sim/` only and renders no UI; the behavior is identical on
      every host because it is the shared deterministic core.
- [ ] N/A. **Accessible.** Keyboard-operable, with visible focus, sensible ARIA, and
      respect for `prefers-reduced-motion` (only if this change adds or edits UI).
      No UI added or edited.

### Localization (i18n)

- [ ] **New player-visible strings follow the contributor policy.** Every user-facing
      string is a `t()` key added to the matching English catalog. I did not edit locale
      overlays, except for the five required non-Latin fills when the M16 wordy-copy
      rule applies (see `src/ui/CLAUDE.md`).
- [ ] Numbers, money, dates, units, and percents go through the i18n formatters
      (`formatNumber`, `formatMoney`, `formatDateTime`, `Intl`).
- [ ] Player-facing text emitted from `src/sim/` or `server/` is re-localized at
      the client boundary in this same change, and
      `npx vitest run tests/localization_fixes.test.ts` passes.
- [x] N/A. This PR adds no player-visible strings.
      (`tests/localization_fixes.test.ts` was run anyway and is green.)

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.

> Commit messages and PR titles use [Conventional Commits](https://www.conventionalcommits.org/)
> with a required scope (`feat(talents): ...`, `fix(net): ...`).
