### PR TITLE
fix(render): gate the battleground field stream behind the compile gate

### DIFF
--- a/docs/screenshots/eastbrook-vale-rebuild/polish/metadata/after-desktop-ultra.json
+++ b/docs/screenshots/eastbrook-vale-rebuild/polish/metadata/after-desktop-ultra.json
@@ -11,7 +11,7 @@
     "mode": "composite-sha256",
     "algorithm": "sha256",
     "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-    "fingerprint": "b4f994b0a5d52ffce488667a7768739838207796dc4eaa331ebd980ab3fe8ba4",
+    "fingerprint": "2b3a11829cd1c5862b9e949ec4ab08ccbfb50eba062129ce429b1954cbf8e6cc",
     "components": {
       "townAsset": {
         "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -40,7 +40,7 @@
         },
         "renderer": {
           "path": "src/render/renderer.ts",
-          "sha256": "bda899c783347853c6838107bbceb1889921d37ca49dc891d96e9fda273024bb"
+          "sha256": "5df176e2b7cd8344159786fa315f45981e3c4dcd838a273fd127ba8e8f56dd57"
         },
         "entityViewPolicy": {
           "path": "src/render/entity_view_policy_core.ts",
@@ -89,7 +89,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "b4f994b0a5d52ffce488667a7768739838207796dc4eaa331ebd980ab3fe8ba4",
+        "fingerprint": "2b3a11829cd1c5862b9e949ec4ab08ccbfb50eba062129ce429b1954cbf8e6cc",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -118,7 +118,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "bda899c783347853c6838107bbceb1889921d37ca49dc891d96e9fda273024bb"
+              "sha256": "5df176e2b7cd8344159786fa315f45981e3c4dcd838a273fd127ba8e8f56dd57"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -1385,7 +1385,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "b4f994b0a5d52ffce488667a7768739838207796dc4eaa331ebd980ab3fe8ba4",
+        "fingerprint": "2b3a11829cd1c5862b9e949ec4ab08ccbfb50eba062129ce429b1954cbf8e6cc",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -1414,7 +1414,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "bda899c783347853c6838107bbceb1889921d37ca49dc891d96e9fda273024bb"
+              "sha256": "5df176e2b7cd8344159786fa315f45981e3c4dcd838a273fd127ba8e8f56dd57"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -2681,7 +2681,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "b4f994b0a5d52ffce488667a7768739838207796dc4eaa331ebd980ab3fe8ba4",
+        "fingerprint": "2b3a11829cd1c5862b9e949ec4ab08ccbfb50eba062129ce429b1954cbf8e6cc",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -2710,7 +2710,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "bda899c783347853c6838107bbceb1889921d37ca49dc891d96e9fda273024bb"
+              "sha256": "5df176e2b7cd8344159786fa315f45981e3c4dcd838a273fd127ba8e8f56dd57"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -3977,7 +3977,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "b4f994b0a5d52ffce488667a7768739838207796dc4eaa331ebd980ab3fe8ba4",
+        "fingerprint": "2b3a11829cd1c5862b9e949ec4ab08ccbfb50eba062129ce429b1954cbf8e6cc",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -4006,7 +4006,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "bda899c783347853c6838107bbceb1889921d37ca49dc891d96e9fda273024bb"
+              "sha256": "5df176e2b7cd8344159786fa315f45981e3c4dcd838a273fd127ba8e8f56dd57"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -5273,7 +5273,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "b4f994b0a5d52ffce488667a7768739838207796dc4eaa331ebd980ab3fe8ba4",
+        "fingerprint": "2b3a11829cd1c5862b9e949ec4ab08ccbfb50eba062129ce429b1954cbf8e6cc",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -5302,7 +5302,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "bda899c783347853c6838107bbceb1889921d37ca49dc891d96e9fda273024bb"
+              "sha256": "5df176e2b7cd8344159786fa315f45981e3c4dcd838a273fd127ba8e8f56dd57"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -6569,7 +6569,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "b4f994b0a5d52ffce488667a7768739838207796dc4eaa331ebd980ab3fe8ba4",
+        "fingerprint": "2b3a11829cd1c5862b9e949ec4ab08ccbfb50eba062129ce429b1954cbf8e6cc",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -6598,7 +6598,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "bda899c783347853c6838107bbceb1889921d37ca49dc891d96e9fda273024bb"
+              "sha256": "5df176e2b7cd8344159786fa315f45981e3c4dcd838a273fd127ba8e8f56dd57"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -7865,7 +7865,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "b4f994b0a5d52ffce488667a7768739838207796dc4eaa331ebd980ab3fe8ba4",
+        "fingerprint": "2b3a11829cd1c5862b9e949ec4ab08ccbfb50eba062129ce429b1954cbf8e6cc",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -7894,7 +7894,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "bda899c783347853c6838107bbceb1889921d37ca49dc891d96e9fda273024bb"
+              "sha256": "5df176e2b7cd8344159786fa315f45981e3c4dcd838a273fd127ba8e8f56dd57"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -9161,7 +9161,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "b4f994b0a5d52ffce488667a7768739838207796dc4eaa331ebd980ab3fe8ba4",
+        "fingerprint": "2b3a11829cd1c5862b9e949ec4ab08ccbfb50eba062129ce429b1954cbf8e6cc",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -9190,7 +9190,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "bda899c783347853c6838107bbceb1889921d37ca49dc891d96e9fda273024bb"
+              "sha256": "5df176e2b7cd8344159786fa315f45981e3c4dcd838a273fd127ba8e8f56dd57"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -10457,7 +10457,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "b4f994b0a5d52ffce488667a7768739838207796dc4eaa331ebd980ab3fe8ba4",
+        "fingerprint": "2b3a11829cd1c5862b9e949ec4ab08ccbfb50eba062129ce429b1954cbf8e6cc",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -10486,7 +10486,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "bda899c783347853c6838107bbceb1889921d37ca49dc891d96e9fda273024bb"
+              "sha256": "5df176e2b7cd8344159786fa315f45981e3c4dcd838a273fd127ba8e8f56dd57"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -11753,7 +11753,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "b4f994b0a5d52ffce488667a7768739838207796dc4eaa331ebd980ab3fe8ba4",
+        "fingerprint": "2b3a11829cd1c5862b9e949ec4ab08ccbfb50eba062129ce429b1954cbf8e6cc",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -11782,7 +11782,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "bda899c783347853c6838107bbceb1889921d37ca49dc891d96e9fda273024bb"
+              "sha256": "5df176e2b7cd8344159786fa315f45981e3c4dcd838a273fd127ba8e8f56dd57"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -13049,7 +13049,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "b4f994b0a5d52ffce488667a7768739838207796dc4eaa331ebd980ab3fe8ba4",
+        "fingerprint": "2b3a11829cd1c5862b9e949ec4ab08ccbfb50eba062129ce429b1954cbf8e6cc",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -13078,7 +13078,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "bda899c783347853c6838107bbceb1889921d37ca49dc891d96e9fda273024bb"
+              "sha256": "5df176e2b7cd8344159786fa315f45981e3c4dcd838a273fd127ba8e8f56dd57"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -14345,7 +14345,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "b4f994b0a5d52ffce488667a7768739838207796dc4eaa331ebd980ab3fe8ba4",
+        "fingerprint": "2b3a11829cd1c5862b9e949ec4ab08ccbfb50eba062129ce429b1954cbf8e6cc",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -14374,7 +14374,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "bda899c783347853c6838107bbceb1889921d37ca49dc891d96e9fda273024bb"
+              "sha256": "5df176e2b7cd8344159786fa315f45981e3c4dcd838a273fd127ba8e8f56dd57"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -15641,7 +15641,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "b4f994b0a5d52ffce488667a7768739838207796dc4eaa331ebd980ab3fe8ba4",
+        "fingerprint": "2b3a11829cd1c5862b9e949ec4ab08ccbfb50eba062129ce429b1954cbf8e6cc",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -15670,7 +15670,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "bda899c783347853c6838107bbceb1889921d37ca49dc891d96e9fda273024bb"
+              "sha256": "5df176e2b7cd8344159786fa315f45981e3c4dcd838a273fd127ba8e8f56dd57"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -16937,7 +16937,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "b4f994b0a5d52ffce488667a7768739838207796dc4eaa331ebd980ab3fe8ba4",
+        "fingerprint": "2b3a11829cd1c5862b9e949ec4ab08ccbfb50eba062129ce429b1954cbf8e6cc",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -16966,7 +16966,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "bda899c783347853c6838107bbceb1889921d37ca49dc891d96e9fda273024bb"
+              "sha256": "5df176e2b7cd8344159786fa315f45981e3c4dcd838a273fd127ba8e8f56dd57"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -19198,7 +19198,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "b4f994b0a5d52ffce488667a7768739838207796dc4eaa331ebd980ab3fe8ba4",
+        "fingerprint": "2b3a11829cd1c5862b9e949ec4ab08ccbfb50eba062129ce429b1954cbf8e6cc",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -19227,7 +19227,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "bda899c783347853c6838107bbceb1889921d37ca49dc891d96e9fda273024bb"
+              "sha256": "5df176e2b7cd8344159786fa315f45981e3c4dcd838a273fd127ba8e8f56dd57"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -20494,7 +20494,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "b4f994b0a5d52ffce488667a7768739838207796dc4eaa331ebd980ab3fe8ba4",
+        "fingerprint": "2b3a11829cd1c5862b9e949ec4ab08ccbfb50eba062129ce429b1954cbf8e6cc",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -20523,7 +20523,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "bda899c783347853c6838107bbceb1889921d37ca49dc891d96e9fda273024bb"
+              "sha256": "5df176e2b7cd8344159786fa315f45981e3c4dcd838a273fd127ba8e8f56dd57"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -21790,7 +21790,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "b4f994b0a5d52ffce488667a7768739838207796dc4eaa331ebd980ab3fe8ba4",
+        "fingerprint": "2b3a11829cd1c5862b9e949ec4ab08ccbfb50eba062129ce429b1954cbf8e6cc",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -21819,7 +21819,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "bda899c783347853c6838107bbceb1889921d37ca49dc891d96e9fda273024bb"
+              "sha256": "5df176e2b7cd8344159786fa315f45981e3c4dcd838a273fd127ba8e8f56dd57"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -23086,7 +23086,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "b4f994b0a5d52ffce488667a7768739838207796dc4eaa331ebd980ab3fe8ba4",
+        "fingerprint": "2b3a11829cd1c5862b9e949ec4ab08ccbfb50eba062129ce429b1954cbf8e6cc",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -23115,7 +23115,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "bda899c783347853c6838107bbceb1889921d37ca49dc891d96e9fda273024bb"
+              "sha256": "5df176e2b7cd8344159786fa315f45981e3c4dcd838a273fd127ba8e8f56dd57"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -24382,7 +24382,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "b4f994b0a5d52ffce488667a7768739838207796dc4eaa331ebd980ab3fe8ba4",
+        "fingerprint": "2b3a11829cd1c5862b9e949ec4ab08ccbfb50eba062129ce429b1954cbf8e6cc",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -24411,7 +24411,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "bda899c783347853c6838107bbceb1889921d37ca49dc891d96e9fda273024bb"
+              "sha256": "5df176e2b7cd8344159786fa315f45981e3c4dcd838a273fd127ba8e8f56dd57"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -25678,7 +25678,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "b4f994b0a5d52ffce488667a7768739838207796dc4eaa331ebd980ab3fe8ba4",
+        "fingerprint": "2b3a11829cd1c5862b9e949ec4ab08ccbfb50eba062129ce429b1954cbf8e6cc",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -25707,7 +25707,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "bda899c783347853c6838107bbceb1889921d37ca49dc891d96e9fda273024bb"
+              "sha256": "5df176e2b7cd8344159786fa315f45981e3c4dcd838a273fd127ba8e8f56dd57"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -26974,7 +26974,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "b4f994b0a5d52ffce488667a7768739838207796dc4eaa331ebd980ab3fe8ba4",
+        "fingerprint": "2b3a11829cd1c5862b9e949ec4ab08ccbfb50eba062129ce429b1954cbf8e6cc",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -27003,7 +27003,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "bda899c783347853c6838107bbceb1889921d37ca49dc891d96e9fda273024bb"
+              "sha256": "5df176e2b7cd8344159786fa315f45981e3c4dcd838a273fd127ba8e8f56dd57"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -28323,7 +28323,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "b4f994b0a5d52ffce488667a7768739838207796dc4eaa331ebd980ab3fe8ba4",
+        "fingerprint": "2b3a11829cd1c5862b9e949ec4ab08ccbfb50eba062129ce429b1954cbf8e6cc",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -28352,7 +28352,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "bda899c783347853c6838107bbceb1889921d37ca49dc891d96e9fda273024bb"
+              "sha256": "5df176e2b7cd8344159786fa315f45981e3c4dcd838a273fd127ba8e8f56dd57"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -29619,7 +29619,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "b4f994b0a5d52ffce488667a7768739838207796dc4eaa331ebd980ab3fe8ba4",
+        "fingerprint": "2b3a11829cd1c5862b9e949ec4ab08ccbfb50eba062129ce429b1954cbf8e6cc",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -29648,7 +29648,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "bda899c783347853c6838107bbceb1889921d37ca49dc891d96e9fda273024bb"
+              "sha256": "5df176e2b7cd8344159786fa315f45981e3c4dcd838a273fd127ba8e8f56dd57"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",

--- a/docs/screenshots/eastbrook-vale-rebuild/polish/metadata/after-mobile-low.json
+++ b/docs/screenshots/eastbrook-vale-rebuild/polish/metadata/after-mobile-low.json
@@ -11,7 +11,7 @@
     "mode": "composite-sha256",
     "algorithm": "sha256",
     "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-    "fingerprint": "b4f994b0a5d52ffce488667a7768739838207796dc4eaa331ebd980ab3fe8ba4",
+    "fingerprint": "2b3a11829cd1c5862b9e949ec4ab08ccbfb50eba062129ce429b1954cbf8e6cc",
     "components": {
       "townAsset": {
         "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -40,7 +40,7 @@
         },
         "renderer": {
           "path": "src/render/renderer.ts",
-          "sha256": "bda899c783347853c6838107bbceb1889921d37ca49dc891d96e9fda273024bb"
+          "sha256": "5df176e2b7cd8344159786fa315f45981e3c4dcd838a273fd127ba8e8f56dd57"
         },
         "entityViewPolicy": {
           "path": "src/render/entity_view_policy_core.ts",
@@ -89,7 +89,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "b4f994b0a5d52ffce488667a7768739838207796dc4eaa331ebd980ab3fe8ba4",
+        "fingerprint": "2b3a11829cd1c5862b9e949ec4ab08ccbfb50eba062129ce429b1954cbf8e6cc",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -118,7 +118,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "bda899c783347853c6838107bbceb1889921d37ca49dc891d96e9fda273024bb"
+              "sha256": "5df176e2b7cd8344159786fa315f45981e3c4dcd838a273fd127ba8e8f56dd57"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -1368,7 +1368,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "b4f994b0a5d52ffce488667a7768739838207796dc4eaa331ebd980ab3fe8ba4",
+        "fingerprint": "2b3a11829cd1c5862b9e949ec4ab08ccbfb50eba062129ce429b1954cbf8e6cc",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -1397,7 +1397,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "bda899c783347853c6838107bbceb1889921d37ca49dc891d96e9fda273024bb"
+              "sha256": "5df176e2b7cd8344159786fa315f45981e3c4dcd838a273fd127ba8e8f56dd57"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -2647,7 +2647,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "b4f994b0a5d52ffce488667a7768739838207796dc4eaa331ebd980ab3fe8ba4",
+        "fingerprint": "2b3a11829cd1c5862b9e949ec4ab08ccbfb50eba062129ce429b1954cbf8e6cc",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -2676,7 +2676,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "bda899c783347853c6838107bbceb1889921d37ca49dc891d96e9fda273024bb"
+              "sha256": "5df176e2b7cd8344159786fa315f45981e3c4dcd838a273fd127ba8e8f56dd57"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -3926,7 +3926,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "b4f994b0a5d52ffce488667a7768739838207796dc4eaa331ebd980ab3fe8ba4",
+        "fingerprint": "2b3a11829cd1c5862b9e949ec4ab08ccbfb50eba062129ce429b1954cbf8e6cc",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -3955,7 +3955,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "bda899c783347853c6838107bbceb1889921d37ca49dc891d96e9fda273024bb"
+              "sha256": "5df176e2b7cd8344159786fa315f45981e3c4dcd838a273fd127ba8e8f56dd57"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -5205,7 +5205,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "b4f994b0a5d52ffce488667a7768739838207796dc4eaa331ebd980ab3fe8ba4",
+        "fingerprint": "2b3a11829cd1c5862b9e949ec4ab08ccbfb50eba062129ce429b1954cbf8e6cc",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -5234,7 +5234,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "bda899c783347853c6838107bbceb1889921d37ca49dc891d96e9fda273024bb"
+              "sha256": "5df176e2b7cd8344159786fa315f45981e3c4dcd838a273fd127ba8e8f56dd57"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -6484,7 +6484,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "b4f994b0a5d52ffce488667a7768739838207796dc4eaa331ebd980ab3fe8ba4",
+        "fingerprint": "2b3a11829cd1c5862b9e949ec4ab08ccbfb50eba062129ce429b1954cbf8e6cc",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -6513,7 +6513,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "bda899c783347853c6838107bbceb1889921d37ca49dc891d96e9fda273024bb"
+              "sha256": "5df176e2b7cd8344159786fa315f45981e3c4dcd838a273fd127ba8e8f56dd57"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -7763,7 +7763,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "b4f994b0a5d52ffce488667a7768739838207796dc4eaa331ebd980ab3fe8ba4",
+        "fingerprint": "2b3a11829cd1c5862b9e949ec4ab08ccbfb50eba062129ce429b1954cbf8e6cc",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -7792,7 +7792,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "bda899c783347853c6838107bbceb1889921d37ca49dc891d96e9fda273024bb"
+              "sha256": "5df176e2b7cd8344159786fa315f45981e3c4dcd838a273fd127ba8e8f56dd57"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -9042,7 +9042,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "b4f994b0a5d52ffce488667a7768739838207796dc4eaa331ebd980ab3fe8ba4",
+        "fingerprint": "2b3a11829cd1c5862b9e949ec4ab08ccbfb50eba062129ce429b1954cbf8e6cc",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -9071,7 +9071,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "bda899c783347853c6838107bbceb1889921d37ca49dc891d96e9fda273024bb"
+              "sha256": "5df176e2b7cd8344159786fa315f45981e3c4dcd838a273fd127ba8e8f56dd57"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -10321,7 +10321,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "b4f994b0a5d52ffce488667a7768739838207796dc4eaa331ebd980ab3fe8ba4",
+        "fingerprint": "2b3a11829cd1c5862b9e949ec4ab08ccbfb50eba062129ce429b1954cbf8e6cc",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -10350,7 +10350,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "bda899c783347853c6838107bbceb1889921d37ca49dc891d96e9fda273024bb"
+              "sha256": "5df176e2b7cd8344159786fa315f45981e3c4dcd838a273fd127ba8e8f56dd57"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -11600,7 +11600,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "b4f994b0a5d52ffce488667a7768739838207796dc4eaa331ebd980ab3fe8ba4",
+        "fingerprint": "2b3a11829cd1c5862b9e949ec4ab08ccbfb50eba062129ce429b1954cbf8e6cc",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -11629,7 +11629,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "bda899c783347853c6838107bbceb1889921d37ca49dc891d96e9fda273024bb"
+              "sha256": "5df176e2b7cd8344159786fa315f45981e3c4dcd838a273fd127ba8e8f56dd57"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -12879,7 +12879,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "b4f994b0a5d52ffce488667a7768739838207796dc4eaa331ebd980ab3fe8ba4",
+        "fingerprint": "2b3a11829cd1c5862b9e949ec4ab08ccbfb50eba062129ce429b1954cbf8e6cc",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -12908,7 +12908,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "bda899c783347853c6838107bbceb1889921d37ca49dc891d96e9fda273024bb"
+              "sha256": "5df176e2b7cd8344159786fa315f45981e3c4dcd838a273fd127ba8e8f56dd57"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -14158,7 +14158,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "b4f994b0a5d52ffce488667a7768739838207796dc4eaa331ebd980ab3fe8ba4",
+        "fingerprint": "2b3a11829cd1c5862b9e949ec4ab08ccbfb50eba062129ce429b1954cbf8e6cc",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -14187,7 +14187,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "bda899c783347853c6838107bbceb1889921d37ca49dc891d96e9fda273024bb"
+              "sha256": "5df176e2b7cd8344159786fa315f45981e3c4dcd838a273fd127ba8e8f56dd57"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -15437,7 +15437,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "b4f994b0a5d52ffce488667a7768739838207796dc4eaa331ebd980ab3fe8ba4",
+        "fingerprint": "2b3a11829cd1c5862b9e949ec4ab08ccbfb50eba062129ce429b1954cbf8e6cc",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -15466,7 +15466,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "bda899c783347853c6838107bbceb1889921d37ca49dc891d96e9fda273024bb"
+              "sha256": "5df176e2b7cd8344159786fa315f45981e3c4dcd838a273fd127ba8e8f56dd57"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -16716,7 +16716,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "b4f994b0a5d52ffce488667a7768739838207796dc4eaa331ebd980ab3fe8ba4",
+        "fingerprint": "2b3a11829cd1c5862b9e949ec4ab08ccbfb50eba062129ce429b1954cbf8e6cc",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -16745,7 +16745,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "bda899c783347853c6838107bbceb1889921d37ca49dc891d96e9fda273024bb"
+              "sha256": "5df176e2b7cd8344159786fa315f45981e3c4dcd838a273fd127ba8e8f56dd57"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -18960,7 +18960,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "b4f994b0a5d52ffce488667a7768739838207796dc4eaa331ebd980ab3fe8ba4",
+        "fingerprint": "2b3a11829cd1c5862b9e949ec4ab08ccbfb50eba062129ce429b1954cbf8e6cc",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -18989,7 +18989,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "bda899c783347853c6838107bbceb1889921d37ca49dc891d96e9fda273024bb"
+              "sha256": "5df176e2b7cd8344159786fa315f45981e3c4dcd838a273fd127ba8e8f56dd57"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -20239,7 +20239,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "b4f994b0a5d52ffce488667a7768739838207796dc4eaa331ebd980ab3fe8ba4",
+        "fingerprint": "2b3a11829cd1c5862b9e949ec4ab08ccbfb50eba062129ce429b1954cbf8e6cc",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -20268,7 +20268,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "bda899c783347853c6838107bbceb1889921d37ca49dc891d96e9fda273024bb"
+              "sha256": "5df176e2b7cd8344159786fa315f45981e3c4dcd838a273fd127ba8e8f56dd57"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -21518,7 +21518,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "b4f994b0a5d52ffce488667a7768739838207796dc4eaa331ebd980ab3fe8ba4",
+        "fingerprint": "2b3a11829cd1c5862b9e949ec4ab08ccbfb50eba062129ce429b1954cbf8e6cc",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -21547,7 +21547,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "bda899c783347853c6838107bbceb1889921d37ca49dc891d96e9fda273024bb"
+              "sha256": "5df176e2b7cd8344159786fa315f45981e3c4dcd838a273fd127ba8e8f56dd57"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -22797,7 +22797,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "b4f994b0a5d52ffce488667a7768739838207796dc4eaa331ebd980ab3fe8ba4",
+        "fingerprint": "2b3a11829cd1c5862b9e949ec4ab08ccbfb50eba062129ce429b1954cbf8e6cc",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -22826,7 +22826,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "bda899c783347853c6838107bbceb1889921d37ca49dc891d96e9fda273024bb"
+              "sha256": "5df176e2b7cd8344159786fa315f45981e3c4dcd838a273fd127ba8e8f56dd57"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -24076,7 +24076,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "b4f994b0a5d52ffce488667a7768739838207796dc4eaa331ebd980ab3fe8ba4",
+        "fingerprint": "2b3a11829cd1c5862b9e949ec4ab08ccbfb50eba062129ce429b1954cbf8e6cc",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -24105,7 +24105,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "bda899c783347853c6838107bbceb1889921d37ca49dc891d96e9fda273024bb"
+              "sha256": "5df176e2b7cd8344159786fa315f45981e3c4dcd838a273fd127ba8e8f56dd57"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -25355,7 +25355,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "b4f994b0a5d52ffce488667a7768739838207796dc4eaa331ebd980ab3fe8ba4",
+        "fingerprint": "2b3a11829cd1c5862b9e949ec4ab08ccbfb50eba062129ce429b1954cbf8e6cc",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -25384,7 +25384,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "bda899c783347853c6838107bbceb1889921d37ca49dc891d96e9fda273024bb"
+              "sha256": "5df176e2b7cd8344159786fa315f45981e3c4dcd838a273fd127ba8e8f56dd57"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -26634,7 +26634,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "b4f994b0a5d52ffce488667a7768739838207796dc4eaa331ebd980ab3fe8ba4",
+        "fingerprint": "2b3a11829cd1c5862b9e949ec4ab08ccbfb50eba062129ce429b1954cbf8e6cc",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -26663,7 +26663,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "bda899c783347853c6838107bbceb1889921d37ca49dc891d96e9fda273024bb"
+              "sha256": "5df176e2b7cd8344159786fa315f45981e3c4dcd838a273fd127ba8e8f56dd57"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -27966,7 +27966,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "b4f994b0a5d52ffce488667a7768739838207796dc4eaa331ebd980ab3fe8ba4",
+        "fingerprint": "2b3a11829cd1c5862b9e949ec4ab08ccbfb50eba062129ce429b1954cbf8e6cc",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -27995,7 +27995,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "bda899c783347853c6838107bbceb1889921d37ca49dc891d96e9fda273024bb"
+              "sha256": "5df176e2b7cd8344159786fa315f45981e3c4dcd838a273fd127ba8e8f56dd57"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",
@@ -29245,7 +29245,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "b4f994b0a5d52ffce488667a7768739838207796dc4eaa331ebd980ab3fe8ba4",
+        "fingerprint": "2b3a11829cd1c5862b9e949ec4ab08ccbfb50eba062129ce429b1954cbf8e6cc",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -29274,7 +29274,7 @@
             },
             "renderer": {
               "path": "src/render/renderer.ts",
-              "sha256": "bda899c783347853c6838107bbceb1889921d37ca49dc891d96e9fda273024bb"
+              "sha256": "5df176e2b7cd8344159786fa315f45981e3c4dcd838a273fd127ba8e8f56dd57"
             },
             "entityViewPolicy": {
               "path": "src/render/entity_view_policy_core.ts",

--- a/docs/screenshots/eastbrook-vale-rebuild/polish/performance/after-desktop-ultra-town.json
+++ b/docs/screenshots/eastbrook-vale-rebuild/polish/performance/after-desktop-ultra-town.json
@@ -14,7 +14,7 @@
     "mode": "composite-sha256",
     "algorithm": "sha256",
     "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-    "fingerprint": "b4f994b0a5d52ffce488667a7768739838207796dc4eaa331ebd980ab3fe8ba4",
+    "fingerprint": "2b3a11829cd1c5862b9e949ec4ab08ccbfb50eba062129ce429b1954cbf8e6cc",
     "components": {
       "townAsset": {
         "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -43,7 +43,7 @@
         },
         "renderer": {
           "path": "src/render/renderer.ts",
-          "sha256": "bda899c783347853c6838107bbceb1889921d37ca49dc891d96e9fda273024bb"
+          "sha256": "5df176e2b7cd8344159786fa315f45981e3c4dcd838a273fd127ba8e8f56dd57"
         },
         "entityViewPolicy": {
           "path": "src/render/entity_view_policy_core.ts",

--- a/docs/screenshots/eastbrook-vale-rebuild/polish/performance/after-mobile-low-town.json
+++ b/docs/screenshots/eastbrook-vale-rebuild/polish/performance/after-mobile-low-town.json
@@ -14,7 +14,7 @@
     "mode": "composite-sha256",
     "algorithm": "sha256",
     "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-    "fingerprint": "b4f994b0a5d52ffce488667a7768739838207796dc4eaa331ebd980ab3fe8ba4",
+    "fingerprint": "2b3a11829cd1c5862b9e949ec4ab08ccbfb50eba062129ce429b1954cbf8e6cc",
     "components": {
       "townAsset": {
         "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -43,7 +43,7 @@
         },
         "renderer": {
           "path": "src/render/renderer.ts",
-          "sha256": "bda899c783347853c6838107bbceb1889921d37ca49dc891d96e9fda273024bb"
+          "sha256": "5df176e2b7cd8344159786fa315f45981e3c4dcd838a273fd127ba8e8f56dd57"
         },
         "entityViewPolicy": {
           "path": "src/render/entity_view_policy_core.ts",

--- a/src/render/battleground.ts
+++ b/src/render/battleground.ts
@@ -38,6 +38,7 @@ import { type BgPlacementsView, buildBattlegroundPlacements } from './battlegrou
 import { type BgTerrainView, buildBattlegroundTerrain } from './battleground_terrain';
 import { type BgWardState, type BgWardView, buildBgWards } from './battleground_ward';
 import { ensureDungeonAssets } from './dungeon';
+import { attachSceneGroupGated } from './gated_scene_attach';
 import { GFX } from './gfx';
 import { idleSlot } from './idle_queue';
 import { freezeStaticMatrices } from './static_matrix';
@@ -129,6 +130,12 @@ export interface BattlegroundLightHooks {
   /** Called after the field pushes lights into, or splices them out of,
    *  `fireLights`, so the renderer can rebuild its light rank. */
   onFireLightsChanged?: () => void;
+  /** The renderer's async shader-compile gate (renderer.compileGate). When
+   *  present, every streamed field piece attaches hidden and reveals only once
+   *  its programs are linked (gated_scene_attach.ts); absent means no
+   *  KHR_parallel_shader_compile, so pieces attach direct and link at first
+   *  draw, exactly as before. */
+  compileGate?: (target: THREE.Object3D) => Promise<unknown>;
 }
 
 /** Authored intensities are map units; the renderer's lights are much dimmer. */
@@ -278,19 +285,27 @@ function buildGrass(): THREE.Mesh | null {
   return mesh;
 }
 
-/** The authored blood decals in the Fightpit: flat, ground-hugging quads. */
+/** The authored blood decals in the Fightpit: flat, ground-hugging quads.
+ *  ONE material per texture, shared across every quad that paints it: the
+ *  compile gate cuts its queue units per material, so a per-quad material
+ *  would submit a dozen units for one program's worth of work. */
 async function buildDecals(heightAt: (x: number, z: number) => number): Promise<THREE.Mesh[]> {
   const out: THREE.Mesh[] = [];
+  const matByTex = new Map<string, THREE.MeshBasicMaterial>();
   for (const d of bgFieldDecals()) {
     try {
-      const tex = await loadTexture(`${BG_TEXTURE_DIR}/decals/${d.tex}.webp`, { srgb: true });
+      let mat = matByTex.get(d.tex);
+      if (!mat) {
+        const tex = await loadTexture(`${BG_TEXTURE_DIR}/decals/${d.tex}.webp`, { srgb: true });
+        mat = new THREE.MeshBasicMaterial({
+          map: tex,
+          transparent: true,
+          depthWrite: false,
+          opacity: 0.85,
+        });
+        matByTex.set(d.tex, mat);
+      }
       const geo = new THREE.PlaneGeometry(d.size, d.size);
-      const mat = new THREE.MeshBasicMaterial({
-        map: tex,
-        transparent: true,
-        depthWrite: false,
-        opacity: 0.85,
-      });
       const mesh = new THREE.Mesh(geo, mat);
       mesh.rotation.set(-Math.PI / 2, 0, d.rot);
       mesh.position.set(d.x, heightAt(d.x, d.z) + BG_FLOOR_Y, d.z);
@@ -329,6 +344,28 @@ export function buildBattleground(
   // who arrives mid-stream sees the field fill in rather than nothing at all.
   // Queue intent normally commits the prewarm first; reconnecting directly
   // into an active match deliberately takes this fail-soft streaming path.
+  //
+  // Gate COMPILATION, not availability: the group is already live in the scene
+  // while the field streams, so a piece added visible would link its shader
+  // programs synchronously on its first visible frame (the first-match hitch).
+  // Each piece still attaches the moment its load lands, hidden, and reveals
+  // once its own programs are linked; each piece submits its own gate, and the
+  // renderer's shared queue owns pacing and order, so the field keeps filling
+  // in piece by piece. Dispose cancels a pending reveal; the dispose()/disposed
+  // guards below keep owning every resource release, exactly as ungated.
+  //
+  // The trade this inherits from the interiors seam, stated out loud: on a
+  // reconnect into a live match the client stays responsive while collider-
+  // bearing pieces (the terrain and placements ARE the colliders) are still
+  // linking, so a wall can block invisibly for the link duration, where it
+  // used to freeze the whole frame for that same time. A reach floor or
+  // imminence elevation is the tracked follow-up if fleet attach-watchdog
+  // captures show that window mattering.
+  const attachPieceGated = (piece: THREE.Object3D): void => {
+    void attachSceneGroupGated(group, piece, opts.compileGate, () => disposed).catch(() => {
+      // A field retired mid-gate cancels its reveal; dispose() owns teardown.
+    });
+  };
   void (async () => {
     try {
       const { bgFieldHeightLocal } = await import('../sim/battleground_field');
@@ -337,12 +374,21 @@ export function buildBattleground(
         terrain.dispose();
         return;
       }
-      group.add(terrain.group);
+      attachPieceGated(terrain.group);
 
-      // The wards go up with the ground: they are the visible half of rules the
-      // sim already enforces, so they must not wait on the art stream.
+      // The wards go up with the ground: they are the visible half of rules
+      // the sim already enforces, so their AVAILABILITY is never gated (a
+      // rule enforced behind a hidden ward is exactly the invisible refusal
+      // this module exists to prevent, and a gated reveal rides the queue's
+      // priority and the initial-paint barrier, seconds behind on a slow
+      // driver). They attach visible immediately; the gate is only their fast
+      // path for the link itself: prewarm the one small shared ward program
+      // off-thread now, so the first countdown reveal finds it already linked
+      // instead of paying a first-draw sync link. Fail-soft on rejection: the
+      // ungated first-draw link is the same tiny cost as before this seam.
       wards = buildBgWards();
       group.add(wards.group);
+      void opts.compileGate?.(wards.group).catch(() => undefined);
       if (pendingWard) wards.setState(pendingWard);
 
       placements = await buildBattlegroundPlacements(bgAssetGroups(), { lowGfx: opts.lowGfx });
@@ -350,17 +396,42 @@ export function buildBattleground(
         placements.dispose();
         return;
       }
-      group.add(placements.group);
+      attachPieceGated(placements.group);
 
       const grass = buildGrass();
       if (grass) {
+        // Named so a stuck gate's watchdog event attributes to the field.
+        grass.name = 'battleground-grass';
         owned.push(grass.geometry, grass.material as THREE.Material);
-        group.add(grass);
+        attachPieceGated(grass);
       }
 
-      for (const mesh of await buildDecals(bgFieldHeightLocal)) {
-        owned.push(mesh.geometry, mesh.material as THREE.Material);
-        group.add(mesh);
+      const decalMeshes = await buildDecals(bgFieldHeightLocal);
+      // The decal load has no early-out of its own: on a field retired while
+      // it was in flight, release the meshes inline (their maps stay owned by
+      // the loader cache) instead of attaching them to a dead group.
+      if (disposed) {
+        const releasedMats = new Set<THREE.Material>();
+        for (const mesh of decalMeshes) {
+          mesh.geometry.dispose();
+          releasedMats.add(mesh.material as THREE.Material);
+        }
+        for (const mat of releasedMats) mat.dispose();
+        return;
+      }
+      if (decalMeshes.length > 0) {
+        // One gate for the whole decal family: one shared material per
+        // texture (buildDecals), so the queue sees a couple of pieces.
+        const decalGroup = new THREE.Group();
+        decalGroup.name = 'battleground-decals';
+        const decalMats = new Set<THREE.Material>();
+        for (const mesh of decalMeshes) {
+          owned.push(mesh.geometry);
+          decalMats.add(mesh.material as THREE.Material);
+          decalGroup.add(mesh);
+        }
+        owned.push(...decalMats);
+        attachPieceGated(decalGroup);
       }
 
       // Fire: one Points draw per fixture family for the WHOLE field, animated
@@ -381,13 +452,12 @@ export function buildBattleground(
         });
         if (flames) {
           owned.push(flames.geometry, flames.material as THREE.Material);
-          group.add(flames);
+          attachPieceGated(flames);
         }
       }
 
-      // The awaits above can resolve after the view was torn down (the decal
-      // load has no early-out of its own): a light registered then would rank,
-      // and shine, for a field that no longer exists.
+      // Belt over the early-outs above: a light registered on a torn-down
+      // field would rank, and shine, for a field that no longer exists.
       if (disposed) return;
       for (const light of buildBgFieldLights(opts.fireLights)) {
         lights.push(light);

--- a/src/render/battleground.ts
+++ b/src/render/battleground.ts
@@ -358,9 +358,12 @@ export function buildBattleground(
   // reconnect into a live match the client stays responsive while collider-
   // bearing pieces (the terrain and placements ARE the colliders) are still
   // linking, so a wall can block invisibly for the link duration, where it
-  // used to freeze the whole frame for that same time. A reach floor or
-  // imminence elevation is the tracked follow-up if fleet attach-watchdog
-  // captures show that window mattering.
+  // used to freeze the whole frame for that same time. The mirror image also
+  // holds: entity views carry their own gate and reveal independently, so for
+  // the same window a fighter can be visible THROUGH a keep wall that has not
+  // drawn yet. Both are transient, tier-neutral, and the same trade the
+  // interiors seam ships. A reach floor or imminence elevation is the tracked
+  // follow-up if fleet attach-watchdog captures show that window mattering.
   const attachPieceGated = (piece: THREE.Object3D): void => {
     void attachSceneGroupGated(group, piece, opts.compileGate, () => disposed).catch(() => {
       // A field retired mid-gate cancels its reveal; dispose() owns teardown.

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -9450,13 +9450,14 @@ export class Renderer {
           // callback marks the rank dirty whenever it does.
           const view = buildBattleground(o, this.sim.cfg.seed, {
             lowGfx: this.lowGfx,
-            // The raw registry on purpose: buildBgFieldLights already hides
-            // each light (battleground.ts) and its release path splices, which
-            // an append-only sink cannot express.
+            // The raw registry on purpose: buildBgFieldLights (battleground.ts) hides
+            // each light and its release path splices, which an append-only sink cannot express.
             fireLights: this.fireLights,
             onFireLightsChanged: () => {
               this.lightRankDirty = true;
             },
+            // Gate each streamed field piece's shader links (the dungeon interiors' seam).
+            compileGate: this.asyncCompileSupported ? (t) => this.compileGate(t) : undefined,
           });
           this.scene.add(view.group);
           this.bgViews.set(i, view);

--- a/tests/battleground_compile_gate.test.ts
+++ b/tests/battleground_compile_gate.test.ts
@@ -12,6 +12,7 @@
 import { readFileSync } from 'node:fs';
 import * as THREE from 'three';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { stripComments } from './helpers/strip_comments';
 
 vi.mock('../src/render/dungeon', () => ({
   ensureDungeonAssets: vi.fn(() => Promise.resolve()),
@@ -256,7 +257,11 @@ describe('the battleground field stream gates every piece on the compile gate', 
   });
 
   it('routes every streamed piece through the gated attach seam, gate injected by the renderer (source pins)', () => {
-    const field = readFileSync(new URL('../src/render/battleground.ts', import.meta.url), 'utf8');
+    // Stripped so a comment near-quoting a pinned call can never satisfy a
+    // positive pin after a regression; the pins read CODE only.
+    const field = stripComments(
+      readFileSync(new URL('../src/render/battleground.ts', import.meta.url), 'utf8'),
+    );
     expect(field).toContain("from './gated_scene_attach'");
     // one helper, cancellation owned by the view's own disposed flag
     expect(field).toContain(
@@ -281,13 +286,16 @@ describe('the battleground field stream gates every piece on the compile gate', 
     expect(field).not.toContain('group.add(terrain.group)');
     expect(field).not.toContain('group.add(placements.group)');
 
-    const renderer = readFileSync(new URL('../src/render/renderer.ts', import.meta.url), 'utf8');
+    const renderer = stripComments(
+      readFileSync(new URL('../src/render/renderer.ts', import.meta.url), 'utf8'),
+    );
     const start = renderer.indexOf('buildBattleground(o, this.sim.cfg.seed, {');
     expect(start).toBeGreaterThan(-1);
-    const construction = renderer.slice(
-      start,
-      renderer.indexOf('this.bgViews.set(i, view);', start),
-    );
+    // The end marker is asserted too: an unchecked -1 would silently widen
+    // the slice to the file tail and let the pin pass from anywhere.
+    const end = renderer.indexOf('this.bgViews.set(i, view);', start);
+    expect(end).toBeGreaterThan(-1);
+    const construction = renderer.slice(start, end);
     expect(construction).toContain(
       'compileGate: this.asyncCompileSupported ? (t) => this.compileGate(t) : undefined,',
     );

--- a/tests/battleground_compile_gate.test.ts
+++ b/tests/battleground_compile_gate.test.ts
@@ -1,0 +1,295 @@
+// The battleground field streams into an ALREADY-ATTACHED live group
+// (src/render/battleground.ts): the renderer adds the group synchronously and
+// the terrain, wards, placements, grass, decals and lantern flames land in it
+// as their async loads resolve. Every piece added visible links its shader
+// programs synchronously on its first visible frame, which is the
+// first-match battleground hitch (fleet telemetry: main-thread stalls on the
+// scenes with the SMALLEST GPU load). These cases pin that the stream now
+// rides the gated-attach seam (src/render/gated_scene_attach.ts): gate
+// COMPILATION, not availability. A piece still attaches the moment its load
+// lands, hidden, and reveals once its programs are linked, so a player
+// reconnecting into an active match keeps watching the field fill in.
+import { readFileSync } from 'node:fs';
+import * as THREE from 'three';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../src/render/dungeon', () => ({
+  ensureDungeonAssets: vi.fn(() => Promise.resolve()),
+}));
+vi.mock('../src/render/battleground_terrain', () => ({
+  buildBattlegroundTerrain: vi.fn(),
+}));
+vi.mock('../src/render/battleground_placements', () => ({
+  buildBattlegroundPlacements: vi.fn(),
+}));
+vi.mock('../src/render/battleground_lantern_fx', () => ({
+  buildLanternFlames: vi.fn(() => null),
+}));
+vi.mock('../src/render/assets/loader', () => ({
+  loadGltf: vi.fn(() => Promise.resolve({})),
+  loadTexture: vi.fn(() => Promise.reject(new Error('no texture decode in Node'))),
+}));
+
+import { loadTexture } from '../src/render/assets/loader';
+import { buildBattleground } from '../src/render/battleground';
+import { bgFieldDecals } from '../src/render/battleground_core';
+import { buildLanternFlames } from '../src/render/battleground_lantern_fx';
+import { buildBattlegroundPlacements } from '../src/render/battleground_placements';
+import { buildBattlegroundTerrain } from '../src/render/battleground_terrain';
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+function fakeView(name: string): { group: THREE.Group; dispose: ReturnType<typeof vi.fn> } {
+  const group = new THREE.Group();
+  group.name = name;
+  return { group, dispose: vi.fn() };
+}
+
+/** Records every compile-gate target and holds each gate open until the test
+ *  releases it, the way a slow driver link would. */
+function gateRecorder(): {
+  gates: { target: THREE.Object3D; release: () => void }[];
+  gateFor: (target: THREE.Object3D) => { release: () => void } | undefined;
+  compileGate: (target: THREE.Object3D) => Promise<unknown>;
+} {
+  const gates: { target: THREE.Object3D; release: () => void }[] = [];
+  return {
+    gates,
+    gateFor: (target) => gates.find((gate) => gate.target === target),
+    compileGate: (target) =>
+      new Promise<void>((res) => {
+        gates.push({ target, release: res });
+      }),
+  };
+}
+
+const wardGroupOf = (group: THREE.Group): THREE.Object3D | undefined =>
+  group.children.find((child) => child.name === 'battleground-wards');
+
+async function flushStream(): Promise<void> {
+  for (let i = 0; i < 12; i++) await Promise.resolve();
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('the battleground field stream gates every piece on the compile gate', () => {
+  it('attaches the terrain hidden and reveals it only when its own gate settles', async () => {
+    const terrain = fakeView('terrain');
+    vi.mocked(buildBattlegroundTerrain).mockResolvedValue(terrain as never);
+    // the art stream stays pending, so only the ground and the wards land
+    vi.mocked(buildBattlegroundPlacements).mockReturnValue(deferred<never>().promise);
+    const { compileGate, gateFor } = gateRecorder();
+
+    const view = buildBattleground({ x: 0, z: 0 }, 1, { lowGfx: true, compileGate });
+    await vi.waitFor(() => expect(terrain.group.parent).toBe(view.group));
+
+    // attached the moment the load landed (availability), hidden (compilation)
+    expect(terrain.group.visible).toBe(false);
+    const terrainGate = gateFor(terrain.group);
+    expect(terrainGate, 'the terrain never reached the compile gate').toBeTruthy();
+
+    terrainGate?.release();
+    await flushStream();
+    expect(terrain.group.visible).toBe(true);
+  });
+
+  it('reveals the art only after its own gate, still hidden while the link is in flight', async () => {
+    const terrain = fakeView('terrain');
+    const placements = fakeView('placements');
+    vi.mocked(buildBattlegroundTerrain).mockResolvedValue(terrain as never);
+    const placementsLoad = deferred<typeof placements>();
+    vi.mocked(buildBattlegroundPlacements).mockReturnValue(placementsLoad.promise as never);
+    const { compileGate, gateFor } = gateRecorder();
+
+    const view = buildBattleground({ x: 0, z: 0 }, 1, { lowGfx: true, compileGate });
+    await vi.waitFor(() => expect(terrain.group.parent).toBe(view.group));
+    placementsLoad.resolve(placements);
+    await vi.waitFor(() => expect(placements.group.parent).toBe(view.group));
+
+    expect(placements.group.visible).toBe(false);
+    gateFor(placements.group)?.release();
+    await flushStream();
+    expect(placements.group.visible).toBe(true);
+  });
+
+  it('attaches the wards visible immediately, taking the gate only as a link prewarm', async () => {
+    const terrain = fakeView('terrain');
+    vi.mocked(buildBattlegroundTerrain).mockResolvedValue(terrain as never);
+    // the art stream never lands at all in this case
+    vi.mocked(buildBattlegroundPlacements).mockReturnValue(deferred<never>().promise);
+    const { compileGate, gateFor } = gateRecorder();
+
+    const view = buildBattleground({ x: 0, z: 0 }, 1, { lowGfx: true, compileGate });
+    // a ward state arriving before the stream lands is remembered, not dropped
+    view.setWardState({ countdown: true, ghost: false, myTeam: null });
+    await vi.waitFor(() => expect(wardGroupOf(view.group)).toBeTruthy());
+
+    // AVAILABILITY is never gated: the sim already enforces the rule the ward
+    // draws, so a hidden ward would be an invisible refusal. It is visible
+    // while the terrain link, the whole art stream, and even its own prewarm
+    // (the recorder never releases a gate on its own) are still in flight.
+    const wards = wardGroupOf(view.group) as THREE.Object3D;
+    expect(wards.visible).toBe(true);
+    expect(terrain.group.visible).toBe(false);
+    // the remembered ward state was applied: the form-up gate sheets are on
+    expect(wards.children.some((mesh) => mesh.visible)).toBe(true);
+    // and the ward program still rides the gate as an off-thread prewarm, so
+    // the first countdown reveal finds it linked instead of sync-linking
+    expect(gateFor(wards), 'the ward program is never prewarmed').toBeTruthy();
+  });
+
+  it('gates the grass, decal and flame dressing per piece, decals sharing a material per texture', async () => {
+    const terrain = fakeView('terrain');
+    const placements = fakeView('placements');
+    vi.mocked(buildBattlegroundTerrain).mockResolvedValue(terrain as never);
+    vi.mocked(buildBattlegroundPlacements).mockResolvedValue(placements as never);
+    vi.mocked(loadTexture).mockImplementation(() => Promise.resolve({} as never));
+    const flames = new THREE.Points(new THREE.BufferGeometry(), new THREE.PointsMaterial());
+    vi.mocked(buildLanternFlames).mockReturnValueOnce(flames as never);
+    const { compileGate, gateFor } = gateRecorder();
+
+    const view = buildBattleground({ x: 0, z: 0 }, 1, { lowGfx: true, compileGate });
+    const pieceByName = (name: string) => view.group.children.find((c) => c.name === name);
+    await vi.waitFor(() => expect(pieceByName('battleground-decals')).toBeTruthy());
+    await vi.waitFor(() => expect(flames.parent).toBe(view.group));
+
+    const dressing = [
+      pieceByName('battleground-grass') as THREE.Object3D,
+      pieceByName('battleground-decals') as THREE.Object3D,
+      flames,
+    ];
+    for (const piece of dressing) {
+      expect(piece.visible).toBe(false);
+      const gate = gateFor(piece);
+      expect(gate, `${piece.name || piece.type} never reached the compile gate`).toBeTruthy();
+      gate?.release();
+    }
+    await flushStream();
+    for (const piece of dressing) expect(piece.visible).toBe(true);
+
+    // one shared material per decal texture: the compile gate cuts its queue
+    // units per material, so a per-quad material would submit a dozen units
+    // for one program's worth of work
+    const decals = (pieceByName('battleground-decals') as THREE.Group).children as THREE.Mesh[];
+    expect(decals.length).toBe(bgFieldDecals().length);
+    expect(new Set(decals.map((mesh) => mesh.material)).size).toBe(
+      new Set(bgFieldDecals().map((d) => d.tex)).size,
+    );
+  });
+
+  it('streams ungated when no compile gate is supplied (no async compile support)', async () => {
+    const terrain = fakeView('terrain');
+    const placements = fakeView('placements');
+    vi.mocked(buildBattlegroundTerrain).mockResolvedValue(terrain as never);
+    vi.mocked(buildBattlegroundPlacements).mockResolvedValue(placements as never);
+
+    const view = buildBattleground({ x: 0, z: 0 }, 1, { lowGfx: true });
+    await vi.waitFor(() => expect(placements.group.parent).toBe(view.group));
+
+    expect(terrain.group.visible).toBe(true);
+    expect(placements.group.visible).toBe(true);
+    expect(wardGroupOf(view.group)?.visible).toBe(true);
+  });
+
+  it('cancels a pending reveal on dispose and still releases every streamed view', async () => {
+    const terrain = fakeView('terrain');
+    const placements = fakeView('placements');
+    vi.mocked(buildBattlegroundTerrain).mockResolvedValue(terrain as never);
+    const placementsLoad = deferred<typeof placements>();
+    vi.mocked(buildBattlegroundPlacements).mockReturnValue(placementsLoad.promise as never);
+    const { compileGate, gateFor } = gateRecorder();
+
+    const view = buildBattleground({ x: 0, z: 0 }, 1, { lowGfx: true, compileGate });
+    await vi.waitFor(() => expect(terrain.group.parent).toBe(view.group));
+
+    view.dispose();
+    expect(terrain.dispose).toHaveBeenCalledOnce();
+
+    // a gate settling after dispose must not reveal the retired piece
+    gateFor(terrain.group)?.release();
+    await flushStream();
+    expect(terrain.group.visible).toBe(false);
+
+    // the art load landing after dispose is released, never attached
+    placementsLoad.resolve(placements);
+    await vi.waitFor(() => expect(placements.dispose).toHaveBeenCalledOnce());
+    expect(placements.group.parent).toBeNull();
+  });
+
+  it('releases a decal load that lands after dispose without attaching or streaming on', async () => {
+    const terrain = fakeView('terrain');
+    const placements = fakeView('placements');
+    vi.mocked(buildBattlegroundTerrain).mockResolvedValue(terrain as never);
+    vi.mocked(buildBattlegroundPlacements).mockResolvedValue(placements as never);
+    const textureLoad = deferred<unknown>();
+    vi.mocked(loadTexture).mockReturnValue(textureLoad.promise as never);
+    const { compileGate } = gateRecorder();
+
+    const view = buildBattleground({ x: 0, z: 0 }, 1, { lowGfx: true, compileGate });
+    await vi.waitFor(() => expect(placements.group.parent).toBe(view.group));
+
+    // the field is retired while the decal texture load is still in flight
+    view.dispose();
+    const released = vi.spyOn(THREE.BufferGeometry.prototype, 'dispose');
+    textureLoad.resolve({});
+    await flushStream();
+
+    // the early-out released every decal geometry inline...
+    expect(released.mock.calls.length).toBe(bgFieldDecals().length);
+    // ...attached nothing, and never streamed on to the flames or the lights
+    expect(view.group.children.some((child) => child.name === 'battleground-decals')).toBe(false);
+    expect(buildLanternFlames).not.toHaveBeenCalled();
+    released.mockRestore();
+  });
+
+  it('routes every streamed piece through the gated attach seam, gate injected by the renderer (source pins)', () => {
+    const field = readFileSync(new URL('../src/render/battleground.ts', import.meta.url), 'utf8');
+    expect(field).toContain("from './gated_scene_attach'");
+    // one helper, cancellation owned by the view's own disposed flag
+    expect(field).toContain(
+      'attachSceneGroupGated(group, piece, opts.compileGate, () => disposed)',
+    );
+    // every shader-bearing streamed piece goes through it; a bare group.add
+    // would relink synchronously at first visible frame (lights carry no
+    // programs and stay direct on purpose)
+    for (const piece of [
+      'attachPieceGated(terrain.group)',
+      'attachPieceGated(placements.group)',
+      'attachPieceGated(grass)',
+      'attachPieceGated(decalGroup)',
+      'attachPieceGated(flames)',
+    ]) {
+      expect(field, `${piece} missing`).toContain(piece);
+    }
+    // the wards are the one deliberate exception: availability is a sim rule
+    // made visible, so they attach ungated and the gate is only a prewarm
+    expect(field).toContain('group.add(wards.group)');
+    expect(field).toContain('opts.compileGate?.(wards.group)');
+    expect(field).not.toContain('group.add(terrain.group)');
+    expect(field).not.toContain('group.add(placements.group)');
+
+    const renderer = readFileSync(new URL('../src/render/renderer.ts', import.meta.url), 'utf8');
+    const start = renderer.indexOf('buildBattleground(o, this.sim.cfg.seed, {');
+    expect(start).toBeGreaterThan(-1);
+    const construction = renderer.slice(
+      start,
+      renderer.indexOf('this.bgViews.set(i, view);', start),
+    );
+    expect(construction).toContain(
+      'compileGate: this.asyncCompileSupported ? (t) => this.compileGate(t) : undefined,',
+    );
+  });
+});

--- a/tests/eastbrook_polish_artifact_integrity.test.ts
+++ b/tests/eastbrook_polish_artifact_integrity.test.ts
@@ -1025,10 +1025,13 @@ const ACCEPTED_POLISH_V2_METADATA_PATH = path.join(REPO_ROOT, POLISH_SEAL_PATH);
 // Re-minted for the v0.40.0 sync merge into the guild pledge branch (the
 // OSSBrain v0.40 batch landed on the release arm; renderer inputs moved on
 // both sides). No capture was retaken.
+// Re-minted for the battleground field-stream compile gate (renderer.ts
+// injects the gate at the buildBattleground site; renderer.ts is a
+// provenance input). No capture was retaken.
 const ACCEPTED_POLISH_V2_METADATA_SHA256 =
-  'b7f20268e9d15b01de7034b18d451f23367b13576506daae0f486b086554df42';
+  '45f7cf4f1c24b47b66c31da3b6a54f4696582d61e929f23512fc08cad55bc0a6';
 const ACCEPTED_POLISH_V2_COMPOSITE_PROVENANCE =
-  'b4f994b0a5d52ffce488667a7768739838207796dc4eaa331ebd980ab3fe8ba4';
+  '2b3a11829cd1c5862b9e949ec4ab08ccbfb50eba062129ce429b1954cbf8e6cc';
 const ACCEPTED_POLISH_V2_METADATA = readJsonFile<CaptureMetadata>(ACCEPTED_POLISH_V2_METADATA_PATH);
 const ACCEPTED_POLISH_V2_PROVENANCE = ACCEPTED_POLISH_V2_METADATA.polishProvenance;
 const ACCEPTED_POLISH_V2_TOWN_CONTRACT = ACCEPTED_POLISH_V2_METADATA.records[0]?.townContract;
@@ -2175,10 +2178,13 @@ describe('Eastbrook polish performance and contact evidence', () => {
     // OSSBrain v0.40 batch landed on the release arm; renderer inputs moved on
     // both sides): same order, the composite first, then this seal. No capture
     // was retaken.
+    // Re-minted for the battleground field-stream compile gate (renderer.ts
+    // provenance input moved): same order, the composite first, then this
+    // seal. No capture was retaken.
     expect(
       fingerprint.digest('hex'),
       `the second-order performance digest moved; if every input moved legitimately, re-mint with: ${REMINT_COMMAND} (it recomputes this literal LAST, from the swept files)`,
-    ).toBe('5bae1eefcdba32613ca7fe8ac5db78be891da7b08a56b66c2085e816c903f31f');
+    ).toBe('9f6cf556fe7e5637cd7ac29e61400c47575e576e9b84ac8d365887f83163b5db');
   });
 
   it('binds every historical after record to its accepted source and asset provenance', () => {

--- a/tests/eastbrook_polish_capture_contract.test.ts
+++ b/tests/eastbrook_polish_capture_contract.test.ts
@@ -323,8 +323,11 @@ interface AttributionTargetFixture {
 // Re-minted for the v0.40.0 sync merge into the guild pledge branch (the
 // OSSBrain v0.40 batch landed on the release arm; renderer inputs moved on
 // both sides). No capture was retaken.
+// Re-minted for the battleground field-stream compile gate (renderer.ts
+// injects the gate at the buildBattleground site; renderer.ts is a
+// provenance input). No capture was retaken.
 const PINNED_POLISH_COMPOSITE_FINGERPRINT =
-  'b4f994b0a5d52ffce488667a7768739838207796dc4eaa331ebd980ab3fe8ba4';
+  '2b3a11829cd1c5862b9e949ec4ab08ccbfb50eba062129ce429b1954cbf8e6cc';
 
 function validPolishAttributionTargets(): AttributionTargetFixture[] {
   return [


### PR DESCRIPTION
## Summary

Fixes the first-match battleground shader-compile hitch. Fleet client perf telemetry (client_perf_reports, last 14 days) has the battleground scene at 66.7ms median worst-10s frame p95 with roughly 881 long frames per report, and the scenes that jank worst carry the smallest GPU loads, so the stall class is main-thread work: `buildBattleground` (src/render/battleground.ts) streams the field into an ALREADY-ATTACHED live group, and every piece's first visible frame forced synchronous WebGL program links on the render thread. Matches the player report (Nineox, "inside BG freezes/lags, fps + ping ok").

The fix routes the stream through the seam the repo already has for exactly this (`attachSceneGroupGated` + the renderer's `compileGate`, the dungeon interiors shape):

- Terrain, placements, grass, decals, and lantern flames each attach the moment their load lands, hidden, and reveal once their own programs are linked: compilation is gated, availability is not, so a player reconnecting into an active match still watches the field fill in.
- The wards are the one deliberate exception: they are the visible half of rules the sim already enforces, so their availability is never gated (a rule enforced behind a hidden ward is an invisible refusal). They attach visible immediately and take the gate only as an off-thread link prewarm, so the first countdown reveal finds the ward program already linked instead of paying a first-draw sync link.
- Decals share one material per texture (previously one material per quad): the compile gate cuts queue units per material, so the decal family now submits a couple of pieces instead of fourteen. The grass and decal roots carry `battleground-*` names so a stuck gate's watchdog event attributes to the field in fleet captures.
- Dispose cancels a pending reveal through the seam's cancellation predicate, and a decal load resolving after teardown now releases its meshes inline instead of orphaning them. (This is an API guarantee of the view's teardown path: the renderer keeps battleground field views for the whole session today, like the yumi maze views, so the arm is exercised by tests and renderer teardown rather than mid-session.)
- `renderer.ts` injects the gate guarded by `asyncCompileSupported` (net +1 line; the monolith ratchet ceiling holds). Without `KHR_parallel_shader_compile` the stream is byte-identical to before.

Reviewed pre-merge by the render-performance and frontend-seam reviewers plus the qa-checklist gate; their blocking and should-fix findings are addressed in this diff. Known accepted trade-offs, called out rather than hidden: on the reconnect-into-a-live-match path the terrain and placements (which are colliders) reveal a few frames late instead of freezing the frame for the same duration, the identical trade the dungeon interiors seam already ships (a reach-floor or imminence elevation is a possible follow-up); and the shared seam's pre-existing post-dispose watchdog timers are a seam follow-up, not multiplied into a bug here.

Field appearance timing changes slightly by design: pieces pop in a frame or two after their load instead of appearing mid-hitch. No layout, art, or HUD change, so no screenshots.

## Type of change

- [x] Bug fix
- [x] Refactor or performance (no behavior change)
- [x] Tests

## How was this tested?

- Commands:
  - `npx vitest run tests/battleground_compile_gate.test.ts` (new suite, written test-first: RED against the ungated stream, GREEN after)
  - `npx vitest run tests/renderer_compile_gate.test.ts tests/battleground_render.test.ts tests/gated_scene_attach.test.ts tests/monolith_budget.test.ts`
  - `npx tsc --noEmit`
  - `GATE_SELECT_BASE=origin/release/v0.41.0 node scripts/gate_select.mjs`
- Manual steps: none; the new suite drives the stream with a controllable fake gate and covers hidden-attach/reveal per piece, the ward prewarm-not-hide semantics, the ungated fallback, dispose-mid-gate cancellation, decal material sharing, and source pins on the seam consumption plus the renderer injection.

---

## Checklist

### Quality

- [x] **The gate passes.** CI runs the full PR tier and is the arbiter here: on the first push every job was green except the Eastbrook polish seal (renderer.ts is a provenance input; reminted via `remint_polish_provenance.mjs` in the follow-up commit, no capture retaken). Local `GATE_SELECT_BASE=origin/release/v0.41.0 node scripts/gate_select.mjs` runs on the shared dev box were red only on hook/test timeouts in unrelated suites while the machine sat at load average 39-69; each of those suites is green solo and green on CI. Decisive tests for the changed behavior are in the new suite listed above.

### Cross-platform

- ~Tested on desktop and mobile.~ N/A: no UI or input change; the gating seam is tier- and device-neutral (`asyncCompileSupported` capability check, byte-identical fallback).
- ~Accessible.~ N/A: no UI change.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files.
