### PR TITLE
feat(server): export client perf report telemetry as Prometheus series

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -575,10 +575,12 @@ For off-box safety, sync the directory to S3 occasionally:
   heavy-jank counts, frame p95 / fps / worst-10s / long-task / render-scale
   histograms, context losses, and perf-doctor suggestion counts, labeled only
   by fixed vocabularies (graphics tier, device class, GPU family, OS family,
-  scene class, suggestion id). The two counter cross products pre-register at
-  zero at boot (house convention, so the jank-share ratio reads 0% rather than
-  "no data" for a healthy cohort); the histograms appear lazily on the first
-  stored report from their cohort. The values are
+  scene class, suggestion id). The whole family follows the exporter's
+  zero-backfill design above: every counter cross product registers at zero and
+  every histogram series is pre-seeded at boot (roughly 600 always-present
+  samples), so the jank-share ratio reads 0% rather than "no data" for a
+  healthy cohort and first post-deploy increments are visible to rate(). The
+  values are
   CLIENT-ATTESTED (the beacon is unauthenticated; the ingest clamps, per-IP
   rate limit, and per-session insert throttle bound the write rate), so
   corroborate a surprising shift against the client_perf_reports table before

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -575,8 +575,10 @@ For off-box safety, sync the directory to S3 occasionally:
   heavy-jank counts, frame p95 / fps / worst-10s / long-task / render-scale
   histograms, context losses, and perf-doctor suggestion counts, labeled only
   by fixed vocabularies (graphics tier, device class, GPU family, OS family,
-  scene class, suggestion id). Series are created lazily on the first stored
-  report, so a fresh boot exposes none until players report. The values are
+  scene class, suggestion id). The two counter cross products pre-register at
+  zero at boot (house convention, so the jank-share ratio reads 0% rather than
+  "no data" for a healthy cohort); the histograms appear lazily on the first
+  stored report from their cohort. The values are
   CLIENT-ATTESTED (the beacon is unauthenticated; the ingest clamps, per-IP
   rate limit, and per-session insert throttle bound the write rate), so
   corroborate a surprising shift against the client_perf_reports table before

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -570,6 +570,17 @@ For off-box safety, sync the directory to S3 occasionally:
   full cross product is still pre-registered at boot by design (a Prometheus
   counter cannot backfill a scrape), and no per-request cardinality bound
   changed: the vocabularies stay content-derived and bounded.
+  The `woc_client_*` family (server/http/client_perf_metrics.ts) distills the
+  public `/api/perf-report` beacons into fleet frame-health series: report and
+  heavy-jank counts, frame p95 / fps / worst-10s / long-task / render-scale
+  histograms, context losses, and perf-doctor suggestion counts, labeled only
+  by fixed vocabularies (graphics tier, device class, GPU family, OS family,
+  scene class, suggestion id). Series are created lazily on the first stored
+  report, so a fresh boot exposes none until players report. The values are
+  CLIENT-ATTESTED (the beacon is unauthenticated; the ingest clamps, per-IP
+  rate limit, and per-session insert throttle bound the write rate), so
+  corroborate a surprising shift against the client_perf_reports table before
+  treating it as fleet truth.
 - **Multi-realm scraping**: one server process hosts exactly one realm, and no
   exported series carries a `realm` label (pinned by the exporter tests; the
   DB-backed business family filters on the realm in its queries instead). Give

--- a/server/http/client_perf_metrics.ts
+++ b/server/http/client_perf_metrics.ts
@@ -156,9 +156,12 @@ export const CLIENT_PERF_WORST10S_BUCKETS_SECONDS = [
   0.0334, 0.05, 0.0667, 0.0834, 0.125, 0.25,
 ] as const;
 export const CLIENT_PERF_FPS_AVG_BUCKETS = [10, 15, 20, 25, 30, 40, 50, 60, 90, 120] as const;
-// Long tasks legitimately run to whole seconds (that is what the observer is
-// for); the tail edges match the multi-second freeze class it corroborates.
-export const CLIENT_PERF_LONG_TASK_BUCKETS_SECONDS = [0.05, 0.1, 0.2, 0.35, 0.5, 1, 2, 5] as const;
+// The top edge sits at the ingest's own clamp: perf_report.ts bounds
+// longTaskP95Ms to 1000ms, so no higher edge is reachable (the multi-second
+// freeze evidence rides raw_summary's browser.longTasks block instead, under
+// its own 60s bound). Raising this tail means raising the ingest clamp in the
+// same change.
+export const CLIENT_PERF_LONG_TASK_BUCKETS_SECONDS = [0.05, 0.1, 0.2, 0.35, 0.5, 1] as const;
 // The governor's floor is 0.3 (perf_report numberIn bound); 1.0 is native.
 export const CLIENT_PERF_RENDER_SCALE_BUCKETS = [0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0] as const;
 
@@ -266,8 +269,13 @@ function osIn(value: string): ClientPerfOsFamily {
     : 'other';
 }
 
-function finiteOrZero(value: number): number {
-  return Number.isFinite(value) ? value : 0;
+// Every observed value routes through this ONE sanitizer, and the jank compare
+// runs on its output, never the raw field: a histogram _sum is treated as
+// monotone by dashboards, so a direct caller's negative finite value must not
+// subtract from it, and an Infinity must neither poison a _sum nor satisfy the
+// jank threshold while its histogram observes zero.
+function observedOrZero(value: number): number {
+  return Number.isFinite(value) && value > 0 ? value : 0;
 }
 
 /**
@@ -337,20 +345,31 @@ export function registerClientPerfMetrics(registry: Registry): ClientPerfMetrics
     registers: [registry],
   });
 
-  // Pre-register the two COUNTER cross products at zero, the registry's house
-  // convention (game_metrics.ts; a Prometheus counter cannot backfill a
-  // scrape): the jank SHARE is a ratio over these two, and a lazily created
-  // numerator makes a healthy cohort read "no data" instead of 0%. The
-  // histograms stay lazy on purpose: they carry no ratio arm and priming them
-  // would be the bulk of the family's scrape payload for no query benefit.
+  // The exporter's zero-backfill design, whole family (game_metrics.ts: "Prom
+  // counters cannot backfill a scrape", histograms pre-seeded with .zero()):
+  // every counter cross product registers at zero and every histogram series
+  // is pre-seeded, so the first post-deploy increment is visible to
+  // increase()/rate() and the jank SHARE reads 0% for a healthy cohort rather
+  // than "no data". The full family is a fixed ~600-sample scrape ceiling,
+  // measured immaterial per scrape.
   for (const gfxTier of CLIENT_PERF_GFX_TIERS) {
     for (const device of CLIENT_PERF_DEVICE_CLASSES) {
-      jankReports.inc({ gfx_tier: gfxTier, device }, 0);
+      const tierDevice = { gfx_tier: gfxTier, device };
+      jankReports.inc(tierDevice, 0);
+      frameP95.zero(tierDevice);
+      fpsAvg.zero(tierDevice);
       for (const gpuFamily of CLIENT_PERF_GPU_FAMILIES) {
-        reports.inc({ gfx_tier: gfxTier, device, gpu_family: gpuFamily }, 0);
+        reports.inc({ ...tierDevice, gpu_family: gpuFamily }, 0);
       }
     }
+    longTask.zero({ gfx_tier: gfxTier });
+    renderScale.zero({ gfx_tier: gfxTier });
   }
+  for (const scene of CLIENT_PERF_SCENE_CLASSES) {
+    for (const device of CLIENT_PERF_DEVICE_CLASSES) worst10s.zero({ scene, device });
+  }
+  for (const os of CLIENT_PERF_OS_FAMILIES) contextLosses.inc({ os }, 0);
+  for (const suggestion of CLIENT_PERF_SUGGESTION_IDS) suggestions.inc({ suggestion }, 0);
 
   return {
     perfReportStored(sample: ClientPerfSample): void {
@@ -368,16 +387,20 @@ export function registerClientPerfMetrics(registry: Registry): ClientPerfMetrics
           ...tierDevice,
           gpu_family: classifyClientPerfGpuFamily(sample.glRendererBucket),
         });
-        frameP95.observe(tierDevice, finiteOrZero(sample.frameP95Ms) / MS_PER_SECOND);
-        fpsAvg.observe(tierDevice, finiteOrZero(sample.fpsAvg));
+        frameP95.observe(tierDevice, observedOrZero(sample.frameP95Ms) / MS_PER_SECOND);
+        fpsAvg.observe(tierDevice, observedOrZero(sample.fpsAvg));
+        const worst10sMs = observedOrZero(sample.worst10sFrameP95Ms);
         worst10s.observe(
           { scene: classifyClientPerfScene(sample.zoneOrScenario), device },
-          finiteOrZero(sample.worst10sFrameP95Ms) / MS_PER_SECOND,
+          worst10sMs / MS_PER_SECOND,
         );
-        if (sample.worst10sFrameP95Ms >= CLIENT_PERF_JANK_THRESHOLD_MS) jankReports.inc(tierDevice);
-        longTask.observe({ gfx_tier: gfxTier }, finiteOrZero(sample.longTaskP95Ms) / MS_PER_SECOND);
-        renderScale.observe({ gfx_tier: gfxTier }, finiteOrZero(sample.effectiveRenderScale));
-        const lost = Math.max(0, Math.floor(finiteOrZero(sample.contextLostCount)));
+        if (worst10sMs >= CLIENT_PERF_JANK_THRESHOLD_MS) jankReports.inc(tierDevice);
+        longTask.observe(
+          { gfx_tier: gfxTier },
+          observedOrZero(sample.longTaskP95Ms) / MS_PER_SECOND,
+        );
+        renderScale.observe({ gfx_tier: gfxTier }, observedOrZero(sample.effectiveRenderScale));
+        const lost = Math.floor(observedOrZero(sample.contextLostCount));
         if (lost > 0) contextLosses.inc({ os: osIn(sample.osFamily) }, lost);
         for (const id of sample.suggestionIds) {
           // The ingest allowlist already filtered these; membership is re-checked

--- a/server/http/client_perf_metrics.ts
+++ b/server/http/client_perf_metrics.ts
@@ -1,0 +1,370 @@
+// The client-perf half of the /metrics exporter: the fleet-wide frame-health
+// series distilled from the /api/perf-report beacons the clients already send.
+// Until this module, those beacons landed ONLY in the client_perf_reports table,
+// so "how do frames feel for players" was answerable by SQL on the production
+// database and nowhere else; these series put the same signal on the one
+// prom-client registry the exporter serves (server/http/metrics.ts), where
+// dashboards and alerting can read it without database access.
+//
+// EMISSION SITE AND SEMANTICS: server/perf_report.ts calls the slot's
+// perfReportStored(row) with the fully SANITIZED insert row, immediately after
+// the row is stored. That placement is load-bearing three ways:
+// - The ingest rate limiter and the per-session insert throttle have already
+//   run, so a beacon flood moves these series no faster than it moves the
+//   table, and the series stay 1:1 with stored rows (a Grafana count and a SQL
+//   count agree).
+// - Every field observed here has already been through perf_report's clamps
+//   and allowlists, so values are finite and bounded before they arrive.
+// - Reports with source 'benchmark' are skipped here (they measure a harness,
+//   not a player) while still reaching storage for the admin reader.
+//
+// CARDINALITY IS BOUNDED BY DESIGN, same contract as game_metrics.ts: every
+// label value comes from one of the fixed vocabularies below. The two ingest
+// fields that are NOT bounded upstream (zone_or_scenario is free text,
+// gl_renderer_bucket has an open-ended slug fallback for unrecognized
+// hardware) NEVER reach a label raw: classifyClientPerfScene and
+// classifyClientPerfGpuFamily collapse them into fixed classes with an
+// explicit fallback, so a hand-rolled beacon cannot mint series. Nothing
+// per-player, per-session, or per-device (account id, character id, session
+// id, ip, exact renderer string) is ever a label.
+//
+// CLIENT-ATTESTED NUMBERS, the same caveat wsInputSeqGap carries: the beacon
+// is public and unauthenticated, so any token holder can post hand-rolled
+// values (bounded upstream by the ingest clamps, the per-IP rate limit, and
+// the per-session insert throttle). A hostile can skew a cohort's
+// distribution, never mint a series; operators corroborate a surprising shift
+// against the stored rows before treating it as fleet truth.
+//
+// Bucket choices are anchored on what the fleet actually reports: the two
+// vsync cadences (16.7ms and 33.4ms, where the desktop median p95 sits), the
+// governor's render-scale floor, and the client's own 250ms worst-10s clamp
+// (src/game/perf.ts caps each frame sample there, so the top bucket edge and
+// the jank threshold both sit at that clamp).
+
+import { Counter, Histogram, type Registry } from 'prom-client';
+
+/** The five graphics tiers the ingest allowlist admits (perf_report.ts gfxTier). */
+export const CLIENT_PERF_GFX_TIERS = ['low', 'medium', 'high', 'ultra', 'insane'] as const;
+export type ClientPerfGfxTier = (typeof CLIENT_PERF_GFX_TIERS)[number];
+
+/** Touch-capable clients vs everything else, from the report's mobileTouch flag. */
+export const CLIENT_PERF_DEVICE_CLASSES = ['desktop', 'mobile'] as const;
+export type ClientPerfDeviceClass = (typeof CLIENT_PERF_DEVICE_CLASSES)[number];
+
+/**
+ * The GPU families worth telling apart in fleet trends. Coarser than the
+ * stored gl_renderer_bucket on purpose: the stored bucket is open-ended
+ * (apple-<chip> variants, a slug fallback for anything unrecognized), which is
+ * fine for a SQL drill-down but can neither bound a label nor keep a rare
+ * device from being fingerprintable. 'intel-igpu' folds intel / intel-uhd /
+ * intel-iris together: they trend together and jointly form the known worst
+ * desktop cohort.
+ */
+export const CLIENT_PERF_GPU_FAMILIES = [
+  'nvidia',
+  'amd',
+  'intel-igpu',
+  'apple',
+  'software',
+  'other',
+] as const;
+export type ClientPerfGpuFamily = (typeof CLIENT_PERF_GPU_FAMILIES)[number];
+
+/** The OS families the ingest allowlist admits (perf_report.ts osFamily). */
+export const CLIENT_PERF_OS_FAMILIES = [
+  'windows',
+  'macos',
+  'linux',
+  'ios',
+  'android',
+  'other',
+] as const;
+export type ClientPerfOsFamily = (typeof CLIENT_PERF_OS_FAMILIES)[number];
+
+/**
+ * Scene classes for the worst-10s series: the scene KIND is what separates the
+ * hitch profiles (interior module streaming vs open-world foliage vs the BG
+ * field), and a fixed class set is what free-text zone ids cannot give a
+ * label. The stock client's zone tokens come from telemetryZoneId
+ * (src/game/world_telemetry.ts): a bare overworld zone id, `dungeon:<id>`,
+ * `delve:<id>`, and the fixed instance tokens `arena`, `yumi_maze`,
+ * `battleground`, `rift`, `instance`, each of which keeps its own class here
+ * (tests/client_perf_scene_parity.test.ts pins the mapping against the real
+ * function). Bare ids classify as 'overworld'; the ingest defaults
+ * ('gameplay', '') land in 'other'. Per-zone drill-down stays in the table.
+ */
+export const CLIENT_PERF_SCENE_CLASSES = [
+  'overworld',
+  'dungeon',
+  'delve',
+  'battleground',
+  'arena',
+  'yumi_maze',
+  'rift',
+  'instance',
+  'other',
+] as const;
+export type ClientPerfSceneClass = (typeof CLIENT_PERF_SCENE_CLASSES)[number];
+
+/**
+ * The client perf-doctor suggestion ids. A deliberate copy of
+ * KNOWN_PERF_SUGGESTION_IDS in server/perf_report.ts (importing it would cycle
+ * perf_report <-> this module); tests/server/http/client_perf_metrics.test.ts
+ * pins the two catalogs equal, the same drift guard the crowd-bucket copy uses.
+ */
+export const CLIENT_PERF_SUGGESTION_IDS = [
+  'hardware-acceleration',
+  'integrated-gpu',
+  'high-dpi',
+  'forced-high-graphics',
+  'low-memory',
+  'browser-stalls',
+  'heap-pressure',
+  'context-loss',
+] as const;
+export type ClientPerfSuggestionId = (typeof CLIENT_PERF_SUGGESTION_IDS)[number];
+
+/**
+ * A report whose worst 10s window p95 reached this many ms counts as janky.
+ * This is the client reporter's own clamp value, so "reached" and "hit the
+ * clamp" are the same test and the jank share is exactly the share of reports
+ * a raw SQL `worst_10s_frame_p95_ms >= 250` returns.
+ */
+export const CLIENT_PERF_JANK_THRESHOLD_MS = 250;
+
+// Series names, exported for the test pins.
+export const WOC_CLIENT_REPORTS_TOTAL = 'woc_client_reports_total';
+export const WOC_CLIENT_JANK_REPORTS_TOTAL = 'woc_client_jank_reports_total';
+export const WOC_CLIENT_FRAME_P95_SECONDS = 'woc_client_frame_p95_seconds';
+export const WOC_CLIENT_FPS_AVG = 'woc_client_fps_avg';
+export const WOC_CLIENT_WORST10S_FRAME_P95_SECONDS = 'woc_client_worst10s_frame_p95_seconds';
+export const WOC_CLIENT_LONG_TASK_P95_SECONDS = 'woc_client_long_task_p95_seconds';
+export const WOC_CLIENT_EFFECTIVE_RENDER_SCALE = 'woc_client_effective_render_scale';
+export const WOC_CLIENT_CONTEXT_LOSSES_TOTAL = 'woc_client_context_losses_total';
+export const WOC_CLIENT_SUGGESTIONS_TOTAL = 'woc_client_suggestions_total';
+
+// Bucket edges are part of the exporter's public contract (a bucket edit
+// silently rewrites every dashboard quantile), so they are exported and pinned
+// by the tests like the RED exporter's duration buckets.
+// 60Hz is 0.0167 and its half-rate miss is 0.0334; the fleet median desktop
+// p95 sits ON the 0.0334 edge, so both cadences are explicit edges.
+export const CLIENT_PERF_FRAME_P95_BUCKETS_SECONDS = [
+  0.0125, 0.0167, 0.02, 0.025, 0.0334, 0.05, 0.0834, 0.125, 0.25,
+] as const;
+// Top edge at the client's 0.25s clamp: everything above it is clamp-resident.
+export const CLIENT_PERF_WORST10S_BUCKETS_SECONDS = [
+  0.0334, 0.05, 0.0667, 0.0834, 0.125, 0.25,
+] as const;
+export const CLIENT_PERF_FPS_AVG_BUCKETS = [10, 15, 20, 25, 30, 40, 50, 60, 90, 120] as const;
+// Long tasks legitimately run to whole seconds (that is what the observer is
+// for); the tail edges match the multi-second freeze class it corroborates.
+export const CLIENT_PERF_LONG_TASK_BUCKETS_SECONDS = [0.05, 0.1, 0.2, 0.35, 0.5, 1, 2, 5] as const;
+// The governor's floor is 0.3 (perf_report numberIn bound); 1.0 is native.
+export const CLIENT_PERF_RENDER_SCALE_BUCKETS = [0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0] as const;
+
+const MS_PER_SECOND = 1000;
+
+/**
+ * The slice of the sanitized insert row this module reads. Structurally
+ * satisfied by db.ts ClientPerfReportInsert, declared apart so the module
+ * depends on the ingest contract, never on the database layer.
+ */
+export interface ClientPerfSample {
+  source: string;
+  gfxTier: string;
+  mobileTouch: boolean;
+  osFamily: string;
+  glRendererBucket: string;
+  zoneOrScenario: string;
+  fpsAvg: number;
+  frameP95Ms: number;
+  worst10sFrameP95Ms: number;
+  longTaskP95Ms: number;
+  effectiveRenderScale: number;
+  contextLostCount: number;
+  suggestionIds: string[];
+}
+
+/**
+ * The client-perf emission hook. The implementation must never throw: an
+ * observability write can never be allowed to break the beacon ingest it
+ * measures (the same contract as GameMetricsCounters).
+ */
+export interface ClientPerfMetricsSink {
+  /** One sanitized perf report, called right after its row is stored. */
+  perfReportStored(sample: ClientPerfSample): void;
+}
+
+/** A sink that drops every report; the slot default until boot wires the real one. */
+export const noopClientPerfMetricsSink: ClientPerfMetricsSink = {
+  perfReportStored() {},
+};
+
+let activeSink: ClientPerfMetricsSink = noopClientPerfMetricsSink;
+
+/**
+ * Install the process-wide client-perf sink. main.ts calls this once at boot
+ * with the exporter-backed implementation; tests install a recording fake and
+ * restore noopClientPerfMetricsSink when done.
+ */
+export function setClientPerfMetricsSink(sink: ClientPerfMetricsSink): void {
+  activeSink = sink;
+}
+
+/** The current client-perf sink. Read at emission time, never captured at import. */
+export function clientPerfMetricsSink(): ClientPerfMetricsSink {
+  return activeSink;
+}
+
+/** Collapse a stored gl_renderer_bucket into its fixed fleet family. */
+export function classifyClientPerfGpuFamily(glRendererBucket: string): ClientPerfGpuFamily {
+  const bucket = glRendererBucket.toLowerCase();
+  if (bucket.startsWith('nvidia')) return 'nvidia';
+  if (bucket.startsWith('amd')) return 'amd';
+  if (bucket.startsWith('intel')) return 'intel-igpu';
+  if (bucket.startsWith('apple')) return 'apple';
+  if (bucket.startsWith('software')) return 'software';
+  return 'other';
+}
+
+// The fixed single-token instance ids telemetryZoneId emits, each mapped to
+// the scene class of the same name.
+const INSTANCE_SCENE_TOKENS: readonly ClientPerfSceneClass[] = [
+  'battleground',
+  'arena',
+  'yumi_maze',
+  'rift',
+  'instance',
+];
+
+/** Collapse a free-text zone_or_scenario into its fixed scene class. */
+export function classifyClientPerfScene(zoneOrScenario: string): ClientPerfSceneClass {
+  if (zoneOrScenario.startsWith('dungeon:')) return 'dungeon';
+  if (zoneOrScenario.startsWith('delve:')) return 'delve';
+  const instanceToken = INSTANCE_SCENE_TOKENS.find((token) => token === zoneOrScenario);
+  if (instanceToken) return instanceToken;
+  // The ingest defaults ('gameplay' for a stock client that sent nothing,
+  // 'benchmark' for the harness) plus the empty string carry no scene at all.
+  if (zoneOrScenario === '' || zoneOrScenario === 'gameplay' || zoneOrScenario === 'benchmark') {
+    return 'other';
+  }
+  return 'overworld';
+}
+
+function tierIn(value: string): ClientPerfGfxTier {
+  // The ingest allowlist already guarantees membership with a 'low' fallback;
+  // this mirrors that fallback so a direct caller cannot widen the label.
+  return (CLIENT_PERF_GFX_TIERS as readonly string[]).includes(value)
+    ? (value as ClientPerfGfxTier)
+    : 'low';
+}
+
+function osIn(value: string): ClientPerfOsFamily {
+  return (CLIENT_PERF_OS_FAMILIES as readonly string[]).includes(value)
+    ? (value as ClientPerfOsFamily)
+    : 'other';
+}
+
+function finiteOrZero(value: number): number {
+  return Number.isFinite(value) ? value : 0;
+}
+
+/**
+ * Create the client-perf series on `registry` and return the sink that feeds
+ * them. main.ts installs the result via setClientPerfMetricsSink at boot.
+ */
+export function registerClientPerfMetrics(registry: Registry): ClientPerfMetricsSink {
+  const reports = new Counter({
+    name: WOC_CLIENT_REPORTS_TOTAL,
+    help: 'Stored gameplay perf reports, by graphics tier, device class, and GPU family.',
+    labelNames: ['gfx_tier', 'device', 'gpu_family'] as const,
+    registers: [registry],
+  });
+  const jankReports = new Counter({
+    name: WOC_CLIENT_JANK_REPORTS_TOTAL,
+    help:
+      'Stored gameplay perf reports whose worst 10s window frame p95 reached the client clamp ' +
+      `(${CLIENT_PERF_JANK_THRESHOLD_MS}ms): the heavy-jank share numerator over woc_client_reports_total.`,
+    labelNames: ['gfx_tier', 'device'] as const,
+    registers: [registry],
+  });
+  const frameP95 = new Histogram({
+    name: WOC_CLIENT_FRAME_P95_SECONDS,
+    help: 'Reported frame-time p95 per report window, by graphics tier and device class.',
+    labelNames: ['gfx_tier', 'device'] as const,
+    buckets: [...CLIENT_PERF_FRAME_P95_BUCKETS_SECONDS],
+    registers: [registry],
+  });
+  const fpsAvg = new Histogram({
+    name: WOC_CLIENT_FPS_AVG,
+    help: 'Reported average fps per report window, by graphics tier and device class.',
+    labelNames: ['gfx_tier', 'device'] as const,
+    buckets: [...CLIENT_PERF_FPS_AVG_BUCKETS],
+    registers: [registry],
+  });
+  const worst10s = new Histogram({
+    name: WOC_CLIENT_WORST10S_FRAME_P95_SECONDS,
+    help: 'Reported worst 10s window frame p95 (client-clamped at 0.25s), by scene class and device class.',
+    labelNames: ['scene', 'device'] as const,
+    buckets: [...CLIENT_PERF_WORST10S_BUCKETS_SECONDS],
+    registers: [registry],
+  });
+  const longTask = new Histogram({
+    name: WOC_CLIENT_LONG_TASK_P95_SECONDS,
+    help: 'Reported main-thread long-task p95 per report window, by graphics tier.',
+    labelNames: ['gfx_tier'] as const,
+    buckets: [...CLIENT_PERF_LONG_TASK_BUCKETS_SECONDS],
+    registers: [registry],
+  });
+  const renderScale = new Histogram({
+    name: WOC_CLIENT_EFFECTIVE_RENDER_SCALE,
+    help: 'Reported effective render scale (governor pressure; 1.0 is native), by graphics tier.',
+    labelNames: ['gfx_tier'] as const,
+    buckets: [...CLIENT_PERF_RENDER_SCALE_BUCKETS],
+    registers: [registry],
+  });
+  const contextLosses = new Counter({
+    name: WOC_CLIENT_CONTEXT_LOSSES_TOTAL,
+    help: 'WebGL context losses summed from stored gameplay perf reports, by OS family.',
+    labelNames: ['os'] as const,
+    registers: [registry],
+  });
+  const suggestions = new Counter({
+    name: WOC_CLIENT_SUGGESTIONS_TOTAL,
+    help: 'Perf-doctor suggestion ids carried by stored gameplay perf reports.',
+    labelNames: ['suggestion'] as const,
+    registers: [registry],
+  });
+
+  return {
+    perfReportStored(sample: ClientPerfSample): void {
+      if (sample.source !== 'gameplay') return;
+      const gfxTier = tierIn(sample.gfxTier);
+      const device: ClientPerfDeviceClass = sample.mobileTouch ? 'mobile' : 'desktop';
+      const tierDevice = { gfx_tier: gfxTier, device };
+
+      reports.inc({
+        ...tierDevice,
+        gpu_family: classifyClientPerfGpuFamily(sample.glRendererBucket),
+      });
+      frameP95.observe(tierDevice, finiteOrZero(sample.frameP95Ms) / MS_PER_SECOND);
+      fpsAvg.observe(tierDevice, finiteOrZero(sample.fpsAvg));
+      worst10s.observe(
+        { scene: classifyClientPerfScene(sample.zoneOrScenario), device },
+        finiteOrZero(sample.worst10sFrameP95Ms) / MS_PER_SECOND,
+      );
+      if (sample.worst10sFrameP95Ms >= CLIENT_PERF_JANK_THRESHOLD_MS) jankReports.inc(tierDevice);
+      longTask.observe({ gfx_tier: gfxTier }, finiteOrZero(sample.longTaskP95Ms) / MS_PER_SECOND);
+      renderScale.observe({ gfx_tier: gfxTier }, finiteOrZero(sample.effectiveRenderScale));
+      const lost = Math.max(0, Math.floor(finiteOrZero(sample.contextLostCount)));
+      if (lost > 0) contextLosses.inc({ os: osIn(sample.osFamily) }, lost);
+      for (const id of sample.suggestionIds) {
+        // The ingest allowlist already filtered these; membership is re-checked
+        // so a direct caller cannot mint a label value.
+        if ((CLIENT_PERF_SUGGESTION_IDS as readonly string[]).includes(id)) {
+          suggestions.inc({ suggestion: id });
+        }
+      }
+    },
+  };
+}

--- a/server/http/client_perf_metrics.ts
+++ b/server/http/client_perf_metrics.ts
@@ -241,8 +241,9 @@ const INSTANCE_SCENE_TOKENS: readonly ClientPerfSceneClass[] = [
 export function classifyClientPerfScene(zoneOrScenario: string): ClientPerfSceneClass {
   if (zoneOrScenario.startsWith('dungeon:')) return 'dungeon';
   if (zoneOrScenario.startsWith('delve:')) return 'delve';
-  const instanceToken = INSTANCE_SCENE_TOKENS.find((token) => token === zoneOrScenario);
-  if (instanceToken) return instanceToken;
+  if ((INSTANCE_SCENE_TOKENS as readonly string[]).includes(zoneOrScenario)) {
+    return zoneOrScenario as ClientPerfSceneClass;
+  }
   // The ingest defaults ('gameplay' for a stock client that sent nothing,
   // 'benchmark' for the harness) plus the empty string carry no scene at all.
   if (zoneOrScenario === '' || zoneOrScenario === 'gameplay' || zoneOrScenario === 'benchmark') {
@@ -336,34 +337,58 @@ export function registerClientPerfMetrics(registry: Registry): ClientPerfMetrics
     registers: [registry],
   });
 
+  // Pre-register the two COUNTER cross products at zero, the registry's house
+  // convention (game_metrics.ts; a Prometheus counter cannot backfill a
+  // scrape): the jank SHARE is a ratio over these two, and a lazily created
+  // numerator makes a healthy cohort read "no data" instead of 0%. The
+  // histograms stay lazy on purpose: they carry no ratio arm and priming them
+  // would be the bulk of the family's scrape payload for no query benefit.
+  for (const gfxTier of CLIENT_PERF_GFX_TIERS) {
+    for (const device of CLIENT_PERF_DEVICE_CLASSES) {
+      jankReports.inc({ gfx_tier: gfxTier, device }, 0);
+      for (const gpuFamily of CLIENT_PERF_GPU_FAMILIES) {
+        reports.inc({ gfx_tier: gfxTier, device, gpu_family: gpuFamily }, 0);
+      }
+    }
+  }
+
   return {
     perfReportStored(sample: ClientPerfSample): void {
-      if (sample.source !== 'gameplay') return;
-      const gfxTier = tierIn(sample.gfxTier);
-      const device: ClientPerfDeviceClass = sample.mobileTouch ? 'mobile' : 'desktop';
-      const tierDevice = { gfx_tier: gfxTier, device };
+      // Guarded like every sibling sink on this registry (game_metrics.ts,
+      // metrics.ts): a throw here would 500 a beacon whose row is already
+      // stored, and the client then re-sends the same worst-10s window, so
+      // dropping one observation is the correct failure mode.
+      try {
+        if (sample.source !== 'gameplay') return;
+        const gfxTier = tierIn(sample.gfxTier);
+        const device: ClientPerfDeviceClass = sample.mobileTouch ? 'mobile' : 'desktop';
+        const tierDevice = { gfx_tier: gfxTier, device };
 
-      reports.inc({
-        ...tierDevice,
-        gpu_family: classifyClientPerfGpuFamily(sample.glRendererBucket),
-      });
-      frameP95.observe(tierDevice, finiteOrZero(sample.frameP95Ms) / MS_PER_SECOND);
-      fpsAvg.observe(tierDevice, finiteOrZero(sample.fpsAvg));
-      worst10s.observe(
-        { scene: classifyClientPerfScene(sample.zoneOrScenario), device },
-        finiteOrZero(sample.worst10sFrameP95Ms) / MS_PER_SECOND,
-      );
-      if (sample.worst10sFrameP95Ms >= CLIENT_PERF_JANK_THRESHOLD_MS) jankReports.inc(tierDevice);
-      longTask.observe({ gfx_tier: gfxTier }, finiteOrZero(sample.longTaskP95Ms) / MS_PER_SECOND);
-      renderScale.observe({ gfx_tier: gfxTier }, finiteOrZero(sample.effectiveRenderScale));
-      const lost = Math.max(0, Math.floor(finiteOrZero(sample.contextLostCount)));
-      if (lost > 0) contextLosses.inc({ os: osIn(sample.osFamily) }, lost);
-      for (const id of sample.suggestionIds) {
-        // The ingest allowlist already filtered these; membership is re-checked
-        // so a direct caller cannot mint a label value.
-        if ((CLIENT_PERF_SUGGESTION_IDS as readonly string[]).includes(id)) {
-          suggestions.inc({ suggestion: id });
+        reports.inc({
+          ...tierDevice,
+          gpu_family: classifyClientPerfGpuFamily(sample.glRendererBucket),
+        });
+        frameP95.observe(tierDevice, finiteOrZero(sample.frameP95Ms) / MS_PER_SECOND);
+        fpsAvg.observe(tierDevice, finiteOrZero(sample.fpsAvg));
+        worst10s.observe(
+          { scene: classifyClientPerfScene(sample.zoneOrScenario), device },
+          finiteOrZero(sample.worst10sFrameP95Ms) / MS_PER_SECOND,
+        );
+        if (sample.worst10sFrameP95Ms >= CLIENT_PERF_JANK_THRESHOLD_MS) jankReports.inc(tierDevice);
+        longTask.observe({ gfx_tier: gfxTier }, finiteOrZero(sample.longTaskP95Ms) / MS_PER_SECOND);
+        renderScale.observe({ gfx_tier: gfxTier }, finiteOrZero(sample.effectiveRenderScale));
+        const lost = Math.max(0, Math.floor(finiteOrZero(sample.contextLostCount)));
+        if (lost > 0) contextLosses.inc({ os: osIn(sample.osFamily) }, lost);
+        for (const id of sample.suggestionIds) {
+          // The ingest allowlist already filtered these; membership is re-checked
+          // so a direct caller cannot mint a label value.
+          if ((CLIENT_PERF_SUGGESTION_IDS as readonly string[]).includes(id)) {
+            suggestions.inc({ suggestion: id });
+          }
         }
+      } catch {
+        // Deliberately silent, matching the sibling sinks: the observation is
+        // lost, the beacon and its stored row are not.
       }
     },
   };

--- a/server/main.ts
+++ b/server/main.ts
@@ -245,6 +245,7 @@ import { createAccessLogSink } from './http/access_log';
 import { setAttackSignalSink } from './http/attack_signals';
 import { registerBusinessMetrics } from './http/business_metrics';
 import { handleClientError } from './http/client_error';
+import { registerClientPerfMetrics, setClientPerfMetricsSink } from './http/client_perf_metrics';
 import { type Config, DEFAULT_DISPATCH, type DispatchMode, loadConfig } from './http/config';
 import { registerDiscordBotMetrics } from './http/discord_bot_metrics';
 import {
@@ -3600,6 +3601,9 @@ export async function startServer(): Promise<http.Server> {
     guildBankLogCache: () => guildBankLogCacheStats(),
   };
   setGameMetricsCounters(registerGameStateMetrics(httpMetrics.registry, gameStateSource));
+  // The client-perf beacon series (server/http/client_perf_metrics.ts): the
+  // perf-report ingest emits through this slot after each stored row.
+  setClientPerfMetricsSink(registerClientPerfMetrics(httpMetrics.registry));
   registerParseMetrics(httpMetrics.registry, game.parseCapture.counters);
   // Hand the same live source to /livez, so a wedged loop answers 503 from outside
   // the process. Registered HERE rather than read from the route arm: the /livez arm

--- a/server/perf_report.ts
+++ b/server/perf_report.ts
@@ -5,6 +5,7 @@ import {
   getCharacter,
   insertClientPerfReport,
 } from './db';
+import { clientPerfMetricsSink } from './http/client_perf_metrics';
 import type { RateLimitOutcome } from './http/types';
 import { json, readBody } from './http_util';
 import { rateLimitNow, requestIp, windowedRateLimitOutcome } from './ratelimit';
@@ -867,6 +868,9 @@ export async function handlePerfReport(
   };
 
   await insertClientPerfReport(row);
+  // AFTER the insert on purpose: the /metrics series stay 1:1 with stored rows
+  // (see server/http/client_perf_metrics.ts for the full emission contract).
+  clientPerfMetricsSink().perfReportStored(row);
   return json(res, 200, { ok: true });
 }
 

--- a/tests/client_perf_scene_parity.test.ts
+++ b/tests/client_perf_scene_parity.test.ts
@@ -1,0 +1,71 @@
+// Cross-boundary drift guard for the client-perf scene classifier
+// (server/http/client_perf_metrics.ts). The zone tokens a stock client reports
+// are minted by telemetryZoneId (src/game/world_telemetry.ts); the server
+// keeps its own knowledge of those token shapes because server/http cannot
+// import src/game. This pin drives the REAL client function at real positions
+// for every band it can emit from and asserts each output lands in its OWN
+// scene class, so a token added to telemetryZoneId without a classifier arm
+// fails here instead of silently polluting the 'overworld' distribution
+// (which is exactly how arena / yumi_maze / rift / instance were missed in
+// this module's first draft). Same pattern as
+// tests/perf_suggestion_id_parity.test.ts: the one file that deliberately
+// imports both sides of the boundary.
+
+import { describe, expect, it } from 'vitest';
+import {
+  CLIENT_PERF_SCENE_CLASSES,
+  classifyClientPerfScene,
+} from '../server/http/client_perf_metrics';
+import { telemetryZoneId } from '../src/game/world_telemetry';
+import {
+  ARENA_X_MIN,
+  BG_X,
+  DUNGEONS,
+  delveOrigin,
+  instanceOrigin,
+  riftInstanceOrigin,
+  YUMI_BAND_X_MAX,
+  YUMI_BAND_X_MIN,
+} from '../src/sim/data';
+
+describe('client perf scene parity', () => {
+  it('maps every band telemetryZoneId can emit from to its own scene class', () => {
+    // Position recipes mirror tests/world_telemetry.test.ts: derived from the
+    // band helpers, never literal coordinates.
+    const cases: Array<[x: number, z: number, expected: string]> = [
+      [0, 0, 'overworld'],
+      [instanceOrigin(DUNGEONS.hollow_crypt.index, 0).x, 0, 'dungeon'],
+      [delveOrigin(0, 0).x, delveOrigin(0, 0).z, 'delve'],
+      // The unmapped-slot fallback still carries the delve: prefix.
+      [delveOrigin(1, 0).x + 300, 0, 'delve'],
+      [ARENA_X_MIN + 10, 0, 'arena'],
+      [YUMI_BAND_X_MIN + 10, 0, 'yumi_maze'],
+      [BG_X, 0, 'battleground'],
+      [riftInstanceOrigin(0, 0).x, riftInstanceOrigin(0, 0).z, 'rift'],
+      [YUMI_BAND_X_MAX + 10, 0, 'instance'],
+    ];
+    for (const [x, z, expected] of cases) {
+      expect(classifyClientPerfScene(telemetryZoneId(x, z))).toBe(expected);
+    }
+  });
+
+  it('never classifies a real client token as other', () => {
+    // 'other' exists for the ingest defaults ('gameplay', 'benchmark', '');
+    // a REAL zone token landing there means the classifier lost a signal.
+    const tokens = [
+      telemetryZoneId(0, 0),
+      telemetryZoneId(instanceOrigin(DUNGEONS.hollow_crypt.index, 0).x, 0),
+      telemetryZoneId(delveOrigin(0, 0).x, delveOrigin(0, 0).z),
+      telemetryZoneId(ARENA_X_MIN + 10, 0),
+      telemetryZoneId(YUMI_BAND_X_MIN + 10, 0),
+      telemetryZoneId(BG_X, 0),
+      telemetryZoneId(riftInstanceOrigin(0, 0).x, riftInstanceOrigin(0, 0).z),
+      telemetryZoneId(YUMI_BAND_X_MAX + 10, 0),
+    ];
+    for (const token of tokens) {
+      const scene = classifyClientPerfScene(token);
+      expect(CLIENT_PERF_SCENE_CLASSES).toContain(scene);
+      expect(scene).not.toBe('other');
+    }
+  });
+});

--- a/tests/server/http/client_perf_metrics.test.ts
+++ b/tests/server/http/client_perf_metrics.test.ts
@@ -260,10 +260,44 @@ describe('registerClientPerfMetrics', () => {
         /^woc_client_frame_p95_seconds_sum\{gfx_tier="high",device="desktop"\} ([\d.]+)$/m,
       ),
     ).toBe(0);
-    // A NaN worst-10s cannot satisfy the jank threshold.
-    expect(text).not.toMatch(/^woc_client_jank_reports_total\{/m);
+    // A NaN worst-10s cannot satisfy the jank threshold (the series exists at
+    // its primed zero).
+    expect(
+      value(text, /^woc_client_jank_reports_total\{gfx_tier="high",device="desktop"\} (\d+)$/m),
+    ).toBe(0);
     // A negative loss count never decrements the counter.
     expect(text).not.toMatch(/^woc_client_context_losses_total\{/m);
+  });
+
+  it('never throws on a malformed direct-caller sample', () => {
+    // The ingest always passes a sanitized row; the guard exists for a direct
+    // caller, where a throw would otherwise 500 a beacon whose row is stored.
+    const registry = new Registry();
+    const sink = registerClientPerfMetrics(registry);
+
+    expect(() =>
+      sink.perfReportStored({ ...sample(), suggestionIds: null as unknown as string[] }),
+    ).not.toThrow();
+  });
+
+  it('pre-registers the counter cross products at zero so ratios read 0%', async () => {
+    const registry = new Registry();
+    registerClientPerfMetrics(registry);
+
+    const text = await registry.metrics();
+    // Both jank-share arms exist before any report; the histograms stay lazy.
+    expect(
+      value(
+        text,
+        /^woc_client_reports_total\{gfx_tier="insane",device="mobile",gpu_family="software"\} (\d+)$/m,
+      ),
+    ).toBe(0);
+    expect(
+      value(text, /^woc_client_jank_reports_total\{gfx_tier="low",device="desktop"\} (\d+)$/m),
+    ).toBe(0);
+    expect(text).not.toMatch(/^woc_client_frame_p95_seconds_count\{/m);
+    expect(text).not.toMatch(/^woc_client_context_losses_total\{/m);
+    expect(text).not.toMatch(/^woc_client_suggestions_total\{/m);
   });
 
   it('skips benchmark-source reports entirely', async () => {
@@ -273,7 +307,15 @@ describe('registerClientPerfMetrics', () => {
     sink.perfReportStored(sample({ source: 'benchmark', zoneOrScenario: 'benchmark' }));
 
     const text = await registry.metrics();
-    expect(text).not.toMatch(/^woc_client_reports_total\{/m);
+    // The report's own cohort counter stays at its primed zero and no
+    // histogram series appears for it.
+    expect(
+      value(
+        text,
+        /^woc_client_reports_total\{gfx_tier="high",device="desktop",gpu_family="nvidia"\} (\d+)$/m,
+      ),
+    ).toBe(0);
+    expect(text).not.toMatch(/^woc_client_frame_p95_seconds_count\{/m);
   });
 
   it('never mints labels outside the vocabularies for hostile field values', async () => {

--- a/tests/server/http/client_perf_metrics.test.ts
+++ b/tests/server/http/client_perf_metrics.test.ts
@@ -1,0 +1,373 @@
+// Unit tests for the client-perf half of the /metrics exporter
+// (server/http/client_perf_metrics.ts): the woc_client_* series fed from stored
+// /api/perf-report rows. These pin the exposed metric NAMES as literals (a
+// rename fails the test, not just a constant swap), prove every label value is
+// drawn from the fixed vocabularies even for hostile inputs (an unrecognized
+// GPU bucket, zone string, or tier never becomes a new series), that benchmark
+// reports are skipped, that the jank counter triggers exactly at the client's
+// 250ms worst-10s clamp, that the suggestion catalog cannot drift from the
+// ingest allowlist, and that the ingest emits through the slot only for rows
+// that were actually stored.
+
+import { EventEmitter } from 'node:events';
+import { Registry } from 'prom-client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../../server/db', () => ({
+  accountAndScopeForToken: vi.fn(),
+  getCharacter: vi.fn(),
+  insertClientPerfReport: vi.fn(async () => {}),
+}));
+
+import { insertClientPerfReport } from '../../../server/db';
+import {
+  CLIENT_PERF_DEVICE_CLASSES,
+  CLIENT_PERF_FPS_AVG_BUCKETS,
+  CLIENT_PERF_FRAME_P95_BUCKETS_SECONDS,
+  CLIENT_PERF_GFX_TIERS,
+  CLIENT_PERF_GPU_FAMILIES,
+  CLIENT_PERF_JANK_THRESHOLD_MS,
+  CLIENT_PERF_LONG_TASK_BUCKETS_SECONDS,
+  CLIENT_PERF_OS_FAMILIES,
+  CLIENT_PERF_RENDER_SCALE_BUCKETS,
+  CLIENT_PERF_SCENE_CLASSES,
+  CLIENT_PERF_SUGGESTION_IDS,
+  CLIENT_PERF_WORST10S_BUCKETS_SECONDS,
+  type ClientPerfSample,
+  classifyClientPerfGpuFamily,
+  classifyClientPerfScene,
+  clientPerfMetricsSink,
+  noopClientPerfMetricsSink,
+  registerClientPerfMetrics,
+  setClientPerfMetricsSink,
+} from '../../../server/http/client_perf_metrics';
+import { handlePerfReport, perfReportInternalsForTest } from '../../../server/perf_report';
+
+function sample(overrides: Partial<ClientPerfSample> = {}): ClientPerfSample {
+  return {
+    source: 'gameplay',
+    gfxTier: 'high',
+    mobileTouch: false,
+    osFamily: 'windows',
+    glRendererBucket: 'nvidia',
+    zoneOrScenario: 'thornpeak_heights',
+    fpsAvg: 48,
+    frameP95Ms: 33.4,
+    worst10sFrameP95Ms: 66.7,
+    longTaskP95Ms: 120,
+    effectiveRenderScale: 0.85,
+    contextLostCount: 0,
+    suggestionIds: [],
+    ...overrides,
+  };
+}
+
+function value(text: string, re: RegExp): number {
+  const m = text.match(re);
+  return m ? Number(m[1]) : Number.NaN;
+}
+
+afterEach(() => {
+  setClientPerfMetricsSink(noopClientPerfMetricsSink);
+  vi.clearAllMocks();
+});
+
+describe('classifyClientPerfGpuFamily', () => {
+  it('maps the stored renderer buckets onto the fixed families', () => {
+    expect(classifyClientPerfGpuFamily('nvidia')).toBe('nvidia');
+    expect(classifyClientPerfGpuFamily('amd')).toBe('amd');
+    expect(classifyClientPerfGpuFamily('intel')).toBe('intel-igpu');
+    expect(classifyClientPerfGpuFamily('intel-uhd')).toBe('intel-igpu');
+    expect(classifyClientPerfGpuFamily('intel-iris')).toBe('intel-igpu');
+    expect(classifyClientPerfGpuFamily('apple')).toBe('apple');
+    expect(classifyClientPerfGpuFamily('apple-m4-pro')).toBe('apple');
+    expect(classifyClientPerfGpuFamily('software')).toBe('software');
+  });
+
+  it('collapses unknown and slug-fallback buckets to other, never a new value', () => {
+    for (const hostile of ['unknown', 'qualcomm-adreno-640', 'x'.repeat(48), '', 'NVIDIA; DROP']) {
+      expect(CLIENT_PERF_GPU_FAMILIES).toContain(classifyClientPerfGpuFamily(hostile));
+    }
+    expect(classifyClientPerfGpuFamily('qualcomm-adreno-640')).toBe('other');
+    expect(classifyClientPerfGpuFamily('unknown')).toBe('other');
+  });
+});
+
+describe('classifyClientPerfScene', () => {
+  it('maps prefixes and the fixed instance tokens onto scene classes', () => {
+    expect(classifyClientPerfScene('dungeon:nythraxis_crypt')).toBe('dungeon');
+    expect(classifyClientPerfScene('delve:collapsed_reliquary')).toBe('delve');
+    expect(classifyClientPerfScene('battleground')).toBe('battleground');
+    expect(classifyClientPerfScene('arena')).toBe('arena');
+    expect(classifyClientPerfScene('yumi_maze')).toBe('yumi_maze');
+    expect(classifyClientPerfScene('rift')).toBe('rift');
+    expect(classifyClientPerfScene('instance')).toBe('instance');
+    expect(classifyClientPerfScene('thornpeak_heights')).toBe('overworld');
+  });
+
+  it('sends the ingest defaults to other and any string to a fixed class', () => {
+    expect(classifyClientPerfScene('')).toBe('other');
+    expect(classifyClientPerfScene('gameplay')).toBe('other');
+    expect(classifyClientPerfScene('benchmark')).toBe('other');
+    for (const hostile of ['a'.repeat(80), 'dungeon', 'delve', 'zone with spaces']) {
+      expect(CLIENT_PERF_SCENE_CLASSES).toContain(classifyClientPerfScene(hostile));
+    }
+  });
+});
+
+describe('vocabulary pins', () => {
+  it('keeps the suggestion catalog equal to the ingest allowlist', () => {
+    expect([...CLIENT_PERF_SUGGESTION_IDS]).toEqual([
+      ...perfReportInternalsForTest.KNOWN_PERF_SUGGESTION_IDS,
+    ]);
+  });
+
+  it('pins the label vocabularies as literals', () => {
+    expect([...CLIENT_PERF_GFX_TIERS]).toEqual(['low', 'medium', 'high', 'ultra', 'insane']);
+    expect([...CLIENT_PERF_DEVICE_CLASSES]).toEqual(['desktop', 'mobile']);
+    expect([...CLIENT_PERF_GPU_FAMILIES]).toEqual([
+      'nvidia',
+      'amd',
+      'intel-igpu',
+      'apple',
+      'software',
+      'other',
+    ]);
+    expect([...CLIENT_PERF_OS_FAMILIES]).toEqual([
+      'windows',
+      'macos',
+      'linux',
+      'ios',
+      'android',
+      'other',
+    ]);
+    expect([...CLIENT_PERF_SCENE_CLASSES]).toEqual([
+      'overworld',
+      'dungeon',
+      'delve',
+      'battleground',
+      'arena',
+      'yumi_maze',
+      'rift',
+      'instance',
+      'other',
+    ]);
+    expect(CLIENT_PERF_JANK_THRESHOLD_MS).toBe(250);
+  });
+
+  it('pins the histogram bucket edges as literals', () => {
+    // The edges are the exporter's public contract: an edit silently rewrites
+    // every dashboard quantile, so a change must be deliberate here too.
+    expect([...CLIENT_PERF_FRAME_P95_BUCKETS_SECONDS]).toEqual([
+      0.0125, 0.0167, 0.02, 0.025, 0.0334, 0.05, 0.0834, 0.125, 0.25,
+    ]);
+    expect([...CLIENT_PERF_WORST10S_BUCKETS_SECONDS]).toEqual([
+      0.0334, 0.05, 0.0667, 0.0834, 0.125, 0.25,
+    ]);
+    expect([...CLIENT_PERF_FPS_AVG_BUCKETS]).toEqual([10, 15, 20, 25, 30, 40, 50, 60, 90, 120]);
+    expect([...CLIENT_PERF_LONG_TASK_BUCKETS_SECONDS]).toEqual([
+      0.05, 0.1, 0.2, 0.35, 0.5, 1, 2, 5,
+    ]);
+    expect([...CLIENT_PERF_RENDER_SCALE_BUCKETS]).toEqual([0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]);
+  });
+});
+
+describe('registerClientPerfMetrics', () => {
+  it('exposes a stored gameplay report under the pinned names and labels', async () => {
+    const registry = new Registry();
+    const sink = registerClientPerfMetrics(registry);
+
+    sink.perfReportStored(
+      sample({ contextLostCount: 2, suggestionIds: ['browser-stalls', 'integrated-gpu'] }),
+    );
+
+    const text = await registry.metrics();
+    expect(
+      value(
+        text,
+        /^woc_client_reports_total\{gfx_tier="high",device="desktop",gpu_family="nvidia"\} (\d+)$/m,
+      ),
+    ).toBe(1);
+    expect(
+      value(
+        text,
+        /^woc_client_frame_p95_seconds_sum\{gfx_tier="high",device="desktop"\} ([\d.]+)$/m,
+      ),
+    ).toBeCloseTo(0.0334, 5);
+    expect(
+      value(text, /^woc_client_fps_avg_sum\{gfx_tier="high",device="desktop"\} ([\d.]+)$/m),
+    ).toBe(48);
+    expect(
+      value(
+        text,
+        /^woc_client_worst10s_frame_p95_seconds_sum\{scene="overworld",device="desktop"\} ([\d.]+)$/m,
+      ),
+    ).toBeCloseTo(0.0667, 5);
+    expect(value(text, /^woc_client_long_task_p95_seconds_sum\{gfx_tier="high"\} ([\d.]+)$/m)).toBe(
+      0.12,
+    );
+    expect(
+      value(text, /^woc_client_effective_render_scale_sum\{gfx_tier="high"\} ([\d.]+)$/m),
+    ).toBeCloseTo(0.85, 5);
+    expect(value(text, /^woc_client_context_losses_total\{os="windows"\} (\d+)$/m)).toBe(2);
+    expect(
+      value(text, /^woc_client_suggestions_total\{suggestion="browser-stalls"\} (\d+)$/m),
+    ).toBe(1);
+    expect(
+      value(text, /^woc_client_suggestions_total\{suggestion="integrated-gpu"\} (\d+)$/m),
+    ).toBe(1);
+  });
+
+  it('counts jank exactly at the client clamp threshold', async () => {
+    const registry = new Registry();
+    const sink = registerClientPerfMetrics(registry);
+
+    sink.perfReportStored(sample({ worst10sFrameP95Ms: CLIENT_PERF_JANK_THRESHOLD_MS - 0.1 }));
+    sink.perfReportStored(sample({ worst10sFrameP95Ms: CLIENT_PERF_JANK_THRESHOLD_MS }));
+
+    const text = await registry.metrics();
+    expect(
+      value(text, /^woc_client_jank_reports_total\{gfx_tier="high",device="desktop"\} (\d+)$/m),
+    ).toBe(1);
+  });
+
+  it('keeps non-finite and negative numerics out of the series', async () => {
+    // These fields arrive clamped from the ingest; the defenses exist for a
+    // direct caller, and a NaN reaching a histogram would poison its _sum.
+    const registry = new Registry();
+    const sink = registerClientPerfMetrics(registry);
+
+    sink.perfReportStored(
+      sample({
+        fpsAvg: Number.NaN,
+        frameP95Ms: Number.POSITIVE_INFINITY,
+        longTaskP95Ms: Number.NEGATIVE_INFINITY,
+        effectiveRenderScale: Number.NaN,
+        worst10sFrameP95Ms: Number.NaN,
+        contextLostCount: -3,
+      }),
+    );
+
+    const text = await registry.metrics();
+    expect(text).not.toMatch(/NaN|Infinity/);
+    expect(
+      value(text, /^woc_client_fps_avg_sum\{gfx_tier="high",device="desktop"\} ([\d.]+)$/m),
+    ).toBe(0);
+    // Infinity is floored to zero, not observed at the top bucket.
+    expect(
+      value(
+        text,
+        /^woc_client_frame_p95_seconds_sum\{gfx_tier="high",device="desktop"\} ([\d.]+)$/m,
+      ),
+    ).toBe(0);
+    // A NaN worst-10s cannot satisfy the jank threshold.
+    expect(text).not.toMatch(/^woc_client_jank_reports_total\{/m);
+    // A negative loss count never decrements the counter.
+    expect(text).not.toMatch(/^woc_client_context_losses_total\{/m);
+  });
+
+  it('skips benchmark-source reports entirely', async () => {
+    const registry = new Registry();
+    const sink = registerClientPerfMetrics(registry);
+
+    sink.perfReportStored(sample({ source: 'benchmark', zoneOrScenario: 'benchmark' }));
+
+    const text = await registry.metrics();
+    expect(text).not.toMatch(/^woc_client_reports_total\{/m);
+  });
+
+  it('never mints labels outside the vocabularies for hostile field values', async () => {
+    const registry = new Registry();
+    const sink = registerClientPerfMetrics(registry);
+
+    sink.perfReportStored(
+      sample({
+        gfxTier: 'god-mode',
+        osFamily: 'templeos',
+        glRendererBucket: 'quantum-9000',
+        zoneOrScenario: 'z'.repeat(80),
+        mobileTouch: true,
+        contextLostCount: 1,
+        suggestionIds: ['not-a-real-suggestion'],
+      }),
+    );
+
+    const text = await registry.metrics();
+    // Unknown tier falls back to the ingest's own 'low' fallback, unknown GPU
+    // to 'other', unknown OS to 'other', and a bare unknown zone reads as
+    // overworld; the invented suggestion id is dropped.
+    expect(
+      value(
+        text,
+        /^woc_client_reports_total\{gfx_tier="low",device="mobile",gpu_family="other"\} (\d+)$/m,
+      ),
+    ).toBe(1);
+    expect(value(text, /^woc_client_context_losses_total\{os="other"\} (\d+)$/m)).toBe(1);
+    expect(text).not.toMatch(/god-mode|templeos|quantum-9000|zzzz|not-a-real-suggestion/);
+  });
+});
+
+describe('perf-report ingest emission', () => {
+  const VALID_IP_A = '203.0.113.77';
+
+  function fakeReq(body: unknown, remoteAddress: string) {
+    const req: any = new EventEmitter();
+    req.method = 'POST';
+    req.url = '/api/perf-report';
+    req.headers = { 'user-agent': 'Mozilla/5.0 (Windows NT 10.0) Chrome/126.0' };
+    req.socket = { remoteAddress };
+    req.destroy = vi.fn();
+    setImmediate(() => {
+      req.emit('data', JSON.stringify(body));
+      req.emit('end');
+    });
+    return req;
+  }
+
+  function fakeRes() {
+    const res: any = {
+      statusCode: 0,
+      body: null as any,
+      writeHead(status: number) {
+        this.statusCode = status;
+      },
+      end(data?: string) {
+        this.body = data ? JSON.parse(data) : null;
+      },
+    };
+    return res;
+  }
+
+  it('emits through the slot only for rows that were stored', async () => {
+    const stored: ClientPerfSample[] = [];
+    setClientPerfMetricsSink({
+      perfReportStored(row) {
+        stored.push(row);
+      },
+    });
+    const body = {
+      sessionId: 'emit-test-session',
+      gfxTier: 'ultra',
+      fpsAvg: 42,
+      frameP95Ms: 40,
+      worst10sFrameP95Ms: 250,
+      zoneOrScenario: 'dungeon:sunken_bastion',
+    };
+
+    await handlePerfReport(fakeReq(body, VALID_IP_A), fakeRes());
+    // Same session immediately again: the per-session insert throttle rejects
+    // it before storage, so the slot must not fire a second time.
+    await handlePerfReport(fakeReq(body, VALID_IP_A), fakeRes());
+
+    expect(insertClientPerfReport).toHaveBeenCalledTimes(1);
+    expect(stored).toHaveLength(1);
+    expect(stored[0].gfxTier).toBe('ultra');
+    expect(stored[0].zoneOrScenario).toBe('dungeon:sunken_bastion');
+    expect(stored[0].worst10sFrameP95Ms).toBe(250);
+  });
+
+  it('holds the no-op sink by default so an unwired ingest never throws', () => {
+    expect(clientPerfMetricsSink()).toBe(noopClientPerfMetricsSink);
+    expect(() => clientPerfMetricsSink().perfReportStored(sample())).not.toThrow();
+  });
+});

--- a/tests/server/http/client_perf_metrics.test.ts
+++ b/tests/server/http/client_perf_metrics.test.ts
@@ -165,9 +165,9 @@ describe('vocabulary pins', () => {
       0.0334, 0.05, 0.0667, 0.0834, 0.125, 0.25,
     ]);
     expect([...CLIENT_PERF_FPS_AVG_BUCKETS]).toEqual([10, 15, 20, 25, 30, 40, 50, 60, 90, 120]);
-    expect([...CLIENT_PERF_LONG_TASK_BUCKETS_SECONDS]).toEqual([
-      0.05, 0.1, 0.2, 0.35, 0.5, 1, 2, 5,
-    ]);
+    // Top edge at the ingest's 1000ms longTaskP95Ms clamp: a higher edge is
+    // unreachable and would pin a lie into the contract.
+    expect([...CLIENT_PERF_LONG_TASK_BUCKETS_SECONDS]).toEqual([0.05, 0.1, 0.2, 0.35, 0.5, 1]);
     expect([...CLIENT_PERF_RENDER_SCALE_BUCKETS]).toEqual([0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]);
   });
 });
@@ -247,6 +247,16 @@ describe('registerClientPerfMetrics', () => {
         contextLostCount: -3,
       }),
     );
+    // A negative finite value must not subtract from a monotone _sum, and an
+    // Infinity worst-10s must not satisfy the jank threshold while its
+    // histogram observes zero: the compare runs on the sanitized value.
+    sink.perfReportStored(
+      sample({
+        frameP95Ms: -50,
+        worst10sFrameP95Ms: Number.POSITIVE_INFINITY,
+        fpsAvg: -10,
+      }),
+    );
 
     const text = await registry.metrics();
     expect(text).not.toMatch(/NaN|Infinity/);
@@ -260,13 +270,13 @@ describe('registerClientPerfMetrics', () => {
         /^woc_client_frame_p95_seconds_sum\{gfx_tier="high",device="desktop"\} ([\d.]+)$/m,
       ),
     ).toBe(0);
-    // A NaN worst-10s cannot satisfy the jank threshold (the series exists at
-    // its primed zero).
+    // Neither a NaN nor an Infinity worst-10s satisfies the jank threshold
+    // (the series exists at its primed zero).
     expect(
       value(text, /^woc_client_jank_reports_total\{gfx_tier="high",device="desktop"\} (\d+)$/m),
     ).toBe(0);
-    // A negative loss count never decrements the counter.
-    expect(text).not.toMatch(/^woc_client_context_losses_total\{/m);
+    // A negative loss count never decrements the primed counter.
+    expect(value(text, /^woc_client_context_losses_total\{os="windows"\} (\d+)$/m)).toBe(0);
   });
 
   it('never throws on a malformed direct-caller sample', () => {
@@ -280,12 +290,14 @@ describe('registerClientPerfMetrics', () => {
     ).not.toThrow();
   });
 
-  it('pre-registers the counter cross products at zero so ratios read 0%', async () => {
+  it('zero-backfills the whole family at registration', async () => {
     const registry = new Registry();
     registerClientPerfMetrics(registry);
 
     const text = await registry.metrics();
-    // Both jank-share arms exist before any report; the histograms stay lazy.
+    // Every counter cross product and every histogram series exists from
+    // boot (the exporter's backfill design), so increase()/rate() see the
+    // first post-deploy increment and the jank share reads 0%, not "no data".
     expect(
       value(
         text,
@@ -295,9 +307,22 @@ describe('registerClientPerfMetrics', () => {
     expect(
       value(text, /^woc_client_jank_reports_total\{gfx_tier="low",device="desktop"\} (\d+)$/m),
     ).toBe(0);
-    expect(text).not.toMatch(/^woc_client_frame_p95_seconds_count\{/m);
-    expect(text).not.toMatch(/^woc_client_context_losses_total\{/m);
-    expect(text).not.toMatch(/^woc_client_suggestions_total\{/m);
+    expect(
+      value(
+        text,
+        /^woc_client_frame_p95_seconds_count\{gfx_tier="ultra",device="desktop"\} (\d+)$/m,
+      ),
+    ).toBe(0);
+    expect(
+      value(
+        text,
+        /^woc_client_worst10s_frame_p95_seconds_count\{scene="rift",device="mobile"\} (\d+)$/m,
+      ),
+    ).toBe(0);
+    expect(value(text, /^woc_client_context_losses_total\{os="linux"\} (\d+)$/m)).toBe(0);
+    expect(value(text, /^woc_client_suggestions_total\{suggestion="context-loss"\} (\d+)$/m)).toBe(
+      0,
+    );
   });
 
   it('skips benchmark-source reports entirely', async () => {
@@ -307,15 +332,19 @@ describe('registerClientPerfMetrics', () => {
     sink.perfReportStored(sample({ source: 'benchmark', zoneOrScenario: 'benchmark' }));
 
     const text = await registry.metrics();
-    // The report's own cohort counter stays at its primed zero and no
-    // histogram series appears for it.
+    // Every series stays at its backfilled zero: nothing was observed.
     expect(
       value(
         text,
         /^woc_client_reports_total\{gfx_tier="high",device="desktop",gpu_family="nvidia"\} (\d+)$/m,
       ),
     ).toBe(0);
-    expect(text).not.toMatch(/^woc_client_frame_p95_seconds_count\{/m);
+    expect(
+      value(
+        text,
+        /^woc_client_frame_p95_seconds_count\{gfx_tier="high",device="desktop"\} (\d+)$/m,
+      ),
+    ).toBe(0);
   });
 
   it('never mints labels outside the vocabularies for hostile field values', async () => {


### PR DESCRIPTION
## Summary

The /api/perf-report beacons every client already sends landed only in the client_perf_reports table, so fleet frame health was answerable only by SQL on the production database. This PR distills those stored reports into a bounded woc_client_* Prometheus series family on the existing /metrics exporter, so frame health is visible in Grafana (dashboards, alerting, PromQL) without database access.

New module server/http/client_perf_metrics.ts, following the game_signals process-wide slot pattern:

- Counters: woc_client_reports_total (gfx_tier x device x gpu_family), woc_client_jank_reports_total (reports whose worst-10s frame p95 reached the client's 250ms clamp), woc_client_context_losses_total (by OS), woc_client_suggestions_total (perf-doctor ids)
- Histograms: frame p95 and average fps (gfx_tier x device), worst-10s frame p95 (scene class x device), main-thread long-task p95 and effective render scale (gfx_tier)

Design points:

- Cardinality is bounded by design: every label value comes from a fixed vocabulary. The two ingest fields that are NOT bounded upstream (zone_or_scenario free text, the open-ended gl_renderer_bucket slug fallback) are collapsed through classifier allowlists with explicit fallbacks, so a hand-rolled beacon can never mint series. Nothing per-player, per-session, or per-device is ever a label.
- The scene classifier covers every token the client's telemetryZoneId emits (overworld ids, dungeon:/delve: prefixes, arena, yumi_maze, battleground, rift, instance), pinned against the real client function by tests/client_perf_scene_parity.test.ts (the perf_suggestion_id_parity pattern).
- Emission happens in server/perf_report.ts after the row insert, behind the existing rate limiter and per-session throttle, so the series stay 1:1 with stored rows; benchmark-source reports are skipped.
- Histogram bucket edges are exported and pinned as part of the exporter contract.
- DEPLOY.md documents the family, including the client-attested caveat (the beacon is public; corroborate surprising shifts against the table).

## Type of change

- [x] Feature: new functionality

## How was this tested?

- Commands: GATE_SELECT_BASE=origin/release/v0.41.0 node scripts/gate_select.mjs (PASS, all 12 steps); npx vitest run tests/server/http/client_perf_metrics.test.ts tests/client_perf_scene_parity.test.ts tests/world_telemetry.test.ts tests/perf_report.test.ts tests/server/http/game_metrics.test.ts tests/game_state_metrics.test.ts tests/server/game_boot_order.test.ts; npx tsc --noEmit; Biome on changed files.
- Manual steps: none required; series appear on /metrics after the first stored gameplay report.

## Checklist

### Quality

- [x] **The gate passes.** node scripts/gate_select.mjs is green; new tests cover the classifiers (including hostile inputs and non-finite numerics), the vocabulary and bucket pins, the exposition names and labels, the jank threshold, the benchmark skip, and the only-stored-rows emission contract.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or .env committed, and ALLOW_DEV_COMMANDS is not enabled in any production path.
- [x] No generated files hand-edited.