### PR TITLE
feat(terms): publish the marketplace Terms revision to the live pages

### DIFF
--- a/TERMS_AND_CONDITIONS.md
+++ b/TERMS_AND_CONDITIONS.md
@@ -2,7 +2,7 @@
 
 **World of ClaudeCraft**
 
-Last updated: 22 July 2026
+Last updated: 25 August 2026
 
 ## 1. Who we are and what these terms cover
 
@@ -18,6 +18,8 @@ We may update these Terms from time to time. When we make material changes we wi
 
 You must be at least 13 years old to use the Service, or older where your country requires a higher minimum age for online services. If you are under the age of majority where you live, you may use the Service only with the involvement and consent of a parent or guardian who agrees to these Terms. The Service is not intended for children under 13.
 
+Participation in the $WOC marketplace (Section 10) has a higher age requirement, set out in Section 10.2.
+
 ## 4. The Game and the source code
 
 We grant you a limited, personal, non-exclusive, non-transferable, revocable licence to access and play the Game for your own non-commercial entertainment, subject to these Terms.
@@ -32,20 +34,21 @@ The "World of ClaudeCraft" and "Levy Street" names, logos, and branding are not 
 
 To play online you create an account. You agree to provide accurate information, to keep your credentials secure, and to be responsible for all activity under your account. Do not share your account or use anyone else's. Tell us promptly if you suspect unauthorised use. We may refuse, reclaim, or rename accounts or characters that breach these Terms or that use names which are offensive, infringing, impersonating, or misleading.
 
-## 6. Acceptable use and code of conduct
+Using more than one account may make you ineligible for prizes, competitions, giveaways, and similar promotions. We may disqualify entries, or withhold or reclaim prizes, where we believe multiple accounts have been used to gain an unfair advantage.
 
-When using the Service you agree not to:
+## 6. Acceptable use and rules of conduct
 
-- Cheat, exploit bugs, automate play, use bots, or use unauthorised third-party software to gain an advantage. Development and testing commands are for local development only and must not be used against the live Service.
-- Harass, threaten, defame, or abuse other players, or post hateful, obscene, or illegal content in chat, names, or anywhere else.
-- Impersonate any person or entity, including us or our staff.
-- Disrupt the Service, including through denial-of-service attacks, excessive automated requests, or attempts to overload or interfere with servers.
-- Access the Service through unauthorised means, scrape it, or probe, scan, or test its security without permission.
-- Reverse engineer, decompile, or attempt to extract source code from the hosted Service, except to the extent applicable law expressly allows and that right cannot be excluded.
-- Sell, trade for real money, or commercially exploit accounts, characters, in-game items, or in-game currency.
-- Use the Service for any unlawful purpose or in breach of these Terms.
+The Service is a shared space. These rules apply across the Game, chat, and any feature where you can communicate or create text. Breaking them can lead to enforcement under Section 19.
 
-We may investigate suspected breaches and may suspend or terminate access, remove content, and report unlawful activity to authorities.
+- **Chat and communication.** Do not spam or flood, misuse channels, or advertise other communities. Do not harass, insult, or troll others, including attacks on a person's religion or beliefs. Do not post hate speech, slurs, or sexual content. Do not make real-world threats, share another person's private information, or organise coordinated harassment.
+- **Names.** Do not use offensive, hateful, sexual, or harassing names, impersonate staff or other players, or use names that evade the profanity filter. Do not name characters, guilds, groups, or pets after real-world religious figures, gods, or sacred concepts. The Game's own fictional faiths and lore are fine to use. This covers character names, display names, guild and group names, and any other editable text.
+- **Hacking and cheating.** Do not use third-party programs that read or change the game client or its memory. Do not manipulate network traffic, use speed, teleport, or automated targeting hacks, or make any unauthorised change to the client that affects gameplay.
+- **Bots and automation.** Do not automate gameplay with macros or external tools, including movement, combat, gathering, trading, AFK automation, or unattended farming.
+- **Exploits and bugs.** Do not deliberately use bugs for advantage, including duplicating items or currency, abusing vendor or economy bugs, or skipping intended restrictions through a known bug. Reporting a bug is welcome and is never punished. Exploiting one is the offence.
+- **Real-money trading.** Do not sell, trade for real money, or commercially exploit accounts, characters, in-game items, or in-game currency, except for sales of eligible in-game items conducted entirely through the $WOC marketplace we operate inside the Game, as Section 10 allows. Selling or trading accounts, characters, or in-game currency for real money remains prohibited everywhere, and selling in-game items for real money anywhere outside that marketplace remains prohibited.
+- **General.** Do not break the law, infringe anyone's rights, or interfere with the Service, its security, or other players' enjoyment of it.
+
+These rules cannot cover every situation. Our moderators may use reasonable discretion to interpret and apply them, and to act against conduct that harms the Service or other players even where it is not listed here. Decisions are made case by case.
 
 ## 7. User content
 
@@ -55,72 +58,154 @@ You are responsible for your User Content and confirm you have the right to shar
 
 ## 8. Virtual items and in-game currency
 
-The Game includes virtual items, gear, and in-game currency. These have no monetary value and cannot be redeemed for real money or anything of value outside the Game. You do not own them. We grant you a limited, revocable licence to use them within the Game only. We may modify, remove, reset, or wipe virtual items, currency, characters, and game worlds at any time, including during testing and balancing, without liability or compensation. The Game is free to play, and we do not sell virtual items or currency.
+The Game includes virtual items, gear, and in-game currency. You do not own them. We grant you a limited, revocable licence to use them within the Game only, and a sale through the $WOC marketplace (Section 10) transfers that licence between accounts rather than transferring ownership of anything.
+
+Outside the $WOC marketplace, virtual items and in-game currency have no monetary value and cannot be redeemed for real money or anything of value outside the Game. We do not sell virtual items or currency, we do not buy them back, and we do not redeem them for money or anything else: the marketplace is player-to-player, and the only real-money value an eligible item ever has is the price another player freely agrees to pay for it there. We make no promise that any item can be sold, will remain eligible for sale, or will hold any price.
+
+We may modify, remove, reset, or wipe virtual items, currency, characters, and game worlds at any time, including during testing and balancing, without liability or compensation. This applies to items bought on the marketplace like any others, and to items held in marketplace custody. The Game is free to play.
 
 ## 9. The $WOC token
 
 A token referred to as $WOC, associated with the community on the Solana network, was created and is controlled by a third party. We do not issue, mint, control, manage, promote as an investment, or guarantee the $WOC token or its value.
 
-- The token is not required to play and has no effect on your account, characters, or progress.
-- Wallet verification in the Game is cosmetic only. It displays optional flair or a badge and involves no transaction and no transfer of funds.
+- The token is not required to play. Holding it, or not holding it, never grants or withholds gameplay power: holding it has no effect on your characters' stats, progression, drop rates, or any other gameplay outcome. The optional marketplace (Section 10) lets players trade eligible earned items among themselves for $WOC; it does not let anyone buy power from us.
+- Linking a wallet to your account is cosmetic and read-only. It is done with one signature, involves no transaction and no transfer of funds, and displays optional flair or a badge.
+- Participating in the $WOC marketplace is separate from wallet linking, entirely optional, and does involve real blockchain transactions: payments and bid bonds that you sign in your own wallet. We never hold your keys, and apart from the refundable bid bond described in Section 10.5, which we hold from when your bond payment confirms until it is returned or forfeited, we never hold your funds. Section 10 governs that participation.
 - Nothing in the Service is financial, investment, legal, or tax advice, or an offer, solicitation, or recommendation to buy, sell, or hold any token or digital asset.
 - Digital assets are volatile and carry risk, including total loss, and may be regulated differently in different countries. You are solely responsible for your own decisions and for complying with the laws that apply to you.
 
 To the fullest extent permitted by law, we are not liable for any loss connected with the $WOC token or any third-party token, wallet, exchange, or blockchain.
 
-## 10. Donations
+## 10. The $WOC marketplace
+
+### 10.1 What it is
+
+The Game includes an optional marketplace where players sell eligible in-game items to other players for $WOC ("the Marketplace"). Sales take the form of auctions, fixed-price listings, or direct sales to a named player agreed through the in-game trade window. The Marketplace is player-to-player: we operate the venue, hold listed items in escrow, and charge the fee described in Section 10.7, but we are not the buyer or the seller in any trade, we do not set prices, and we do not sell items or tokens ourselves.
+
+Prices are denominated in US dollars. Payment is made in $WOC: the number of tokens due is calculated only when payment is requested, from a quote based on a current market price of $WOC, and that number can change between quotes. A listing's US dollar price does not change; only the token count at settlement moves with the market. We do not peg or guarantee any exchange rate.
+
+The Marketplace may be unavailable, disabled, or paused at any time (Section 10.10).
+
+### 10.2 Who may participate
+
+To list, bid, or buy you need: an account in good standing, a verified linked Solana wallet, and acceptance of these Marketplace terms (Section 10.3). You must be at least 18 years old, or the age of majority where you live if that is higher, to participate in the Marketplace.
+
+The Marketplace is available in the browser version of the Game only. It is not available in the desktop, Steam, iOS, or Android builds. We may restrict or refuse Marketplace access by account, realm, or jurisdiction, including where local law would prohibit or condition it.
+
+### 10.3 Accepting these Marketplace terms
+
+Your first Marketplace commitment requires you to accept these Marketplace terms, and we record that acceptance against your account with the time it happened. We only record acceptance through an interface that presents these terms to you, or a clearly labelled link to them, at or before the moment you accept: an acceptance control you act on yourself, such as a checkbox beside the commitment it covers. We do not treat playing the Game, linking a wallet, or any action taken in an interface that did not present these terms as acceptance.
+
+### 10.4 Listings, custody, and escrow
+
+When you list an item, or agree a direct sale, the exact item copy leaves your character's bags and is held by the Game in escrow for the life of the listing. While escrowed it cannot be equipped, used, traded, mailed, or listed anywhere else, and you cannot get it back except as these terms describe. If the listing ends without a completed sale (it expires unsold, the reserve is not met, you cancel where cancellation is allowed, the buyer never pays, or the sale otherwise fails), the same copy is returned to you by in-game mail. If the sale completes, the same copy is delivered to the buyer: placed directly into their character's bags, or sent by in-game mail.
+
+We decide which item categories are eligible for the Marketplace, per realm, and may change eligibility at any time. Items already bound to a character, quest items, and any other items or categories we exclude cannot be listed. Delisting a category does not disturb completed sales.
+
+A seller cannot cancel a listing while any bid stands, including a bid whose bond is still being paid, or while a buyer's payment may be in progress; a cancellation requested while a buy-now purchase is pending takes effect only if that purchase does not complete, and player support can cancel a listing only once no payment is in flight. A bid is binding once you sign its bond transaction; before that you may abandon it, and a bid whose bond is never paid lapses on its own after a short period.
+
+### 10.5 Bidding, bid bonds, and forfeiture
+
+Placing an auction bid requires a small refundable bond, denominated in US dollars and paid in $WOC when the bid is placed. The bond is our protection against bidders who win and never pay; it works like this:
+
+- The bond is a percentage of your bid (currently 5%, within a fixed minimum and maximum); the resolved bond amount is shown before you commit. You sign the bond transaction in your own wallet, and your bid becomes active only when that transaction is confirmed.
+- Your bond is returned when you are outbid (subject to the second-chance offer below), when the auction ends below its reserve, and when a buy-now purchase closes the auction.
+- If you win and complete payment, your bond is returned after settlement confirms.
+- If you win and do not pay within the settlement window, you forfeit the bond: it is not returned to you, it never goes to the seller, and it is split between the Game treasury and the permanent token burn. Failing to pay also earns your account a Marketplace strike; repeated strikes earn progressively longer suspensions from the Marketplace.
+
+A bid confirmed in the final minutes of an auction extends the auction by a short period so it can be answered; the total extension is capped at a fixed period past the listed end time.
+
+A seller may enable a second-chance offer when creating a listing. If the winner does not pay, the highest eligible remaining bidder becomes the buyer at their own bid amount, with a fresh settlement window. If that bidder's bond has not yet been returned, it is held again and remains subject to this Section; a bond already returned is not taken again. Not paying within the new window carries the same consequences as any winning bid, except that only a bond we hold can be forfeited.
+
+Direct sales agreed through the trade window carry no bond. If you agree a direct purchase and do not pay within its window, the item returns to the seller and your account earns a strike on the same ladder.
+
+On listings other than direct sales, abandoning a buy-now purchase without paying carries no bond and no strike, but it temporarily blocks you from re-claiming that listing, and repeated abandonments within a short period temporarily block new buy-now purchases across your account.
+
+### 10.6 Payment, settlement, and delivery
+
+A winning bidder or buyer pays inside a limited settlement window. Payment works by requesting a quote (the number of $WOC tokens equal to the agreed US dollar price at the current market price; each quote is valid for a short period shown with it), then signing a single Solana transaction in your own wallet that pays the seller, the treasury, and the burn in one step. The Game verifies that transaction's finality on the Solana network before delivering the item.
+
+You pay the network transaction fee. If the market price of $WOC moves between your commitment and your payment, the token count due will differ from the estimate you saw when you committed; the US dollar price does not change. If you do not pay within the settlement window, the sale fails and Section 10.5's consequences apply.
+
+When the price of $WOC cannot be read reliably, or the pricing service is degraded or unreachable, the Marketplace stops accepting new listings, offers, purchases, and bids, and stops issuing payment quotes, until pricing recovers. Auctions keep counting down, settlement windows continue to run during the pause, and a payment already broadcast is still verified and delivered.
+
+### 10.7 Fees and the burn
+
+Every completed sale carries a 10% fee, paid by the seller out of the sale amount: 7% of the settlement amount goes to the Game treasury, 3% is permanently burned (destroyed, removing those tokens from circulation), and the seller receives the remainder, paid to the wallet that was verified on their account when the listing was created. Each fee leg is rounded up to the whole cent, so the seller's share can fall up to two cents below 90%. The split is computed inside the settlement transaction and shown to both parties before they confirm, and the treasury and burn addresses are visible on-chain in every settlement transaction. We may change the fee or the split prospectively; a change never applies to a sale already agreed.
+
+### 10.8 Finality, disputes, and refunds
+
+A completed sale is final. Solana transactions cannot be reversed by us or anyone else, and we cannot un-send a payment or claw back a delivered item. Before a sale completes, the protections in Sections 10.4 to 10.6 (escrow, bonds, verified settlement) are the remedy: a failed sale returns the item to the seller and, except for forfeiture under Section 10.5, returns the bond to the bidder.
+
+If something goes wrong, contact player support. We may investigate any listing, sale, or settlement; place a settlement under operator review; suspend or cancel listings (returning the item and refunding bonds where no completed sale stands); exclude sales from public price statistics; and apply or lift strikes and suspensions. These operator remedies act on in-game items, bonds not yet forfeited, and account standing. We do not refund completed on-chain payments, and we are not an arbiter of disputes between players beyond these remedies. Nothing in this Section limits rights you have under consumer laws that cannot be excluded (Section 16).
+
+Every completed sale is recorded in a public, per-item sales history that includes the item, price, and the trading characters.
+
+### 10.9 Marketplace conduct
+
+In the Marketplace you agree not to: bid on or buy your own listings, directly or through another account or wallet you control; place bids you do not intend to honour; manipulate prices, including wash trading and shill bidding; use the Marketplace to disguise or settle trades made outside it; interfere with other players' listings or settlements; or evade a strike, suspension, or restriction with another account or wallet. We may remove listings, cancel sales that have not completed, and suspend Marketplace access or the account itself for conduct in this Section, in addition to Section 6.
+
+### 10.10 Availability and changes
+
+The Marketplace is an optional feature of an evolving Game. We may change its rules, fees (prospectively, per Section 10.7), eligibility, and parameters; suspend it; or discontinue it, at any time. If we suspend or discontinue it, escrowed items are returned to their sellers, in-progress settlements are completed or failed under the rules above, and bonds not forfeited are returned. We owe no compensation for lost listings, expected sale proceeds, or the ability to sell.
+
+### 10.11 Taxes and your law
+
+You are solely responsible for any taxes arising from your Marketplace sales and purchases, and for determining whether the Marketplace is lawful for you where you live. We do not withhold or remit taxes for you and we do not provide tax advice.
+
+## 11. Donations
 
 Donations through Ko-fi are voluntary. Ko-fi facilitates payments directly through a third-party payment provider such as PayPal or Stripe. Donations are not a purchase, are non-refundable except where the law requires, and do not entitle you to any product, in-game advantage, ownership, equity, token, or other benefit.
 
-## 11. Service availability and changes
+## 12. Service availability and changes
 
 The Game is in active development and is provided on an evolving basis. We may change, suspend, limit, or discontinue all or part of the Service, including features, characters, items, and game worlds, at any time and without notice. We do not guarantee uptime, availability, or that the Service will be uninterrupted or error free. We may need to reset or wipe data for technical or balancing reasons.
 
-## 12. Third-party services
+## 13. Third-party services
 
 The Service links to and relies on third-party services, including GitHub, Ko-fi, PayPal, Stripe, Discord, the Solana network, and any advertising or analytics providers we use. We do not control these services and are not responsible for them. Your use of them is governed by their terms.
 
-## 13. Intellectual property and no affiliation
+## 14. Intellectual property and no affiliation
 
 World of ClaudeCraft is an independent, community project. It is not affiliated with, endorsed by, sponsored by, or associated with any third-party company, game, product, or brand. All third-party names, marks, and trademarks are the property of their respective owners. Any such names that appear are used only descriptively and do not imply any association.
 
 Except for your User Content, the Service, including its original content, features, design, media assets, and branding, is owned by us or our licensors and is protected by intellectual property laws. You may not copy, distribute, or create derivative works from the Service, from the media assets described in Section 4, or from our names, logos, and branding, except as these Terms or the licence recorded in `CREDITS.md` expressly allows, or with our prior written permission. Your rights in the source code are governed by the MIT Licence as described in Section 4, and this Section does not restrict them.
 
-If you believe content on the Service infringes your intellectual property, contact us using Section 22 with enough detail to identify the work and the allegedly infringing material, and we will respond appropriately.
+If you believe content on the Service infringes your intellectual property, contact us using Section 23 with enough detail to identify the work and the allegedly infringing material, and we will respond appropriately.
 
-## 14. Disclaimer of warranties
+## 15. Disclaimer of warranties
 
 To the fullest extent permitted by law, the Service is provided "as is" and "as available," without warranties of any kind, whether express, implied, or statutory, including warranties of merchantability, fitness for a particular purpose, title, and non-infringement. We do not warrant that the Service will be secure, uninterrupted, error free, or free of harmful components, or that data will not be lost.
 
-## 15. Consumer law
+## 16. Consumer law
 
 Nothing in these Terms limits rights you have under laws that cannot be excluded, including, for consumers in New Zealand, the Consumer Guarantees Act 1993 and the Fair Trading Act 1986, and similar consumer protection laws elsewhere. Where the Service is supplied free of charge and for personal use, those guarantees apply only to the extent the law requires.
 
-## 16. Limitation of liability
+## 17. Limitation of liability
 
 To the fullest extent permitted by law, we and our directors, employees, and contractors will not be liable for any indirect, incidental, special, consequential, or punitive damages, or for any loss of data, progress, profits, goodwill, or virtual items, arising from or related to your use of or inability to use the Service. To the extent we are found liable despite the above, our total liability for all claims relating to the Service is limited to NZD 100. Some jurisdictions do not allow certain limitations, so some of these may not apply to you.
 
-## 17. Indemnification
+## 18. Indemnification
 
 You agree to indemnify and hold us harmless from any claims, losses, liabilities, and expenses, including reasonable legal fees, arising from your breach of these Terms, your User Content, or your misuse of the Service, to the extent permitted by law.
 
-## 18. Suspension and termination
+## 19. Suspension and termination
 
-You may stop using the Service and delete your account at any time. We may suspend or terminate your access at any time, with or without notice, if you breach these Terms, if we are required to by law, or to protect the Service or other users. On termination, your licence to use the Service ends. Sections that by their nature should survive will survive, including Sections 8 to 17 and 19 to 22.
+You may stop using the Service and delete your account at any time. We may suspend or terminate your access at any time, with or without notice, if you breach these Terms, if we are required to by law, or to protect the Service or other users. On termination, your licence to use the Service ends. If your account is terminated while you have items in Marketplace escrow or settlements in progress, we resolve them under Section 10 before or alongside closure. Sections that by their nature should survive will survive, including Sections 8 to 18 and 20 to 23.
 
-## 19. Governing law and disputes
+## 20. Governing law and disputes
 
 These Terms are governed by the laws of New Zealand. The courts of New Zealand have non-exclusive jurisdiction over any dispute, without affecting any mandatory rights you have to bring proceedings in your country of residence.
 
-## 20. General
+## 21. General
 
 If any provision of these Terms is held unenforceable, the rest remains in effect. Our failure to enforce a provision is not a waiver. You may not assign these Terms without our consent. We may assign them in connection with a merger, acquisition, or sale of assets. These Terms are the entire agreement between you and us regarding the Service.
 
-## 21. App store terms
+## 22. App store terms
 
-If you download the App from a third-party app store or platform (each a "Distributor"), the following additional terms apply. In the event of a conflict between these Terms and a Distributor's required terms, the Distributor's required terms apply for that App only and only to the extent of the conflict.
+If you download the App from a third-party app store or platform (each a "Distributor"), the following additional terms apply. In the event of a conflict between these Terms and a Distributor's required terms, the Distributor's required terms apply for that App only and only to the extent of the conflict. The $WOC marketplace (Section 10) is not available in the App on any platform.
 
-### 21.1 Apple App Store
+### 22.1 Apple App Store
 
 These terms apply if you obtain the App from Apple. You acknowledge and agree that:
 
@@ -131,15 +216,15 @@ These terms apply if you obtain the App from Apple. You acknowledge and agree th
 5. **Product claims.** We, not Apple, are responsible for addressing any claims by you or a third party relating to the App or your use of it, including product liability claims, claims that the App fails to conform to a legal or regulatory requirement, and claims under consumer protection, privacy, or similar laws.
 6. **Intellectual property.** In the event of a third-party claim that the App or your use of it infringes that third party's intellectual property rights, we, not Apple, are solely responsible for the investigation, defence, settlement, and discharge of that claim.
 7. **Legal compliance.** You represent and warrant that you are not located in a country subject to a U.S. Government embargo or designated as a "terrorist supporting" country, and that you are not listed on any U.S. Government list of prohibited or restricted parties.
-8. **Developer name and contact.** Questions, complaints, or claims regarding the App should be directed to us using the contact details in Section 22.
+8. **Developer name and contact.** Questions, complaints, or claims regarding the App should be directed to us using the contact details in Section 23.
 9. **Third-party terms.** You must comply with applicable third-party terms of agreement when using the App.
 10. **Third-party beneficiary.** Apple and Apple's subsidiaries are third-party beneficiaries of these Terms, and upon your acceptance of these Terms, Apple will have the right, and will be deemed to have accepted the right, to enforce these Terms against you as a third-party beneficiary.
 
-### 21.2 Google Play
+### 22.2 Google Play
 
 These terms apply if you obtain the App from Google Play. Your use of the App must comply with the then-current Google Play Terms of Service. Google is not a party to these Terms and is not responsible for the App. Any claim relating to the App is between you and us, not Google.
 
-## 22. Contact us
+## 23. Contact us
 
 Email: tony@levystreet.com
 

--- a/TERMS_AND_CONDITIONS_MARKETPLACE_DRAFT.md
+++ b/TERMS_AND_CONDITIONS_MARKETPLACE_DRAFT.md
@@ -1,6 +1,14 @@
 # Terms and Conditions (marketplace revision)
 
-**DRAFT FOR COUNSEL. NOT IN FORCE.**
+**DRAFT FOR COUNSEL. PUBLISHED 25 AUGUST 2026 BY OWNER DECISION, AHEAD OF COUNSEL SIGN-OFF.**
+
+The owner elected to publish this revision as the live Terms on 25 August 2026
+without waiting for counsel review. The published text is this draft's
+marketplace changes applied onto the RICHER live page text (the live
+`public/terms.html` carried a newer Section 5 and Section 6 than this draft's
+base; see the publication commit). The `[COUNSEL]` questions below remain OPEN:
+counsel review of the published text is still owed, and this file remains the
+counsel working copy.
 
 This document is a proposed revision of `TERMS_AND_CONDITIONS.md` (the live
 Terms, last updated 22 July 2026). It is kept beside the live Terms and does not

--- a/public/terms.html
+++ b/public/terms.html
@@ -6,19 +6,19 @@
   <meta name="color-scheme" content="dark" />
   <meta name="theme-color" content="#08080d" />
   <title>Terms and Conditions - World of ClaudeCraft</title>
-  <meta name="description" content="Terms and Conditions for World of ClaudeCraft, covering accounts, acceptable use, virtual items, app store terms, and legal notices." />
+  <meta name="description" content="Terms and Conditions for World of ClaudeCraft, covering accounts, acceptable use, virtual items, the $WOC marketplace, app store terms, and legal notices." />
   <meta name="robots" content="index, follow, max-image-preview:large" />
   <link rel="canonical" href="https://worldofclaudecraft.com/terms" />
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="World of ClaudeCraft" />
   <meta property="og:title" content="Terms and Conditions - World of ClaudeCraft" />
-  <meta property="og:description" content="Terms and Conditions for World of ClaudeCraft, covering accounts, acceptable use, virtual items, app store terms, and legal notices." />
+  <meta property="og:description" content="Terms and Conditions for World of ClaudeCraft, covering accounts, acceptable use, virtual items, the $WOC marketplace, app store terms, and legal notices." />
   <meta property="og:url" content="https://worldofclaudecraft.com/terms" />
   <meta property="og:image" content="https://worldofclaudecraft.com/woc_logo_square.webp" />
   <meta property="og:image:alt" content="World of ClaudeCraft" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Terms and Conditions - World of ClaudeCraft" />
-  <meta name="twitter:description" content="Terms and Conditions for World of ClaudeCraft, covering accounts, acceptable use, virtual items, app store terms, and legal notices." />
+  <meta name="twitter:description" content="Terms and Conditions for World of ClaudeCraft, covering accounts, acceptable use, virtual items, the $WOC marketplace, app store terms, and legal notices." />
   <meta name="twitter:image" content="https://worldofclaudecraft.com/woc_logo_square.webp" />
   <script type="application/ld+json">
   {
@@ -26,7 +26,7 @@
     "@type": "WebPage",
     "name": "Terms and Conditions - World of ClaudeCraft",
     "url": "https://worldofclaudecraft.com/terms",
-    "description": "Terms and Conditions for World of ClaudeCraft, covering accounts, acceptable use, virtual items, app store terms, and legal notices.",
+    "description": "Terms and Conditions for World of ClaudeCraft, covering accounts, acceptable use, virtual items, the $WOC marketplace, app store terms, and legal notices.",
     "inLanguage": "en",
     "isPartOf": { "@type": "WebSite", "name": "World of ClaudeCraft", "url": "https://worldofclaudecraft.com/" },
     "dateModified": "2026-07-13"
@@ -83,7 +83,7 @@
       <header class="hero">
         <p class="eyebrow">Legal</p>
         <h1>Terms and Conditions</h1>
-        <p class="updated">Last updated: 22 July 2026</p>
+        <p class="updated">Last updated: 25 August 2026</p>
       </header>
       <article class="content">
         <p><strong>World of ClaudeCraft</strong></p>
@@ -94,6 +94,7 @@
         <p>We may update these Terms from time to time. When we make material changes we will update the date above and, where appropriate, give additional notice. Your continued use of the Service after an update means you accept the revised Terms.</p>
         <h2>3. Eligibility</h2>
         <p>You must be at least 13 years old to use the Service, or older where your country requires a higher minimum age for online services. If you are under the age of majority where you live, you may use the Service only with the involvement and consent of a parent or guardian who agrees to these Terms. The Service is not intended for children under 13.</p>
+        <p>Participation in the <span class="token-name">$WOC</span> marketplace (Section 10) has a higher age requirement, set out in Section 10.2.</p>
         <h2>4. The Game and the source code</h2>
         <p>We grant you a limited, personal, non-exclusive, non-transferable, revocable licence to access and play the Game for your own non-commercial entertainment, subject to these Terms.</p>
         <p>The Game's source code is published in a public repository and is licensed to you under the MIT Licence, the full text of which is in the <code>LICENSE</code> file in that repository. Nothing in these Terms limits, reduces, or conditions the rights the MIT Licence grants you in that source code. These Terms govern your use of the hosted Service we operate, which is separate from your rights in the code.</p>
@@ -103,13 +104,14 @@
         <p>To play online you create an account. You agree to provide accurate information, to keep your credentials secure, and to be responsible for all activity under your account. Do not share your account or use anyone else's. Tell us promptly if you suspect unauthorised use. We may refuse, reclaim, or rename accounts or characters that breach these Terms or that use names which are offensive, infringing, impersonating, or misleading.</p>
         <p>Using more than one account may make you ineligible for prizes, competitions, giveaways, and similar promotions. We may disqualify entries, or withhold or reclaim prizes, where we believe multiple accounts have been used to gain an unfair advantage.</p>
         <h2>6. Acceptable use and rules of conduct</h2>
-        <p>The Service is a shared space. These rules apply across the Game, chat, and any feature where you can communicate or create text. Breaking them can lead to enforcement under Section 18.</p>
+        <p>The Service is a shared space. These rules apply across the Game, chat, and any feature where you can communicate or create text. Breaking them can lead to enforcement under Section 19.</p>
         <ul>
         <li><strong>Chat and communication.</strong> Do not spam or flood, misuse channels, or advertise other communities. Do not harass, insult, or troll others, including attacks on a person's religion or beliefs. Do not post hate speech, slurs, or sexual content. Do not make real-world threats, share another person's private information, or organise coordinated harassment.</li>
         <li><strong>Names.</strong> Do not use offensive, hateful, sexual, or harassing names, impersonate staff or other players, or use names that evade the profanity filter. Do not name characters, guilds, groups, or pets after real-world religious figures, gods, or sacred concepts. The Game's own fictional faiths and lore are fine to use. This covers character names, display names, guild and group names, and any other editable text.</li>
         <li><strong>Hacking and cheating.</strong> Do not use third-party programs that read or change the game client or its memory. Do not manipulate network traffic, use speed, teleport, or automated targeting hacks, or make any unauthorised change to the client that affects gameplay.</li>
         <li><strong>Bots and automation.</strong> Do not automate gameplay with macros or external tools, including movement, combat, gathering, trading, AFK automation, or unattended farming.</li>
         <li><strong>Exploits and bugs.</strong> Do not deliberately use bugs for advantage, including duplicating items or currency, abusing vendor or economy bugs, or skipping intended restrictions through a known bug. Reporting a bug is welcome and is never punished. Exploiting one is the offence.</li>
+        <li><strong>Real-money trading.</strong> Do not sell, trade for real money, or commercially exploit accounts, characters, in-game items, or in-game currency, except for sales of eligible in-game items conducted entirely through the <span class="token-name">$WOC</span> marketplace we operate inside the Game, as Section 10 allows. Selling or trading accounts, characters, or in-game currency for real money remains prohibited everywhere, and selling in-game items for real money anywhere outside that marketplace remains prohibited.</li>
         <li><strong>General.</strong> Do not break the law, infringe anyone's rights, or interfere with the Service, its security, or other players' enjoyment of it.</li>
         </ul>
         <p>These rules cannot cover every situation. Our moderators may use reasonable discretion to interpret and apply them, and to act against conduct that harms the Service or other players even where it is not listed here. Decisions are made case by case.</p>
@@ -117,43 +119,88 @@
         <p>The Service lets you create content, including character names and chat messages ("User Content"). You keep any rights you have in your User Content. You grant us a worldwide, non-exclusive, royalty-free licence to host, store, reproduce, transmit, display, and moderate your User Content for the purpose of operating, securing, and improving the Service.</p>
         <p>You are responsible for your User Content and confirm you have the right to share it and that it does not breach these Terms or any law. We may review, moderate, refuse, or remove User Content, and may withhold or remove names, at our discretion. We are not obliged to monitor User Content, but we may.</p>
         <h2>8. Virtual items and in-game currency</h2>
-        <p>The Game includes virtual items, gear, and in-game currency. These have no monetary value and cannot be redeemed for real money or anything of value outside the Game. You do not own them. We grant you a limited, revocable licence to use them within the Game only. We may modify, remove, reset, or wipe virtual items, currency, characters, and game worlds at any time, including during testing and balancing, without liability or compensation. The Game is free to play, and we do not sell virtual items or currency.</p>
+        <p>The Game includes virtual items, gear, and in-game currency. You do not own them. We grant you a limited, revocable licence to use them within the Game only, and a sale through the <span class="token-name">$WOC</span> marketplace (Section 10) transfers that licence between accounts rather than transferring ownership of anything.</p>
+        <p>Outside the <span class="token-name">$WOC</span> marketplace, virtual items and in-game currency have no monetary value and cannot be redeemed for real money or anything of value outside the Game. We do not sell virtual items or currency, we do not buy them back, and we do not redeem them for money or anything else: the marketplace is player-to-player, and the only real-money value an eligible item ever has is the price another player freely agrees to pay for it there. We make no promise that any item can be sold, will remain eligible for sale, or will hold any price.</p>
+        <p>We may modify, remove, reset, or wipe virtual items, currency, characters, and game worlds at any time, including during testing and balancing, without liability or compensation. This applies to items bought on the marketplace like any others, and to items held in marketplace custody. The Game is free to play.</p>
         <h2>9. The <span class="token-name">$WOC</span> token</h2>
         <p>A token referred to as <span class="token-name">$WOC</span>, associated with the community on the Solana network, was created and is controlled by a third party. We do not issue, mint, control, manage, promote as an investment, or guarantee the <span class="token-name">$WOC</span> token or its value.</p>
         <ul>
-        <li>The token is not required to play and has no effect on your account, characters, or progress.</li>
-        <li>Wallet verification in the Game is cosmetic only. It displays optional flair or a badge and involves no transaction and no transfer of funds.</li>
+        <li>The token is not required to play. Holding it, or not holding it, never grants or withholds gameplay power: holding it has no effect on your characters' stats, progression, drop rates, or any other gameplay outcome. The optional marketplace (Section 10) lets players trade eligible earned items among themselves for <span class="token-name">$WOC</span>; it does not let anyone buy power from us.</li>
+        <li>Linking a wallet to your account is cosmetic and read-only. It is done with one signature, involves no transaction and no transfer of funds, and displays optional flair or a badge.</li>
+        <li>Participating in the <span class="token-name">$WOC</span> marketplace is separate from wallet linking, entirely optional, and does involve real blockchain transactions: payments and bid bonds that you sign in your own wallet. We never hold your keys, and apart from the refundable bid bond described in Section 10.5, which we hold from when your bond payment confirms until it is returned or forfeited, we never hold your funds. Section 10 governs that participation.</li>
         <li>Nothing in the Service is financial, investment, legal, or tax advice, or an offer, solicitation, or recommendation to buy, sell, or hold any token or digital asset.</li>
         <li>Digital assets are volatile and carry risk, including total loss, and may be regulated differently in different countries. You are solely responsible for your own decisions and for complying with the laws that apply to you.</li>
         </ul>
         <p>To the fullest extent permitted by law, we are not liable for any loss connected with the <span class="token-name">$WOC</span> token or any third-party token, wallet, exchange, or blockchain.</p>
-        <h2>10. Donations</h2>
+        <h2>10. The <span class="token-name">$WOC</span> marketplace</h2>
+        <h3>10.1 What it is</h3>
+        <p>The Game includes an optional marketplace where players sell eligible in-game items to other players for <span class="token-name">$WOC</span> ("the Marketplace"). Sales take the form of auctions, fixed-price listings, or direct sales to a named player agreed through the in-game trade window. The Marketplace is player-to-player: we operate the venue, hold listed items in escrow, and charge the fee described in Section 10.7, but we are not the buyer or the seller in any trade, we do not set prices, and we do not sell items or tokens ourselves.</p>
+        <p>Prices are denominated in US dollars. Payment is made in <span class="token-name">$WOC</span>: the number of tokens due is calculated only when payment is requested, from a quote based on a current market price of <span class="token-name">$WOC</span>, and that number can change between quotes. A listing's US dollar price does not change; only the token count at settlement moves with the market. We do not peg or guarantee any exchange rate.</p>
+        <p>The Marketplace may be unavailable, disabled, or paused at any time (Section 10.10).</p>
+        <h3>10.2 Who may participate</h3>
+        <p>To list, bid, or buy you need: an account in good standing, a verified linked Solana wallet, and acceptance of these Marketplace terms (Section 10.3). You must be at least 18 years old, or the age of majority where you live if that is higher, to participate in the Marketplace.</p>
+        <p>The Marketplace is available in the browser version of the Game only. It is not available in the desktop, Steam, iOS, or Android builds. We may restrict or refuse Marketplace access by account, realm, or jurisdiction, including where local law would prohibit or condition it.</p>
+        <h3>10.3 Accepting these Marketplace terms</h3>
+        <p>Your first Marketplace commitment requires you to accept these Marketplace terms, and we record that acceptance against your account with the time it happened. We only record acceptance through an interface that presents these terms to you, or a clearly labelled link to them, at or before the moment you accept: an acceptance control you act on yourself, such as a checkbox beside the commitment it covers. We do not treat playing the Game, linking a wallet, or any action taken in an interface that did not present these terms as acceptance.</p>
+        <h3>10.4 Listings, custody, and escrow</h3>
+        <p>When you list an item, or agree a direct sale, the exact item copy leaves your character's bags and is held by the Game in escrow for the life of the listing. While escrowed it cannot be equipped, used, traded, mailed, or listed anywhere else, and you cannot get it back except as these terms describe. If the listing ends without a completed sale (it expires unsold, the reserve is not met, you cancel where cancellation is allowed, the buyer never pays, or the sale otherwise fails), the same copy is returned to you by in-game mail. If the sale completes, the same copy is delivered to the buyer: placed directly into their character's bags, or sent by in-game mail.</p>
+        <p>We decide which item categories are eligible for the Marketplace, per realm, and may change eligibility at any time. Items already bound to a character, quest items, and any other items or categories we exclude cannot be listed. Delisting a category does not disturb completed sales.</p>
+        <p>A seller cannot cancel a listing while any bid stands, including a bid whose bond is still being paid, or while a buyer's payment may be in progress; a cancellation requested while a buy-now purchase is pending takes effect only if that purchase does not complete, and player support can cancel a listing only once no payment is in flight. A bid is binding once you sign its bond transaction; before that you may abandon it, and a bid whose bond is never paid lapses on its own after a short period.</p>
+        <h3>10.5 Bidding, bid bonds, and forfeiture</h3>
+        <p>Placing an auction bid requires a small refundable bond, denominated in US dollars and paid in <span class="token-name">$WOC</span> when the bid is placed. The bond is our protection against bidders who win and never pay; it works like this:</p>
+        <ul>
+        <li>The bond is a percentage of your bid (currently 5%, within a fixed minimum and maximum); the resolved bond amount is shown before you commit. You sign the bond transaction in your own wallet, and your bid becomes active only when that transaction is confirmed.</li>
+        <li>Your bond is returned when you are outbid (subject to the second-chance offer below), when the auction ends below its reserve, and when a buy-now purchase closes the auction.</li>
+        <li>If you win and complete payment, your bond is returned after settlement confirms.</li>
+        <li>If you win and do not pay within the settlement window, you forfeit the bond: it is not returned to you, it never goes to the seller, and it is split between the Game treasury and the permanent token burn. Failing to pay also earns your account a Marketplace strike; repeated strikes earn progressively longer suspensions from the Marketplace.</li>
+        </ul>
+        <p>A bid confirmed in the final minutes of an auction extends the auction by a short period so it can be answered; the total extension is capped at a fixed period past the listed end time.</p>
+        <p>A seller may enable a second-chance offer when creating a listing. If the winner does not pay, the highest eligible remaining bidder becomes the buyer at their own bid amount, with a fresh settlement window. If that bidder's bond has not yet been returned, it is held again and remains subject to this Section; a bond already returned is not taken again. Not paying within the new window carries the same consequences as any winning bid, except that only a bond we hold can be forfeited.</p>
+        <p>Direct sales agreed through the trade window carry no bond. If you agree a direct purchase and do not pay within its window, the item returns to the seller and your account earns a strike on the same ladder.</p>
+        <p>On listings other than direct sales, abandoning a buy-now purchase without paying carries no bond and no strike, but it temporarily blocks you from re-claiming that listing, and repeated abandonments within a short period temporarily block new buy-now purchases across your account.</p>
+        <h3>10.6 Payment, settlement, and delivery</h3>
+        <p>A winning bidder or buyer pays inside a limited settlement window. Payment works by requesting a quote (the number of <span class="token-name">$WOC</span> tokens equal to the agreed US dollar price at the current market price; each quote is valid for a short period shown with it), then signing a single Solana transaction in your own wallet that pays the seller, the treasury, and the burn in one step. The Game verifies that transaction's finality on the Solana network before delivering the item.</p>
+        <p>You pay the network transaction fee. If the market price of <span class="token-name">$WOC</span> moves between your commitment and your payment, the token count due will differ from the estimate you saw when you committed; the US dollar price does not change. If you do not pay within the settlement window, the sale fails and Section 10.5's consequences apply.</p>
+        <p>When the price of <span class="token-name">$WOC</span> cannot be read reliably, or the pricing service is degraded or unreachable, the Marketplace stops accepting new listings, offers, purchases, and bids, and stops issuing payment quotes, until pricing recovers. Auctions keep counting down, settlement windows continue to run during the pause, and a payment already broadcast is still verified and delivered.</p>
+        <h3>10.7 Fees and the burn</h3>
+        <p>Every completed sale carries a 10% fee, paid by the seller out of the sale amount: 7% of the settlement amount goes to the Game treasury, 3% is permanently burned (destroyed, removing those tokens from circulation), and the seller receives the remainder, paid to the wallet that was verified on their account when the listing was created. Each fee leg is rounded up to the whole cent, so the seller's share can fall up to two cents below 90%. The split is computed inside the settlement transaction and shown to both parties before they confirm, and the treasury and burn addresses are visible on-chain in every settlement transaction. We may change the fee or the split prospectively; a change never applies to a sale already agreed.</p>
+        <h3>10.8 Finality, disputes, and refunds</h3>
+        <p>A completed sale is final. Solana transactions cannot be reversed by us or anyone else, and we cannot un-send a payment or claw back a delivered item. Before a sale completes, the protections in Sections 10.4 to 10.6 (escrow, bonds, verified settlement) are the remedy: a failed sale returns the item to the seller and, except for forfeiture under Section 10.5, returns the bond to the bidder.</p>
+        <p>If something goes wrong, contact player support. We may investigate any listing, sale, or settlement; place a settlement under operator review; suspend or cancel listings (returning the item and refunding bonds where no completed sale stands); exclude sales from public price statistics; and apply or lift strikes and suspensions. These operator remedies act on in-game items, bonds not yet forfeited, and account standing. We do not refund completed on-chain payments, and we are not an arbiter of disputes between players beyond these remedies. Nothing in this Section limits rights you have under consumer laws that cannot be excluded (Section 16).</p>
+        <p>Every completed sale is recorded in a public, per-item sales history that includes the item, price, and the trading characters.</p>
+        <h3>10.9 Marketplace conduct</h3>
+        <p>In the Marketplace you agree not to: bid on or buy your own listings, directly or through another account or wallet you control; place bids you do not intend to honour; manipulate prices, including wash trading and shill bidding; use the Marketplace to disguise or settle trades made outside it; interfere with other players' listings or settlements; or evade a strike, suspension, or restriction with another account or wallet. We may remove listings, cancel sales that have not completed, and suspend Marketplace access or the account itself for conduct in this Section, in addition to Section 6.</p>
+        <h3>10.10 Availability and changes</h3>
+        <p>The Marketplace is an optional feature of an evolving Game. We may change its rules, fees (prospectively, per Section 10.7), eligibility, and parameters; suspend it; or discontinue it, at any time. If we suspend or discontinue it, escrowed items are returned to their sellers, in-progress settlements are completed or failed under the rules above, and bonds not forfeited are returned. We owe no compensation for lost listings, expected sale proceeds, or the ability to sell.</p>
+        <h3>10.11 Taxes and your law</h3>
+        <p>You are solely responsible for any taxes arising from your Marketplace sales and purchases, and for determining whether the Marketplace is lawful for you where you live. We do not withhold or remit taxes for you and we do not provide tax advice.</p>
+        <h2>11. Donations</h2>
         <p>Donations through Ko-fi are voluntary. Ko-fi facilitates payments directly through a third-party payment provider such as PayPal or Stripe. Donations are not a purchase, are non-refundable except where the law requires, and do not entitle you to any product, in-game advantage, ownership, equity, token, or other benefit.</p>
-        <h2>11. Service availability and changes</h2>
+        <h2>12. Service availability and changes</h2>
         <p>The Game is in active development and is provided on an evolving basis. We may change, suspend, limit, or discontinue all or part of the Service, including features, characters, items, and game worlds, at any time and without notice. We do not guarantee uptime, availability, or that the Service will be uninterrupted or error free. We may need to reset or wipe data for technical or balancing reasons.</p>
-        <h2>12. Third-party services</h2>
+        <h2>13. Third-party services</h2>
         <p>The Service links to and relies on third-party services, including GitHub, Ko-fi, PayPal, Stripe, Discord, the Solana network, and any advertising or analytics providers we use. We do not control these services and are not responsible for them. Your use of them is governed by their terms.</p>
-        <h2>13. Intellectual property and no affiliation</h2>
+        <h2>14. Intellectual property and no affiliation</h2>
         <p>World of ClaudeCraft is an independent, community project. It is not affiliated with, endorsed by, sponsored by, or associated with any third-party company, game, product, or brand. All third-party names, marks, and trademarks are the property of their respective owners. Any such names that appear are used only descriptively and do not imply any association.</p>
         <p>Except for your User Content, the Service, including its original content, features, design, media assets, and branding, is owned by us or our licensors and is protected by intellectual property laws. You may not copy, distribute, or create derivative works from the Service, from the media assets described in Section 4, or from our names, logos, and branding, except as these Terms or the licence recorded in <code>CREDITS.md</code> expressly allows, or with our prior written permission. Your rights in the source code are governed by the MIT Licence as described in Section 4, and this Section does not restrict them.</p>
-        <p>If you believe content on the Service infringes your intellectual property, contact us using Section 22 with enough detail to identify the work and the allegedly infringing material, and we will respond appropriately.</p>
-        <h2>14. Disclaimer of warranties</h2>
+        <p>If you believe content on the Service infringes your intellectual property, contact us using Section 23 with enough detail to identify the work and the allegedly infringing material, and we will respond appropriately.</p>
+        <h2>15. Disclaimer of warranties</h2>
         <p>To the fullest extent permitted by law, the Service is provided "as is" and "as available," without warranties of any kind, whether express, implied, or statutory, including warranties of merchantability, fitness for a particular purpose, title, and non-infringement. We do not warrant that the Service will be secure, uninterrupted, error free, or free of harmful components, or that data will not be lost.</p>
-        <h2>15. Consumer law</h2>
+        <h2>16. Consumer law</h2>
         <p>Nothing in these Terms limits rights you have under laws that cannot be excluded, including, for consumers in New Zealand, the Consumer Guarantees Act 1993 and the Fair Trading Act 1986, and similar consumer protection laws elsewhere. Where the Service is supplied free of charge and for personal use, those guarantees apply only to the extent the law requires.</p>
-        <h2>16. Limitation of liability</h2>
+        <h2>17. Limitation of liability</h2>
         <p>To the fullest extent permitted by law, we and our directors, employees, and contractors will not be liable for any indirect, incidental, special, consequential, or punitive damages, or for any loss of data, progress, profits, goodwill, or virtual items, arising from or related to your use of or inability to use the Service. To the extent we are found liable despite the above, our total liability for all claims relating to the Service is limited to NZD 100. Some jurisdictions do not allow certain limitations, so some of these may not apply to you.</p>
-        <h2>17. Indemnification</h2>
+        <h2>18. Indemnification</h2>
         <p>You agree to indemnify and hold us harmless from any claims, losses, liabilities, and expenses, including reasonable legal fees, arising from your breach of these Terms, your User Content, or your misuse of the Service, to the extent permitted by law.</p>
-        <h2>18. Suspension and termination</h2>
-        <p>You may stop using the Service and delete your account at any time. We may suspend or terminate your access at any time, with or without notice, if you breach these Terms, if we are required to by law, or to protect the Service or other users. On termination, your licence to use the Service ends. Sections that by their nature should survive will survive, including Sections 8 to 17 and 19 to 22.</p>
-        <h2>19. Governing law and disputes</h2>
+        <h2>19. Suspension and termination</h2>
+        <p>You may stop using the Service and delete your account at any time. We may suspend or terminate your access at any time, with or without notice, if you breach these Terms, if we are required to by law, or to protect the Service or other users. On termination, your licence to use the Service ends. If your account is terminated while you have items in Marketplace escrow or settlements in progress, we resolve them under Section 10 before or alongside closure. Sections that by their nature should survive will survive, including Sections 8 to 18 and 20 to 23.</p>
+        <h2>20. Governing law and disputes</h2>
         <p>These Terms are governed by the laws of New Zealand. The courts of New Zealand have non-exclusive jurisdiction over any dispute, without affecting any mandatory rights you have to bring proceedings in your country of residence.</p>
-        <h2>20. General</h2>
+        <h2>21. General</h2>
         <p>If any provision of these Terms is held unenforceable, the rest remains in effect. Our failure to enforce a provision is not a waiver. You may not assign these Terms without our consent. We may assign them in connection with a merger, acquisition, or sale of assets. These Terms are the entire agreement between you and us regarding the Service.</p>
-        <h2>21. App store terms</h2>
-        <p>If you download the App from a third-party app store or platform (each a "Distributor"), the following additional terms apply. In the event of a conflict between these Terms and a Distributor's required terms, the Distributor's required terms apply for that App only and only to the extent of the conflict.</p>
-        <h3>21.1 Apple App Store</h3>
+        <h2>22. App store terms</h2>
+        <p>If you download the App from a third-party app store or platform (each a "Distributor"), the following additional terms apply. In the event of a conflict between these Terms and a Distributor's required terms, the Distributor's required terms apply for that App only and only to the extent of the conflict. The <span class="token-name">$WOC</span> marketplace (Section 10) is not available in the App on any platform.</p>
+        <h3>22.1 Apple App Store</h3>
         <p>These terms apply if you obtain the App from Apple. You acknowledge and agree that:</p>
         <ol>
         <li><strong>Acknowledgement.</strong> These Terms are between you and us only, not with Apple. We, not Apple, are solely responsible for the App and its content.</li>
@@ -163,13 +210,13 @@
         <li><strong>Product claims.</strong> We, not Apple, are responsible for addressing any claims by you or a third party relating to the App or your use of it, including product liability claims, claims that the App fails to conform to a legal or regulatory requirement, and claims under consumer protection, privacy, or similar laws.</li>
         <li><strong>Intellectual property.</strong> In the event of a third-party claim that the App or your use of it infringes that third party's intellectual property rights, we, not Apple, are solely responsible for the investigation, defence, settlement, and discharge of that claim.</li>
         <li><strong>Legal compliance.</strong> You represent and warrant that you are not located in a country subject to a U.S. Government embargo or designated as a "terrorist supporting" country, and that you are not listed on any U.S. Government list of prohibited or restricted parties.</li>
-        <li><strong>Developer name and contact.</strong> Questions, complaints, or claims regarding the App should be directed to us using the contact details in Section 22.</li>
+        <li><strong>Developer name and contact.</strong> Questions, complaints, or claims regarding the App should be directed to us using the contact details in Section 23.</li>
         <li><strong>Third-party terms.</strong> You must comply with applicable third-party terms of agreement when using the App.</li>
         <li><strong>Third-party beneficiary.</strong> Apple and Apple's subsidiaries are third-party beneficiaries of these Terms, and upon your acceptance of these Terms, Apple will have the right, and will be deemed to have accepted the right, to enforce these Terms against you as a third-party beneficiary.</li>
         </ol>
-        <h3>21.2 Google Play</h3>
+        <h3>22.2 Google Play</h3>
         <p>These terms apply if you obtain the App from Google Play. Your use of the App must comply with the then-current Google Play Terms of Service. Google is not a party to these Terms and is not responsible for the App. Any claim relating to the App is between you and us, not Google.</p>
-        <h2>22. Contact us</h2>
+        <h2>23. Contact us</h2>
         <p>Email: tony@levystreet.com</p>
         <p>Postal: Dream Home AI Limited, 262 Thorndon Quay, Wellington 6011, New Zealand</p>
       </article>


### PR DESCRIPTION
## What

Publishes the marketplace Terms and Conditions to the live site pages, by owner decision ahead of counsel sign-off (the decision and the still-open counsel questions are recorded in the draft file's header).

- Base text is the LIVE `public/terms.html`, not the draft's own base: the live page had drifted ahead of `TERMS_AND_CONDITIONS.md` (expanded Section 6 conduct rules, the Section 5 promotions paragraph) and that rewrite had dropped the explicit real-money-trading ban entirely. The draft's enumerated marketplace changes are applied onto the live text, which also reinstates the RMT ban with the marketplace carve-out.
- Changes applied: Section 3 marketplace age pointer; the real-money-trading conduct rule with the Section 10 carve-out; rescoped Sections 8 (virtual items) and 9 ($WOC token); the new Section 10 marketplace contract (10.1 to 10.11); sections 10 to 22 renumbered 11 to 23 with every in-text cross-reference audited (conduct enforcement pointer, IP contact pointer, Apple contact pointer, the survival list expanded to 8 to 18 and 20 to 23); the termination escrow-resolution sentence; the app-store marketplace exclusion; date stamped 25 August 2026; SEO descriptions updated.
- `TERMS_AND_CONDITIONS.md` regenerated to the identical text, curing the known page/markdown drift: normalized page and markdown content compare byte-identical (28,569 chars).
- The editorial `[COUNSEL]` markers are stripped from the published text; the draft file remains the counsel working copy and its header now records the publication decision.
- No code changes: both consent surfaces (trade window, Exchange window) already link `/terms` with no anchor.

## Test plan

- [x] `tests/client_shell.test.ts` + `tests/terms_link.test.ts`: 124 pass (client_shell reads terms.html directly)
- [x] Automated content-parity check: page text and markdown text identical after normalization
- [x] Cross-reference audit: every "Section N" occurrence in the final page verified against the new numbering
- [x] Hygiene scan: no COUNSEL markers, no draft language, no em/en dashes, sections 1 to 23 sequential in both files

🤖 Generated with [Claude Code](https://claude.com/claude-code)