### PR TITLE
fix(content): raise Drowned Litany Bountiful Coffer and epic drop rates

### DIFF
--- a/tests/delves.test.ts
+++ b/tests/delves.test.ts
@@ -3785,24 +3785,36 @@ describe('The Drowned Litany (Phase 7 Drowned Reliquary Rite)', () => {
     // earlier draw shifts run.seed): only claimDelveRun's own p values are
     // under test here. The roll is delve-agnostic (keyed on tierId only), so
     // this pins the one shared formula regardless of which delve calls it.
-    const runSeedFor = (seed: number, tier: 'normal' | 'heroic') => {
+    const runFor = (seed: number, tier: 'normal' | 'heroic') => {
       const s = makeSim('warrior', seed);
       enterLitany(s, tier);
-      return s.delveRunForPlayer(s.playerId)!.seed;
+      return s.delveRunForPlayer(s.playerId)!;
     };
     const rolls = (runSeed: number, p: number) => new Rng((runSeed ^ 0x600dc0ff) >>> 0).chance(p);
 
     // Both top-level seeds were found by brute-force search: each produces a
     // run.seed that MISSES under the retired 5%/2% odds and HITS under the
     // live 20%/8% ones (the chase epics were landing near 1-in-700 per
-    // heroic clear before this bump, see drowned_litany_loot.ts).
-    const heroicSeed = runSeedFor(1, 'heroic');
-    expect(rolls(heroicSeed, 0.05)).toBe(false);
-    expect(rolls(heroicSeed, 0.2)).toBe(true);
+    // heroic clear before this bump, see drowned_litany_loot.ts). Also
+    // assert the LIVE run.bountiful directly, not just the re-derived
+    // formula: a regression of runs.ts's live constant back to the retired
+    // 5%/2% would leave the re-derivation above untouched (it hardcodes both
+    // odds itself) but must flip these to false.
+    const heroicRun = runFor(1, 'heroic');
+    expect(rolls(heroicRun.seed, 0.05)).toBe(false);
+    expect(rolls(heroicRun.seed, 0.2)).toBe(true);
+    expect(heroicRun.bountiful).toBe(true);
 
-    const normalSeed = runSeedFor(53, 'normal');
-    expect(rolls(normalSeed, 0.02)).toBe(false);
-    expect(rolls(normalSeed, 0.08)).toBe(true);
+    const normalRun = runFor(53, 'normal');
+    expect(rolls(normalRun.seed, 0.02)).toBe(false);
+    expect(rolls(normalRun.seed, 0.08)).toBe(true);
+    expect(normalRun.bountiful).toBe(true);
+
+    // Negative controls (also brute-force found): seeds whose run.seed MISSES
+    // even at the raised rate, so this test cannot be satisfied by a mutant
+    // that hardcodes run.bountiful = true regardless of the roll.
+    expect(runFor(2, 'heroic').bountiful).toBe(false);
+    expect(runFor(1, 'normal').bountiful).toBe(false);
   });
 
   it('rejects a rite difficulty commit from a player away from the reliquary', () => {


### PR DESCRIPTION
## Summary

Players reported that The Drowned Litany's chase epics (`blackwater_vanguard_chest`,
`siltstep_leggings`, `sunken_reliquary_hood`) are effectively unobtainable: after 80+
heroic clears at a flawless Hard rite (perfect play), only the class-based blue/rare
spoils were dropping, never an epic.

The math checks out against the live code. Getting an epic required two independent
rolls to land: the delve's Bountiful Coffer spawn (`claimDelveRun`,
`src/sim/delves/runs.ts`, rolled once per run: Heroic 5% / Normal 2%), AND a 3% epic
roll inside `drownedLitanyChestItemsForTier` (`src/sim/content/delves/drowned_litany_loot.ts`)
once a Bountiful Coffer is opened. Compounded, that is **0.15% per heroic clear
(~1 in 667)** and **0.06% per normal clear (~1 in 1667)**, for items that are weaker
than a normal (non-heroic) dungeon epic per their stat lines. Meanwhile hitting
"just" a rare requires a flawless Hard-tier rite (a real skill/attention bar) at a
20% roll on top, averaging 5 clears, unaffected by this change.

This PR raises both gates 4x each:

| Roll | Before | After |
|---|---|---|
| Bountiful Coffer (Heroic) | 5% | **20%** |
| Bountiful Coffer (Normal) | 2% | **8%** |
| Epic, inside a Bountiful Coffer | 3% | **12%** |
| **Compounded epic (Heroic clear)** | 0.15% (~1 in 667) | **~2.4% (~1 in 42)** |
| **Compounded epic (Normal clear)** | 0.06% (~1 in 1667) | **~0.96% (~1 in 104)** |

That is a **16x** improvement on the reported number, turning a near-impossible grind
into a realistic target-farming goal while leveling through the delve's 12+ level
band, without touching the (unrelated, unreported) 20% rare-at-flawless-Hard roll or
the guaranteed rare on every Bountiful Coffer.

**Scope note, flagged by review:** the Bountiful Coffer spawn roll in `claimDelveRun`
is delve-agnostic (keyed on `tierId`, not `delveId`), so this bump also raises the
Collapsed Reliquary delve's own Bountiful Coffer rate 4x, not just The Drowned
Litany's. Kept deliberate rather than forking the roll per delve: it is one canonical
mechanism, and the Collapsed Reliquary's Bountiful Coffer (higher item-level ceiling,
`docs/prd/DELVE_HANDOFF.md` 7.7) was equally under-tuned at 5%/2%. Called out here so
a reviewer can weigh in if that is not wanted.

**Separately, not fixed here:** review also surfaced that the Drowned Reliquary Rite's
Bountiful Coffer check has no gate on actually solving the rite (a tries-exhausted
"low" grant on a Bountiful run still gets the guaranteed rare and rolls the epic
chance), unlike the Collapsed Reliquary's lockpick coffer, which requires a real
solve. That is a separate, pre-existing gap this rate bump makes more consequential
but does not introduce; filed as
[levy-street/world-of-claudecraft#3639](https://github.com/levy-street/world-of-claudecraft/issues/3639)
rather than folded into this PR.

```mermaid
flowchart LR
    subgraph Before["Before (launch tuning)"]
        direction LR
        H1["Heroic clear"] -->|5%| B1["Bountiful Coffer"]
        B1 -->|3%| E1["Chase epic<br/>0.15% overall, ~1 in 667"]
    end
    subgraph After["After this PR"]
        direction LR
        H2["Heroic clear"] -->|20%| B2["Bountiful Coffer"]
        B2 -->|12%| E2["Chase epic<br/>2.4% overall, ~1 in 42 (16x)"]
    end
```

## Related issues

Reported directly by a player, not filed as a separate GitHub issue. Surfaces a
separate, pre-existing gap, filed as
[#3639](https://github.com/levy-street/world-of-claudecraft/issues/3639) and
intentionally not fixed here.

## Type of change

- [x] Bug fix
- [ ] Feature: new functionality
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [ ] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx vitest run tests/drowned_litany_loot.test.ts tests/delves.test.ts tests/reliquary_content.test.ts tests/litany_spawn_collision.test.ts tests/litany_tooltip.test.ts tests/litany_polygon_shell.test.ts tests/lockpick_bountiful_jam.test.ts` (all passed)
  - `npx vitest run tests/parity` (the drowned_litany golden scenario pins `run.bountiful = false` explicitly, so it is unaffected; full parity suite green, draw-order digest unchanged)
  - `npx vitest run tests/deeds.test.ts tests/reliquary_state.test.ts tests/reliquary_view.test.ts tests/architecture.test.ts tests/localization_fixes.test.ts tests/deeds_content.test.ts tests/guide.test.ts` (green)
  - `npx tsc --noEmit` (clean)
  - `node scripts/gate_select.mjs`
- Manual steps:
  - Verified the exact new thresholds with a deterministic p-aware stub RNG (`tests/drowned_litany_loot.test.ts`), so a regression back to the retired 3%/5%/2% constants would fail the suite, not just a statistical flake.
  - Brute-force found a real `run.seed` (via the actual `claimDelveRun` formula) that misses under the old odds and hits under the new ones, for each tier, and pinned the formula check directly in `tests/delves.test.ts` (decoupled from the exact global rng draw count preceding it, per review).
  - Dispatched `architecture-reviewer` and `content-obligations-reviewer` fresh against the diff: both confirmed no determinism, parity, or content-obligation regressions; their findings on scope disclosure and doc staleness are addressed above and in the diff.

## Screenshots / recordings

Not a UI change (no window, tooltip, or HUD text changed): this is a pure loot-table
probability tuning. Attaching the reporter's own evidence for context:

![Repeated blue drops across 80+ clears](../docs/screenshots/drowned-litany-reliquary-droprate/reported-repeat-blue-drops.jpg)
![The Drowned Litany Reliquary page stuck at 2/8 after 84 clears](../docs/screenshots/drowned-litany-reliquary-droprate/reported-reliquary-2-of-8.jpg)

---

## Checklist

### Quality

- [x] **The gate passes.** `node scripts/gate_select.mjs` is green. I added or updated
      decisive tests for changed behavior and recorded the manual checks above.

### Cross-platform

- [x] N/A. No UI, no visual change.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings (drop rates are never surfaced as
      numbers in the UI).

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not
      enabled in any production path.
- [x] I didn't hand-edit generated files.
