### PR TITLE
fix(social): persist guild pledges over logout and seat offline pledgers on accept

### DIFF
--- a/docs/prd/guild-pledge-board.md
+++ b/docs/prd/guild-pledge-board.md
@@ -67,9 +67,15 @@ high-score board) with the recruitment column:
   - Block policy: a pledge is guild-scoped consent. A per-officer block still
     suppresses the ONLINE invite delivery (the silent fake-success arm of the
     invite flow), and that arm leaves the request standing, exactly like an
-    invite the pledger never answered, so nothing an officer observes can
-    reveal a block. The OFFLINE seat is not gated on any single officer's
-    block relationship: the player asked the guild, and the guild said yes.
+    invite the pledger never answered, so the board row itself never reveals
+    a block. (The invite flow's own refusal messages are a separate,
+    pre-existing observation surface, not changed here.) The OFFLINE seat is
+    not gated on any single officer's block relationship: the player asked
+    the guild, and the guild said yes.
+  - Declining the guild's invite withdraws the pledge: an explicit "no" to
+    the guild you pledged to ends the standing request, so a declined player
+    can never be seated offline afterwards. Letting an invite expire or
+    logging out with it pending is NOT a withdrawal; the request stands.
 - Reject removes the pledge and advances that player's cooldown ladder for
   THIS guild (below).
 - Per-guild settings, officer-plus editable: pledges on/off, minimum pledge

--- a/docs/prd/guild-pledge-board.md
+++ b/docs/prd/guild-pledge-board.md
@@ -62,7 +62,14 @@ high-score board) with the recruitment column:
     the rejection ladder either way, exactly like a real invite.
   - A refused accept (guild full, pledger already guilded elsewhere) leaves
     or resolves the pledge accordingly: full keeps it on the board; already
-    guilded drops the stale pledge.
+    guilded drops the stale pledge. Founding a guild also counts as joining
+    one and clears the founder's standing pledge.
+  - Block policy: a pledge is guild-scoped consent. A per-officer block still
+    suppresses the ONLINE invite delivery (the silent fake-success arm of the
+    invite flow), and that arm leaves the request standing, exactly like an
+    invite the pledger never answered, so nothing an officer observes can
+    reveal a block. The OFFLINE seat is not gated on any single officer's
+    block relationship: the player asked the guild, and the guild said yes.
 - Reject removes the pledge and advances that player's cooldown ladder for
   THIS guild (below).
 - Per-guild settings, officer-plus editable: pledges on/off, minimum pledge

--- a/docs/prd/guild-pledge-board.md
+++ b/docs/prd/guild-pledge-board.md
@@ -48,8 +48,21 @@ high-score board) with the recruitment column:
 - GM and officers (the `GUILD_BANK_EDIT_RANKS` officer-plus family) get a
   Pledges tab in the guild UI: every open pledge (name, class, level, when),
   with Accept and Reject.
-- Accept sends the standard guild invite (the existing invite flow; the
-  invite, not the accept, is what creates membership) and removes the pledge.
+- Accept, REVISED 2026-08-26 (owner decision): the pledge is the player's
+  standing request to join, so it persists across logout and only resolves on
+  a definite outcome.
+  - Pledger ONLINE: accept sends the standard guild invite (the existing
+    invite flow; the invite, not the accept, is what creates membership). The
+    pledge stays on the board until the player actually joins (joining any
+    guild clears it), so an invite that expires or drops at logout never
+    destroys the request.
+  - Pledger OFFLINE: accept seats them directly as a member (the pledge is
+    their standing consent; there is no one online to hand an invite to).
+    They find themselves in the guild on their next login. Acceptance wipes
+    the rejection ladder either way, exactly like a real invite.
+  - A refused accept (guild full, pledger already guilded elsewhere) leaves
+    or resolves the pledge accordingly: full keeps it on the board; already
+    guilded drops the stale pledge.
 - Reject removes the pledge and advances that player's cooldown ladder for
   THIS guild (below).
 - Per-guild settings, officer-plus editable: pledges on/off, minimum pledge

--- a/docs/prd/guild-pledge-board.md
+++ b/docs/prd/guild-pledge-board.md
@@ -59,7 +59,10 @@ high-score board) with the recruitment column:
   - Pledger OFFLINE: accept seats them directly as a member (the pledge is
     their standing consent; there is no one online to hand an invite to).
     They find themselves in the guild on their next login. Acceptance wipes
-    the rejection ladder either way, exactly like a real invite.
+    the rejection ladder either way, exactly like a real invite. The seat
+    consumes the pledge in the same transaction, so a withdraw or decline
+    racing the accept rolls the seat back instead of seating a player who
+    just said no.
   - A refused accept (guild full, pledger already guilded elsewhere) leaves
     or resolves the pledge accordingly: full keeps it on the board; already
     guilded drops the stale pledge. Founding a guild also counts as joining
@@ -76,8 +79,10 @@ high-score board) with the recruitment column:
     the guild you pledged to ends the standing request, so a declined player
     can never be seated offline afterwards. Letting an invite expire or
     logging out with it pending is NOT a withdrawal; the request stands.
-- Reject removes the pledge and advances that player's cooldown ladder for
-  THIS guild (below).
+- Reject removes the pledge, advances that player's cooldown ladder for THIS
+  guild (below), and cancels any still-pending invite an earlier accept sent
+  (both sides hear the cancel), so an officer's explicit no always stops the
+  join.
 - Per-guild settings, officer-plus editable: pledges on/off, minimum pledge
   level, and the pledge note (shown on the board).
 - Every new pledge notifies online GM/officers with an in-game chat line.

--- a/server/game.ts
+++ b/server/game.ts
@@ -7606,7 +7606,7 @@ export class GameServer {
             .catch(logSocialErr);
         break;
       case 'guild_decline':
-        this.social.guildDecline(this.actorFor(session));
+        void this.social.guildDecline(this.actorFor(session)).catch(logSocialErr);
         break;
       case 'guild_leave':
         void this.social.guildLeave(this.actorFor(session)).catch(logSocialErr);

--- a/server/social.ts
+++ b/server/social.ts
@@ -144,13 +144,18 @@ export interface SocialDb {
   guildMembership(
     charId: number,
   ): Promise<{ guildId: number; guildName: string; rank: GuildRank } | null>;
-  // seat a member atomically, enforcing the cap under concurrent accepts
+  // seat a member atomically, enforcing the cap under concurrent accepts.
+  // requirePledge additionally consumes the character's pledge to THIS guild
+  // inside the same transaction and refuses with 'no_pledge' when it is gone:
+  // the pledge is the seat's consent, so a withdraw or decline racing the
+  // caller's read must roll the seat back, never seat a player who said no.
   addGuildMemberAtomic(
     guildId: number,
     charId: number,
     rank: GuildRank,
     limit: number,
-  ): Promise<'ok' | 'full' | 'already_member' | 'no_guild'>;
+    requirePledge?: boolean,
+  ): Promise<'ok' | 'full' | 'already_member' | 'no_guild' | 'no_pledge'>;
   removeGuildMember(charId: number): Promise<void>;
   // Rank write predicated on BOTH the character and the guild the caller
   // authorized against, returning whether a row actually moved. False means
@@ -920,6 +925,10 @@ export class SocialService {
       // here would charge a founder for a guild that was never created.
       return false;
     }
+    // Read before the create: its transaction clears any standing pledge
+    // (founding a guild is joining one), and the live tag plus the old
+    // guild's board need the pre-clear row to know what to refresh.
+    const priorPledge = await this.db.pledgeOf(actor.characterId);
     const result = await this.db.createGuildWithLeader(name, actor.characterId);
     if ('error' in result) {
       this.err(
@@ -946,6 +955,14 @@ export class SocialService {
     // guildsFounded deed stat, which only this success arm may ever produce
     // (a refused create above must never reach it).
     this.tx.onGuildFounded(actor.characterId);
+    if (priorPledge) {
+      // The create transaction consumed the founder's standing pledge:
+      // restamp the live tag from durable truth (now empty) so a later guild
+      // leave cannot resurface it, and refresh the pledged guild's board so
+      // the row does not linger there.
+      await this.refreshPledgeBadge(actor.characterId);
+      await this.pushGuild(priorPledge.guildId);
+    }
     this.info(
       actor.characterId,
       `You found the guild <${name}>! You are its Guild Master.`,
@@ -1045,6 +1062,7 @@ export class SocialService {
     }
     // Joining any guild clears the character's pledge (the aspiration ended,
     // one way or the other).
+    const priorPledge = await this.db.pledgeOf(actor.characterId);
     await this.db.deletePledge(actor.characterId);
     // Seated in the DB: stamp the live sim before any push resolves.
     this.tx.onGuildMembershipChanged(actor.characterId, {
@@ -1052,6 +1070,15 @@ export class SocialService {
       guildName: invite.guildName,
       rank: 'member',
     });
+    if (priorPledge) {
+      // Restamp the live pledge tag from durable truth (now empty): the guild
+      // label shadows it while guilded, but without the restamp a later guild
+      // leave resurfaces a stale "pledged" nameplate line until relog. When
+      // the pledge was to a DIFFERENT guild, refresh that board too so the
+      // row does not linger there.
+      await this.refreshPledgeBadge(actor.characterId);
+      if (priorPledge.guildId !== invite.guildId) await this.pushGuild(priorPledge.guildId);
+    }
     await this.broadcastGuild(invite.guildId, [
       { type: 'log', text: `${actor.name} has joined the guild.`, color: '#40ff7f' },
     ]);
@@ -1191,6 +1218,19 @@ export class SocialService {
       await this.pushGuild(membership.guildId);
       return;
     }
+    // With the pledge surviving an accept, reject is now reachable while the
+    // accept's invite is still pending. The officer's explicit "no" must stop
+    // the join, not just bump the ladder, so a same-guild pending invite is
+    // cancelled here, both sides notified (the guildRenamed cancel shape).
+    const pending = this.pendingGuildInvites.get(target.id);
+    if (pending && pending.guildId === membership.guildId) {
+      this.takeGuildInvite(target.id);
+      const cancelled: SocialEvent[] = [{ type: 'guildInviteCancelled' }];
+      this.tx.deliver(target.id, cancelled);
+      if (pending.fromCharacterId !== target.id) {
+        this.tx.deliver(pending.fromCharacterId, cancelled);
+      }
+    }
     await this.db.deletePledge(target.id);
     const accountId = await this.db.accountIdForCharacter(target.id);
     if (accountId !== null) await this.db.bumpPledgeLadder(membership.guildId, accountId);
@@ -1227,6 +1267,7 @@ export class SocialService {
       target.id,
       'member',
       GUILD_MEMBER_LIMIT,
+      true,
     );
     if (result === 'no_guild') {
       this.err(actor.characterId, 'That guild no longer exists.');
@@ -1247,10 +1288,16 @@ export class SocialService {
       this.tx.pushSnapshot(target.id);
       return;
     }
-    // Seated in the DB. The pledge resolves, and acceptance wipes the
-    // rejection ladder exactly like a real invite (the guild said
-    // "we do want you", docs/prd/guild-pledge-board.md).
-    await this.db.deletePledge(target.id);
+    if (result === 'no_pledge') {
+      // A withdraw or decline landed between the officer's pledge read and
+      // the seat transaction: the consent is gone, so the seat rolled back.
+      this.err(actor.characterId, `${target.name} has no pledge to your guild.`);
+      await this.pushGuild(membership.guildId);
+      return;
+    }
+    // Seated in the DB with the pledge consumed in the same transaction, and
+    // acceptance wipes the rejection ladder exactly like a real invite (the
+    // guild said "we do want you", docs/prd/guild-pledge-board.md).
     const accountId = await this.db.accountIdForCharacter(target.id);
     if (accountId !== null) await this.db.wipePledgeLadder(membership.guildId, accountId);
     // No-ops while they stay offline; covers a login racing the seat.

--- a/server/social.ts
+++ b/server/social.ts
@@ -955,39 +955,43 @@ export class SocialService {
     return true;
   }
 
-  async guildInvite(actor: SocialActor, name: string): Promise<void> {
+  /** 'sent' when a real invite went out, 'blocked' for the silent fake-success
+   *  arm (the target blocks the inviter), 'refused' when the actor was told
+   *  why nothing happened. Callers that resolve a pledge off this outcome
+   *  (guildPledgeDecide) must only do so on a definite resolution. */
+  async guildInvite(actor: SocialActor, name: string): Promise<'sent' | 'blocked' | 'refused'> {
     const membership = await this.db.guildMembership(actor.characterId);
     if (!membership) {
       this.err(actor.characterId, 'You are not in a guild.');
-      return;
+      return 'refused';
     }
     if (membership.rank === 'member') {
       this.err(actor.characterId, 'Only officers and the Guild Master may invite.');
-      return;
+      return 'refused';
     }
     const target = await this.resolveTarget(actor, name);
-    if (!target) return;
+    if (!target) return 'refused';
     if (target.id === actor.characterId) {
       this.err(actor.characterId, 'You are already in the guild.');
-      return;
+      return 'refused';
     }
     if (!this.tx.isOnline(target.id)) {
       this.err(actor.characterId, `${target.name} must be online to be invited.`);
-      return;
+      return 'refused';
     }
     if (await this.db.guildMembership(target.id)) {
       this.err(actor.characterId, `${target.name} is already in a guild.`);
-      return;
+      return 'refused';
     }
     const existing = this.pendingGuildInvites.get(target.id);
     if (existing && existing.expiresAt >= this.now()) {
       this.err(actor.characterId, `${target.name} already has a pending guild invitation.`);
-      return;
+      return 'refused';
     }
     const members = await this.db.guildMembers(membership.guildId);
     if (members.length >= GUILD_MEMBER_LIMIT) {
       this.err(actor.characterId, 'Your guild is full.');
-      return;
+      return 'refused';
     }
     // A target who has the inviter on their ignore list never sees the invite.
     // From the inviter's side this is indistinguishable from an ordinary
@@ -995,7 +999,7 @@ export class SocialService {
     // No pending state is created, so other guilds can still invite the target.
     if (this.tx.isBlocking(target.id, actor.characterId)) {
       this.info(actor.characterId, `You have invited ${target.name} to the guild.`);
-      return;
+      return 'blocked';
     }
     this.rememberGuildInvite(target.id, {
       guildId: membership.guildId,
@@ -1012,6 +1016,7 @@ export class SocialService {
       { type: 'guildInvite', fromName: actor.name, guildName: membership.guildName },
     ]);
     this.info(actor.characterId, `You have invited ${target.name} to the guild.`);
+    return 'sent';
   }
 
   async guildAccept(actor: SocialActor): Promise<void> {
@@ -1163,11 +1168,21 @@ export class SocialService {
       return;
     }
     if (accept) {
-      // Accept sends the standard guild invite; membership stays the invite
-      // flow's (which also wipes the ladder). The pledge itself resolves.
-      await this.db.deletePledge(target.id);
-      await this.refreshPledgeBadge(target.id);
-      await this.guildInvite(actor, target.name);
+      if (!this.tx.isOnline(target.id)) {
+        await this.seatOfflinePledger(actor, target, membership);
+        return;
+      }
+      // Online: accept sends the standard guild invite; membership stays the
+      // invite flow's (which also wipes the ladder). The pledge is the
+      // player's standing request, so it only resolves on a definite outcome:
+      // joining deletes it (guildAccept), a refused send leaves it on the
+      // board, and the silent blocked arm drops it so repeated accepts stay
+      // indistinguishable from the ordinary decline-then-nothing.
+      const outcome = await this.guildInvite(actor, target.name);
+      if (outcome === 'blocked') {
+        await this.db.deletePledge(target.id);
+        await this.refreshPledgeBadge(target.id);
+      }
       await this.pushGuild(membership.guildId);
       return;
     }
@@ -1187,6 +1202,58 @@ export class SocialService {
     await this.refreshPledgeBadge(target.id);
     await this.pushGuild(membership.guildId);
     this.tx.pushSnapshot(target.id);
+  }
+
+  /** Seat an OFFLINE pledger directly. The pledge is the player's standing
+   *  request to join, so officer acceptance completes membership without the
+   *  online invite handshake (which cannot reach an offline character); they
+   *  find themselves in the guild on their next login (the join path stamps
+   *  membership from durable truth). Failure arms leave the pledge on the
+   *  board so an accepted request never silently disappears. */
+  private async seatOfflinePledger(
+    actor: SocialActor,
+    target: { id: number; name: string },
+    membership: { guildId: number; guildName: string },
+  ): Promise<void> {
+    const result = await this.db.addGuildMemberAtomic(
+      membership.guildId,
+      target.id,
+      'member',
+      GUILD_MEMBER_LIMIT,
+    );
+    if (result === 'no_guild') {
+      this.err(actor.characterId, 'That guild no longer exists.');
+      return;
+    }
+    if (result === 'full') {
+      // The pledge stays: the officer can free a seat and accept again.
+      this.err(actor.characterId, 'Your guild is full.');
+      return;
+    }
+    if (result === 'already_member') {
+      // The pledger joined a guild since pledging: the pledge is stale.
+      await this.db.deletePledge(target.id);
+      this.err(actor.characterId, `${target.name} is already in a guild.`);
+      await this.pushGuild(membership.guildId);
+      return;
+    }
+    // Seated in the DB. The pledge resolves, and acceptance wipes the
+    // rejection ladder exactly like a real invite (the guild said
+    // "we do want you", docs/prd/guild-pledge-board.md).
+    await this.db.deletePledge(target.id);
+    const accountId = await this.db.accountIdForCharacter(target.id);
+    if (accountId !== null) await this.db.wipePledgeLadder(membership.guildId, accountId);
+    // No-ops while they stay offline; covers a login racing the seat.
+    this.tx.onGuildMembershipChanged(target.id, {
+      guildId: membership.guildId,
+      guildName: membership.guildName,
+      rank: 'member',
+    });
+    await this.refreshPledgeBadge(target.id);
+    await this.broadcastGuild(membership.guildId, [
+      { type: 'log', text: `${target.name} has joined the guild.`, color: '#40ff7f' },
+    ]);
+    await this.pushGuild(membership.guildId);
   }
 
   async setGuildPledgeSettings(

--- a/server/social.ts
+++ b/server/social.ts
@@ -1178,9 +1178,10 @@ export class SocialService {
       // joining deletes it (guildAccept), and a pledger who already joined a
       // guild since pledging left the request stale, so it drops here. Every
       // other refusal (full, a pending invite) AND the silent blocked arm
-      // leave the request standing: the pledge surviving an accept must never
-      // depend on the block relationship, or the board becomes an oracle for
-      // "this player has me blocked".
+      // leave the request standing: whether the row survives an accept never
+      // depends on the block relationship, so the BOARD is not a block
+      // oracle. (The invite flow's own refusal messages remain a separate,
+      // pre-existing observation surface; see guildInvite.)
       const outcome = await this.guildInvite(actor, target.name);
       if (outcome === 'refused' && (await this.db.guildMembership(target.id))) {
         await this.db.deletePledge(target.id);
@@ -1237,10 +1238,13 @@ export class SocialService {
       return;
     }
     if (result === 'already_member') {
-      // The pledger joined a guild since pledging: the pledge is stale.
+      // The pledger joined a guild since pledging: the pledge is stale. The
+      // badge restamp covers a login racing this arm (no-op while offline).
       await this.db.deletePledge(target.id);
+      await this.refreshPledgeBadge(target.id);
       this.err(actor.characterId, `${target.name} is already in a guild.`);
       await this.pushGuild(membership.guildId);
+      this.tx.pushSnapshot(target.id);
       return;
     }
     // Seated in the DB. The pledge resolves, and acceptance wipes the
@@ -1307,8 +1311,21 @@ export class SocialService {
     this.tx.applyPledge(charId, pledge?.guildName ?? '', tier);
   }
 
-  guildDecline(actor: SocialActor): void {
-    this.takeGuildInvite(actor.characterId);
+  async guildDecline(actor: SocialActor): Promise<void> {
+    const invite = this.takeGuildInvite(actor.characterId);
+    if (!invite) return;
+    // Declining the invite from the guild you pledged to is an explicit
+    // withdrawal of that standing request. Without this, the surviving
+    // pledge would let an officer seat the decliner directly the moment
+    // they log off (a consent bypass). An invite from any OTHER guild
+    // leaves the pledge untouched.
+    const pledge = await this.db.pledgeOf(actor.characterId);
+    if (pledge && pledge.guildId === invite.guildId) {
+      await this.db.deletePledge(actor.characterId);
+      await this.refreshPledgeBadge(actor.characterId);
+      await this.pushGuild(invite.guildId);
+      this.tx.pushSnapshot(actor.characterId);
+    }
   }
 
   async guildLeave(actor: SocialActor): Promise<void> {

--- a/server/social.ts
+++ b/server/social.ts
@@ -1175,13 +1175,17 @@ export class SocialService {
       // Online: accept sends the standard guild invite; membership stays the
       // invite flow's (which also wipes the ladder). The pledge is the
       // player's standing request, so it only resolves on a definite outcome:
-      // joining deletes it (guildAccept), a refused send leaves it on the
-      // board, and the silent blocked arm drops it so repeated accepts stay
-      // indistinguishable from the ordinary decline-then-nothing.
+      // joining deletes it (guildAccept), and a pledger who already joined a
+      // guild since pledging left the request stale, so it drops here. Every
+      // other refusal (full, a pending invite) AND the silent blocked arm
+      // leave the request standing: the pledge surviving an accept must never
+      // depend on the block relationship, or the board becomes an oracle for
+      // "this player has me blocked".
       const outcome = await this.guildInvite(actor, target.name);
-      if (outcome === 'blocked') {
+      if (outcome === 'refused' && (await this.db.guildMembership(target.id))) {
         await this.db.deletePledge(target.id);
         await this.refreshPledgeBadge(target.id);
+        this.tx.pushSnapshot(target.id);
       }
       await this.pushGuild(membership.guildId);
       return;
@@ -1208,8 +1212,10 @@ export class SocialService {
    *  request to join, so officer acceptance completes membership without the
    *  online invite handshake (which cannot reach an offline character); they
    *  find themselves in the guild on their next login (the join path stamps
-   *  membership from durable truth). Failure arms leave the pledge on the
-   *  board so an accepted request never silently disappears. */
+   *  membership from durable truth). A full guild keeps the request on the
+   *  board so the officer can free a seat and accept again; a pledger who
+   *  joined a guild since pledging left the request stale, so that arm
+   *  drops it. */
   private async seatOfflinePledger(
     actor: SocialActor,
     target: { id: number; name: string },

--- a/server/social_db.ts
+++ b/server/social_db.ts
@@ -431,7 +431,8 @@ export class PgSocialDb implements SocialDb {
     charId: number,
     rank: GuildRank,
     limit: number,
-  ): Promise<'ok' | 'full' | 'already_member' | 'no_guild'> {
+    requirePledge = false,
+  ): Promise<'ok' | 'full' | 'already_member' | 'no_guild' | 'no_pledge'> {
     const client = await this.pool.connect();
     try {
       await client.query('BEGIN');
@@ -468,6 +469,19 @@ export class PgSocialDb implements SocialDb {
       if (ins.rowCount === 0) {
         await client.query('ROLLBACK');
         return 'already_member';
+      }
+      if (requirePledge) {
+        // The pledge is the seat's consent: consume it in the same
+        // transaction, so a withdraw or decline racing the caller's pledge
+        // read rolls the seat back instead of seating a player who said no.
+        const consumed = await client.query(
+          'DELETE FROM guild_pledges WHERE character_id = $1 AND guild_id = $2',
+          [charId, guildId],
+        );
+        if ((consumed.rowCount ?? 0) === 0) {
+          await client.query('ROLLBACK');
+          return 'no_pledge';
+        }
       }
       await client.query('COMMIT');
       this.guildRoster.bust(guildId);

--- a/server/social_db.ts
+++ b/server/social_db.ts
@@ -391,6 +391,10 @@ export class PgSocialDb implements SocialDb {
         await client.query('ROLLBACK');
         return { error: 'already_in_guild' };
       }
+      // Founding a guild is joining one: clear any standing pledge in the
+      // same transaction, so no stale request lingers on another guild's
+      // board (docs/prd/guild-pledge-board.md).
+      await client.query('DELETE FROM guild_pledges WHERE character_id = $1', [leaderId]);
       await client.query('COMMIT');
       this.guildRoster.bust(guildId);
       bustAdminGuildListReads();

--- a/tests/social_db_guild_names.test.ts
+++ b/tests/social_db_guild_names.test.ts
@@ -39,16 +39,20 @@ describe('PgSocialDb case-insensitive guild creation', () => {
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [{ id: 12 }] })
       .mockResolvedValueOnce({ rows: [], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // founder pledge clear
       .mockResolvedValueOnce({ rows: [] });
 
     await expect(db.createGuildWithLeader('Dawn Guard', 8)).resolves.toEqual({ guildId: 12 });
 
+    // The DELETE is the founder's standing-pledge clear, inside the same
+    // transaction as the seat (docs/prd/guild-pledge-board.md).
     expect(client.query.mock.calls.map(([sql]) => String(sql).trim().split(/\s+/)[0])).toEqual([
       'BEGIN',
       'SELECT',
       'SELECT',
       'INSERT',
       'INSERT',
+      'DELETE',
       'COMMIT',
     ]);
     expect(client.query.mock.calls[1]).toEqual([

--- a/tests/social_db_seat_pledge.test.ts
+++ b/tests/social_db_seat_pledge.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  bustGuildList: vi.fn(),
+}));
+
+vi.mock('../server/admin_guilds_read', () => ({
+  bustAdminGuildListReads: mocks.bustGuildList,
+}));
+
+import { PgSocialDb } from '../server/social_db';
+
+function harness() {
+  const client = {
+    query: vi.fn(),
+    release: vi.fn(),
+  };
+  const pool = {
+    connect: vi.fn().mockResolvedValue(client),
+    query: vi.fn().mockResolvedValue({ rows: [], rowCount: 1 }),
+  };
+  return { client, db: new PgSocialDb(pool as never) };
+}
+
+// The pledge is the offline seat's consent (docs/prd/guild-pledge-board.md):
+// requirePledge consumes it inside the SAME transaction as the member insert,
+// so a withdraw or decline racing the caller's pledge read rolls the whole
+// seat back instead of seating a player who just said no.
+describe('PgSocialDb pledge-consuming seat (addGuildMemberAtomic requirePledge)', () => {
+  beforeEach(() => {
+    mocks.bustGuildList.mockReset();
+  });
+
+  it('consumes the pledge inside the seat transaction and commits', async () => {
+    const { client, db } = harness();
+    client.query
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockResolvedValueOnce({ rows: [{ id: 7 }], rowCount: 1 }) // guild FOR UPDATE
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // membership check
+      .mockResolvedValueOnce({ rows: [{ n: 3 }], rowCount: 1 }) // cap count
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 }) // member insert
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 }) // pledge consume
+      .mockResolvedValueOnce({ rows: [] }); // COMMIT
+
+    await expect(db.addGuildMemberAtomic(7, 44, 'member', 100, true)).resolves.toBe('ok');
+
+    const verbs = client.query.mock.calls.map(([sql]) => String(sql).trim().split(/\s+/)[0]);
+    expect(verbs).toEqual(['BEGIN', 'SELECT', 'SELECT', 'SELECT', 'INSERT', 'DELETE', 'COMMIT']);
+    // The consume is scoped to BOTH the character and THIS guild, so a pledge
+    // to some other guild can never stand in as consent for this seat.
+    expect(client.query.mock.calls[5]).toEqual([
+      'DELETE FROM guild_pledges WHERE character_id = $1 AND guild_id = $2',
+      [44, 7],
+    ]);
+    expect(mocks.bustGuildList).toHaveBeenCalled();
+  });
+
+  it('rolls the whole seat back when the pledge is gone', async () => {
+    const { client, db } = harness();
+    client.query
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockResolvedValueOnce({ rows: [{ id: 7 }], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 })
+      .mockResolvedValueOnce({ rows: [{ n: 3 }], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // pledge already gone
+      .mockResolvedValueOnce({ rows: [] }); // ROLLBACK
+
+    await expect(db.addGuildMemberAtomic(7, 44, 'member', 100, true)).resolves.toBe('no_pledge');
+
+    const verbs = client.query.mock.calls.map(([sql]) => String(sql).trim().split(/\s+/)[0]);
+    expect(verbs).toEqual(['BEGIN', 'SELECT', 'SELECT', 'SELECT', 'INSERT', 'DELETE', 'ROLLBACK']);
+    expect(mocks.bustGuildList).not.toHaveBeenCalled();
+  });
+
+  it('does not touch pledges on a plain seat', async () => {
+    const { client, db } = harness();
+    client.query
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockResolvedValueOnce({ rows: [{ id: 7 }], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 })
+      .mockResolvedValueOnce({ rows: [{ n: 3 }], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [] }); // COMMIT
+
+    await expect(db.addGuildMemberAtomic(7, 44, 'member', 100)).resolves.toBe('ok');
+
+    const verbs = client.query.mock.calls.map(([sql]) => String(sql).trim().split(/\s+/)[0]);
+    expect(verbs).toEqual(['BEGIN', 'SELECT', 'SELECT', 'SELECT', 'INSERT', 'COMMIT']);
+  });
+});

--- a/tests/social_system.test.ts
+++ b/tests/social_system.test.ts
@@ -180,6 +180,9 @@ class FakeDb implements SocialDb {
     const id = this.nextGuildId++;
     this.guilds.set(id, name);
     this.members.set(leaderId, { guildId: id, rank: 'leader' });
+    // Mirrors the real transaction: founding a guild clears the founder's
+    // standing pledge.
+    this.pledges.delete(leaderId);
     return { guildId: id };
   }
   async deleteGuild(id: number): Promise<void> {
@@ -2598,19 +2601,71 @@ describe('guild pledges', () => {
     expect(await h.db.pledgeOf(4)).toBeNull();
   });
 
-  it('accepting a pledger who blocks the officer stays silent and resolves the pledge', async () => {
+  it('accepting a pledger who blocks the officer stays silent and leaves the request standing', async () => {
     const h = await seed();
     h.tx.setOnline(4);
     await h.svc.guildPledge(h.actor(4), 'Bookbinders');
     h.db.blocks.set(4, new Set([2]));
     await h.svc.guildPledgeDecide(h.actor(2), 'Aspirant', true);
-    // The fake-success arm: the officer sees the ordinary confirmation, no
-    // invite reaches the blocker, and the pledge resolves so repeated accepts
-    // stay indistinguishable from decline-then-nothing.
+    // The fake-success arm: the officer sees the ordinary confirmation and no
+    // invite reaches the blocker. The pledge stays standing, exactly like an
+    // invite the pledger never answered, so nothing the officer observes
+    // (including the board row surviving) can reveal the block.
     expect(h.tx.textFor(2)).toContain('You have invited Aspirant to the guild.');
     expect((h.tx.delivered.get(4) ?? []).filter((e) => e.type === 'guildInvite')).toHaveLength(0);
-    expect(await h.db.pledgeOf(4)).toBeNull();
+    expect(await h.db.pledgeOf(4)).toMatchObject({ guildName: 'Bookbinders' });
     expect(await h.db.guildMembership(4)).toBeNull();
+  });
+
+  it('an online accept for a pledger who joined elsewhere drops the stale pledge', async () => {
+    const h = await seed();
+    h.tx.setOnline(4);
+    await h.svc.guildPledge(h.actor(4), 'Bookbinders');
+    h.add(5, 'Scribe');
+    const other = await h.db.createGuildWithLeader('Inkwrights', 5);
+    if ('error' in other) throw new Error('guild seed failed');
+    await h.db.addGuildMemberAtomic(other.guildId, 4, 'member', 50);
+    await h.svc.guildPledgeDecide(h.actor(2), 'Aspirant', true);
+    expect(h.tx.errorsFor(2).at(-1)).toBe('Aspirant is already in a guild.');
+    expect(await h.db.pledgeOf(4)).toBeNull();
+    expect((await h.db.guildMembership(4))?.guildName).toBe('Inkwrights');
+  });
+
+  it('an online accept against a full guild refuses and keeps the pledge on the board', async () => {
+    const h = await seed();
+    h.tx.setOnline(4);
+    await h.svc.guildPledge(h.actor(4), 'Bookbinders');
+    for (let i = 0; i < GUILD_MEMBER_LIMIT - 3; i++) {
+      const id = 100 + i;
+      h.add(id, `Filler${i}`);
+      await h.db.addGuildMemberAtomic(h.guildId, id, 'member', GUILD_MEMBER_LIMIT);
+    }
+    await h.svc.guildPledgeDecide(h.actor(2), 'Aspirant', true);
+    expect(h.tx.errorsFor(2).at(-1)).toBe('Your guild is full.');
+    expect(await h.db.pledgeOf(4)).toMatchObject({ guildName: 'Bookbinders' });
+  });
+
+  it('a duplicate accept hits the pending-invite refusal and keeps the pledge', async () => {
+    const h = await seed();
+    h.tx.setOnline(4);
+    await h.svc.guildPledge(h.actor(4), 'Bookbinders');
+    await h.svc.guildPledgeDecide(h.actor(2), 'Aspirant', true);
+    await h.svc.guildPledgeDecide(h.actor(2), 'Aspirant', true);
+    expect(h.tx.errorsFor(2).at(-1)).toBe('Aspirant already has a pending guild invitation.');
+    expect(await h.db.pledgeOf(4)).toMatchObject({ guildName: 'Bookbinders' });
+    // The first accept's invite still stands and seats them normally.
+    await h.svc.guildAccept(h.actor(4));
+    expect(await h.db.guildMembership(4)).toMatchObject({ guildName: 'Bookbinders' });
+    expect(await h.db.pledgeOf(4)).toBeNull();
+  });
+
+  it('founding a guild clears the founder standing pledge', async () => {
+    const h = await seed();
+    await h.svc.guildPledge(h.actor(4), 'Bookbinders');
+    expect(await h.db.pledgeOf(4)).not.toBeNull();
+    const ok = await h.svc.guildCreate(h.actor(4), 'Aspirant Collective');
+    expect(ok).toBe(true);
+    expect(await h.db.pledgeOf(4)).toBeNull();
   });
 
   it('withdraw clears the pledge and restamps the badge', async () => {

--- a/tests/social_system.test.ts
+++ b/tests/social_system.test.ts
@@ -2659,6 +2659,33 @@ describe('guild pledges', () => {
     expect(await h.db.pledgeOf(4)).toBeNull();
   });
 
+  it('declining the pledged guild invite withdraws the pledge: no offline force-seat', async () => {
+    const h = await seed();
+    h.tx.setOnline(4);
+    await h.svc.guildPledge(h.actor(4), 'Bookbinders');
+    await h.svc.guildPledgeDecide(h.actor(2), 'Aspirant', true);
+    // The explicit "no" to the guild they pledged to ends the standing
+    // request, so a later accept cannot seat them while offline.
+    await h.svc.guildDecline(h.actor(4));
+    expect(await h.db.pledgeOf(4)).toBeNull();
+    h.tx.setOffline(4);
+    await h.svc.guildPledgeDecide(h.actor(2), 'Aspirant', true);
+    expect(h.tx.errorsFor(2).at(-1)).toBe('Aspirant has no pledge to your guild.');
+    expect(await h.db.guildMembership(4)).toBeNull();
+  });
+
+  it('declining an unrelated guild invite leaves the pledge standing', async () => {
+    const h = await seed();
+    h.add(5, 'Scribe');
+    const other = await h.db.createGuildWithLeader('Inkwrights', 5);
+    if ('error' in other) throw new Error('guild seed failed');
+    h.tx.setOnline(4);
+    await h.svc.guildPledge(h.actor(4), 'Bookbinders');
+    await h.svc.guildInvite(h.actor(5), 'Aspirant');
+    await h.svc.guildDecline(h.actor(4));
+    expect(await h.db.pledgeOf(4)).toMatchObject({ guildName: 'Bookbinders' });
+  });
+
   it('founding a guild clears the founder standing pledge', async () => {
     const h = await seed();
     await h.svc.guildPledge(h.actor(4), 'Bookbinders');

--- a/tests/social_system.test.ts
+++ b/tests/social_system.test.ts
@@ -200,11 +200,19 @@ class FakeDb implements SocialDb {
     c: number,
     rank: GuildRank,
     limit: number,
-  ): Promise<'ok' | 'full' | 'already_member' | 'no_guild'> {
+    requirePledge = false,
+  ): Promise<'ok' | 'full' | 'already_member' | 'no_guild' | 'no_pledge'> {
     if (!this.guilds.has(guildId)) return 'no_guild';
     if (this.members.has(c)) return 'already_member';
     const count = [...this.members.values()].filter((m) => m.guildId === guildId).length;
     if (count >= limit) return 'full';
+    // Mirrors the real transaction: the pledge is consumed with the seat, and
+    // a missing pledge to THIS guild refuses the whole seat.
+    if (requirePledge) {
+      const p = this.pledges.get(c);
+      if (!p || p.guildId !== guildId) return 'no_pledge';
+      this.pledges.delete(c);
+    }
     this.members.set(c, { guildId, rank });
     return 'ok';
   }
@@ -2529,6 +2537,9 @@ describe('guild pledges', () => {
     await h.svc.guildAccept(h.actor(4));
     expect(await h.db.guildMembership(4)).toMatchObject({ guildName: 'Bookbinders' });
     expect(await h.db.pledgeOf(4)).toBeNull();
+    // Joining restamps the live pledge tag from durable truth (now empty), so
+    // a later guild leave cannot resurface a stale pledged nameplate line.
+    expect(h.tx.pledgeStamps.at(-1)).toEqual({ characterId: 4, pledgeGuild: '', guildTier: 0 });
   });
 
   it('accepting an OFFLINE pledger seats them directly, wiping the ladder, no invite involved', async () => {
@@ -2688,11 +2699,56 @@ describe('guild pledges', () => {
 
   it('founding a guild clears the founder standing pledge', async () => {
     const h = await seed();
+    h.tx.setOnline(2);
+    h.tx.setOnline(4);
     await h.svc.guildPledge(h.actor(4), 'Bookbinders');
     expect(await h.db.pledgeOf(4)).not.toBeNull();
+    const boardPushes = h.tx.snapshotCount.get(2) ?? 0;
     const ok = await h.svc.guildCreate(h.actor(4), 'Aspirant Collective');
     expect(ok).toBe(true);
     expect(await h.db.pledgeOf(4)).toBeNull();
+    // The live tag restamps from durable truth (now empty) and the pledged
+    // guild's officers hear the board row disappear.
+    expect(h.tx.pledgeStamps.at(-1)).toEqual({ characterId: 4, pledgeGuild: '', guildTier: 0 });
+    expect(h.tx.snapshotCount.get(2) ?? 0).toBeGreaterThan(boardPushes);
+  });
+
+  it('rejecting after an accept cancels the outstanding invite: the reject stops the join', async () => {
+    const h = await seed();
+    h.tx.setOnline(4);
+    await h.svc.guildPledge(h.actor(4), 'Bookbinders');
+    await h.svc.guildPledgeDecide(h.actor(2), 'Aspirant', true);
+    expect((h.tx.delivered.get(4) ?? []).filter((e) => e.type === 'guildInvite')).toHaveLength(1);
+    // The officer changes their mind while the invite is still pending: the
+    // explicit no must cancel the invite, not just bump the ladder.
+    await h.svc.guildPledgeDecide(h.actor(2), 'Aspirant', false);
+    expect(await h.db.pledgeOf(4)).toBeNull();
+    expect(
+      (h.tx.delivered.get(4) ?? []).filter((e) => e.type === 'guildInviteCancelled'),
+    ).toHaveLength(1);
+    // The inviting officer hears the cancel too (the guildRenamed shape).
+    expect(
+      (h.tx.delivered.get(2) ?? []).filter((e) => e.type === 'guildInviteCancelled'),
+    ).toHaveLength(1);
+    // The cancelled invite can no longer seat them.
+    await h.svc.guildAccept(h.actor(4));
+    expect(await h.db.guildMembership(4)).toBeNull();
+    expect(h.tx.errorsFor(4).at(-1)).toBe('The guild invitation has expired.');
+  });
+
+  it('a withdraw racing the offline seat rolls the seat back', async () => {
+    const h = await seed();
+    await h.svc.guildPledge(h.actor(4), 'Bookbinders');
+    // The pledger's withdraw lands after the officer's pledge read but before
+    // the seat transaction: the consent is gone, so the seat must refuse.
+    const realSeat = h.db.addGuildMemberAtomic.bind(h.db);
+    h.db.addGuildMemberAtomic = async (guildId, charId, rank, limit, requirePledge) => {
+      await h.db.deletePledge(4);
+      return realSeat(guildId, charId, rank, limit, requirePledge);
+    };
+    await h.svc.guildPledgeDecide(h.actor(2), 'Aspirant', true);
+    expect(await h.db.guildMembership(4)).toBeNull();
+    expect(h.tx.errorsFor(2).at(-1)).toBe('Aspirant has no pledge to your guild.');
   });
 
   it('withdraw clears the pledge and restamps the badge', async () => {

--- a/tests/social_system.test.ts
+++ b/tests/social_system.test.ts
@@ -3,6 +3,7 @@ import { resolveRealm } from '../server/realm';
 import {
   type CharInfo,
   type CharRef,
+  GUILD_MEMBER_LIMIT,
   type GuildEventRow,
   type GuildRank,
   PLEDGE_REPLEDGE_COOLDOWN_MS,
@@ -2511,17 +2512,105 @@ describe('guild pledges', () => {
     expect(await h.db.pledgeOf(4)).toBeNull();
   });
 
-  it('accept resolves the pledge into the standard invite', async () => {
+  it('accept with the pledger online resolves into the standard invite', async () => {
     const h = await seed();
     h.tx.setOnline(4);
     await h.svc.guildPledge(h.actor(4), 'Bookbinders');
     await h.svc.guildPledgeDecide(h.actor(2), 'Aspirant', true);
-    expect(await h.db.pledgeOf(4)).toBeNull();
     const invites = (h.tx.delivered.get(4) ?? []).filter((e) => e.type === 'guildInvite');
     expect(invites).toHaveLength(1);
+    // The pledge is the standing request: it outlives the invite send, so a
+    // dropped or ignored invite can never make the request disappear.
+    expect(await h.db.pledgeOf(4)).not.toBeNull();
     // Accepting the invite seats them; joining clears any pledge state.
     await h.svc.guildAccept(h.actor(4));
     expect(await h.db.guildMembership(4)).toMatchObject({ guildName: 'Bookbinders' });
+    expect(await h.db.pledgeOf(4)).toBeNull();
+  });
+
+  it('accepting an OFFLINE pledger seats them directly, wiping the ladder, no invite involved', async () => {
+    const h = await seed();
+    h.tx.setOnline(1);
+    await h.svc.guildPledge(h.actor(4), 'Bookbinders');
+    // Seed a ladder rung so the wipe is observable: acceptance is the guild
+    // saying "we do want you", exactly like a real invite.
+    const account = await h.db.accountIdForCharacter(4);
+    await h.db.bumpPledgeLadder(h.guildId, account!);
+    await h.svc.guildPledgeDecide(h.actor(2), 'Aspirant', true);
+    expect(await h.db.guildMembership(4)).toMatchObject({
+      guildName: 'Bookbinders',
+      rank: 'member',
+    });
+    expect(await h.db.pledgeOf(4)).toBeNull();
+    expect(await h.db.pledgeLadder(h.guildId, account!)).toBeNull();
+    expect((h.tx.delivered.get(4) ?? []).filter((e) => e.type === 'guildInvite')).toHaveLength(0);
+    // Online members heard the join line.
+    expect(h.tx.textFor(1)).toContain('Aspirant has joined the guild.');
+  });
+
+  it('an offline accept against a full guild refuses and keeps the pledge on the board', async () => {
+    const h = await seed();
+    await h.svc.guildPledge(h.actor(4), 'Bookbinders');
+    // Fill the roster to the real service cap (the seed already added 3).
+    for (let i = 0; i < GUILD_MEMBER_LIMIT - 3; i++) {
+      const id = 100 + i;
+      h.add(id, `Filler${i}`);
+      await h.db.addGuildMemberAtomic(h.guildId, id, 'member', GUILD_MEMBER_LIMIT);
+    }
+    await h.svc.guildPledgeDecide(h.actor(2), 'Aspirant', true);
+    expect(h.tx.errorsFor(2).at(-1)).toBe('Your guild is full.');
+    expect(await h.db.guildMembership(4)).toBeNull();
+    expect(await h.db.pledgeOf(4)).toMatchObject({ guildName: 'Bookbinders' });
+  });
+
+  it('an offline accept for a pledger who joined elsewhere drops the stale pledge', async () => {
+    const h = await seed();
+    await h.svc.guildPledge(h.actor(4), 'Bookbinders');
+    h.add(5, 'Scribe');
+    const other = await h.db.createGuildWithLeader('Inkwrights', 5);
+    if ('error' in other) throw new Error('guild seed failed');
+    await h.db.addGuildMemberAtomic(other.guildId, 4, 'member', 50);
+    await h.svc.guildPledgeDecide(h.actor(2), 'Aspirant', true);
+    expect(h.tx.errorsFor(2).at(-1)).toBe('Aspirant is already in a guild.');
+    expect(await h.db.pledgeOf(4)).toBeNull();
+    expect((await h.db.guildMembership(4))?.guildName).toBe('Inkwrights');
+  });
+
+  it('a pledge survives logout: the dropped invite leaves the request standing, an offline re-accept seats them', async () => {
+    const h = await seed();
+    h.tx.setOnline(4);
+    await h.svc.guildPledge(h.actor(4), 'Bookbinders');
+    // Officer accepts while the pledger is online: the invite goes out.
+    await h.svc.guildPledgeDecide(h.actor(2), 'Aspirant', true);
+    expect((h.tx.delivered.get(4) ?? []).filter((e) => e.type === 'guildInvite')).toHaveLength(1);
+    // The pledger logs out before answering: the pending invite drops, but
+    // the pledge row persists.
+    h.svc.forget(4);
+    h.tx.setOffline(4);
+    expect(await h.db.pledgeOf(4)).toMatchObject({ guildName: 'Bookbinders' });
+    // The dropped invite is truly gone.
+    await h.svc.guildAccept(h.actor(4));
+    expect(await h.db.guildMembership(4)).toBeNull();
+    // The officer accepts the still-standing pledge while they are offline:
+    // seated directly, found in the guild on next login.
+    await h.svc.guildPledgeDecide(h.actor(2), 'Aspirant', true);
+    expect(await h.db.guildMembership(4)).toMatchObject({ guildName: 'Bookbinders' });
+    expect(await h.db.pledgeOf(4)).toBeNull();
+  });
+
+  it('accepting a pledger who blocks the officer stays silent and resolves the pledge', async () => {
+    const h = await seed();
+    h.tx.setOnline(4);
+    await h.svc.guildPledge(h.actor(4), 'Bookbinders');
+    h.db.blocks.set(4, new Set([2]));
+    await h.svc.guildPledgeDecide(h.actor(2), 'Aspirant', true);
+    // The fake-success arm: the officer sees the ordinary confirmation, no
+    // invite reaches the blocker, and the pledge resolves so repeated accepts
+    // stay indistinguishable from decline-then-nothing.
+    expect(h.tx.textFor(2)).toContain('You have invited Aspirant to the guild.');
+    expect((h.tx.delivered.get(4) ?? []).filter((e) => e.type === 'guildInvite')).toHaveLength(0);
+    expect(await h.db.pledgeOf(4)).toBeNull();
+    expect(await h.db.guildMembership(4)).toBeNull();
   });
 
   it('withdraw clears the pledge and restamps the badge', async () => {


### PR DESCRIPTION
## Summary

Guild pledges now persist over logout, and accepting an offline pledger's request actually works: they are seated into the guild while offline and find themselves in the guild on their next login.

Previously, `guildPledgeDecide` (Accept on the Pledges tab) deleted the pledge row first and then routed through the online-only `guildInvite` flow. Accepting an offline pledger therefore destroyed the request ("must be online to be invited") and invited no one, and a pledger who logged out with the invite pending lost both the invite (dropped on disconnect) and the already-deleted pledge. This is the "his request to join the guild disappears" report.

The pledge is now treated as the player's standing request to join, resolved only on a definite outcome:

- Pledger ONLINE: accept keeps the existing invite handshake unchanged, but the pledge survives until the player actually joins (`guildAccept` already deletes it on join). An invite that expires or drops at logout no longer destroys the request; the officer can simply accept again. A refusal because the pledger already joined a guild drops the stale pledge; every other refusal (full, a pending invite) keeps it on the board.
- Pledger OFFLINE: accept seats them directly via `addGuildMemberAtomic` (row-locked, cap-checked; the pledge is their standing consent and there is no one online to hand an invite to). The join is broadcast to the guild, the rejection ladder is wiped exactly like a real invite, and the login join path stamps membership from durable truth, so no login-side changes were needed. A full guild refuses and keeps the pledge; a pledger who joined elsewhere reads "already in a guild" and the stale pledge drops.
- Declining the guild's invite withdraws the pledge: an explicit "no" to the guild you pledged to ends the standing request, so a declined player can never be seated offline afterwards (this closes a consent bypass the persistence change would otherwise have introduced). Letting an invite expire or logging out with it pending is deliberately NOT a withdrawal. Declining an unrelated guild's invite leaves the pledge untouched.
- Block policy (documented in the PRD): the blocked fake-success arm of the invite flow leaves the pledge standing exactly like an unanswered invite, so the board row itself never reveals a block. The invite flow's own refusal messages remain a separate, pre-existing observation surface, unchanged here. The offline seat is guild-scoped consent and is not gated on any single officer's block relationship.
- `createGuildWithLeader` now clears the founder's standing pledge inside its transaction, closing the one membership-creating path that never cleared a pledge (the PRD's "joining ANY guild clears the pledge" rule).

`guildInvite` now reports `'sent' | 'blocked' | 'refused'` so the accept arm resolves the pledge off a definite outcome; all its player-facing behavior is unchanged. No new player-facing strings were introduced: every message in the new arms reuses existing, already-matched `server_i18n` English, so the DICT completeness and S3 guards stay untouched. The PRD (`docs/prd/guild-pledge-board.md`) records the revised accept semantics.

Two fresh review passes ran over this change. A QA coverage pass found the block-state oracle in the blocked arm, the stale-pledge leak on the online refusal, the `guildCreate` gap, and the missing online-arm tests (fixed in the second commit). A privacy/security pass then confirmed the authorization gating, SQL parameterization, atomic cap enforcement, and dual-guild prevention are clean, and found the decline consent bypass (fixed in the third commit).

Known follow-ups deliberately left out of this PR (flagging for an owner decision):

- The officer Pledges tab has no per-row presence flag or "Invited" state, so accepting an online pledger is confirmed only by the "You have invited ..." chat line while the row stays until the join. A richer row state needs a snapshot-shape change plus new catalog strings.
- Pledges have no TTL, and a pledge is now standing consent to be seated: a months-old pledge can seat a lapsed player the moment an officer accepts. If that is unwanted, a staleness cutoff needs an owner-picked number.
- The offline-seated player gets no mail/notification; they discover the membership on next login via the guild frame.
- Two officers racing the same offline accept: the loser reads "{name} is already in a guild." for a join that succeeded into their own guild (benign, tiny window; a dedicated message would cost a 22-locale fill).

## Type of change

- [x] Feature: new functionality
- [x] Bug fix

## How was this tested?

- Commands:
  - `GATE_SELECT_BASE=origin/release/v0.40.1 node scripts/gate_select.mjs` (green)
  - `npx vitest run tests/social_system.test.ts` (155 passing; 11 new/updated pledge cases: offline accept seats directly and wipes the ladder; full guild keeps the pledge, online and offline; stale pledge drops for an elsewhere-guilded pledger, online and offline; pledge survives logout end-to-end with a dropped invite then an offline re-accept; duplicate accept hits the pending-invite refusal; blocked-officer arm leaves the request standing; founding a guild clears the founder's pledge; declining the pledged guild's invite withdraws the pledge and blocks the offline seat; declining an unrelated invite leaves it standing)
  - `npx vitest run tests/localization_fixes.test.ts tests/world_api_parity.test.ts tests/monolith_budget.test.ts tests/snapshots.test.ts tests/social_view.test.ts tests/guild_stamp_fence.test.ts tests/guild_motd_login.test.ts tests/server/guild_roster.test.ts tests/server/guild_roster_cache.test.ts` (all green)
  - `npx tsc --noEmit` (clean)
- Manual steps: N/A (server-side flow, covered by the service-level suite above)

---

## Checklist

### Quality

- [x] **The gate passes.** `node scripts/gate_select.mjs` is green with decisive tests added for every new arm.

### Cross-platform

- ~Tested on desktop and mobile.~ N/A: no UI change (the dashboard renders from pushed guild views unchanged).
- ~Accessible.~ N/A

### Localization (i18n)

- [x] Player-facing text emitted from `server/` is re-localized at the client boundary: this change deliberately reuses ONLY existing matched strings ("Your guild is full.", "{name} is already in a guild.", "That guild no longer exists.", "{name} has joined the guild."), and `npx vitest run tests/localization_fixes.test.ts` passes.
- [x] N/A otherwise: this PR adds no new player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] No generated files hand-edited.
