### PR TITLE
perf(server): persist custody parcels as overlay rows, not whole-book writes

### DIFF
--- a/server/db.ts
+++ b/server/db.ts
@@ -58,6 +58,7 @@ import {
 } from './guild_bank_state';
 import { isUniqueViolation } from './http_util';
 import {
+  advanceCustodyWatermarkIn,
   confirmBakedCustodyRefs,
   deleteBakedCustodyRefsIn,
   MAIL_CUSTODY_PARCELS_SCHEMA,
@@ -3501,26 +3502,21 @@ export async function saveCharacterAndMarketState(
       await client.query('ROLLBACK');
       return false;
     }
-    await client.query(
-      `INSERT INTO world_state (key, data, updated_at) VALUES ($1, $2, now())
-       ON CONFLICT (key) DO UPDATE SET data = EXCLUDED.data, updated_at = now()`,
-      // Same realm-scoped key loadMarketState/saveMarketState use: the leave
-      // flush must land where the market is read back, or the escrowed listing
-      // is written to a key nothing loads and the item is stranded on next boot.
-      [marketStateKey(REALM), JSON.stringify(market)],
-    );
-    await client.query(
-      `INSERT INTO world_state (key, data, updated_at) VALUES ($1, $2, now())
-       ON CONFLICT (key) DO UPDATE SET data = EXCLUDED.data, updated_at = now()`,
-      [mailStateKey(REALM), JSON.stringify(mail)],
-    );
+    const inTx = (text: string, values: unknown[]) => client.query(text, values);
+    // Same realm-scoped key loadMarketState/saveMarketState use: the leave
+    // flush must land where the market is read back, or the escrowed listing
+    // is written to a key nothing loads and the item is stranded on next boot.
+    await upsertWorldStateRowIn(inTx, marketStateKey(REALM), market);
+    await upsertWorldStateRowIn(inTx, mailStateKey(REALM), mail);
     // Guild bank books ride the SAME fenced transaction (Guild Bank Phase 3):
     // the character UPDATE above already passed the lease fence, so these can
     // never land for a displaced session, and a failure anywhere rolls back
     // the character, market, mail, and book halves together.
     await writeGuildBankRows(client, guildBanks ?? [], results);
-    // The custody bake rides this same fenced transaction (see saveMailState).
-    await deleteBakedCustodyRefsIn((text, values) => client.query(text, values), bakedCustodyRefs);
+    // The custody bake and the watermark advance ride this same fenced
+    // transaction (see saveMailState).
+    await deleteBakedCustodyRefsIn(inTx, bakedCustodyRefs);
+    await advanceCustodyWatermarkIn(inTx);
     await client.query('COMMIT');
     confirmBakedCustodyRefs(bakedCustodyRefs);
     return true;
@@ -4406,6 +4402,22 @@ export async function loadWorldState<T>(key: string): Promise<T | null> {
   return (res.rows[0]?.data as T) ?? null;
 }
 
+/** The one world_state upsert shape, shared by the single-statement
+ *  saveWorldState and the in-transaction blob writers
+ *  (saveCharacterAndMarketState, saveMailState): one copy so the
+ *  ON CONFLICT contract cannot drift between them. */
+async function upsertWorldStateRowIn(
+  query: (text: string, values: unknown[]) => Promise<unknown>,
+  key: string,
+  data: unknown,
+): Promise<void> {
+  await query(
+    `INSERT INTO world_state (key, data, updated_at) VALUES ($1, $2, now())
+     ON CONFLICT (key) DO UPDATE SET data = EXCLUDED.data, updated_at = now()`,
+    [key, JSON.stringify(data)],
+  );
+}
+
 export async function saveWorldState(key: string, data: unknown): Promise<void> {
   // The pre-scoping bare 'market' row is RETAINED as the rollback artifact for
   // the partitioned market backfill (server/market_backfill.ts) and is never
@@ -4421,11 +4433,7 @@ export async function saveWorldState(key: string, data: unknown): Promise<void> 
   if (key.startsWith(MARKET_KEY_PREFIX)) {
     assertMarketWriteGateOpen();
   }
-  await pool.query(
-    `INSERT INTO world_state (key, data, updated_at) VALUES ($1, $2, now())
-     ON CONFLICT (key) DO UPDATE SET data = EXCLUDED.data, updated_at = now()`,
-    [key, JSON.stringify(data)],
-  );
+  await upsertWorldStateRowIn((text, values) => pool.query(text, values), key, data);
 }
 
 // Boot-ordering write gate for the World Market. Before ensureSchema's
@@ -4503,24 +4511,21 @@ export async function saveMailState(save: MailSave): Promise<void> {
   // Custody overlay bake (mail_custody_overlay.ts): the snapshot runs before
   // anything awaits, and no awaited gap separates the caller's
   // serializeMail() from this entry, so every snapshotted parcel is inside
-  // `save` or durably collected out of it. The bake DELETE rides the SAME
-  // transaction as the book upsert: the blob without a parcel and the row's
-  // removal must commit together, or a failed post-commit delete bracketing
-  // a collection could later replay a collected parcel.
+  // `save` or durably collected out of it. The bake DELETE and the
+  // watermark advance ride the SAME transaction as the book upsert: the
+  // blob without a parcel and the row's removal must commit together, or a
+  // failed post-commit delete bracketing a collection could later replay a
+  // collected parcel. Every book write takes this one transactional path
+  // (no refs-empty shortcut) so the watermark keeps advancing on quiet
+  // realms too.
   const bakedCustodyRefs = snapshotPendingCustodyRefs();
-  if (bakedCustodyRefs.length === 0) {
-    await saveWorldState(mailStateKey(REALM), save);
-    return;
-  }
   const client = await pool.connect();
   try {
     await client.query('BEGIN');
-    await client.query(
-      `INSERT INTO world_state (key, data, updated_at) VALUES ($1, $2, now())
-       ON CONFLICT (key) DO UPDATE SET data = EXCLUDED.data, updated_at = now()`,
-      [mailStateKey(REALM), JSON.stringify(save)],
-    );
-    await deleteBakedCustodyRefsIn((text, values) => client.query(text, values), bakedCustodyRefs);
+    const inTx = (text: string, values: unknown[]) => client.query(text, values);
+    await upsertWorldStateRowIn(inTx, mailStateKey(REALM), save);
+    await deleteBakedCustodyRefsIn(inTx, bakedCustodyRefs);
+    await advanceCustodyWatermarkIn(inTx);
     await client.query('COMMIT');
   } catch (err) {
     await client.query('ROLLBACK').catch(() => {});

--- a/server/db.ts
+++ b/server/db.ts
@@ -58,7 +58,8 @@ import {
 } from './guild_bank_state';
 import { isUniqueViolation } from './http_util';
 import {
-  deleteBakedCustodyRefs,
+  confirmBakedCustodyRefs,
+  deleteBakedCustodyRefsIn,
   MAIL_CUSTODY_PARCELS_SCHEMA,
   snapshotPendingCustodyRefs,
 } from './mail_custody_overlay';
@@ -3518,8 +3519,10 @@ export async function saveCharacterAndMarketState(
     // never land for a displaced session, and a failure anywhere rolls back
     // the character, market, mail, and book halves together.
     await writeGuildBankRows(client, guildBanks ?? [], results);
+    // The custody bake rides this same fenced transaction (see saveMailState).
+    await deleteBakedCustodyRefsIn((text, values) => client.query(text, values), bakedCustodyRefs);
     await client.query('COMMIT');
-    await deleteBakedCustodyRefs(bakedCustodyRefs);
+    confirmBakedCustodyRefs(bakedCustodyRefs);
     return true;
   } catch (err) {
     await client.query('ROLLBACK').catch(() => {});
@@ -4500,11 +4503,32 @@ export async function saveMailState(save: MailSave): Promise<void> {
   // Custody overlay bake (mail_custody_overlay.ts): the snapshot runs before
   // anything awaits, and no awaited gap separates the caller's
   // serializeMail() from this entry, so every snapshotted parcel is inside
-  // `save` or durably collected out of it. The delete runs only after the
-  // book committed and is non-throwing by contract.
+  // `save` or durably collected out of it. The bake DELETE rides the SAME
+  // transaction as the book upsert: the blob without a parcel and the row's
+  // removal must commit together, or a failed post-commit delete bracketing
+  // a collection could later replay a collected parcel.
   const bakedCustodyRefs = snapshotPendingCustodyRefs();
-  await saveWorldState(mailStateKey(REALM), save);
-  await deleteBakedCustodyRefs(bakedCustodyRefs);
+  if (bakedCustodyRefs.length === 0) {
+    await saveWorldState(mailStateKey(REALM), save);
+    return;
+  }
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    await client.query(
+      `INSERT INTO world_state (key, data, updated_at) VALUES ($1, $2, now())
+       ON CONFLICT (key) DO UPDATE SET data = EXCLUDED.data, updated_at = now()`,
+      [mailStateKey(REALM), JSON.stringify(save)],
+    );
+    await deleteBakedCustodyRefsIn((text, values) => client.query(text, values), bakedCustodyRefs);
+    await client.query('COMMIT');
+  } catch (err) {
+    await client.query('ROLLBACK').catch(() => {});
+    throw err;
+  } finally {
+    client.release();
+  }
+  confirmBakedCustodyRefs(bakedCustodyRefs);
 }
 
 // Shared Rift event history/scheduler, realm-scoped. Runtime group instances are

--- a/server/db.ts
+++ b/server/db.ts
@@ -57,6 +57,11 @@ import {
   mergeGuildBankRow,
 } from './guild_bank_state';
 import { isUniqueViolation } from './http_util';
+import {
+  deleteBakedCustodyRefs,
+  MAIL_CUSTODY_PARCELS_SCHEMA,
+  snapshotPendingCustodyRefs,
+} from './mail_custody_overlay';
 import { MAPS_SCHEMA } from './maps_db';
 import {
   LEGACY_MARKET_KEY,
@@ -1333,6 +1338,11 @@ export async function ensureSchema(): Promise<void> {
     // (idempotent), like the other schema modules.
     await client.query(ACCOUNT_WEALTH_SCHEMA);
     await client.query(SUSPICION_FLAGS_SCHEMA);
+    // The $WOC custody mail overlay (server/mail_custody_overlay.ts): one
+    // durable row per booked parcel until the next full mail-book write
+    // bakes it. No FK on purpose: rows must survive character deletion long
+    // enough for an operator to attribute them.
+    await client.query(MAIL_CUSTODY_PARCELS_SCHEMA);
     // Map editor tables: saved/forked custom maps and uploaded GLB assets.
     // Both FK-reference accounts(id), so they run after SCHEMA. Applied
     // unconditionally (idempotent), like the other schema modules.
@@ -3455,6 +3465,11 @@ export async function saveCharacterAndMarketState(
   // Out-parameter, same contract as saveCharacterAndGuildBankState's.
   results?: GuildBankWriteResult[],
 ): Promise<boolean> {
+  // Custody overlay bake, the saveMailState contract: snapshot at entry
+  // (before anything awaits; the mail argument was serialized synchronously
+  // just before this call), delete only on the committed arm below. The
+  // fence-refused false arm and every rollback keep the rows.
+  const bakedCustodyRefs = snapshotPendingCustodyRefs();
   // Gate the escrow flush on the boot backfill just like saveMarketState:
   // this writes the realm-market row, so it must not run before ensureSchema
   // has confirmed the marker and opened the gate. Checked before any pool work.
@@ -3504,6 +3519,7 @@ export async function saveCharacterAndMarketState(
     // the character, market, mail, and book halves together.
     await writeGuildBankRows(client, guildBanks ?? [], results);
     await client.query('COMMIT');
+    await deleteBakedCustodyRefs(bakedCustodyRefs);
     return true;
   } catch (err) {
     await client.query('ROLLBACK').catch(() => {});
@@ -4481,7 +4497,14 @@ export async function loadMailState(): Promise<MailSave | null> {
 }
 
 export async function saveMailState(save: MailSave): Promise<void> {
+  // Custody overlay bake (mail_custody_overlay.ts): the snapshot runs before
+  // anything awaits, and no awaited gap separates the caller's
+  // serializeMail() from this entry, so every snapshotted parcel is inside
+  // `save` or durably collected out of it. The delete runs only after the
+  // book committed and is non-throwing by contract.
+  const bakedCustodyRefs = snapshotPendingCustodyRefs();
   await saveWorldState(mailStateKey(REALM), save);
+  await deleteBakedCustodyRefs(bakedCustodyRefs);
 }
 
 // Shared Rift event history/scheduler, realm-scoped. Runtime group instances are

--- a/server/game.ts
+++ b/server/game.ts
@@ -277,6 +277,7 @@ import {
   type ListReadGuardState,
 } from './list_read_guard';
 import { type LiveSharedIp, sharedIpsFromLiveSessions } from './live_shared_ips';
+import { mergeCustodyParcelOverlay } from './mail_custody_overlay';
 import { EMPTY_ACCOUNT_COSMETICS, reconcileWornMechChromaForJoin } from './mech_chroma_reconcile';
 import {
   applyMobScanTick,
@@ -4684,6 +4685,9 @@ export class GameServer {
   async loadMail(): Promise<void> {
     try {
       this.sim.loadMail(await loadMailState());
+      // Only after a SUCCESSFUL load: replay the durable custody parcel rows
+      // the last crash window left (book-once dedupes the ones the blob has).
+      await mergeCustodyParcelOverlay(this.sim);
     } catch (err) {
       console.error('failed to load mail:', err);
     }
@@ -6023,10 +6027,6 @@ export class GameServer {
     const session = this.sessionByCharacterId(characterId);
     if (!session || session.left || session.dirtyGuildBanks.size === 0) return;
     await this.saveCharacter(session);
-  }
-
-  async persistMailBlob(): Promise<void> {
-    await this.enqueueMarketWrite(() => saveMailState(this.sim.serializeMail()));
   }
 
   // Force-close every live session for the account. A bearer token is a reusable

--- a/server/mail_custody_overlay.ts
+++ b/server/mail_custody_overlay.ts
@@ -21,10 +21,19 @@
 // only after a SUCCESSFUL book load; merging onto an unloaded book would
 // re-book parcels the stored blob still owns.
 //
-// Retention: rows are bounded by parcels booked between two full book writes
-// plus crash leftovers, and both populations are cleaned by the next bake
-// after the next boot's merge, so this table needs no retention-sweep
-// registration.
+// The rollback guard is the accounting watermark (mail_custody_watermark):
+// rows at or before `accounted_through` are provably inside a committed book
+// write or durably collected out of it, so the boot merge deletes them
+// instead of replaying them (replaying could re-book a parcel COLLECTED
+// under an old binary running without the bake). The soundness argument
+// lives on advanceCustodyWatermarkIn; the watermark only ever advances
+// inside a committed book-write transaction, and only after a boot merge
+// that examined every surviving row.
+//
+// Retention: healthy rows are cleaned by the bake and the watermark cutoff;
+// the constant-window residue prune below joins the nightly retention sweep
+// for the two populations those paths structurally cannot reach (refused
+// rows an operator never resolved, and rows for realms no process serves).
 
 import {
   type LetterDef,
@@ -51,6 +60,11 @@ CREATE TABLE IF NOT EXISTS mail_custody_parcels (
 );
 CREATE INDEX IF NOT EXISTS mail_custody_parcels_realm_created
   ON mail_custody_parcels (realm, created_at);
+CREATE TABLE IF NOT EXISTS mail_custody_watermark (
+  realm TEXT PRIMARY KEY,
+  accounted_through TIMESTAMPTZ NOT NULL,
+  last_book_write TIMESTAMPTZ NOT NULL
+);
 `;
 
 export type CustodyParcelLetter = 'delivery' | 'return' | 'sold_notice';
@@ -87,6 +101,13 @@ export interface CustodyParcelBook {
 // durable full-book write. One custody bridge per realm process, so
 // module-level like the escrow counters in woc_market_custody.ts.
 const pendingBake = new Set<string>();
+
+// True once THIS boot's merge examined every surviving overlay row (all
+// pages drained, no error). Until then the watermark must not advance: an
+// unexamined row's parcel is not in the in-memory book, so no book write
+// this process makes can account for it, and advancing past it would let a
+// later boot's merge delete it unreplayed.
+let bootMergeComplete = false;
 
 /** Persist one booked parcel. Idempotent per custodyRef (a retry after a
  *  crash re-inserts harmlessly; the book-once dedupe owns exactly-once on
@@ -138,6 +159,38 @@ export async function deleteBakedCustodyRefsIn(
   );
 }
 
+/** Advance the accounting watermark INSIDE a committed full-book write
+ *  transaction. `accounted_through` takes the PREVIOUS book write's
+ *  transaction start (`last_book_write`), never this one's: a row with
+ *  created_at at or before that instant had its INSERT execute before write
+ *  N began, so its parcel was booked strictly earlier still, and because
+ *  every book write rides the market serial FIFO, write N+1's
+ *  serializeMail() started only after write N committed. Every such parcel
+ *  is therefore inside the book THIS transaction writes, or durably
+ *  collected out of it. The argument uses one database clock plus the
+ *  FIFO's real-time ordering only: no wall-clock read outside a
+ *  transaction, no cross-connection ordering assumption, no comparison a
+ *  serialize-to-BEGIN gap can invert. Rows booked after this write
+ *  serialized land past the watermark and replay at boot, where the
+ *  book-once dedupe keeps them single.
+ *
+ *  No-ops until this boot's merge fully drained (bootMergeComplete): a
+ *  frozen watermark only means rows replay through the dedupe instead of
+ *  being deleted, which is always safe. */
+export async function advanceCustodyWatermarkIn(
+  query: (text: string, values: unknown[]) => Promise<unknown>,
+): Promise<void> {
+  if (!bootMergeComplete) return;
+  await query(
+    `INSERT INTO mail_custody_watermark (realm, accounted_through, last_book_write)
+     VALUES ($1, '-infinity', now())
+     ON CONFLICT (realm) DO UPDATE
+       SET accounted_through = mail_custody_watermark.last_book_write,
+           last_book_write = now()`,
+    [REALM],
+  );
+}
+
 /** Forget the baked refs AFTER their transaction committed (never before: a
  *  rollback must leave them pending so the next write re-bakes them). */
 export function confirmBakedCustodyRefs(refs: readonly string[]): void {
@@ -145,8 +198,9 @@ export function confirmBakedCustodyRefs(refs: readonly string[]): void {
 }
 
 // The last boot merge's counts plus the live bake-set size, for the market
-// monitor readout: a growing overlay table or a stuck refused row must be
-// visible to an operator without a log grep.
+// monitor readout: a growing overlay table, a stuck refused row, or a
+// FAILED merge (ok false) must be visible to an operator without a log
+// grep.
 let lastMergeCounts: CustodyOverlayMergeCounts | null = null;
 export function custodyOverlayStats(): {
   pendingBake: number;
@@ -156,12 +210,13 @@ export function custodyOverlayStats(): {
 }
 
 /** Residue reaper for the nightly retention sweep. The bake and the boot
- *  merge's stale cutoff clean every healthy row, so this drains only the
- *  residue those paths structurally cannot reach: refused rows an operator
- *  never resolved, and rows for a realm no process serves any more. The
- *  window is a constant (deliberately no env knob, the stepup-challenges
- *  pattern): far past any plausible investigation, and rows this old
- *  describe parcels whose settlement machinery gave up long ago. */
+ *  merge's watermark cutoff clean every healthy row, so this drains only
+ *  the residue those paths structurally cannot reach: refused rows an
+ *  operator never resolved, and rows for a realm no process serves any
+ *  more. The window is a constant (deliberately no env knob, the
+ *  stepup-challenges pattern): far past any plausible investigation, and
+ *  rows this old describe parcels whose settlement machinery gave up long
+ *  ago. */
 export const MAIL_CUSTODY_RESIDUE_RETENTION_DAYS = 30;
 
 export async function pruneMailCustodyParcelsBatch(batchSize: number): Promise<number> {
@@ -181,16 +236,24 @@ function isCustodyParcelLetter(value: unknown): value is CustodyParcelLetter {
   return value === 'delivery' || value === 'return' || value === 'sold_notice';
 }
 
-/** The boot merge's page bound: past it the merge logs loudly and leaves the
- *  remainder for the next boot or bake, so a pathological backlog can never
- *  hold the boot path hostage. */
+/** The boot merge's page size. Pages continue until the table drains or
+ *  MERGE_MAX_PAGES is hit, so a pathological backlog can never hold the
+ *  boot path hostage; an undrained merge leaves the watermark frozen (see
+ *  advanceCustodyWatermarkIn), so unexamined rows replay at a later boot
+ *  rather than ever being classified stale. */
 export const MERGE_PAGE_LIMIT = 10_000;
+export const MERGE_MAX_PAGES = 20;
 
 export interface CustodyOverlayMergeCounts {
   replayed: number;
   present: number;
   refused: number;
   stale: number;
+  /** True only when every surviving row was examined (all pages drained, no
+   *  error). False is the operator's failed-merge signal: all-zero counts
+   *  with ok false is a failed merge, not an empty table, and the watermark
+   *  stays frozen for the whole uptime. */
+  ok: boolean;
 }
 
 /** Boot merge: replay the surviving overlay rows for this realm through the
@@ -198,86 +261,108 @@ export interface CustodyOverlayMergeCounts {
  *  its custodyRef; one the crash window lost re-books. Every accounted ref
  *  joins pendingBake so the next full-book write cleans its row.
  *
- *  THE STALE CUTOFF is the rollback-window guard: a row whose created_at
- *  predates the mail blob's own updated_at describes a parcel that some
- *  committed full-book write already accounted for, in the blob or durably
- *  collected out of it (the writers snapshot at entry, and only this realm's
- *  single process writes its blob), so replaying it could re-book a
- *  COLLECTED parcel: the one dupe an old binary running without the bake
- *  could otherwise leave behind. Stale rows are deleted, never replayed;
- *  both timestamps are database-clock now(), so no host skew. A row that is
- *  fresh but refused (its items no longer validate, which a parcel that
- *  booked once should never hit) is kept and reported for the operator, and
- *  becomes stale, then cleaned, once a later book write postdates it.
+ *  THE WATERMARK CUTOFF is the rollback-window guard: a row at or before
+ *  `accounted_through` is provably inside a committed book write or durably
+ *  collected out of it (the soundness argument is on
+ *  advanceCustodyWatermarkIn), so replaying it could re-book a COLLECTED
+ *  parcel: the one dupe an old binary running without the bake could
+ *  otherwise leave behind. Such rows are deleted, never replayed, and the
+ *  comparison happens entirely in SQL so the microsecond timestamps never
+ *  round-trip through a millisecond Date. A row that is past the watermark
+ *  but refused (its items no longer validate, which a parcel that booked
+ *  once should never hit) is kept and reported for the operator, and is
+ *  cleaned once the advancing watermark passes it.
  *
- *  Never throws: the book already loaded successfully by the time this runs,
- *  and a merge failure must read as "parcels replay on a later boot", not as
- *  a mail-load failure. */
+ *  Never throws: the book already loaded successfully by the time this
+ *  runs, and a merge failure must read as "the watermark stays frozen and
+ *  every row replays at a later boot", never as a mail-load failure. */
 export async function mergeCustodyParcelOverlay(
   book: CustodyParcelBook,
 ): Promise<CustodyOverlayMergeCounts> {
-  const counts: CustodyOverlayMergeCounts = { replayed: 0, present: 0, refused: 0, stale: 0 };
+  const counts: CustodyOverlayMergeCounts = {
+    replayed: 0,
+    present: 0,
+    refused: 0,
+    stale: 0,
+    ok: false,
+  };
   try {
-    // The blob's durability point (db.ts mailStateKey format).
-    const blob = await pool.query(`SELECT updated_at FROM world_state WHERE key = $1`, [
-      `mail:${REALM}`,
-    ]);
-    const bookWrittenAtMs = blob.rows[0] ? new Date(blob.rows[0].updated_at).getTime() : null;
-    const res = await pool.query(
-      `SELECT custody_ref, recipient_key, recipient_name, letter, items, created_at
-       FROM mail_custody_parcels WHERE realm = $1 ORDER BY created_at, custody_ref
-       LIMIT ${MERGE_PAGE_LIMIT}`,
+    // The watermark cutoff, entirely in SQL. `<=` is sound because
+    // accounted_through is itself a transaction start: a row created at
+    // exactly that instant was still booked strictly before it (booking
+    // precedes the INSERT's execution). No watermark row (or '-infinity')
+    // deletes nothing.
+    const stale = await pool.query(
+      `DELETE FROM mail_custody_parcels
+        WHERE realm = $1
+          AND created_at <= (SELECT accounted_through FROM mail_custody_watermark WHERE realm = $1)`,
       [REALM],
     );
-    const staleRefs: string[] = [];
-    for (const r of res.rows) {
-      const ref = String(r.custody_ref);
-      if (bookWrittenAtMs !== null && new Date(r.created_at).getTime() <= bookWrittenAtMs) {
-        staleRefs.push(ref);
-        continue;
+    counts.stale = stale.rowCount ?? 0;
+    // Keyset pages over the primary key: the merge drains the whole table
+    // (bounded per statement), because any row left unexamined freezes the
+    // watermark for the entire uptime.
+    let afterRef = '';
+    for (let page = 0; ; page++) {
+      if (page >= MERGE_MAX_PAGES) {
+        console.error(
+          `[mail_custody] overlay merge stopped at ${MERGE_MAX_PAGES} pages of ${MERGE_PAGE_LIMIT}; the watermark stays frozen and the remainder replays at a later boot`,
+        );
+        break;
       }
-      const letter: unknown = r.letter;
-      if (!isCustodyParcelLetter(letter) || !Array.isArray(r.items)) {
-        counts.refused++;
-        console.error(`[mail_custody] overlay row malformed for custodyRef ${ref}`);
-        continue;
-      }
-      const recipient = { key: String(r.recipient_key), name: String(r.recipient_name) };
-      if (book.mailSystemParcel(recipient, CUSTODY_PARCEL_LETTERS[letter], r.items, ref)) {
-        counts.replayed++;
-      } else if (book.hasCustodyParcel(ref)) {
-        counts.present++;
-      } else {
-        counts.refused++;
-        console.error(`[mail_custody] overlay replay refused for custodyRef ${ref}`);
-        continue;
-      }
-      pendingBake.add(ref);
-    }
-    if (staleRefs.length > 0) {
-      counts.stale = staleRefs.length;
-      await pool.query(`DELETE FROM mail_custody_parcels WHERE custody_ref = ANY($1::text[])`, [
-        staleRefs,
-      ]);
-    }
-    if (res.rows.length >= MERGE_PAGE_LIMIT) {
-      console.error(
-        `[mail_custody] overlay merge page full at ${MERGE_PAGE_LIMIT} rows; remainder waits for the next boot or bake`,
+      const res = await pool.query(
+        `SELECT custody_ref, recipient_key, recipient_name, letter, items
+         FROM mail_custody_parcels WHERE realm = $1 AND custody_ref > $2
+         ORDER BY custody_ref LIMIT ${MERGE_PAGE_LIMIT}`,
+        [REALM, afterRef],
       );
+      for (const r of res.rows) {
+        const ref = String(r.custody_ref);
+        const letter: unknown = r.letter;
+        if (!isCustodyParcelLetter(letter) || !Array.isArray(r.items)) {
+          counts.refused++;
+          console.error(`[mail_custody] overlay row malformed for custodyRef ${ref}`);
+          continue;
+        }
+        const recipient = { key: String(r.recipient_key), name: String(r.recipient_name) };
+        if (book.mailSystemParcel(recipient, CUSTODY_PARCEL_LETTERS[letter], r.items, ref)) {
+          counts.replayed++;
+        } else if (book.hasCustodyParcel(ref)) {
+          counts.present++;
+        } else {
+          counts.refused++;
+          console.error(`[mail_custody] overlay replay refused for custodyRef ${ref}`);
+          continue;
+        }
+        pendingBake.add(ref);
+      }
+      if (res.rows.length < MERGE_PAGE_LIMIT) {
+        counts.ok = true;
+        break;
+      }
+      afterRef = String(res.rows[res.rows.length - 1].custody_ref);
     }
-    if (res.rows.length > 0) {
+    if (counts.replayed + counts.present + counts.refused + counts.stale > 0) {
       console.log(
         `mail custody overlay: ${counts.replayed} parcels replayed, ${counts.present} already in the book, ${counts.refused} refused, ${counts.stale} stale rows cleaned`,
       );
     }
   } catch (err) {
-    console.error('[mail_custody] overlay merge failed (parcels replay on a later boot):', err);
+    counts.ok = false;
+    console.error(
+      '[mail_custody] overlay merge failed; the watermark stays frozen and every row replays at a later boot:',
+      err,
+    );
   }
+  if (counts.ok) bootMergeComplete = true;
   lastMergeCounts = counts;
   return counts;
 }
 
-/** Test-only: the module-level bake set survives across cases otherwise. */
+/** Test-only: the module-level bake set, merge stats, and watermark gate
+ *  survive across cases otherwise. */
 export function resetCustodyParcelOverlayForTests(): void {
   pendingBake.clear();
+  lastMergeCounts = null;
+  bootMergeComplete = false;
 }

--- a/server/mail_custody_overlay.ts
+++ b/server/mail_custody_overlay.ts
@@ -33,6 +33,9 @@ import {
   WOC_MARKET_SOLD_LETTER,
 } from '../src/sim/content/letters';
 import type { InvSlot } from '../src/sim/types';
+// Deliberate cycle with ./db (which imports this module's SCHEMA const):
+// safe ONLY because `pool` is dereferenced inside function bodies, never at
+// module scope. Do not add module-scope pool usage here.
 import { pool } from './db';
 import { REALM } from './realm';
 
@@ -46,7 +49,8 @@ CREATE TABLE IF NOT EXISTS mail_custody_parcels (
   items JSONB NOT NULL,
   created_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
-CREATE INDEX IF NOT EXISTS mail_custody_parcels_realm ON mail_custody_parcels (realm);
+CREATE INDEX IF NOT EXISTS mail_custody_parcels_realm_created
+  ON mail_custody_parcels (realm, created_at);
 `;
 
 export type CustodyParcelLetter = 'delivery' | 'return' | 'sold_notice';
@@ -115,72 +119,162 @@ export function snapshotPendingCustodyRefs(): string[] {
   return [...pendingBake];
 }
 
-/** Delete the snapshotted rows after their full-book write provably
- *  committed. Deliberately non-throwing: this runs AFTER the commit, so a
- *  failure here must not re-mark a committed save as failed. Rows linger,
- *  their refs stay pending (removed only on successful delete), and the
- *  next full-book write retries; a crash meanwhile replays them through the
- *  book-once dedupe. */
-export async function deleteBakedCustodyRefs(refs: readonly string[]): Promise<void> {
+/** Issue the bake DELETE on the SAME client, INSIDE the transaction that
+ *  makes the book durable: "blob durable without the parcel" and "row gone"
+ *  must commit together, or two failed post-commit deletes bracketing a
+ *  collection would leave a row that replays a collected parcel (the
+ *  structural exactly-once the old whole-book write had for free). A throw
+ *  here rolls the book write back with it, which is the correct atomicity.
+ *  The realm qualifier is defensive scoping (refs are globally unique
+ *  today). */
+export async function deleteBakedCustodyRefsIn(
+  query: (text: string, values: unknown[]) => Promise<unknown>,
+  refs: readonly string[],
+): Promise<void> {
   if (refs.length === 0) return;
-  try {
-    await pool.query(`DELETE FROM mail_custody_parcels WHERE custody_ref = ANY($1::text[])`, [
-      [...refs],
-    ]);
-    for (const ref of refs) pendingBake.delete(ref);
-  } catch (err) {
-    console.error('[mail_custody] baked row delete failed (the next book write retries):', err);
-  }
+  await query(
+    `DELETE FROM mail_custody_parcels WHERE custody_ref = ANY($1::text[]) AND realm = $2`,
+    [[...refs], REALM],
+  );
+}
+
+/** Forget the baked refs AFTER their transaction committed (never before: a
+ *  rollback must leave them pending so the next write re-bakes them). */
+export function confirmBakedCustodyRefs(refs: readonly string[]): void {
+  for (const ref of refs) pendingBake.delete(ref);
+}
+
+// The last boot merge's counts plus the live bake-set size, for the market
+// monitor readout: a growing overlay table or a stuck refused row must be
+// visible to an operator without a log grep.
+let lastMergeCounts: CustodyOverlayMergeCounts | null = null;
+export function custodyOverlayStats(): {
+  pendingBake: number;
+  lastMerge: CustodyOverlayMergeCounts | null;
+} {
+  return { pendingBake: pendingBake.size, lastMerge: lastMergeCounts };
+}
+
+/** Residue reaper for the nightly retention sweep. The bake and the boot
+ *  merge's stale cutoff clean every healthy row, so this drains only the
+ *  residue those paths structurally cannot reach: refused rows an operator
+ *  never resolved, and rows for a realm no process serves any more. The
+ *  window is a constant (deliberately no env knob, the stepup-challenges
+ *  pattern): far past any plausible investigation, and rows this old
+ *  describe parcels whose settlement machinery gave up long ago. */
+export const MAIL_CUSTODY_RESIDUE_RETENTION_DAYS = 30;
+
+export async function pruneMailCustodyParcelsBatch(batchSize: number): Promise<number> {
+  const res = await pool.query(
+    `DELETE FROM mail_custody_parcels
+      WHERE ctid IN (
+        SELECT ctid FROM mail_custody_parcels
+         WHERE created_at < now() - ($1 || ' days')::interval
+         ORDER BY created_at
+         LIMIT $2)`,
+    [String(MAIL_CUSTODY_RESIDUE_RETENTION_DAYS), Math.max(1, Math.floor(batchSize))],
+  );
+  return res.rowCount ?? 0;
 }
 
 function isCustodyParcelLetter(value: unknown): value is CustodyParcelLetter {
   return value === 'delivery' || value === 'return' || value === 'sold_notice';
 }
 
-/** Boot merge: replay every surviving overlay row for this realm through the
+/** The boot merge's page bound: past it the merge logs loudly and leaves the
+ *  remainder for the next boot or bake, so a pathological backlog can never
+ *  hold the boot path hostage. */
+export const MERGE_PAGE_LIMIT = 10_000;
+
+export interface CustodyOverlayMergeCounts {
+  replayed: number;
+  present: number;
+  refused: number;
+  stale: number;
+}
+
+/** Boot merge: replay the surviving overlay rows for this realm through the
  *  book-once parcel entry. A parcel already in the loaded blob dedupes on
  *  its custodyRef; one the crash window lost re-books. Every accounted ref
- *  joins pendingBake so the next full-book write cleans its row. A row that
- *  is refused AND absent (its items no longer validate, which a parcel that
- *  booked once should never hit) is kept in the table and reported, so the
- *  operator can attribute it instead of it silently vanishing. */
+ *  joins pendingBake so the next full-book write cleans its row.
+ *
+ *  THE STALE CUTOFF is the rollback-window guard: a row whose created_at
+ *  predates the mail blob's own updated_at describes a parcel that some
+ *  committed full-book write already accounted for, in the blob or durably
+ *  collected out of it (the writers snapshot at entry, and only this realm's
+ *  single process writes its blob), so replaying it could re-book a
+ *  COLLECTED parcel: the one dupe an old binary running without the bake
+ *  could otherwise leave behind. Stale rows are deleted, never replayed;
+ *  both timestamps are database-clock now(), so no host skew. A row that is
+ *  fresh but refused (its items no longer validate, which a parcel that
+ *  booked once should never hit) is kept and reported for the operator, and
+ *  becomes stale, then cleaned, once a later book write postdates it.
+ *
+ *  Never throws: the book already loaded successfully by the time this runs,
+ *  and a merge failure must read as "parcels replay on a later boot", not as
+ *  a mail-load failure. */
 export async function mergeCustodyParcelOverlay(
   book: CustodyParcelBook,
-): Promise<{ replayed: number; present: number; refused: number }> {
-  const res = await pool.query(
-    `SELECT custody_ref, recipient_key, recipient_name, letter, items
-     FROM mail_custody_parcels WHERE realm = $1 ORDER BY created_at, custody_ref`,
-    [REALM],
-  );
-  let replayed = 0;
-  let present = 0;
-  let refused = 0;
-  for (const r of res.rows) {
-    const ref = String(r.custody_ref);
-    const letter: unknown = r.letter;
-    if (!isCustodyParcelLetter(letter) || !Array.isArray(r.items)) {
-      refused++;
-      console.error(`[mail_custody] overlay row malformed for custodyRef ${ref}`);
-      continue;
-    }
-    const recipient = { key: String(r.recipient_key), name: String(r.recipient_name) };
-    if (book.mailSystemParcel(recipient, CUSTODY_PARCEL_LETTERS[letter], r.items, ref)) {
-      replayed++;
-    } else if (book.hasCustodyParcel(ref)) {
-      present++;
-    } else {
-      refused++;
-      console.error(`[mail_custody] overlay replay refused for custodyRef ${ref}`);
-      continue;
-    }
-    pendingBake.add(ref);
-  }
-  if (replayed > 0 || refused > 0) {
-    console.log(
-      `mail custody overlay: ${replayed} parcels replayed, ${present} already in the book, ${refused} refused`,
+): Promise<CustodyOverlayMergeCounts> {
+  const counts: CustodyOverlayMergeCounts = { replayed: 0, present: 0, refused: 0, stale: 0 };
+  try {
+    // The blob's durability point (db.ts mailStateKey format).
+    const blob = await pool.query(`SELECT updated_at FROM world_state WHERE key = $1`, [
+      `mail:${REALM}`,
+    ]);
+    const bookWrittenAtMs = blob.rows[0] ? new Date(blob.rows[0].updated_at).getTime() : null;
+    const res = await pool.query(
+      `SELECT custody_ref, recipient_key, recipient_name, letter, items, created_at
+       FROM mail_custody_parcels WHERE realm = $1 ORDER BY created_at, custody_ref
+       LIMIT ${MERGE_PAGE_LIMIT}`,
+      [REALM],
     );
+    const staleRefs: string[] = [];
+    for (const r of res.rows) {
+      const ref = String(r.custody_ref);
+      if (bookWrittenAtMs !== null && new Date(r.created_at).getTime() <= bookWrittenAtMs) {
+        staleRefs.push(ref);
+        continue;
+      }
+      const letter: unknown = r.letter;
+      if (!isCustodyParcelLetter(letter) || !Array.isArray(r.items)) {
+        counts.refused++;
+        console.error(`[mail_custody] overlay row malformed for custodyRef ${ref}`);
+        continue;
+      }
+      const recipient = { key: String(r.recipient_key), name: String(r.recipient_name) };
+      if (book.mailSystemParcel(recipient, CUSTODY_PARCEL_LETTERS[letter], r.items, ref)) {
+        counts.replayed++;
+      } else if (book.hasCustodyParcel(ref)) {
+        counts.present++;
+      } else {
+        counts.refused++;
+        console.error(`[mail_custody] overlay replay refused for custodyRef ${ref}`);
+        continue;
+      }
+      pendingBake.add(ref);
+    }
+    if (staleRefs.length > 0) {
+      counts.stale = staleRefs.length;
+      await pool.query(`DELETE FROM mail_custody_parcels WHERE custody_ref = ANY($1::text[])`, [
+        staleRefs,
+      ]);
+    }
+    if (res.rows.length >= MERGE_PAGE_LIMIT) {
+      console.error(
+        `[mail_custody] overlay merge page full at ${MERGE_PAGE_LIMIT} rows; remainder waits for the next boot or bake`,
+      );
+    }
+    if (res.rows.length > 0) {
+      console.log(
+        `mail custody overlay: ${counts.replayed} parcels replayed, ${counts.present} already in the book, ${counts.refused} refused, ${counts.stale} stale rows cleaned`,
+      );
+    }
+  } catch (err) {
+    console.error('[mail_custody] overlay merge failed (parcels replay on a later boot):', err);
   }
-  return { replayed, present, refused };
+  lastMergeCounts = counts;
+  return counts;
 }
 
 /** Test-only: the module-level bake set survives across cases otherwise. */

--- a/server/mail_custody_overlay.ts
+++ b/server/mail_custody_overlay.ts
@@ -1,0 +1,189 @@
+// Durable per-parcel overlay for $WOC custody mail. Booking a custody parcel
+// used to persist by re-serializing and rewriting the ENTIRE per-realm mail
+// blob (89 MB in production, roughly 250 ms of main-thread stringify per
+// parcel on the shared market serial writer), so each delivered item, return,
+// and sold notice cost the world loop an amount proportional to the book, not
+// the parcel. Instead, each booked parcel writes ONE small row here, durable
+// before the settlement advances. The parcel itself lives in the in-memory
+// book as before and reaches the blob on the next full book write (the 30 s
+// autosave or the leave-path atomic save), after which its row is deleted
+// ("baked").
+//
+// Crash contract. A durable FULL-BOOK write is also the collection-durability
+// event, so rows are deleted only for parcels booked BEFORE that write
+// serialized (the pendingBake snapshot below), never by comparing book
+// contents: a parcel collected fast still gets its row deleted (the book
+// without it is durable truth), while a parcel booked mid-write keeps its
+// row. At boot, surviving rows REPLAY through the sim's book-once
+// mailSystemParcel: a parcel already inside the loaded blob dedupes on its
+// custodyRef, and one the crash window lost is re-booked (the letter re-dates
+// to the reboot, which is the existing crash-window semantics). Replay runs
+// only after a SUCCESSFUL book load; merging onto an unloaded book would
+// re-book parcels the stored blob still owns.
+//
+// Retention: rows are bounded by parcels booked between two full book writes
+// plus crash leftovers, and both populations are cleaned by the next bake
+// after the next boot's merge, so this table needs no retention-sweep
+// registration.
+
+import {
+  type LetterDef,
+  WOC_MARKET_DELIVERY_LETTER,
+  WOC_MARKET_RETURN_LETTER,
+  WOC_MARKET_SOLD_LETTER,
+} from '../src/sim/content/letters';
+import type { InvSlot } from '../src/sim/types';
+import { pool } from './db';
+import { REALM } from './realm';
+
+export const MAIL_CUSTODY_PARCELS_SCHEMA = `
+CREATE TABLE IF NOT EXISTS mail_custody_parcels (
+  custody_ref TEXT PRIMARY KEY,
+  realm TEXT NOT NULL,
+  recipient_key TEXT NOT NULL,
+  recipient_name TEXT NOT NULL,
+  letter TEXT NOT NULL,
+  items JSONB NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS mail_custody_parcels_realm ON mail_custody_parcels (realm);
+`;
+
+export type CustodyParcelLetter = 'delivery' | 'return' | 'sold_notice';
+
+/** The letter templates by overlay kind: the same mapping the custody bridge
+ *  books with, so a replayed parcel is byte-for-byte the letter the delivery
+ *  path would have sent. */
+export const CUSTODY_PARCEL_LETTERS: Record<CustodyParcelLetter, LetterDef> = {
+  delivery: WOC_MARKET_DELIVERY_LETTER,
+  return: WOC_MARKET_RETURN_LETTER,
+  sold_notice: WOC_MARKET_SOLD_LETTER,
+};
+
+export interface CustodyParcelRow {
+  custodyRef: string;
+  recipient: { key: string; name: string };
+  letter: CustodyParcelLetter;
+  items: InvSlot[];
+}
+
+/** The slice of Sim the boot merge needs (the real Sim satisfies it). */
+export interface CustodyParcelBook {
+  mailSystemParcel(
+    recipient: { key: string; name: string },
+    letter: LetterDef,
+    items: InvSlot[],
+    custodyRef?: string,
+  ): boolean;
+  hasCustodyParcel(custodyRef: string): boolean;
+}
+
+// Refs booked in THIS process (inserted here or replayed by the boot merge)
+// whose parcels sit in the in-memory book but are not yet baked into a
+// durable full-book write. One custody bridge per realm process, so
+// module-level like the escrow counters in woc_market_custody.ts.
+const pendingBake = new Set<string>();
+
+/** Persist one booked parcel. Idempotent per custodyRef (a retry after a
+ *  crash re-inserts harmlessly; the book-once dedupe owns exactly-once on
+ *  the mail side). Resolving is the parcel's durability: callers must not
+ *  advance a settlement until this resolves. */
+export async function persistCustodyParcelRow(row: CustodyParcelRow): Promise<void> {
+  await pool.query(
+    `INSERT INTO mail_custody_parcels (custody_ref, realm, recipient_key, recipient_name, letter, items)
+     VALUES ($1, $2, $3, $4, $5, $6::jsonb)
+     ON CONFLICT (custody_ref) DO NOTHING`,
+    [
+      row.custodyRef,
+      REALM,
+      row.recipient.key,
+      row.recipient.name,
+      row.letter,
+      JSON.stringify(row.items),
+    ],
+  );
+  pendingBake.add(row.custodyRef);
+}
+
+/** Snapshot the refs pending bake, taken by a full-book writer AT ENTRY,
+ *  before anything awaits: no awaited gap separates the caller's
+ *  serializeMail() argument from the callee's first statement, so every
+ *  snapshotted parcel is inside the book being written or durably collected
+ *  out of it, and a parcel booked later (necessarily across an await) is
+ *  never snapshotted. */
+export function snapshotPendingCustodyRefs(): string[] {
+  return [...pendingBake];
+}
+
+/** Delete the snapshotted rows after their full-book write provably
+ *  committed. Deliberately non-throwing: this runs AFTER the commit, so a
+ *  failure here must not re-mark a committed save as failed. Rows linger,
+ *  their refs stay pending (removed only on successful delete), and the
+ *  next full-book write retries; a crash meanwhile replays them through the
+ *  book-once dedupe. */
+export async function deleteBakedCustodyRefs(refs: readonly string[]): Promise<void> {
+  if (refs.length === 0) return;
+  try {
+    await pool.query(`DELETE FROM mail_custody_parcels WHERE custody_ref = ANY($1::text[])`, [
+      [...refs],
+    ]);
+    for (const ref of refs) pendingBake.delete(ref);
+  } catch (err) {
+    console.error('[mail_custody] baked row delete failed (the next book write retries):', err);
+  }
+}
+
+function isCustodyParcelLetter(value: unknown): value is CustodyParcelLetter {
+  return value === 'delivery' || value === 'return' || value === 'sold_notice';
+}
+
+/** Boot merge: replay every surviving overlay row for this realm through the
+ *  book-once parcel entry. A parcel already in the loaded blob dedupes on
+ *  its custodyRef; one the crash window lost re-books. Every accounted ref
+ *  joins pendingBake so the next full-book write cleans its row. A row that
+ *  is refused AND absent (its items no longer validate, which a parcel that
+ *  booked once should never hit) is kept in the table and reported, so the
+ *  operator can attribute it instead of it silently vanishing. */
+export async function mergeCustodyParcelOverlay(
+  book: CustodyParcelBook,
+): Promise<{ replayed: number; present: number; refused: number }> {
+  const res = await pool.query(
+    `SELECT custody_ref, recipient_key, recipient_name, letter, items
+     FROM mail_custody_parcels WHERE realm = $1 ORDER BY created_at, custody_ref`,
+    [REALM],
+  );
+  let replayed = 0;
+  let present = 0;
+  let refused = 0;
+  for (const r of res.rows) {
+    const ref = String(r.custody_ref);
+    const letter: unknown = r.letter;
+    if (!isCustodyParcelLetter(letter) || !Array.isArray(r.items)) {
+      refused++;
+      console.error(`[mail_custody] overlay row malformed for custodyRef ${ref}`);
+      continue;
+    }
+    const recipient = { key: String(r.recipient_key), name: String(r.recipient_name) };
+    if (book.mailSystemParcel(recipient, CUSTODY_PARCEL_LETTERS[letter], r.items, ref)) {
+      replayed++;
+    } else if (book.hasCustodyParcel(ref)) {
+      present++;
+    } else {
+      refused++;
+      console.error(`[mail_custody] overlay replay refused for custodyRef ${ref}`);
+      continue;
+    }
+    pendingBake.add(ref);
+  }
+  if (replayed > 0 || refused > 0) {
+    console.log(
+      `mail custody overlay: ${replayed} parcels replayed, ${present} already in the book, ${refused} refused`,
+    );
+  }
+  return { replayed, present, refused };
+}
+
+/** Test-only: the module-level bake set survives across cases otherwise. */
+export function resetCustodyParcelOverlayForTests(): void {
+  pendingBake.clear();
+}

--- a/server/main.ts
+++ b/server/main.ts
@@ -2899,7 +2899,6 @@ const wocMarketService = new WocMarketService({
         return liveGame().sim;
       },
       wocCustodySession: (characterId) => liveGame().wocCustodySession(characterId),
-      persistMailBlob: () => liveGame().persistMailBlob(),
       enqueueCharacterWrite: (characterId, job) =>
         liveGame().enqueueCharacterWrite(characterId, job),
       serializeCharacterForPersist: (characterId) =>

--- a/server/main.ts
+++ b/server/main.ts
@@ -292,6 +292,7 @@ import {
   readArenaLeaderboard,
   readProjectStats,
 } from './leaderboard';
+import { custodyOverlayStats, pruneMailCustodyParcelsBatch } from './mail_custody_overlay';
 import { MAX_MAP_SAVE_BYTES } from './maps';
 import {
   mapDeleteCore,
@@ -3012,6 +3013,10 @@ configureInternalWocMarketStuckRead(async () => ({
   // The extract-side per-listing serialize cost (event-loop CPU): the number
   // the SAVE_IDLE bound's sizing argument rests on.
   escrowSerialize: wocEscrowSerializeStats(),
+  // The custody mail overlay: a growing pendingBake or a lastMerge with
+  // refused rows is the stuck-parcel signal an operator needs without a
+  // log grep (mail_custody_overlay.ts).
+  custodyOverlay: custodyOverlayStats(),
   // Stamp-ledger high-water crossings (the counted half of the intent-map
   // bound: the maps never shed entries, so crossings are the incident count).
   stampHighWater: wocStampHighWaterCount(),
@@ -3809,6 +3814,14 @@ export async function startServer(): Promise<http.Server> {
         // constant is the window; deliberately no env knob).
         name: 'woc_market_stepup_challenges',
         pruneBatch: (n) => pruneExpiredWocStepUpChallengesBatch(pool, n),
+      },
+      {
+        // $WOC custody mail overlay residue: the bake and the boot merge's
+        // stale cutoff clean every healthy row, so this entry drains only
+        // refused rows an operator never resolved and rows for realms no
+        // process serves (constant window; deliberately no env knob).
+        name: 'mail_custody_parcels',
+        pruneBatch: (n) => pruneMailCustodyParcelsBatch(n),
       },
       {
         // Closed, fully-disposed $WOC Exchange listings (bids + settlements

--- a/server/woc_market_custody.ts
+++ b/server/woc_market_custody.ts
@@ -2,26 +2,30 @@
 // live Sim (docs/prd/woc/marketplace.md "Item custody"). Escrow extraction
 // runs against the online seller's live bags; deliveries and returns book
 // Ravenpost system parcels (instance payloads intact, book-once by
-// custodyRef) and persist the realm mail blob before the caller advances its
-// settlement row, so a crash anywhere in between reconciles to exactly one
-// parcel. The sim stays currency-blind: nothing here mentions prices, tokens,
+// custodyRef) and persist a durable per-parcel overlay row
+// (mail_custody_overlay.ts) before the caller advances its settlement row,
+// so a crash anywhere in between reconciles to exactly one parcel and a
+// parcel never costs a whole-book write. The sim stays currency-blind: nothing here mentions prices, tokens,
 // or wallets, only item copies and letters.
 
-import {
-  WOC_MARKET_DELIVERY_LETTER,
-  WOC_MARKET_RETURN_LETTER,
-  WOC_MARKET_SOLD_LETTER,
-} from '../src/sim/content/letters';
+import { randomUUID } from 'node:crypto';
+import { WOC_MARKET_RETURN_LETTER } from '../src/sim/content/letters';
 import type { ExtractRef } from '../src/sim/inventory_extract';
 import type { CharacterState, Sim } from '../src/sim/sim';
 import { cloneItemInstancePayload, type InvSlot } from '../src/sim/types';
 import { gameMetricsCounters } from './http/game_signals';
+import {
+  CUSTODY_PARCEL_LETTERS,
+  type CustodyParcelRow,
+  persistCustodyParcelRow,
+} from './mail_custody_overlay';
 import type { WocCustodyExtract, WocCustodyGrant, WocMarketCustody } from './woc_market';
 import { createWocEscrowGate, type WocEscrowGate } from './woc_market_escrow_gate';
 
 /** The narrow slice of GameServer the custody module consumes (game.ts
- *  wocCustodySession / persistMailBlob plus the public sim, and the
- *  per-character save FIFO seam the escrow persist rides). */
+ *  wocCustodySession plus the public sim, and the per-character save FIFO
+ *  seam the escrow persist rides). Parcel durability rides the per-parcel
+ *  overlay row (mail_custody_overlay.ts), never a whole-book write. */
 export interface WocCustodyGameHost {
   sim: Sim;
   wocCustodySession(characterId: number): {
@@ -30,7 +34,6 @@ export interface WocCustodyGameHost {
     name: string;
     leaseNonce: string | undefined;
   } | null;
-  persistMailBlob(): Promise<void>;
   /** The per-character save FIFO (game.ts characterSaveQueues): a job runs
    *  only after every earlier save or job for that character settled, so
    *  commit order is enqueue order. A job must never await another enqueue
@@ -79,11 +82,7 @@ export const ESCROW_QUEUE_WARN_MS = 2_000;
  *  tunables-ladder pin beside its siblings. */
 export const ESCROW_QUEUE_WARN_THROTTLE_MS = 30_000;
 
-const LETTERS = {
-  delivery: WOC_MARKET_DELIVERY_LETTER,
-  return: WOC_MARKET_RETURN_LETTER,
-  sold_notice: WOC_MARKET_SOLD_LETTER,
-} as const;
+const LETTERS = CUSTODY_PARCEL_LETTERS;
 
 /** Process-lifetime per-listing serialize cost (the escrow write-path rider):
  *  the extract-side serializeCharacterForPersist is synchronous CPU on the
@@ -114,12 +113,16 @@ export function createWocMarketCustody(
      *  gate per realm process; injectable so main.ts can put its stats on
      *  the ops readout and tests can saturate it. */
     escrowGate?: WocEscrowGate;
+    /** The per-parcel durable write (mail_custody_overlay.ts by default);
+     *  injectable so the custody tests run without a pool. */
+    persistParcelRow?: (row: CustodyParcelRow) => Promise<void>;
   } = {},
 ): WocMarketCustody {
   const escrowWaitMs = opts.escrowWaitMs ?? ESCROW_QUEUE_WAIT_MS;
   const escrowWarnMs = opts.escrowWarnMs ?? ESCROW_QUEUE_WARN_MS;
   const escrowWarnThrottleMs = opts.escrowWarnThrottleMs ?? ESCROW_QUEUE_WARN_THROTTLE_MS;
   const escrowGate = opts.escrowGate ?? createWocEscrowGate();
+  const persistParcelRow = opts.persistParcelRow ?? persistCustodyParcelRow;
   /** Depth cap 1 per character: the ids with an escrow job queued or
    *  running. Released when the WORK settles; a FIFO that never settles
    *  (a non-query hang past every db bound) would pin its character's slot
@@ -418,12 +421,18 @@ export function createWocMarketCustody(
         restoreInto(host, pid, slot);
         return;
       }
-      host.sim.mailSystemParcel(
-        { key: String(characterId), name: String(characterId) },
-        WOC_MARKET_RETURN_LETTER,
-        [slot],
+      // A generated ref makes even this compensation parcel replay-safe: the
+      // overlay row re-books it after a crash and the book-once dedupe keeps
+      // it single. Fire-and-forget like the old whole-book write (the durable
+      // listing row still holds the item until the next flush lands), but a
+      // failed row write is at least visible now.
+      const custodyRef = `woc-return:${randomUUID()}`;
+      const recipient = { key: String(characterId), name: String(characterId) };
+      host.sim.mailSystemParcel(recipient, WOC_MARKET_RETURN_LETTER, [slot], custodyRef);
+      void persistParcelRow({ custodyRef, recipient, letter: 'return', items: [slot] }).catch(
+        (err) =>
+          console.error(`[woc_market] return parcel row write failed for ${custodyRef}`, err),
       );
-      void host.persistMailBlob().catch(() => {});
     },
 
     ownsLiveCharacter(accountId: number, characterId: number): boolean {
@@ -475,10 +484,14 @@ export function createWocMarketCustody(
         throw new Error(`woc_market: mail parcel refused for custodyRef ${custodyRef}`);
       }
       // Failure here PROPAGATES too: the caller must not advance its settlement
-      // or dispose flag until the blob holding the parcel is durable. The
-      // in-memory letter stays booked; the custodyRef dedupe makes the retry
-      // (this process) or the re-book (after a restart) exactly-once.
-      await host.persistMailBlob();
+      // or dispose flag until the parcel is durable. Durability is the
+      // PER-PARCEL overlay row (mail_custody_overlay.ts), never a whole-book
+      // write: the in-memory letter stays booked and reaches the blob on the
+      // next full book write, and a crash before that replays the row through
+      // the book-once dedupe at boot, so the retry (this process) or the
+      // re-book (after a restart) stays exactly-once. Booking a parcel now
+      // costs the loop the parcel, not the book.
+      await persistParcelRow({ custodyRef, recipient, letter, items });
     },
 
     hasParcel(custodyRef: string): boolean {

--- a/server/woc_market_delivery.ts
+++ b/server/woc_market_delivery.ts
@@ -223,7 +223,7 @@ export function createWocMarketDeliveryArms(ctx: WocDeliveryCtx): WocMarketDeliv
    *  new binary the tail cannot tear, so this converges a FINITE set and runs
    *  at minute scale over a bounded id page. The FINALIZE work per beat is
    *  bounded at ctx.sweepBatch like every other arm (each finalized row also
-   *  costs a realm mail-book write on the shared serial writer, and the one
+   *  costs a durable custody parcel row write, and the one
    *  time residue is plentiful, the first boot after a legacy upgrade, is
    *  exactly when the realm can least absorb an unbounded burst); a truncated
    *  page resumes right behind the last processed row on the next beat. */

--- a/tests/mail_custody_overlay_pg_integration.test.ts
+++ b/tests/mail_custody_overlay_pg_integration.test.ts
@@ -88,7 +88,7 @@ describeDb('mail custody overlay (REAL Postgres)', () => {
     overlay.resetCustodyParcelOverlayForTests();
     const sim2 = new Sim({ seed: 43, playerClass: 'warrior', noPlayer: true });
     const merged = await overlay.mergeCustodyParcelOverlay(sim2);
-    expect(merged).toEqual({ replayed: 1, present: 0, refused: 0 });
+    expect(merged).toEqual({ replayed: 1, present: 0, refused: 0, stale: 0 });
     expect(sim2.hasCustodyParcel(REF)).toBe(true);
 
     // CLEAN SHUTDOWN: the next full-book write carries the parcel; the bake
@@ -103,6 +103,22 @@ describeDb('mail custody overlay (REAL Postgres)', () => {
     sim3.loadMail(await db.loadMailState());
     expect(sim3.hasCustodyParcel(REF)).toBe(true);
     const remerge = await overlay.mergeCustodyParcelOverlay(sim3);
-    expect(remerge).toEqual({ replayed: 0, present: 0, refused: 0 });
+    expect(remerge).toEqual({ replayed: 0, present: 0, refused: 0, stale: 0 });
+
+    // The rollback guard end to end: a row PREDATING the blob's own
+    // durability point describes a parcel some committed book write already
+    // accounted for; the merge deletes it instead of replaying it.
+    await pool.query(
+      `INSERT INTO mail_custody_parcels (custody_ref, realm, recipient_key, recipient_name, letter, items, created_at)
+       VALUES ('stale:pg:1', $1, '4242', 'Buyer', 'delivery', $2::jsonb, now() - interval '1 hour')`,
+      [(await import('../server/realm')).REALM, JSON.stringify(ROW.items)],
+    );
+    const sim4 = new Sim({ seed: 45, playerClass: 'warrior', noPlayer: true });
+    sim4.loadMail(await db.loadMailState());
+    const staleMerge = await overlay.mergeCustodyParcelOverlay(sim4);
+    expect(staleMerge).toEqual({ replayed: 0, present: 0, refused: 0, stale: 1 });
+    expect(sim4.hasCustodyParcel('stale:pg:1')).toBe(false);
+    const left = await pool.query(`SELECT count(*)::int AS n FROM mail_custody_parcels`);
+    expect(left.rows[0].n).toBe(0);
   });
 });

--- a/tests/mail_custody_overlay_pg_integration.test.ts
+++ b/tests/mail_custody_overlay_pg_integration.test.ts
@@ -1,0 +1,108 @@
+// Opt-in REAL-Postgres proof for the custody parcel overlay: the table DDL
+// through the real ensureSchema (pinning the db.ts registration), the
+// insert/merge/bake lifecycle against a REAL Sim post office, and the
+// crash-then-clean-shutdown story end to end. The mocked-pool suite
+// (tests/server/mail_custody_overlay.test.ts) pins shapes and set
+// semantics; this one proves the SQL and the durability claim.
+//
+// Gated on TEST_DATABASE_URL like every other *_integration.test.ts:
+// without it the file skips green and CI's DB-free floor is unchanged.
+
+import type { Pool as PgPool } from 'pg';
+import { Pool } from 'pg';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+
+const ADMIN_URL = process.env.TEST_DATABASE_URL;
+const VERIFY_DB = 'wocc_mail_custody_verify';
+
+function verifyUrl(admin: string): string {
+  const u = new URL(admin);
+  u.pathname = `/${VERIFY_DB}`;
+  return u.toString();
+}
+
+if (ADMIN_URL) process.env.DATABASE_URL = verifyUrl(ADMIN_URL);
+
+const describeDb = ADMIN_URL ? describe : describe.skip;
+
+describeDb('mail custody overlay (REAL Postgres)', () => {
+  let admin: PgPool;
+  let pool: PgPool;
+  let db: typeof import('../server/db');
+  let overlay: typeof import('../server/mail_custody_overlay');
+
+  beforeAll(async () => {
+    admin = new Pool({ connectionString: ADMIN_URL, max: 2 });
+    const own = new URL(ADMIN_URL as string).pathname.replace(/^\//, '');
+    // Never drop the database the caller pointed us at.
+    expect(own).not.toBe(VERIFY_DB);
+    await admin.query(
+      `SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = $1 AND pid <> pg_backend_pid()`,
+      [VERIFY_DB],
+    );
+    await admin.query(`DROP DATABASE IF EXISTS ${VERIFY_DB}`);
+    await admin.query(`CREATE DATABASE ${VERIFY_DB}`);
+
+    db = await import('../server/db');
+    overlay = await import('../server/mail_custody_overlay');
+
+    // The REAL boot path: proves the mail_custody_parcels registration in
+    // ensureSchema, not just the DDL string.
+    await db.ensureSchema();
+
+    pool = new Pool({ connectionString: verifyUrl(ADMIN_URL as string), max: 4 });
+  }, 120_000);
+
+  afterAll(async () => {
+    await pool?.end().catch(() => {});
+    await db?.pool?.end().catch(() => {});
+    await admin?.end().catch(() => {});
+  }, 30_000);
+
+  const REF = 'settlement:pg:1';
+  const ROW = {
+    custodyRef: REF,
+    recipient: { key: '4242', name: 'Buyer' },
+    letter: 'delivery' as const,
+    items: [{ itemId: 'rusty_hatchet', count: 1 }],
+  };
+
+  it('carries a parcel through crash replay, then bakes it into a clean book write', async () => {
+    overlay.resetCustodyParcelOverlayForTests();
+
+    // Book + persist the row (the parcel path; the book itself is the live
+    // sim's and is deliberately NOT written here).
+    const sim1 = new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+    expect(
+      sim1.mailSystemParcel(ROW.recipient, overlay.CUSTODY_PARCEL_LETTERS.delivery, ROW.items, REF),
+    ).toBe(true);
+    await overlay.persistCustodyParcelRow(ROW);
+    // Idempotent re-insert (the retry arm).
+    await overlay.persistCustodyParcelRow(ROW);
+    const stored = await pool.query(`SELECT custody_ref, letter FROM mail_custody_parcels`);
+    expect(stored.rows).toEqual([{ custody_ref: REF, letter: 'delivery' }]);
+
+    // CRASH: the process dies before any full-book write. A new process
+    // loads a book WITHOUT the parcel and merges the overlay.
+    overlay.resetCustodyParcelOverlayForTests();
+    const sim2 = new Sim({ seed: 43, playerClass: 'warrior', noPlayer: true });
+    const merged = await overlay.mergeCustodyParcelOverlay(sim2);
+    expect(merged).toEqual({ replayed: 1, present: 0, refused: 0 });
+    expect(sim2.hasCustodyParcel(REF)).toBe(true);
+
+    // CLEAN SHUTDOWN: the next full-book write carries the parcel; the bake
+    // inside saveMailState deletes the row.
+    await db.saveMailState(sim2.serializeMail());
+    const after = await pool.query(`SELECT count(*)::int AS n FROM mail_custody_parcels`);
+    expect(after.rows[0].n).toBe(0);
+
+    // Next boot: the parcel now arrives from the blob itself, no overlay
+    // rows left to replay, and the book-once state is intact.
+    const sim3 = new Sim({ seed: 44, playerClass: 'warrior', noPlayer: true });
+    sim3.loadMail(await db.loadMailState());
+    expect(sim3.hasCustodyParcel(REF)).toBe(true);
+    const remerge = await overlay.mergeCustodyParcelOverlay(sim3);
+    expect(remerge).toEqual({ replayed: 0, present: 0, refused: 0 });
+  });
+});

--- a/tests/mail_custody_overlay_pg_integration.test.ts
+++ b/tests/mail_custody_overlay_pg_integration.test.ts
@@ -88,14 +88,20 @@ describeDb('mail custody overlay (REAL Postgres)', () => {
     overlay.resetCustodyParcelOverlayForTests();
     const sim2 = new Sim({ seed: 43, playerClass: 'warrior', noPlayer: true });
     const merged = await overlay.mergeCustodyParcelOverlay(sim2);
-    expect(merged).toEqual({ replayed: 1, present: 0, refused: 0, stale: 0 });
+    expect(merged).toEqual({ replayed: 1, present: 0, refused: 0, stale: 0, ok: true });
     expect(sim2.hasCustodyParcel(REF)).toBe(true);
 
     // CLEAN SHUTDOWN: the next full-book write carries the parcel; the bake
-    // inside saveMailState deletes the row.
+    // inside saveMailState deletes the row, and the accounting watermark is
+    // born (accounted_through starts at -infinity: a first write has no
+    // previous write to vouch for).
     await db.saveMailState(sim2.serializeMail());
     const after = await pool.query(`SELECT count(*)::int AS n FROM mail_custody_parcels`);
     expect(after.rows[0].n).toBe(0);
+    const wmBorn = await pool.query(
+      `SELECT (accounted_through = '-infinity'::timestamptz) AS neg FROM mail_custody_watermark`,
+    );
+    expect(wmBorn.rows).toEqual([{ neg: true }]);
 
     // Next boot: the parcel now arrives from the blob itself, no overlay
     // rows left to replay, and the book-once state is intact.
@@ -103,11 +109,22 @@ describeDb('mail custody overlay (REAL Postgres)', () => {
     sim3.loadMail(await db.loadMailState());
     expect(sim3.hasCustodyParcel(REF)).toBe(true);
     const remerge = await overlay.mergeCustodyParcelOverlay(sim3);
-    expect(remerge).toEqual({ replayed: 0, present: 0, refused: 0, stale: 0 });
+    expect(remerge).toEqual({ replayed: 0, present: 0, refused: 0, stale: 0, ok: true });
 
-    // The rollback guard end to end: a row PREDATING the blob's own
-    // durability point describes a parcel some committed book write already
-    // accounted for; the merge deletes it instead of replaying it.
+    // A SECOND book write advances accounted_through to the FIRST write's
+    // transaction start (the two-column lag): finite now, and strictly
+    // behind last_book_write, compared in SQL at full precision.
+    await db.saveMailState(sim3.serializeMail());
+    const wm = await pool.query(
+      `SELECT (accounted_through = '-infinity'::timestamptz) AS neg,
+              (accounted_through < last_book_write) AS ordered
+         FROM mail_custody_watermark`,
+    );
+    expect(wm.rows).toEqual([{ neg: false, ordered: true }]);
+
+    // The rollback guard end to end: a row at or before accounted_through
+    // describes a parcel some committed book write already accounted for;
+    // the merge deletes it instead of replaying it.
     await pool.query(
       `INSERT INTO mail_custody_parcels (custody_ref, realm, recipient_key, recipient_name, letter, items, created_at)
        VALUES ('stale:pg:1', $1, '4242', 'Buyer', 'delivery', $2::jsonb, now() - interval '1 hour')`,
@@ -116,7 +133,7 @@ describeDb('mail custody overlay (REAL Postgres)', () => {
     const sim4 = new Sim({ seed: 45, playerClass: 'warrior', noPlayer: true });
     sim4.loadMail(await db.loadMailState());
     const staleMerge = await overlay.mergeCustodyParcelOverlay(sim4);
-    expect(staleMerge).toEqual({ replayed: 0, present: 0, refused: 0, stale: 1 });
+    expect(staleMerge).toEqual({ replayed: 0, present: 0, refused: 0, stale: 1, ok: true });
     expect(sim4.hasCustodyParcel('stale:pg:1')).toBe(false);
     const left = await pool.query(`SELECT count(*)::int AS n FROM mail_custody_parcels`);
     expect(left.rows[0].n).toBe(0);

--- a/tests/server/mail_custody_overlay.test.ts
+++ b/tests/server/mail_custody_overlay.test.ts
@@ -14,9 +14,13 @@ const db = vi.hoisted(() => ({ query: vi.fn<TestQuery>() }));
 vi.mock('../../server/db', () => ({ pool: { query: db.query } }));
 
 import {
-  deleteBakedCustodyRefs,
+  CUSTODY_PARCEL_LETTERS,
+  confirmBakedCustodyRefs,
+  custodyOverlayStats,
+  deleteBakedCustodyRefsIn,
   mergeCustodyParcelOverlay,
   persistCustodyParcelRow,
+  pruneMailCustodyParcelsBatch,
   resetCustodyParcelOverlayForTests,
   snapshotPendingCustodyRefs,
 } from '../../server/mail_custody_overlay';
@@ -64,60 +68,81 @@ describe('persistCustodyParcelRow', () => {
 });
 
 describe('the bake set', () => {
-  it('deletes exactly the snapshot; refs booked after it stay pending', async () => {
+  it('deletes exactly the snapshot on the writer client; refs booked after it stay pending', async () => {
     await persistCustodyParcelRow(row('a'));
     await persistCustodyParcelRow(row('b'));
     const snap = snapshotPendingCustodyRefs();
     await persistCustodyParcelRow(row('c'));
+    // The DELETE rides the book write's OWN transaction client, injected;
+    // the pool spy must stay untouched.
     query.mockClear();
-    await deleteBakedCustodyRefs(snap);
-    expect(query).toHaveBeenCalledTimes(1);
-    const [sql, params] = query.mock.calls[0];
+    const txQuery = vi.fn(async (_text: string, _values: unknown[]) => ({ rows: [] }));
+    await deleteBakedCustodyRefsIn(txQuery, snap);
+    expect(query).not.toHaveBeenCalled();
+    expect(txQuery).toHaveBeenCalledTimes(1);
+    const [sql, params] = txQuery.mock.calls[0];
     expect(sql).toMatch(/DELETE FROM mail_custody_parcels WHERE custody_ref = ANY/);
-    expect(params).toEqual([['a', 'b']]);
+    // Realm-qualified, defensive scoping.
+    expect(sql).toMatch(/AND realm = \$2/);
+    expect(params).toEqual([['a', 'b'], REALM]);
+    // The set forgets refs only on the caller's post-commit confirm: a
+    // rollback must leave them pending so the next write re-bakes them.
+    expect(snapshotPendingCustodyRefs()).toEqual(['a', 'b', 'c']);
+    confirmBakedCustodyRefs(snap);
     // 'c' was booked after the snapshot (necessarily across an await, so
     // after the full-book serialize): its row must survive this bake.
     expect(snapshotPendingCustodyRefs()).toEqual(['c']);
+    expect(custodyOverlayStats().pendingBake).toBe(1);
   });
 
-  it('keeps the refs pending when the delete fails, so the next write retries', async () => {
-    await persistCustodyParcelRow(row('a'));
-    const snap = snapshotPendingCustodyRefs();
-    query.mockRejectedValueOnce(new Error('db down'));
-    // Non-throwing by contract: this runs after a COMMIT, and a failure here
-    // must never re-mark the committed save as failed.
-    await expect(deleteBakedCustodyRefs(snap)).resolves.toBeUndefined();
-    expect(snapshotPendingCustodyRefs()).toEqual(['a']);
-    query.mockResolvedValueOnce({ rows: [] });
-    await deleteBakedCustodyRefs(snapshotPendingCustodyRefs());
-    expect(snapshotPendingCustodyRefs()).toEqual([]);
+  it('issues no statement for an empty snapshot', async () => {
+    const txQuery = vi.fn(async (_text: string, _values: unknown[]) => ({ rows: [] }));
+    await deleteBakedCustodyRefsIn(txQuery, []);
+    expect(txQuery).not.toHaveBeenCalled();
   });
 
-  it('deletes nothing for an empty snapshot', async () => {
-    await deleteBakedCustodyRefs([]);
-    expect(query).not.toHaveBeenCalled();
+  it('prunes only aged residue, batched', async () => {
+    query.mockResolvedValueOnce({ rows: [], rowCount: 3 } as never);
+    await expect(pruneMailCustodyParcelsBatch(500)).resolves.toBe(3);
+    const [sql, params] = query.mock.calls[0];
+    expect(sql).toMatch(/DELETE FROM mail_custody_parcels/);
+    expect(sql).toMatch(/created_at < now\(\) - \(\$1 \|\| ' days'\)::interval/);
+    expect(sql).toMatch(/LIMIT \$2/);
+    expect(params).toEqual(['30', 500]);
   });
 });
 
 describe('mergeCustodyParcelOverlay', () => {
-  function overlayRows(refs: string[], letter = 'delivery') {
+  const FRESH = new Date('2026-08-26T12:00:00Z');
+  function overlayRows(refs: string[], letter = 'delivery', createdAt: Date = FRESH) {
     return refs.map((ref) => ({
       custody_ref: ref,
       recipient_key: '4242',
       recipient_name: 'Buyer',
       letter,
       items: GOOD_ITEMS,
+      created_at: createdAt,
     }));
   }
 
+  /** First query of every merge: the mail blob's durability timestamp. */
+  function mockBlobWrittenAt(at: Date | null) {
+    query.mockResolvedValueOnce({ rows: at === null ? [] : [{ updated_at: at }] });
+  }
+
   it('replays a crash-lost parcel into a real book, and dedupes it on the next boot', async () => {
-    // The crash story: the parcel row survived, the blob write did not.
+    // The crash story: the parcel row survived, the blob write did not (no
+    // blob row at all, so no cutoff applies).
     const sim = new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+    mockBlobWrittenAt(null);
     query.mockResolvedValueOnce({ rows: overlayRows(['settlement:9']) });
     const first = await mergeCustodyParcelOverlay(sim);
-    expect(first).toEqual({ replayed: 1, present: 0, refused: 0 });
-    expect(query.mock.calls[0][0]).toMatch(/FROM mail_custody_parcels WHERE realm = \$1/);
-    expect(query.mock.calls[0][1]).toEqual([REALM]);
+    expect(first).toEqual({ replayed: 1, present: 0, refused: 0, stale: 0 });
+    expect(query.mock.calls[0][0]).toMatch(/SELECT updated_at FROM world_state/);
+    expect(query.mock.calls[1][0]).toMatch(/FROM mail_custody_parcels WHERE realm = \$1/);
+    // The page bound: a pathological backlog cannot hold the boot hostage.
+    expect(query.mock.calls[1][0]).toMatch(/LIMIT 10000/);
+    expect(query.mock.calls[1][1]).toEqual([REALM]);
     expect(sim.postOffice.mail).toHaveLength(1);
     expect(sim.postOffice.mail[0].custodyRef).toBe('settlement:9');
     expect(sim.postOffice.mail[0].items.map((s) => s.itemId)).toEqual(['rusty_hatchet']);
@@ -126,17 +151,42 @@ describe('mergeCustodyParcelOverlay', () => {
     expect(snapshotPendingCustodyRefs()).toEqual(['settlement:9']);
 
     // Second boot with the parcel already inside the loaded blob: the
-    // book-once dedupe reports it present and books nothing new.
+    // book-once dedupe reports it present and books nothing new. The blob
+    // write predates the row here (booked mid-write), so the cutoff must
+    // NOT eat it.
     resetCustodyParcelOverlayForTests();
+    mockBlobWrittenAt(new Date(FRESH.getTime() - 60_000));
     query.mockResolvedValueOnce({ rows: overlayRows(['settlement:9']) });
     const second = await mergeCustodyParcelOverlay(sim);
-    expect(second).toEqual({ replayed: 0, present: 1, refused: 0 });
+    expect(second).toEqual({ replayed: 0, present: 1, refused: 0, stale: 0 });
     expect(sim.postOffice.mail).toHaveLength(1);
     expect(snapshotPendingCustodyRefs()).toEqual(['settlement:9']);
   });
 
+  it('deletes a stale row instead of replaying it (the rollback re-book guard)', async () => {
+    // A committed book write POSTDATES the row: that write accounted for the
+    // parcel, in the blob or durably collected out of it. Replaying it could
+    // re-book a collected parcel, so the row is cleaned, never replayed.
+    const sim = new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+    mockBlobWrittenAt(new Date(FRESH.getTime() + 60_000));
+    query.mockResolvedValueOnce({
+      rows: [
+        ...overlayRows(['collected:1']),
+        ...overlayRows(['fresh:1'], 'delivery', new Date(FRESH.getTime() + 120_000)),
+      ],
+    });
+    const result = await mergeCustodyParcelOverlay(sim);
+    expect(result).toEqual({ replayed: 1, present: 0, refused: 0, stale: 1 });
+    expect(sim.postOffice.mail.map((m) => m.custodyRef)).toEqual(['fresh:1']);
+    const del = query.mock.calls[2];
+    expect(del[0]).toMatch(/DELETE FROM mail_custody_parcels WHERE custody_ref = ANY/);
+    expect(del[1]).toEqual([['collected:1']]);
+    expect(snapshotPendingCustodyRefs()).toEqual(['fresh:1']);
+  });
+
   it('keeps a malformed or refused row out of the bake set instead of destroying it', async () => {
     const sim = new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+    mockBlobWrittenAt(null);
     query.mockResolvedValueOnce({
       rows: [
         ...overlayRows(['bogus:1'], 'not_a_letter'),
@@ -148,15 +198,28 @@ describe('mergeCustodyParcelOverlay', () => {
           recipient_name: 'Buyer',
           letter: 'delivery',
           items: [{ itemId: 'no_such_item_id', count: 1 }],
+          created_at: FRESH,
         },
         ...overlayRows(['ok:1']),
       ],
     });
     const result = await mergeCustodyParcelOverlay(sim);
-    expect(result).toEqual({ replayed: 1, present: 0, refused: 2 });
+    expect(result).toEqual({ replayed: 1, present: 0, refused: 2, stale: 0 });
     // Only the accounted ref may ever be baked away; the refused rows'
     // absence from the set is what keeps their rows in the table.
     expect(snapshotPendingCustodyRefs()).toEqual(['ok:1']);
+  });
+
+  it('never throws: a merge failure reads as replay-later, not as a load failure', async () => {
+    const sim = new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+    query.mockRejectedValueOnce(new Error('db down'));
+    await expect(mergeCustodyParcelOverlay(sim)).resolves.toEqual({
+      replayed: 0,
+      present: 0,
+      refused: 0,
+      stale: 0,
+    });
+    expect(sim.postOffice.mail).toHaveLength(0);
   });
 });
 
@@ -175,29 +238,64 @@ describe('bake and merge wiring order', () => {
   const dbSrc = readFileSync(path.resolve(process.cwd(), 'server/db.ts'), 'utf8');
   const gameSrc = readFileSync(path.resolve(process.cwd(), 'server/game.ts'), 'utf8');
 
-  it('saveMailState snapshots at entry and deletes only after the book write', () => {
+  it('saveMailState snapshots at entry and bakes inside the book transaction', () => {
     const body = dbSrc.slice(dbSrc.indexOf('export async function saveMailState'));
     const snapshotAt = body.indexOf('snapshotPendingCustodyRefs()');
-    const writeAt = body.indexOf('saveWorldState(mailStateKey');
-    const deleteAt = body.indexOf('deleteBakedCustodyRefs(');
+    const beginAt = body.indexOf("client.query('BEGIN')");
+    const writeAt = body.indexOf('INSERT INTO world_state');
+    const deleteAt = body.indexOf('deleteBakedCustodyRefsIn(');
+    const commitAt = body.indexOf("client.query('COMMIT')");
+    const confirmAt = body.indexOf('confirmBakedCustodyRefs(');
+    // Snapshot before anything awaits; the bake DELETE strictly inside the
+    // transaction (after the upsert, before COMMIT), so the blob and the row
+    // removal commit together; the in-memory confirm only after COMMIT.
     expect(snapshotAt).toBeGreaterThan(-1);
-    expect(writeAt).toBeGreaterThan(snapshotAt);
+    expect(snapshotAt).toBeLessThan(body.indexOf('await '));
+    expect(writeAt).toBeGreaterThan(beginAt);
     expect(deleteAt).toBeGreaterThan(writeAt);
+    expect(deleteAt).toBeLessThan(commitAt);
+    expect(confirmAt).toBeGreaterThan(commitAt);
   });
 
-  it('the atomic leave-path save deletes only on the committed arm', () => {
+  it('the atomic leave-path save bakes inside the fenced transaction, confirmed after COMMIT', () => {
     const start = dbSrc.indexOf('export async function saveCharacterAndMarketState');
     const body = dbSrc.slice(start, dbSrc.indexOf('export', start + 10));
     const snapshotAt = body.indexOf('snapshotPendingCustodyRefs()');
+    const deleteAt = body.indexOf('deleteBakedCustodyRefsIn(');
     const commitAt = body.indexOf("await client.query('COMMIT')");
-    const deleteAt = body.indexOf('deleteBakedCustodyRefs(');
-    // Snapshot at entry, before the first await; delete strictly after the
-    // COMMIT; and exactly one delete call, so neither the fence-refused
-    // false arm nor the rollback arm can reach one.
+    const confirmAt = body.indexOf('confirmBakedCustodyRefs(');
+    // Snapshot at entry, before the first await; the DELETE inside the
+    // transaction; the confirm on the committed arm only, so neither the
+    // fence-refused false arm nor a rollback can forget a pending ref.
     expect(snapshotAt).toBeGreaterThan(-1);
     expect(snapshotAt).toBeLessThan(body.indexOf('await '));
-    expect(deleteAt).toBeGreaterThan(commitAt);
-    expect(body.split('deleteBakedCustodyRefs(')).toHaveLength(2);
+    expect(deleteAt).toBeGreaterThan(-1);
+    expect(deleteAt).toBeLessThan(commitAt);
+    expect(confirmAt).toBeGreaterThan(commitAt);
+    expect(body.split('deleteBakedCustodyRefsIn(')).toHaveLength(2);
+    expect(body.split('confirmBakedCustodyRefs(')).toHaveLength(2);
+  });
+
+  it('serializeMail is a deep snapshot: later book mutations cannot reach written bytes', () => {
+    // The bake contract assumes the serialized book is frozen at thunk entry;
+    // a lazy or copy-on-write serializeMail would silently break it.
+    const sim = new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+    sim.mailSystemParcel(
+      { key: '4242', name: 'Buyer' },
+      CUSTODY_PARCEL_LETTERS.delivery,
+      GOOD_ITEMS,
+      'snap:1',
+    );
+    const snapshot = sim.serializeMail();
+    const before = JSON.stringify(snapshot);
+    sim.mailSystemParcel(
+      { key: '4242', name: 'Buyer' },
+      CUSTODY_PARCEL_LETTERS.delivery,
+      GOOD_ITEMS,
+      'snap:2',
+    );
+    sim.postOffice.mail[0].items.push({ itemId: 'rusty_hatchet', count: 99 });
+    expect(JSON.stringify(snapshot)).toBe(before);
   });
 
   it('game.loadMail merges the overlay only after a successful book load', () => {

--- a/tests/server/mail_custody_overlay.test.ts
+++ b/tests/server/mail_custody_overlay.test.ts
@@ -1,23 +1,33 @@
 // The durable per-parcel custody overlay (server/mail_custody_overlay.ts):
 // SQL shapes against a mocked pool, the snapshot/bake set semantics that keep
 // a row alive until its parcel is provably inside a committed full-book
-// write, and the boot merge driven against a REAL Sim post office, because
-// the replay-through-book-once-dedupe is exactly what a fake book would
-// paper over.
+// write, the accounting watermark's advance gate, and the boot merge driven
+// against a REAL Sim post office, because the replay-through-book-once-dedupe
+// is exactly what a fake book would paper over. The transaction-level
+// contract (one client, ordered statements, rollback keeps refs) is proven
+// behaviorally in tests/server/save_mail_state_custody_bake.test.ts; the
+// source pins at the bottom anchor only what a behavioral test cannot see
+// (statement POSITIONS inside the writers and the callers).
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-type TestQuery = (text: string, values?: readonly unknown[]) => Promise<{ rows: unknown[] }>;
+type TestQuery = (
+  text: string,
+  values?: readonly unknown[],
+) => Promise<{ rows: unknown[]; rowCount?: number }>;
 
 const db = vi.hoisted(() => ({ query: vi.fn<TestQuery>() }));
 
 vi.mock('../../server/db', () => ({ pool: { query: db.query } }));
 
 import {
+  advanceCustodyWatermarkIn,
   CUSTODY_PARCEL_LETTERS,
   confirmBakedCustodyRefs,
   custodyOverlayStats,
   deleteBakedCustodyRefsIn,
+  MERGE_MAX_PAGES,
+  MERGE_PAGE_LIMIT,
   mergeCustodyParcelOverlay,
   persistCustodyParcelRow,
   pruneMailCustodyParcelsBatch,
@@ -102,7 +112,7 @@ describe('the bake set', () => {
   });
 
   it('prunes only aged residue, batched', async () => {
-    query.mockResolvedValueOnce({ rows: [], rowCount: 3 } as never);
+    query.mockResolvedValueOnce({ rows: [], rowCount: 3 });
     await expect(pruneMailCustodyParcelsBatch(500)).resolves.toBe(3);
     const [sql, params] = query.mock.calls[0];
     expect(sql).toMatch(/DELETE FROM mail_custody_parcels/);
@@ -112,37 +122,91 @@ describe('the bake set', () => {
   });
 });
 
+/** Drive one fully-drained empty merge so the watermark gate opens (the
+ *  module arms it only after a complete merge). */
+async function completeEmptyMerge(): Promise<void> {
+  const sim = new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+  query.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+  query.mockResolvedValueOnce({ rows: [] });
+  const counts = await mergeCustodyParcelOverlay(sim);
+  expect(counts.ok).toBe(true);
+  query.mockClear();
+}
+
+describe('advanceCustodyWatermarkIn', () => {
+  it('no-ops until a boot merge has fully drained', async () => {
+    const txQuery = vi.fn(async (_text: string, _values: unknown[]) => ({ rows: [] }));
+    await advanceCustodyWatermarkIn(txQuery);
+    expect(txQuery).not.toHaveBeenCalled();
+  });
+
+  it('advances accounted_through to the PREVIOUS book write on the caller client, once armed', async () => {
+    await completeEmptyMerge();
+    const txQuery = vi.fn(async (_text: string, _values: unknown[]) => ({ rows: [] }));
+    await advanceCustodyWatermarkIn(txQuery);
+    expect(query).not.toHaveBeenCalled();
+    expect(txQuery).toHaveBeenCalledTimes(1);
+    const [sql, params] = txQuery.mock.calls[0];
+    // The two-column lag is the soundness core: accounted_through takes the
+    // PREVIOUS write's transaction start, never this one's, so a row
+    // inserted between a writer's serialize and its BEGIN can never be
+    // classified stale.
+    expect(sql).toMatch(/INSERT INTO mail_custody_watermark/);
+    expect(sql).toMatch(/VALUES \(\$1, '-infinity', now\(\)\)/);
+    expect(sql).toMatch(/ON CONFLICT \(realm\) DO UPDATE/);
+    expect(sql).toMatch(/SET accounted_through = mail_custody_watermark\.last_book_write/);
+    expect(sql).toMatch(/last_book_write = now\(\)/);
+    expect(params).toEqual([REALM]);
+  });
+
+  it('stays frozen for the whole uptime after a failed merge', async () => {
+    const sim = new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+    query.mockRejectedValueOnce(new Error('db down'));
+    const counts = await mergeCustodyParcelOverlay(sim);
+    expect(counts.ok).toBe(false);
+    const txQuery = vi.fn(async (_text: string, _values: unknown[]) => ({ rows: [] }));
+    await advanceCustodyWatermarkIn(txQuery);
+    expect(txQuery).not.toHaveBeenCalled();
+  });
+});
+
 describe('mergeCustodyParcelOverlay', () => {
-  const FRESH = new Date('2026-08-26T12:00:00Z');
-  function overlayRows(refs: string[], letter = 'delivery', createdAt: Date = FRESH) {
+  function overlayRows(refs: string[], letter = 'delivery', items: unknown = GOOD_ITEMS) {
     return refs.map((ref) => ({
       custody_ref: ref,
       recipient_key: '4242',
       recipient_name: 'Buyer',
       letter,
-      items: GOOD_ITEMS,
-      created_at: createdAt,
+      items,
     }));
   }
 
-  /** First query of every merge: the mail blob's durability timestamp. */
-  function mockBlobWrittenAt(at: Date | null) {
-    query.mockResolvedValueOnce({ rows: at === null ? [] : [{ updated_at: at }] });
+  /** First query of every merge: the in-SQL watermark cutoff DELETE. */
+  function mockStaleDelete(rowCount: number) {
+    query.mockResolvedValueOnce({ rows: [], rowCount });
   }
 
   it('replays a crash-lost parcel into a real book, and dedupes it on the next boot', async () => {
-    // The crash story: the parcel row survived, the blob write did not (no
-    // blob row at all, so no cutoff applies).
     const sim = new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
-    mockBlobWrittenAt(null);
+    mockStaleDelete(0);
     query.mockResolvedValueOnce({ rows: overlayRows(['settlement:9']) });
     const first = await mergeCustodyParcelOverlay(sim);
-    expect(first).toEqual({ replayed: 1, present: 0, refused: 0, stale: 0 });
-    expect(query.mock.calls[0][0]).toMatch(/SELECT updated_at FROM world_state/);
-    expect(query.mock.calls[1][0]).toMatch(/FROM mail_custody_parcels WHERE realm = \$1/);
-    // The page bound: a pathological backlog cannot hold the boot hostage.
-    expect(query.mock.calls[1][0]).toMatch(/LIMIT 10000/);
-    expect(query.mock.calls[1][1]).toEqual([REALM]);
+    expect(first).toEqual({ replayed: 1, present: 0, refused: 0, stale: 0, ok: true });
+    // The cutoff runs entirely in SQL at full timestamp precision: rows at
+    // or before the accounting watermark are deleted, never replayed, and
+    // never round-trip through a millisecond Date.
+    const cutoff = query.mock.calls[0];
+    expect(cutoff[0]).toMatch(/DELETE FROM mail_custody_parcels/);
+    expect(cutoff[0]).toMatch(/realm = \$1/);
+    expect(cutoff[0]).toMatch(
+      /created_at <= \(SELECT accounted_through FROM mail_custody_watermark WHERE realm = \$1\)/,
+    );
+    expect(cutoff[1]).toEqual([REALM]);
+    // The replay SELECT is a primary-key keyset page.
+    const select = query.mock.calls[1];
+    expect(select[0]).toMatch(/FROM mail_custody_parcels WHERE realm = \$1 AND custody_ref > \$2/);
+    expect(select[0]).toMatch(/ORDER BY custody_ref LIMIT 10000/);
+    expect(select[1]).toEqual([REALM, '']);
     expect(sim.postOffice.mail).toHaveLength(1);
     expect(sim.postOffice.mail[0].custodyRef).toBe('settlement:9');
     expect(sim.postOffice.mail[0].items.map((s) => s.itemId)).toEqual(['rusty_hatchet']);
@@ -151,66 +215,114 @@ describe('mergeCustodyParcelOverlay', () => {
     expect(snapshotPendingCustodyRefs()).toEqual(['settlement:9']);
 
     // Second boot with the parcel already inside the loaded blob: the
-    // book-once dedupe reports it present and books nothing new. The blob
-    // write predates the row here (booked mid-write), so the cutoff must
-    // NOT eat it.
+    // book-once dedupe reports it present and books nothing new.
     resetCustodyParcelOverlayForTests();
-    mockBlobWrittenAt(new Date(FRESH.getTime() - 60_000));
+    mockStaleDelete(0);
     query.mockResolvedValueOnce({ rows: overlayRows(['settlement:9']) });
     const second = await mergeCustodyParcelOverlay(sim);
-    expect(second).toEqual({ replayed: 0, present: 1, refused: 0, stale: 0 });
+    expect(second).toEqual({ replayed: 0, present: 1, refused: 0, stale: 0, ok: true });
     expect(sim.postOffice.mail).toHaveLength(1);
     expect(snapshotPendingCustodyRefs()).toEqual(['settlement:9']);
   });
 
-  it('deletes a stale row instead of replaying it (the rollback re-book guard)', async () => {
-    // A committed book write POSTDATES the row: that write accounted for the
-    // parcel, in the blob or durably collected out of it. Replaying it could
-    // re-book a collected parcel, so the row is cleaned, never replayed.
+  it('counts the rows the watermark cutoff deleted and still replays fresh ones', async () => {
     const sim = new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
-    mockBlobWrittenAt(new Date(FRESH.getTime() + 60_000));
-    query.mockResolvedValueOnce({
-      rows: [
-        ...overlayRows(['collected:1']),
-        ...overlayRows(['fresh:1'], 'delivery', new Date(FRESH.getTime() + 120_000)),
-      ],
-    });
+    mockStaleDelete(2);
+    query.mockResolvedValueOnce({ rows: overlayRows(['fresh:1']) });
     const result = await mergeCustodyParcelOverlay(sim);
-    expect(result).toEqual({ replayed: 1, present: 0, refused: 0, stale: 1 });
+    expect(result).toEqual({ replayed: 1, present: 0, refused: 0, stale: 2, ok: true });
     expect(sim.postOffice.mail.map((m) => m.custodyRef)).toEqual(['fresh:1']);
-    const del = query.mock.calls[2];
-    expect(del[0]).toMatch(/DELETE FROM mail_custody_parcels WHERE custody_ref = ANY/);
-    expect(del[1]).toEqual([['collected:1']]);
     expect(snapshotPendingCustodyRefs()).toEqual(['fresh:1']);
   });
 
   it('keeps a malformed or refused row out of the bake set instead of destroying it', async () => {
     const sim = new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
-    mockBlobWrittenAt(null);
-    query.mockResolvedValueOnce({
-      rows: [
-        ...overlayRows(['bogus:1'], 'not_a_letter'),
-        // A parcel whose items no longer validate: refused by the book and
-        // absent, so the row must survive for the operator.
-        {
-          custody_ref: 'refused:1',
-          recipient_key: '4242',
-          recipient_name: 'Buyer',
-          letter: 'delivery',
-          items: [{ itemId: 'no_such_item_id', count: 1 }],
-          created_at: FRESH,
-        },
-        ...overlayRows(['ok:1']),
-      ],
-    });
-    const result = await mergeCustodyParcelOverlay(sim);
-    expect(result).toEqual({ replayed: 1, present: 0, refused: 2, stale: 0 });
-    // Only the accounted ref may ever be baked away; the refused rows'
-    // absence from the set is what keeps their rows in the table.
-    expect(snapshotPendingCustodyRefs()).toEqual(['ok:1']);
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      mockStaleDelete(0);
+      query.mockResolvedValueOnce({
+        rows: [
+          // Both malformed dimensions, one row each: an unknown letter kind,
+          // and non-array items.
+          ...overlayRows(['bogus:1'], 'not_a_letter'),
+          ...overlayRows(['bogus:2'], 'delivery', { itemId: 'rusty_hatchet' }),
+          // A parcel whose items no longer validate: refused by the book and
+          // absent, so the row must survive for the operator.
+          ...overlayRows(['refused:1'], 'delivery', [{ itemId: 'no_such_item_id', count: 1 }]),
+          ...overlayRows(['ok:1']),
+        ],
+      });
+      const result = await mergeCustodyParcelOverlay(sim);
+      expect(result).toEqual({ replayed: 1, present: 0, refused: 3, stale: 0, ok: true });
+      // Only the accounted ref may ever be baked away; the refused rows'
+      // absence from the set is what keeps their rows in the table. And no
+      // statement beyond the cutoff and the page SELECT ran: nothing
+      // deletes a refused row.
+      expect(snapshotPendingCustodyRefs()).toEqual(['ok:1']);
+      expect(query).toHaveBeenCalledTimes(2);
+    } finally {
+      errorSpy.mockRestore();
+    }
   });
 
-  it('never throws: a merge failure reads as replay-later, not as a load failure', async () => {
+  it('pages the whole table on the keyset and reports ok only when drained', async () => {
+    const sim = new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      // One FULL page of cheap (malformed, so no book work) rows, then a
+      // short page carrying the real parcel.
+      const fullPage = overlayRows(
+        Array.from({ length: MERGE_PAGE_LIMIT }, (_, i) => `bulk:${String(i).padStart(6, '0')}`),
+        'not_a_letter',
+      );
+      mockStaleDelete(0);
+      query.mockResolvedValueOnce({ rows: fullPage });
+      query.mockResolvedValueOnce({ rows: overlayRows(['tail:1']) });
+      const result = await mergeCustodyParcelOverlay(sim);
+      expect(result).toEqual({
+        replayed: 1,
+        present: 0,
+        refused: MERGE_PAGE_LIMIT,
+        stale: 0,
+        ok: true,
+      });
+      // The second page resumes strictly after the first page's last ref.
+      expect(query).toHaveBeenCalledTimes(3);
+      expect(query.mock.calls[2][1]).toEqual([
+        REALM,
+        `bulk:${String(MERGE_PAGE_LIMIT - 1).padStart(6, '0')}`,
+      ]);
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it('stops at the page cap with ok false, leaving the watermark frozen', async () => {
+    const sim = new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const fullPage = overlayRows(
+        Array.from({ length: MERGE_PAGE_LIMIT }, (_, i) => `bulk:${String(i).padStart(6, '0')}`),
+        'not_a_letter',
+      );
+      mockStaleDelete(0);
+      // Every page comes back full: the cap must stop the loop, not the
+      // boot path.
+      query.mockResolvedValue({ rows: fullPage });
+      const result = await mergeCustodyParcelOverlay(sim);
+      expect(result.ok).toBe(false);
+      expect(query).toHaveBeenCalledTimes(1 + MERGE_MAX_PAGES);
+      // An undrained merge must never arm the watermark: the unexamined
+      // remainder would otherwise be classified stale at a later boot.
+      const txQuery = vi.fn(async (_text: string, _values: unknown[]) => ({ rows: [] }));
+      await advanceCustodyWatermarkIn(txQuery);
+      expect(txQuery).not.toHaveBeenCalled();
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it('never throws, and a failed merge is distinguishable from an empty one on the readout', async () => {
     const sim = new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
     query.mockRejectedValueOnce(new Error('db down'));
     await expect(mergeCustodyParcelOverlay(sim)).resolves.toEqual({
@@ -218,59 +330,141 @@ describe('mergeCustodyParcelOverlay', () => {
       present: 0,
       refused: 0,
       stale: 0,
+      ok: false,
     });
     expect(sim.postOffice.mail).toHaveLength(0);
+    // The ops readout carries the failure: all-zero counts with ok false is
+    // a FAILED merge, not an empty table.
+    expect(custodyOverlayStats().lastMerge).toEqual({
+      replayed: 0,
+      present: 0,
+      refused: 0,
+      stale: 0,
+      ok: false,
+    });
+  });
+
+  it('keeps partial progress visible when a later page fails', async () => {
+    const sim = new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const fullPage = overlayRows(
+        Array.from({ length: MERGE_PAGE_LIMIT }, (_, i) => `bulk:${String(i).padStart(6, '0')}`),
+        'not_a_letter',
+      );
+      mockStaleDelete(1);
+      query.mockResolvedValueOnce({ rows: fullPage });
+      query.mockRejectedValueOnce(new Error('db down mid-merge'));
+      const result = await mergeCustodyParcelOverlay(sim);
+      expect(result).toEqual({
+        replayed: 0,
+        present: 0,
+        refused: MERGE_PAGE_LIMIT,
+        stale: 1,
+        ok: false,
+      });
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it('resetCustodyParcelOverlayForTests clears the readout too', async () => {
+    const sim = new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+    mockStaleDelete(0);
+    query.mockResolvedValueOnce({ rows: [] });
+    await mergeCustodyParcelOverlay(sim);
+    expect(custodyOverlayStats().lastMerge).not.toBeNull();
+    resetCustodyParcelOverlayForTests();
+    expect(custodyOverlayStats().lastMerge).toBeNull();
+    expect(custodyOverlayStats().pendingBake).toBe(0);
   });
 });
 
 // ---------------------------------------------------------------------------
 // Wiring-order pins. The bake contract is positional (snapshot before the
-// serialize-adjacent await, delete only after the committed arm), and the
-// merge must only run after a successful book load: these read the source
-// because the ordering IS the contract, and a refactor that reorders it
-// silently reopens the fast-collect dupe or the failed-load clobber.
+// serialize-adjacent await, the bake and the watermark advance inside the
+// transaction, confirm after the committed arm), and the merge must only run
+// after a successful book load: these read the source because the ordering
+// IS the contract. Comments are stripped first (the sibling
+// main_retention_wiring.test.ts rationale: a commented-out call must never
+// satisfy an order pin), every index is guarded against -1, and each slice
+// is bounded to its function. The statement-level behavior (one client,
+// rollback keeps refs) is proven in save_mail_state_custody_bake.test.ts.
 // ---------------------------------------------------------------------------
 
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
+import { stripComments } from '../helpers/strip_comments';
+
+function boundedBody(src: string, startNeedle: string, endNeedle: string): string {
+  const start = src.indexOf(startNeedle);
+  expect(start).toBeGreaterThan(-1);
+  const end = src.indexOf(endNeedle, start + startNeedle.length);
+  expect(end).toBeGreaterThan(start);
+  return src.slice(start, end);
+}
 
 describe('bake and merge wiring order', () => {
-  const dbSrc = readFileSync(path.resolve(process.cwd(), 'server/db.ts'), 'utf8');
-  const gameSrc = readFileSync(path.resolve(process.cwd(), 'server/game.ts'), 'utf8');
+  const dbSrc = stripComments(readFileSync(path.resolve(process.cwd(), 'server/db.ts'), 'utf8'));
+  const gameSrc = stripComments(
+    readFileSync(path.resolve(process.cwd(), 'server/game.ts'), 'utf8'),
+  );
 
-  it('saveMailState snapshots at entry and bakes inside the book transaction', () => {
-    const body = dbSrc.slice(dbSrc.indexOf('export async function saveMailState'));
+  it('saveMailState snapshots at entry; bake and watermark ride the book transaction', () => {
+    const body = boundedBody(dbSrc, 'export async function saveMailState', '\nexport ');
     const snapshotAt = body.indexOf('snapshotPendingCustodyRefs()');
+    const firstAwaitAt = body.indexOf('await ');
     const beginAt = body.indexOf("client.query('BEGIN')");
-    const writeAt = body.indexOf('INSERT INTO world_state');
+    const writeAt = body.indexOf('upsertWorldStateRowIn(');
     const deleteAt = body.indexOf('deleteBakedCustodyRefsIn(');
+    const advanceAt = body.indexOf('advanceCustodyWatermarkIn(');
     const commitAt = body.indexOf("client.query('COMMIT')");
     const confirmAt = body.indexOf('confirmBakedCustodyRefs(');
-    // Snapshot before anything awaits; the bake DELETE strictly inside the
-    // transaction (after the upsert, before COMMIT), so the blob and the row
-    // removal commit together; the in-memory confirm only after COMMIT.
-    expect(snapshotAt).toBeGreaterThan(-1);
-    expect(snapshotAt).toBeLessThan(body.indexOf('await '));
-    expect(writeAt).toBeGreaterThan(beginAt);
-    expect(deleteAt).toBeGreaterThan(writeAt);
-    expect(deleteAt).toBeLessThan(commitAt);
+    for (const at of [
+      snapshotAt,
+      firstAwaitAt,
+      beginAt,
+      writeAt,
+      deleteAt,
+      advanceAt,
+      commitAt,
+      confirmAt,
+    ]) {
+      expect(at).toBeGreaterThan(-1);
+    }
+    // Snapshot before anything awaits; the book upsert, the bake DELETE,
+    // and the watermark advance strictly inside the transaction (after
+    // BEGIN, before COMMIT); the in-memory confirm only after COMMIT.
+    expect(snapshotAt).toBeLessThan(firstAwaitAt);
+    expect(beginAt).toBeLessThan(writeAt);
+    expect(writeAt).toBeLessThan(deleteAt);
+    expect(deleteAt).toBeLessThan(advanceAt);
+    expect(advanceAt).toBeLessThan(commitAt);
     expect(confirmAt).toBeGreaterThan(commitAt);
   });
 
-  it('the atomic leave-path save bakes inside the fenced transaction, confirmed after COMMIT', () => {
-    const start = dbSrc.indexOf('export async function saveCharacterAndMarketState');
-    const body = dbSrc.slice(start, dbSrc.indexOf('export', start + 10));
+  it('the atomic leave-path save bakes and advances inside the fenced transaction', () => {
+    const body = boundedBody(
+      dbSrc,
+      'export async function saveCharacterAndMarketState',
+      '\nexport ',
+    );
     const snapshotAt = body.indexOf('snapshotPendingCustodyRefs()');
+    const firstAwaitAt = body.indexOf('await ');
     const deleteAt = body.indexOf('deleteBakedCustodyRefsIn(');
+    const advanceAt = body.indexOf('advanceCustodyWatermarkIn(');
     const commitAt = body.indexOf("await client.query('COMMIT')");
     const confirmAt = body.indexOf('confirmBakedCustodyRefs(');
-    // Snapshot at entry, before the first await; the DELETE inside the
-    // transaction; the confirm on the committed arm only, so neither the
-    // fence-refused false arm nor a rollback can forget a pending ref.
-    expect(snapshotAt).toBeGreaterThan(-1);
-    expect(snapshotAt).toBeLessThan(body.indexOf('await '));
-    expect(deleteAt).toBeGreaterThan(-1);
-    expect(deleteAt).toBeLessThan(commitAt);
+    for (const at of [snapshotAt, firstAwaitAt, deleteAt, advanceAt, commitAt, confirmAt]) {
+      expect(at).toBeGreaterThan(-1);
+    }
+    // Snapshot at entry, before the first await; the DELETE and the advance
+    // inside the transaction; the confirm on the committed arm only, so
+    // neither the fence-refused false arm nor a rollback can forget a
+    // pending ref.
+    expect(snapshotAt).toBeLessThan(firstAwaitAt);
+    expect(deleteAt).toBeLessThan(advanceAt);
+    expect(advanceAt).toBeLessThan(commitAt);
     expect(confirmAt).toBeGreaterThan(commitAt);
     expect(body.split('deleteBakedCustodyRefsIn(')).toHaveLength(2);
     expect(body.split('confirmBakedCustodyRefs(')).toHaveLength(2);
@@ -299,16 +493,28 @@ describe('bake and merge wiring order', () => {
   });
 
   it('game.loadMail merges the overlay only after a successful book load', () => {
-    const start = gameSrc.indexOf('async loadMail()');
-    const body = gameSrc.slice(start, gameSrc.indexOf('async saveMail()', start));
+    const body = boundedBody(gameSrc, 'async loadMail()', 'async saveMail()');
     const loadAt = body.indexOf('this.sim.loadMail(await loadMailState())');
     const mergeAt = body.indexOf('mergeCustodyParcelOverlay(this.sim)');
     const catchAt = body.indexOf('catch');
+    for (const at of [loadAt, mergeAt, catchAt]) {
+      expect(at).toBeGreaterThan(-1);
+    }
     // The merge sits after the load INSIDE the same try: a failed load must
     // skip it (merging onto an unloaded book would re-book parcels the
     // stored blob still owns).
-    expect(loadAt).toBeGreaterThan(-1);
     expect(mergeAt).toBeGreaterThan(loadAt);
     expect(mergeAt).toBeLessThan(catchAt);
+  });
+
+  it('both callers serialize the book synchronously at the call, never across an await', () => {
+    // The third leg of the snapshot contract: no awaited gap between the
+    // caller's serializeMail() and the writer's entry. A hoist above an
+    // await would silently reopen the fast-collect bake hole with every
+    // other pin still green.
+    expect(gameSrc).toContain('saveMailState(this.sim.serializeMail())');
+    expect(gameSrc).toMatch(
+      /saveCharacterAndMarketState\(\s*session\.characterId,\s*snap\.level,\s*snap,\s*this\.sim\.serializeMarket\(\),\s*this\.sim\.serializeMail\(\),/,
+    );
   });
 });

--- a/tests/server/mail_custody_overlay.test.ts
+++ b/tests/server/mail_custody_overlay.test.ts
@@ -1,0 +1,216 @@
+// The durable per-parcel custody overlay (server/mail_custody_overlay.ts):
+// SQL shapes against a mocked pool, the snapshot/bake set semantics that keep
+// a row alive until its parcel is provably inside a committed full-book
+// write, and the boot merge driven against a REAL Sim post office, because
+// the replay-through-book-once-dedupe is exactly what a fake book would
+// paper over.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type TestQuery = (text: string, values?: readonly unknown[]) => Promise<{ rows: unknown[] }>;
+
+const db = vi.hoisted(() => ({ query: vi.fn<TestQuery>() }));
+
+vi.mock('../../server/db', () => ({ pool: { query: db.query } }));
+
+import {
+  deleteBakedCustodyRefs,
+  mergeCustodyParcelOverlay,
+  persistCustodyParcelRow,
+  resetCustodyParcelOverlayForTests,
+  snapshotPendingCustodyRefs,
+} from '../../server/mail_custody_overlay';
+import { REALM } from '../../server/realm';
+import { Sim } from '../../src/sim/sim';
+
+const { query } = db;
+
+const GOOD_ITEMS = [{ itemId: 'rusty_hatchet', count: 1 }];
+
+function row(ref: string) {
+  return {
+    custodyRef: ref,
+    recipient: { key: '4242', name: 'Buyer' },
+    letter: 'delivery' as const,
+    items: GOOD_ITEMS,
+  };
+}
+
+beforeEach(() => {
+  resetCustodyParcelOverlayForTests();
+  query.mockReset();
+  query.mockResolvedValue({ rows: [] });
+});
+
+describe('persistCustodyParcelRow', () => {
+  it('writes one idempotent realm-scoped row per parcel, keyed by custodyRef', async () => {
+    await persistCustodyParcelRow(row('settlement:9'));
+    expect(query).toHaveBeenCalledTimes(1);
+    const [sql, params] = query.mock.calls[0];
+    expect(sql).toMatch(/INSERT INTO mail_custody_parcels/);
+    // Idempotent by ref: a retry after a crash re-inserts harmlessly; the
+    // book-once dedupe owns exactly-once on the mail side.
+    expect(sql).toMatch(/ON CONFLICT \(custody_ref\) DO NOTHING/);
+    expect(params).toEqual([
+      'settlement:9',
+      REALM,
+      '4242',
+      'Buyer',
+      'delivery',
+      JSON.stringify(GOOD_ITEMS),
+    ]);
+    expect(snapshotPendingCustodyRefs()).toEqual(['settlement:9']);
+  });
+});
+
+describe('the bake set', () => {
+  it('deletes exactly the snapshot; refs booked after it stay pending', async () => {
+    await persistCustodyParcelRow(row('a'));
+    await persistCustodyParcelRow(row('b'));
+    const snap = snapshotPendingCustodyRefs();
+    await persistCustodyParcelRow(row('c'));
+    query.mockClear();
+    await deleteBakedCustodyRefs(snap);
+    expect(query).toHaveBeenCalledTimes(1);
+    const [sql, params] = query.mock.calls[0];
+    expect(sql).toMatch(/DELETE FROM mail_custody_parcels WHERE custody_ref = ANY/);
+    expect(params).toEqual([['a', 'b']]);
+    // 'c' was booked after the snapshot (necessarily across an await, so
+    // after the full-book serialize): its row must survive this bake.
+    expect(snapshotPendingCustodyRefs()).toEqual(['c']);
+  });
+
+  it('keeps the refs pending when the delete fails, so the next write retries', async () => {
+    await persistCustodyParcelRow(row('a'));
+    const snap = snapshotPendingCustodyRefs();
+    query.mockRejectedValueOnce(new Error('db down'));
+    // Non-throwing by contract: this runs after a COMMIT, and a failure here
+    // must never re-mark the committed save as failed.
+    await expect(deleteBakedCustodyRefs(snap)).resolves.toBeUndefined();
+    expect(snapshotPendingCustodyRefs()).toEqual(['a']);
+    query.mockResolvedValueOnce({ rows: [] });
+    await deleteBakedCustodyRefs(snapshotPendingCustodyRefs());
+    expect(snapshotPendingCustodyRefs()).toEqual([]);
+  });
+
+  it('deletes nothing for an empty snapshot', async () => {
+    await deleteBakedCustodyRefs([]);
+    expect(query).not.toHaveBeenCalled();
+  });
+});
+
+describe('mergeCustodyParcelOverlay', () => {
+  function overlayRows(refs: string[], letter = 'delivery') {
+    return refs.map((ref) => ({
+      custody_ref: ref,
+      recipient_key: '4242',
+      recipient_name: 'Buyer',
+      letter,
+      items: GOOD_ITEMS,
+    }));
+  }
+
+  it('replays a crash-lost parcel into a real book, and dedupes it on the next boot', async () => {
+    // The crash story: the parcel row survived, the blob write did not.
+    const sim = new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+    query.mockResolvedValueOnce({ rows: overlayRows(['settlement:9']) });
+    const first = await mergeCustodyParcelOverlay(sim);
+    expect(first).toEqual({ replayed: 1, present: 0, refused: 0 });
+    expect(query.mock.calls[0][0]).toMatch(/FROM mail_custody_parcels WHERE realm = \$1/);
+    expect(query.mock.calls[0][1]).toEqual([REALM]);
+    expect(sim.postOffice.mail).toHaveLength(1);
+    expect(sim.postOffice.mail[0].custodyRef).toBe('settlement:9');
+    expect(sim.postOffice.mail[0].items.map((s) => s.itemId)).toEqual(['rusty_hatchet']);
+    // An accounted ref joins the bake set so the next full-book write
+    // cleans its row.
+    expect(snapshotPendingCustodyRefs()).toEqual(['settlement:9']);
+
+    // Second boot with the parcel already inside the loaded blob: the
+    // book-once dedupe reports it present and books nothing new.
+    resetCustodyParcelOverlayForTests();
+    query.mockResolvedValueOnce({ rows: overlayRows(['settlement:9']) });
+    const second = await mergeCustodyParcelOverlay(sim);
+    expect(second).toEqual({ replayed: 0, present: 1, refused: 0 });
+    expect(sim.postOffice.mail).toHaveLength(1);
+    expect(snapshotPendingCustodyRefs()).toEqual(['settlement:9']);
+  });
+
+  it('keeps a malformed or refused row out of the bake set instead of destroying it', async () => {
+    const sim = new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+    query.mockResolvedValueOnce({
+      rows: [
+        ...overlayRows(['bogus:1'], 'not_a_letter'),
+        // A parcel whose items no longer validate: refused by the book and
+        // absent, so the row must survive for the operator.
+        {
+          custody_ref: 'refused:1',
+          recipient_key: '4242',
+          recipient_name: 'Buyer',
+          letter: 'delivery',
+          items: [{ itemId: 'no_such_item_id', count: 1 }],
+        },
+        ...overlayRows(['ok:1']),
+      ],
+    });
+    const result = await mergeCustodyParcelOverlay(sim);
+    expect(result).toEqual({ replayed: 1, present: 0, refused: 2 });
+    // Only the accounted ref may ever be baked away; the refused rows'
+    // absence from the set is what keeps their rows in the table.
+    expect(snapshotPendingCustodyRefs()).toEqual(['ok:1']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Wiring-order pins. The bake contract is positional (snapshot before the
+// serialize-adjacent await, delete only after the committed arm), and the
+// merge must only run after a successful book load: these read the source
+// because the ordering IS the contract, and a refactor that reorders it
+// silently reopens the fast-collect dupe or the failed-load clobber.
+// ---------------------------------------------------------------------------
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+describe('bake and merge wiring order', () => {
+  const dbSrc = readFileSync(path.resolve(process.cwd(), 'server/db.ts'), 'utf8');
+  const gameSrc = readFileSync(path.resolve(process.cwd(), 'server/game.ts'), 'utf8');
+
+  it('saveMailState snapshots at entry and deletes only after the book write', () => {
+    const body = dbSrc.slice(dbSrc.indexOf('export async function saveMailState'));
+    const snapshotAt = body.indexOf('snapshotPendingCustodyRefs()');
+    const writeAt = body.indexOf('saveWorldState(mailStateKey');
+    const deleteAt = body.indexOf('deleteBakedCustodyRefs(');
+    expect(snapshotAt).toBeGreaterThan(-1);
+    expect(writeAt).toBeGreaterThan(snapshotAt);
+    expect(deleteAt).toBeGreaterThan(writeAt);
+  });
+
+  it('the atomic leave-path save deletes only on the committed arm', () => {
+    const start = dbSrc.indexOf('export async function saveCharacterAndMarketState');
+    const body = dbSrc.slice(start, dbSrc.indexOf('export', start + 10));
+    const snapshotAt = body.indexOf('snapshotPendingCustodyRefs()');
+    const commitAt = body.indexOf("await client.query('COMMIT')");
+    const deleteAt = body.indexOf('deleteBakedCustodyRefs(');
+    // Snapshot at entry, before the first await; delete strictly after the
+    // COMMIT; and exactly one delete call, so neither the fence-refused
+    // false arm nor the rollback arm can reach one.
+    expect(snapshotAt).toBeGreaterThan(-1);
+    expect(snapshotAt).toBeLessThan(body.indexOf('await '));
+    expect(deleteAt).toBeGreaterThan(commitAt);
+    expect(body.split('deleteBakedCustodyRefs(')).toHaveLength(2);
+  });
+
+  it('game.loadMail merges the overlay only after a successful book load', () => {
+    const start = gameSrc.indexOf('async loadMail()');
+    const body = gameSrc.slice(start, gameSrc.indexOf('async saveMail()', start));
+    const loadAt = body.indexOf('this.sim.loadMail(await loadMailState())');
+    const mergeAt = body.indexOf('mergeCustodyParcelOverlay(this.sim)');
+    const catchAt = body.indexOf('catch');
+    // The merge sits after the load INSIDE the same try: a failed load must
+    // skip it (merging onto an unloaded book would re-book parcels the
+    // stored blob still owns).
+    expect(loadAt).toBeGreaterThan(-1);
+    expect(mergeAt).toBeGreaterThan(loadAt);
+    expect(mergeAt).toBeLessThan(catchAt);
+  });
+});

--- a/tests/server/main_retention_wiring.test.ts
+++ b/tests/server/main_retention_wiring.test.ts
@@ -55,6 +55,7 @@ describe('retention sweep wiring in server/main.ts', () => {
       'pruneResolvedWocOffersBatch(',
       'pruneBookedWocCustodyClaimsBatch(',
       'pruneExpiredWocStepUpChallengesBatch(',
+      'pruneMailCustodyParcelsBatch(',
       'pruneClosedWocListingsBatch(',
     ]) {
       expect(preListen).not.toContain(call);
@@ -122,6 +123,7 @@ describe('retention sweep wiring in server/main.ts', () => {
       'pruneResolvedWocOffersBatch(',
       'pruneBookedWocCustodyClaimsBatch(',
       'pruneExpiredWocStepUpChallengesBatch(',
+      'pruneMailCustodyParcelsBatch(',
       'pruneClosedWocListingsBatch(',
     ]) {
       expect(count(MAIN, call)).toBe(1);
@@ -187,6 +189,9 @@ describe('retention sweep wiring in server/main.ts', () => {
     // Deliberately knobless: expired step-up nonces are garbage, not history,
     // so the drain takes no retention-days argument to misthread.
     expect(MAIN).toContain('pruneExpiredWocStepUpChallengesBatch(pool, n)');
+    // The custody-mail overlay residue prune is knobless too (constant
+    // 30-day window inside the module, no retention-days argument).
+    expect(MAIN).toContain('pruneMailCustodyParcelsBatch(n)');
     // The custody-claims window relation check must actually be WIRED (the
     // helper is unit-tested in the market SQL floor; this catches dead code),
     // with both knobs threaded in the documented order (whitespace-collapsed

--- a/tests/server/main_retention_wiring.test.ts
+++ b/tests/server/main_retention_wiring.test.ts
@@ -237,6 +237,7 @@ describe('retention sweep wiring in server/main.ts', () => {
       'woc_market_directed_offers',
       'woc_market_custody_claims',
       'woc_market_stepup_challenges',
+      'mail_custody_parcels',
       'woc_market_listings',
     ]);
     expect(new Set(names).size).toBe(names.length);

--- a/tests/server/save_mail_state_custody_bake.test.ts
+++ b/tests/server/save_mail_state_custody_bake.test.ts
@@ -1,0 +1,144 @@
+// Behavioral proof of the custody bake transaction in db.saveMailState. The
+// wiring-order source pins (tests/server/mail_custody_overlay.test.ts) anchor
+// statement POSITIONS, but only observing the statements on ONE client proves
+// the contract itself: the blob upsert, the bake DELETE, and the watermark
+// advance all ride the same transaction on the same connection (a bake
+// through pool.query would sit OUTSIDE the transaction and silently reopen
+// the failed-delete-brackets-a-collection dupe), and a mid-transaction
+// failure rolls the book write back with the refs still pending. Runs the
+// real db.ts against a mocked pg Pool.
+
+process.env.DATABASE_URL ||= 'postgres://test:test@127.0.0.1:5433/wocc_save_mail_bake';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+interface Recorded {
+  text: string;
+  values?: readonly unknown[];
+}
+
+const rec = vi.hoisted(() => ({
+  client: [] as Recorded[],
+  poolDirect: [] as Recorded[],
+  failOn: null as ((text: string) => boolean) | null,
+}));
+
+vi.mock('pg', () => {
+  class FakePool {
+    async connect() {
+      return {
+        query: async (text: string, values?: readonly unknown[]) => {
+          rec.client.push({ text, values });
+          if (rec.failOn?.(text)) throw new Error('injected client failure');
+          return { rows: [], rowCount: 0 };
+        },
+        release: () => {},
+      };
+    }
+    async query(text: string, values?: readonly unknown[]) {
+      rec.poolDirect.push({ text, values });
+      return { rows: [], rowCount: 0 };
+    }
+    on() {
+      return this;
+    }
+    async end() {}
+  }
+  return { Pool: FakePool, default: { Pool: FakePool } };
+});
+
+import * as db from '../../server/db';
+import {
+  mergeCustodyParcelOverlay,
+  persistCustodyParcelRow,
+  resetCustodyParcelOverlayForTests,
+  snapshotPendingCustodyRefs,
+} from '../../server/mail_custody_overlay';
+import { REALM } from '../../server/realm';
+
+type MailSaveArg = Parameters<typeof db.saveMailState>[0];
+const SAVE = { book: 'frozen' } as unknown as MailSaveArg;
+
+/** Collapse a recorded statement to its kind so the ORDER is assertable. */
+function kind(text: string): string {
+  const t = text.trim().toUpperCase();
+  if (t.startsWith('BEGIN')) return 'BEGIN';
+  if (t.startsWith('COMMIT')) return 'COMMIT';
+  if (t.startsWith('ROLLBACK')) return 'ROLLBACK';
+  if (t.includes('INSERT INTO WORLD_STATE')) return 'BOOK_UPSERT';
+  if (t.includes('DELETE FROM MAIL_CUSTODY_PARCELS')) return 'BAKE_DELETE';
+  if (t.includes('MAIL_CUSTODY_WATERMARK')) return 'WATERMARK';
+  return 'OTHER';
+}
+
+const ROW = {
+  custodyRef: 'settlement:tx:1',
+  recipient: { key: '4242', name: 'Buyer' },
+  letter: 'delivery' as const,
+  items: [{ itemId: 'rusty_hatchet', count: 1 }],
+};
+
+/** A book stub for arming the watermark gate via an empty, fully-drained
+ *  merge (the merge reads only through the mocked pool, which returns no
+ *  rows, so the book is never consulted). */
+const EMPTY_BOOK = {
+  mailSystemParcel: () => true,
+  hasCustodyParcel: () => false,
+};
+
+beforeEach(() => {
+  resetCustodyParcelOverlayForTests();
+  rec.client.length = 0;
+  rec.poolDirect.length = 0;
+  rec.failOn = null;
+});
+
+describe('saveMailState custody bake transaction', () => {
+  it('runs upsert, bake, and watermark in ONE transaction on ONE client, then confirms', async () => {
+    await mergeCustodyParcelOverlay(EMPTY_BOOK);
+    await persistCustodyParcelRow(ROW);
+    rec.client.length = 0;
+    rec.poolDirect.length = 0;
+
+    await db.saveMailState(SAVE);
+    expect(rec.client.map((s) => kind(s.text))).toEqual([
+      'BEGIN',
+      'BOOK_UPSERT',
+      'BAKE_DELETE',
+      'WATERMARK',
+      'COMMIT',
+    ]);
+    // The bake must never ride a separate pooled connection: outside the
+    // transaction it could commit while the book write rolls back, leaving
+    // a deleted row for an undurable parcel.
+    expect(rec.poolDirect).toEqual([]);
+    const upsert = rec.client.find((s) => kind(s.text) === 'BOOK_UPSERT');
+    expect(upsert?.values).toEqual([`mail:${REALM}`, JSON.stringify(SAVE)]);
+    const bake = rec.client.find((s) => kind(s.text) === 'BAKE_DELETE');
+    expect(bake?.values).toEqual([['settlement:tx:1'], REALM]);
+    // Committed: the ref is confirmed out of the pending set.
+    expect(snapshotPendingCustodyRefs()).toEqual([]);
+  });
+
+  it('a failed bake rolls the book write back and keeps the refs pending', async () => {
+    await mergeCustodyParcelOverlay(EMPTY_BOOK);
+    await persistCustodyParcelRow(ROW);
+    rec.client.length = 0;
+    rec.failOn = (text) => kind(text) === 'BAKE_DELETE';
+
+    await expect(db.saveMailState(SAVE)).rejects.toThrow('injected client failure');
+    const kinds = rec.client.map((s) => kind(s.text));
+    expect(kinds).toEqual(['BEGIN', 'BOOK_UPSERT', 'BAKE_DELETE', 'ROLLBACK']);
+    expect(kinds).not.toContain('COMMIT');
+    // Every rollback keeps every row pending: the next write re-bakes it.
+    expect(snapshotPendingCustodyRefs()).toEqual(['settlement:tx:1']);
+  });
+
+  it('takes the same transactional path with no pending refs, watermark still frozen pre-merge', async () => {
+    // No merge ran (a failed-load boot): the watermark must not advance, and
+    // an empty bake set issues no DELETE, but the book write still commits.
+    await db.saveMailState(SAVE);
+    expect(rec.client.map((s) => kind(s.text))).toEqual(['BEGIN', 'BOOK_UPSERT', 'COMMIT']);
+    expect(rec.poolDirect).toEqual([]);
+  });
+});

--- a/tests/server/woc_market_custody.test.ts
+++ b/tests/server/woc_market_custody.test.ts
@@ -13,7 +13,8 @@
 
 process.env.DATABASE_URL ||= 'postgres://test:test@127.0.0.1:5433/wocc_woc_market_custody';
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+import type { CustodyParcelRow } from '../../server/mail_custody_overlay';
 import { createWocMarketCustody, type WocCustodyGameHost } from '../../server/woc_market_custody';
 import { isCataloguedRelicItem } from '../../src/sim/content/reliquary';
 import { Sim } from '../../src/sim/sim';
@@ -22,20 +23,21 @@ import type { InvSlot } from '../../src/sim/types';
 const RECIPIENT = { key: '4242', name: 'Buyer' };
 const REF = 'settlement:9';
 
-/** A host over a real Sim: no live session (deliveries never need one) and a
- *  persist hook whose calls are counted so "did it try to persist" is decidable. */
+/** A host over a real Sim: no live session (deliveries never need one). The
+ *  per-parcel durable write is injected as a recorder, so "did it persist,
+ *  and what row" is decidable, and a spy on serializeMail pins that the
+ *  parcel path never serializes the whole book. */
 function makeHost(over: Partial<WocCustodyGameHost> = {}): {
   host: WocCustodyGameHost;
   persists: () => number;
+  parcelRows: CustodyParcelRow[];
+  persistParcelRow: (row: CustodyParcelRow) => Promise<void>;
 } {
-  let persists = 0;
+  const parcelRows: CustodyParcelRow[] = [];
   const sim = new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
   const host: WocCustodyGameHost = {
     sim,
     wocCustodySession: () => null,
-    persistMailBlob: async () => {
-      persists++;
-    },
     // Pass-through FIFO and a fixup-free persist snapshot: these tests have
     // no GameServer, so the session fixups and queue ordering are exercised
     // by tests/server/woc_market_escrow_queue.test.ts instead.
@@ -51,7 +53,14 @@ function makeHost(over: Partial<WocCustodyGameHost> = {}): {
     escrowSessionLost: () => {},
     ...over,
   };
-  return { host, persists: () => persists };
+  return {
+    host,
+    persists: () => parcelRows.length,
+    parcelRows,
+    persistParcelRow: async (row) => {
+      parcelRows.push(row);
+    },
+  };
 }
 
 const GOOD: InvSlot = { itemId: 'rusty_hatchet', count: 1 };
@@ -59,8 +68,8 @@ const UNKNOWN: InvSlot = { itemId: 'no_such_item_id', count: 1 };
 
 describe('persistMailParcel propagates a refused parcel', () => {
   it('throws, and does NOT persist, when no offered slot survives validation', async () => {
-    const { host, persists } = makeHost();
-    const custody = createWocMarketCustody(host);
+    const { host, persists, persistParcelRow } = makeHost();
+    const custody = createWocMarketCustody(host, { persistParcelRow });
     await expect(custody.persistMailParcel(RECIPIENT, 'delivery', [UNKNOWN], REF)).rejects.toThrow(
       /refused/,
     );
@@ -71,18 +80,32 @@ describe('persistMailParcel propagates a refused parcel', () => {
   });
 
   it('names the custody ref in the error so the stuck row is findable in a log', async () => {
-    const { host } = makeHost();
-    const custody = createWocMarketCustody(host);
+    const { host, persistParcelRow } = makeHost();
+    const custody = createWocMarketCustody(host, { persistParcelRow });
     await expect(
       custody.persistMailParcel(RECIPIENT, 'delivery', [UNKNOWN], 'settlement:777'),
     ).rejects.toThrow(/settlement:777/);
   });
 
-  it('books and persists exactly once on the happy path', async () => {
-    const { host, persists } = makeHost();
-    const custody = createWocMarketCustody(host);
+  it('books and persists exactly once on the happy path, never serializing the book', async () => {
+    const { host, persists, parcelRows, persistParcelRow } = makeHost();
+    const custody = createWocMarketCustody(host, { persistParcelRow });
+    // The acceptance pin of the rewrite: booking one parcel must cost the
+    // parcel, not the book. No full serializeMail may run on this path (the
+    // old persistMailBlob stringified the whole 89 MB production book per
+    // parcel).
+    const serializeSpy = vi.spyOn(host.sim, 'serializeMail');
     await custody.persistMailParcel(RECIPIENT, 'delivery', [GOOD], REF);
+    expect(serializeSpy).not.toHaveBeenCalled();
     expect(persists()).toBe(1);
+    // The durable row carries exactly what a boot replay needs to re-book
+    // this letter through the book-once dedupe.
+    expect(parcelRows[0]).toEqual({
+      custodyRef: REF,
+      recipient: RECIPIENT,
+      letter: 'delivery',
+      items: [GOOD],
+    });
     expect(host.sim.postOffice.mail).toHaveLength(1);
     expect(host.sim.postOffice.mail[0].items.map((s) => s.itemId)).toEqual(['rusty_hatchet']);
     expect(host.sim.postOffice.mail[0].custodyRef).toBe(REF);
@@ -92,21 +115,21 @@ describe('persistMailParcel propagates a refused parcel', () => {
     // The book-once dedupe answers "already booked" as success, which must not
     // be confused with the refusal above: a retry after a crash has to be able
     // to complete rather than throwing forever.
-    const { host, persists } = makeHost();
-    const custody = createWocMarketCustody(host);
+    const { host, persists, persistParcelRow } = makeHost();
+    const custody = createWocMarketCustody(host, { persistParcelRow });
     await custody.persistMailParcel(RECIPIENT, 'delivery', [GOOD], REF);
     await custody.persistMailParcel(RECIPIENT, 'delivery', [GOOD], REF);
     expect(host.sim.postOffice.mail).toHaveLength(1);
     expect(persists()).toBe(2);
   });
 
-  it('propagates a persist failure too, so nothing advances on a dead blob write', async () => {
-    const { host } = makeHost({
-      persistMailBlob: async () => {
+  it('propagates a persist failure too, so nothing advances on a dead row write', async () => {
+    const { host } = makeHost();
+    const custody = createWocMarketCustody(host, {
+      persistParcelRow: async () => {
         throw new Error('db down');
       },
     });
-    const custody = createWocMarketCustody(host);
     await expect(custody.persistMailParcel(RECIPIENT, 'delivery', [GOOD], REF)).rejects.toThrow(
       'db down',
     );
@@ -115,8 +138,8 @@ describe('persistMailParcel propagates a refused parcel', () => {
   it('carries a goods-free notice through, which legitimately attaches nothing', async () => {
     // The sold_notice arm passes no items on purpose. "Nothing booked" must not
     // read as a refusal when nothing was offered, or every sale notice throws.
-    const { host, persists } = makeHost();
-    const custody = createWocMarketCustody(host);
+    const { host, persists, persistParcelRow } = makeHost();
+    const custody = createWocMarketCustody(host, { persistParcelRow });
     await custody.persistMailParcel(RECIPIENT, 'sold_notice', [], 'sold:9');
     expect(persists()).toBe(1);
     expect(host.sim.postOffice.mail).toHaveLength(1);

--- a/tests/server/woc_market_escrow_queue.test.ts
+++ b/tests/server/woc_market_escrow_queue.test.ts
@@ -48,6 +48,7 @@ import {
   setGameMetricsCounters,
   type WocEscrowQueueOutcome,
 } from '../../server/http/game_signals';
+import type { CustodyParcelRow } from '../../server/mail_custody_overlay';
 import type { CharacterSaveArgs, WocMarketCustody } from '../../server/woc_market';
 import { WocMarketService } from '../../server/woc_market';
 import { createWocMarketCustody, wocEscrowSerializeStats } from '../../server/woc_market_custody';
@@ -169,6 +170,9 @@ interface Rig {
   custody: WocMarketCustody;
   db: FakeWocMarketDb;
   service: WocMarketService;
+  /** Every durable custody parcel row the bridge wrote (the per-parcel
+   *  overlay seam that replaced the whole-book persistMailBlob). */
+  parcelRows: CustodyParcelRow[];
   /** Every character write across BOTH channels, in commit order, with
    *  whether that blob still holds the escrow item. */
   commits: Array<{ channel: string; holdsItem: boolean }>;
@@ -198,13 +202,13 @@ function makeRig(
   };
   const session = join(SELLER, SELLER_CHAR, 'Selara');
   server.sim.addItem(EPIC_ITEM, 1, session.pid, { silent: true });
+  const parcelRows: CustodyParcelRow[] = [];
   const custody = createWocMarketCustody(
     {
       get sim() {
         return server.sim;
       },
       wocCustodySession: (characterId) => server.wocCustodySession(characterId),
-      persistMailBlob: () => server.persistMailBlob(),
       enqueueCharacterWrite: (characterId, job) => server.enqueueCharacterWrite(characterId, job),
       serializeCharacterForPersist: (characterId) =>
         server.serializeCharacterForPersist(characterId),
@@ -213,7 +217,12 @@ function makeRig(
       escrowSessionLost: (pid, characterId, kind) =>
         server.escrowSessionLost(pid, characterId, kind),
     },
-    opts,
+    {
+      ...opts,
+      persistParcelRow: async (row) => {
+        parcelRows.push(row);
+      },
+    },
   );
   const db = new FakeWocMarketDb({
     characters: [{ characterId: SELLER_CHAR, accountId: SELLER, name: 'Selara', realm: REALM }],
@@ -249,6 +258,7 @@ function makeRig(
     custody,
     db,
     service,
+    parcelRows,
     commits,
     itemIndex: () => inventory().findIndex((s) => s.itemId === EPIC_ITEM),
     bagsHold: (itemId) => inventory().some((s) => s.itemId === itemId),
@@ -468,7 +478,7 @@ describe('the escrow critical section rides the per-character save queue (H5)', 
     // Positive control for that absence: the return-parcel arm is real and
     // fires when the extraction pid is genuinely gone from the sim.
     const idsBefore = new Set(rig.server.sim.postOffice.mail.map((m) => m.id));
-    const mailSpy = vi.spyOn(rig.server, 'persistMailBlob');
+    const rowsBefore = rig.parcelRows.length;
     rig.custody.restoreCopy(999_999, SELLER_CHAR, { itemId: EPIC_ITEM, count: 2 });
     expect(rig.server.sim.postOffice.mail).toHaveLength(mailBefore + 1);
     const booked = rig.server.sim.postOffice.mail.filter((m) => !idsBefore.has(m.id));
@@ -480,9 +490,16 @@ describe('the escrow critical section rides the per-character save queue (H5)', 
     expect(booked[0]?.letterId).toBe('woc_market_return');
     expect(booked[0]?.letterId).toBe(WOC_MARKET_RETURN_LETTER.letterId);
     expect(booked[0]?.items).toEqual([{ itemId: EPIC_ITEM, count: 2 }]);
-    // The in-memory book alone is not the item: the blob write is what makes
-    // the parcel survive a restart.
-    expect(mailSpy).toHaveBeenCalledTimes(1);
+    // The in-memory book alone is not the item: the durable parcel row is
+    // what makes the parcel survive a restart (the boot merge replays it
+    // through the book-once dedupe). The row carries the SAME ref the letter
+    // was booked with, so the replay can never double-book.
+    expect(rig.parcelRows.length).toBe(rowsBefore + 1);
+    const row = rig.parcelRows.at(-1);
+    expect(row?.letter).toBe('return');
+    expect(row?.recipient.key).toBe(String(SELLER_CHAR));
+    expect(row?.items).toEqual([{ itemId: EPIC_ITEM, count: 2 }]);
+    expect(row?.custodyRef).toBe(booked[0]?.custodyRef);
   });
 
   it('a refusal mid-leave restores the LIVE bags, never a second rail', async () => {

--- a/tests/server/woc_market_hot_reads.test.ts
+++ b/tests/server/woc_market_hot_reads.test.ts
@@ -1208,6 +1208,10 @@ describe('production wiring (server/main.ts, source-pinned)', () => {
     // The extract-side serialize cost, the number the SAVE_IDLE sizing
     // argument rests on.
     expect(code).toContain('escrowSerialize: wocEscrowSerializeStats()');
+    // The custody mail overlay readout: pendingBake plus the last merge's
+    // counts and ok flag, the stuck-parcel signal an operator needs without
+    // a log grep.
+    expect(code).toContain('custodyOverlay: custodyOverlayStats()');
     // The character-save FIFO gauge reads the queue's live key count.
     expect(code).toContain('savePendingKeys: () => game.characterSaveQueues.pendingKeys()');
     // The drain rung's wiring: shutdown calls markDraining() first, and the


### PR DESCRIPTION
## Summary

Booking a $WOC custody parcel now costs the loop the parcel, not the mail book.

Previously every parcel the marketplace booked (delivered item, returned listing item, seller sold notice, driven by the 5 s delivery sweep) ran `GameServer.persistMailBlob`: a full `sim.serializeMail()` stringify and whole-JSONB-row rewrite on the shared market serial writer. Against the production 89 MB book (#3560) that is roughly 250 ms of main-thread time per parcel, queued behind the 30 s autosave, and it scales with the book, not the parcel.

The new shape (`server/mail_custody_overlay.ts`):

- **Booking**: `persistMailParcel` books the letter in the in-memory post office exactly as before (book-once by `custodyRef`), then writes ONE durable row into the new `mail_custody_parcels` table (`INSERT ... ON CONFLICT (custody_ref) DO NOTHING`), awaited before the caller advances its settlement. Durability semantics are unchanged: nothing advances until the parcel is durable somewhere, and the custodian holds `delivering` until the write resolves.
- **Baking**: the parcel reaches the blob on the next full book write (the 30 s autosave `saveMailState` or the leave-path `saveCharacterAndMarketState`). Both writers snapshot the pending refs AT ENTRY (no awaited gap separates the caller's `serializeMail()` from the callee's first statement, so the snapshot is exactly serialize-time) and issue the bake DELETE INSIDE the same transaction as the book write, on the writer's own client: "blob durable without the parcel" and "row gone" commit together, so no failure interleaving can strand a row past a committed write. A fence-refused atomic save (`false`) and every rollback keep every row; the in-memory set forgets refs only on the committed arm.
- **The accounting watermark** (`mail_custody_watermark`, the review round 2 rework): the rollback guard no longer reads the blob's `updated_at` (whose transaction start postdates the writer's serialize, so a parcel row inserted in that gap, or left behind by a failed merge or a paged backlog, could be classified stale and deleted while its parcel was never in any durable book). Each serialized book write now advances `accounted_through` to the PREVIOUS write's transaction start, inside its own transaction: sound from the market FIFO's ordering alone (a row created at or before write N's transaction start was booked before write N+1 serialized), with no wall-clock read outside a transaction and no cross-connection ordering assumption. The advance is gated on the boot merge having drained every surviving row, so a failed or truncated merge freezes the watermark and every unexamined row replays at a later boot instead of ever being deleted. The merge compares `created_at <= accounted_through` entirely in SQL at full microsecond precision.
- **Crash recovery**: at boot, `game.loadMail` merges surviving rows into the loaded book, only after a SUCCESSFUL load, replaying each through the sim's book-once dedupe: a parcel already in the blob reports present, a crash-lost one re-books, and a refused row is kept in the table and logged for the operator instead of silently vanishing (it is cleaned once the advancing watermark passes it). The merge drains the whole table in primary-key keyset pages (`MERGE_PAGE_LIMIT` per statement, `MERGE_MAX_PAGES` cap, loud when capped), never throws (a failure reads as "the watermark stays frozen and every row replays at a later boot", never as a mail-load failure), and its counts plus an `ok` flag plus the live bake-set size are on the market ops readout (`custodyOverlay` in the `/internal/woc-market/stuck` payload), so a failed merge is distinguishable from an empty table. The snapshot-by-refs (never book-contents) bake is what keeps a fast-collected parcel (booked and collected between two saves) from ever replaying.
- **Retention**: healthy rows are cleaned by the bake and the watermark cutoff; a constant-window residue prune (`mail_custody_parcels`, 30 days, no env knob, the stepup-challenges pattern) joins the nightly retention sweep for the two populations nothing else can reach: refused rows an operator never resolved and rows for realms no process serves.
- **Compensation**: `restoreCopy`'s player-gone return parcel gets a generated `woc-return:<uuid>` ref, so even compensation mail is replay-safe; its row write stays fire-and-forget like the old whole-book write it replaces, but a failure is at least logged now.
- `GameServer.persistMailBlob` is deleted; the custody host interface no longer needs it. The parcel insert deliberately does NOT ride the market serial writer: the bake is keyed by explicit ref snapshots, not write interleaving, so the FIFO's ordering is not needed and a settlement burst is a burst of small row inserts.

Retention: rows are bounded by parcels booked between two full book writes plus crash leftovers, and both are cleaned by the next bake after the next boot's merge, with the residue prune as the backstop. The table has no FK on purpose: rows must survive character deletion long enough for an operator to attribute them.

Deliberate tradeoff, on the record: the old whole-book write per parcel incidentally made recent COLLECTIONS durable at settlement cadence; collection durability is now only the 30 s autosave and the leave path, so the pre-existing crash window that re-delivers an already-collected letter (bags durable via the character save, book blob stale) is wider under marketplace load. That window predates this PR and is bounded by the autosave interval.

## Related issues

Fixes the "every $WOC custody parcel re-serializes and rewrites the whole mail book" report. Same whole-book family as #3560/#3561; the autosave arm remains #3561's.

## Type of change

- [x] Bug fix (performance defect on the world loop)
- [x] Refactor or performance

## How was this tested?

- Commands:
  - `GATE_SELECT_BASE=origin/release/v0.40.1 node scripts/gate_select.mjs` (green)
  - `npx vitest run tests/server/mail_custody_overlay.test.ts` (20 passing: SQL shapes including the realm-qualified in-transaction bake DELETE, the in-SQL watermark cutoff, and the residue prune; the watermark advance gate across the armed, unarmed, and failed-merge arms; snapshot/confirm set semantics with the booked-after-snapshot arm; boot merge against a REAL Sim post office with replay, dedupe, both malformed dimensions, refused and stale rows, keyset paging, the page cap freezing the watermark, partial-failure counts, and the never-throws contract; the serializeMail deep-snapshot pin; comment-stripped, bounded, missing-needle-guarded wiring-order pins for both writers, the merge placement, and BOTH callers' synchronous serializeMail adjacency)
  - `npx vitest run tests/server/save_mail_state_custody_bake.test.ts` (3 passing behavioral proofs of `db.saveMailState` against a mocked pg Pool: the blob upsert, bake DELETE, and watermark advance ride ONE transaction on ONE client with `pool.query` never touched, a failed bake rolls the book write back and keeps the refs pending, and the refs-empty path still commits transactionally with the watermark frozen pre-merge)
  - `npx vitest run tests/server/woc_market_custody.test.ts tests/server/woc_market_escrow_queue.test.ts tests/server/woc_market_delivery.test.ts tests/server/woc_market_service.test.ts tests/monolith_budget.test.ts` (all passing; the custody happy path pins that `sim.serializeMail` is NEVER called on the parcel path)
  - `TEST_DATABASE_URL=... npx vitest run tests/mail_custody_overlay_pg_integration.test.ts` (passing against real PostgreSQL 16: ensureSchema registration of both tables, idempotent insert, crash replay into a fresh Sim, bake-on-clean-shutdown emptying the table, the watermark born at `-infinity` and advancing to the previous write's transaction start on the second write with the ordering asserted in SQL, and the rollback guard deleting a backdated row end to end)
  - `npx tsc --noEmit` (clean); `server/game.ts` and `server/db.ts` stay at or under their monolith ceilings (game.ts is untouched by round 2; db.ts shrank via the shared world_state upsert helper).
- Manual steps: N/A (server-only)

## Review rounds

A server-hot-path review and a migration-safety review ran over the initial commit; every should-fix landed in the second commit (the in-transaction bake DELETE, the first-cut rollback guard, the retention prune, the ops-readout stats, the page-bounded non-throwing merge, the realm-qualified DELETE, and the serializeMail deep-snapshot pin).

Round 2 (the posted PR review plus an adversarial durability audit) found the first-cut stale cutoff unsound: comparing `created_at` against the blob's `updated_at` deletes a crash-lost parcel row without replay under four triggers (the serialize-to-BEGIN race on the off-FIFO insert, any failed boot merge, a failed load followed by autosaves, and the page-limit remainder). This round's commit replaces it with the accounting watermark above, adds the behavioral one-client transaction test the review asked for (the old source pins could not catch a bake moved onto `pool.query` or a deleted `BEGIN`), makes a failed merge visible on the ops readout, adds `pruneMailCustodyParcelsBatch` to the retention wiring pin lists (pre-listen ban, exactly-once, closure threading), hardens the source pins (comment-stripped, bounded slices, every needle guarded), covers the non-array-items malformed dimension, pins the `custodyOverlay` readout key, and deduplicates the world_state upsert into one shared helper.

## Rollback note

The DDL is additive (two tables); a rollback simply leaves both unread. An old binary neither writes rows nor advances the watermark, so after a roll-forward the frozen `accounted_through` still only ever classifies rows a committed book write provably accounted for: no loss is possible by construction. The residual dupe window (a parcel row inserted after the last watermark advance, whose parcel was collected under the old binary) is bounded by one book-write interval and empty on a clean-stop rollback, since the final book write bakes those rows away. No operator action is needed around a rollback.

---

## Checklist

### Quality

- [x] **The gate passes.** Decisive tests added for the parcel path, the bake transaction, the watermark, the crash replay, and the wiring order.

### Cross-platform

- ~Tested on desktop and mobile.~ N/A: no UI change.

### Localization (i18n)

- [x] N/A. No player-visible strings (overlay log lines are dev-channel).

### Hygiene

- [x] No secrets committed; no generated files hand-edited; `ALLOW_DEV_COMMANDS` untouched.
