### PR TITLE
feat(exchange): Solana wallet card above the Browse filters

### DIFF
--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -15939,12 +15939,13 @@
     flex: none;
     align-items: stretch;
   }
-  /* The banner strip under the tabs holds only the two STANDING banners (a
-     paused realm, an unlinked wallet), which move on an operator action or a
-     wallet link, never on a click. The notice and busy line live in the
-     footer bar below the body instead, in a slot that keeps its height, so a
-     toast that comes and goes never shifts the rows or the form. All three
-     share one look: a themed well inside the panel, never a second panel. */
+  /* The banner strip under the tabs (above the Browse filters) holds only the
+     STANDING banners (a paused realm, the Solana wallet card), which move on an
+     operator action or a wallet event, never on a click. The notice and busy
+     line live in the footer bar below the body instead, in a slot that keeps
+     its height, so a toast that comes and goes never shifts the rows or the
+     form. All share one look: a themed well inside the panel, never a second
+     panel. */
   #woc-market-window .wm-strip {
     flex: none;
     display: flex;
@@ -15989,16 +15990,36 @@
   #woc-market-window .wm-notice-error {
     border-color: var(--color-border-invalid);
   }
+  /* The Solana wallet card: the Claudium panel's .cl-wallet-connect grid (title
+     over the state sentence, the action button spanning both rows on the far
+     edge) in this window's own tokens, so it reads as the same card without
+     borrowing the store's palette. */
   #woc-market-window .wm-banner-wallet {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(160px, 220px);
+    grid-template-rows: auto auto;
+    gap: 4px var(--spacing-md);
+    align-items: start;
+    padding: var(--spacing-sm) 10px;
     border-color: var(--color-accent);
   }
-  /* The banner's connect shortcut rides the flex row's far edge: the label
-     soaks the remaining width, the button keeps its own. */
-  #woc-market-window .wm-banner-wallet span {
-    flex: 1;
+  #woc-market-window .wm-banner-wallet > strong {
+    color: var(--gold);
+    font-family: var(--title-font);
+    font-size: 13px;
+    line-height: 17px;
+  }
+  #woc-market-window .wm-banner-wallet p {
+    margin: 0;
+    color: var(--color-text-muted);
+    font-size: 12px;
+    line-height: 16px;
   }
   #woc-market-window .wm-banner-wallet button {
-    flex: none;
+    grid-column: 2;
+    grid-row: 1 / 3;
+    align-self: center;
+    width: 100%;
     white-space: nowrap;
   }
   /* The shared ring (hud.css .woc-spinner) inside a flex line: the container's

--- a/src/styles/hud.mobile.css
+++ b/src/styles/hud.mobile.css
@@ -3899,6 +3899,17 @@
     position: static;
     max-height: none;
   }
+  /* The Solana wallet card stacks on the phone sheet (the Claudium card's own
+     touch rule): the button drops under the sentence at the 44px floor rather
+     than squeezing the copy into half the width. */
+  body.mobile-touch #woc-market-window .wm-banner-wallet {
+    grid-template-columns: minmax(0, 1fr);
+  }
+  body.mobile-touch #woc-market-window .wm-banner-wallet button {
+    grid-column: 1;
+    grid-row: auto;
+    min-height: 44px;
+  }
   /* Row rhythm on the phone sheet (the 15 QA sign-off note): taller cells
      than the desktop 6px, and the FIRST row clears the header hairline with
      its own top padding instead of starting flush against it. */

--- a/src/ui/claudium_window.ts
+++ b/src/ui/claudium_window.ts
@@ -18,6 +18,7 @@ import { esc } from './esc';
 import { formatNumber, t } from './i18n';
 import { svgIcon } from './ui_icons';
 import { usdDollarsText } from './usd_text';
+import { walletCardKeys } from './wallet_card_keys';
 import type { WalletConnectionView } from './wallet_connection_view';
 
 export type ClaudiumRail = 'stripe' | 'sol' | 'usdc' | 'woc';
@@ -316,39 +317,8 @@ export class ClaudiumWindow {
   private walletConnectionHtml(): string {
     const state = this.deps.walletState?.();
     if (!state?.enabled) return '';
-    let bodyKey:
-      | 'hudChrome.wocStore.wallet.unlinked'
-      | 'hudChrome.wocStore.wallet.connectedUnlinked'
-      | 'hudChrome.wocStore.wallet.linkedDisconnected'
-      | 'hudChrome.wocStore.wallet.linkedConnected'
-      | 'hudChrome.wocStore.wallet.mismatched';
-    let actionKey:
-      | 'hudChrome.wocStore.wallet.connect'
-      | 'hudChrome.wocStore.wallet.verify'
-      | 'hudChrome.wocStore.wallet.reconnect'
-      | 'hudChrome.wocStore.wallet.manage';
-    switch (state.kind) {
-      case 'connected_unlinked':
-        bodyKey = 'hudChrome.wocStore.wallet.connectedUnlinked';
-        actionKey = 'hudChrome.wocStore.wallet.verify';
-        break;
-      case 'linked_disconnected':
-        bodyKey = 'hudChrome.wocStore.wallet.linkedDisconnected';
-        actionKey = 'hudChrome.wocStore.wallet.reconnect';
-        break;
-      case 'linked_connected':
-        bodyKey = 'hudChrome.wocStore.wallet.linkedConnected';
-        actionKey = 'hudChrome.wocStore.wallet.manage';
-        break;
-      case 'mismatched':
-        bodyKey = 'hudChrome.wocStore.wallet.mismatched';
-        actionKey = 'hudChrome.wocStore.wallet.verify';
-        break;
-      default:
-        bodyKey = 'hudChrome.wocStore.wallet.unlinked';
-        actionKey = 'hudChrome.wocStore.wallet.connect';
-        break;
-    }
+    // The copy table is shared with the $WOC Exchange's card (wallet_card_keys).
+    const { bodyKey, actionKey } = walletCardKeys(state.kind);
     return (
       `<div class="cl-wallet-connect">` +
       `<strong>${esc(t('hudChrome.wocStore.wallet.title'))}</strong>` +

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -2360,6 +2360,7 @@ export class Hud {
       if (bagsWindowShown($('#bags').style.display)) this.bagsWindow.refreshMoneyRow();
       this.playerCard.refresh();
       this.claudiumWindow.onWalletChanged();
+      this.wocMarketWindow.onWalletChanged();
     });
     $('#pf-name').textContent = sim.player.name;
     this.drawPlayerFramePortrait();

--- a/src/ui/wallet_card_keys.ts
+++ b/src/ui/wallet_card_keys.ts
@@ -1,0 +1,43 @@
+// The "Solana wallet" card's copy, chosen from the wallet connection kind: one
+// body sentence and one action label per state, shared by the Claudium panel
+// and the $WOC Exchange so the two cards never drift apart (the same
+// "Reconnect wallet" / "Manage wallet" button on both). Pure over its input;
+// the callers own the markup and the t() resolution.
+
+import type { TranslationKey } from './i18n';
+import type { WalletConnectionKind } from './wallet_connection_view';
+
+export interface WalletCardKeys {
+  bodyKey: TranslationKey;
+  actionKey: TranslationKey;
+}
+
+export function walletCardKeys(kind: WalletConnectionKind): WalletCardKeys {
+  switch (kind) {
+    case 'connected_unlinked':
+      return {
+        bodyKey: 'hudChrome.wocStore.wallet.connectedUnlinked',
+        actionKey: 'hudChrome.wocStore.wallet.verify',
+      };
+    case 'linked_disconnected':
+      return {
+        bodyKey: 'hudChrome.wocStore.wallet.linkedDisconnected',
+        actionKey: 'hudChrome.wocStore.wallet.reconnect',
+      };
+    case 'linked_connected':
+      return {
+        bodyKey: 'hudChrome.wocStore.wallet.linkedConnected',
+        actionKey: 'hudChrome.wocStore.wallet.manage',
+      };
+    case 'mismatched':
+      return {
+        bodyKey: 'hudChrome.wocStore.wallet.mismatched',
+        actionKey: 'hudChrome.wocStore.wallet.verify',
+      };
+    default:
+      return {
+        bodyKey: 'hudChrome.wocStore.wallet.unlinked',
+        actionKey: 'hudChrome.wocStore.wallet.connect',
+      };
+  }
+}

--- a/src/ui/woc_market_chrome.ts
+++ b/src/ui/woc_market_chrome.ts
@@ -20,6 +20,8 @@ import { formatDateTime, formatDuration, formatNumber, t } from './i18n';
 import { ITEM_QUALITY_LABEL_KEYS, itemQualityLabel } from './item_kind_label';
 import { itemSlotLabel } from './item_slot_labels';
 import { svgIcon } from './ui_icons';
+import { walletCardKeys } from './wallet_card_keys';
+import type { WalletConnectionView } from './wallet_connection_view';
 
 /** The browse faces' control row: the sort control LEADS the row (the 15 QA
  *  sign-off note), the filters follow it, the pager closes the row. Pure
@@ -242,25 +244,40 @@ export function wocBondScheduleNotesHtml(args: {
 }
 
 /**
- * The two standing banners under the tab strip (a paused realm, an unlinked
- * wallet): they change on an operator action or a wallet link, never on a
- * click, so the tab panel does not shift under the pointer. The wallet banner
- * carries its own way in: the same shared connect flow the store and daily
- * rewards buttons open (the window's connect-wallet click action), one click
- * from where the player was told to link.
+ * The standing banners under the tab strip, above the Browse filters: a paused
+ * realm, and the "Solana wallet" card. Both change on an operator action or a
+ * wallet event, never on a click, so the tab panel does not shift under the
+ * pointer. The wallet card is the Claudium panel's card (the same title, the
+ * same per-state sentence, the same Connect / Verify / Reconnect / Manage
+ * button via wallet_card_keys), so a player sees one wallet story across the
+ * two windows; it stands whenever the wallet feature is on, a linked and
+ * connected wallet included, because "Manage wallet" is the way to change or
+ * unlink it from here. The button rides the window's connect-wallet click
+ * action into the shared flow the store and daily rewards buttons open, one
+ * click from where the player was told to link.
  */
-export function wocMarketBannersHtml(args: { paused: boolean; walletLinked: boolean }): string {
+export function wocMarketBannersHtml(args: {
+  paused: boolean;
+  wallet: WalletConnectionView | null;
+}): string {
   const banners =
     (args.paused
       ? `<div class="wm-banner wm-banner-paused">${esc(t('hudChrome.wocMarket.pausedBanner'))}</div>`
-      : '') +
-    (args.walletLinked
-      ? ''
-      : `<div class="wm-banner wm-banner-wallet"><span>${esc(t('hudChrome.wocMarket.walletBanner'))}</span>` +
-        `<button type="button" data-action="connect-wallet" ${FOCUS_KEY_ATTR}="wm-connect-wallet">${esc(
-          t('hudChrome.wocMarket.walletBannerCta'),
-        )}</button></div>`);
+      : '') + wocWalletCardHtml(args.wallet);
   return banners === '' ? '' : `<div class="wm-strip">${banners}</div>`;
+}
+
+function wocWalletCardHtml(wallet: WalletConnectionView | null): string {
+  if (wallet === null || !wallet.enabled) return '';
+  const { bodyKey, actionKey } = walletCardKeys(wallet.kind);
+  return (
+    `<div class="wm-banner wm-banner-wallet" data-wallet-kind="${esc(wallet.kind)}">` +
+    `<strong>${esc(t('hudChrome.wocStore.wallet.title'))}</strong>` +
+    `<p>${esc(t(bodyKey))}</p>` +
+    `<button type="button" data-action="connect-wallet" ${FOCUS_KEY_ATTR}="wm-connect-wallet">${esc(
+      t(actionKey),
+    )}</button></div>`
+  );
 }
 
 /**

--- a/src/ui/woc_market_view.ts
+++ b/src/ui/woc_market_view.ts
@@ -394,6 +394,20 @@ export function browseQualityOptions(
 }
 
 /**
+ * The pending quote's own repaint key, at SECOND resolution like every other
+ * countdown in the view digest: the display has no finer grain, so a finer
+ * key would rebuild the window many times per second for a string that did
+ * not change. Empty when there is no deadline to count.
+ */
+export function wocQuoteCountdownSig(
+  expiresAtMs: number | null | undefined,
+  nowMs: number,
+): string {
+  if (expiresAtMs === undefined || expiresAtMs === null) return '';
+  return String(Math.max(0, Math.ceil((expiresAtMs - nowMs) / 1000)));
+}
+
+/**
  * Resolve the Browse item filter's free-text query to catalog item ids, the
  * sell combobox's matching rule (case-insensitive substring over the
  * localized display name).

--- a/src/ui/woc_market_window.ts
+++ b/src/ui/woc_market_window.ts
@@ -43,12 +43,13 @@ import { tabStripHtml, tabStripModel } from './tab_strip_view';
 import { termsUrlFor } from './terms_link';
 import { svgIcon } from './ui_icons';
 import { usdText } from './usd_text';
-import { verifiedWocBalance } from './wallet_balance';
+import { verifiedWocBalance, walletConnectionView } from './wallet_balance';
 import {
   type WalletBridgeReason,
   walletBridgeReason,
   walletBridgeReasonText,
 } from './wallet_bridge_reason_text';
+import type { WalletConnectionKind } from './wallet_connection_view';
 import { overWalletBalance } from './woc_affordable_core';
 import { wocActivityHtml } from './woc_market_activity_html';
 import {
@@ -81,6 +82,7 @@ import {
   type WocMarketViewModel,
   type WocSellRowModel,
   wocMarketViewSig,
+  wocQuoteCountdownSig,
 } from './woc_market_view';
 import { wocTokensText } from './woc_tokens_text';
 
@@ -292,6 +294,7 @@ export class WocMarketWindow {
   private walletTokens(): number | null {
     return verifiedWocBalance();
   }
+  private paintedWalletKind: WalletConnectionKind | null = null;
   private busy = false;
   private busyLabel: TranslationKey | null = null;
   /** Bumped every time a mutation starts AND every time the window closes. A
@@ -570,28 +573,25 @@ export class WocMarketWindow {
     });
   }
 
-  /**
-   * The pending quote's own repaint key.
-   *
-   * The quote panel is WINDOW state, so it never reaches the pure model and the
-   * model's digest cannot move for it. Without this the "expires in" countdown
-   * rendered once and then sat there, frozen, while the quote it described ran
-   * out underneath the player.
-   *
-   * Second resolution, matching every other countdown in that digest: the
-   * display has no finer grain, so a finer key would rebuild the window many
-   * times per second for a string that did not change.
-   */
+  /** The pending quote's own repaint key: the quote panel is WINDOW state, so it
+   *  never reaches the pure model and its digest cannot move for it. Without this
+   *  the "expires in" countdown sat frozen while the quote ran out under the player. */
   private quoteCountdownSig(): string {
-    const expiresAtMs = this.pendingQuote?.quote.expiresAtMs;
-    if (expiresAtMs === undefined || expiresAtMs === null) return '';
-    return String(Math.max(0, Math.ceil((expiresAtMs - Date.now()) / 1000)));
+    return wocQuoteCountdownSig(this.pendingQuote?.quote.expiresAtMs, Date.now());
   }
 
   /** Language fan-out arm: self-gated, one rebuild, signature re-latched. */
   relocalize(): void {
     if (!this.isOpen) return;
     this.render();
+  }
+
+  /** Wallet fan-out arm (Hud's onWalletUiChange, the Claudium panel's twin): the
+   *  card is module state the view digest never sees, so a connect repaints here.
+   *  Gated on the card's own state, so a balance tick alone rebuilds nothing. */
+  onWalletChanged(): void {
+    if (walletConnectionView().kind === this.paintedWalletKind) return;
+    this.relocalize();
   }
 
   // -------------------------------------------------------------------------
@@ -841,10 +841,10 @@ export class WocMarketWindow {
     // The standing banners and the footer are chrome builders (the pure-core
     // split); the window resolves its own state (notice sentence, busy label)
     // and the builders own the markup.
-    const bannerStrip = wocMarketBannersHtml({
-      paused: model.paused,
-      walletLinked: model.walletLinked,
-    });
+    // The wallet card is shared connection state, not model state: onWalletChanged() repaints it.
+    const wallet = walletConnectionView();
+    this.paintedWalletKind = wallet.kind;
+    const bannerStrip = wocMarketBannersHtml({ paused: model.paused, wallet });
     const foot = wocMarketFootHtml({
       paused: model.paused,
       tokensPerUsd: model.tokensPerUsd,

--- a/tests/language_fanout_registry.test.ts
+++ b/tests/language_fanout_registry.test.ts
@@ -336,9 +336,9 @@ const ANSWERED: readonly AnsweredSurface[] = [
   },
   {
     file: 'woc_market_window.ts',
-    memos: ['lastSig'],
+    memos: ['lastSig', 'paintedWalletKind'],
     answer: 'this.wocMarketWindow.relocalize',
-    why: 'the Exchange listing rows, statuses and countdowns digest into lastSig; relocalize() self-gates on isOpen, rebuilds once, and render() re-latches the signature',
+    why: "the Exchange listing rows, statuses and countdowns digest into lastSig; relocalize() self-gates on isOpen, rebuilds once, and render() re-latches the signature. paintedWalletKind is the Solana wallet card's state (a locale-free connection kind) that gates onWalletChanged() only; the same render() repaints the card in the current language and re-latches the kind, so the one relocalize() arm answers both memos",
   },
   {
     file: 'professions_window.ts',

--- a/tests/monolith_budget.test.ts
+++ b/tests/monolith_budget.test.ts
@@ -72,6 +72,11 @@ const MONOLITHS: MonolithRow[] = [
     // window carries only state, handler arms and passthroughs. Exact
     // count, zero headroom; the sell-tab combobox block is the next
     // standing extraction candidate.
+    // Held at 2487 for the Solana wallet card (the Claudium card above the
+    // Browse filters): the card's markup landed in the chrome builder, and
+    // the window's gated wallet fan-out arm was paid for by moving the quote
+    // countdown key's arithmetic to the view core (wocQuoteCountdownSig).
+    // Exact count, zero headroom.
     file: 'src/ui/woc_market_window.ts',
     ceiling: 2487,
     seam: 'a pure view-core module beside it (src/ui/woc_market_view.ts) that this window renders from',
@@ -125,7 +130,10 @@ const MONOLITHS: MonolithRow[] = [
     // relocalize wiring (the window itself lives in
     // src/ui/hud/guild_board/). Then down one at the controller-tutorial
     // merge. Exact count, zero slack.
-    ceiling: 18488,
+    // Plus 1 for the Exchange's Solana wallet card: the ONE line is the
+    // onWalletUiChange fan-out onto wocMarketWindow.onWalletChanged(), the
+    // Claudium panel's existing arm. Exact count.
+    ceiling: 18489,
     seam: 'pure view core + thin painter on PainterHost (src/ui/CLAUDE.md)',
   },
   {

--- a/tests/wallet_card_keys.test.ts
+++ b/tests/wallet_card_keys.test.ts
@@ -1,0 +1,56 @@
+// The Solana wallet card's copy table is shared by the Claudium panel and the
+// $WOC Exchange (src/ui/wallet_card_keys.ts); this pins the state -> copy map
+// directly so neither card can drift from the other or from the connection
+// view's own action vocabulary (wallet_connection_view.ts).
+
+import { describe, expect, it } from 'vitest';
+import { walletCardKeys } from '../src/ui/wallet_card_keys';
+import {
+  buildWalletConnectionView,
+  type WalletConnectionKind,
+} from '../src/ui/wallet_connection_view';
+
+describe('wallet_card_keys', () => {
+  it('maps every connection kind to its sentence and its one action', () => {
+    const cases: Array<[WalletConnectionKind, string, string]> = [
+      ['unlinked', 'unlinked', 'connect'],
+      ['connected_unlinked', 'connectedUnlinked', 'verify'],
+      ['linked_disconnected', 'linkedDisconnected', 'reconnect'],
+      ['linked_connected', 'linkedConnected', 'manage'],
+      ['mismatched', 'mismatched', 'verify'],
+    ];
+    for (const [kind, body, action] of cases) {
+      expect(walletCardKeys(kind)).toEqual({
+        bodyKey: `hudChrome.wocStore.wallet.${body}`,
+        actionKey: `hudChrome.wocStore.wallet.${action}`,
+      });
+    }
+  });
+
+  it('agrees with the connection view about which action each state offers', () => {
+    // The view decides the action; the card only spells it. A disagreement here
+    // would put a "Manage wallet" button on a state the view calls reconnect.
+    const linked = buildWalletConnectionView({
+      enabled: true,
+      linkedAddress: 'L',
+      connectedAddress: null,
+      linkedBalance: 1,
+      connectedBalance: null,
+    });
+    expect(linked.action).toBe('reconnect');
+    expect(walletCardKeys(linked.kind).actionKey).toBe('hudChrome.wocStore.wallet.reconnect');
+    const connected = buildWalletConnectionView({
+      enabled: true,
+      linkedAddress: 'L',
+      connectedAddress: 'L',
+      linkedBalance: 1,
+      connectedBalance: null,
+    });
+    expect(connected.action).toBe('manage');
+    expect(walletCardKeys(connected.kind).actionKey).toBe('hudChrome.wocStore.wallet.manage');
+  });
+
+  it('falls back to the connect copy for the disabled kind, which callers hide', () => {
+    expect(walletCardKeys('disabled').actionKey).toBe('hudChrome.wocStore.wallet.connect');
+  });
+});

--- a/tests/woc_market_chrome.test.ts
+++ b/tests/woc_market_chrome.test.ts
@@ -9,11 +9,13 @@
 import { readFileSync } from 'node:fs';
 import { afterEach, describe, expect, it } from 'vitest';
 import { formatDateTime, setLanguage, t } from '../src/ui/i18n';
+import { buildWalletConnectionView } from '../src/ui/wallet_connection_view';
 import {
   wocBrowseStripHtml,
   wocEndsAtText,
   wocErrorStatusHtml,
   wocLoadingStatusHtml,
+  wocMarketBannersHtml,
   wocSalesHistoryHtml,
   wocSellEmptyHtml,
   wocSpinnerHtml,
@@ -189,5 +191,61 @@ describe('woc_market_chrome: the resolved sell caption', () => {
       '',
     );
     expect(future).toContain('mythic');
+  });
+});
+
+describe('woc_market_chrome: the standing banners', () => {
+  const view = (linked: string | null, connected: string | null) =>
+    buildWalletConnectionView({
+      enabled: true,
+      linkedAddress: linked,
+      connectedAddress: connected,
+      linkedBalance: null,
+      connectedBalance: null,
+    });
+
+  it('renders nothing at all when there is no banner to stand', () => {
+    expect(wocMarketBannersHtml({ paused: false, wallet: null })).toBe('');
+    const off = buildWalletConnectionView({
+      enabled: false,
+      linkedAddress: null,
+      connectedAddress: null,
+      linkedBalance: null,
+      connectedBalance: null,
+    });
+    expect(wocMarketBannersHtml({ paused: false, wallet: off })).toBe('');
+  });
+
+  it('the wallet card is the Claudium card: title, state sentence, one action button', () => {
+    const html = wocMarketBannersHtml({ paused: false, wallet: view(null, null) });
+    expect(html).toContain('<div class="wm-strip">');
+    expect(html).toContain('class="wm-banner wm-banner-wallet" data-wallet-kind="unlinked"');
+    expect(html).toContain(`<strong>${t('hudChrome.wocStore.wallet.title')}</strong>`);
+    expect(html).toContain(`<p>${t('hudChrome.wocStore.wallet.unlinked')}</p>`);
+    // The button keeps the window's connect-wallet click action and its focus
+    // key, so the existing handler arm and the focus-restore ladder both reach it.
+    expect(html).toContain(
+      `<button type="button" data-action="connect-wallet" data-focus-key="wm-connect-wallet">${t(
+        'hudChrome.wocStore.wallet.connect',
+      )}</button>`,
+    );
+  });
+
+  it('spells the linked states as Reconnect wallet and Manage wallet, never hiding the card', () => {
+    const disconnected = wocMarketBannersHtml({ paused: false, wallet: view('L', null) });
+    expect(disconnected).toContain('data-wallet-kind="linked_disconnected"');
+    expect(disconnected).toContain(`>${t('hudChrome.wocStore.wallet.reconnect')}</button>`);
+    const connected = wocMarketBannersHtml({ paused: false, wallet: view('L', 'L') });
+    expect(connected).toContain('data-wallet-kind="linked_connected"');
+    expect(connected).toContain(`>${t('hudChrome.wocStore.wallet.manage')}</button>`);
+    const mismatched = wocMarketBannersHtml({ paused: false, wallet: view('L', 'M') });
+    expect(mismatched).toContain(`>${t('hudChrome.wocStore.wallet.verify')}</button>`);
+  });
+
+  it('the paused banner leads the strip, the wallet card follows it', () => {
+    const html = wocMarketBannersHtml({ paused: true, wallet: view(null, null) });
+    expect(html.indexOf('wm-banner-paused')).toBeGreaterThan(-1);
+    expect(html.indexOf('wm-banner-paused')).toBeLessThan(html.indexOf('wm-banner-wallet'));
+    expect(html).toContain(t('hudChrome.wocMarket.pausedBanner'));
   });
 });

--- a/tests/woc_market_view.test.ts
+++ b/tests/woc_market_view.test.ts
@@ -20,6 +20,7 @@ import {
   type WocSaleView,
   type WocSettlementView,
   wocMarketViewSig,
+  wocQuoteCountdownSig,
 } from '../src/ui/woc_market_view';
 
 // Pure core: DOM/i18n-free, deterministic, the caller passes nowMs. Inputs are
@@ -857,5 +858,24 @@ describe('the Browse filters resolve in the view core', () => {
     // Past the cap the query is too broad to narrow: null (no filter), never
     // a truncated arbitrary subset that would silently hide listings.
     expect(browseItemFilterIds('sword', name, ids, 1)).toBeNull();
+  });
+});
+
+describe('wocQuoteCountdownSig: the pending quote repaint key', () => {
+  it('keys on SECONDS, matching the resolution the countdown is displayed at', () => {
+    // A finer key would rebuild the window many times per second for a string
+    // that did not change; the ceiling keeps 0.2s remaining reading as 1, the
+    // way the countdown itself is shown.
+    const now = 1_000_000;
+    expect(wocQuoteCountdownSig(now + 90_000, now)).toBe('90');
+    expect(wocQuoteCountdownSig(now + 90_400, now)).toBe('91');
+    expect(wocQuoteCountdownSig(now + 200, now)).toBe('1');
+  });
+
+  it('floors at zero once the quote has run out, and is empty with no deadline', () => {
+    // No pending quote means no key at all, so an idle window still rests.
+    expect(wocQuoteCountdownSig(500, 1_000)).toBe('0');
+    expect(wocQuoteCountdownSig(null, 1_000)).toBe('');
+    expect(wocQuoteCountdownSig(undefined, 1_000)).toBe('');
   });
 });

--- a/tests/woc_market_window.test.ts
+++ b/tests/woc_market_window.test.ts
@@ -1366,12 +1366,12 @@ describe('woc_market_window: the quote countdown actually moves', () => {
     expect(render).toContain('this.quoteCountdownSig()');
   });
 
-  it('keys on SECONDS, matching the resolution the countdown is displayed at', () => {
-    // A finer key would rebuild many times per second for an unchanged string.
+  it('keys through the view core on the WINDOW clock, from the pending quote alone', () => {
+    // The arithmetic (seconds, empty with no deadline) lives in the pure core and
+    // is pinned behaviorally in tests/woc_market_view.test.ts; the window's part
+    // is to feed it its own pending quote and the wall clock it owns.
     const sig = between('private quoteCountdownSig()', '/** Language fan-out arm');
-    expect(sig).toContain('/ 1000');
-    // And no pending quote means no key at all, so an idle window still rests.
-    expect(sig).toContain("return ''");
+    expect(sig).toContain('wocQuoteCountdownSig(this.pendingQuote?.quote.expiresAtMs, Date.now())');
   });
 });
 

--- a/tests/woc_market_window_rig.test.ts
+++ b/tests/woc_market_window_rig.test.ts
@@ -24,6 +24,7 @@ import { ITEMS } from '../src/sim/data';
 import type { InvSlot } from '../src/sim/types';
 import { itemDisplayName } from '../src/ui/entity_i18n';
 import { ensureLocaleLoaded, setLanguage, t } from '../src/ui/i18n';
+import { setWalletConnectionAddresses, setWalletUiEnabled } from '../src/ui/wallet_balance';
 import {
   type WocMarketHooks,
   WocMarketWindow,
@@ -318,6 +319,11 @@ beforeEach(() => {
   document.body.innerHTML = '';
   vi.useRealTimers();
   setLanguage('en');
+  // The Solana wallet card reads the shared connection state (wallet_balance),
+  // the same module the window's balance gate reads; each test starts from the
+  // feature-off default so only the wallet arms below paint the card.
+  setWalletUiEnabled(false);
+  setWalletConnectionAddresses(null, null);
 });
 
 describe('WocMarketWindow live rig: open, browse, select', () => {
@@ -402,20 +408,62 @@ describe('WocMarketWindow live rig: open, browse, select', () => {
     expect(q(r.root, '.wm-bid-form .wm-disclosures').hasAttribute('hidden')).toBe(true);
   });
 
-  it('the unlinked-wallet banner carries the connect shortcut into the shared flow', async () => {
+  it('the Solana wallet card stands above the Browse filters and carries the connect shortcut into the shared flow', async () => {
+    setWalletUiEnabled(true);
     const r = rig({ walletLinked: false });
     r.win.open();
     await flush();
-    const button = q<HTMLButtonElement>(
-      r.root,
-      '.wm-banner-wallet button[data-action="connect-wallet"]',
-    );
+    const card = q<HTMLElement>(r.root, '.wm-strip .wm-banner-wallet');
+    expect(card.getAttribute('data-wallet-kind')).toBe('unlinked');
+    expect(card.querySelector('strong')?.textContent).toBe(t('hudChrome.wocStore.wallet.title'));
+    expect(card.querySelector('p')?.textContent).toBe(t('hudChrome.wocStore.wallet.unlinked'));
+    // Above the filters: the strip precedes the tab panel that holds the sort
+    // and filter row, so the card is the first thing under the tabs.
+    const strip = q<HTMLElement>(r.root, '.wm-strip');
+    const panel = q<HTMLElement>(r.root, '#woc-market-panel');
+    expect(strip.compareDocumentPosition(panel) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(panel.querySelector('.wm-browse select, .wm-browse input')).not.toBeNull();
+    const button = q<HTMLButtonElement>(card, 'button[data-action="connect-wallet"]');
+    expect(button.textContent).toBe(t('hudChrome.wocStore.wallet.connect'));
     button.click();
     expect(r.openWallet).toHaveBeenCalledTimes(1);
   });
 
-  it('a linked wallet paints no banner and no connect shortcut', async () => {
+  it("a linked wallet keeps the card with the Claudium panel's Manage / Reconnect button, and a wallet change repaints it", async () => {
+    setWalletUiEnabled(true);
+    setWalletConnectionAddresses('linked', 'linked');
     const r = rig({ walletLinked: true });
+    r.win.open();
+    await flush();
+    const manage = q<HTMLButtonElement>(
+      r.root,
+      '.wm-banner-wallet button[data-action="connect-wallet"]',
+    );
+    expect(manage.textContent).toBe(t('hudChrome.wocStore.wallet.manage'));
+    expect(q(r.root, '.wm-banner-wallet p').textContent).toBe(
+      t('hudChrome.wocStore.wallet.linkedConnected'),
+    );
+    manage.focus();
+    // The wallet app disconnects: the Hud's onWalletUiChange fan-out reaches
+    // the window, which repaints the card (no digest moves for this) and keeps
+    // the player's focus on the button they were on.
+    setWalletConnectionAddresses('linked', null);
+    r.win.onWalletChanged();
+    const reconnect = q<HTMLButtonElement>(
+      r.root,
+      '.wm-banner-wallet button[data-action="connect-wallet"]',
+    );
+    expect(reconnect.textContent).toBe(t('hudChrome.wocStore.wallet.reconnect'));
+    expect(q(r.root, '.wm-banner-wallet').getAttribute('data-wallet-kind')).toBe(
+      'linked_disconnected',
+    );
+    expect(document.activeElement).toBe(reconnect);
+    reconnect.click();
+    expect(r.openWallet).toHaveBeenCalledTimes(1);
+  });
+
+  it('paints no wallet card when the wallet feature is off in this build', async () => {
+    const r = rig({ walletLinked: false });
     r.win.open();
     await flush();
     expect(r.root.querySelector('.wm-banner-wallet')).toBeNull();


### PR DESCRIPTION
## Summary

Puts the Claudium panel's **"Solana wallet" card** at the top of the $WOC Exchange, in the banner strip under the tabs and directly above the marketplace sort/filter row: the same title, the same per-state sentence, and the same **Connect wallet / Verify and link / Reconnect wallet / Manage wallet** button.

Before, the Exchange showed only a thin "link a wallet" line while unlinked and nothing at all once linked, so a player whose wallet app had disconnected had to leave for the store to reconnect it. The card now stands whenever the wallet feature is on, and its button rides the Exchange's existing `connect-wallet` action into the shared wallet flow.

What changed:

- **`src/ui/wallet_card_keys.ts`** (new): the connection-kind → copy table, now used by *both* `claudium_window.ts` and the Exchange chrome, so the two cards cannot drift.
- **`woc_market_chrome.ts`**: `wocMarketBannersHtml` takes the `WalletConnectionView` and renders the card. The button keeps `data-action="connect-wallet"` and its focus key, so the existing click arm and the focus-restore ladder both reach it.
- **`woc_market_window.ts`**: reads `walletConnectionView()` beside the balance read it already makes, and gains `onWalletChanged()`, gated on the card's state so a balance tick alone rebuilds nothing. Held inside the 2487-line pin by moving the quote-countdown key's arithmetic to the view core (`wocQuoteCountdownSig`).
- **`hud.ts`**: the `onWalletUiChange` fan-out now reaches the Exchange too (+1 line, re-pinned in `monolith_budget.test.ts` with the file's existing "+1 wiring" precedent — flagging for the maintainer since the budget file calls raises a maintainer decision).
- **CSS**: the card grid in the window's own tokens (`components.css`); stacks to one column with a 44px button on touch (`hud.mobile.css`).

Reuses the existing `hudChrome.wocStore.wallet.*` strings; no new player-visible strings. The retired `hudChrome.wocMarket.walletBanner` / `walletBannerCta` keys are left in the catalogs for a follow-up cleanup.

## Type of change

- [x] Feature: new functionality
- [ ] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `node scripts/gate_select.mjs` (fell back to the full suite): **3105 / 3130 test files green.** The i18n/wiki/SFX artifact step passed. Four files failed in the run:
    - `tests/language_fanout_registry.test.ts` — caused by this branch (the new `paintedWalletKind` memo needed a registry classification); fixed in the commit, passes.
    - `tests/ci_leg_runner.test.ts` — **pre-existing**: fails identically on a clean `release/v0.40.1` worktree (its subprocess tail expects a "Closing rpc" vitest warning line that this environment's vitest doesn't print).
    - `tests/desktop_publish_guard.test.ts` — **pre-existing**: reads only `vite.config.ts` / `desktop-publish.yml` / `desktop_download.ts`, all byte-identical to `release/v0.40.1` on this branch.
    - `tests/defer_launcher_preloads.test.ts` — 33 s timeout under the 7-worker load; passes in isolation.
    Because the gate stops at a red vitest step, its later legs (builds, browser regression) did not run locally; CI covers them.
  - `npm run check:ts`, `npx biome check` on the changed files, `npm run i18n:scan`
  - `npx vitest run` over the 55 related files (woc_market_*, claudium_*, wallet_*, i18n_*, `monolith_budget`, `architecture`, `window_fill_css`): 1006 passing
- New / updated tests:
  - `tests/woc_market_window_rig.test.ts`: the card renders above the Browse filters with the connect shortcut; a linked wallet shows *Manage wallet*, flips to *Reconnect wallet* on `onWalletChanged()` with focus kept on the button; the card is absent when the wallet feature is off.
  - `tests/woc_market_chrome.test.ts`: builder pins for every wallet state, the paused banner ordering, and the empty strip.
  - `tests/wallet_card_keys.test.ts`: the shared copy table agrees with `buildWalletConnectionView`'s action per state.
  - `tests/woc_market_view.test.ts`: `wocQuoteCountdownSig` keys on seconds, floors at zero, and is empty with no deadline (the pin that previously lived as a source scan in the window test).
  - `tests/monolith_budget.test.ts`: `woc_market_window.ts` held at 2487; `hud.ts` 18488 → 18489.
- Manual steps: ran the full local stack (game client + server, economy service with the live oracle, payout service) and checked the Exchange with the card in place.

## Screenshots / recordings

Verified on the local stack by the maintainer; desktop and mobile captures to be added under `docs/screenshots` (`/pr-screenshots`).

---

## Checklist

### Quality

- [ ] **The gate passes.** Not fully green locally: two failures are pre-existing on `release/v0.40.1` (`ci_leg_runner`, `desktop_publish_guard`, see above), one was a load timeout; every failure attributable to this branch is fixed. Decisive tests for the changed behavior were added and the manual checks are recorded above.

### Cross-platform

- [ ] **Tested on desktop and mobile.** Desktop verified on the local stack; the touch layout (single column, 44px button) is covered by the `hud.mobile.css` rule mirroring the Claudium card's, not yet eyeballed on a phone viewport.
- [x] **Accessible.** The button is a real `<button>` reachable by keyboard, keeps the window's focus key so focus survives the wallet-change repaint (tested), and inherits the window's `:focus-visible` styling. No motion added.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings (it reuses the existing `hudChrome.wocStore.wallet.*` keys).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
