### PR TITLE
fix(hud): mail indicator no longer steals Enter-to-chat after mouse click

### DIFF
--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -540,6 +540,7 @@ import { ReannounceMarker } from './live_region_reannounce';
 import { isCombatFlavorLog } from './log_event_route';
 import { lowHealthVignette } from './low_health';
 import { type LowResourceView, lowResourceViewInto } from './low_resource';
+import { blurIfPointerClick } from './pointer_blur';
 import { mailIndicatorView } from './mailbox_view';
 import { MailboxWindow } from './mailbox_window';
 import { onMapArtReady } from './map_art';
@@ -9262,6 +9263,7 @@ export class Hud {
     el.addEventListener('click', (ev) => {
       ev.preventDefault();
       ev.stopPropagation();
+      blurIfPointerClick(ev, el);
       this.openMailbox();
     });
     el.addEventListener('keydown', (ev) => {


### PR DESCRIPTION
## Summary
Closes #3450. Clicking the mail envelope on the minimap left the button focused, so the next Enter keydown opened the mailbox instead of chat. Now a pointer click drops focus from the button (the existing `blurIfPointerClick` path), while keyboard activation keeps its focus so the opener/focus-restore pattern still works.

## Changes
- `src/ui/hud.ts`: Added `blurIfPointerClick(ev, el)` call inside the mail indicator's click handler, matching the pattern already used by other chrome buttons (market indicator, chat tabs, etc.)

## Testing
- All existing tests pass: `minimap_rim_badges`, `mailbox_window`, `mailbox_window_focus`, `focus_restore`, `pointer_blur`, `architecture` (109 + 71 + 19 + 5 = 204 tests green)
- Reproduced the bug locally: clicking the mail indicator with mouse focus, then pressing Enter opened the mailbox instead of chat
- After fix: mouse click drops focus from the button, Enter correctly opens chat
- Keyboard activation (Tab + Enter/Space) still works correctly — focus is preserved for keyboard users

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)