### PR TITLE
feat(desktop): notify on ready check while the player is away

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -1110,7 +1110,7 @@ ipcMain.handle('desktop-show-notification', (event, payload) => {
   if (!trustedSender(event)) return false;
   if (!payload || typeof payload !== 'object') return false;
   const kind = payload.kind;
-  if (kind !== 'update-ready' && kind !== 'party-invite') return false;
+  if (kind !== 'update-ready' && kind !== 'party-invite' && kind !== 'ready-check') return false;
   if (typeof payload.title !== 'string' || typeof payload.body !== 'string') return false;
   const title = clampText(payload.title, 120);
   const body = clampText(payload.body, 240);

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -198,7 +198,7 @@ contextBridge.exposeInMainWorld('wocDesktop', {
     ipcRenderer.invoke('desktop-gamepad-activity').catch(() => {});
   },
   // An OS notification, with both strings already rendered by the renderer's
-  // t(). Refused here unless it is one of the two kinds main will accept, and
+  // t(). Refused here unless it is one of the kinds main will accept, and
   // rebuilt into a fresh object so no renderer prototype crosses the bridge,
   // pre-capped so a hostile page cannot ship unbounded strings across the IPC
   // (main re-clamps to the visible 120/240 without trusting these caps).
@@ -208,7 +208,7 @@ contextBridge.exposeInMainWorld('wocDesktop', {
   showNotification: (payload) => {
     if (!payload || typeof payload !== 'object') return;
     const kind = payload.kind;
-    if (kind !== 'update-ready' && kind !== 'party-invite') return;
+    if (kind !== 'update-ready' && kind !== 'party-invite' && kind !== 'ready-check') return;
     if (typeof payload.title !== 'string' || typeof payload.body !== 'string') return;
     const message = { kind, title: payload.title.slice(0, 512), body: payload.body.slice(0, 1024) };
     try {

--- a/src/game/desktop_notifications.ts
+++ b/src/game/desktop_notifications.ts
@@ -1,7 +1,7 @@
 // OS notifications posted through the desktop shell: the player alt-tabbed away
 // (or minimized the window) and something happened that is worth pulling them
-// back for. Two triggers today: a downloaded update becoming restart-ready, and
-// an incoming party invite.
+// back for. Three triggers today: a downloaded update becoming restart-ready,
+// an incoming party invite, and the party leader starting a ready check.
 //
 // Lives in src/game so main.ts stays a firewall and so the decision half stays
 // DOM-free and directly Node-testable (tests/desktop_notifications.test.ts).
@@ -21,6 +21,7 @@ import { desktopPresentationHidden } from './desktop_presentation';
 
 export interface DesktopNotifyCore {
   partyInvite(event: SimEvent, localPid: number): { name: string } | null;
+  readyCheckStart(event: SimEvent, localPid: number): { name: string } | null;
   updateReady(
     prevMode: UpdateToastState['mode'],
     state: UpdateToastState,
@@ -45,6 +46,13 @@ export function createDesktopNotifyCore(): DesktopNotifyCore {
       // (src/sim/social/party.ts): offline it equals the local player's id,
       // online the server routes each event to its addressee. The undefined
       // arm is shape robustness, not the offline case.
+      if (event.pid !== undefined && event.pid !== localPid) return null;
+      return { name: event.fromName };
+    },
+    readyCheckStart(event, localPid) {
+      if (event.type !== 'readyCheckStart') return null;
+      // Same addressing gate as partyInvite: the sim stamps each member's pid
+      // (src/sim/social/ready_check.ts) and never emits to the leader.
       if (event.pid !== undefined && event.pid !== localPid) return null;
       return { name: event.fromName };
     },
@@ -136,22 +144,32 @@ export function initDesktopNotifications(bridge: DesktopBridge): void {
 /**
  * Scan one frame's sim events for anything worth a notification. Called from
  * the frame path in both modes, so it early-outs before touching anything and
- * allocates only on a matching invite, never on the empty-batch or no-match
- * frames. (tests/client_frame_allocations.test.ts scans the caller, src/main.ts
- * frame(), not this module; the per-match allocation here is the notification
- * itself, off the steady-state path.)
- * Deliberately unthrottled: each invite is a discrete act by another player.
+ * allocates only on a matching invite or ready check, never on the empty-batch
+ * or no-match frames. (tests/client_frame_allocations.test.ts scans the caller,
+ * src/main.ts frame(), not this module; the per-match allocation here is the
+ * notification itself, off the steady-state path.)
+ * Deliberately unthrottled: each match is a discrete act by another player.
  */
 export function desktopNotifyOnSimEvents(events: readonly SimEvent[], localPid: number): void {
   if (send === null || core === null || events.length === 0) return;
   for (let i = 0; i < events.length; i++) {
     const invite = core.partyInvite(events[i], localPid);
-    if (invite === null) continue;
+    if (invite !== null) {
+      if (!playerIsAway()) continue;
+      send({
+        kind: 'party-invite',
+        title: t('desktop.notify.partyInviteTitle'),
+        body: t('desktop.notify.partyInviteBody', { name: invite.name }),
+      });
+      continue;
+    }
+    const readyCheck = core.readyCheckStart(events[i], localPid);
+    if (readyCheck === null) continue;
     if (!playerIsAway()) continue;
     send({
-      kind: 'party-invite',
-      title: t('desktop.notify.partyInviteTitle'),
-      body: t('desktop.notify.partyInviteBody', { name: invite.name }),
+      kind: 'ready-check',
+      title: t('desktop.notify.readyCheckTitle'),
+      body: t('desktop.notify.readyCheckBody', { name: readyCheck.name }),
     });
   }
 }

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -60,7 +60,7 @@ export interface DesktopUpdateEvent {
 // (coalescing, click routing) off it, and the two strings arrive already
 // localized because the main process has no i18n runtime.
 export interface DesktopNotificationRequest {
-  kind: 'update-ready' | 'party-invite';
+  kind: 'update-ready' | 'party-invite' | 'ready-check';
   title: string;
   body: string;
 }

--- a/src/ui/i18n.catalog/shell.ts
+++ b/src/ui/i18n.catalog/shell.ts
@@ -148,6 +148,8 @@ export const shellStrings = {
         updateReadyBody: 'Restart World of ClaudeCraft to apply the update.',
         partyInviteTitle: 'Party invite',
         partyInviteBody: '{name} invited you to a party.',
+        readyCheckTitle: 'Ready check',
+        readyCheckBody: '{name} started a ready check.',
       },
       crash: {
         title: 'World of ClaudeCraft',

--- a/src/ui/i18n.catalog/translation_keys.generated.ts
+++ b/src/ui/i18n.catalog/translation_keys.generated.ts
@@ -784,6 +784,8 @@ export type TranslationKeyFlat =
   | 'desktop.crash.title'
   | 'desktop.notify.partyInviteBody'
   | 'desktop.notify.partyInviteTitle'
+  | 'desktop.notify.readyCheckBody'
+  | 'desktop.notify.readyCheckTitle'
   | 'desktop.notify.updateReadyBody'
   | 'desktop.notify.updateReadyTitle'
   | 'desktop.notify.updateReadyTitleNoVersion'

--- a/src/ui/i18n.locales/ja_JP.ts
+++ b/src/ui/i18n.locales/ja_JP.ts
@@ -8043,6 +8043,8 @@ export const ja_JP: Partial<Record<TranslationKey, string>> = {
   'desktop.notify.updateReadyBody': 'アップデートを適用するには World of ClaudeCraft を再起動してください。',
   'desktop.notify.partyInviteTitle': 'パーティ招待',
   'desktop.notify.partyInviteBody': '{name}があなたをパーティに招待しています。',
+  'desktop.notify.readyCheckTitle': '準備確認',
+  'desktop.notify.readyCheckBody': '{name}が準備確認を開始しました。',
   'desktop.crash.title': 'World of ClaudeCraft',
   'desktop.crash.body': 'ゲーム画面が停止しました。再読み込みしますか？',
   'desktop.crash.reload': '再読み込み',

--- a/src/ui/i18n.locales/ko_KR.ts
+++ b/src/ui/i18n.locales/ko_KR.ts
@@ -8033,6 +8033,8 @@ export const ko_KR: Partial<Record<TranslationKey, string>> = {
   'desktop.notify.updateReadyBody': '업데이트를 적용하려면 World of ClaudeCraft를 다시 시작하세요.',
   'desktop.notify.partyInviteTitle': '파티 초대',
   'desktop.notify.partyInviteBody': '{name}님이 파티에 초대했습니다.',
+  'desktop.notify.readyCheckTitle': '준비 확인',
+  'desktop.notify.readyCheckBody': '{name}님이 준비 확인을 시작했습니다.',
   'desktop.crash.title': 'World of ClaudeCraft',
   'desktop.crash.body': '게임 화면이 응답하지 않습니다. 다시 불러올까요?',
   'desktop.crash.reload': '다시 불러오기',

--- a/src/ui/i18n.locales/ru_RU.ts
+++ b/src/ui/i18n.locales/ru_RU.ts
@@ -8159,6 +8159,8 @@ export const ru_RU: Partial<Record<TranslationKey, string>> = {
   'desktop.notify.updateReadyBody': 'Перезапустите World of ClaudeCraft, чтобы применить обновление.',
   'desktop.notify.partyInviteTitle': 'Приглашение в группу',
   'desktop.notify.partyInviteBody': '{name} приглашает вас в группу.',
+  'desktop.notify.readyCheckTitle': 'Проверка готовности',
+  'desktop.notify.readyCheckBody': '{name} начал проверку готовности.',
   'desktop.crash.title': 'World of ClaudeCraft',
   'desktop.crash.body': 'Игровой экран перестал отвечать. Перезагрузить его?',
   'desktop.crash.reload': 'Перезагрузить',

--- a/src/ui/i18n.locales/zh_CN.ts
+++ b/src/ui/i18n.locales/zh_CN.ts
@@ -7736,6 +7736,8 @@ export const zh_CN: Partial<Record<TranslationKey, string>> = {
   'desktop.notify.updateReadyBody': '重启 World of ClaudeCraft 以应用更新。',
   'desktop.notify.partyInviteTitle': '组队邀请',
   'desktop.notify.partyInviteBody': '{name} 邀请你加入队伍。',
+  'desktop.notify.readyCheckTitle': '准备确认',
+  'desktop.notify.readyCheckBody': '{name} 发起了准备确认。',
   'desktop.crash.title': 'World of ClaudeCraft',
   'desktop.crash.body': '游戏画面已停止响应。要重新加载吗？',
   'desktop.crash.reload': '重新加载',

--- a/src/ui/i18n.locales/zh_TW.ts
+++ b/src/ui/i18n.locales/zh_TW.ts
@@ -7735,6 +7735,8 @@ export const zh_TW: Partial<Record<TranslationKey, string>> = {
   'desktop.notify.updateReadyBody': '重新啟動 World of ClaudeCraft 以套用更新。',
   'desktop.notify.partyInviteTitle': '組隊邀請',
   'desktop.notify.partyInviteBody': '{name} 邀請你加入隊伍。',
+  'desktop.notify.readyCheckTitle': '準備確認',
+  'desktop.notify.readyCheckBody': '{name} 發起了準備確認。',
   'desktop.crash.title': 'World of ClaudeCraft',
   'desktop.crash.body': '遊戲畫面已停止運作。要重新載入嗎？',
   'desktop.crash.reload': '重新載入',

--- a/src/ui/i18n.resolved.generated/cs_CZ.ts
+++ b/src/ui/i18n.resolved.generated/cs_CZ.ts
@@ -8331,7 +8331,9 @@ export const cs_CZ: EnTranslations = {
       "updateReadyTitleNoVersion": "Aktualizace je připravena",
       "updateReadyBody": "Restartuj World of ClaudeCraft, aby se aktualizace použila.",
       "partyInviteTitle": "Pozvánka do skupiny",
-      "partyInviteBody": "{name} tě pozval(a) do skupiny."
+      "partyInviteBody": "{name} tě pozval(a) do skupiny.",
+      "readyCheckTitle": "Ready check",
+      "readyCheckBody": "{name} started a ready check."
     },
     "crash": {
       "title": "World of ClaudeCraft",

--- a/src/ui/i18n.resolved.generated/da_DK.ts
+++ b/src/ui/i18n.resolved.generated/da_DK.ts
@@ -8331,7 +8331,9 @@ export const da_DK: EnTranslations = {
       "updateReadyTitleNoVersion": "Opdatering er klar",
       "updateReadyBody": "Genstart World of ClaudeCraft for at anvende opdateringen.",
       "partyInviteTitle": "Gruppeinvitation",
-      "partyInviteBody": "{name} inviterede dig til en gruppe."
+      "partyInviteBody": "{name} inviterede dig til en gruppe.",
+      "readyCheckTitle": "Ready check",
+      "readyCheckBody": "{name} started a ready check."
     },
     "crash": {
       "title": "World of ClaudeCraft",

--- a/src/ui/i18n.resolved.generated/de_DE.ts
+++ b/src/ui/i18n.resolved.generated/de_DE.ts
@@ -8331,7 +8331,9 @@ export const de_DE: EnTranslations = {
       "updateReadyTitleNoVersion": "Update ist bereit",
       "updateReadyBody": "Starte World of ClaudeCraft neu, um das Update zu übernehmen.",
       "partyInviteTitle": "Gruppeneinladung",
-      "partyInviteBody": "{name} hat dich zu einer Gruppe eingeladen."
+      "partyInviteBody": "{name} hat dich zu einer Gruppe eingeladen.",
+      "readyCheckTitle": "Ready check",
+      "readyCheckBody": "{name} started a ready check."
     },
     "crash": {
       "title": "World of ClaudeCraft",

--- a/src/ui/i18n.resolved.generated/en.ts
+++ b/src/ui/i18n.resolved.generated/en.ts
@@ -8331,7 +8331,9 @@ export const en: EnTranslations = {
       "updateReadyTitleNoVersion": "Update is ready",
       "updateReadyBody": "Restart World of ClaudeCraft to apply the update.",
       "partyInviteTitle": "Party invite",
-      "partyInviteBody": "{name} invited you to a party."
+      "partyInviteBody": "{name} invited you to a party.",
+      "readyCheckTitle": "Ready check",
+      "readyCheckBody": "{name} started a ready check."
     },
     "crash": {
       "title": "World of ClaudeCraft",

--- a/src/ui/i18n.resolved.generated/en_CA.ts
+++ b/src/ui/i18n.resolved.generated/en_CA.ts
@@ -8331,7 +8331,9 @@ export const en_CA: EnTranslations = {
       "updateReadyTitleNoVersion": "Update is ready",
       "updateReadyBody": "Restart World of ClaudeCraft to apply the update.",
       "partyInviteTitle": "Party invite",
-      "partyInviteBody": "{name} invited you to a party."
+      "partyInviteBody": "{name} invited you to a party.",
+      "readyCheckTitle": "Ready check",
+      "readyCheckBody": "{name} started a ready check."
     },
     "crash": {
       "title": "World of ClaudeCraft",

--- a/src/ui/i18n.resolved.generated/en_XA.ts
+++ b/src/ui/i18n.resolved.generated/en_XA.ts
@@ -8331,7 +8331,9 @@ export const en_XA: EnTranslations = {
       "updateReadyTitleNoVersion": "[Úþðáţé íš ŕéáðý]",
       "updateReadyBody": "[Ŕéšţáŕţ Ŵóŕļð óƒ ÇļáúðéÇŕáƒţ ţó áþþļý ţĥé úþðáţé.]",
       "partyInviteTitle": "[Þáŕţý íñʋíţé]",
-      "partyInviteBody": "[{name} íñʋíţéð ýóú ţó á þáŕţý.]"
+      "partyInviteBody": "[{name} íñʋíţéð ýóú ţó á þáŕţý.]",
+      "readyCheckTitle": "[Ŕéáðý çĥéçķ]",
+      "readyCheckBody": "[{name} šţáŕţéð á ŕéáðý çĥéçķ.]"
     },
     "crash": {
       "title": "[Ŵóŕļð óƒ ÇļáúðéÇŕáƒţ]",

--- a/src/ui/i18n.resolved.generated/es.ts
+++ b/src/ui/i18n.resolved.generated/es.ts
@@ -8331,7 +8331,9 @@ export const es: EnTranslations = {
       "updateReadyTitleNoVersion": "La actualización está lista",
       "updateReadyBody": "Reinicia World of ClaudeCraft para aplicar la actualización.",
       "partyInviteTitle": "Invitación de grupo",
-      "partyInviteBody": "{name} te invitó a un grupo."
+      "partyInviteBody": "{name} te invitó a un grupo.",
+      "readyCheckTitle": "Ready check",
+      "readyCheckBody": "{name} started a ready check."
     },
     "crash": {
       "title": "World of ClaudeCraft",

--- a/src/ui/i18n.resolved.generated/es_ES.ts
+++ b/src/ui/i18n.resolved.generated/es_ES.ts
@@ -8331,7 +8331,9 @@ export const es_ES: EnTranslations = {
       "updateReadyTitleNoVersion": "La actualización está lista",
       "updateReadyBody": "Reinicia World of ClaudeCraft para aplicar la actualización.",
       "partyInviteTitle": "Invitación de grupo",
-      "partyInviteBody": "{name} te invitó a un grupo."
+      "partyInviteBody": "{name} te invitó a un grupo.",
+      "readyCheckTitle": "Ready check",
+      "readyCheckBody": "{name} started a ready check."
     },
     "crash": {
       "title": "World of ClaudeCraft",

--- a/src/ui/i18n.resolved.generated/fr_CA.ts
+++ b/src/ui/i18n.resolved.generated/fr_CA.ts
@@ -8331,7 +8331,9 @@ export const fr_CA: EnTranslations = {
       "updateReadyTitleNoVersion": "La mise à jour est prête",
       "updateReadyBody": "Redémarrez World of ClaudeCraft pour appliquer la mise à jour.",
       "partyInviteTitle": "Invitation de groupe",
-      "partyInviteBody": "{name} vous invite à rejoindre son groupe."
+      "partyInviteBody": "{name} vous invite à rejoindre son groupe.",
+      "readyCheckTitle": "Ready check",
+      "readyCheckBody": "{name} started a ready check."
     },
     "crash": {
       "title": "World of ClaudeCraft",

--- a/src/ui/i18n.resolved.generated/fr_FR.ts
+++ b/src/ui/i18n.resolved.generated/fr_FR.ts
@@ -8331,7 +8331,9 @@ export const fr_FR: EnTranslations = {
       "updateReadyTitleNoVersion": "La mise à jour est prête",
       "updateReadyBody": "Redémarrez World of ClaudeCraft pour appliquer la mise à jour.",
       "partyInviteTitle": "Invitation de groupe",
-      "partyInviteBody": "{name} vous invite à rejoindre son groupe."
+      "partyInviteBody": "{name} vous invite à rejoindre son groupe.",
+      "readyCheckTitle": "Ready check",
+      "readyCheckBody": "{name} started a ready check."
     },
     "crash": {
       "title": "World of ClaudeCraft",

--- a/src/ui/i18n.resolved.generated/id_ID.ts
+++ b/src/ui/i18n.resolved.generated/id_ID.ts
@@ -8331,7 +8331,9 @@ export const id_ID: EnTranslations = {
       "updateReadyTitleNoVersion": "Pembaruan siap",
       "updateReadyBody": "Mulai ulang World of ClaudeCraft untuk menerapkan pembaruan.",
       "partyInviteTitle": "Undangan Kelompok",
-      "partyInviteBody": "{name} telah mengundangmu ke kelompoknya."
+      "partyInviteBody": "{name} telah mengundangmu ke kelompoknya.",
+      "readyCheckTitle": "Ready check",
+      "readyCheckBody": "{name} started a ready check."
     },
     "crash": {
       "title": "World of ClaudeCraft",

--- a/src/ui/i18n.resolved.generated/it_IT.ts
+++ b/src/ui/i18n.resolved.generated/it_IT.ts
@@ -8331,7 +8331,9 @@ export const it_IT: EnTranslations = {
       "updateReadyTitleNoVersion": "L'aggiornamento è pronto",
       "updateReadyBody": "Riavvia World of ClaudeCraft per applicare l'aggiornamento.",
       "partyInviteTitle": "Invito al gruppo",
-      "partyInviteBody": "{name} ti ha invitato a unirti al suo gruppo."
+      "partyInviteBody": "{name} ti ha invitato a unirti al suo gruppo.",
+      "readyCheckTitle": "Ready check",
+      "readyCheckBody": "{name} started a ready check."
     },
     "crash": {
       "title": "World of ClaudeCraft",

--- a/src/ui/i18n.resolved.generated/ja_JP.ts
+++ b/src/ui/i18n.resolved.generated/ja_JP.ts
@@ -8331,7 +8331,9 @@ export const ja_JP: EnTranslations = {
       "updateReadyTitleNoVersion": "アップデートの準備ができました",
       "updateReadyBody": "アップデートを適用するには World of ClaudeCraft を再起動してください。",
       "partyInviteTitle": "パーティ招待",
-      "partyInviteBody": "{name}があなたをパーティに招待しています。"
+      "partyInviteBody": "{name}があなたをパーティに招待しています。",
+      "readyCheckTitle": "準備確認",
+      "readyCheckBody": "{name}が準備確認を開始しました。"
     },
     "crash": {
       "title": "World of ClaudeCraft",

--- a/src/ui/i18n.resolved.generated/ko_KR.ts
+++ b/src/ui/i18n.resolved.generated/ko_KR.ts
@@ -8331,7 +8331,9 @@ export const ko_KR: EnTranslations = {
       "updateReadyTitleNoVersion": "업데이트 준비 완료",
       "updateReadyBody": "업데이트를 적용하려면 World of ClaudeCraft를 다시 시작하세요.",
       "partyInviteTitle": "파티 초대",
-      "partyInviteBody": "{name}님이 파티에 초대했습니다."
+      "partyInviteBody": "{name}님이 파티에 초대했습니다.",
+      "readyCheckTitle": "준비 확인",
+      "readyCheckBody": "{name}님이 준비 확인을 시작했습니다."
     },
     "crash": {
       "title": "World of ClaudeCraft",

--- a/src/ui/i18n.resolved.generated/nl_NL.ts
+++ b/src/ui/i18n.resolved.generated/nl_NL.ts
@@ -8331,7 +8331,9 @@ export const nl_NL: EnTranslations = {
       "updateReadyTitleNoVersion": "Update is klaar",
       "updateReadyBody": "Herstart World of ClaudeCraft om de update toe te passen.",
       "partyInviteTitle": "Groepsuitnodiging",
-      "partyInviteBody": "{name} heeft je uitgenodigd voor een groep."
+      "partyInviteBody": "{name} heeft je uitgenodigd voor een groep.",
+      "readyCheckTitle": "Ready check",
+      "readyCheckBody": "{name} started a ready check."
     },
     "crash": {
       "title": "World of ClaudeCraft",

--- a/src/ui/i18n.resolved.generated/pending.ts
+++ b/src/ui/i18n.resolved.generated/pending.ts
@@ -10,6 +10,8 @@
 
 export const pending: Record<string, readonly string[]> = {
   "es": [
+    "desktop.notify.readyCheckBody",
+    "desktop.notify.readyCheckTitle",
     "hudChrome.actionBar.conflictAccept",
     "hudChrome.actionBar.conflictBody",
     "hudChrome.actionBar.conflictTitle",
@@ -78,6 +80,8 @@ export const pending: Record<string, readonly string[]> = {
     "wallet.browser.stepUpBody"
   ],
   "es_ES": [
+    "desktop.notify.readyCheckBody",
+    "desktop.notify.readyCheckTitle",
     "hudChrome.actionBar.conflictAccept",
     "hudChrome.actionBar.conflictBody",
     "hudChrome.actionBar.conflictTitle",
@@ -146,6 +150,8 @@ export const pending: Record<string, readonly string[]> = {
     "wallet.browser.stepUpBody"
   ],
   "fr_FR": [
+    "desktop.notify.readyCheckBody",
+    "desktop.notify.readyCheckTitle",
     "hudChrome.actionBar.conflictAccept",
     "hudChrome.actionBar.conflictBody",
     "hudChrome.actionBar.conflictTitle",
@@ -214,6 +220,8 @@ export const pending: Record<string, readonly string[]> = {
     "wallet.browser.stepUpBody"
   ],
   "fr_CA": [
+    "desktop.notify.readyCheckBody",
+    "desktop.notify.readyCheckTitle",
     "hudChrome.actionBar.conflictAccept",
     "hudChrome.actionBar.conflictBody",
     "hudChrome.actionBar.conflictTitle",
@@ -283,6 +291,8 @@ export const pending: Record<string, readonly string[]> = {
   ],
   "en_CA": [],
   "it_IT": [
+    "desktop.notify.readyCheckBody",
+    "desktop.notify.readyCheckTitle",
     "hudChrome.actionBar.conflictAccept",
     "hudChrome.actionBar.conflictBody",
     "hudChrome.actionBar.conflictTitle",
@@ -351,6 +361,8 @@ export const pending: Record<string, readonly string[]> = {
     "wallet.browser.stepUpBody"
   ],
   "de_DE": [
+    "desktop.notify.readyCheckBody",
+    "desktop.notify.readyCheckTitle",
     "hudChrome.actionBar.conflictAccept",
     "hudChrome.actionBar.conflictBody",
     "hudChrome.actionBar.conflictTitle",
@@ -451,6 +463,8 @@ export const pending: Record<string, readonly string[]> = {
     "hudChrome.wocMarket.walletUsdBalance"
   ],
   "pt_BR": [
+    "desktop.notify.readyCheckBody",
+    "desktop.notify.readyCheckTitle",
     "hudChrome.actionBar.conflictAccept",
     "hudChrome.actionBar.conflictBody",
     "hudChrome.actionBar.conflictTitle",
@@ -527,6 +541,8 @@ export const pending: Record<string, readonly string[]> = {
     "hudChrome.wocMarket.walletUsdBalance"
   ],
   "cs_CZ": [
+    "desktop.notify.readyCheckBody",
+    "desktop.notify.readyCheckTitle",
     "hudChrome.actionBar.conflictAccept",
     "hudChrome.actionBar.conflictBody",
     "hudChrome.actionBar.conflictTitle",
@@ -595,6 +611,8 @@ export const pending: Record<string, readonly string[]> = {
     "wallet.browser.stepUpBody"
   ],
   "nl_NL": [
+    "desktop.notify.readyCheckBody",
+    "desktop.notify.readyCheckTitle",
     "hudChrome.actionBar.conflictAccept",
     "hudChrome.actionBar.conflictBody",
     "hudChrome.actionBar.conflictTitle",
@@ -663,6 +681,8 @@ export const pending: Record<string, readonly string[]> = {
     "wallet.browser.stepUpBody"
   ],
   "pl_PL": [
+    "desktop.notify.readyCheckBody",
+    "desktop.notify.readyCheckTitle",
     "hudChrome.actionBar.conflictAccept",
     "hudChrome.actionBar.conflictBody",
     "hudChrome.actionBar.conflictTitle",
@@ -731,6 +751,8 @@ export const pending: Record<string, readonly string[]> = {
     "wallet.browser.stepUpBody"
   ],
   "id_ID": [
+    "desktop.notify.readyCheckBody",
+    "desktop.notify.readyCheckTitle",
     "hudChrome.actionBar.conflictAccept",
     "hudChrome.actionBar.conflictBody",
     "hudChrome.actionBar.conflictTitle",
@@ -799,6 +821,8 @@ export const pending: Record<string, readonly string[]> = {
     "wallet.browser.stepUpBody"
   ],
   "tr_TR": [
+    "desktop.notify.readyCheckBody",
+    "desktop.notify.readyCheckTitle",
     "hudChrome.actionBar.conflictAccept",
     "hudChrome.actionBar.conflictBody",
     "hudChrome.actionBar.conflictTitle",
@@ -867,6 +891,8 @@ export const pending: Record<string, readonly string[]> = {
     "wallet.browser.stepUpBody"
   ],
   "sv_SE": [
+    "desktop.notify.readyCheckBody",
+    "desktop.notify.readyCheckTitle",
     "hudChrome.actionBar.conflictAccept",
     "hudChrome.actionBar.conflictBody",
     "hudChrome.actionBar.conflictTitle",
@@ -935,6 +961,8 @@ export const pending: Record<string, readonly string[]> = {
     "wallet.browser.stepUpBody"
   ],
   "vi_VN": [
+    "desktop.notify.readyCheckBody",
+    "desktop.notify.readyCheckTitle",
     "hudChrome.actionBar.conflictAccept",
     "hudChrome.actionBar.conflictBody",
     "hudChrome.actionBar.conflictTitle",
@@ -1003,6 +1031,8 @@ export const pending: Record<string, readonly string[]> = {
     "wallet.browser.stepUpBody"
   ],
   "da_DK": [
+    "desktop.notify.readyCheckBody",
+    "desktop.notify.readyCheckTitle",
     "hudChrome.actionBar.conflictAccept",
     "hudChrome.actionBar.conflictBody",
     "hudChrome.actionBar.conflictTitle",

--- a/src/ui/i18n.resolved.generated/pl_PL.ts
+++ b/src/ui/i18n.resolved.generated/pl_PL.ts
@@ -8331,7 +8331,9 @@ export const pl_PL: EnTranslations = {
       "updateReadyTitleNoVersion": "Aktualizacja jest gotowa",
       "updateReadyBody": "Uruchom ponownie World of ClaudeCraft, aby zastosować aktualizację.",
       "partyInviteTitle": "Zaproszenie do drużyny",
-      "partyInviteBody": "{name} zaprasza cię do swojej drużyny."
+      "partyInviteBody": "{name} zaprasza cię do swojej drużyny.",
+      "readyCheckTitle": "Ready check",
+      "readyCheckBody": "{name} started a ready check."
     },
     "crash": {
       "title": "World of ClaudeCraft",

--- a/src/ui/i18n.resolved.generated/pt_BR.ts
+++ b/src/ui/i18n.resolved.generated/pt_BR.ts
@@ -8331,7 +8331,9 @@ export const pt_BR: EnTranslations = {
       "updateReadyTitleNoVersion": "A atualização está pronta",
       "updateReadyBody": "Reinicie o World of ClaudeCraft para aplicar a atualização.",
       "partyInviteTitle": "Convite de grupo",
-      "partyInviteBody": "{name} convidou você para um grupo."
+      "partyInviteBody": "{name} convidou você para um grupo.",
+      "readyCheckTitle": "Ready check",
+      "readyCheckBody": "{name} started a ready check."
     },
     "crash": {
       "title": "World of ClaudeCraft",

--- a/src/ui/i18n.resolved.generated/ru_RU.ts
+++ b/src/ui/i18n.resolved.generated/ru_RU.ts
@@ -8331,7 +8331,9 @@ export const ru_RU: EnTranslations = {
       "updateReadyTitleNoVersion": "Обновление готово",
       "updateReadyBody": "Перезапустите World of ClaudeCraft, чтобы применить обновление.",
       "partyInviteTitle": "Приглашение в группу",
-      "partyInviteBody": "{name} приглашает вас в группу."
+      "partyInviteBody": "{name} приглашает вас в группу.",
+      "readyCheckTitle": "Проверка готовности",
+      "readyCheckBody": "{name} начал проверку готовности."
     },
     "crash": {
       "title": "World of ClaudeCraft",

--- a/src/ui/i18n.resolved.generated/sv_SE.ts
+++ b/src/ui/i18n.resolved.generated/sv_SE.ts
@@ -8331,7 +8331,9 @@ export const sv_SE: EnTranslations = {
       "updateReadyTitleNoVersion": "Uppdatering är klar",
       "updateReadyBody": "Starta om World of ClaudeCraft för att tillämpa uppdateringen.",
       "partyInviteTitle": "Gruppinbjudan",
-      "partyInviteBody": "{name} bjöd in dig till en grupp."
+      "partyInviteBody": "{name} bjöd in dig till en grupp.",
+      "readyCheckTitle": "Ready check",
+      "readyCheckBody": "{name} started a ready check."
     },
     "crash": {
       "title": "World of ClaudeCraft",

--- a/src/ui/i18n.resolved.generated/tr_TR.ts
+++ b/src/ui/i18n.resolved.generated/tr_TR.ts
@@ -8331,7 +8331,9 @@ export const tr_TR: EnTranslations = {
       "updateReadyTitleNoVersion": "Güncelleme hazır",
       "updateReadyBody": "Güncellemeyi uygulamak için World of ClaudeCraft'ı yeniden başlat.",
       "partyInviteTitle": "Grup daveti",
-      "partyInviteBody": "{name} seni grubuna davet etti."
+      "partyInviteBody": "{name} seni grubuna davet etti.",
+      "readyCheckTitle": "Ready check",
+      "readyCheckBody": "{name} started a ready check."
     },
     "crash": {
       "title": "World of ClaudeCraft",

--- a/src/ui/i18n.resolved.generated/vi_VN.ts
+++ b/src/ui/i18n.resolved.generated/vi_VN.ts
@@ -8331,7 +8331,9 @@ export const vi_VN: EnTranslations = {
       "updateReadyTitleNoVersion": "Bản cập nhật đã sẵn sàng",
       "updateReadyBody": "Khởi động lại World of ClaudeCraft để áp dụng bản cập nhật.",
       "partyInviteTitle": "Lời mời tổ đội",
-      "partyInviteBody": "{name} đã mời bạn gia nhập tổ đội của họ."
+      "partyInviteBody": "{name} đã mời bạn gia nhập tổ đội của họ.",
+      "readyCheckTitle": "Ready check",
+      "readyCheckBody": "{name} started a ready check."
     },
     "crash": {
       "title": "World of ClaudeCraft",

--- a/src/ui/i18n.resolved.generated/zh_CN.ts
+++ b/src/ui/i18n.resolved.generated/zh_CN.ts
@@ -8331,7 +8331,9 @@ export const zh_CN: EnTranslations = {
       "updateReadyTitleNoVersion": "更新已就绪",
       "updateReadyBody": "重启 World of ClaudeCraft 以应用更新。",
       "partyInviteTitle": "组队邀请",
-      "partyInviteBody": "{name} 邀请你加入队伍。"
+      "partyInviteBody": "{name} 邀请你加入队伍。",
+      "readyCheckTitle": "准备确认",
+      "readyCheckBody": "{name} 发起了准备确认。"
     },
     "crash": {
       "title": "World of ClaudeCraft",

--- a/src/ui/i18n.resolved.generated/zh_TW.ts
+++ b/src/ui/i18n.resolved.generated/zh_TW.ts
@@ -8331,7 +8331,9 @@ export const zh_TW: EnTranslations = {
       "updateReadyTitleNoVersion": "更新已就緒",
       "updateReadyBody": "重新啟動 World of ClaudeCraft 以套用更新。",
       "partyInviteTitle": "組隊邀請",
-      "partyInviteBody": "{name} 邀請你加入隊伍。"
+      "partyInviteBody": "{name} 邀請你加入隊伍。",
+      "readyCheckTitle": "準備確認",
+      "readyCheckBody": "{name} 發起了準備確認。"
     },
     "crash": {
       "title": "World of ClaudeCraft",

--- a/tests/desktop_notifications.test.ts
+++ b/tests/desktop_notifications.test.ts
@@ -75,6 +75,12 @@ const inviteEvent = (fields: { pid?: number; fromName: string }): SimEvent => ({
   ...(fields.pid !== undefined ? { pid: fields.pid } : {}),
 });
 
+const readyCheckEvent = (fields: { pid?: number; fromName: string }): SimEvent => ({
+  type: 'readyCheckStart',
+  fromName: fields.fromName,
+  ...(fields.pid !== undefined ? { pid: fields.pid } : {}),
+});
+
 beforeEach(() => {
   document.hasFocus = () => focused;
   focused = true;
@@ -121,6 +127,42 @@ describe('createDesktopNotifyCore party invites', () => {
     expect(
       core.partyInvite(
         { type: 'guildInvite', fromName: 'Ayla', guildName: 'Oathsworn' },
+        LOCAL_PID,
+      ),
+    ).toBeNull();
+  });
+});
+
+describe('createDesktopNotifyCore ready checks', () => {
+  it('fires for an event with no pid at all (shape robustness: every real emission stamps one)', () => {
+    const core = createDesktopNotifyCore();
+    expect(core.readyCheckStart(readyCheckEvent({ fromName: 'Zev' }), LOCAL_PID)).toEqual({
+      name: 'Zev',
+    });
+  });
+
+  it('fires for an online event addressed to this player', () => {
+    const core = createDesktopNotifyCore();
+    expect(
+      core.readyCheckStart(readyCheckEvent({ pid: LOCAL_PID, fromName: 'Zev' }), LOCAL_PID),
+    ).toEqual({ name: 'Zev' });
+  });
+
+  it('ignores an event addressed to a different player', () => {
+    const core = createDesktopNotifyCore();
+    expect(
+      core.readyCheckStart(readyCheckEvent({ pid: LOCAL_PID + 1, fromName: 'Zev' }), LOCAL_PID),
+    ).toBeNull();
+  });
+
+  it('ignores every other event type, even one addressed to this player', () => {
+    const core = createDesktopNotifyCore();
+    expect(
+      core.readyCheckStart(inviteEvent({ pid: LOCAL_PID, fromName: 'Zev' }), LOCAL_PID),
+    ).toBeNull();
+    expect(
+      core.readyCheckStart(
+        { type: 'guildInvite', fromName: 'Zev', guildName: 'Oathsworn' },
         LOCAL_PID,
       ),
     ).toBeNull();
@@ -317,19 +359,38 @@ describe('desktopNotifyOnSimEvents', () => {
     expect(sent).toEqual([]);
   });
 
-  it('posts one notification per invite in a frame, and nothing for other events', () => {
+  it('posts a ready check while the player is away', () => {
+    const { sent } = boot();
+    setPlayer({ hidden: false, focused: false });
+    desktopNotifyOnSimEvents([readyCheckEvent({ pid: LOCAL_PID, fromName: 'Zev' })], LOCAL_PID);
+    expect(sent).toEqual([
+      { kind: 'ready-check', title: 'Ready check', body: 'Zev started a ready check.' },
+    ]);
+  });
+
+  it('posts no ready check while the player is present at the window', () => {
+    const { sent } = boot();
+    setPlayer({ hidden: false, focused: true });
+    desktopNotifyOnSimEvents([readyCheckEvent({ pid: LOCAL_PID, fromName: 'Zev' })], LOCAL_PID);
+    expect(sent).toEqual([]);
+  });
+
+  it('posts one notification per matching invite or ready check, and nothing for others', () => {
     const { sent } = boot();
     setPlayer({ hidden: true, focused: false });
     desktopNotifyOnSimEvents(
       [
-        { type: 'readyCheckStart', fromName: 'Zev', pid: LOCAL_PID },
+        readyCheckEvent({ pid: LOCAL_PID, fromName: 'Zev' }),
         inviteEvent({ pid: LOCAL_PID, fromName: 'Ayla' }),
         inviteEvent({ pid: LOCAL_PID + 1, fromName: 'Nym' }),
+        readyCheckEvent({ pid: LOCAL_PID + 1, fromName: 'Kor' }),
         inviteEvent({ fromName: 'Rin' }),
+        { type: 'guildInvite', fromName: 'Vex', guildName: 'Oathsworn' },
       ],
       LOCAL_PID,
     );
     expect(sent.map((request) => request.body)).toEqual([
+      'Zev started a ready check.',
       'Ayla invited you to a party.',
       'Rin invited you to a party.',
     ]);

--- a/tests/electron_ipc_channels.test.ts
+++ b/tests/electron_ipc_channels.test.ts
@@ -298,7 +298,9 @@ describe('electron IPC channel contract (preload <-> main)', () => {
     const body = main.slice(start, end);
     expect(body).toContain('if (!trustedSender(event)) return false;');
     expect(body).toContain("if (!payload || typeof payload !== 'object') return false;");
-    expect(body).toContain("if (kind !== 'update-ready' && kind !== 'party-invite') return false;");
+    expect(body).toContain(
+      "if (kind !== 'update-ready' && kind !== 'party-invite' && kind !== 'ready-check') return false;",
+    );
     expect(body).toContain(
       "if (typeof payload.title !== 'string' || typeof payload.body !== 'string') return false;",
     );
@@ -376,7 +378,9 @@ describe('electron IPC channel contract (preload <-> main)', () => {
     expect(showEnd).toBeGreaterThan(showStart);
     const show = preload.slice(showStart, showEnd);
     expect(show).toContain("if (!payload || typeof payload !== 'object') return;");
-    expect(show).toContain("if (kind !== 'update-ready' && kind !== 'party-invite') return;");
+    expect(show).toContain(
+      "if (kind !== 'update-ready' && kind !== 'party-invite' && kind !== 'ready-check') return;",
+    );
     expect(show).toContain(
       "if (typeof payload.title !== 'string' || typeof payload.body !== 'string') return;",
     );


### PR DESCRIPTION
## Summary

Lets the desktop client post an OS notification when the party or raid leader starts a ready check while the player is away from the game window (minimized or focused on another application). The desktop shell already does this for party invites; this change extends the exact same pipeline with a second trigger, so an alt-tabbed player is pulled back before the 30 s ready-check timeout.

What changed:

- `src/game/desktop_notifications.ts`: a `readyCheckStart` trigger on the pure decision core, with the same per-member pid addressing gate as party invites (the sim never emits the event to the leader), behind the same away gate.
- `src/runtime.ts`: `'ready-check'` added to the `DesktopNotificationRequest.kind` union.
- `electron/preload.cjs` and `electron/main.cjs`: `'ready-check'` added to both kind whitelists. The per-kind rate guard and click-to-focus behavior apply unchanged.
- `src/ui/i18n.catalog/shell.ts`: English keys `desktop.notify.readyCheckTitle` and `desktop.notify.readyCheckBody`, plus the five M16 non-Latin overlay fills (zh_CN, zh_TW, ja_JP, ko_KR, ru_RU) reusing each locale's established `hudChrome.readyCheck.prompt` terminology, and the regenerated i18n artifacts.

Web and mobile builds no-op automatically (no desktop bridge), and older installed shells drop the unknown kind gracefully through the preload whitelist.

## Related issues

Closes #3699

## Type of change

- [x] Feature: new functionality
- [ ] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [ ] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `node scripts/gate_select.mjs`: PASS, all 12 steps green (rebased onto `release/v0.41.0`).
  - `npx vitest run tests/desktop_notifications.test.ts tests/electron_ipc_channels.test.ts tests/ready_check.test.ts tests/electron_notify_guard.test.ts`: all green.
  - `npx vitest run tests/i18n_completeness.test.ts tests/localization_coverage.test.ts`: all green (M16 fills verified).
  - `npx tsc --noEmit`: clean.
- Manual steps: N/A (behavior is pinned by the new unit tests: the decision core fires only for `readyCheckStart` events addressed to the local player, posts only while the window is hidden or unfocused, and stays silent while the player is present).

New tests: core decision coverage for the ready-check trigger (fires for local pid and shape-robust no-pid events, ignores other players and other event types), end-to-end frame tests for the away and present arms, and the multi-event frame test now covers both triggers side by side. The pinned Electron whitelist strings in `tests/electron_ipc_channels.test.ts` are updated to the three-kind form.

## Screenshots / recordings

N/A: no in-game UI changes. The visible surface is the OS notification toast, which reuses the existing party-invite notification path unchanged.

---

## Checklist

### Quality

- [x] **The gate passes.** `node scripts/gate_select.mjs` is green (or `npm run gate` for
      the full suite). I added or updated decisive
      tests for changed behavior and recorded any manual checks above.

### Cross-platform

- ~Tested on desktop and mobile.~ N/A: no in-page UI change; the feature is desktop-shell-only and no-ops elsewhere.
- ~Accessible.~ N/A: no UI added or edited.

### Localization (i18n)

- [x] **New player-visible strings follow the contributor policy.** Every user-facing
      string is a `t()` key added to the matching English catalog. I did not edit locale
      overlays, except for the five required non-Latin fills when the M16 wordy-copy
      rule applies (see `src/ui/CLAUDE.md`).
- ~Numbers, money, dates, units, and percents go through the i18n formatters.~ N/A: no numeric copy.
- ~Player-facing text emitted from `src/sim/` or `server/` is re-localized at the client boundary.~ N/A: the sim event already existed; no new sim/server text.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.
