### PR TITLE
perf(server): aggregate account-wealth escrow totals inside Postgres

### DIFF
--- a/server/account_wealth.ts
+++ b/server/account_wealth.ts
@@ -1,9 +1,16 @@
 // The account-wealth sweep: the logic half over account_wealth_db.ts (which
-// owns the SQL). Parses the per-realm mail and market blobs into per-character
-// escrow totals (pure, unit-tested directly), orchestrates one refresh pass,
-// runs the self-clocked sweep loop, and owns the TTL cache the top-holders
-// endpoint reads through. See account_wealth_db.ts's header for why the totals
-// are materialised at all.
+// owns the SQL). Orchestrates one refresh pass (purse totals, then the
+// SQL-aggregated escrow totals), runs the self-clocked sweep loop, and owns
+// the TTL cache the top-holders endpoint reads through. See
+// account_wealth_db.ts's header for why the totals are materialised at all.
+//
+// The escrow aggregation runs INSIDE Postgres (aggregateEscrowTotals): the
+// per-realm mail and market blobs never travel to Node, so a pass costs the
+// main thread nothing proportional to the size of the books. The pure Node
+// fold below (escrowTotalsFromStateRows) is retained ONLY as the parity
+// oracle for that SQL: it defines the semantics, its unit tests keep the
+// spec executable in CI, and tests/account_wealth_pg_integration.test.ts
+// pins the SQL against it on a shared fixture. It is not on the sweep path.
 
 import type {
   AccountPurseRefreshCounts,
@@ -57,6 +64,12 @@ export function parseEscrowStateKey(
 }
 
 /**
+ * THE PARITY ORACLE, not the sweep path: the sweep aggregates in SQL
+ * (account_wealth_db.ts aggregateEscrowTotals), and this fold is the
+ * executable definition that SQL is pinned against
+ * (tests/account_wealth_pg_integration.test.ts). Keep the two in lockstep:
+ * any semantic change lands in BOTH, same change.
+ *
  * Fold the mail and market blobs into per-character escrow totals. Keys follow
  * the market sellerKey convention: a stable character id string, with legacy
  * pre-rekey saves possibly still keyed by character NAME (resolved against the
@@ -117,7 +130,9 @@ export function escrowTotalsFromStateRows(rows: EscrowStateRow[]): EscrowCharact
 /** The db functions one refresh pass needs, injectable for pool-less tests. */
 export interface AccountWealthSweepDeps {
   refreshAccountPurseTotals(): Promise<AccountPurseRefreshCounts>;
-  listEscrowStateRows(): Promise<EscrowStateRow[]>;
+  /** The SQL-side escrow aggregation (account_wealth_db.ts): per-character
+   *  totals computed inside Postgres, never the blobs themselves. */
+  aggregateEscrowTotals(): Promise<EscrowCharacterTotal[]>;
   /** Resolves to the number of stale escrow rows zeroed. */
   applyEscrowTotals(totals: EscrowCharacterTotal[]): Promise<number>;
   // The cross-process guard (account_wealth_db.ts withAccountWealthSweepLock):
@@ -134,18 +149,17 @@ export interface AccountWealthRefreshSummary {
   staleEscrowZeroed: number;
 }
 
-/** One full refresh: purse totals in SQL, then the Node-parsed escrow pass.
- *  Callers other than tests reach it through the sweep loop, which wraps every
- *  pass in the cross-process lock. */
+/** One full refresh: purse totals in SQL, then the SQL-aggregated escrow
+ *  pass. Callers other than tests reach it through the sweep loop, which
+ *  wraps every pass in the cross-process lock. */
 export async function refreshAccountWealth(
   deps: Pick<
     AccountWealthSweepDeps,
-    'refreshAccountPurseTotals' | 'listEscrowStateRows' | 'applyEscrowTotals'
+    'refreshAccountPurseTotals' | 'aggregateEscrowTotals' | 'applyEscrowTotals'
   >,
 ): Promise<AccountWealthRefreshSummary> {
   const purse = await deps.refreshAccountPurseTotals();
-  const rows = await deps.listEscrowStateRows();
-  const totals = escrowTotalsFromStateRows(rows);
+  const totals = await deps.aggregateEscrowTotals();
   const staleEscrowZeroed = await deps.applyEscrowTotals(totals);
   return {
     purseRowsChanged: purse.rowsChanged,

--- a/server/account_wealth.ts
+++ b/server/account_wealth.ts
@@ -68,7 +68,13 @@ export function parseEscrowStateKey(
  * (account_wealth_db.ts aggregateEscrowTotals), and this fold is the
  * executable definition that SQL is pinned against
  * (tests/account_wealth_pg_integration.test.ts). Keep the two in lockstep:
- * any semantic change lands in BOTH, same change.
+ * any semantic change lands in BOTH, same change. Two deliberate SQL-side
+ * divergences, both outside any real blob: a copper value at or past
+ * Number.MAX_SAFE_INTEGER + 1 is SKIPPED by the SQL (this fold would
+ * mis-sum it in doubles and applyEscrowTotals would then abort on the
+ * bigint cast, so skipping is the arm that keeps the sweep alive), and a
+ * key padded with exotic Unicode whitespace stays name-keyed in SQL where
+ * String.trim would strip it (the SQL trims the ASCII whitespace set).
  *
  * Fold the mail and market blobs into per-character escrow totals. Keys follow
  * the market sellerKey convention: a stable character id string, with legacy

--- a/server/account_wealth_db.ts
+++ b/server/account_wealth_db.ts
@@ -147,14 +147,88 @@ export interface EscrowStateRow {
   data: unknown;
 }
 
-/** Every realm's mail and market blob (the escrow inputs the sweep parses in
- *  Node). The retained bare legacy 'market' rollback row does not match the
- *  'market:%' pattern and is deliberately excluded. */
-export async function listEscrowStateRows(): Promise<EscrowStateRow[]> {
-  const res = await pool.query(
-    `SELECT key, data FROM world_state WHERE key LIKE 'mail:%' OR key LIKE 'market:%'`,
+// Number.MAX_SAFE_INTEGER, the id-key bound the retired Node fold enforced via
+// Number.isSafeInteger; the SQL arm must draw the identical line so a key just
+// past it stays name-resolved on both sides.
+const MAX_SAFE_INTEGER_SQL = '9007199254740991';
+
+/** Per-character escrow totals aggregated INSIDE Postgres. The jsonb
+ *  expansion of every realm's mail and market blob never leaves the database:
+ *  the result set is proportional to the number of distinct recipients with
+ *  escrowed copper, never to the size of the books (the production mail row
+ *  has been 89 MB; shipping and JSON.parse-ing it in Node blocked the world
+ *  loop for hundreds of ms every sweep tick).
+ *
+ *  Semantics mirror the Node fold `escrowTotalsFromStateRows` exactly (that
+ *  fold is retained in server/account_wealth.ts as the parity oracle, pinned
+ *  by tests/account_wealth_pg_integration.test.ts): realm is everything after
+ *  the key's first colon; the bare legacy 'market' rollback row does not
+ *  match 'market:%' and is excluded; a letter or collection entry counts only
+ *  when its recipient key is a string and its copper is a number whose floor
+ *  is at least 1; keys are trimmed and the house-stock '' key is skipped;
+ *  an all-digit key within Number.MAX_SAFE_INTEGER resolves by character id
+ *  (merged across realms), anything else stays a realm-scoped legacy name.
+ *
+ *  Both expansions scan every realm's blobs, so the read rides the heavy
+ *  allowance like refreshAccountPurseTotals. The CASE around each
+ *  jsonb_array_elements input is load-bearing: the lateral evaluates before
+ *  any WHERE guard could, and a malformed blob whose 'mail'/'collections' is
+ *  not an array must yield zero rows, not fail the whole sweep. */
+export async function aggregateEscrowTotals(): Promise<EscrowCharacterTotal[]> {
+  const res = await runWithStatementTimeout(DB_HEAVY_STATEMENT_TIMEOUT_MS, (query) =>
+    query(
+      `WITH entries AS (
+         SELECT substr(w.key, strpos(w.key, ':') + 1) AS realm,
+                btrim(elem->>'recipientKey') AS raw_key,
+                floor((elem->>'copper')::numeric)::bigint AS copper,
+                true AS is_mail
+         FROM world_state w
+         CROSS JOIN LATERAL jsonb_array_elements(
+           CASE WHEN jsonb_typeof(w.data->'mail') = 'array' THEN w.data->'mail' END
+         ) AS elem
+         WHERE w.key LIKE 'mail:%'
+           AND jsonb_typeof(elem->'recipientKey') = 'string'
+           AND jsonb_typeof(elem->'copper') = 'number'
+           AND floor((elem->>'copper')::numeric) >= 1
+         UNION ALL
+         SELECT substr(w.key, strpos(w.key, ':') + 1),
+                btrim(elem->>'key'),
+                floor((elem->>'copper')::numeric)::bigint,
+                false
+         FROM world_state w
+         CROSS JOIN LATERAL jsonb_array_elements(
+           CASE WHEN jsonb_typeof(w.data->'collections') = 'array' THEN w.data->'collections' END
+         ) AS elem
+         WHERE w.key LIKE 'market:%'
+           AND jsonb_typeof(elem->'key') = 'string'
+           AND jsonb_typeof(elem->'copper') = 'number'
+           AND floor((elem->>'copper')::numeric) >= 1
+       ),
+       keyed AS (
+         SELECT CASE WHEN raw_key ~ '^[0-9]+$' AND raw_key::numeric <= ${MAX_SAFE_INTEGER_SQL}
+                     THEN (raw_key::numeric)::bigint END AS character_id,
+                realm, raw_key, copper, is_mail
+         FROM entries
+         WHERE raw_key <> ''
+       )
+       SELECT character_id,
+              CASE WHEN character_id IS NULL THEN raw_key END AS character_name,
+              CASE WHEN character_id IS NULL THEN realm END AS realm,
+              COALESCE(sum(copper) FILTER (WHERE is_mail), 0)::bigint AS mail_copper,
+              COALESCE(sum(copper) FILTER (WHERE NOT is_mail), 0)::bigint AS market_copper
+       FROM keyed
+       GROUP BY character_id,
+                CASE WHEN character_id IS NULL THEN raw_key END,
+                CASE WHEN character_id IS NULL THEN realm END`,
+    ),
   );
-  return res.rows.map((row) => ({ key: row.key, data: row.data }));
+  return res.rows.map((row) => ({
+    characterId: row.character_id === null ? null : Number(row.character_id),
+    characterName: row.character_name ?? null,
+    realm: row.realm ?? null,
+    mailCopper: Number(row.mail_copper),
+    marketCopper: Number(row.market_copper),
+  }));
 }
 
 /** Per-character escrow totals resolved by stable character id, or (for legacy

--- a/server/account_wealth_db.ts
+++ b/server/account_wealth_db.ts
@@ -200,10 +200,14 @@ export async function aggregateEscrowTotals(): Promise<EscrowCharacterTotal[]> {
     //   same must-not-abort rule for absurd stored values that would
     //   overflow the bigint pipeline (the retired Node fold would have
     //   mis-summed those in doubles and then failed in applyEscrowTotals).
-    // - The id-key test is a NESTED CASE, never an AND: PostgreSQL does not
-    //   guarantee short-circuit order, and the regex must bound the digits
-    //   (leading zeros aside, 16 significant digits) before the ::numeric
-    //   cast may run.
+    // - The id-key test and the copper guard are both CASE-armored, never
+    //   bare AND chains: PostgreSQL does not guarantee AND evaluation order,
+    //   so the digit-bounding regex must run before raw_key's ::numeric cast
+    //   (leading zeros aside, 16 significant digits), and copper's
+    //   jsonb_typeof check must run before its cast (a non-number copper
+    //   would otherwise abort the whole sweep if the planner ever reordered
+    //   the quals). CASE is the one construct whose evaluation order is
+    //   guaranteed.
     return query(
       `WITH books AS (
          SELECT realm, true AS is_mail,
@@ -222,15 +226,18 @@ export async function aggregateEscrowTotals(): Promise<EscrowCharacterTotal[]> {
                   CASE WHEN b.is_mail THEN elem->>'recipientKey' ELSE elem->>'key' END,
                   E' \\t\\n\\r\\f\\v'
                 ) AS raw_key,
-                floor((elem->>'copper')::numeric)::bigint AS copper
+                floor(cn.copper_numeric)::bigint AS copper
          FROM books b
          CROSS JOIN LATERAL jsonb_array_elements(b.arr) AS elem
+         CROSS JOIN LATERAL (
+           SELECT CASE WHEN jsonb_typeof(elem->'copper') = 'number'
+                       THEN (elem->>'copper')::numeric END AS copper_numeric
+         ) cn
          WHERE jsonb_typeof(
                  CASE WHEN b.is_mail THEN elem->'recipientKey' ELSE elem->'key' END
                ) = 'string'
-           AND jsonb_typeof(elem->'copper') = 'number'
-           AND (elem->>'copper')::numeric >= 1
-           AND (elem->>'copper')::numeric < 9007199254740992
+           AND cn.copper_numeric >= 1
+           AND cn.copper_numeric < 9007199254740992
        ),
        keyed AS (
          SELECT CASE WHEN raw_key ~ '^0*[0-9]{1,16}$' THEN

--- a/server/account_wealth_db.ts
+++ b/server/account_wealth_db.ts
@@ -152,6 +152,17 @@ export interface EscrowStateRow {
 // past it stays name-resolved on both sides.
 const MAX_SAFE_INTEGER_SQL = '9007199254740991';
 
+// The one-statement work_mem raise for the escrow aggregate. Measured on a
+// 134k-letter, 103 MB book (PostgreSQL 16): at the stock 4 MB the pass
+// spills ~145 MB of temp-file writes and re-reads every tick (690 ms); at
+// 128 MB the sort fits but the expansion tuplestore still spills ~107 MB
+// (565 ms); at 256 MB nothing spills (500 ms). A book grown past the bound
+// degrades back to a graceful spill, never a failure. Safe to hold: exactly
+// one statement runs under it per pass, and the sweep is globally serialized
+// across realm processes by the advisory lock, so the allocation can never
+// multiply.
+export const ESCROW_AGGREGATE_WORK_MEM = '256MB';
+
 /** Per-character escrow totals aggregated INSIDE Postgres. The jsonb
  *  expansion of every realm's mail and market blob never leaves the database:
  *  the result set is proportional to the number of distinct recipients with
@@ -175,38 +186,57 @@ const MAX_SAFE_INTEGER_SQL = '9007199254740991';
  *  any WHERE guard could, and a malformed blob whose 'mail'/'collections' is
  *  not an array must yield zero rows, not fail the whole sweep. */
 export async function aggregateEscrowTotals(): Promise<EscrowCharacterTotal[]> {
-  const res = await runWithStatementTimeout(DB_HEAVY_STATEMENT_TIMEOUT_MS, (query) =>
-    query(
-      `WITH entries AS (
-         SELECT substr(w.key, strpos(w.key, ':') + 1) AS realm,
-                btrim(elem->>'recipientKey') AS raw_key,
-                floor((elem->>'copper')::numeric)::bigint AS copper,
-                true AS is_mail
-         FROM world_state w
-         CROSS JOIN LATERAL jsonb_array_elements(
-           CASE WHEN jsonb_typeof(w.data->'mail') = 'array' THEN w.data->'mail' END
-         ) AS elem
-         WHERE w.key LIKE 'mail:%'
-           AND jsonb_typeof(elem->'recipientKey') = 'string'
-           AND jsonb_typeof(elem->'copper') = 'number'
-           AND floor((elem->>'copper')::numeric) >= 1
+  const res = await runWithStatementTimeout(DB_HEAVY_STATEMENT_TIMEOUT_MS, async (query) => {
+    // SET LOCAL: scoped to this transaction only (see the constant's comment).
+    await query(`SET LOCAL work_mem = '${ESCROW_AGGREGATE_WORK_MEM}'`);
+    // Statement shape notes, all load-bearing:
+    // - The inner OFFSET 0 subqueries compute each blob's array datum ONCE;
+    //   without the barrier the planner inlines the expression into both the
+    //   jsonb_typeof guard and the value use and detoasts the 89 MB blob
+    //   twice per pass.
+    // - The CASE around each jsonb_array_elements input yields NULL (zero
+    //   rows) for a malformed non-array 'mail'/'collections' instead of
+    //   failing the whole sweep; the copper upper bound below serves the
+    //   same must-not-abort rule for absurd stored values that would
+    //   overflow the bigint pipeline (the retired Node fold would have
+    //   mis-summed those in doubles and then failed in applyEscrowTotals).
+    // - The id-key test is a NESTED CASE, never an AND: PostgreSQL does not
+    //   guarantee short-circuit order, and the regex must bound the digits
+    //   (leading zeros aside, 16 significant digits) before the ::numeric
+    //   cast may run.
+    return query(
+      `WITH books AS (
+         SELECT realm, true AS is_mail,
+                CASE WHEN jsonb_typeof(arr) = 'array' THEN arr END AS arr
+         FROM (SELECT substr(w.key, strpos(w.key, ':') + 1) AS realm, w.data->'mail' AS arr
+               FROM world_state w WHERE w.key LIKE 'mail:%' OFFSET 0) m
          UNION ALL
-         SELECT substr(w.key, strpos(w.key, ':') + 1),
-                btrim(elem->>'key'),
-                floor((elem->>'copper')::numeric)::bigint,
-                false
-         FROM world_state w
-         CROSS JOIN LATERAL jsonb_array_elements(
-           CASE WHEN jsonb_typeof(w.data->'collections') = 'array' THEN w.data->'collections' END
-         ) AS elem
-         WHERE w.key LIKE 'market:%'
-           AND jsonb_typeof(elem->'key') = 'string'
+         SELECT realm, false,
+                CASE WHEN jsonb_typeof(arr) = 'array' THEN arr END
+         FROM (SELECT substr(w.key, strpos(w.key, ':') + 1) AS realm, w.data->'collections' AS arr
+               FROM world_state w WHERE w.key LIKE 'market:%' OFFSET 0) c
+       ),
+       entries AS (
+         SELECT b.realm, b.is_mail,
+                btrim(
+                  CASE WHEN b.is_mail THEN elem->>'recipientKey' ELSE elem->>'key' END,
+                  E' \\t\\n\\r\\f\\v'
+                ) AS raw_key,
+                floor((elem->>'copper')::numeric)::bigint AS copper
+         FROM books b
+         CROSS JOIN LATERAL jsonb_array_elements(b.arr) AS elem
+         WHERE jsonb_typeof(
+                 CASE WHEN b.is_mail THEN elem->'recipientKey' ELSE elem->'key' END
+               ) = 'string'
            AND jsonb_typeof(elem->'copper') = 'number'
-           AND floor((elem->>'copper')::numeric) >= 1
+           AND (elem->>'copper')::numeric >= 1
+           AND (elem->>'copper')::numeric < 9007199254740992
        ),
        keyed AS (
-         SELECT CASE WHEN raw_key ~ '^[0-9]+$' AND raw_key::numeric <= ${MAX_SAFE_INTEGER_SQL}
-                     THEN (raw_key::numeric)::bigint END AS character_id,
+         SELECT CASE WHEN raw_key ~ '^0*[0-9]{1,16}$' THEN
+                  CASE WHEN raw_key::numeric <= ${MAX_SAFE_INTEGER_SQL}
+                       THEN (raw_key::numeric)::bigint END
+                END AS character_id,
                 realm, raw_key, copper, is_mail
          FROM entries
          WHERE raw_key <> ''
@@ -220,8 +250,8 @@ export async function aggregateEscrowTotals(): Promise<EscrowCharacterTotal[]> {
        GROUP BY character_id,
                 CASE WHEN character_id IS NULL THEN raw_key END,
                 CASE WHEN character_id IS NULL THEN realm END`,
-    ),
-  );
+    );
+  });
   return res.rows.map((row) => ({
     characterId: row.character_id === null ? null : Number(row.character_id),
     characterName: row.character_name ?? null,

--- a/server/main.ts
+++ b/server/main.ts
@@ -53,8 +53,8 @@ import {
   TOP_WEALTH_HOLDERS_LIMIT,
 } from './account_wealth';
 import {
+  aggregateEscrowTotals,
   applyEscrowTotals,
-  listEscrowStateRows,
   refreshAccountPurseTotals,
   topWealthHolders,
   withAccountWealthSweepLock,
@@ -3881,7 +3881,7 @@ export async function startServer(): Promise<http.Server> {
   configureSuspicionFlagDataset(listSuspicionFlagDataset);
   const accountWealthSweep = startAccountWealthSweep({
     refreshAccountPurseTotals,
-    listEscrowStateRows,
+    aggregateEscrowTotals,
     applyEscrowTotals,
     // The sweep's queries are global, so exactly one process across all realms
     // runs a pass; losers of the advisory lock stand down until their next tick.

--- a/tests/account_wealth.test.ts
+++ b/tests/account_wealth.test.ts
@@ -125,31 +125,33 @@ describe('escrowTotalsFromStateRows', () => {
 });
 
 describe('refreshAccountWealth', () => {
-  it('runs the SQL purse pass, then folds the escrow blobs into the apply call', async () => {
+  it('runs the SQL purse pass, then feeds the SQL-aggregated totals to the apply call', async () => {
     const calls: string[] = [];
     const deps = {
       refreshAccountPurseTotals: vi.fn(async () => {
         calls.push('purses');
         return { rowsChanged: 7, orphansZeroed: 2 };
       }),
-      listEscrowStateRows: vi.fn(async () => {
-        calls.push('list');
-        return [{ key: 'mail:eastbrook', data: { mail: [{ recipientKey: '12', copper: 750 }] } }];
+      aggregateEscrowTotals: vi.fn(async () => {
+        calls.push('aggregate');
+        return [
+          { characterId: 12, characterName: null, realm: null, mailCopper: 750, marketCopper: 0 },
+        ];
       }),
       applyEscrowTotals: vi.fn(async () => {
         calls.push('apply');
         return 3;
       }),
     };
-    // The summary carries every db count plus the folded entry count, so the
-    // sweep's log line can name what the pass touched.
+    // The summary carries every db count plus the aggregated entry count, so
+    // the sweep's log line can name what the pass touched.
     await expect(refreshAccountWealth(deps)).resolves.toEqual({
       purseRowsChanged: 7,
       orphanPursesZeroed: 2,
       escrowEntries: 1,
       staleEscrowZeroed: 3,
     });
-    expect(calls).toEqual(['purses', 'list', 'apply']);
+    expect(calls).toEqual(['purses', 'aggregate', 'apply']);
     expect(deps.applyEscrowTotals).toHaveBeenCalledWith([
       { characterId: 12, characterName: null, realm: null, mailCopper: 750, marketCopper: 0 },
     ]);
@@ -186,8 +188,8 @@ describe('startAccountWealthSweep', () => {
       refreshAccountPurseTotals: vi
         .fn(async () => ({ rowsChanged: 5, orphansZeroed: 1 }))
         .mockRejectedValueOnce(new Error('transient')),
-      listEscrowStateRows: vi.fn(async () => [
-        { key: 'mail:eastbrook', data: { mail: [{ recipientKey: '12', copper: 750 }] } },
+      aggregateEscrowTotals: vi.fn(async () => [
+        { characterId: 12, characterName: null, realm: null, mailCopper: 750, marketCopper: 0 },
       ]),
       applyEscrowTotals: vi.fn(async () => 2),
       withSweepLock: vi.fn(async (run: () => Promise<void>) => {
@@ -231,7 +233,7 @@ describe('startAccountWealthSweep', () => {
     const onInfo = vi.fn();
     const deps = {
       refreshAccountPurseTotals: vi.fn(async () => ({ rowsChanged: 0, orphansZeroed: 0 })),
-      listEscrowStateRows: vi.fn(async () => []),
+      aggregateEscrowTotals: vi.fn(async () => []),
       applyEscrowTotals: vi.fn(async () => 0),
       // A losing try-lock never runs the pass and is not an error.
       withSweepLock: vi.fn(async () => false),
@@ -254,7 +256,7 @@ describe('startAccountWealthSweep', () => {
       refreshAccountPurseTotals: vi.fn(async () => {
         throw new Error('statement timeout');
       }),
-      listEscrowStateRows: vi.fn(async () => []),
+      aggregateEscrowTotals: vi.fn(async () => []),
       applyEscrowTotals: vi.fn(async () => 0),
       withSweepLock: vi.fn(async (run: () => Promise<void>) => {
         vi.advanceTimersByTime(2_000);
@@ -279,7 +281,7 @@ describe('startAccountWealthSweep', () => {
     const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
     const deps = {
       refreshAccountPurseTotals: vi.fn(async () => ({ rowsChanged: 0, orphansZeroed: 0 })),
-      listEscrowStateRows: vi.fn(async () => []),
+      aggregateEscrowTotals: vi.fn(async () => []),
       applyEscrowTotals: vi.fn(async () => 0),
       withSweepLock: vi.fn(async (run: () => Promise<void>) => {
         await run();

--- a/tests/account_wealth_db.test.ts
+++ b/tests/account_wealth_db.test.ts
@@ -179,7 +179,7 @@ describe('aggregateEscrowTotals', () => {
     // and the house-stock '' key is skipped.
     expect(sql).toMatch(/raw_key ~ '\^0\*\[0-9\]\{1,16\}\$'/);
     expect(sql).toMatch(
-      /CASE WHEN raw_key ~ [^]*THEN\s+CASE WHEN raw_key::numeric <= 9007199254740991/,
+      /CASE WHEN raw_key ~ [\s\S]*THEN\s+CASE WHEN raw_key::numeric <= 9007199254740991/,
     );
     expect(sql).toMatch(/raw_key <> ''/);
   });

--- a/tests/account_wealth_db.test.ts
+++ b/tests/account_wealth_db.test.ts
@@ -170,9 +170,16 @@ describe('aggregateEscrowTotals', () => {
     expect(sql).toMatch(/CASE WHEN jsonb_typeof\(arr\) = 'array' THEN arr END/);
     // Entry guards mirror positiveCopper + the string-key requirement, with
     // the absurd-copper upper bound that keeps the bigint pipeline alive.
-    expect(sql).toMatch(/jsonb_typeof\(elem->'copper'\) = 'number'/);
-    expect(sql).toMatch(/\(elem->>'copper'\)::numeric >= 1/);
-    expect(sql).toMatch(/\(elem->>'copper'\)::numeric < 9007199254740992/);
+    // The ::numeric cast on copper is CASE-armored behind the jsonb_typeof
+    // check (PostgreSQL guarantees no AND evaluation order, so a bare AND
+    // chain could cast a non-number copper and abort the sweep), and that
+    // guarded expression is the ONLY place the cast appears.
+    expect(sql).toMatch(
+      /CASE WHEN jsonb_typeof\(elem->'copper'\) = 'number'\s+THEN \(elem->>'copper'\)::numeric END AS copper_numeric/,
+    );
+    expect(sql.match(/\(elem->>'copper'\)::numeric/g)).toHaveLength(1);
+    expect(sql).toMatch(/cn\.copper_numeric >= 1/);
+    expect(sql).toMatch(/cn\.copper_numeric < 9007199254740992/);
     // The id-key line: a digit-bounding regex runs BEFORE the ::numeric cast
     // in a NESTED CASE (PostgreSQL guarantees no AND short-circuit order),
     // the bound is Number.MAX_SAFE_INTEGER like the oracle's isSafeInteger,

--- a/tests/account_wealth_db.test.ts
+++ b/tests/account_wealth_db.test.ts
@@ -105,6 +105,8 @@ describe('refreshAccountPurseTotals', () => {
 
 describe('aggregateEscrowTotals', () => {
   it('aggregates inside Postgres on the heavy allowance, never shipping a blob to Node', async () => {
+    // First statement under the transaction is the work_mem raise.
+    query.mockResolvedValueOnce(queryResult([]));
     query.mockResolvedValueOnce(
       queryResult([
         {
@@ -138,8 +140,13 @@ describe('aggregateEscrowTotals', () => {
     // every realm's blobs), never the bare pool default.
     expect(runWithStatementTimeout).toHaveBeenCalledTimes(1);
     expect(runWithStatementTimeout.mock.calls[0][0]).toBe(60_000);
-    expect(boundedQuery).toHaveBeenCalledTimes(1);
-    const sql = boundedQuery.mock.calls[0][0];
+    // Two statements under the one transaction: the per-statement work_mem
+    // raise (at the stock 4 MB the production-size expansion spills ~145 MB
+    // of temp file per pass; see ESCROW_AGGREGATE_WORK_MEM), then the
+    // aggregate itself.
+    expect(boundedQuery).toHaveBeenCalledTimes(2);
+    expect(boundedQuery.mock.calls[0][0]).toBe("SET LOCAL work_mem = '256MB'");
+    const sql = boundedQuery.mock.calls[1][0];
     // The core of the fix: the data column is expanded in SQL, never selected
     // whole for a Node-side parse.
     expect(sql).not.toMatch(/SELECT key, data/);
@@ -148,22 +155,32 @@ describe('aggregateEscrowTotals', () => {
     // never the bare legacy 'market' rollback row.
     expect(sql).toMatch(/key LIKE 'mail:%'/);
     expect(sql).toMatch(/key LIKE 'market:%'/);
+    // The single-detoast barrier: each blob's array datum is computed once
+    // inside an OFFSET 0 subquery, then guarded; inlining the -> into both
+    // the typeof and the value would detoast the 89 MB blob twice.
+    expect(sql).toMatch(
+      /w\.data->'mail' AS arr\s+FROM world_state w WHERE w\.key LIKE 'mail:%' OFFSET 0/,
+    );
+    expect(sql).toMatch(
+      /w\.data->'collections' AS arr\s+FROM world_state w WHERE w\.key LIKE 'market:%' OFFSET 0/,
+    );
     // The malformed-blob guard: the lateral input is CASE-guarded on
     // jsonb_typeof so a non-array 'mail'/'collections' yields zero rows
     // instead of failing the whole sweep statement.
+    expect(sql).toMatch(/CASE WHEN jsonb_typeof\(arr\) = 'array' THEN arr END/);
+    // Entry guards mirror positiveCopper + the string-key requirement, with
+    // the absurd-copper upper bound that keeps the bigint pipeline alive.
+    expect(sql).toMatch(/jsonb_typeof\(elem->'copper'\) = 'number'/);
+    expect(sql).toMatch(/\(elem->>'copper'\)::numeric >= 1/);
+    expect(sql).toMatch(/\(elem->>'copper'\)::numeric < 9007199254740992/);
+    // The id-key line: a digit-bounding regex runs BEFORE the ::numeric cast
+    // in a NESTED CASE (PostgreSQL guarantees no AND short-circuit order),
+    // the bound is Number.MAX_SAFE_INTEGER like the oracle's isSafeInteger,
+    // and the house-stock '' key is skipped.
+    expect(sql).toMatch(/raw_key ~ '\^0\*\[0-9\]\{1,16\}\$'/);
     expect(sql).toMatch(
-      /jsonb_array_elements\(\s*CASE WHEN jsonb_typeof\(w\.data->'mail'\) = 'array' THEN w\.data->'mail' END\s*\)/,
+      /CASE WHEN raw_key ~ [^]*THEN\s+CASE WHEN raw_key::numeric <= 9007199254740991/,
     );
-    expect(sql).toMatch(
-      /jsonb_array_elements\(\s*CASE WHEN jsonb_typeof\(w\.data->'collections'\) = 'array' THEN w\.data->'collections' END\s*\)/,
-    );
-    // Entry guards mirror positiveCopper + the string-key requirement.
-    expect(sql).toMatch(/jsonb_typeof\(elem->'recipientKey'\) = 'string'/);
-    expect(sql).toMatch(/jsonb_typeof\(elem->'key'\) = 'string'/);
-    expect(sql).toMatch(/floor\(\(elem->>'copper'\)::numeric\) >= 1/);
-    // The id-key line is Number.MAX_SAFE_INTEGER, same as the Node oracle's
-    // Number.isSafeInteger, and the house-stock '' key is skipped.
-    expect(sql).toMatch(/9007199254740991/);
     expect(sql).toMatch(/raw_key <> ''/);
   });
 });

--- a/tests/account_wealth_db.test.ts
+++ b/tests/account_wealth_db.test.ts
@@ -34,10 +34,10 @@ vi.mock('../server/db', () => ({
 import {
   ACCOUNT_WEALTH_SWEEP_LOCK_KEY,
   accountWealthBreakdown,
+  aggregateEscrowTotals,
   applyEscrowTotals,
   LARGE_GOLD_MOVEMENTS_TIMEOUT_MS,
   largeGoldMovementsForAccount,
-  listEscrowStateRows,
   refreshAccountPurseTotals,
   topWealthHolders,
   withAccountWealthSweepLock,
@@ -103,12 +103,68 @@ describe('refreshAccountPurseTotals', () => {
   });
 });
 
-describe('listEscrowStateRows', () => {
-  it('reads only the realm-scoped mail/market blobs (never the legacy bare row)', async () => {
-    query.mockResolvedValueOnce(queryResult([{ key: 'mail:eastbrook', data: { mail: [] } }]));
-    const rows = await listEscrowStateRows();
-    expect(rows).toEqual([{ key: 'mail:eastbrook', data: { mail: [] } }]);
-    expect(query.mock.calls[0][0]).toMatch(/key LIKE 'mail:%' OR key LIKE 'market:%'/);
+describe('aggregateEscrowTotals', () => {
+  it('aggregates inside Postgres on the heavy allowance, never shipping a blob to Node', async () => {
+    query.mockResolvedValueOnce(
+      queryResult([
+        {
+          character_id: '12',
+          character_name: null,
+          realm: null,
+          mail_copper: '750',
+          market_copper: '0',
+        },
+        {
+          character_id: null,
+          character_name: 'Oldname',
+          realm: 'eastbrook',
+          mail_copper: '0',
+          market_copper: '300',
+        },
+      ]),
+    );
+    const totals = await aggregateEscrowTotals();
+    expect(totals).toEqual([
+      { characterId: 12, characterName: null, realm: null, mailCopper: 750, marketCopper: 0 },
+      {
+        characterId: null,
+        characterName: 'Oldname',
+        realm: 'eastbrook',
+        mailCopper: 0,
+        marketCopper: 300,
+      },
+    ]);
+    // Rides the heavy allowance like the purse scan (the expansion detoasts
+    // every realm's blobs), never the bare pool default.
+    expect(runWithStatementTimeout).toHaveBeenCalledTimes(1);
+    expect(runWithStatementTimeout.mock.calls[0][0]).toBe(60_000);
+    expect(boundedQuery).toHaveBeenCalledTimes(1);
+    const sql = boundedQuery.mock.calls[0][0];
+    // The core of the fix: the data column is expanded in SQL, never selected
+    // whole for a Node-side parse.
+    expect(sql).not.toMatch(/SELECT key, data/);
+    expect(sql).toMatch(/jsonb_array_elements/);
+    // Realm scoping matches the retired Node fold: realm-keyed blobs only,
+    // never the bare legacy 'market' rollback row.
+    expect(sql).toMatch(/key LIKE 'mail:%'/);
+    expect(sql).toMatch(/key LIKE 'market:%'/);
+    // The malformed-blob guard: the lateral input is CASE-guarded on
+    // jsonb_typeof so a non-array 'mail'/'collections' yields zero rows
+    // instead of failing the whole sweep statement.
+    expect(sql).toMatch(
+      /jsonb_array_elements\(\s*CASE WHEN jsonb_typeof\(w\.data->'mail'\) = 'array' THEN w\.data->'mail' END\s*\)/,
+    );
+    expect(sql).toMatch(
+      /jsonb_array_elements\(\s*CASE WHEN jsonb_typeof\(w\.data->'collections'\) = 'array' THEN w\.data->'collections' END\s*\)/,
+    );
+    // Entry guards mirror positiveCopper + the string-key requirement.
+    expect(sql).toMatch(/jsonb_typeof\(elem->'recipientKey'\) = 'string'/);
+    expect(sql).toMatch(/jsonb_typeof\(elem->'key'\) = 'string'/);
+    expect(sql).toMatch(/floor\(\(elem->>'copper'\)::numeric\) >= 1/);
+    // The id-key line is Number.MAX_SAFE_INTEGER, same as the Node oracle's
+    // Number.isSafeInteger, and the house-stock '' key is skipped.
+    expect(sql).toMatch(/9007199254740991/);
+    expect(sql).toMatch(/raw_key <> ''/);
   });
 });
 

--- a/tests/account_wealth_pg_integration.test.ts
+++ b/tests/account_wealth_pg_integration.test.ts
@@ -1,0 +1,273 @@
+// Opt-in REAL-Postgres proof for the account-wealth escrow aggregation.
+//
+// WHY THIS FILE EXISTS. tests/account_wealth_db.test.ts pins the SQL's SHAPE
+// against a mocked pool, and tests/account_wealth.test.ts keeps the Node
+// oracle (escrowTotalsFromStateRows) executable in CI. Neither can prove the
+// jsonb expansion itself: the typeof guards against malformed blobs, the
+// safe-integer id line, the realm-scoped legacy-name merge, or the resolve
+// and upsert against real characters and accounts. This suite drives the REAL
+// exported functions against a REAL PostgreSQL 16 server with the REAL boot
+// schema, and pins the SQL aggregate byte-identical to the Node oracle on a
+// shared fixture (the acceptance criterion of the sweep rework).
+//
+// DISPOSABLE DATABASE, NEVER A SHARED ONE. Same discipline as
+// tests/guild_bank_pg_integration.test.ts: DROP and CREATE a private database
+// on the server TEST_DATABASE_URL points at, refuse to run against the URL's
+// own database, boot the real ensureSchema() into it.
+//
+// Gated on TEST_DATABASE_URL like every other *_integration.test.ts: without
+// it the file skips green and CI's DB-free floor is unchanged.
+
+import type { Pool as PgPool } from 'pg';
+import { Pool } from 'pg';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+const ADMIN_URL = process.env.TEST_DATABASE_URL;
+const VERIFY_DB = 'wocc_account_wealth_verify';
+
+function verifyUrl(admin: string): string {
+  const u = new URL(admin);
+  u.pathname = `/${VERIFY_DB}`;
+  return u.toString();
+}
+
+// server/db.ts reads DATABASE_URL at module load and builds its pool from it.
+// Nothing above is a static import of a server module, so this assignment
+// runs first and points the modules under test at the disposable database.
+if (ADMIN_URL) process.env.DATABASE_URL = verifyUrl(ADMIN_URL);
+
+const describeDb = ADMIN_URL ? describe : describe.skip;
+
+describeDb('account wealth escrow aggregation (REAL Postgres)', () => {
+  let admin: PgPool;
+  let pool: PgPool;
+  let db: typeof import('../server/db');
+  let wealthDb: typeof import('../server/account_wealth_db');
+  let wealth: typeof import('../server/account_wealth');
+  let realm: string;
+
+  let nextSeq = 0;
+  const seq = () => ++nextSeq;
+
+  async function makeAccount(): Promise<number> {
+    const res = await pool.query(
+      `INSERT INTO accounts (username, password_hash) VALUES ($1, 'x') RETURNING id`,
+      [`awverify_${seq()}`],
+    );
+    return Number(res.rows[0].id);
+  }
+
+  async function makeCharacter(
+    accountId: number,
+    name: string,
+    charRealm: string,
+  ): Promise<number> {
+    const res = await pool.query(
+      `INSERT INTO characters (account_id, name, class, realm, level, state)
+       VALUES ($1, $2, 'warrior', $3, 1, '{}'::jsonb) RETURNING id`,
+      [accountId, name, charRealm],
+    );
+    return Number(res.rows[0].id);
+  }
+
+  async function putWorldState(key: string, data: unknown): Promise<void> {
+    await pool.query(
+      `INSERT INTO world_state (key, data) VALUES ($1, $2::jsonb)
+       ON CONFLICT (key) DO UPDATE SET data = EXCLUDED.data, updated_at = now()`,
+      [key, JSON.stringify(data)],
+    );
+  }
+
+  async function wealthRow(
+    accountId: number,
+  ): Promise<{ mail: number; market: number; total: number } | null> {
+    const res = await pool.query(
+      `SELECT mail_copper, market_copper, total_copper FROM account_wealth WHERE account_id = $1`,
+      [accountId],
+    );
+    const row = res.rows[0];
+    if (!row) return null;
+    return {
+      mail: Number(row.mail_copper),
+      market: Number(row.market_copper),
+      total: Number(row.total_copper),
+    };
+  }
+
+  beforeAll(async () => {
+    admin = new Pool({ connectionString: ADMIN_URL, max: 2 });
+    const own = new URL(ADMIN_URL as string).pathname.replace(/^\//, '');
+    // Never drop the database the caller pointed us at.
+    expect(own).not.toBe(VERIFY_DB);
+    await admin.query(
+      `SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = $1 AND pid <> pg_backend_pid()`,
+      [VERIFY_DB],
+    );
+    await admin.query(`DROP DATABASE IF EXISTS ${VERIFY_DB}`);
+    await admin.query(`CREATE DATABASE ${VERIFY_DB}`);
+
+    db = await import('../server/db');
+    wealthDb = await import('../server/account_wealth_db');
+    wealth = await import('../server/account_wealth');
+    realm = (await import('../server/realm')).REALM;
+
+    await db.ensureSchema();
+
+    pool = new Pool({ connectionString: verifyUrl(ADMIN_URL as string), max: 8 });
+  }, 120_000);
+
+  afterAll(async () => {
+    await pool?.end().catch(() => {});
+    await db?.pool?.end().catch(() => {});
+    await admin?.end().catch(() => {});
+  }, 30_000);
+
+  // The full escrow lifecycle on one fixture: the SQL aggregate is pinned
+  // byte-identical to the Node oracle, then resolves and upserts through the
+  // real applyEscrowTotals, then zeroes when the books empty.
+  it('aggregates the fixture identically to the Node oracle and settles it end to end', async () => {
+    const accountA = await makeAccount();
+    const accountB = await makeAccount();
+    const accountC = await makeAccount();
+    const idKeyed = await makeCharacter(accountA, 'AwvIdKeyed', realm);
+    // Legacy name-keyed characters: names are only unique per realm, so the
+    // same name on two realms must resolve to two different accounts.
+    await makeCharacter(accountB, 'AwvOldname', realm);
+    await makeCharacter(accountC, 'AwvOldname', 'awv-frostmark');
+
+    await putWorldState(`mail:${realm}`, {
+      mail: [
+        // Ordinary id-keyed letters: sum, with a leading-zero and a padded
+        // variant merging into the same character id.
+        { recipientKey: String(idKeyed), copper: 500 },
+        { recipientKey: `0${idKeyed}`, copper: 250 },
+        { recipientKey: ` ${idKeyed} `, copper: 40 },
+        // Legacy name-keyed letter, realm-scoped.
+        { recipientKey: 'AwvOldname', copper: 300 },
+        // Floors: 2.9 counts 2; 0.9 floors to zero and is skipped.
+        { recipientKey: String(idKeyed), copper: 2.9 },
+        { recipientKey: String(idKeyed), copper: 0.9 },
+        // Skipped entirely: house key, zero, negative, non-number copper,
+        // non-string key, missing fields, null entry.
+        { recipientKey: '', copper: 100 },
+        { recipientKey: String(idKeyed), copper: 0 },
+        { recipientKey: String(idKeyed), copper: -50 },
+        { recipientKey: String(idKeyed), copper: '50' },
+        { recipientKey: 42, copper: 10 },
+        { recipientKey: String(idKeyed) },
+        null,
+        // An all-digit key past Number.MAX_SAFE_INTEGER stays name-resolved
+        // (and matches no character, so it never reaches account_wealth).
+        { recipientKey: '9007199254740993', copper: 5 },
+      ],
+    });
+    await putWorldState('mail:awv-frostmark', {
+      mail: [
+        // Id keys merge across realms; the twin name stays realm-scoped.
+        { recipientKey: String(idKeyed), copper: 5 },
+        { recipientKey: 'AwvOldname', copper: 20 },
+      ],
+    });
+    await putWorldState(`market:${realm}`, {
+      collections: [
+        { key: String(idKeyed), copper: 60 },
+        { key: 'AwvOldname', copper: 30 },
+        { key: '', copper: 999 },
+      ],
+    });
+    // Malformed blobs must contribute nothing and fail nothing.
+    await putWorldState('mail:awv-badshape', { mail: { not: 'an array' } });
+    await putWorldState('mail:awv-scalar', 'just a string');
+    // The retained bare legacy market rollback row is excluded by key shape.
+    await putWorldState('market', { collections: [{ key: String(idKeyed), copper: 77_777 }] });
+
+    // --- The parity pin: SQL aggregate == Node oracle on the same rows. ---
+    const raw = await pool.query(
+      `SELECT key, data FROM world_state WHERE key LIKE 'mail:%' OR key LIKE 'market:%'`,
+    );
+    const oracle = wealth.escrowTotalsFromStateRows(
+      raw.rows.map((row) => ({ key: row.key, data: row.data })),
+    );
+    const aggregated = await wealthDb.aggregateEscrowTotals();
+    const canon = (rows: (typeof oracle)[number][]) =>
+      [...rows].sort((a, b) =>
+        JSON.stringify([a.characterId, a.characterName, a.realm]).localeCompare(
+          JSON.stringify([b.characterId, b.characterName, b.realm]),
+        ),
+      );
+    expect(canon(aggregated)).toEqual(canon(oracle));
+
+    // Spot-check the aggregate against hand-computed sums so the parity pin
+    // can never pass by both sides being wrong the same way.
+    expect(canon(aggregated)).toEqual(
+      canon([
+        // 500 + 250 + 40 + floor(2.9) across realms (+5 frostmark) = 797.
+        {
+          characterId: idKeyed,
+          characterName: null,
+          realm: null,
+          mailCopper: 797,
+          marketCopper: 60,
+        },
+        {
+          characterId: null,
+          characterName: 'AwvOldname',
+          realm,
+          mailCopper: 300,
+          marketCopper: 30,
+        },
+        {
+          characterId: null,
+          characterName: 'AwvOldname',
+          realm: 'awv-frostmark',
+          mailCopper: 20,
+          marketCopper: 0,
+        },
+        {
+          characterId: null,
+          characterName: '9007199254740993',
+          realm,
+          mailCopper: 5,
+          marketCopper: 0,
+        },
+      ]),
+    );
+
+    // --- End to end: resolve + upsert through the real applyEscrowTotals. ---
+    await wealthDb.applyEscrowTotals(aggregated);
+    expect(await wealthRow(accountA)).toEqual({ mail: 797, market: 60, total: 857 });
+    expect(await wealthRow(accountB)).toEqual({ mail: 300, market: 30, total: 330 });
+    expect(await wealthRow(accountC)).toEqual({ mail: 20, market: 0, total: 20 });
+
+    // --- Collected books zero the escrow on the next pass. ---
+    await putWorldState(`mail:${realm}`, { mail: [] });
+    await putWorldState('mail:awv-frostmark', { mail: [] });
+    await putWorldState(`market:${realm}`, { collections: [] });
+    await wealthDb.applyEscrowTotals(await wealthDb.aggregateEscrowTotals());
+    expect(await wealthRow(accountA)).toEqual({ mail: 0, market: 0, total: 0 });
+    expect(await wealthRow(accountB)).toEqual({ mail: 0, market: 0, total: 0 });
+    expect(await wealthRow(accountC)).toEqual({ mail: 0, market: 0, total: 0 });
+  });
+
+  it('holds the parity and the sums on a large book (the flat-cost claim, sampled)', async () => {
+    const account = await makeAccount();
+    const charId = await makeCharacter(account, 'AwvBulk', realm);
+    const letters: { recipientKey: string; copper: number }[] = [];
+    let expected = 0;
+    for (let i = 0; i < 20_000; i++) {
+      // Every third letter carries copper; the rest are the item-only bulk
+      // that dominates a real book.
+      const copper = i % 3 === 0 ? (i % 97) + 1 : 0;
+      expected += copper;
+      letters.push({ recipientKey: String(charId), copper });
+    }
+    await putWorldState('mail:awv-bulk', { mail: letters });
+    const aggregated = await wealthDb.aggregateEscrowTotals();
+    const bulk = aggregated.find((t) => t.characterId === charId);
+    expect(bulk?.mailCopper).toBe(expected);
+    const oracle = wealth
+      .escrowTotalsFromStateRows([{ key: 'mail:awv-bulk', data: { mail: letters } }])
+      .find((t) => t.characterId === charId);
+    expect(bulk?.mailCopper).toBe(oracle?.mailCopper);
+  });
+});

--- a/tests/account_wealth_pg_integration.test.ts
+++ b/tests/account_wealth_pg_integration.test.ts
@@ -142,6 +142,10 @@ describeDb('account wealth escrow aggregation (REAL Postgres)', () => {
         { recipientKey: String(idKeyed), copper: 500 },
         { recipientKey: `0${idKeyed}`, copper: 250 },
         { recipientKey: ` ${idKeyed} `, copper: 40 },
+        // Control-character padding trims like String.trim on both sides,
+        // and a whitespace-only key collapses to the skipped '' key.
+        { recipientKey: `\t${idKeyed}\n`, copper: 8 },
+        { recipientKey: '\t', copper: 11 },
         // Legacy name-keyed letter, realm-scoped.
         { recipientKey: 'AwvOldname', copper: 300 },
         // Floors: 2.9 counts 2; 0.9 floors to zero and is skipped.
@@ -156,9 +160,11 @@ describeDb('account wealth escrow aggregation (REAL Postgres)', () => {
         { recipientKey: 42, copper: 10 },
         { recipientKey: String(idKeyed) },
         null,
-        // An all-digit key past Number.MAX_SAFE_INTEGER stays name-resolved
-        // (and matches no character, so it never reaches account_wealth).
+        // All-digit keys past Number.MAX_SAFE_INTEGER stay name-resolved
+        // (and match no character, so they never reach account_wealth),
+        // including one long past the SQL's 16-significant-digit regex line.
         { recipientKey: '9007199254740993', copper: 5 },
+        { recipientKey: '123456789012345678901', copper: 3 },
       ],
     });
     await putWorldState('mail:awv-frostmark', {
@@ -201,12 +207,12 @@ describeDb('account wealth escrow aggregation (REAL Postgres)', () => {
     // can never pass by both sides being wrong the same way.
     expect(canon(aggregated)).toEqual(
       canon([
-        // 500 + 250 + 40 + floor(2.9) across realms (+5 frostmark) = 797.
+        // 500 + 250 + 40 + 8 + floor(2.9) across realms (+5 frostmark) = 805.
         {
           characterId: idKeyed,
           characterName: null,
           realm: null,
-          mailCopper: 797,
+          mailCopper: 805,
           marketCopper: 60,
         },
         {
@@ -230,12 +236,19 @@ describeDb('account wealth escrow aggregation (REAL Postgres)', () => {
           mailCopper: 5,
           marketCopper: 0,
         },
+        {
+          characterId: null,
+          characterName: '123456789012345678901',
+          realm,
+          mailCopper: 3,
+          marketCopper: 0,
+        },
       ]),
     );
 
     // --- End to end: resolve + upsert through the real applyEscrowTotals. ---
     await wealthDb.applyEscrowTotals(aggregated);
-    expect(await wealthRow(accountA)).toEqual({ mail: 797, market: 60, total: 857 });
+    expect(await wealthRow(accountA)).toEqual({ mail: 805, market: 60, total: 865 });
     expect(await wealthRow(accountB)).toEqual({ mail: 300, market: 30, total: 330 });
     expect(await wealthRow(accountC)).toEqual({ mail: 20, market: 0, total: 20 });
 
@@ -247,6 +260,22 @@ describeDb('account wealth escrow aggregation (REAL Postgres)', () => {
     expect(await wealthRow(accountA)).toEqual({ mail: 0, market: 0, total: 0 });
     expect(await wealthRow(accountB)).toEqual({ mail: 0, market: 0, total: 0 });
     expect(await wealthRow(accountC)).toEqual({ mail: 0, market: 0, total: 0 });
+  });
+
+  it('skips an absurd copper value instead of aborting the sweep (deliberate oracle divergence)', async () => {
+    const account = await makeAccount();
+    const charId = await makeCharacter(account, 'AwvAbsurd', realm);
+    await putWorldState('mail:awv-absurd', {
+      mail: [
+        // At MAX_SAFE_INTEGER + 1 the bigint pipeline would abort in
+        // applyEscrowTotals even under the retired Node fold; the SQL skips
+        // the entry so the pass stays alive, and sums the sane sibling.
+        { recipientKey: String(charId), copper: 9007199254740992 },
+        { recipientKey: String(charId), copper: 25 },
+      ],
+    });
+    const aggregated = await wealthDb.aggregateEscrowTotals();
+    expect(aggregated.find((t) => t.characterId === charId)?.mailCopper).toBe(25);
   });
 
   it('holds the parity and the sums on a large book (the flat-cost claim, sampled)', async () => {

--- a/tests/account_wealth_pg_integration.test.ts
+++ b/tests/account_wealth_pg_integration.test.ts
@@ -157,6 +157,13 @@ describeDb('account wealth escrow aggregation (REAL Postgres)', () => {
         { recipientKey: String(idKeyed), copper: 0 },
         { recipientKey: String(idKeyed), copper: -50 },
         { recipientKey: String(idKeyed), copper: '50' },
+        // Non-castable coppers: '50' above would survive a ::numeric cast,
+        // so these three pin that the typeof CASE armor (not qual luck)
+        // keeps a string, object, or boolean copper from aborting the
+        // statement.
+        { recipientKey: String(idKeyed), copper: 'abc' },
+        { recipientKey: String(idKeyed), copper: { nested: true } },
+        { recipientKey: String(idKeyed), copper: true },
         { recipientKey: 42, copper: 10 },
         { recipientKey: String(idKeyed) },
         null,


### PR DESCRIPTION
## Summary

The 60-second account wealth sweep no longer ships or parses any mail or market blob in Node. Previously `listEscrowStateRows` ran `SELECT key, data FROM world_state WHERE key LIKE 'mail:%' OR key LIKE 'market:%'` and folded the blobs in the process: against the production 89 MB mail row (#3560) that was a contiguous main-thread `JSON.parse` block of roughly 400 ms once a minute, which the 20 Hz world loop paid as a stall visible in `nodejs_eventloop_lag_max_seconds`.

The escrow totals are now aggregated INSIDE Postgres (`aggregateEscrowTotals` in `server/account_wealth_db.ts`): a single statement on the heavy timeout allowance expands `data->'mail'` and `data->'collections'` with `jsonb_array_elements`, mirrors the retired Node fold's semantics exactly (trimmed keys, the skipped house `''` key, floor-and-positive copper, all-digit keys within `Number.MAX_SAFE_INTEGER` resolving by character id merged across realms, everything else a realm-scoped legacy name, the bare legacy `market` row excluded), and returns one row per distinct recipient with escrowed copper. The sweep's Node-side cost is now proportional to that result set, never to book size. `applyEscrowTotals` and the sweep loop, lock, and one-line summary are unchanged.

The Node fold `escrowTotalsFromStateRows` is retained as the parity oracle: its unit tests keep the semantics executable in CI, and a new opt-in real-Postgres suite (`tests/account_wealth_pg_integration.test.ts`, gated on `TEST_DATABASE_URL`) pins the SQL byte-identical to the oracle on a fixture covering the edge cases (leading-zero and whitespace-padded keys, unsafe-integer and 21-digit keys, fractional/zero/negative/non-number copper, non-string keys, malformed and scalar blobs, multi-realm same-name characters), then runs the resolve/upsert/zero cycle end to end and a 20k-letter book.

A database-performance review with measured evidence shaped the final statement:

- `SET LOCAL work_mem = '256MB'` for this one statement. Measured on a 134k-letter, 103 MB book (PostgreSQL 16): stock 4 MB spills ~145 MB of temp file per pass (690 ms); 128 MB still spills the ~107 MB expansion tuplestore (565 ms); 256 MB spills nothing (500 ms). One statement per pass, globally serialized by the sweep's advisory lock, so the allocation cannot multiply; a book grown past the bound degrades to a graceful spill, never a failure. (Numbers are from a dev machine, not the production host; the shape, not the absolute, is the claim.)
- Each blob's array datum is computed once behind an `OFFSET 0` barrier (inlining the `->` into both the `jsonb_typeof` guard and the value detoasts the 89 MB blob twice).
- The id-key test is a digit-bounded regex (`^0*[0-9]{1,16}$`) inside a NESTED `CASE` before the `::numeric` cast (PostgreSQL does not guarantee `AND` short-circuit order), so no key can abort the sweep.
- Copper values at or past `Number.MAX_SAFE_INTEGER + 1` are skipped rather than aborting the bigint pipeline (a deliberate, documented divergence: the old fold would have mis-summed them in doubles and then failed inside `applyEscrowTotals` anyway).

## Related issues

Fixes the "account wealth sweep parses every realm's mail and market blob in Node every 60 seconds" report. Same whole-book family as #3560/#3561; the 30 s autosave arm remains #3561's.

## Type of change

- [x] Bug fix (performance defect on the world loop)
- [x] Refactor or performance

## How was this tested?

- Commands:
  - `GATE_SELECT_BASE=origin/release/v0.40.1 node scripts/gate_select.mjs` (green)
  - `npx vitest run tests/account_wealth.test.ts tests/account_wealth_db.test.ts` (29 passing: sweep loop, SQL-shape pins including the work_mem raise, oracle semantics)
  - `TEST_DATABASE_URL=... npx vitest run tests/account_wealth_pg_integration.test.ts` (3 passing against real PostgreSQL 16: oracle parity, end-to-end settle and zero, absurd-copper robustness, 20k-letter book)
  - Bench (134k letters, 103 MB, PG 16): see the numbers above; `EXPLAIN (ANALYZE, BUFFERS)` at 4/128/256 MB work_mem.
  - `npx tsc --noEmit` (clean)
- Manual steps: N/A (server-only; the sweep's log line and admin surfaces are unchanged)

---

## Checklist

### Quality

- [x] **The gate passes.** Decisive tests added for the aggregate, the parity contract, and every review finding.

### Cross-platform

- ~Tested on desktop and mobile.~ N/A: no UI change.

### Localization (i18n)

- [x] N/A. No player-visible strings (the sweep log line is dev-channel and unchanged).

### Hygiene

- [x] No secrets committed; no generated files hand-edited; `ALLOW_DEV_COMMANDS` untouched.
