### PR TITLE
test(render): pin the single writer of the render-side sheathe cache

### DIFF
--- a/tests/weapon_stow_single_writer.test.ts
+++ b/tests/weapon_stow_single_writer.test.ts
@@ -1,0 +1,104 @@
+// `EntityView.weaponStowed` is a LAST-RENDERED cache, diffed to decide when to
+// play the sheathe gesture. It must have exactly one writer in the per-entity
+// loop, and that writer must be the stow overlay: the union of the sim's Z-key
+// bit with the swim latch (and, since the mounts landed, with riding).
+//
+// The failure this pins is not obvious from either diff on its own. With two
+// diffs against the same field computing different targets, a swimmer holding a
+// drawn weapon (`e.weaponStowed === false`, `swimming === true`) has the first
+// write `false` and the second write `true` on every single frame. Each write
+// is a genuine target change, so `requestStow` replays the sheathe one-shot
+// forever; `CharacterVisual.currentIsOneShot` never clears, and the base-state
+// machine's `baseChanged && !this.currentIsOneShot` gate then suppresses every
+// fade. The state machine still latches swim/swimSurface/swimIdle correctly and
+// the authored clips are all bound — nothing ever fades in, and the rig sits
+// frozen a third of a second into the sheathe gesture (for a player rig that
+// clip is 1H_Melee_Attack_Chop) for as long as the swim lasts.
+//
+// It has regressed twice: the swimming PR removed the older Z-key diff, and two
+// later release merges resurrected it (one parent carrying the deletion, the
+// other the untouched lines), which is a shape no reviewer sees in a diff. The
+// deletion is on the release line for the third time; this file is what keeps
+// it there.
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import {
+  createStowTransition,
+  requestStow,
+  tickStow,
+} from '../src/render/characters/stow_transition';
+import { stripComments } from './helpers/strip_comments';
+
+// Comments stripped so header prose quoting `.setWeaponStowed(` or
+// `v.weaponStowed = ` can neither satisfy nor red these pins.
+const rendererSource = stripComments(
+  readFileSync(new URL('../src/render/renderer.ts', import.meta.url), 'utf8'),
+);
+
+describe('the weapon stow overlay is the single writer of the render-side cache', () => {
+  it('drives the sheathe gesture from exactly one call site', () => {
+    const calls = rendererSource.match(/\.setWeaponStowed\(/g) ?? [];
+    expect(calls).toHaveLength(1);
+    expect(rendererSource).toMatch(/v\.visual\.setWeaponStowed\(stowed\)/);
+  });
+
+  it('feeds that call the union of the sim bit and the swim latch', () => {
+    // Either spelling of the overlay is fine: the inline union, or the pure
+    // `weaponStowedOverlay(e.weaponStowed, swimming, ...)` helper it may be
+    // extracted into. What matters is that the sim bit and the swim latch are
+    // combined BEFORE the one diff, never diffed separately.
+    expect(rendererSource).toMatch(
+      /const stowed = (?:e\.weaponStowed \|\| swimming|weaponStowedOverlay\(e\.weaponStowed, swimming)/,
+    );
+  });
+
+  it('has no second diff against the bare sim bit', () => {
+    expect(rendererSource).not.toMatch(/if \(e\.weaponStowed !== v\.weaponStowed\)/);
+    // One reset (`= false`) on the pooled-visual swap path plus the overlay's
+    // own write. A third assignment is a second writer by another name.
+    const writes = rendererSource.match(/v\.weaponStowed = /g) ?? [];
+    expect(writes).toHaveLength(2);
+  });
+});
+
+// Why one writer, played out on the real transition module: the renderer's diff
+// is what feeds `requestStow`, so two targets per frame are two requests.
+describe('the sheathe transition under a per-frame stow request', () => {
+  const SWAP_DELAY = 0.31; // the player rig's gesture midpoint, near enough
+  const DT = 1 / 60;
+
+  it('never lands the swap when two writers disagree every frame', () => {
+    const t = createStowTransition();
+    let gestureReplays = 0;
+    let swaps = 0;
+    // A swimmer with a weapon drawn: the bare sim bit says false, the swim
+    // overlay says true, and both are applied on every frame.
+    for (let frame = 0; frame < 600; frame++) {
+      for (const target of [false, true]) {
+        if (requestStow(t, target, SWAP_DELAY)) gestureReplays++;
+      }
+      if (tickStow(t, DT) === 'swap') swaps++;
+    }
+    // Ten seconds of swimming: the one-shot is replayed twice on every frame
+    // (which is what pins currentIsOneShot true), and the gesture never
+    // completes. Two per frame less the very first request, which happens to
+    // match the transition's initial target.
+    expect(gestureReplays).toBe(600 * 2 - 1);
+    expect(swaps).toBe(0);
+    expect(t.attached).toBe(false);
+  });
+
+  it('lands it once, and settles, with the single overlay writer', () => {
+    const t = createStowTransition();
+    let gestureReplays = 0;
+    let swaps = 0;
+    for (let frame = 0; frame < 600; frame++) {
+      if (requestStow(t, true, SWAP_DELAY)) gestureReplays++;
+      if (tickStow(t, DT) === 'swap') swaps++;
+    }
+    expect(gestureReplays).toBe(1);
+    expect(swaps).toBe(1);
+    expect(t.attached).toBe(true);
+    expect(t.timer).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Swimming and diving played **no stroke at all** while the weapon was drawn. The body froze
about a third of a second into a sword-chop windup and held it for the whole swim: on the
surface, underwater, and while treading. Nothing in the swim lane was at fault.
`EntityView.weaponStowed` is a last-rendered cache, diffed to decide when to play the sheathe
gesture, and it had **two writers computing different targets** in the same per-entity loop of
`renderer.ts`:

- the older Z-key diff against the bare sim bit — `if (e.weaponStowed !== v.weaponStowed)`
- the stow overlay's union with the swim latch — `const stowed = e.weaponStowed || swimming`

A swimmer holding a drawn weapon makes them disagree permanently: the first writes `false`, the
second `true`, on every frame. Each write is a genuine target change, so `requestStow` replays
the sheathe one-shot and re-arms its swap timer every frame. The gesture never lands,
`CharacterVisual.currentIsOneShot` never clears, and the base-state machine's
`baseChanged && !this.currentIsOneShot` gate suppresses every fade. The state machine still
latches `swim`/`swimSurface`/`swimIdle` correctly and all four water clips are bound; they
simply never fade in.

**Retargeted at `release/v0.42.0`, and now test-only.** The renderer deletion this PR originally
carried is already on the release line: it rode in with the mount work (#3439 carries the
Lanternback Troll commit `ea13d3d82e`, which removed the older diff and folded riding into the
same overlay), so `release/v0.42.0` has one writer today. #3727 on the v0.42 candidate extracts
that overlay into `weaponStowedOverlay(...)` and pins the mount half.

What is left, and what this PR is now, is the **swim-side regression pin**:
`tests/weapon_stow_single_writer.test.ts`, one new file, no `src/` change.

- A source pin on `renderer.ts` (comments stripped via `tests/helpers/strip_comments`):
  exactly one `.setWeaponStowed(` call site, no `if (e.weaponStowed !== v.weaponStowed)` diff,
  and exactly two `v.weaponStowed = ` assignments (the pooled-visual reset plus the overlay's
  own write). It accepts either spelling of the overlay, the inline union or the extracted
  `weaponStowedOverlay(e.weaponStowed, swimming, ...)` helper, so it is green both on
  `release/v0.42.0` as it stands and on the candidate with #3727 integrated.
- A behavioural pair on the real `stow_transition` module: two conflicting per-frame requests
  replay the gesture twice per frame and never land the swap (`swaps === 0`, `attached` stays
  `false` over ten seconds), where one writer lands it once and settles (`attached: true`,
  `timer: 0`).

## Related issues

Release tracker: #3780. Related: #3727 (mount half of the same single-writer defect, on the
candidate). Supersedes #3395.

## Type of change

- [ ] Feature: new functionality
- [ ] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `node scripts/gate_select.mjs` on this head, on top of `release/v0.42.0` at `1fdf0f55a3`.
  - `npx vitest run tests/weapon_stow_single_writer.test.ts` — 5/5 green.
  - Decisiveness: re-inserting the older Z-key diff into `renderer.ts` reds two of the three
    source pins (`drives the sheathe gesture from exactly one call site`,
    `has no second diff against the bare sim bit`); removing it again restores green.
  - The same source regexes were dry-run against the `ossbrain-release/v0.42.0` head
    (`c8af1202e6`, with #3727's `weaponStowedOverlay(...)` shape): one call site, overlay
    matched, no second diff, two writes. The pin does not red the candidate.
- Manual steps (from the original fix, measured headless at the deepest built-in lake
  (165, 1103) with a drawn weapon, reading the live mixer off `renderer.views.get(id).visual`):

  | state | two writers | one writer |
  |---|---|---|
  | dive + forward | `swim` / `1H_Melee_Attack_Chop` @1.00, every `Swim_*` action `isRunning() === false` | `swim` / **`Swim_Breaststroke`** @1.00, alone |
  | surface + forward | `swimSurface` / `1H_Melee_Attack_Chop` @1.00 | `swimSurface` / **`Swim_Freestyle`** @1.00, alone |
  | stopped | `swimIdle` / `1H_Melee_Attack_Chop` @1.00 | `swimIdle` / **`Swim_Tread`** @1.00, alone |
  | entry gesture | `stow.timer` re-armed every frame, `attached` never flips | completes: `attached: true`, `timer: 0` |

## Screenshots / recordings

N/A for this revision (test-only). The frozen pose is a sword-chop windup: body upright, weapon
in hand, while the state machine reports `swimSurface`/`swim`/`swimIdle`.

---

## Checklist

### Quality

- [x] **The gate passes.** `node scripts/gate_select.mjs` is green on this head.

### Cross-platform

- [x] N/A — no UI surface, no runtime change; one test file.
- [x] **Accessible.** N/A, no UI added or edited.

### Localization (i18n)

- [x] N/A. No player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled
      in any production path.
- [x] I didn't hand-edit generated files. `renderer.ts` is untouched in this revision, so no
      Eastbrook provenance re-mint is needed.

---

Note for reviewers: this is the third time the deletion has reached a release line. The
swimming PR removed the older diff, and two later release merges resurrected it, one parent
carrying the deletion and the other the untouched lines, which is a shape no reviewer sees in a
diff. That is what this test is for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
