### PR TITLE
fix(desktop): let the GPU process start under Steam's overlay on Linux

### DIFF
--- a/docs/desktop-release.md
+++ b/docs/desktop-release.md
@@ -394,7 +394,6 @@ Linux AppImage caveat: the updater requires the `APPIMAGE` env (set automaticall
 when running a real AppImage); running the raw unpacked binary logs an updater error
 and skips, by design.
 
-
 ## Steam
 
 Build: `npm run electron:build:steam` on each OS runner (signing env still applies on

--- a/docs/desktop-release.md
+++ b/docs/desktop-release.md
@@ -394,38 +394,6 @@ Linux AppImage caveat: the updater requires the `APPIMAGE` env (set automaticall
 when running a real AppImage); running the raw unpacked binary logs an updater error
 and skips, by design.
 
-Steam-on-Linux caveat: Steam preloads `gameoverlayrenderer.so` into every native Linux game
-it launches, and with that library mapped Chromium's GPU process cannot start. The browser
-process retries, gives up, and dies on a `CHECK`:
-
-```
-FATAL:content/browser/gpu/gpu_data_manager_impl_private.cc] GPU process isn't usable. Goodbye.
-```
-
-`SIGTRAP`, no window, no `main.log`. To a player that is Steam's launching spinner, forever.
-`electron/steam_overlay_guard.cjs` appends `--disable-gpu-sandbox` when, and only when, the
-overlay is actually preloaded. Measured on a Steam Deck with the overlay in place: no flags
-crashes; `--disable-gpu-sandbox`, `--no-sandbox` and `--in-process-gpu` all boot. The narrowest
-one ships, because the RENDERER sandbox is the boundary that contains page content and it stays
-on. It boots on real hardware rather than falling back to software (3 runs of 3 reported the
-Deck's AMD adapter `0x1002:0x1435` active, with `webgl`, `gpu_compositing` and `rasterization`
-all `enabled`), which is the thing to re-check if this is ever changed: a "fix" that silently
-swapped in SwiftShader would be worse than the crash.
-
-Two things that look like fixes and are not, both measured rather than assumed:
-- **Stripping the overlay from `LD_PRELOAD`.** It cannot be done from inside the app, since
-  `ld.so` reads the variable at exec time. Every shape of re-exec fails: a detached parent exits
-  at once and Steam reads that as the game closing; a parent blocked in `spawnSync` cannot run a
-  signal handler, and the child lands in its own `app-world-of-claudecraft-<pid>.scope` while the
-  parent stays in `app-steam@autostart.service`, so Steam's stop kills the parent and strands the
-  game; a supervising parent can forward signals but is itself an Electron process with the
-  overlay mapped, so it dies of the crash it exists to avoid.
-- **Turning the overlay off in Steam.** It does not stop the injection. With `AllowOverlay=0` on
-  the shortcut, Steam still handed the launch both `gameoverlayrenderer.so` paths. Do not ship a
-  Linux depot betting on the Steamworks per-app overlay setting.
-
-Verify a Steam launch by grepping `main.log` for `[steam] Steam overlay detected`. This applies
-to the Steam depot channel as much as to a non-Steam shortcut, since Steam injects either way.
 
 ## Steam
 
@@ -473,6 +441,51 @@ Rules that keep this working:
   updates flow through Steam; keep it that way.
 - `steam_appid.txt` is not needed (`electron/steam.cjs` passes the app id
   straight to `init`) and must not ship.
+
+Steam-on-Linux caveat: Steam preloads `gameoverlayrenderer.so` into every native Linux game
+it launches, and with that library mapped Chromium's GPU process cannot start. The browser
+process retries, gives up, and dies on a `CHECK`:
+
+```
+FATAL:content/browser/gpu/gpu_data_manager_impl_private.cc] GPU process isn't usable. Goodbye.
+```
+
+`SIGTRAP`, no window, no `main.log`. To a player that is Steam's launching spinner, forever.
+`electron/steam_overlay_guard.cjs` appends `--disable-gpu-sandbox` when, and only when, the
+overlay is actually preloaded. Measured on a Steam Deck with the overlay in place: no flags
+crashes; `--disable-gpu-sandbox`, `--no-sandbox` and `--in-process-gpu` all boot. The narrowest
+one ships, because the RENDERER sandbox is the boundary that contains page content and it stays
+on. It boots on real hardware rather than falling back to software (3 runs of 3 reported the
+Deck's AMD adapter `0x1002:0x1435` active, with `webgl`, `gpu_compositing` and `rasterization`
+all `enabled`), which is the thing to re-check if this is ever changed: a "fix" that silently
+swapped in SwiftShader would be worse than the crash.
+
+Two things that look like fixes and are not, both measured rather than assumed:
+- **Stripping the overlay from `LD_PRELOAD`.** It cannot be done from inside the app, since
+  `ld.so` reads the variable at exec time. Every shape of re-exec fails: a detached parent exits
+  at once and Steam reads that as the game closing; a parent blocked in `spawnSync` cannot run a
+  signal handler, and the child lands in its own `app-world-of-claudecraft-<pid>.scope` while the
+  parent stays in `app-steam@autostart.service`, so Steam's stop kills the parent and strands the
+  game; a supervising parent can forward signals but is itself an Electron process with the
+  overlay mapped, so it dies of the crash it exists to avoid.
+- **Turning the overlay off in Steam.** It does not stop the injection. With `AllowOverlay=0` on
+  the shortcut, Steam still handed the launch both `gameoverlayrenderer.so` paths. Do not ship a
+  Linux depot betting on the Steamworks per-app overlay setting.
+
+Verify a Steam launch by grepping `main.log` for `[steam] Steam overlay detected` (pinned by
+`tests/electron_steam_overlay_guard.test.ts`, so a reword cannot break the procedure quietly).
+Steam injects the overlay into depot builds as well as non-Steam shortcuts, and the crash
+reproduces on a non-AppImage binary, so this is very unlikely to be AppImage-specific. It has
+NOT been verified on a real depot launch though: running `linux-unpacked/` standalone is not a
+faithful stand-in (Steam launches it through `reaper`, potentially inside the Steam Linux
+Runtime container, and the layout expects env that the AppImage's AppRun sets). Confirm on an
+actual depot build before trusting this section for the Steam channel.
+
+Adjacent, and worth knowing before it is rediscovered the hard way: the PRIME relaunch above
+spawns `detached` and exits the parent, which is the thing Steam reads as the game closing. It
+fires whenever `/sys/class/drm` holds two or more `card*` entries, so a hybrid laptop launched
+through Steam takes that path and Steam stops tracking the process that survives. A Steam Deck
+reports one card, so it does not arise there.
 
 ## Epic Games Store
 

--- a/docs/desktop-release.md
+++ b/docs/desktop-release.md
@@ -394,6 +394,39 @@ Linux AppImage caveat: the updater requires the `APPIMAGE` env (set automaticall
 when running a real AppImage); running the raw unpacked binary logs an updater error
 and skips, by design.
 
+Steam-on-Linux caveat: Steam preloads `gameoverlayrenderer.so` into every native Linux game
+it launches, and with that library mapped Chromium's GPU process cannot start. The browser
+process retries, gives up, and dies on a `CHECK`:
+
+```
+FATAL:content/browser/gpu/gpu_data_manager_impl_private.cc] GPU process isn't usable. Goodbye.
+```
+
+`SIGTRAP`, no window, no `main.log`. To a player that is Steam's launching spinner, forever.
+`electron/steam_overlay_guard.cjs` appends `--disable-gpu-sandbox` when, and only when, the
+overlay is actually preloaded. Measured on a Steam Deck with the overlay in place: no flags
+crashes; `--disable-gpu-sandbox`, `--no-sandbox` and `--in-process-gpu` all boot. The narrowest
+one ships, because the RENDERER sandbox is the boundary that contains page content and it stays
+on. It boots on real hardware rather than falling back to software (3 runs of 3 reported the
+Deck's AMD adapter `0x1002:0x1435` active, with `webgl`, `gpu_compositing` and `rasterization`
+all `enabled`), which is the thing to re-check if this is ever changed: a "fix" that silently
+swapped in SwiftShader would be worse than the crash.
+
+Two things that look like fixes and are not, both measured rather than assumed:
+- **Stripping the overlay from `LD_PRELOAD`.** It cannot be done from inside the app, since
+  `ld.so` reads the variable at exec time. Every shape of re-exec fails: a detached parent exits
+  at once and Steam reads that as the game closing; a parent blocked in `spawnSync` cannot run a
+  signal handler, and the child lands in its own `app-world-of-claudecraft-<pid>.scope` while the
+  parent stays in `app-steam@autostart.service`, so Steam's stop kills the parent and strands the
+  game; a supervising parent can forward signals but is itself an Electron process with the
+  overlay mapped, so it dies of the crash it exists to avoid.
+- **Turning the overlay off in Steam.** It does not stop the injection. With `AllowOverlay=0` on
+  the shortcut, Steam still handed the launch both `gameoverlayrenderer.so` paths. Do not ship a
+  Linux depot betting on the Steamworks per-app overlay setting.
+
+Verify a Steam launch by grepping `main.log` for `[steam] Steam overlay detected`. This applies
+to the Steam depot channel as much as to a non-Steam shortcut, since Steam injects either way.
+
 ## Steam
 
 Build: `npm run electron:build:steam` on each OS runner (signing env still applies on

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -65,6 +65,7 @@ const {
 } = require('./diagnostics.cjs');
 const { initLogging } = require('./logging.cjs');
 const { DEFAULT_SHELL_STRINGS, sanitizeShellStrings } = require('./shell_strings.cjs');
+const { allowGpuUnderSteamOverlay } = require('./steam_overlay_guard.cjs');
 const { attachRendererCrashRecovery, installProcessCrashGuards } = require('./crash_guard.cjs');
 const { initUpdater } = require('./updater.cjs');
 const {
@@ -229,6 +230,14 @@ if (gpuForceDisabledByEnv) {
 } else {
   forceHighPerformanceGpu({ app, log });
 }
+
+// Steam preloads its overlay into every native Linux game, and with that library mapped
+// Chromium's GPU process cannot start: the browser process gives up with a CHECK and the app
+// dies on SIGTRAP with no window and no log, which is the launching spinner that never ends.
+// Relaxing the GPU sandbox is enough and is the narrowest fix; the renderer stays sandboxed.
+// Applies ONLY when Steam actually injected, so an ordinary launch keeps the full sandbox.
+// Must be before app 'ready', like the switches above, or Chromium never reads it.
+allowGpuUnderSteamOverlay({ app, log });
 
 // Player-visible strings for main-process dialogs (crash recovery): the
 // renderer pushes t()-localized values via 'desktop-set-strings'

--- a/electron/steam_overlay_guard.cjs
+++ b/electron/steam_overlay_guard.cjs
@@ -86,7 +86,10 @@ function allowGpuUnderSteamOverlay(deps = {}) {
   // for "did this launch relax the sandbox". It has to be false exactly when nothing happened.
   const appendSwitch = app?.commandLine?.appendSwitch;
   if (typeof appendSwitch !== 'function') {
-    deps.log?.warn?.('[steam] Steam overlay detected but the GPU sandbox could not be relaxed', {
+    // Deliberately does NOT contain OVERLAY_DETECTED_LOG: the docs make that string the
+    // operator's grep for "the guard fired", so a failure line carrying it would match on the
+    // one path where it did not.
+    deps.log?.warn?.('[steam] overlay present but the GPU sandbox could not be relaxed', {
       reason: 'no app.commandLine.appendSwitch',
     });
     return false;

--- a/electron/steam_overlay_guard.cjs
+++ b/electron/steam_overlay_guard.cjs
@@ -1,0 +1,99 @@
+const nodePath = require('node:path');
+
+// Steam preloads gameoverlayrenderer.so into every native Linux game it launches, and with it
+// mapped this app never starts: Chromium's GPU process fails to come up, retries, and the
+// browser process gives up with
+//
+//   FATAL:content/browser/gpu/gpu_data_manager_impl_private.cc] GPU process isn't usable. Goodbye.
+//
+// which is a CHECK, so the process dies on SIGTRAP with no window and no main.log. To the
+// player that is Steam's launching spinner, forever. This is the normal way to install on a
+// Steam Deck (download the AppImage, add it as a non-Steam game), and Steam injects the same
+// library into depot builds, so it breaks the Steam channel too.
+//
+// Relaxing the GPU sandbox is enough, and is the narrowest thing that is: the RENDERER stays
+// sandboxed, which is the boundary that matters, since the renderer is what runs page content.
+// Measured on a Steam Deck (SteamOS 3, Game Mode, gamescope), overlay preloaded throughout:
+//
+//   no flags                  SIGTRAP, the fatal above
+//   --disable-gpu-sandbox     boots
+//   --no-sandbox              boots (a much larger relaxation, so not this one)
+//   --in-process-gpu          boots (drops GPU process isolation entirely, so not this one)
+//
+// And it boots on real hardware rather than quietly falling back to software, which is the
+// thing worth checking for a WebGL game: 3 runs out of 3 reported the Deck's own AMD adapter
+// (0x1002:0x1435) active with webgl, gpu_compositing and rasterization all enabled. A "fix"
+// that silently swapped in SwiftShader would have been worse than the crash.
+//
+// Deliberately NOT unconditional: a normal desktop launch keeps the full sandbox, and only a
+// session Steam actually injected into relaxes it. The cost is scoped to the launches that
+// would otherwise not start at all.
+//
+// Rejected alternatives, both measured rather than assumed:
+//   - Stripping the overlay from LD_PRELOAD. It cannot be done from inside the app: the
+//     variable is read by ld.so at exec time, so it needs a re-exec, and every shape of that
+//     fails. A detached parent exits immediately, which Steam reads as the game closing. A
+//     parent blocked in spawnSync cannot run a signal handler, and the child lands in its own
+//     app-world-of-claudecraft-<pid>.scope while the parent stays in app-steam@autostart.service,
+//     so Steam's stop kills the parent and strands the game. A supervising parent can forward
+//     signals but is itself an Electron process with the overlay still mapped, so it dies of
+//     the very crash it exists to avoid.
+//   - Turning the overlay off in Steam. It does not stop the injection: with AllowOverlay=0 on
+//     the shortcut, Steam still handed the launch both gameoverlayrenderer.so paths. Valve has
+//     said the same for Windows, that disabling stops the overlay UI but not the library, which
+//     carries other Steamworks plumbing.
+
+const STEAM_OVERLAY_LIB = 'gameoverlayrenderer.so';
+// Relaxes the GPU process sandbox only. The renderer sandbox, which is the one containing page
+// content, is untouched.
+const GPU_SANDBOX_SWITCH = 'disable-gpu-sandbox';
+
+/**
+ * True when Steam launched this process with its overlay preloaded.
+ *
+ * glibc separates LD_PRELOAD entries on spaces AND colons, with no escaping, so both are split
+ * on; a path containing either is unrepresentable to the loader anyway. Matched on the
+ * BASENAME because Steam injects both its ubuntu12_32 and ubuntu12_64 copies and the absolute
+ * prefix moves with the Steam install (~/.local/share/Steam, ~/.steam/steam, flatpak, Deck).
+ */
+function steamOverlayPreloaded(env = process.env) {
+  const preload = env.LD_PRELOAD;
+  if (typeof preload !== 'string' || preload === '') return false;
+  return preload
+    .split(/[:\s]+/)
+    .some((entry) => entry !== '' && nodePath.basename(entry) === STEAM_OVERLAY_LIB);
+}
+
+/**
+ * Append the GPU-sandbox relaxation when, and only when, Steam's overlay is preloaded.
+ *
+ * MUST be called before app 'ready': Chromium reads its command line when the GPU process is
+ * created, and a switch appended after that is simply ignored. Returns true when the switch was
+ * added, so the caller can record it; a launch that did not need it is left completely alone.
+ */
+function allowGpuUnderSteamOverlay(deps = {}) {
+  const platform = deps.platform ?? process.platform;
+  const env = deps.env ?? process.env;
+  const app = deps.app;
+  if (platform !== 'linux') return false;
+  if (!steamOverlayPreloaded(env)) return false;
+
+  try {
+    app?.commandLine?.appendSwitch?.(GPU_SANDBOX_SWITCH);
+  } catch (err) {
+    deps.log?.warn?.('[steam] could not relax the GPU sandbox', err);
+    return false;
+  }
+  deps.log?.info?.(
+    '[steam] Steam overlay detected; relaxing the GPU sandbox so the GPU process can start',
+    { switch: GPU_SANDBOX_SWITCH },
+  );
+  return true;
+}
+
+module.exports = {
+  GPU_SANDBOX_SWITCH,
+  STEAM_OVERLAY_LIB,
+  allowGpuUnderSteamOverlay,
+  steamOverlayPreloaded,
+};

--- a/electron/steam_overlay_guard.cjs
+++ b/electron/steam_overlay_guard.cjs
@@ -47,6 +47,9 @@ const STEAM_OVERLAY_LIB = 'gameoverlayrenderer.so';
 // Relaxes the GPU process sandbox only. The renderer sandbox, which is the one containing page
 // content, is untouched.
 const GPU_SANDBOX_SWITCH = 'disable-gpu-sandbox';
+// docs/desktop-release.md tells an operator to grep main.log for this, which makes it a support
+// procedure rather than prose: pinned by the test so a reword cannot break it silently.
+const OVERLAY_DETECTED_LOG = '[steam] Steam overlay detected';
 
 /**
  * True when Steam launched this process with its overlay preloaded.
@@ -78,21 +81,34 @@ function allowGpuUnderSteamOverlay(deps = {}) {
   if (platform !== 'linux') return false;
   if (!steamOverlayPreloaded(env)) return false;
 
+  // Checked rather than optional-chained away: a missing app or commandLine would otherwise
+  // append nothing, log success and return true, and the log line is the operator's grep handle
+  // for "did this launch relax the sandbox". It has to be false exactly when nothing happened.
+  const appendSwitch = app?.commandLine?.appendSwitch;
+  if (typeof appendSwitch !== 'function') {
+    deps.log?.warn?.('[steam] Steam overlay detected but the GPU sandbox could not be relaxed', {
+      reason: 'no app.commandLine.appendSwitch',
+    });
+    return false;
+  }
   try {
-    app?.commandLine?.appendSwitch?.(GPU_SANDBOX_SWITCH);
+    appendSwitch.call(app.commandLine, GPU_SANDBOX_SWITCH);
   } catch (err) {
     deps.log?.warn?.('[steam] could not relax the GPU sandbox', err);
     return false;
   }
   deps.log?.info?.(
-    '[steam] Steam overlay detected; relaxing the GPU sandbox so the GPU process can start',
-    { switch: GPU_SANDBOX_SWITCH },
+    `${OVERLAY_DETECTED_LOG}; relaxing the GPU sandbox so the GPU process can start`,
+    {
+      switch: GPU_SANDBOX_SWITCH,
+    },
   );
   return true;
 }
 
 module.exports = {
   GPU_SANDBOX_SWITCH,
+  OVERLAY_DETECTED_LOG,
   STEAM_OVERLAY_LIB,
   allowGpuUnderSteamOverlay,
   steamOverlayPreloaded,

--- a/electron/steam_overlay_guard.d.cts
+++ b/electron/steam_overlay_guard.d.cts
@@ -1,0 +1,20 @@
+// Type declarations for the CommonJS Steam overlay guard (electron/steam_overlay_guard.cjs),
+// which electron/main.cjs invokes at runtime and tests/electron_steam_overlay_guard.test.ts
+// exercises directly. main.cjs itself runs outside tsc; these types serve the test.
+
+export const STEAM_OVERLAY_LIB: string;
+export const GPU_SANDBOX_SWITCH: string;
+
+export function steamOverlayPreloaded(env?: Record<string, string | undefined>): boolean;
+
+export interface AllowGpuUnderSteamOverlayDeps {
+  platform?: string;
+  env?: Record<string, string | undefined>;
+  app?: { commandLine?: { appendSwitch?(name: string): void } } | null;
+  log?: {
+    info?(...args: unknown[]): void;
+    warn?(...args: unknown[]): void;
+  };
+}
+
+export function allowGpuUnderSteamOverlay(deps?: AllowGpuUnderSteamOverlayDeps): boolean;

--- a/electron/steam_overlay_guard.d.cts
+++ b/electron/steam_overlay_guard.d.cts
@@ -4,6 +4,7 @@
 
 export const STEAM_OVERLAY_LIB: string;
 export const GPU_SANDBOX_SWITCH: string;
+export const OVERLAY_DETECTED_LOG: string;
 
 export function steamOverlayPreloaded(env?: Record<string, string | undefined>): boolean;
 

--- a/tests/electron_steam_overlay_guard.test.ts
+++ b/tests/electron_steam_overlay_guard.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   allowGpuUnderSteamOverlay,
   GPU_SANDBOX_SWITCH,
+  OVERLAY_DETECTED_LOG,
   STEAM_OVERLAY_LIB,
   steamOverlayPreloaded,
 } from '../electron/steam_overlay_guard.cjs';
@@ -116,7 +117,10 @@ describe('allowGpuUnderSteamOverlay', () => {
     expect(f.switches).toEqual([]);
   });
 
-  it('records the decision, so main.log can answer "did this launch relax the sandbox"', () => {
+  it('logs the exact token docs/desktop-release.md tells an operator to grep for', () => {
+    // The doc names this string as the way to verify a Steam launch, which makes it a support
+    // procedure rather than prose. Asserting only that log.info fired would let a reword break
+    // the documented check with the suite still green.
     const log = { info: vi.fn(), warn: vi.fn() };
     allowGpuUnderSteamOverlay({
       platform: 'linux',
@@ -124,7 +128,13 @@ describe('allowGpuUnderSteamOverlay', () => {
       app: fakeApp().app,
       log,
     });
-    expect(log.info).toHaveBeenCalled();
+    expect(log.info).toHaveBeenCalledWith(
+      expect.stringContaining(OVERLAY_DETECTED_LOG),
+      expect.anything(),
+    );
+    expect(OVERLAY_DETECTED_LOG).toBe('[steam] Steam overlay detected');
+    const doc = readFileSync(new URL('../docs/desktop-release.md', import.meta.url), 'utf8');
+    expect(doc).toContain(OVERLAY_DETECTED_LOG);
   });
 
   it('never takes the app down if appending fails', () => {

--- a/tests/electron_steam_overlay_guard.test.ts
+++ b/tests/electron_steam_overlay_guard.test.ts
@@ -1,0 +1,192 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  allowGpuUnderSteamOverlay,
+  GPU_SANDBOX_SWITCH,
+  STEAM_OVERLAY_LIB,
+  steamOverlayPreloaded,
+} from '../electron/steam_overlay_guard.cjs';
+
+const STEAM = '/home/deck/.local/share/Steam';
+const O32 = `${STEAM}/ubuntu12_32/gameoverlayrenderer.so`;
+const O64 = `${STEAM}/ubuntu12_64/gameoverlayrenderer.so`;
+// Exactly what Steam sets, leading empty element and all.
+const STEAM_PRELOAD = `:${O32}:${O64}`;
+
+function fakeApp() {
+  const switches: string[] = [];
+  return { switches, app: { commandLine: { appendSwitch: (n: string) => switches.push(n) } } };
+}
+
+describe('the switch itself (a load-bearing literal)', () => {
+  it('is the GPU sandbox switch, spelled the way Chromium spells it', () => {
+    // Chromium matches switch names EXACTLY and silently ignores unknown ones, so a typo here
+    // ships a build that still dies on SIGTRAP under Steam with nothing to show for it.
+    expect(GPU_SANDBOX_SWITCH).toBe('disable-gpu-sandbox');
+  });
+
+  it('is NOT one of the broader relaxations that also worked', () => {
+    // --no-sandbox and --in-process-gpu both fixed the crash on the Deck too. They are not what
+    // ships: --no-sandbox drops the RENDERER sandbox, which is the boundary that actually
+    // contains page content, and --in-process-gpu removes GPU process isolation entirely.
+    expect(GPU_SANDBOX_SWITCH).not.toBe('no-sandbox');
+    expect(GPU_SANDBOX_SWITCH).not.toBe('in-process-gpu');
+  });
+
+  it('pins the library name it looks for', () => {
+    expect(STEAM_OVERLAY_LIB).toBe('gameoverlayrenderer.so');
+  });
+});
+
+describe('steamOverlayPreloaded', () => {
+  it('detects the value Steam actually sets', () => {
+    expect(steamOverlayPreloaded({ LD_PRELOAD: STEAM_PRELOAD })).toBe(true);
+  });
+
+  it('detects either architecture on its own', () => {
+    // Steam injects both copies; ld.so ignores the wrong-ELF-class one, so either may be the
+    // one that matters and both must count.
+    expect(steamOverlayPreloaded({ LD_PRELOAD: O32 })).toBe(true);
+    expect(steamOverlayPreloaded({ LD_PRELOAD: O64 })).toBe(true);
+  });
+
+  it('splits on spaces as well as colons, which is what glibc accepts', () => {
+    expect(steamOverlayPreloaded({ LD_PRELOAD: `/opt/mangohud.so ${O64}` })).toBe(true);
+  });
+
+  it('finds it among other preloads', () => {
+    expect(steamOverlayPreloaded({ LD_PRELOAD: `/opt/mangohud.so:${O64}:/opt/gamemode.so` })).toBe(
+      true,
+    );
+  });
+
+  it('matches the BASENAME, not a substring of the path', () => {
+    // The absolute prefix moves with the Steam install (~/.steam/steam, flatpak, Deck), so the
+    // basename is the stable part; a directory that merely contains the name is not the library.
+    expect(steamOverlayPreloaded({ LD_PRELOAD: '/opt/gameoverlayrenderer.so.d/other.so' })).toBe(
+      false,
+    );
+    expect(steamOverlayPreloaded({ LD_PRELOAD: '/weird/prefix-gameoverlayrenderer.so' })).toBe(
+      false,
+    );
+  });
+
+  it.each([
+    ['an unrelated preload', { LD_PRELOAD: '/opt/mangohud.so' }],
+    ['an empty value', { LD_PRELOAD: '' }],
+    ['only the empty element Steam prefixes', { LD_PRELOAD: ':' }],
+    ['no LD_PRELOAD at all', {}],
+  ])('is false for %s', (_label, env) => {
+    expect(steamOverlayPreloaded(env as Record<string, string | undefined>)).toBe(false);
+  });
+});
+
+describe('allowGpuUnderSteamOverlay', () => {
+  it('appends the switch when Steam injected its overlay', () => {
+    const f = fakeApp();
+    const applied = allowGpuUnderSteamOverlay({
+      platform: 'linux',
+      env: { LD_PRELOAD: STEAM_PRELOAD },
+      app: f.app,
+    });
+
+    expect(applied).toBe(true);
+    expect(f.switches).toEqual(['disable-gpu-sandbox']);
+  });
+
+  it('leaves an ordinary launch completely alone', () => {
+    // The whole point of gating it: a desktop launch keeps the full sandbox. An unconditional
+    // relaxation would spend the security of every launch on the few that need it.
+    const f = fakeApp();
+    const applied = allowGpuUnderSteamOverlay({
+      platform: 'linux',
+      env: { LD_PRELOAD: '/opt/mangohud.so' },
+      app: f.app,
+    });
+
+    expect(applied).toBe(false);
+    expect(f.switches).toEqual([]);
+  });
+
+  it.each(['win32', 'darwin'])('is inert on %s, where Steam does not preload', (platform) => {
+    const f = fakeApp();
+    expect(
+      allowGpuUnderSteamOverlay({ platform, env: { LD_PRELOAD: STEAM_PRELOAD }, app: f.app }),
+    ).toBe(false);
+    expect(f.switches).toEqual([]);
+  });
+
+  it('records the decision, so main.log can answer "did this launch relax the sandbox"', () => {
+    const log = { info: vi.fn(), warn: vi.fn() };
+    allowGpuUnderSteamOverlay({
+      platform: 'linux',
+      env: { LD_PRELOAD: STEAM_PRELOAD },
+      app: fakeApp().app,
+      log,
+    });
+    expect(log.info).toHaveBeenCalled();
+  });
+
+  it('never takes the app down if appending fails', () => {
+    const log = { info: vi.fn(), warn: vi.fn() };
+    const app = {
+      commandLine: {
+        appendSwitch: () => {
+          throw new Error('nope');
+        },
+      },
+    };
+    expect(() =>
+      allowGpuUnderSteamOverlay({
+        platform: 'linux',
+        env: { LD_PRELOAD: STEAM_PRELOAD },
+        app,
+        log,
+      }),
+    ).not.toThrow();
+    expect(log.warn).toHaveBeenCalled();
+  });
+
+  it('survives a missing app object', () => {
+    expect(() =>
+      allowGpuUnderSteamOverlay({
+        platform: 'linux',
+        env: { LD_PRELOAD: STEAM_PRELOAD },
+        app: null,
+      }),
+    ).not.toThrow();
+  });
+});
+
+describe('main.cjs wiring', () => {
+  const raw = readFileSync(new URL('../electron/main.cjs', import.meta.url), 'utf8');
+  // Comments stripped first: a commented-out call would otherwise satisfy every check below
+  // while shipping a build that still dies under Steam.
+  const main = raw.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^[ \t]*\/\/.*$/gm, '');
+
+  it('calls it exactly once, at module top level', () => {
+    expect(main.match(/allowGpuUnderSteamOverlay\(/g) ?? []).toHaveLength(1);
+    expect(main).toMatch(/^allowGpuUnderSteamOverlay\(\{ app, log \}\);/m);
+    expect(main).toContain("require('./steam_overlay_guard.cjs')");
+  });
+
+  it('runs BEFORE app ready, or Chromium never reads the switch', () => {
+    // Chromium reads its command line when the GPU process is created. A switch appended after
+    // app 'ready' is accepted by the API and silently ignored, which is the worst failure shape:
+    // the code looks right and the crash persists.
+    const call = main.indexOf('allowGpuUnderSteamOverlay({');
+    const ready = main.indexOf('app.whenReady(');
+    expect(call).toBeGreaterThan(-1);
+    expect(ready).toBeGreaterThan(-1);
+    expect(call).toBeLessThan(ready);
+  });
+
+  it('sits beside the other Chromium switch work, after logging exists', () => {
+    // It takes `log`, so it has to be after initLogging; grouping it with the GPU force keeps
+    // both switch appenders in one place.
+    expect(main.indexOf('initLogging(')).toBeLessThan(main.indexOf('allowGpuUnderSteamOverlay({'));
+    expect(main.indexOf('forceHighPerformanceGpu({ app, log });')).toBeLessThan(
+      main.indexOf('allowGpuUnderSteamOverlay({'),
+    );
+  });
+});

--- a/tests/electron_steam_overlay_guard.test.ts
+++ b/tests/electron_steam_overlay_guard.test.ts
@@ -137,6 +137,23 @@ describe('allowGpuUnderSteamOverlay', () => {
     expect(doc).toContain(OVERLAY_DETECTED_LOG);
   });
 
+  it('keeps the grep token OFF the failure path', () => {
+    // The doc makes this string the operator's "the guard fired" check, so a warn line
+    // containing it would match on the one launch where it did not fire: the same false-success
+    // shape as the return value, moved one layer out.
+    const log = { info: vi.fn(), warn: vi.fn() };
+    allowGpuUnderSteamOverlay({
+      platform: 'linux',
+      env: { LD_PRELOAD: STEAM_PRELOAD },
+      app: null,
+      log,
+    });
+
+    expect(log.warn).toHaveBeenCalled();
+    const warned = String(log.warn.mock.calls[0]?.[0] ?? '');
+    expect(warned).not.toContain(OVERLAY_DETECTED_LOG);
+  });
+
   it('never takes the app down if appending fails', () => {
     const log = { info: vi.fn(), warn: vi.fn() };
     const app = {
@@ -157,14 +174,27 @@ describe('allowGpuUnderSteamOverlay', () => {
     expect(log.warn).toHaveBeenCalled();
   });
 
-  it('survives a missing app object', () => {
-    expect(() =>
-      allowGpuUnderSteamOverlay({
-        platform: 'linux',
-        env: { LD_PRELOAD: STEAM_PRELOAD },
-        app: null,
-      }),
-    ).not.toThrow();
+  it.each([
+    ['a missing app object', null],
+    ['an app with no commandLine', {}],
+    ['a commandLine with no appendSwitch', { commandLine: {} }],
+    ['a non-function appendSwitch', { commandLine: { appendSwitch: 'nope' } }],
+  ])('reports FALSE when nothing was appended (%s)', (_label, app) => {
+    // Returning true here would log the operator's grep token on a launch where the switch
+    // never landed, so the one signal telling them the guard fired would be wrong exactly when
+    // it did not. The previous version of this test asserted only "does not throw", which
+    // passes either way, and that is how the regression stayed unpinned.
+    const log = { info: vi.fn(), warn: vi.fn() };
+    const applied = allowGpuUnderSteamOverlay({
+      platform: 'linux',
+      env: { LD_PRELOAD: STEAM_PRELOAD },
+      app: app as never,
+      log,
+    });
+
+    expect(applied).toBe(false);
+    expect(log.info).not.toHaveBeenCalled();
+    expect(log.warn).toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary

Closes #3660.

Steam preloads `gameoverlayrenderer.so` into every native Linux game it launches, and with that library mapped Chromium's GPU process cannot start. The browser process retries, gives up, and dies on a `CHECK`:

```
FATAL:content/browser/gpu/gpu_data_manager_impl_private.cc] GPU process isn't usable. Goodbye.
```

That is `SIGTRAP`, with no window and no `main.log`. To a player it is Steam's launching spinner, forever. Adding the AppImage as a non-Steam game is the normal way to install on a Steam Deck, so this is the default experience there.

**Probably not limited to non-Steam shortcuts.** Steam injects the same library into depot builds, and the crash reproduces on a non-AppImage binary, so it is very unlikely to be AppImage-specific. A real depot launch is NOT verified though, see "Not verified" below.

## How it works

`electron/steam_overlay_guard.cjs` appends `--disable-gpu-sandbox` when, and only when, Steam's overlay is actually preloaded. It runs beside the existing GPU switch work in `main.cjs`, before app `ready` (Chromium reads its command line when the GPU process is created; a switch appended later is accepted and silently ignored).

Three flags were measured on a Deck with the overlay in place, and all three boot: `--disable-gpu-sandbox`, `--no-sandbox`, `--in-process-gpu`. The narrowest ships. `--no-sandbox` drops the **renderer** sandbox, which is the boundary that contains page content; `--in-process-gpu` removes GPU process isolation entirely. Under this change the renderer stays sandboxed.

It is deliberately conditional: an ordinary desktop launch keeps the full sandbox, and only a session Steam injected into relaxes anything.

## What this replaces

An earlier revision of this branch stripped the overlay from `LD_PRELOAD` and re-exec'd. That is all deleted. It could not work: `ld.so` reads the variable at exec time, so a re-exec is required, and every shape of one fails. A detached parent exits at once and Steam reads that as the game closing. A parent blocked in `spawnSync` keeps Steam's running-state correct but cannot run a signal handler, and the child lands in its own `app-world-of-claudecraft-<pid>.scope` while the parent stays in `app-steam@autostart.service`, so Steam's stop kills the parent and strands the game. A supervising parent can forward signals but is itself an Electron process with the overlay mapped, so it dies of the crash it exists to avoid. All three were measured, not reasoned about.

Turning the overlay off in Steam does not help either: with `AllowOverlay=0` on the shortcut, Steam still handed the launch both `gameoverlayrenderer.so` paths.

## Related issues

Closes #3660. Independent of #3659 (the Linux deep-link fix); they no longer touch any file in common.

## Type of change

- [x] Bug fix
- [x] Tests
- [x] Documentation

## How was this tested?

- Commands: `npx vitest run tests/electron_steam_overlay_guard.test.ts` (22 tests), full electron suite `npx vitest run tests/electron_` (32 files, 564 tests), `npx tsc --noEmit` clean, `npm run ci:changed` exit 0, `npm run security:gate` PASS. The switch name is mutation-checked: swapping it for `no-sandbox` fails three tests.
- Manual steps, all on a Steam Deck running stock SteamOS 3 in Game Mode:
  - **Root cause** captured with `ELECTRON_ENABLE_LOGGING=1`: the fatal above. `SIGTRAP` is Chromium's `CHECK`, so this is the GPU process failing, not the zygote/sandbox bootstrap that a preloaded `.so` classically breaks.
  - **Flag matrix**, overlay preloaded throughout, guard disabled so this is raw behavior. 133 = SIGTRAP, 124 = survived:

    | launch | result |
    | --- | --- |
    | no flags | 133, the fatal above |
    | `--disable-gpu-sandbox` | 124, boots |
    | `--no-sandbox` | 124, boots |
    | `--in-process-gpu` | 124, boots |

  - **Hardware, not SwiftShader**, which is the check that matters for a WebGL game. 3 runs of 3 with the overlay preloaded reported `adapters: [ { vendorId: '0x1002', deviceId: '0x1435', active: true } ]` (the Deck's own AMD Van Gogh APU) with `webgl`, `gpu_compositing`, `rasterization` and `opengl` all enabled.
  - **The shipped artifact**, built from this branch, run twice against the exact value Steam sets (leading empty element, both architectures): detection fires, switch applies, app boots, hardware adapter active.
  - **Through Steam itself**, with the shortcut's launch options cleared so Steam really injects: launched from the library and plays.
  - **Depot layout, inconclusive.** Two methods were tried and neither settles it. Extracting the AppImage and running the inner binary showed the crash, but that is not a faithful stand-in: `AppRun` also exports `LD_LIBRARY_PATH`, `PATH`, `XDG_DATA_DIRS` and `GSETTINGS_SCHEMA_DIR`, none of which are set that way. Shipping the real `linux-unpacked/` to the Deck produced an unusable harness (the no-overlay control failed too, most likely the single-instance lock across back-to-back runs). What stands is only that the crash reproduces on a non-AppImage binary.

## Not verified

**Whether a real Steam depot launch is affected, and whether this fixes it there.** See the depot bullet above for why neither method settled it. This matters for the Steam release and is worth someone with depot access confirming; `docs/desktop-release.md` carries the same caveat.

Whether the Steam overlay itself *functions* (Shift-Tab, F12, the Deck's on-screen keyboard) now that the app survives. Valve does not support the overlay for browser-engine games, and every Electron and NW.js report says it does not work on Linux, so the expectation is "app runs, overlay inert". That is still strictly better than the app not starting.

## Screenshots / recordings

N/A, no visual surface changes.

