### PR TITLE
fix(build): bundle the mail bot-welcome purge migration into dist-server

### DIFF
--- a/scripts/build_server.mjs
+++ b/scripts/build_server.mjs
@@ -50,4 +50,14 @@ await esbuild.build({
   alias: { '#bot-detector': usePrivate ? privateImpl : stubImpl },
 });
 
+await esbuild.build({
+  entryPoints: ['scripts/migrate_mail_bot_welcome_purge.ts'],
+  bundle: true,
+  platform: 'node',
+  format: 'cjs',
+  external: ['pg-native'],
+  outfile: 'dist-server/migrate_mail_bot_welcome_purge.cjs',
+  alias: { '#bot-detector': usePrivate ? privateImpl : stubImpl },
+});
+
 console.log(`[build:server] bot detector: ${usePrivate ? 'private' : 'stub (no-op)'}`);


### PR DESCRIPTION
## Summary

The mail purge script (issue #3560, merged with PR 3566) was specced as a manual deploy-window step and never added to `scripts/build_server.mjs`, so the deploy playbook's `docker compose run --rm game node dist-server/migrate_<name>.cjs` migration pattern could not run it. It has now been missed in two prod deploy windows while the mail book grew to 96.6MB serialized (~157k letters, ~140k bot welcomes), which is the ~300ms event-loop stall every 30-second autosave that players feel as world hitches.

This adds the missing esbuild entry, byte-mirroring the rift-forge and old-cragmaw blocks. The woc-deploy playbook gains the matching gated dry-run/apply tasks (`eastbrook_run_mail_welcome_purge`, default false) so the purge runs inside the next deploy's stopped-server migration window.

## Type of change

- [x] Build, CI, or tooling

## How was this tested?

- Commands: `node scripts/build_server.mjs` produces `dist-server/migrate_mail_bot_welcome_purge.cjs`; the bundled script executes and its strict arg parser refuses unknown arguments (the pinned behavior).
- The migration logic itself is unchanged and already covered by its merged test suite.

## Checklist

- [x] **The gate passes.** `node scripts/gate_select.mjs` green (build-script-only diff).
- [x] N/A. This PR adds no player-visible strings.