### PR TITLE
fix(desktop): register the worldofclaudecraft:// handler on Linux

### DIFF
--- a/.claude/agents/release-malware-audit.md
+++ b/.claude/agents/release-malware-audit.md
@@ -135,9 +135,9 @@ You MUST account for these before calling anything malicious:
   `docs/security/malware-scan-catalog.md`, pinned by `tests/malware_scan.test.ts`). The
   demotions are file-scoped, so read any NEW or changed process call in either hard, and any
   process execution elsewhere in `electron/` is still a high-severity finding to confirm.
-  Both files import `execFile` under an alias, so the scanner's call-site regex does not see
-  their actual calls: check the call sites by eye rather than trusting the scan, and confirm
-  the options object still carries no `shell` key.
+  The scan surfaces each file's actual call sites at medium, not merely its `child_process`
+  import, so use the report to find the spawns. What the scan cannot judge is the options
+  object: confirm by eye that it still carries no `shell` key.
 - **`server/auth.ts` and admin code legitimately compare passwords/tokens.** A comparison of a
   password against a STORED/derived value is normal auth; a comparison against a hardcoded
   string LITERAL is a backdoor. Read which it is. `server/auth.ts` itself uses `scrypt` plus

--- a/.claude/agents/release-malware-audit.md
+++ b/.claude/agents/release-malware-audit.md
@@ -123,13 +123,21 @@ You MUST account for these before calling anything malicious:
   and `process.env`.** Screenshot/E2E/asset scripts spawn browsers and read `GAME_URL`.
   These are dev tooling, not shipped client/server runtime. Weigh `child_process` in
   `src/sim`/`src/render`/`src/ui` far more heavily than in `scripts/`.
-- **`electron/gpu_preference.cjs` is the one sanctioned process execution in shipped app
-  code.** It runs the Windows `reg` binary via `execFileSync` with a fixed argv (no shell, no
-  user-tainted input) to pin the desktop app to the discrete GPU; the scanner demotes the
-  process-execution rule to medium for exactly that file (`pathSev`, documented in
+- **Two files are sanctioned process execution in shipped app code.**
+  `electron/gpu_preference.cjs` runs the Windows `reg` binary via `execFileSync` with a fixed
+  argv resolved absolutely from `SystemRoot` (no shell, no user-tainted input) to pin the
+  desktop app to the discrete GPU. `electron/linux_url_handler.cjs` runs
+  `update-desktop-database` and `xdg-mime` via `execFile` (never `shell: true`) to register the
+  `worldofclaudecraft://` deep link that carries the Discord login code; its command names are
+  literals resolved via `PATH`, and its one environment-derived argv (the XDG applications dir)
+  is absoluteness-checked and passed as a single unparsed argument. The scanner demotes the
+  process-execution rule to medium for exactly those two files (`pathSev`, documented in
   `docs/security/malware-scan-catalog.md`, pinned by `tests/malware_scan.test.ts`). The
-  demotion is file-scoped, so read any NEW or changed process call there hard, and any process
-  execution elsewhere in `electron/` is still a high-severity finding to confirm.
+  demotions are file-scoped, so read any NEW or changed process call in either hard, and any
+  process execution elsewhere in `electron/` is still a high-severity finding to confirm.
+  Both files import `execFile` under an alias, so the scanner's call-site regex does not see
+  their actual calls: check the call sites by eye rather than trusting the scan, and confirm
+  the options object still carries no `shell` key.
 - **`server/auth.ts` and admin code legitimately compare passwords/tokens.** A comparison of a
   password against a STORED/derived value is normal auth; a comparison against a hardcoded
   string LITERAL is a backdoor. Read which it is. `server/auth.ts` itself uses `scrypt` plus

--- a/docs/desktop-release.md
+++ b/docs/desktop-release.md
@@ -408,15 +408,27 @@ equal: `tests/electron_linux_url_handler.test.ts` derives the expected basename 
 `package.json` `name` AND pins that no `executableName` / `desktopName` override exists,
 so either kind of rename fails there rather than silently breaking Discord login.
 
-Four deliberate narrowings worth knowing before changing any of it:
+Deliberate narrowings worth knowing before changing any of it:
 - `CHROME_DESKTOP` is set only when the entry actually exists on disk (ours or the
   deb's), and is restored immediately after the registration call. Setting it
   unconditionally would make a Steam depot, an Epic package, or a dev run point
   `xdg-settings` at a dangling name, which can REPLACE a working association; leaving it
   set leaks our app identity to every child process, including the browser opened for
   the Discord login itself.
-- The entry is written temp-then-`rename`, so a concurrent second instance cannot leave a
-  torn file and a symlink at the destination is replaced rather than followed.
+- The entry is written temp-then-`rename` (with `wx` on the temp), so a concurrent second
+  instance cannot leave a torn file and a symlink at either path is refused or replaced rather
+  than followed.
+- The AppImage entry is `world-of-claudecraft-appimage.desktop`, deliberately NOT the deb's
+  basename. Same basename means the same desktop-file ID, and a user-level file wins outright,
+  so reusing it would let one AppImage run replace the deb's entry everywhere; with `TryExec`
+  that becomes a silent removal once the AppImage is deleted, and `apt reinstall` cannot fix it
+  because the shadowing file is in `$HOME`. `CHROME_DESKTOP` is pointed at whichever entry
+  actually exists, ours first, the deb's second.
+- The association (`update-desktop-database` and `xdg-mime`) runs AFTER
+  `app.setAsDefaultProtocolClient`, never alongside it. Electron's Linux path shells out to
+  `xdg-settings`, which runs `xdg-mime default` itself against the same unlocked
+  read-modify-write file; on a torn read `xdg-settings` restores the ORIGINAL association and
+  fails, which is exactly the broken state this exists to remove.
 - An unchanged entry still re-runs the association commands. The file being identical does
   not mean the association survived: another app can claim the scheme and a desktop
   environment can reset `mimeapps.list`, and without the re-assert that breaks Discord

--- a/docs/desktop-release.md
+++ b/docs/desktop-release.md
@@ -397,16 +397,21 @@ and skips, by design.
 Linux deep-link caveat: `worldofclaudecraft://` is owned by a `.desktop` entry, not by
 an OS registry, so `electron/linux_url_handler.cjs` runs before
 `app.setAsDefaultProtocolClient` on both Linux channels. On the AppImage it writes
-`~/.local/share/applications/world-of-claudecraft.desktop` (the entry electron-builder
+`~/.local/share/applications/world-of-claudecraft-appimage.desktop` (the entry electron-builder
 bakes into the squashfs is never installed unless the player has AppImageLauncher) and
-runs `update-desktop-database` + `xdg-mime default`. It then repoints `CHROME_DESKTOP`
-at that filename, because Electron resolves the name it hands `xdg-settings` from that
-variable and, with no `desktopName` in `package.json`, the name it infers comes from
-`app.name` (`World of ClaudeCraft.desktop`) while electron-builder names the real file
-after `executableName` (`world-of-claudecraft.desktop`). Those two names MUST stay
-equal: `tests/electron_linux_url_handler.test.ts` derives the expected basename from
-`package.json` `name` AND pins that no `executableName` / `desktopName` override exists,
-so either kind of rename fails there rather than silently breaking Discord login.
+runs `update-desktop-database` + `xdg-mime default`. It then repoints `CHROME_DESKTOP` at
+whichever entry belongs to the channel it is running as: ours on an AppImage run, the deb's
+(`world-of-claudecraft.desktop`, installed by dpkg) otherwise. That matters, because pointing
+it at ours unconditionally would make a deb launch register the AppImage's entry, which is the
+same shadowing the distinct filename exists to prevent, reached through `CHROME_DESKTOP`
+instead of the desktop-file ID.
+
+The repoint is needed at all because Electron resolves the name it hands `xdg-settings` from
+that variable, and with no `desktopName` in `package.json` the name it infers comes from
+`app.name` (`World of ClaudeCraft.desktop`), which matches no file on disk. The deb's basename
+MUST keep tracking `executableName`: `tests/electron_linux_url_handler.test.ts` derives it from
+`package.json` `name` AND pins that no `executableName` / `desktopName` override exists, so
+either kind of rename fails there rather than silently breaking Discord login.
 
 Deliberate narrowings worth knowing before changing any of it:
 - `CHROME_DESKTOP` is set only when the entry actually exists on disk (ours or the
@@ -698,9 +703,13 @@ product exist. Coding and merge stay dark-safe without those credentials.
    stock SteamOS or Bazzite box is the realistic case): the AppImage must register its
    own handler on first launch. Confirm with
    `xdg-mime query default x-scheme-handler/worldofclaudecraft` returning
-   `world-of-claudecraft.desktop`, then `xdg-open "worldofclaudecraft://desktop-login?code=x"`
-   reaching the running game. A regression here shows up as the OS "choose an
-   application" dialog, which cannot select an AppImage at all.
+   `world-of-claudecraft-appimage.desktop` (the AppImage entry is deliberately NOT the deb's
+   basename), then `gio open "worldofclaudecraft://desktop-login?code=x"` reaching the running
+   game. Use `gio open`, not `xdg-open`: on stock SteamOS, which is the box this step names,
+   `xdg-open` takes its KDE branch and calls a `kfmclient` that is not installed, so it fails
+   for reasons unrelated to the handler. `gio open` is also the path a GTK browser takes.
+   A regression here shows up as the OS "choose an application" dialog, which cannot select an
+   AppImage at all.
 4. Play 5 minutes: steady frame rate, alt-tab out/in does not hitch or freeze the
    world (backgroundThrottling stays off).
 5. Website channel only: with a higher-version build on the feed, the update toast

--- a/docs/desktop-release.md
+++ b/docs/desktop-release.md
@@ -394,6 +394,43 @@ Linux AppImage caveat: the updater requires the `APPIMAGE` env (set automaticall
 when running a real AppImage); running the raw unpacked binary logs an updater error
 and skips, by design.
 
+Linux deep-link caveat: `worldofclaudecraft://` is owned by a `.desktop` entry, not by
+an OS registry, so `electron/linux_url_handler.cjs` runs before
+`app.setAsDefaultProtocolClient` on both Linux channels. On the AppImage it writes
+`~/.local/share/applications/world-of-claudecraft.desktop` (the entry electron-builder
+bakes into the squashfs is never installed unless the player has AppImageLauncher) and
+runs `update-desktop-database` + `xdg-mime default`. It then repoints `CHROME_DESKTOP`
+at that filename, because Electron resolves the name it hands `xdg-settings` from that
+variable and, with no `desktopName` in `package.json`, the name it infers comes from
+`app.name` (`World of ClaudeCraft.desktop`) while electron-builder names the real file
+after `executableName` (`world-of-claudecraft.desktop`). Those two names MUST stay
+equal: `tests/electron_linux_url_handler.test.ts` derives the expected basename from
+`package.json` `name` AND pins that no `executableName` / `desktopName` override exists,
+so either kind of rename fails there rather than silently breaking Discord login.
+
+Four deliberate narrowings worth knowing before changing any of it:
+- `CHROME_DESKTOP` is set only when the entry actually exists on disk (ours or the
+  deb's), and is restored immediately after the registration call. Setting it
+  unconditionally would make a Steam depot, an Epic package, or a dev run point
+  `xdg-settings` at a dangling name, which can REPLACE a working association; leaving it
+  set leaks our app identity to every child process, including the browser opened for
+  the Discord login itself.
+- The entry is written temp-then-`rename`, so a concurrent second instance cannot leave a
+  torn file and a symlink at the destination is replaced rather than followed.
+- An unchanged entry still re-runs the association commands. The file being identical does
+  not mean the association survived: another app can claim the scheme and a desktop
+  environment can reset `mimeapps.list`, and without the re-assert that breaks Discord
+  login permanently with no relaunch that recovers it.
+- Not `app.setDesktopName()`, the public API for the same value: it also drives the
+  Wayland app id and X11 `WM_CLASS`, which electron-builder independently writes as
+  `StartupWMClass` from `productName`. Changing one without the other breaks the
+  window-to-launcher association that works today.
+
+An AppImageLauncher user ends up with two entries (theirs, `appimagekit_*.desktop`, plus
+ours); ours takes the scheme default, which is the working one. All of it is best-effort:
+a player with no `xdg-utils` or a read-only home still signs in with a username and
+password, which never leaves the shell.
+
 ## Steam
 
 Build: `npm run electron:build:steam` on each OS runner (signing env still applies on
@@ -645,6 +682,13 @@ product exist. Coding and merge stay dark-safe without those credentials.
 3. Login both paths: email/password in-app, and Discord via the external browser +
    `worldofclaudecraft://desktop-login` deep link handoff (app focuses and enters
    the world; second-instance and cold-start deep links both work).
+   On Linux run this on a machine with NO prior install and no AppImageLauncher (a
+   stock SteamOS or Bazzite box is the realistic case): the AppImage must register its
+   own handler on first launch. Confirm with
+   `xdg-mime query default x-scheme-handler/worldofclaudecraft` returning
+   `world-of-claudecraft.desktop`, then `xdg-open "worldofclaudecraft://desktop-login?code=x"`
+   reaching the running game. A regression here shows up as the OS "choose an
+   application" dialog, which cannot select an AppImage at all.
 4. Play 5 minutes: steady frame rate, alt-tab out/in does not hitch or freeze the
    world (backgroundThrottling stays off).
 5. Website channel only: with a higher-version build on the feed, the update toast

--- a/docs/security/malware-scan-catalog.md
+++ b/docs/security/malware-scan-catalog.md
@@ -137,11 +137,11 @@ makes `--gate` and `tests/malware_scan.test.ts` usable as a gate:
   `PATH`, and one argv element is environment-derived (the XDG applications dir),
   checked for absoluteness and otherwise passed as a single unparsed argument. Both
   demotions are one file wide; same-directory neighbors stay high, and eval / egress /
-  decode-then-execute still trip at high in both files. Note the known blind spot that
-  applies here: both files import `execFile` under an alias, so the call-site regex
-  never matches and only the `child_process` import trips. The real control on the
-  no-shell property is the unit test pinning the options object
-  (`tests/electron_linux_url_handler.test.ts`), not this scanner.
+  decode-then-execute still trip at high in both files. The demotion covers each file's
+  REAL CALL SITES, not just its `child_process` import, so a scan report points a
+  reviewer at the actual spawns. What the scanner cannot judge is the options object,
+  so the control against a later `shell: true` is the unit test pinning its absence
+  (`tests/electron_linux_url_handler.test.ts`).
 - **Reviewed wallet bridge findings stay visible.** The reviewed
   Reown bridge in `src/net/wallet_connect.ts` keeps its Web3 import and transaction
   deserialization findings visible at medium. Every neighboring Web3 use and all

--- a/docs/security/malware-scan-catalog.md
+++ b/docs/security/malware-scan-catalog.md
@@ -125,12 +125,23 @@ makes `--gate` and `tests/malware_scan.test.ts` usable as a gate:
 - **Path-aware priors.** `child_process`/`exec` and "god-mode" identifiers in
   `scripts/`, `headless/`, and `tests/` are dev tooling and demoted below the gate
   threshold; the same construct in `src/**`/`server/**` stays high. `web3` /
-  `key-exfil` / `crypto-mining` / `exfiltration` are never demoted. One `pathSev`
-  exception in shipped app code: `electron/gpu_preference.cjs` demotes the
-  process-execution rule to medium, because it runs the Windows `reg` binary with a
-  fixed argv (no shell, no user-tainted input) to force the discrete GPU. The
-  demotion is one file wide; same-directory neighbors stay high, and eval / egress /
-  decode-then-execute still trip at high in that file.
+  `key-exfil` / `crypto-mining` / `exfiltration` are never demoted. TWO `pathSev`
+  exceptions in shipped app code demote the process-execution rule to medium, both
+  no-shell (array argv straight to execve):
+  `electron/gpu_preference.cjs`, which runs the Windows `reg` binary with a fixed
+  argv resolved absolutely from `SystemRoot` (no user-tainted input) to force the
+  discrete GPU; and `electron/linux_url_handler.cjs`, which runs
+  `update-desktop-database` and `xdg-mime` to register the `worldofclaudecraft://`
+  deep link that carries the Discord login code. The second is the weaker case and is
+  stated precisely on purpose: the command names are literals but are resolved via
+  `PATH`, and one argv element is environment-derived (the XDG applications dir),
+  checked for absoluteness and otherwise passed as a single unparsed argument. Both
+  demotions are one file wide; same-directory neighbors stay high, and eval / egress /
+  decode-then-execute still trip at high in both files. Note the known blind spot that
+  applies here: both files import `execFile` under an alias, so the call-site regex
+  never matches and only the `child_process` import trips. The real control on the
+  no-shell property is the unit test pinning the options object
+  (`tests/electron_linux_url_handler.test.ts`), not this scanner.
 - **Reviewed wallet bridge findings stay visible.** The reviewed
   Reown bridge in `src/net/wallet_connect.ts` keeps its Web3 import and transaction
   deserialization findings visible at medium. Every neighboring Web3 use and all

--- a/electron/linux_url_handler.cjs
+++ b/electron/linux_url_handler.cjs
@@ -52,7 +52,17 @@ const nodePath = require('node:path');
 // it: one CHROME_DESKTOP value then serves both channels, and on a machine with both the
 // user-level AppImage entry cleanly shadows the system-level deb one per the XDG lookup order.
 const DESKTOP_ENTRY_BASENAME = 'world-of-claudecraft';
-const DESKTOP_ENTRY_NAME = `${DESKTOP_ENTRY_BASENAME}.desktop`;
+// What dpkg installs. We never write this file, only look for it.
+const DEB_ENTRY_NAME = `${DESKTOP_ENTRY_BASENAME}.desktop`;
+// What WE write, for an AppImage run. Deliberately NOT the deb's basename. Those two paths are
+// the same desktop-file ID, and XDG first-match means a user-level file wins outright, so
+// reusing the name would have one AppImage run replace the deb's entry everywhere it is looked
+// up. Combined with TryExec that turns into a silent removal: delete the AppImage afterwards
+// and the launcher refuses to load the entry at all, so a deb-installed game vanishes from the
+// applications menu and the scheme resolves to nothing, with `apt reinstall` unable to fix it
+// because the shadowing file lives in $HOME. A distinct name costs one branch below.
+const NO_ASSOCIATE = () => {};
+const APPIMAGE_ENTRY_NAME = `${DESKTOP_ENTRY_BASENAME}-appimage.desktop`;
 
 // Rejected outright rather than escaped. A newline would let a crafted filename inject
 // further key=value lines (an attacker-chosen Exec); the shell-reserved characters would
@@ -191,16 +201,21 @@ function configureLinuxDesktopName(deps = {}) {
   // AppImageLauncher-integrated entry, say) with a dangling one: strictly worse than today.
   const fileExists = deps.fileExists ?? nodeExistsSync;
   const userDir = deps.dir ?? desktopEntryDir(env, deps.homeDir ?? nodeOs.homedir());
-  const resolves =
-    fileExists(nodePath.join(userDir, DESKTOP_ENTRY_NAME)) ||
-    fileExists(nodePath.join(SYSTEM_APPLICATIONS_DIR, DESKTOP_ENTRY_NAME));
-  if (!resolves) return noop;
+  // Ours first: on a machine with both, the AppImage the player just launched is the one the
+  // scheme should resolve to. Falling back to the deb's entry keeps that channel working
+  // without our ever writing to /usr/share.
+  const found = fileExists(nodePath.join(userDir, APPIMAGE_ENTRY_NAME))
+    ? APPIMAGE_ENTRY_NAME
+    : fileExists(nodePath.join(SYSTEM_APPLICATIONS_DIR, DEB_ENTRY_NAME))
+      ? DEB_ENTRY_NAME
+      : null;
+  if (!found) return noop;
 
   const had = Object.hasOwn(env, 'CHROME_DESKTOP');
   const previous = env.CHROME_DESKTOP;
-  env.CHROME_DESKTOP = DESKTOP_ENTRY_NAME;
+  env.CHROME_DESKTOP = found;
   return {
-    desktopName: DESKTOP_ENTRY_NAME,
+    desktopName: found,
     // Restored by the caller once the registration has run. It is a process-wide variable
     // inherited by every child, including the browser we spawn for the Discord login itself
     // (shell.openExternal -> xdg-open). Chromium reads CHROME_DESKTOP for its own shell
@@ -221,7 +236,8 @@ function configureLinuxDesktopName(deps = {}) {
  *   'invalid-scheme' the caller passed something that is not a URL scheme
  *   'unsafe-path'   the AppImage lives somewhere we refuse to encode (see unrepresentable)
  *   'unsafe-dir'    the XDG applications dir did not resolve to an absolute path
- *   'unchanged'     the entry on disk already matches, so no write and no xdg-utils work
+ *   'unchanged'     the entry on disk already matches, so no write (the caller's associate
+ *                   still re-asserts the default, see below)
  *   'installed'     the entry was written and the association commands were kicked off
  *   'failed'        the write itself failed (read-only home, no permission)
  *
@@ -237,12 +253,12 @@ function installDesktopEntry(deps = {}) {
   const scheme = deps.scheme;
   const productName = deps.productName ?? PRODUCT_NAME;
 
-  if (platform !== 'linux') return { status: 'not-appimage' };
+  if (platform !== 'linux') return { status: 'not-appimage', associate: NO_ASSOCIATE };
   const appImagePath = deps.appImagePath ?? appImagePathFrom(env);
-  if (!appImagePath) return { status: 'not-appimage' };
+  if (!appImagePath) return { status: 'not-appimage', associate: NO_ASSOCIATE };
   if (typeof scheme !== 'string' || !VALID_SCHEME.test(scheme)) {
     log?.warn?.('[deeplink] refusing to register an invalid URL scheme', { scheme });
-    return { status: 'invalid-scheme' };
+    return { status: 'invalid-scheme', associate: NO_ASSOCIATE };
   }
 
   const execArgument = execArgumentFor(appImagePath);
@@ -250,7 +266,7 @@ function installDesktopEntry(deps = {}) {
     log?.warn?.('[deeplink] AppImage path cannot be encoded in a .desktop entry', {
       appImagePath,
     });
-    return { status: 'unsafe-path' };
+    return { status: 'unsafe-path', associate: NO_ASSOCIATE };
   }
 
   // os.homedir() returns $HOME verbatim on POSIX, so a hostile or malformed HOME (with
@@ -258,10 +274,10 @@ function installDesktopEntry(deps = {}) {
   const dir = deps.dir ?? desktopEntryDir(env, deps.homeDir ?? nodeOs.homedir());
   if (!nodePath.isAbsolute(dir)) {
     log?.warn?.('[deeplink] refusing a non-absolute applications dir', { dir });
-    return { status: 'unsafe-dir' };
+    return { status: 'unsafe-dir', associate: NO_ASSOCIATE };
   }
 
-  const file = nodePath.join(dir, DESKTOP_ENTRY_NAME);
+  const file = nodePath.join(dir, APPIMAGE_ENTRY_NAME);
   const entry = buildDesktopEntry({
     execArgument,
     scheme,
@@ -274,7 +290,7 @@ function installDesktopEntry(deps = {}) {
   });
   if (!entry) {
     log?.warn?.('[deeplink] refusing to write an unrepresentable .desktop entry');
-    return { status: 'unsafe-path' };
+    return { status: 'unsafe-path', associate: NO_ASSOCIATE };
   }
 
   const readFile = deps.readFile ?? nodeReadFileSync;
@@ -288,10 +304,20 @@ function installDesktopEntry(deps = {}) {
   // xdg-mime then makes it the DEFAULT rather than merely a candidate. Both are best-effort:
   // a distro without xdg-utils still gets a valid entry on disk, and desktop environments
   // that read mimeapps.list directly pick it up on their own.
-  const associate = () => {
+  //
+  // RETURNED rather than called: it must not overlap Electron's own registration. Every
+  // url-scheme branch of xdg-settings runs `xdg-mime default` itself, and xdg-mime is an
+  // unlocked read-modify-write (`awk ... > "$f.new" && mv "$f.new" "$f"`) at a fixed path, so
+  // two concurrent runs write the same temp file. Worse than a lost update: xdg-settings reads
+  // the current default, sets ours, re-queries to verify, and on a torn read writes the ORIGINAL
+  // back and fails, which restores exactly the broken state this module exists to remove. The
+  // caller runs this after setAsDefaultProtocolClient has returned.
+  const associate = (rewrote) => {
     const runCommand = deps.runCommand ?? defaultRunCommand;
-    runCommand('update-desktop-database', [dir], log);
-    runCommand('xdg-mime', ['default', DESKTOP_ENTRY_NAME, `x-scheme-handler/${scheme}`], log);
+    // Only when the bytes actually changed: an unchanged entry means the MIME cache already
+    // describes it, so rebuilding it is a subprocess spent on nothing.
+    if (rewrote) runCommand('update-desktop-database', [dir], log);
+    runCommand('xdg-mime', ['default', APPIMAGE_ENTRY_NAME, `x-scheme-handler/${scheme}`], log);
   };
 
   // An unchanged FILE does not imply an intact ASSOCIATION: another application can claim the
@@ -300,11 +326,8 @@ function installDesktopEntry(deps = {}) {
   // break Discord login permanently, with no relaunch that ever recovers it. The two commands
   // are async, unref'd, and timeout-bounded, so re-asserting costs nothing on the boot path.
   if (existing === entry) {
-    associate();
-    log?.info?.('[deeplink] Linux URL scheme handler entry current, association re-asserted', {
-      file,
-    });
-    return { status: 'unchanged', file, entry };
+    log?.info?.('[deeplink] entry current; the association will be re-asserted', { file });
+    return { status: 'unchanged', file, entry, associate: () => associate(false) };
   }
 
   const mkdir = deps.mkdir ?? nodeMkdirSync;
@@ -331,12 +354,11 @@ function installDesktopEntry(deps = {}) {
     }
   } catch (err) {
     log?.warn?.('[deeplink] could not write the .desktop entry', err);
-    return { status: 'failed', file, entry };
+    return { status: 'failed', file, entry, associate: NO_ASSOCIATE };
   }
 
-  associate();
   log?.info?.('[deeplink] installed the Linux URL scheme handler', { file, scheme });
-  return { status: 'installed', file, entry };
+  return { status: 'installed', file, entry, associate: () => associate(true) };
 }
 
 /**
@@ -375,9 +397,10 @@ function registerLinuxUrlHandler(deps = {}) {
 }
 
 module.exports = {
+  APPIMAGE_ENTRY_NAME,
+  DEB_ENTRY_NAME,
   SYSTEM_APPLICATIONS_DIR,
   DESKTOP_ENTRY_BASENAME,
-  DESKTOP_ENTRY_NAME,
   PRODUCT_NAME,
   appImagePathFrom,
   defaultRunCommand,

--- a/electron/linux_url_handler.cjs
+++ b/electron/linux_url_handler.cjs
@@ -4,6 +4,7 @@ const {
   mkdirSync: nodeMkdirSync,
   readFileSync: nodeReadFileSync,
   renameSync: nodeRenameSync,
+  unlinkSync: nodeUnlinkSync,
   writeFileSync: nodeWriteFileSync,
 } = require('node:fs');
 const nodeOs = require('node:os');
@@ -135,6 +136,9 @@ function buildDesktopEntry({ execArgument, scheme, productName, tryExecPath }) {
   if (typeof execArgument !== 'string' || execArgument === '') return null;
   if (typeof scheme !== 'string' || !VALID_SCHEME.test(scheme)) return null;
   if (typeof productName !== 'string' || unrepresentable(productName)) return null;
+  if (tryExecPath != null && (typeof tryExecPath !== 'string' || unrepresentable(tryExecPath))) {
+    return null;
+  }
   const lines = [
     '[Desktop Entry]',
     'Type=Application',
@@ -146,6 +150,10 @@ function buildDesktopEntry({ execArgument, scheme, productName, tryExecPath }) {
   if (tryExecPath) lines.push(`TryExec=${tryExecPath}`);
   lines.push(
     `Icon=${DESKTOP_ENTRY_BASENAME}`,
+    // Matches the StartupWMClass electron-builder writes into the deb entry (it derives it
+    // from productName), so a window started from this entry groups under it instead of
+    // opening an unlabelled second taskbar item.
+    `StartupWMClass=${productName}`,
     'Terminal=false',
     'Categories=Game;',
     `MimeType=x-scheme-handler/${scheme};`,
@@ -258,9 +266,11 @@ function installDesktopEntry(deps = {}) {
     execArgument,
     scheme,
     productName,
-    // Only when the raw path needs no quoting: TryExec is a plain path key, not an Exec line,
-    // so it has no quoting or field-code layer to hide behind.
-    tryExecPath: EXEC_BARE_SAFE.test(appImagePath) ? appImagePath : null,
+    // Every path the module is willing to write, not just unquoted ones: TryExec is a plain
+    // path key with no Exec quoting or field-code layer, so a space in it needs no treatment.
+    // Gating it on the narrower unquoted set dropped it for exactly the paths most likely to
+    // go stale later (a space or a percent), which is where a launcher most needs it.
+    tryExecPath: appImagePath,
   });
   if (!entry) {
     log?.warn?.('[deeplink] refusing to write an unrepresentable .desktop entry');
@@ -306,8 +316,19 @@ function installDesktopEntry(deps = {}) {
     // crash or a concurrent second instance can never leave a torn entry, and it REPLACES a
     // symlink at the destination instead of following it into whatever it points at.
     const temp = `${file}.${process.pid}.tmp`;
-    writeFile(temp, entry, 'utf8');
-    rename(temp, file);
+    // 'wx' fails instead of following a symlink someone planted at the predictable temp path;
+    // the destination is already covered because rename replaces rather than follows.
+    try {
+      writeFile(temp, entry, { encoding: 'utf8', flag: 'wx' });
+      rename(temp, file);
+    } catch (err) {
+      // A rename that fails after the write lands would otherwise litter the applications
+      // directory with a .tmp file that nothing ever cleans up.
+      try {
+        (deps.removeFile ?? nodeUnlinkSync)(temp);
+      } catch {}
+      throw err;
+    }
   } catch (err) {
     log?.warn?.('[deeplink] could not write the .desktop entry', err);
     return { status: 'failed', file, entry };
@@ -323,11 +344,11 @@ function installDesktopEntry(deps = {}) {
  *
  * The safety property this module rests on lives HERE, not in the callers: execFile with an
  * ARRAY argv and NO `shell` option, so every argument reaches execve untouched and no
- * argument can ever be re-parsed by a shell. `execFile` is imported under an alias, which
- * means the malware scanner's call-site regex does not see this line at all (only the
- * child_process import on line 1, which scripts/malware_scan.mjs demotes for this file) --
- * so the test that pins these arguments is the real control against a later `shell: true`,
- * not the scanner. execFile is injectable for exactly that test.
+ * argument can ever be re-parsed by a shell. The scanner sees this call (the injectable
+ * parameter is itself named execFile, which its call-site regex matches) and demotes it to
+ * medium along with the import, so a reviewer reading a scan report finds the real spawn, not
+ * just the require. What the scanner cannot judge is the OPTIONS object, so the test pinning
+ * the absence of a `shell` key is the control against a later change adding one.
  */
 function defaultRunCommand(command, args, log, execFile = nodeExecFile) {
   try {

--- a/electron/linux_url_handler.cjs
+++ b/electron/linux_url_handler.cjs
@@ -47,10 +47,9 @@ const nodePath = require('node:path');
 // read-only home still gets a working game, just no deep link (they can sign in with a
 // username and password, which never leaves the app).
 
-// The basename electron-builder gives the .deb's entry (LinuxPackager.executableName, which
-// is package.json `name` lowercased). The AppImage entry we write below deliberately reuses
-// it: one CHROME_DESKTOP value then serves both channels, and on a machine with both the
-// user-level AppImage entry cleanly shadows the system-level deb one per the XDG lookup order.
+// The basename electron-builder gives the .deb's entry (LinuxPackager.executableName, which is
+// package.json `name` lowercased), and the icon name dpkg installs into the icon theme. The
+// AppImage entry deliberately does NOT reuse it; APPIMAGE_ENTRY_NAME below says why.
 const DESKTOP_ENTRY_BASENAME = 'world-of-claudecraft';
 // What dpkg installs. We never write this file, only look for it.
 const DEB_ENTRY_NAME = `${DESKTOP_ENTRY_BASENAME}.desktop`;
@@ -61,7 +60,6 @@ const DEB_ENTRY_NAME = `${DESKTOP_ENTRY_BASENAME}.desktop`;
 // and the launcher refuses to load the entry at all, so a deb-installed game vanishes from the
 // applications menu and the scheme resolves to nothing, with `apt reinstall` unable to fix it
 // because the shadowing file lives in $HOME. A distinct name costs one branch below.
-const NO_ASSOCIATE = () => {};
 const APPIMAGE_ENTRY_NAME = `${DESKTOP_ENTRY_BASENAME}-appimage.desktop`;
 
 // Rejected outright rather than escaped. A newline would let a crafted filename inject
@@ -71,6 +69,8 @@ const APPIMAGE_ENTRY_NAME = `${DESKTOP_ENTRY_BASENAME}-appimage.desktop`;
 // handler that runs the wrong command. No real download path contains any of them, so
 // refusing to install is both safer and honest.
 const PRODUCT_NAME = 'World of ClaudeCraft';
+/** Returned by every arm with nothing to associate, so the caller never null-checks. */
+const NO_ASSOCIATE = () => {};
 // Where a system package (the .deb) puts its copy. Read only to answer "does this name
 // resolve to anything at all", never written.
 const SYSTEM_APPLICATIONS_DIR = '/usr/share/applications';
@@ -201,14 +201,19 @@ function configureLinuxDesktopName(deps = {}) {
   // AppImageLauncher-integrated entry, say) with a dangling one: strictly worse than today.
   const fileExists = deps.fileExists ?? nodeExistsSync;
   const userDir = deps.dir ?? desktopEntryDir(env, deps.homeDir ?? nodeOs.homedir());
-  // Ours first: on a machine with both, the AppImage the player just launched is the one the
-  // scheme should resolve to. Falling back to the deb's entry keeps that channel working
-  // without our ever writing to /usr/share.
-  const found = fileExists(nodePath.join(userDir, APPIMAGE_ENTRY_NAME))
-    ? APPIMAGE_ENTRY_NAME
-    : fileExists(nodePath.join(SYSTEM_APPLICATIONS_DIR, DEB_ENTRY_NAME))
-      ? DEB_ENTRY_NAME
-      : null;
+  // Whichever entry belongs to the channel THIS process is, never just whichever exists. An
+  // AppImage run prefers ours; anything else (deb, Steam depot, dev) prefers the deb's and stops
+  // there. Preferring ours unconditionally re-created the shadowing this module already fixed
+  // once, by a different route: a deb launch on a box where the player had tried the AppImage
+  // would hand xdg-settings OUR filename, so the deb player's scheme resolved to the AppImage,
+  // re-asserted on every launch, and TryExec finished it off once the AppImage was deleted. The
+  // deb has no way back from that, because nothing rewrites the user-level file.
+  const onAppImage = (deps.appImagePath ?? appImagePathFrom(env)) !== null;
+  const ours = fileExists(nodePath.join(userDir, APPIMAGE_ENTRY_NAME)) ? APPIMAGE_ENTRY_NAME : null;
+  const theirs = fileExists(nodePath.join(SYSTEM_APPLICATIONS_DIR, DEB_ENTRY_NAME))
+    ? DEB_ENTRY_NAME
+    : null;
+  const found = onAppImage ? (ours ?? theirs) : theirs;
   if (!found) return noop;
 
   const had = Object.hasOwn(env, 'CHROME_DESKTOP');
@@ -238,7 +243,7 @@ function configureLinuxDesktopName(deps = {}) {
  *   'unsafe-dir'    the XDG applications dir did not resolve to an absolute path
  *   'unchanged'     the entry on disk already matches, so no write (the caller's associate
  *                   still re-asserts the default, see below)
- *   'installed'     the entry was written and the association commands were kicked off
+ *   'installed'     the entry was written; call `associate` to register it
  *   'failed'        the write itself failed (read-only home, no permission)
  *
  * The unchanged path matters: this runs on every launch, and re-running xdg-mime each time

--- a/electron/linux_url_handler.cjs
+++ b/electron/linux_url_handler.cjs
@@ -1,0 +1,369 @@
+const { execFile: nodeExecFile } = require('node:child_process');
+const {
+  existsSync: nodeExistsSync,
+  mkdirSync: nodeMkdirSync,
+  readFileSync: nodeReadFileSync,
+  renameSync: nodeRenameSync,
+  writeFileSync: nodeWriteFileSync,
+} = require('node:fs');
+const nodeOs = require('node:os');
+const nodePath = require('node:path');
+
+// Make the worldofclaudecraft:// deep link resolvable on Linux, which is what carries the
+// Discord login code back from the OS browser into the shell (main.cjs handleDeepLink).
+//
+// Two separate breakages, both silent, both fixed here:
+//
+//  1. The AppImage installs NOTHING. electron-builder does emit a correct .desktop file
+//     (Exec + MimeType=x-scheme-handler/worldofclaudecraft, from the top-level `protocols`
+//     block in package.json), but it lives inside the AppImage's squashfs and is only ever
+//     read if the player has AppImageLauncher or hand-integrates the file. SteamOS, Bazzite,
+//     and a plain "download and chmod +x" have neither, so xdg-open finds no handler at all
+//     and the Discord callback dead-ends in a "choose an application" dialog that cannot
+//     select an AppImage. The .deb is unaffected: dpkg installs its copy to
+//     /usr/share/applications and runs update-desktop-database for us.
+//
+//  2. app.setAsDefaultProtocolClient is a hard no-op on Linux for BOTH channels. Electron's
+//     Linux path shells out to `xdg-settings set default-url-scheme-handler <scheme>
+//     <desktop-name>`, and it resolves that name from the CHROME_DESKTOP environment
+//     variable. We never set desktopName in package.json, so the name Electron uses is
+//     inferred rather than known: Electron's own setDesktopName docs spell out the failure
+//     mode, that an inferred name "may not match the packaged app's actual .desktop file".
+//     It does not match. electron-builder names the real file after executableName, so the
+//     deb ships "world-of-claudecraft.desktop" while the inferred name derives from app.name
+//     (productName, "World of ClaudeCraft"). Pointing CHROME_DESKTOP at the filename that
+//     actually exists is the whole fix for the deb, and it lets the AppImage reuse Electron's
+//     own registration on top of the one we run below.
+//
+//     Deliberately NOT app.setDesktopName(), the public API for the same value: that one also
+//     governs the Wayland app id and the X11 WM_CLASS, and electron-builder independently
+//     writes StartupWMClass from productName ("World of ClaudeCraft"). Changing the app id
+//     without also setting package.json desktopName + linux.syncDesktopName would desync the
+//     two and break the window-to-launcher association that works today. Fixing the URL
+//     scheme must not cost a correct taskbar icon; that is a separate, packaging-level change.
+//
+// Everything here is best-effort: a player with no writable XDG data dir, no xdg-utils, or a
+// read-only home still gets a working game, just no deep link (they can sign in with a
+// username and password, which never leaves the app).
+
+// The basename electron-builder gives the .deb's entry (LinuxPackager.executableName, which
+// is package.json `name` lowercased). The AppImage entry we write below deliberately reuses
+// it: one CHROME_DESKTOP value then serves both channels, and on a machine with both the
+// user-level AppImage entry cleanly shadows the system-level deb one per the XDG lookup order.
+const DESKTOP_ENTRY_BASENAME = 'world-of-claudecraft';
+const DESKTOP_ENTRY_NAME = `${DESKTOP_ENTRY_BASENAME}.desktop`;
+
+// Rejected outright rather than escaped. A newline would let a crafted filename inject
+// further key=value lines (an attacker-chosen Exec); the shell-reserved characters would
+// need the desktop-entry spec's double layer of quoting (Exec argument quoting, then
+// desktop-file string escaping) to survive intact, and getting that subtly wrong ships a
+// handler that runs the wrong command. No real download path contains any of them, so
+// refusing to install is both safer and honest.
+const PRODUCT_NAME = 'World of ClaudeCraft';
+// Where a system package (the .deb) puts its copy. Read only to answer "does this name
+// resolve to anything at all", never written.
+const SYSTEM_APPLICATIONS_DIR = '/usr/share/applications';
+const EXEC_RESERVED_CHARS = /["`$\\]/;
+
+/**
+ * True for any C0 control character or DEL. These are spec-invalid in a desktop-entry string
+ * (desktop-file-validate rejects them), and newline / carriage return are the actual injection
+ * vector. Checked by code point rather than a regex class: a literal control character inside a
+ * regex is its own readability and lint trap, and this states the intent directly. SPACE is
+ * deliberately NOT unsafe, since quoting it is the whole point of "~/My Games/woc.AppImage".
+ */
+function hasControlCharacter(value) {
+  for (let i = 0; i < value.length; i += 1) {
+    const code = value.charCodeAt(i);
+    if (code < 0x20 || code === 0x7f) return true;
+  }
+  return false;
+}
+
+/** A string that cannot be represented safely in a .desktop value, whatever the key. */
+function unrepresentable(value) {
+  return EXEC_RESERVED_CHARS.test(value) || hasControlCharacter(value);
+}
+// Characters that need no quoting at all in an Exec value (the same conservative set
+// electron-builder uses when it builds the deb's Exec line).
+const EXEC_BARE_SAFE = /^[/0-9A-Za-z._-]+$/;
+// A URL scheme per RFC 3986: letter, then letters/digits/+/-/. Anything else would be spliced
+// straight into the MimeType line and the xdg-mime argument.
+const VALID_SCHEME = /^[A-Za-z][A-Za-z0-9+.-]*$/;
+
+/**
+ * The user-level directory that owns .desktop entries, honoring XDG_DATA_HOME when it is set
+ * to an absolute path (the spec says a relative value is invalid and must be ignored).
+ */
+function desktopEntryDir(env = process.env, homeDir = nodeOs.homedir()) {
+  const xdgDataHome = typeof env.XDG_DATA_HOME === 'string' ? env.XDG_DATA_HOME.trim() : '';
+  const base = nodePath.isAbsolute(xdgDataHome)
+    ? xdgDataHome
+    : nodePath.join(homeDir, '.local', 'share');
+  return nodePath.join(base, 'applications');
+}
+
+/**
+ * The AppImage path as an Exec argument, or null when it cannot be represented safely.
+ * Bare when it needs no quoting, double-quoted otherwise so the common "~/My Games/woc.AppImage"
+ * case works instead of splitting into two arguments.
+ */
+function execArgumentFor(appImagePath) {
+  if (typeof appImagePath !== 'string' || appImagePath === '') return null;
+  if (!nodePath.isAbsolute(appImagePath)) return null;
+  if (unrepresentable(appImagePath)) return null;
+  // A literal % MUST be doubled. The launcher expands field codes (%u, %f, ...) across the
+  // whole Exec value, and GLib silently drops an unrecognized %X pair, so a real download
+  // path like ~/Games 100%/woc.AppImage would be handed to exec with the "%/" eaten: exactly
+  // the silent dead-end this module exists to remove. Escaped rather than rejected because,
+  // unlike the shell-reserved characters above, this transformation is unambiguous.
+  const escaped = appImagePath.replace(/%/g, '%%');
+  return EXEC_BARE_SAFE.test(escaped) ? escaped : `"${escaped}"`;
+}
+
+/**
+ * The .desktop entry body. `%u` is what hands the URL to us as argv, which is where both
+ * deep-link paths in main.cjs read it from (the cold-start process.argv scan and the
+ * 'second-instance' argv when the game is already running). Deliberately NOT NoDisplay:
+ * a visible entry is one the player can also pick by hand out of the desktop environment's
+ * "open with" dialog if the xdg-mime association below never lands.
+ */
+function buildDesktopEntry({ execArgument, scheme, productName, tryExecPath }) {
+  // Validated rather than assumed: this function is exported, and the module's whole safety
+  // story is "nothing unrepresentable reaches the file", which must not depend on every future
+  // caller remembering to check. A newline in productName alone injects arbitrary keys.
+  if (typeof execArgument !== 'string' || execArgument === '') return null;
+  if (typeof scheme !== 'string' || !VALID_SCHEME.test(scheme)) return null;
+  if (typeof productName !== 'string' || unrepresentable(productName)) return null;
+  const lines = [
+    '[Desktop Entry]',
+    'Type=Application',
+    `Name=${productName}`,
+    `Exec=${execArgument} %u`,
+  ];
+  // Lets the desktop environment skip this entry on its own once the AppImage behind it is
+  // gone, so a deleted AppImage degrades to "no handler" instead of "a handler that fails".
+  if (tryExecPath) lines.push(`TryExec=${tryExecPath}`);
+  lines.push(
+    `Icon=${DESKTOP_ENTRY_BASENAME}`,
+    'Terminal=false',
+    'Categories=Game;',
+    `MimeType=x-scheme-handler/${scheme};`,
+  );
+  return `${lines.join('\n')}\n`;
+}
+
+/**
+ * The AppImage this process is running from, or null when it is not one. AppRun exports
+ * APPIMAGE as the path of the outer .AppImage file, which is the only path that survives this
+ * process exiting (process.execPath points inside the runtime's FUSE mount, which is torn
+ * down with us, so an entry built from it would break on the very next launch).
+ */
+function appImagePathFrom(env = process.env) {
+  const appImage = typeof env.APPIMAGE === 'string' ? env.APPIMAGE.trim() : '';
+  return nodePath.isAbsolute(appImage) ? appImage : null;
+}
+
+/**
+ * Point Electron's Linux protocol registration at a .desktop filename that exists (see the
+ * header, breakage 2). Safe on every channel: the deb installs this name, the AppImage gets
+ * it written by installDesktopEntry below, and on a dev run the name simply resolves to
+ * nothing, exactly as today. No-op off Linux, where CHROME_DESKTOP means nothing and
+ * setAsDefaultProtocolClient uses the registry / LaunchServices instead.
+ */
+function configureLinuxDesktopName(deps = {}) {
+  const platform = deps.platform ?? process.platform;
+  const env = deps.env ?? process.env;
+  const noop = { desktopName: null, restore: () => {} };
+  if (platform !== 'linux') return noop;
+
+  // Only when the file is actually on disk (we just wrote it, or the deb installed it).
+  // Setting it unconditionally would make a Steam depot, an Epic package, or a dev run hand
+  // xdg-settings a name resolving to nothing, which can REPLACE a working association (an
+  // AppImageLauncher-integrated entry, say) with a dangling one: strictly worse than today.
+  const fileExists = deps.fileExists ?? nodeExistsSync;
+  const userDir = deps.dir ?? desktopEntryDir(env, deps.homeDir ?? nodeOs.homedir());
+  const resolves =
+    fileExists(nodePath.join(userDir, DESKTOP_ENTRY_NAME)) ||
+    fileExists(nodePath.join(SYSTEM_APPLICATIONS_DIR, DESKTOP_ENTRY_NAME));
+  if (!resolves) return noop;
+
+  const had = Object.hasOwn(env, 'CHROME_DESKTOP');
+  const previous = env.CHROME_DESKTOP;
+  env.CHROME_DESKTOP = DESKTOP_ENTRY_NAME;
+  return {
+    desktopName: DESKTOP_ENTRY_NAME,
+    // Restored by the caller once the registration has run. It is a process-wide variable
+    // inherited by every child, including the browser we spawn for the Discord login itself
+    // (shell.openExternal -> xdg-open). Chromium reads CHROME_DESKTOP for its own shell
+    // integration, so a freshly spawned Chromium whose user then accepts "make this my
+    // default browser" would register OUR desktop file as the http/https handler.
+    restore: () => {
+      if (had) env.CHROME_DESKTOP = previous;
+      else delete env.CHROME_DESKTOP;
+    },
+  };
+}
+
+/**
+ * Write the user-level .desktop entry for an AppImage run and associate it with the scheme.
+ *
+ * Returns a status object rather than throwing, so main.cjs can log the outcome and carry on:
+ *   'not-appimage'  nothing to do (deb, Steam depot, dev run, or any non-Linux host)
+ *   'invalid-scheme' the caller passed something that is not a URL scheme
+ *   'unsafe-path'   the AppImage lives somewhere we refuse to encode (see unrepresentable)
+ *   'unsafe-dir'    the XDG applications dir did not resolve to an absolute path
+ *   'unchanged'     the entry on disk already matches, so no write and no xdg-utils work
+ *   'installed'     the entry was written and the association commands were kicked off
+ *   'failed'        the write itself failed (read-only home, no permission)
+ *
+ * The unchanged path matters: this runs on every launch, and re-running xdg-mime each time
+ * would spend two subprocesses to reassert something already true. A moved or renamed
+ * AppImage changes Exec, which fails the comparison and re-installs, which is what keeps the
+ * entry pointing at a file that still exists after a manual re-download.
+ */
+function installDesktopEntry(deps = {}) {
+  const platform = deps.platform ?? process.platform;
+  const env = deps.env ?? process.env;
+  const log = deps.log;
+  const scheme = deps.scheme;
+  const productName = deps.productName ?? PRODUCT_NAME;
+
+  if (platform !== 'linux') return { status: 'not-appimage' };
+  const appImagePath = deps.appImagePath ?? appImagePathFrom(env);
+  if (!appImagePath) return { status: 'not-appimage' };
+  if (typeof scheme !== 'string' || !VALID_SCHEME.test(scheme)) {
+    log?.warn?.('[deeplink] refusing to register an invalid URL scheme', { scheme });
+    return { status: 'invalid-scheme' };
+  }
+
+  const execArgument = execArgumentFor(appImagePath);
+  if (!execArgument) {
+    log?.warn?.('[deeplink] AppImage path cannot be encoded in a .desktop entry', {
+      appImagePath,
+    });
+    return { status: 'unsafe-path' };
+  }
+
+  // os.homedir() returns $HOME verbatim on POSIX, so a hostile or malformed HOME (with
+  // XDG_DATA_HOME unset or relative) would otherwise land mkdir/write on a CWD-relative tree.
+  const dir = deps.dir ?? desktopEntryDir(env, deps.homeDir ?? nodeOs.homedir());
+  if (!nodePath.isAbsolute(dir)) {
+    log?.warn?.('[deeplink] refusing a non-absolute applications dir', { dir });
+    return { status: 'unsafe-dir' };
+  }
+
+  const file = nodePath.join(dir, DESKTOP_ENTRY_NAME);
+  const entry = buildDesktopEntry({
+    execArgument,
+    scheme,
+    productName,
+    // Only when the raw path needs no quoting: TryExec is a plain path key, not an Exec line,
+    // so it has no quoting or field-code layer to hide behind.
+    tryExecPath: EXEC_BARE_SAFE.test(appImagePath) ? appImagePath : null,
+  });
+  if (!entry) {
+    log?.warn?.('[deeplink] refusing to write an unrepresentable .desktop entry');
+    return { status: 'unsafe-path' };
+  }
+
+  const readFile = deps.readFile ?? nodeReadFileSync;
+  let existing = null;
+  try {
+    existing = String(readFile(file, 'utf8'));
+  } catch {
+    existing = null;
+  }
+  // update-desktop-database rebuilds the MIME cache that maps the scheme to this entry;
+  // xdg-mime then makes it the DEFAULT rather than merely a candidate. Both are best-effort:
+  // a distro without xdg-utils still gets a valid entry on disk, and desktop environments
+  // that read mimeapps.list directly pick it up on their own.
+  const associate = () => {
+    const runCommand = deps.runCommand ?? defaultRunCommand;
+    runCommand('update-desktop-database', [dir], log);
+    runCommand('xdg-mime', ['default', DESKTOP_ENTRY_NAME, `x-scheme-handler/${scheme}`], log);
+  };
+
+  // An unchanged FILE does not imply an intact ASSOCIATION: another application can claim the
+  // scheme, and a desktop environment can reset or rewrite mimeapps.list. Skipping the write
+  // is safe (the bytes are identical); skipping the association would let a stolen default
+  // break Discord login permanently, with no relaunch that ever recovers it. The two commands
+  // are async, unref'd, and timeout-bounded, so re-asserting costs nothing on the boot path.
+  if (existing === entry) {
+    associate();
+    log?.info?.('[deeplink] Linux URL scheme handler entry current, association re-asserted', {
+      file,
+    });
+    return { status: 'unchanged', file, entry };
+  }
+
+  const mkdir = deps.mkdir ?? nodeMkdirSync;
+  const writeFile = deps.writeFile ?? nodeWriteFileSync;
+  const rename = deps.rename ?? nodeRenameSync;
+  try {
+    mkdir(dir, { recursive: true });
+    // Write-then-rename, never a direct write: rename is atomic within the directory, so a
+    // crash or a concurrent second instance can never leave a torn entry, and it REPLACES a
+    // symlink at the destination instead of following it into whatever it points at.
+    const temp = `${file}.${process.pid}.tmp`;
+    writeFile(temp, entry, 'utf8');
+    rename(temp, file);
+  } catch (err) {
+    log?.warn?.('[deeplink] could not write the .desktop entry', err);
+    return { status: 'failed', file, entry };
+  }
+
+  associate();
+  log?.info?.('[deeplink] installed the Linux URL scheme handler', { file, scheme });
+  return { status: 'installed', file, entry };
+}
+
+/**
+ * Fire-and-forget subprocess: never blocks startup, never rejects, never throws.
+ *
+ * The safety property this module rests on lives HERE, not in the callers: execFile with an
+ * ARRAY argv and NO `shell` option, so every argument reaches execve untouched and no
+ * argument can ever be re-parsed by a shell. `execFile` is imported under an alias, which
+ * means the malware scanner's call-site regex does not see this line at all (only the
+ * child_process import on line 1, which scripts/malware_scan.mjs demotes for this file) --
+ * so the test that pins these arguments is the real control against a later `shell: true`,
+ * not the scanner. execFile is injectable for exactly that test.
+ */
+function defaultRunCommand(command, args, log, execFile = nodeExecFile) {
+  try {
+    const child = execFile(command, args, { timeout: 5_000 }, (err) => {
+      if (err) log?.warn?.(`[deeplink] ${command} failed`, err);
+    });
+    child?.unref?.();
+  } catch (err) {
+    log?.warn?.(`[deeplink] could not run ${command}`, err);
+  }
+}
+
+/**
+ * The single entry point main.cjs calls, before app.setAsDefaultProtocolClient so the
+ * filename is already correct (and, on an AppImage, the file already on disk) by the time
+ * Electron runs its own xdg-settings registration.
+ */
+function registerLinuxUrlHandler(deps = {}) {
+  const install = installDesktopEntry(deps);
+  // Ordered second on purpose: it gates on the entry EXISTING, which the install above may
+  // have just created.
+  const { desktopName, restore } = configureLinuxDesktopName(deps);
+  return { desktopName, restore, ...install };
+}
+
+module.exports = {
+  SYSTEM_APPLICATIONS_DIR,
+  DESKTOP_ENTRY_BASENAME,
+  DESKTOP_ENTRY_NAME,
+  PRODUCT_NAME,
+  appImagePathFrom,
+  defaultRunCommand,
+  buildDesktopEntry,
+  configureLinuxDesktopName,
+  desktopEntryDir,
+  execArgumentFor,
+  installDesktopEntry,
+  registerLinuxUrlHandler,
+};

--- a/electron/linux_url_handler.d.cts
+++ b/electron/linux_url_handler.d.cts
@@ -1,0 +1,86 @@
+// Type declarations for the CommonJS Linux URL-scheme-handler helper
+// (electron/linux_url_handler.cjs), which electron/main.cjs invokes at runtime and
+// tests/electron_linux_url_handler.test.ts exercises directly. main.cjs itself runs outside
+// tsc; these types serve the test.
+
+export const DESKTOP_ENTRY_NAME: string;
+export const DESKTOP_ENTRY_BASENAME: string;
+export const PRODUCT_NAME: string;
+export const SYSTEM_APPLICATIONS_DIR: string;
+
+export function desktopEntryDir(env?: Record<string, string | undefined>, homeDir?: string): string;
+export function execArgumentFor(appImagePath: unknown): string | null;
+export function defaultRunCommand(
+  command: string,
+  args: string[],
+  log?: LinuxUrlHandlerLog,
+  execFile?: (
+    command: string,
+    args: string[],
+    options: Record<string, unknown>,
+    callback: (err: unknown) => void,
+  ) => { unref?(): void } | undefined,
+): void;
+export function appImagePathFrom(env?: Record<string, string | undefined>): string | null;
+export function buildDesktopEntry(entry: {
+  execArgument: unknown;
+  scheme: unknown;
+  productName: unknown;
+  tryExecPath?: string | null;
+}): string | null;
+
+export interface LinuxUrlHandlerLog {
+  info?(...args: unknown[]): void;
+  warn?(...args: unknown[]): void;
+}
+
+export interface ConfigureLinuxDesktopNameDeps {
+  platform?: string;
+  env?: Record<string, string | undefined>;
+  dir?: string;
+  homeDir?: string;
+  fileExists?: (path: string) => boolean;
+}
+export interface LinuxDesktopName {
+  desktopName: string | null;
+  restore: () => void;
+}
+export function configureLinuxDesktopName(deps?: ConfigureLinuxDesktopNameDeps): LinuxDesktopName;
+
+export type InstallDesktopEntryStatus =
+  | 'not-appimage'
+  | 'invalid-scheme'
+  | 'unsafe-dir'
+  | 'unsafe-path'
+  | 'unchanged'
+  | 'installed'
+  | 'failed';
+
+export interface InstallDesktopEntryDeps {
+  platform?: string;
+  env?: Record<string, string | undefined>;
+  scheme?: string;
+  productName?: string;
+  appImagePath?: string | null;
+  dir?: string;
+  homeDir?: string;
+  readFile?: (file: string, encoding: string) => string;
+  writeFile?: (file: string, data: string, encoding: string) => void;
+  mkdir?: (dir: string, options: { recursive: boolean }) => unknown;
+  rename?: (from: string, to: string) => void;
+  fileExists?: (path: string) => boolean;
+  runCommand?: (command: string, args: string[], log?: LinuxUrlHandlerLog) => void;
+  log?: LinuxUrlHandlerLog;
+}
+
+export interface InstallDesktopEntryResult {
+  status: InstallDesktopEntryStatus;
+  file?: string;
+  entry?: string;
+}
+
+export function installDesktopEntry(deps?: InstallDesktopEntryDeps): InstallDesktopEntryResult;
+
+export function registerLinuxUrlHandler(
+  deps?: InstallDesktopEntryDeps & ConfigureLinuxDesktopNameDeps,
+): InstallDesktopEntryResult & LinuxDesktopName;

--- a/electron/linux_url_handler.d.cts
+++ b/electron/linux_url_handler.d.cts
@@ -3,7 +3,8 @@
 // tests/electron_linux_url_handler.test.ts exercises directly. main.cjs itself runs outside
 // tsc; these types serve the test.
 
-export const DESKTOP_ENTRY_NAME: string;
+export const APPIMAGE_ENTRY_NAME: string;
+export const DEB_ENTRY_NAME: string;
 export const DESKTOP_ENTRY_BASENAME: string;
 export const PRODUCT_NAME: string;
 export const SYSTEM_APPLICATIONS_DIR: string;
@@ -78,6 +79,9 @@ export interface InstallDesktopEntryResult {
   status: InstallDesktopEntryStatus;
   file?: string;
   entry?: string;
+  /** Runs update-desktop-database and xdg-mime. MUST be called after
+   * app.setAsDefaultProtocolClient, never concurrently with it. */
+  associate: () => void;
 }
 
 export function installDesktopEntry(deps?: InstallDesktopEntryDeps): InstallDesktopEntryResult;

--- a/electron/linux_url_handler.d.cts
+++ b/electron/linux_url_handler.d.cts
@@ -65,7 +65,8 @@ export interface InstallDesktopEntryDeps {
   dir?: string;
   homeDir?: string;
   readFile?: (file: string, encoding: string) => string;
-  writeFile?: (file: string, data: string, encoding: string) => void;
+  writeFile?: (file: string, data: string, options: unknown) => void;
+  removeFile?: (file: string) => void;
   mkdir?: (dir: string, options: { recursive: boolean }) => unknown;
   rename?: (from: string, to: string) => void;
   fileExists?: (path: string) => boolean;

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -1191,17 +1191,22 @@ ipcMain.on('desktop-renderer-error', (event, payload) => {
 // xdg-settings. No-op on win32/darwin and on every non-AppImage Linux channel.
 const linuxUrlHandler = registerLinuxUrlHandler({ scheme: deepLinkProtocol, log });
 
-if (process.defaultApp) {
-  app.setAsDefaultProtocolClient(deepLinkProtocol, process.execPath, [
-    path.resolve(process.argv[1]),
-  ]);
-} else {
-  app.setAsDefaultProtocolClient(deepLinkProtocol);
-}
 // CHROME_DESKTOP is process-wide and inherited by every child, including the browser we open
-// for the Discord login itself. It exists only for the registration above, so put it back the
-// moment that call returns (no-op on win32/darwin, and when nothing was set).
-linuxUrlHandler.restore();
+// for the Discord login itself. It exists only for the registration below, so the restore runs
+// in a finally: a throw from setAsDefaultProtocolClient would otherwise leave our app identity
+// set for every child, which is the exact outcome the module documents as the reason to
+// restore it. No-op on win32/darwin, and when nothing was set.
+try {
+  if (process.defaultApp) {
+    app.setAsDefaultProtocolClient(deepLinkProtocol, process.execPath, [
+      path.resolve(process.argv[1]),
+    ]);
+  } else {
+    app.setAsDefaultProtocolClient(deepLinkProtocol);
+  }
+} finally {
+  linuxUrlHandler.restore();
+}
 
 const singleInstance = app.requestSingleInstanceLock();
 if (!singleInstance) {

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -65,6 +65,7 @@ const {
 } = require('./diagnostics.cjs');
 const { initLogging } = require('./logging.cjs');
 const { DEFAULT_SHELL_STRINGS, sanitizeShellStrings } = require('./shell_strings.cjs');
+const { registerLinuxUrlHandler } = require('./linux_url_handler.cjs');
 const { attachRendererCrashRecovery, installProcessCrashGuards } = require('./crash_guard.cjs');
 const { initUpdater } = require('./updater.cjs');
 const {
@@ -1183,6 +1184,13 @@ ipcMain.on('desktop-renderer-error', (event, payload) => {
   log.error('[renderer]', entry);
 });
 
+// Linux has no OS-level protocol registry to write: the scheme is owned by a .desktop
+// entry, which an AppImage never installs and which Electron's own registration misnames.
+// electron/linux_url_handler.cjs fixes both, and MUST run first so the file and the
+// CHROME_DESKTOP name are in place before setAsDefaultProtocolClient shells out to
+// xdg-settings. No-op on win32/darwin and on every non-AppImage Linux channel.
+const linuxUrlHandler = registerLinuxUrlHandler({ scheme: deepLinkProtocol, log });
+
 if (process.defaultApp) {
   app.setAsDefaultProtocolClient(deepLinkProtocol, process.execPath, [
     path.resolve(process.argv[1]),
@@ -1190,6 +1198,10 @@ if (process.defaultApp) {
 } else {
   app.setAsDefaultProtocolClient(deepLinkProtocol);
 }
+// CHROME_DESKTOP is process-wide and inherited by every child, including the browser we open
+// for the Discord login itself. It exists only for the registration above, so put it back the
+// moment that call returns (no-op on win32/darwin, and when nothing was set).
+linuxUrlHandler.restore();
 
 const singleInstance = app.requestSingleInstanceLock();
 if (!singleInstance) {

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -1206,6 +1206,12 @@ try {
   }
 } finally {
   linuxUrlHandler.restore();
+  // AFTER setAsDefaultProtocolClient, never alongside it. Electron's Linux path shells out to
+  // xdg-settings, which runs `xdg-mime default` itself against the same unlocked file, and a
+  // torn read there makes it restore the ORIGINAL association and fail: exactly the broken
+  // state this is meant to fix. Ours stays as the fallback for when Electron's registration
+  // does not take.
+  linuxUrlHandler.associate();
 }
 
 const singleInstance = app.requestSingleInstanceLock();

--- a/scripts/malware_scan.mjs
+++ b/scripts/malware_scan.mjs
@@ -483,11 +483,12 @@ export const RULES = [
       'written into a .desktop file, a separate threat model guarded separately in that module. ' +
       'pathSev demotes exactly those two files to medium (still visible to triage, no longer ' +
       'gate-blocking). The demotion is file-scoped, so a NEW exec added in either is demoted ' +
-      'too: re-audit their process calls on change. NOTE that the demoted files import execFile ' +
-      'under an alias, so the call-site regex never matches there and only the child_process ' +
-      'import trips; the real control on the no-shell property is the unit test that pins the ' +
-      'options object (tests/electron_linux_url_handler.test.ts). Other categories (eval, ' +
-      'egress, decode-then-execute) still trip at high in both files.',
+      'too: re-audit their process calls on change. The demotion covers the REAL CALL SITES in ' +
+      'both files, not merely the child_process import, so a scan report shows a reviewer the ' +
+      'actual spawns. What a scan cannot judge is the options object, so the control against a ' +
+      'later `shell: true` is the unit test pinning its absence ' +
+      '(tests/electron_linux_url_handler.test.ts). Other categories (eval, egress, ' +
+      'decode-then-execute) still trip at high in both files.',
     pathSev: [
       {
         re: /^electron\/gpu_preference\.cjs$/,

--- a/scripts/malware_scan.mjs
+++ b/scripts/malware_scan.mjs
@@ -468,16 +468,33 @@ export const RULES = [
     re: /\bchild_process\b|(?<![\w.])(execSync|execFileSync|execFile|spawnSync)\s*\(/,
     why: 'Shell/process execution',
     note:
-      'legit in scripts/ and server build tooling; suspicious in app code. One sanctioned ' +
-      'exception in shipped app code: electron/gpu_preference.cjs runs the Windows `reg` binary ' +
-      'with a FIXED argv (execFileSync, no shell, no user-tainted input) to pin the app to the ' +
-      'discrete GPU, so pathSev demotes exactly that file to medium (still visible to triage, no ' +
-      'longer gate-blocking). The demotion is file-scoped, so a NEW exec added there is demoted ' +
-      'too: re-audit its process calls on change. Other categories (eval, egress, decode-then-' +
-      'execute) still trip at high in that file.',
+      'legit in scripts/ and server build tooling; suspicious in app code. TWO sanctioned ' +
+      'exceptions in shipped app code, both no-shell (array argv straight to execve): ' +
+      '(1) electron/gpu_preference.cjs runs the Windows `reg` binary (execFileSync) with a ' +
+      'FIXED argv, resolved to an absolute path from SystemRoot, to pin the app to the ' +
+      'discrete GPU; (2) electron/linux_url_handler.cjs runs `update-desktop-database` and ' +
+      '`xdg-mime` (execFile, never shell:true) to register the worldofclaudecraft:// deep link ' +
+      'that carries the Discord login code. Exception 2 is the weaker of the two and is ' +
+      'described precisely on purpose: the command NAMES are literals but are resolved through ' +
+      'PATH, not absolute; one argv element is environment-derived (the XDG applications dir, ' +
+      'from XDG_DATA_HOME or HOME), checked only for absoluteness and otherwise passed as a ' +
+      'single unparsed argument; and the scheme is validated against RFC 3986 before use. The ' +
+      'AppImage path is NOT part of this rationale, since it never reaches argv at all: it is ' +
+      'written into a .desktop file, a separate threat model guarded separately in that module. ' +
+      'pathSev demotes exactly those two files to medium (still visible to triage, no longer ' +
+      'gate-blocking). The demotion is file-scoped, so a NEW exec added in either is demoted ' +
+      'too: re-audit their process calls on change. NOTE that the demoted files import execFile ' +
+      'under an alias, so the call-site regex never matches there and only the child_process ' +
+      'import trips; the real control on the no-shell property is the unit test that pins the ' +
+      'options object (tests/electron_linux_url_handler.test.ts). Other categories (eval, ' +
+      'egress, decode-then-execute) still trip at high in both files.',
     pathSev: [
       {
         re: /^electron\/gpu_preference\.cjs$/,
+        sev: 'medium',
+      },
+      {
+        re: /^electron\/linux_url_handler\.cjs$/,
         sev: 'medium',
       },
     ],

--- a/tests/electron_linux_url_handler.test.ts
+++ b/tests/electron_linux_url_handler.test.ts
@@ -1,0 +1,738 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterAll, describe, expect, it, vi } from 'vitest';
+import {
+  appImagePathFrom,
+  buildDesktopEntry,
+  configureLinuxDesktopName,
+  DESKTOP_ENTRY_BASENAME,
+  DESKTOP_ENTRY_NAME,
+  defaultRunCommand,
+  desktopEntryDir,
+  execArgumentFor,
+  installDesktopEntry,
+  PRODUCT_NAME,
+  registerLinuxUrlHandler,
+} from '../electron/linux_url_handler.cjs';
+
+const PKG = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8'));
+
+const APPIMAGE = '/home/deck/Applications/world-of-claudecraft.AppImage';
+const SCHEME = 'worldofclaudecraft';
+const APPS_DIR = '/home/deck/.local/share/applications';
+const ENTRY_PATH = `${APPS_DIR}/world-of-claudecraft.desktop`;
+
+// Built without literals so no control character ever appears in this source file.
+const NL = String.fromCharCode(10);
+const CR = String.fromCharCode(13);
+const TAB = String.fromCharCode(9);
+const DQUOTE = String.fromCharCode(34);
+
+type Ran = { command: string; args: string[] };
+
+/** An installDesktopEntry dep set with the filesystem and xdg-utils faked out. */
+function harness({
+  existing = null,
+  writeThrows = false,
+  mkdirThrows = false,
+  entryExists = false,
+  env = { APPIMAGE, HOME: '/home/deck' } as Record<string, string | undefined>,
+}: {
+  existing?: string | null;
+  writeThrows?: boolean;
+  mkdirThrows?: boolean;
+  entryExists?: boolean;
+  env?: Record<string, string | undefined>;
+} = {}) {
+  const written: { file: string; data: string }[] = [];
+  const renamed: { from: string; to: string }[] = [];
+  const dirs: { dir: string; options: unknown }[] = [];
+  const ran: Ran[] = [];
+  return {
+    written,
+    renamed,
+    dirs,
+    ran,
+    deps: {
+      platform: 'linux',
+      env,
+      scheme: SCHEME,
+      dir: APPS_DIR,
+      fileExists: () => entryExists,
+      readFile: () => {
+        if (existing === null) throw new Error('ENOENT');
+        return existing;
+      },
+      writeFile: (file: string, data: string) => {
+        if (writeThrows) throw new Error('EROFS: read-only file system');
+        written.push({ file, data });
+      },
+      rename: (from: string, to: string) => {
+        renamed.push({ from, to });
+      },
+      mkdir: (dir: string, options: unknown) => {
+        if (mkdirThrows) throw new Error('EROFS: read-only file system');
+        dirs.push({ dir, options });
+      },
+      runCommand: (command: string, args: string[]) => {
+        ran.push({ command, args });
+      },
+      log: { info: vi.fn(), warn: vi.fn() },
+    },
+  };
+}
+
+const entryFor = (execArgument: string, tryExecPath: string | null = null) =>
+  buildDesktopEntry({
+    execArgument,
+    scheme: SCHEME,
+    productName: PRODUCT_NAME,
+    tryExecPath,
+  }) as string;
+
+describe('the .desktop entry filename (a cross-package literal)', () => {
+  it('matches the basename electron-builder gives the deb', () => {
+    // electron-builder installs /usr/share/applications/<executableName>.desktop, and
+    // executableName defaults to package.json `name` lowercased (LinuxPackager). Our AppImage
+    // entry and the CHROME_DESKTOP value must both use that exact name, or the deb fix
+    // silently reverts to pointing at a file that does not exist. Derived from package.json
+    // here rather than restated, so a rename fails this test instead of shipping.
+    expect(DESKTOP_ENTRY_NAME).toBe(`${String(PKG.name).toLowerCase()}.desktop`);
+    expect(DESKTOP_ENTRY_NAME).toBe('world-of-claudecraft.desktop');
+    expect(DESKTOP_ENTRY_NAME).toBe(`${DESKTOP_ENTRY_BASENAME}.desktop`);
+  });
+
+  it('pins the electron-builder inputs that the derivation ASSUMES are unset', () => {
+    // executableName (either spelling) or desktopName + syncDesktopName would each rename the
+    // installed file WITHOUT changing package.json `name`, silently repointing CHROME_DESKTOP
+    // at nothing and re-breaking Discord login on the deb. The derivation above cannot see
+    // them, so pin their absence: setting one turns THIS red instead of shipping the bug.
+    expect(PKG.build.executableName).toBeUndefined();
+    expect(PKG.build.linux?.executableName).toBeUndefined();
+    expect(PKG.build.linux?.syncDesktopName).toBeFalsy();
+    expect(PKG.desktopName).toBeUndefined();
+  });
+
+  it('keeps the icon name tied to the same basename electron-builder installs', () => {
+    // The deb installs its icon at /usr/share/icons/hicolor/<size>/apps/<executableName>.png,
+    // so a rename that moved the entry filename but left Icon= behind ships a blank icon.
+    expect(DESKTOP_ENTRY_BASENAME).toBe(String(PKG.name).toLowerCase());
+  });
+
+  it('uses the shipping product name for the entry Name', () => {
+    expect(PRODUCT_NAME).toBe(PKG.build.productName);
+    expect(PRODUCT_NAME).toBe('World of ClaudeCraft');
+  });
+
+  it('registers the same scheme package.json declares to electron-builder', () => {
+    // The MimeType line we write and the `protocols` block electron-builder bakes into the deb
+    // entry have to name one scheme, and main.cjs's deepLinkProtocol has to be that scheme
+    // too, or the callback URL lands on a handler nobody registered.
+    expect(PKG.build.protocols[0].schemes).toContain(SCHEME);
+    const main = readFileSync(new URL('../electron/main.cjs', import.meta.url), 'utf8');
+    expect(main).toContain(`const deepLinkProtocol = '${SCHEME}';`);
+  });
+});
+
+describe('main.cjs wiring', () => {
+  const raw = readFileSync(new URL('../electron/main.cjs', import.meta.url), 'utf8');
+  // Comments are stripped before every scan below. Without this the pins are vacuous in the
+  // WORST direction: commenting the call out while debugging leaves them green, shipping a
+  // dead fix. Block comments first so a // inside one cannot resurrect the rest of the line.
+  const main = raw.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^[ \t]*\/\/.*$/gm, '');
+
+  it('installs the handler BEFORE setAsDefaultProtocolClient', () => {
+    // Ordering is the whole point: Electron's Linux registration shells out to xdg-settings
+    // with CHROME_DESKTOP, so the name must already be corrected and (on an AppImage) the file
+    // already written by the time that call runs.
+    const install = main.indexOf('registerLinuxUrlHandler({');
+    const register = main.indexOf('app.setAsDefaultProtocolClient(');
+    expect(install).toBeGreaterThan(-1);
+    expect(register).toBeGreaterThan(-1);
+    expect(install).toBeLessThan(register);
+  });
+
+  it('restores CHROME_DESKTOP AFTER the registration, never before', () => {
+    // Restoring early would defeat the registration; never restoring leaks our app identity
+    // into every child process, including the login browser.
+    const register = main.indexOf('app.setAsDefaultProtocolClient(');
+    const restore = main.indexOf('linuxUrlHandler.restore()');
+    expect(restore).toBeGreaterThan(-1);
+    expect(restore).toBeGreaterThan(register);
+  });
+
+  it('actually CALLS it, exactly once, and not from inside a comment', () => {
+    const calls = main.match(/registerLinuxUrlHandler\(/g) ?? [];
+    expect(calls).toHaveLength(1);
+    expect(main).toContain("require('./linux_url_handler.cjs')");
+  });
+
+  it('calls it at module top level, not deferred into a callback', () => {
+    // Text order is not execution order: app.whenReady().then(() => register(...)) keeps the
+    // call ABOVE setAsDefaultProtocolClient in the file while running after it. An unindented
+    // call is the cheap, robust proxy for "runs during module evaluation".
+    expect(main).toMatch(/^const linuxUrlHandler = registerLinuxUrlHandler\(\{/m);
+  });
+
+  it('passes the real deep-link scheme, not a hardcoded copy', () => {
+    expect(main).toMatch(/registerLinuxUrlHandler\(\{\s*scheme:\s*deepLinkProtocol\s*,/);
+  });
+});
+
+describe('execArgumentFor', () => {
+  it('leaves an ordinary absolute path unquoted', () => {
+    expect(execArgumentFor(APPIMAGE)).toBe(APPIMAGE);
+  });
+
+  it('quotes a path with spaces so it stays ONE Exec argument', () => {
+    // The common real case: ~/My Games/woc.AppImage. Unquoted, the desktop entry would try to
+    // run "/home/deck/My" with "Games/woc.AppImage" as an argument.
+    expect(execArgumentFor('/home/deck/My Games/woc.AppImage')).toBe(
+      `${DQUOTE}/home/deck/My Games/woc.AppImage${DQUOTE}`,
+    );
+  });
+
+  it('quotes shell-reserved characters that are legal in a filename', () => {
+    expect(execArgumentFor('/home/deck/woc (1).AppImage')).toBe(
+      `${DQUOTE}/home/deck/woc (1).AppImage${DQUOTE}`,
+    );
+  });
+
+  it('DOUBLES a literal percent, which the spec requires', () => {
+    // Launchers expand %-field-codes across the whole Exec value before shell-parsing it, and
+    // GLib drops an unrecognized %X pair outright. Left alone, ~/Downloads/WoC%20(1).AppImage
+    // launches WoC0(1).AppImage: a broken handler that we then promote to DEFAULT, which is
+    // the exact dead end this module exists to remove.
+    expect(execArgumentFor('/home/deck/WoC%20(1).AppImage')).toBe(
+      `${DQUOTE}/home/deck/WoC%%20(1).AppImage${DQUOTE}`,
+    );
+    expect(execArgumentFor('/home/deck/Games 100%/woc.AppImage')).toBe(
+      `${DQUOTE}/home/deck/Games 100%%/woc.AppImage${DQUOTE}`,
+    );
+  });
+
+  it('treats a single quote as safe by QUOTING it, never bare', () => {
+    // Safe only because it always takes the double-quoted branch, where shell parsing makes it
+    // literal. Pinned so a future widening of EXEC_BARE_SAFE cannot silently un-quote it.
+    const out = execArgumentFor("/home/deck/rocco's games/woc.AppImage");
+    expect(out).toBe(`${DQUOTE}/home/deck/rocco's games/woc.AppImage${DQUOTE}`);
+  });
+
+  it.each([
+    ['newline (would inject extra .desktop keys)', `/home/deck/woc${NL}Exec=/bin/sh.AppImage`],
+    ['carriage return', `/home/deck/woc${CR}X.AppImage`],
+    ['tab (spec-invalid control character)', `/home/deck/woc${TAB}X.AppImage`],
+    ['double quote', `/home/deck/wo${DQUOTE}c.AppImage`],
+    ['backslash (rebuilds a newline via the \\n escape)', '/home/deck/wo\\c.AppImage'],
+    ['backtick', '/home/deck/wo`c`.AppImage'],
+    ['dollar', '/home/deck/wo$HOME.AppImage'],
+  ])('refuses %s rather than escaping it', (_label, badPath) => {
+    expect(execArgumentFor(badPath)).toBeNull();
+  });
+
+  it('refuses a relative path, which would resolve against an unknown cwd', () => {
+    expect(execArgumentFor('Applications/woc.AppImage')).toBeNull();
+  });
+
+  it('refuses empty and non-string input', () => {
+    expect(execArgumentFor('')).toBeNull();
+    expect(execArgumentFor(undefined)).toBeNull();
+    expect(execArgumentFor(42)).toBeNull();
+  });
+});
+
+describe('appImagePathFrom', () => {
+  it('reads the outer AppImage path from APPIMAGE', () => {
+    expect(appImagePathFrom({ APPIMAGE })).toBe(APPIMAGE);
+  });
+
+  it('trims, which FLIPS the result from no-install to install', () => {
+    // Not a cosmetic trim: without it a padded value fails isAbsolute and the whole feature
+    // silently turns off, so the behavior difference deserves its own pin.
+    expect(appImagePathFrom({ APPIMAGE: `  ${APPIMAGE}  ` })).toBe(APPIMAGE);
+  });
+
+  it('is null off an AppImage, which is how the deb and Steam depot opt out', () => {
+    expect(appImagePathFrom({})).toBeNull();
+  });
+
+  it('rejects a relative APPIMAGE', () => {
+    expect(appImagePathFrom({ APPIMAGE: 'relative/woc.AppImage' })).toBeNull();
+  });
+});
+
+describe('desktopEntryDir', () => {
+  it('defaults to ~/.local/share/applications', () => {
+    expect(desktopEntryDir({}, '/home/deck')).toBe(APPS_DIR);
+  });
+
+  it('honors an absolute XDG_DATA_HOME', () => {
+    expect(desktopEntryDir({ XDG_DATA_HOME: '/var/data' }, '/home/deck')).toBe(
+      '/var/data/applications',
+    );
+  });
+
+  it('trims XDG_DATA_HOME instead of embedding the space in the path', () => {
+    expect(desktopEntryDir({ XDG_DATA_HOME: '/var/data ' }, '/home/deck')).toBe(
+      '/var/data/applications',
+    );
+  });
+
+  it('ignores a relative XDG_DATA_HOME, which the XDG spec calls invalid', () => {
+    expect(desktopEntryDir({ XDG_DATA_HOME: '.local/share' }, '/home/deck')).toBe(APPS_DIR);
+  });
+});
+
+describe('buildDesktopEntry', () => {
+  const entry = entryFor(APPIMAGE, APPIMAGE);
+
+  it('is pinned to its exact body', () => {
+    // A whole-string pin, not toContain: an ADDED or duplicated key (a second Exec= wins in
+    // some parsers) is exactly the regression a substring check cannot see.
+    expect(entry).toBe(
+      [
+        '[Desktop Entry]',
+        'Type=Application',
+        'Name=World of ClaudeCraft',
+        `Exec=${APPIMAGE} %u`,
+        `TryExec=${APPIMAGE}`,
+        'Icon=world-of-claudecraft',
+        'Terminal=false',
+        'Categories=Game;',
+        `MimeType=x-scheme-handler/${SCHEME};`,
+        '',
+      ].join(NL),
+    );
+  });
+
+  it('passes the URL through as argv with %u', () => {
+    // %u is what makes the clicked worldofclaudecraft:// URL reach process.argv, which is where
+    // BOTH deep-link paths in main.cjs read it from. %U (plural) or a missing code would launch
+    // the game with no URL and the login would hang forever.
+    expect(entry).toContain(`Exec=${APPIMAGE} %u`);
+  });
+
+  it('omits TryExec when the path needs quoting', () => {
+    // TryExec is a plain path key with no quoting layer, so a quoted Exec argument must not be
+    // copied into it verbatim.
+    expect(entryFor(`${DQUOTE}/a b/c.AppImage${DQUOTE}`, null)).not.toContain('TryExec');
+  });
+
+  it('is NOT NoDisplay, so it stays hand-pickable in an "open with" dialog', () => {
+    expect(entry).not.toContain('NoDisplay');
+  });
+
+  it('refuses a productName that would inject extra keys', () => {
+    // The module is exported and its safety story is "nothing unrepresentable reaches the
+    // file"; that must not depend on every future caller remembering to validate.
+    expect(
+      buildDesktopEntry({
+        execArgument: '/x',
+        scheme: SCHEME,
+        productName: `World${NL}Exec=/bin/sh`,
+      }),
+    ).toBeNull();
+  });
+
+  it.each([
+    ['a malformed scheme', { execArgument: '/x', scheme: 'not a scheme', productName: 'W' }],
+    ['an empty exec argument', { execArgument: '', scheme: SCHEME, productName: 'W' }],
+    ['a non-string exec argument', { execArgument: 42, scheme: SCHEME, productName: 'W' }],
+  ])('refuses %s', (_label, args) => {
+    expect(buildDesktopEntry(args)).toBeNull();
+  });
+});
+
+describe('installDesktopEntry', () => {
+  it('writes the entry and associates the scheme on an AppImage run', () => {
+    const h = harness();
+    const result = installDesktopEntry(h.deps);
+
+    expect(result.status).toBe('installed');
+    expect(h.written).toHaveLength(1);
+    expect(h.written[0].data).toContain(`Exec=${APPIMAGE} %u`);
+  });
+
+  it('writes to a temp file and RENAMES it into place', () => {
+    // Atomic within the directory, so a crash or a concurrent second instance can never leave
+    // a torn entry, and rename REPLACES a symlink at the destination instead of following it
+    // into whatever it points at (a planted symlink would otherwise truncate that target).
+    const h = harness();
+    installDesktopEntry(h.deps);
+
+    expect(h.written[0].file).not.toBe(ENTRY_PATH);
+    expect(h.written[0].file.startsWith(`${ENTRY_PATH}.`)).toBe(true);
+    expect(h.written[0].file.endsWith('.tmp')).toBe(true);
+    expect(h.renamed).toEqual([{ from: h.written[0].file, to: ENTRY_PATH }]);
+  });
+
+  it('creates the applications dir RECURSIVELY', () => {
+    // Without recursive, a fresh SteamOS or Bazzite home (no ~/.local/share/applications yet)
+    // throws ENOENT and the player silently gets no deep link. That is the target machine.
+    const h = harness();
+    installDesktopEntry(h.deps);
+    expect(h.dirs).toEqual([{ dir: APPS_DIR, options: { recursive: true } }]);
+  });
+
+  it('rebuilds the MIME cache AND sets the default handler', () => {
+    // Two distinct jobs: update-desktop-database makes the association visible at all, xdg-mime
+    // promotes it from candidate to default. Dropping either leaves the Discord callback
+    // landing in the "choose an application" dialog this whole module exists to fix.
+    const h = harness();
+    installDesktopEntry(h.deps);
+
+    expect(h.ran).toEqual([
+      { command: 'update-desktop-database', args: [APPS_DIR] },
+      {
+        command: 'xdg-mime',
+        args: ['default', 'world-of-claudecraft.desktop', `x-scheme-handler/${SCHEME}`],
+      },
+    ]);
+  });
+
+  it('skips the WRITE but re-asserts the ASSOCIATION when the entry already matches', () => {
+    // An unchanged file does not imply an intact association: another app can claim the scheme
+    // and a desktop environment can reset mimeapps.list. Re-asserting is what lets a stolen
+    // default heal on the next launch instead of breaking Discord login permanently.
+    const h = harness({ existing: entryFor(APPIMAGE, APPIMAGE) });
+    const result = installDesktopEntry(h.deps);
+
+    expect(result.status).toBe('unchanged');
+    expect(h.written).toEqual([]);
+    expect(h.renamed).toEqual([]);
+    expect(h.ran.map((r) => r.command)).toEqual(['update-desktop-database', 'xdg-mime']);
+  });
+
+  it('re-installs when the AppImage moved, so Exec never points at a deleted file', () => {
+    const h = harness({ existing: entryFor('/home/deck/Downloads/old.AppImage') });
+    const result = installDesktopEntry(h.deps);
+
+    expect(result.status).toBe('installed');
+    expect(h.written[0].data).toContain(`Exec=${APPIMAGE} %u`);
+  });
+
+  it.each([
+    ['a non-AppImage Linux channel (deb, Steam depot, dev run)', { platform: 'linux', env: {} }],
+    ['Windows', { platform: 'win32', env: { APPIMAGE } }],
+    ['macOS', { platform: 'darwin', env: { APPIMAGE } }],
+  ])('is a no-op on %s', (_label, overrides) => {
+    const h = harness();
+    const result = installDesktopEntry({ ...h.deps, ...overrides });
+
+    expect(result.status).toBe('not-appimage');
+    expect(h.written).toEqual([]);
+    expect(h.ran).toEqual([]);
+  });
+
+  it('refuses an AppImage path it cannot encode, and writes nothing', () => {
+    const h = harness({ env: { APPIMAGE: `/home/deck/woc${NL}Exec=/bin/sh.AppImage` } });
+    const result = installDesktopEntry(h.deps);
+
+    expect(result.status).toBe('unsafe-path');
+    expect(h.written).toEqual([]);
+    expect(h.ran).toEqual([]);
+    expect(h.deps.log.warn).toHaveBeenCalled();
+  });
+
+  it('refuses a non-absolute applications dir instead of writing under the cwd', () => {
+    // os.homedir() returns $HOME verbatim on POSIX, so a malformed HOME would otherwise land
+    // mkdir and the write on a cwd-relative tree.
+    const h = harness();
+    const result = installDesktopEntry({ ...h.deps, dir: 'relative/applications' });
+
+    expect(result.status).toBe('unsafe-dir');
+    expect(h.written).toEqual([]);
+    expect(h.ran).toEqual([]);
+  });
+
+  it.each([
+    ['a space', 'not a scheme'],
+    ['a leading digit', '1woc'],
+    ['a path separator', 'woc/../x'],
+    ['an empty string', ''],
+    ['a non-string', undefined],
+  ])('refuses a scheme with %s', (_label, scheme) => {
+    const h = harness();
+    const result = installDesktopEntry({ ...h.deps, scheme });
+
+    expect(result.status).toBe('invalid-scheme');
+    expect(h.written).toEqual([]);
+    expect(h.ran).toEqual([]);
+  });
+
+  it('ACCEPTS a legal non-trivial scheme (positive control)', () => {
+    // Without this, a regex tightened to only match the literal 'worldofclaudecraft' passes.
+    const h = harness();
+    expect(installDesktopEntry({ ...h.deps, scheme: 'x-woc.test+1' }).status).toBe('installed');
+  });
+
+  it.each([
+    ['the write fails', { writeThrows: true }],
+    ['mkdir fails first, as it does on a genuinely read-only home', { mkdirThrows: true }],
+  ])('survives when %s, and skips the xdg calls', (_label, opts) => {
+    // A failed write must never take the app down: the player can still sign in with a username
+    // and password, which never leaves the shell.
+    const h = harness(opts);
+    const result = installDesktopEntry(h.deps);
+
+    expect(result.status).toBe('failed');
+    expect(h.ran).toEqual([]);
+    expect(h.deps.log.warn).toHaveBeenCalled();
+  });
+});
+
+describe('defaultRunCommand (the real subprocess seam)', () => {
+  // Every other test injects a fake runCommand, so without these the shipped path is never
+  // exercised. It is also the ONLY control on the no-shell invariant: the module imports
+  // execFile under an alias, so the malware scanner's call-site regex does not match it, and
+  // scripts/malware_scan.mjs demotes this file's child_process import to medium. A later
+  // `shell: true` would pass the gate silently; it must fail HERE instead.
+  function capture() {
+    const calls: Array<{ command: string; args: unknown; options: Record<string, unknown> }> = [];
+    const unref = vi.fn();
+    const execFile = (
+      command: string,
+      args: string[],
+      options: Record<string, unknown>,
+      _cb: (err: unknown) => void,
+    ) => {
+      calls.push({ command, args, options });
+      return { unref };
+    };
+    return { calls, unref, execFile };
+  }
+
+  it('passes an ARRAY argv and NEVER a shell option', () => {
+    const c = capture();
+    defaultRunCommand(
+      'xdg-mime',
+      ['default', 'a.desktop', 'x-scheme-handler/woc'],
+      undefined,
+      c.execFile,
+    );
+
+    expect(c.calls).toHaveLength(1);
+    expect(c.calls[0].command).toBe('xdg-mime');
+    expect(Array.isArray(c.calls[0].args)).toBe(true);
+    expect(c.calls[0].args).toEqual(['default', 'a.desktop', 'x-scheme-handler/woc']);
+    // Absent, not merely falsy: `shell: false` would pass a truthiness check but shows someone
+    // has been editing this options object, which is exactly what should get re-reviewed.
+    expect(Object.hasOwn(c.calls[0].options, 'shell')).toBe(false);
+    expect(c.calls[0].options.timeout).toBe(5_000);
+  });
+
+  it('never interpolates the args into the command string', () => {
+    // The single-string form is what would reintroduce shell parsing of a path we do not
+    // content-check (the XDG applications dir).
+    const c = capture();
+    defaultRunCommand('update-desktop-database', [APPS_DIR], undefined, c.execFile);
+
+    expect(c.calls[0].command).toBe('update-desktop-database');
+    expect(c.calls[0].command).not.toContain('/home/deck');
+    expect(c.calls[0].command).not.toContain(' ');
+  });
+
+  it('unrefs the child so a hung xdg-utils cannot hold the app open', () => {
+    const c = capture();
+    defaultRunCommand('xdg-mime', [], undefined, c.execFile);
+    expect(c.unref).toHaveBeenCalled();
+  });
+
+  it('swallows a spawn throw and warns instead of taking the app down', () => {
+    const log = { info: vi.fn(), warn: vi.fn() };
+    const throwing = () => {
+      throw new Error('ENOENT: xdg-mime not installed');
+    };
+    expect(() => defaultRunCommand('xdg-mime', [], log, throwing)).not.toThrow();
+    expect(log.warn).toHaveBeenCalled();
+  });
+});
+
+describe('configureLinuxDesktopName', () => {
+  it('points CHROME_DESKTOP at the filename that actually exists on disk', () => {
+    // Electron infers the name from app.name ("World of ClaudeCraft.desktop"), but
+    // electron-builder names the real file after executableName. Without this correction
+    // setAsDefaultProtocolClient hands xdg-settings a name matching nothing, on the deb too.
+    const env: Record<string, string | undefined> = {
+      CHROME_DESKTOP: 'World of ClaudeCraft.desktop',
+    };
+    const out = configureLinuxDesktopName({
+      platform: 'linux',
+      env,
+      dir: APPS_DIR,
+      fileExists: () => true,
+    });
+
+    expect(out.desktopName).toBe(DESKTOP_ENTRY_NAME);
+    expect(env.CHROME_DESKTOP).toBe('world-of-claudecraft.desktop');
+  });
+
+  it('leaves CHROME_DESKTOP ALONE when no such entry exists anywhere', () => {
+    // The Steam depot, the Epic package and a dev run have no entry. Pointing xdg-settings at
+    // a dangling name there could REPLACE a working association (an AppImageLauncher entry,
+    // say) with a broken one: strictly worse than doing nothing.
+    const env: Record<string, string | undefined> = { CHROME_DESKTOP: 'other.desktop' };
+    const out = configureLinuxDesktopName({
+      platform: 'linux',
+      env,
+      dir: APPS_DIR,
+      fileExists: () => false,
+    });
+
+    expect(out.desktopName).toBeNull();
+    expect(env.CHROME_DESKTOP).toBe('other.desktop');
+  });
+
+  it('accepts the DEB entry in /usr/share/applications, not just our own', () => {
+    const env: Record<string, string | undefined> = {};
+    const seen: string[] = [];
+    const out = configureLinuxDesktopName({
+      platform: 'linux',
+      env,
+      dir: APPS_DIR,
+      fileExists: (p: string) => {
+        seen.push(p);
+        return p === `/usr/share/applications/${DESKTOP_ENTRY_NAME}`;
+      },
+    });
+
+    expect(out.desktopName).toBe(DESKTOP_ENTRY_NAME);
+    expect(seen).toContain(`/usr/share/applications/${DESKTOP_ENTRY_NAME}`);
+  });
+
+  it('restore() puts a previous value back exactly', () => {
+    const env: Record<string, string | undefined> = { CHROME_DESKTOP: 'previous.desktop' };
+    const out = configureLinuxDesktopName({
+      platform: 'linux',
+      env,
+      dir: APPS_DIR,
+      fileExists: () => true,
+    });
+    expect(env.CHROME_DESKTOP).toBe(DESKTOP_ENTRY_NAME);
+
+    out.restore();
+    expect(env.CHROME_DESKTOP).toBe('previous.desktop');
+  });
+
+  it('restore() DELETES the key when there was none, rather than leaving undefined', () => {
+    // A lingering CHROME_DESKTOP=undefined would still be inherited by children as the string
+    // "undefined" through some spawn paths; the key must genuinely go away.
+    const env: Record<string, string | undefined> = {};
+    const out = configureLinuxDesktopName({
+      platform: 'linux',
+      env,
+      dir: APPS_DIR,
+      fileExists: () => true,
+    });
+    out.restore();
+
+    expect(Object.hasOwn(env, 'CHROME_DESKTOP')).toBe(false);
+  });
+
+  it.each(['win32', 'darwin'])('leaves %s alone (no xdg-settings path there)', (platform) => {
+    const env: Record<string, string | undefined> = {};
+    const out = configureLinuxDesktopName({ platform, env, fileExists: () => true });
+
+    expect(out.desktopName).toBeNull();
+    expect(env.CHROME_DESKTOP).toBeUndefined();
+  });
+});
+
+describe('registerLinuxUrlHandler', () => {
+  it('installs the entry AND then corrects the desktop name', () => {
+    // Ordering inside the composite matters: the name check gates on the entry existing, which
+    // the install may have only just created.
+    const h = harness({ entryExists: true });
+    const result = registerLinuxUrlHandler(h.deps);
+
+    expect(result.status).toBe('installed');
+    expect(result.desktopName).toBe('world-of-claudecraft.desktop');
+    expect(h.deps.env.CHROME_DESKTOP).toBe('world-of-claudecraft.desktop');
+    result.restore();
+    expect(Object.hasOwn(h.deps.env, 'CHROME_DESKTOP')).toBe(false);
+  });
+
+  it('still corrects the desktop name on the deb, where there is no entry to write', () => {
+    const env: Record<string, string | undefined> = {};
+    const result = registerLinuxUrlHandler({
+      platform: 'linux',
+      env,
+      scheme: SCHEME,
+      dir: APPS_DIR,
+      fileExists: () => true,
+    });
+
+    expect(result.status).toBe('not-appimage');
+    expect(result.desktopName).toBe('world-of-claudecraft.desktop');
+    expect(env.CHROME_DESKTOP).toBe('world-of-claudecraft.desktop');
+  });
+
+  it('does nothing at all off Linux, and still hands back a usable restore()', () => {
+    const env: Record<string, string | undefined> = { APPIMAGE };
+    const result = registerLinuxUrlHandler({ platform: 'win32', env, scheme: SCHEME });
+
+    expect(result.status).toBe('not-appimage');
+    expect(result.desktopName).toBeNull();
+    expect(env.CHROME_DESKTOP).toBeUndefined();
+    expect(() => result.restore()).not.toThrow();
+  });
+});
+
+describe('installDesktopEntry against a REAL filesystem', () => {
+  // Everything above injects fs, so the production default layer (desktopEntryDir from
+  // XDG_DATA_HOME, real mkdir/write/rename) is otherwise never executed. This exercises it end
+  // to end with only the subprocesses faked.
+  const root = mkdtempSync(path.join(tmpdir(), 'woc-urlhandler-'));
+  afterAll(() => rmSync(root, { recursive: true, force: true }));
+
+  const ran: Ran[] = [];
+  const deps = {
+    platform: 'linux',
+    scheme: SCHEME,
+    env: { APPIMAGE, XDG_DATA_HOME: root },
+    runCommand: (command: string, args: string[]) => ran.push({ command, args }),
+    log: { info: vi.fn(), warn: vi.fn() },
+  };
+  const expectedFile = path.join(root, 'applications', DESKTOP_ENTRY_NAME);
+
+  it('derives the path from XDG_DATA_HOME and really creates the file', () => {
+    const result = installDesktopEntry(deps);
+
+    expect(result.status).toBe('installed');
+    expect(result.file).toBe(expectedFile);
+    expect(existsSync(expectedFile)).toBe(true);
+    expect(readFileSync(expectedFile, 'utf8')).toContain(`Exec=${APPIMAGE} %u`);
+    // The default productName, which main.cjs never passes, reaches the real file.
+    expect(readFileSync(expectedFile, 'utf8')).toContain(`Name=${PRODUCT_NAME}`);
+  });
+
+  it('leaves no temp file behind', () => {
+    const { readdirSync } = require('node:fs');
+    expect(
+      readdirSync(path.join(root, 'applications')).filter((f: string) => f.endsWith('.tmp')),
+    ).toEqual([]);
+  });
+
+  it('is idempotent on a second run against the file it just wrote', () => {
+    ran.length = 0;
+    const result = installDesktopEntry(deps);
+
+    expect(result.status).toBe('unchanged');
+    // Still re-asserts the association, which is the self-heal path.
+    expect(ran.map((r) => r.command)).toEqual(['update-desktop-database', 'xdg-mime']);
+  });
+
+  it('REPLACES a symlink at the destination instead of writing through it', () => {
+    // A same-uid process could plant a symlink here; a plain write would truncate its target.
+    const { symlinkSync, unlinkSync } = require('node:fs');
+    const victim = path.join(root, 'victim.txt');
+    writeFileSync(victim, 'untouched', 'utf8');
+    unlinkSync(expectedFile);
+    symlinkSync(victim, expectedFile);
+
+    expect(installDesktopEntry(deps).status).toBe('installed');
+    expect(readFileSync(victim, 'utf8')).toBe('untouched');
+    expect(readFileSync(expectedFile, 'utf8')).toContain('[Desktop Entry]');
+  });
+});

--- a/tests/electron_linux_url_handler.test.ts
+++ b/tests/electron_linux_url_handler.test.ts
@@ -36,21 +36,25 @@ function harness({
   existing = null,
   writeThrows = false,
   mkdirThrows = false,
+  renameThrows = false,
   entryExists = false,
   env = { APPIMAGE, HOME: '/home/deck' } as Record<string, string | undefined>,
 }: {
   existing?: string | null;
   writeThrows?: boolean;
   mkdirThrows?: boolean;
+  renameThrows?: boolean;
   entryExists?: boolean;
   env?: Record<string, string | undefined>;
 } = {}) {
-  const written: { file: string; data: string }[] = [];
+  const written: { file: string; data: string; options: unknown }[] = [];
+  const removed: string[] = [];
   const renamed: { from: string; to: string }[] = [];
   const dirs: { dir: string; options: unknown }[] = [];
   const ran: Ran[] = [];
   return {
     written,
+    removed,
     renamed,
     dirs,
     ran,
@@ -64,12 +68,16 @@ function harness({
         if (existing === null) throw new Error('ENOENT');
         return existing;
       },
-      writeFile: (file: string, data: string) => {
+      writeFile: (file: string, data: string, options: unknown) => {
         if (writeThrows) throw new Error('EROFS: read-only file system');
-        written.push({ file, data });
+        written.push({ file, data, options });
       },
       rename: (from: string, to: string) => {
+        if (renameThrows) throw new Error('EXDEV: cross-device link');
         renamed.push({ from, to });
+      },
+      removeFile: (file: string) => {
+        removed.push(file);
       },
       mkdir: (dir: string, options: unknown) => {
         if (mkdirThrows) throw new Error('EROFS: read-only file system');
@@ -153,13 +161,15 @@ describe('main.cjs wiring', () => {
     expect(install).toBeLessThan(register);
   });
 
-  it('restores CHROME_DESKTOP AFTER the registration, never before', () => {
-    // Restoring early would defeat the registration; never restoring leaks our app identity
-    // into every child process, including the login browser.
+  it('restores CHROME_DESKTOP after the registration, from a finally', () => {
+    // Restoring early would defeat the registration; not restoring at all leaks our app
+    // identity into every child, including the login browser. A finally makes it hold even if
+    // setAsDefaultProtocolClient throws, which is the case a plain trailing call misses.
     const register = main.indexOf('app.setAsDefaultProtocolClient(');
     const restore = main.indexOf('linuxUrlHandler.restore()');
     expect(restore).toBeGreaterThan(-1);
     expect(restore).toBeGreaterThan(register);
+    expect(main).toMatch(/\}\s*finally\s*\{\s*linuxUrlHandler\.restore\(\);\s*\}/);
   });
 
   it('actually CALLS it, exactly once, and not from inside a comment', () => {
@@ -298,6 +308,7 @@ describe('buildDesktopEntry', () => {
         `Exec=${APPIMAGE} %u`,
         `TryExec=${APPIMAGE}`,
         'Icon=world-of-claudecraft',
+        'StartupWMClass=World of ClaudeCraft',
         'Terminal=false',
         'Categories=Game;',
         `MimeType=x-scheme-handler/${SCHEME};`,
@@ -313,10 +324,26 @@ describe('buildDesktopEntry', () => {
     expect(entry).toContain(`Exec=${APPIMAGE} %u`);
   });
 
-  it('omits TryExec when the path needs quoting', () => {
-    // TryExec is a plain path key with no quoting layer, so a quoted Exec argument must not be
-    // copied into it verbatim.
-    expect(entryFor(`${DQUOTE}/a b/c.AppImage${DQUOTE}`, null)).not.toContain('TryExec');
+  it('carries TryExec for a path with spaces, UNQUOTED', () => {
+    // TryExec is a plain path key, not an Exec line: no field codes, no shell parsing, so a
+    // space needs no treatment and the quoted Exec form must NOT be copied into it. Gating this
+    // on the unquoted-safe set dropped TryExec for exactly the paths most likely to go stale,
+    // which is where a launcher most needs it to skip a dead entry.
+    const spaced = '/home/deck/My Games/woc.AppImage';
+    const entry = entryFor(`${DQUOTE}${spaced}${DQUOTE}`, spaced);
+    expect(entry).toContain(`TryExec=${spaced}`);
+    expect(entry).toContain(`Exec=${DQUOTE}${spaced}${DQUOTE} %u`);
+  });
+
+  it('refuses a tryExecPath it could not represent', () => {
+    expect(
+      buildDesktopEntry({
+        execArgument: '/x',
+        scheme: SCHEME,
+        productName: PRODUCT_NAME,
+        tryExecPath: `/x${NL}Exec=/bin/sh`,
+      }),
+    ).toBeNull();
   });
 
   it('is NOT NoDisplay, so it stays hand-pickable in an "open with" dialog', () => {
@@ -365,6 +392,49 @@ describe('installDesktopEntry', () => {
     expect(h.written[0].file.startsWith(`${ENTRY_PATH}.`)).toBe(true);
     expect(h.written[0].file.endsWith('.tmp')).toBe(true);
     expect(h.renamed).toEqual([{ from: h.written[0].file, to: ENTRY_PATH }]);
+  });
+
+  it('writes TryExec even when the AppImage path needs QUOTING in Exec', () => {
+    // The decisive level for this: the bug was installDesktopEntry deciding what to hand
+    // buildDesktopEntry, not buildDesktopEntry itself, so asserting on the built string alone
+    // cannot see it. A spaced path is quoted in Exec and must still appear bare in TryExec.
+    const spaced = '/home/deck/My Games/woc.AppImage';
+    const h = harness({ env: { APPIMAGE: spaced, HOME: '/home/deck' } });
+    installDesktopEntry(h.deps);
+
+    expect(h.written[0].data).toContain(`TryExec=${spaced}`);
+    expect(h.written[0].data).toContain(`Exec=${DQUOTE}${spaced}${DQUOTE} %u`);
+  });
+
+  it('writes TryExec for a path carrying a percent, which Exec has to escape', () => {
+    const pct = '/home/deck/Games 100%/woc.AppImage';
+    const h = harness({ env: { APPIMAGE: pct, HOME: '/home/deck' } });
+    installDesktopEntry(h.deps);
+
+    // Escaped in Exec (field codes), literal in TryExec (plain path key).
+    expect(h.written[0].data).toContain(
+      `Exec=${DQUOTE}/home/deck/Games 100%%/woc.AppImage${DQUOTE} %u`,
+    );
+    expect(h.written[0].data).toContain(`TryExec=${pct}`);
+  });
+
+  it('creates the temp file EXCLUSIVELY, so a planted symlink is an error not a write', () => {
+    // rename already protects the destination (it replaces rather than follows), but the temp
+    // path is predictable, so 'wx' is what stops a same-user process aiming it at another file.
+    const h = harness();
+    installDesktopEntry(h.deps);
+    expect(h.written[0].options).toEqual({ encoding: 'utf8', flag: 'wx' });
+  });
+
+  it('cleans up the temp file when the rename fails', () => {
+    // Otherwise a failed rename leaves a .tmp behind in the applications directory that nothing
+    // ever removes, and the next launch writes another one.
+    const h = harness({ renameThrows: true });
+    const result = installDesktopEntry(h.deps);
+
+    expect(result.status).toBe('failed');
+    expect(h.removed).toEqual([h.written[0].file]);
+    expect(h.ran).toEqual([]);
   });
 
   it('creates the applications dir RECURSIVELY', () => {

--- a/tests/electron_linux_url_handler.test.ts
+++ b/tests/electron_linux_url_handler.test.ts
@@ -3,11 +3,12 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterAll, describe, expect, it, vi } from 'vitest';
 import {
+  APPIMAGE_ENTRY_NAME,
   appImagePathFrom,
   buildDesktopEntry,
   configureLinuxDesktopName,
+  DEB_ENTRY_NAME,
   DESKTOP_ENTRY_BASENAME,
-  DESKTOP_ENTRY_NAME,
   defaultRunCommand,
   desktopEntryDir,
   execArgumentFor,
@@ -21,7 +22,7 @@ const PKG = JSON.parse(readFileSync(new URL('../package.json', import.meta.url),
 const APPIMAGE = '/home/deck/Applications/world-of-claudecraft.AppImage';
 const SCHEME = 'worldofclaudecraft';
 const APPS_DIR = '/home/deck/.local/share/applications';
-const ENTRY_PATH = `${APPS_DIR}/world-of-claudecraft.desktop`;
+const ENTRY_PATH = `${APPS_DIR}/world-of-claudecraft-appimage.desktop`;
 
 // Built without literals so no control character ever appears in this source file.
 const NL = String.fromCharCode(10);
@@ -106,9 +107,19 @@ describe('the .desktop entry filename (a cross-package literal)', () => {
     // entry and the CHROME_DESKTOP value must both use that exact name, or the deb fix
     // silently reverts to pointing at a file that does not exist. Derived from package.json
     // here rather than restated, so a rename fails this test instead of shipping.
-    expect(DESKTOP_ENTRY_NAME).toBe(`${String(PKG.name).toLowerCase()}.desktop`);
-    expect(DESKTOP_ENTRY_NAME).toBe('world-of-claudecraft.desktop');
-    expect(DESKTOP_ENTRY_NAME).toBe(`${DESKTOP_ENTRY_BASENAME}.desktop`);
+    expect(DEB_ENTRY_NAME).toBe(`${String(PKG.name).toLowerCase()}.desktop`);
+    expect(DEB_ENTRY_NAME).toBe('world-of-claudecraft.desktop');
+    expect(DEB_ENTRY_NAME).toBe(`${DESKTOP_ENTRY_BASENAME}.desktop`);
+  });
+
+  it('does NOT reuse the deb basename for the entry it writes', () => {
+    // Same basename means the same desktop-file ID, and XDG first-match makes a user-level file
+    // win outright, so one AppImage run would replace the deb's entry everywhere it is looked
+    // up. With TryExec that becomes a silent removal: delete the AppImage and the launcher
+    // refuses the entry, so a deb-installed game disappears from the menu and the scheme
+    // resolves to nothing, unfixable by `apt reinstall` because the file is in $HOME.
+    expect(APPIMAGE_ENTRY_NAME).not.toBe(DEB_ENTRY_NAME);
+    expect(APPIMAGE_ENTRY_NAME).toBe('world-of-claudecraft-appimage.desktop');
   });
 
   it('pins the electron-builder inputs that the derivation ASSUMES are unset', () => {
@@ -169,7 +180,9 @@ describe('main.cjs wiring', () => {
     const restore = main.indexOf('linuxUrlHandler.restore()');
     expect(restore).toBeGreaterThan(-1);
     expect(restore).toBeGreaterThan(register);
-    expect(main).toMatch(/\}\s*finally\s*\{\s*linuxUrlHandler\.restore\(\);\s*\}/);
+    expect(main).toMatch(
+      /\}\s*finally\s*\{\s*linuxUrlHandler\.restore\(\);\s*linuxUrlHandler\.associate\(\);\s*\}/,
+    );
   });
 
   it('actually CALLS it, exactly once, and not from inside a comment', () => {
@@ -434,6 +447,7 @@ describe('installDesktopEntry', () => {
 
     expect(result.status).toBe('failed');
     expect(h.removed).toEqual([h.written[0].file]);
+    result.associate();
     expect(h.ran).toEqual([]);
   });
 
@@ -450,13 +464,18 @@ describe('installDesktopEntry', () => {
     // promotes it from candidate to default. Dropping either leaves the Discord callback
     // landing in the "choose an application" dialog this whole module exists to fix.
     const h = harness();
-    installDesktopEntry(h.deps);
+    const result = installDesktopEntry(h.deps);
 
+    // Nothing has run yet: the caller owns the timing, so it can keep it clear of Electron's
+    // own xdg-settings pass (see the module comment on the shared unlocked file).
+    expect(h.ran).toEqual([]);
+
+    result.associate();
     expect(h.ran).toEqual([
       { command: 'update-desktop-database', args: [APPS_DIR] },
       {
         command: 'xdg-mime',
-        args: ['default', 'world-of-claudecraft.desktop', `x-scheme-handler/${SCHEME}`],
+        args: ['default', 'world-of-claudecraft-appimage.desktop', `x-scheme-handler/${SCHEME}`],
       },
     ]);
   });
@@ -471,7 +490,11 @@ describe('installDesktopEntry', () => {
     expect(result.status).toBe('unchanged');
     expect(h.written).toEqual([]);
     expect(h.renamed).toEqual([]);
-    expect(h.ran.map((r) => r.command)).toEqual(['update-desktop-database', 'xdg-mime']);
+
+    result.associate();
+    // Only xdg-mime: the bytes did not change, so the MIME cache already describes this entry
+    // and rebuilding it would be a subprocess spent on nothing.
+    expect(h.ran.map((r) => r.command)).toEqual(['xdg-mime']);
   });
 
   it('re-installs when the AppImage moved, so Exec never points at a deleted file', () => {
@@ -492,6 +515,8 @@ describe('installDesktopEntry', () => {
 
     expect(result.status).toBe('not-appimage');
     expect(h.written).toEqual([]);
+    expect(typeof result.associate).toBe('function');
+    result.associate();
     expect(h.ran).toEqual([]);
   });
 
@@ -501,6 +526,7 @@ describe('installDesktopEntry', () => {
 
     expect(result.status).toBe('unsafe-path');
     expect(h.written).toEqual([]);
+    result.associate();
     expect(h.ran).toEqual([]);
     expect(h.deps.log.warn).toHaveBeenCalled();
   });
@@ -513,6 +539,7 @@ describe('installDesktopEntry', () => {
 
     expect(result.status).toBe('unsafe-dir');
     expect(h.written).toEqual([]);
+    result.associate();
     expect(h.ran).toEqual([]);
   });
 
@@ -528,6 +555,7 @@ describe('installDesktopEntry', () => {
 
     expect(result.status).toBe('invalid-scheme');
     expect(h.written).toEqual([]);
+    result.associate();
     expect(h.ran).toEqual([]);
   });
 
@@ -547,6 +575,7 @@ describe('installDesktopEntry', () => {
     const result = installDesktopEntry(h.deps);
 
     expect(result.status).toBe('failed');
+    result.associate();
     expect(h.ran).toEqual([]);
     expect(h.deps.log.warn).toHaveBeenCalled();
   });
@@ -603,7 +632,10 @@ describe('defaultRunCommand (the real subprocess seam)', () => {
     expect(c.calls[0].command).not.toContain(' ');
   });
 
-  it('unrefs the child so a hung xdg-utils cannot hold the app open', () => {
+  it('unrefs the child, and bounds it with a timeout', () => {
+    // The timeout is what actually bounds a hang: execFile with a callback keeps the stdout and
+    // stderr pipes ref'd, so unref on the process handle does not by itself release the loop.
+    // Both are asserted because both are deliberate.
     const c = capture();
     defaultRunCommand('xdg-mime', [], undefined, c.execFile);
     expect(c.unref).toHaveBeenCalled();
@@ -634,8 +666,8 @@ describe('configureLinuxDesktopName', () => {
       fileExists: () => true,
     });
 
-    expect(out.desktopName).toBe(DESKTOP_ENTRY_NAME);
-    expect(env.CHROME_DESKTOP).toBe('world-of-claudecraft.desktop');
+    expect(out.desktopName).toBe(APPIMAGE_ENTRY_NAME);
+    expect(env.CHROME_DESKTOP).toBe('world-of-claudecraft-appimage.desktop');
   });
 
   it('leaves CHROME_DESKTOP ALONE when no such entry exists anywhere', () => {
@@ -663,12 +695,14 @@ describe('configureLinuxDesktopName', () => {
       dir: APPS_DIR,
       fileExists: (p: string) => {
         seen.push(p);
-        return p === `/usr/share/applications/${DESKTOP_ENTRY_NAME}`;
+        return p === `/usr/share/applications/${DEB_ENTRY_NAME}`;
       },
     });
 
-    expect(out.desktopName).toBe(DESKTOP_ENTRY_NAME);
-    expect(seen).toContain(`/usr/share/applications/${DESKTOP_ENTRY_NAME}`);
+    // Reports the DEB's name here, not ours: we never wrote a user-level entry on this box, so
+    // pointing CHROME_DESKTOP at our filename would name a file that does not exist.
+    expect(out.desktopName).toBe(DEB_ENTRY_NAME);
+    expect(seen).toContain(`/usr/share/applications/${DEB_ENTRY_NAME}`);
   });
 
   it('restore() puts a previous value back exactly', () => {
@@ -679,7 +713,7 @@ describe('configureLinuxDesktopName', () => {
       dir: APPS_DIR,
       fileExists: () => true,
     });
-    expect(env.CHROME_DESKTOP).toBe(DESKTOP_ENTRY_NAME);
+    expect(env.CHROME_DESKTOP).toBe(APPIMAGE_ENTRY_NAME);
 
     out.restore();
     expect(env.CHROME_DESKTOP).toBe('previous.desktop');
@@ -717,8 +751,8 @@ describe('registerLinuxUrlHandler', () => {
     const result = registerLinuxUrlHandler(h.deps);
 
     expect(result.status).toBe('installed');
-    expect(result.desktopName).toBe('world-of-claudecraft.desktop');
-    expect(h.deps.env.CHROME_DESKTOP).toBe('world-of-claudecraft.desktop');
+    expect(result.desktopName).toBe('world-of-claudecraft-appimage.desktop');
+    expect(h.deps.env.CHROME_DESKTOP).toBe('world-of-claudecraft-appimage.desktop');
     result.restore();
     expect(Object.hasOwn(h.deps.env, 'CHROME_DESKTOP')).toBe(false);
   });
@@ -730,10 +764,12 @@ describe('registerLinuxUrlHandler', () => {
       env,
       scheme: SCHEME,
       dir: APPS_DIR,
-      fileExists: () => true,
+      // Only the deb's system entry exists on this box; we never wrote a user-level one.
+      fileExists: (p: string) => p === `/usr/share/applications/${DEB_ENTRY_NAME}`,
     });
 
     expect(result.status).toBe('not-appimage');
+    // The DEB's name: on that channel we never write an entry, so ours would not exist.
     expect(result.desktopName).toBe('world-of-claudecraft.desktop');
     expect(env.CHROME_DESKTOP).toBe('world-of-claudecraft.desktop');
   });
@@ -764,7 +800,7 @@ describe('installDesktopEntry against a REAL filesystem', () => {
     runCommand: (command: string, args: string[]) => ran.push({ command, args }),
     log: { info: vi.fn(), warn: vi.fn() },
   };
-  const expectedFile = path.join(root, 'applications', DESKTOP_ENTRY_NAME);
+  const expectedFile = path.join(root, 'applications', APPIMAGE_ENTRY_NAME);
 
   it('derives the path from XDG_DATA_HOME and really creates the file', () => {
     const result = installDesktopEntry(deps);
@@ -789,8 +825,10 @@ describe('installDesktopEntry against a REAL filesystem', () => {
     const result = installDesktopEntry(deps);
 
     expect(result.status).toBe('unchanged');
-    // Still re-asserts the association, which is the self-heal path.
-    expect(ran.map((r) => r.command)).toEqual(['update-desktop-database', 'xdg-mime']);
+    result.associate();
+    // Still re-asserts the association (the self-heal path), but only the part that asserts
+    // anything: the bytes are unchanged, so the MIME cache already describes this entry.
+    expect(ran.map((r) => r.command)).toEqual(['xdg-mime']);
   });
 
   it('REPLACES a symlink at the destination instead of writing through it', () => {

--- a/tests/electron_linux_url_handler.test.ts
+++ b/tests/electron_linux_url_handler.test.ts
@@ -583,10 +583,9 @@ describe('installDesktopEntry', () => {
 
 describe('defaultRunCommand (the real subprocess seam)', () => {
   // Every other test injects a fake runCommand, so without these the shipped path is never
-  // exercised. It is also the ONLY control on the no-shell invariant: the module imports
-  // execFile under an alias, so the malware scanner's call-site regex does not match it, and
-  // scripts/malware_scan.mjs demotes this file's child_process import to medium. A later
-  // `shell: true` would pass the gate silently; it must fail HERE instead.
+  // exercised. It is also the control on the no-shell invariant: the scanner DOES see this call
+  // (it reports linux_url_handler.cjs at the execFile line, demoted to medium), but it cannot
+  // judge the OPTIONS object, so a later `shell: true` would pass the gate. It must fail HERE.
   function capture() {
     const calls: Array<{ command: string; args: unknown; options: Record<string, unknown> }> = [];
     const unref = vi.fn();
@@ -657,6 +656,7 @@ describe('configureLinuxDesktopName', () => {
     // electron-builder names the real file after executableName. Without this correction
     // setAsDefaultProtocolClient hands xdg-settings a name matching nothing, on the deb too.
     const env: Record<string, string | undefined> = {
+      APPIMAGE,
       CHROME_DESKTOP: 'World of ClaudeCraft.desktop',
     };
     const out = configureLinuxDesktopName({
@@ -705,8 +705,53 @@ describe('configureLinuxDesktopName', () => {
     expect(seen).toContain(`/usr/share/applications/${DEB_ENTRY_NAME}`);
   });
 
+  it.each([
+    ['an AppImage run picks OURS', { APPIMAGE }, APPIMAGE_ENTRY_NAME],
+    ['a deb run picks THEIRS, even with ours present', {}, DEB_ENTRY_NAME],
+  ])('%s when both entries exist', (_label, env, expected) => {
+    // The channel decides, not merely which file exists. Preferring ours unconditionally made a
+    // deb launch hand xdg-settings the AppImage's filename, so the deb player's scheme resolved
+    // to the AppImage and TryExec finished it off once that AppImage was deleted. Same
+    // shadowing the distinct filename prevents, reached through CHROME_DESKTOP instead.
+    const out = configureLinuxDesktopName({
+      platform: 'linux',
+      env: env as Record<string, string | undefined>,
+      dir: APPS_DIR,
+      fileExists: () => true,
+    });
+    expect(out.desktopName).toBe(expected);
+  });
+
+  it('a deb run with ONLY a stale AppImage entry registers nothing', () => {
+    // The dangerous shape: the player tried the AppImage once, then installed the deb. Naming
+    // our entry here would point the deb's scheme at a file it does not own and cannot repair.
+    const env: Record<string, string | undefined> = {};
+    const out = configureLinuxDesktopName({
+      platform: 'linux',
+      env,
+      dir: APPS_DIR,
+      fileExists: (p: string) => p.includes('-appimage.desktop'),
+    });
+
+    expect(out.desktopName).toBeNull();
+    expect(env.CHROME_DESKTOP).toBeUndefined();
+  });
+
+  it('an AppImage run falls back to the deb entry when ours is missing', () => {
+    const out = configureLinuxDesktopName({
+      platform: 'linux',
+      env: { APPIMAGE },
+      dir: APPS_DIR,
+      fileExists: (p: string) => p === `/usr/share/applications/${DEB_ENTRY_NAME}`,
+    });
+    expect(out.desktopName).toBe(DEB_ENTRY_NAME);
+  });
+
   it('restore() puts a previous value back exactly', () => {
-    const env: Record<string, string | undefined> = { CHROME_DESKTOP: 'previous.desktop' };
+    const env: Record<string, string | undefined> = {
+      APPIMAGE,
+      CHROME_DESKTOP: 'previous.desktop',
+    };
     const out = configureLinuxDesktopName({
       platform: 'linux',
       env,

--- a/tests/malware_scan.test.ts
+++ b/tests/malware_scan.test.ts
@@ -342,20 +342,48 @@ describe('malware_scan: path-aware severity priors', () => {
     expect(effectiveSeverity(cpRule, 'scripts/perf_tour.mjs')).toBe('low');
     expect(effectiveSeverity(cpRule, 'tests/foo.test.ts')).toBe('low');
   });
-  it('demotes child_process to medium ONLY at the desktop GPU-preference helper', () => {
+  it('demotes child_process to medium ONLY at the two reviewed desktop shell helpers', () => {
     // electron/gpu_preference.cjs runs `reg` with a fixed argv to force the discrete GPU.
     expect(effectiveSeverity(cpRule, 'electron/gpu_preference.cjs')).toBe('medium');
-    // Same-directory neighbors stay HIGH; the exception is exactly one file wide.
+    // electron/linux_url_handler.cjs runs update-desktop-database + xdg-mime (execFile, no
+    // shell) to register the deep link that carries the Discord login code back to the shell.
+    expect(effectiveSeverity(cpRule, 'electron/linux_url_handler.cjs')).toBe('medium');
+    // Same-directory neighbors stay HIGH; the exception is exactly two files wide.
     expect(effectiveSeverity(cpRule, 'electron/main.cjs')).toBe('high');
     expect(effectiveSeverity(cpRule, 'electron/steam.cjs')).toBe('high');
     expect(effectiveSeverity(cpRule, 'electron/gpu_preference.ts')).toBe('high');
-    // The exempt path list is load-bearing: widening the regex or appending a second
+    expect(effectiveSeverity(cpRule, 'electron/linux_url_handler.ts')).toBe('high');
+    // The exempt path list is load-bearing: widening a regex or appending a THIRD
     // pathSev entry must show up as a test diff (same standard as the redact.ts pin).
     const cp = cpRule as { pathSev?: Array<{ re: RegExp; sev: string }> };
-    expect(cp.pathSev).toHaveLength(1);
-    expect(cp.pathSev?.[0].re.source).toBe('^electron\\/gpu_preference\\.cjs$');
-    expect(cp.pathSev?.[0].re.flags).toBe('');
-    expect(cp.pathSev?.[0].sev).toBe('medium');
+    expect(cp.pathSev).toHaveLength(2);
+    expect(cp.pathSev?.map((p) => p.re.source)).toEqual([
+      '^electron\\/gpu_preference\\.cjs$',
+      '^electron\\/linux_url_handler\\.cjs$',
+    ]);
+    expect(cp.pathSev?.map((p) => p.re.flags)).toEqual(['', '']);
+    expect(cp.pathSev?.map((p) => p.sev)).toEqual(['medium', 'medium']);
+  });
+
+  it('the URL-handler demotion does not blind the other rce / exfil rules there', () => {
+    // Same standard the GPU helper is held to: only process execution is demoted, and only
+    // in this one file. Inert string probes handed to scanText, never executed.
+    const inHandler = { path: 'electron/linux_url_handler.cjs' };
+    const highHits = (text: string) =>
+      (scanText(text, inHandler) as Array<{ severity: string; category: string }>).filter(
+        (f) => f.severity === 'high',
+      );
+    expect(highHits('eval(payload);').length).toBeGreaterThan(0);
+    expect(highHits('const c = atob(blob); eval(c);').length).toBeGreaterThan(0);
+    expect(highHits("fs.readFileSync('/home/u/.ssh/id_rsa');").length).toBeGreaterThan(0);
+    // The process-execution hit itself is medium, present, never silently dropped.
+    const execHits = scanText("execFile('xdg-mime', args);", inHandler) as Array<{
+      severity: string;
+      category: string;
+    }>;
+    expect(execHits.some((f) => f.category === 'rce-obfuscation' && f.severity === 'medium')).toBe(
+      true,
+    );
   });
   it('the GPU-helper demotion does not blind the other rce / exfil rules there', () => {
     const inHelper = { path: 'electron/gpu_preference.cjs' };


### PR DESCRIPTION
## Summary

Discord login is broken for every Linux AppImage player, and has been since the desktop
build shipped. The OAuth callback redirects to `worldofclaudecraft://desktop-login?code=...`,
nothing on the system owns that scheme, and the player lands in an "open with" dialog that
cannot select an AppImage at all. There is no workaround from inside the app; the only way in
today is a username and password.

Two independent causes, both silent:

1. **The AppImage installs no `.desktop` entry.** electron-builder does emit a correct one
   (`Exec` plus `MimeType=x-scheme-handler/worldofclaudecraft`, from the top-level `protocols`
   block), but it is sealed inside the squashfs and is only ever installed if the player has
   AppImageLauncher. SteamOS, Bazzite, and a plain "download and chmod +x" have neither. The
   `.deb` is unaffected: dpkg installs its copy and runs `update-desktop-database`.

2. **`app.setAsDefaultProtocolClient` is a no-op on Linux, for the deb too.** Electron resolves
   the name it hands `xdg-settings` from `CHROME_DESKTOP`, and with no `desktopName` in
   `package.json` it infers one from `app.name` (`World of ClaudeCraft.desktop`) while
   electron-builder names the real file after `executableName`
   (`world-of-claudecraft.desktop`). The name never matched anything on disk.

## How it works

`electron/linux_url_handler.cjs` runs immediately before `app.setAsDefaultProtocolClient`:

- On an AppImage run it writes `~/.local/share/applications/world-of-claudecraft.desktop`
  (built from `env.APPIMAGE`, since `process.execPath` lives in a FUSE mount that dies with the
  process), then runs `update-desktop-database` and `xdg-mime default`.
- On both Linux channels it repoints `CHROME_DESKTOP` at the filename that actually exists, then
  restores it once the registration returns.
- Off Linux, and on every non-AppImage channel, it is inert.

Deliberate narrowings, each guarding against making something worse:

- `CHROME_DESKTOP` is set **only when the entry exists** (ours or the deb's). Setting it
  unconditionally would make a Steam depot, an Epic package, or a dev run point `xdg-settings`
  at a dangling name, which can replace a working association with a broken one.
- It is **restored immediately**, because it is process-wide and inherited by every child,
  including the browser opened for the Discord login itself. Chromium reads `CHROME_DESKTOP` for
  its own shell integration.
- The entry is written **temp-then-rename**: atomic within the directory, and it replaces a
  symlink at the destination rather than following it.
- An unchanged entry still **re-asserts the association**. The file being byte-identical does not
  mean the association survived; another app can claim the scheme and a desktop environment can
  reset `mimeapps.list`. Without the re-assert that breaks login permanently, with no relaunch
  that recovers it.
- A literal `%` in the path is escaped to `%%`. Launchers expand field codes across the whole
  `Exec` value before shell-parsing and GLib drops an unrecognized `%X` pair, so
  `~/Downloads/WoC%20(1).AppImage` would otherwise launch `WoC0(1).AppImage` and be promoted to
  default: the same dead end, made sticky.
- Not `app.setDesktopName()`, the public API for the same value: it also drives the Wayland app
  id and X11 `WM_CLASS`, which electron-builder independently writes as `StartupWMClass` from
  `productName`. Changing one without the other would break window-to-launcher association that
  works today. That is a packaging-level change for another PR.

Everything is best-effort and returns a status rather than throwing: a player with no
`xdg-utils` or a read-only home still gets a working game.

`scripts/malware_scan.mjs` gains a second `pathSev` exception for the new file (`execFile`,
never `shell: true`), with its pin widened in `tests/malware_scan.test.ts` and the rationale
recorded in `docs/security/malware-scan-catalog.md` and the release auditor's instructions, as
the catalog's own "extending" step requires.

## Related issues

N/A

## Type of change

- [x] Bug fix
- [x] Tests
- [x] Documentation

## How was this tested?

- Commands: `npx vitest run tests/electron_linux_url_handler.test.ts` (77 tests),
  `npx vitest run tests/malware_scan.test.ts` (88), plus `architecture`, `monolith_budget`,
  `electron_builder_config`, `electron_gpu_preference`, `desktop_uninstall_cleanup`
  (415 total). `npx tsc --noEmit` clean, `npm run ci:changed` exit 0,
  `npm run security:gate` PASS.
- Manual steps: built a website-channel x86_64 AppImage against production and ran it on a
  **Steam Deck on stock SteamOS**, no prior install, no AppImageLauncher.
  - Before: `xdg-mime query default x-scheme-handler/worldofclaudecraft` returned **empty**, and
    `~/.local/share/applications` had no entry. Bug reproduced on real hardware.
  - After first launch: entry written with `Exec=... %u` and the `MimeType` line, no temp file
    left behind, `xdg-mime query default` returns `world-of-claudecraft.desktop`, and
    `gio mime x-scheme-handler/worldofclaudecraft` lists it as default, registered, and
    recommended.
  - `gio open "worldofclaudecraft://desktop-login?code=..."` launches the app; the
    single-instance lock hands off correctly (secondary instances start and quit, primary
    survives). Relaunch logs the `entry current, association re-asserted` self-heal path.
  - Decisive check: the entry's `Exec` was temporarily swapped for a probe recording its argv.
    The launcher passed exactly one element, `worldofclaudecraft://desktop-login?code=ARGV-PROOF-42&extra=x`,
    complete with query string. That is what both deep-link paths in `main.cjs` read.

**Not verified end to end:** an intentionally invalid code fired at the running app surfaced no
UI error. Delivery is proven all the way into the app's argv; the final hop
(`handleDeepLink` -> `deliverLoginCode` -> renderer exchange) is pre-existing code shared with
Windows and macOS and was not exercised with a real Discord account.

**Two notes for anyone re-running this locally:** `xdg-open` is broken on SteamOS independently
of this change (it takes the KDE branch and calls `kfmclient`, which is not installed), so test
with `gio open`, which is what GTK browsers use. And the test AppImage had to be built with
electron-builder's static-runtime toolset because the legacy FUSE2 toolset ships an x86_64-only
`mksquashfs` that cannot run on an arm64 mac host; CI builds on Linux and is unaffected.

## Screenshots / recordings

N/A, no visual surface changes.
