### PR TITLE
feat(market): expose operator sale provenance

### DIFF
--- a/server/concurrent_indexes.ts
+++ b/server/concurrent_indexes.ts
@@ -59,6 +59,11 @@ import {
   PLAYER_REPORTS_RETENTION_INVALID_INDEX_DROP_SQL,
 } from './player_reports_retention_index';
 import {
+  WOC_MARKET_OPS_CLOSED_INDEX_SQL,
+  WOC_MARKET_OPS_CLOSED_INVALID_INDEX_CHECK_SQL,
+  WOC_MARKET_OPS_CLOSED_INVALID_INDEX_DROP_SQL,
+} from './woc_market_ops_listings_index';
+import {
   WOC_MARKET_SALES_SELLER_INDEX_SQL,
   WOC_MARKET_SALES_SELLER_INVALID_INDEX_CHECK_SQL,
   WOC_MARKET_SALES_SELLER_INVALID_INDEX_DROP_SQL,
@@ -155,5 +160,13 @@ export const CONCURRENT_INDEX_MIGRATIONS: readonly ConcurrentIndexMigration[] = 
     createSql: WOC_MARKET_SALES_SELLER_INDEX_SQL,
     checkSql: WOC_MARKET_SALES_SELLER_INVALID_INDEX_CHECK_SQL,
     dropSql: WOC_MARKET_SALES_SELLER_INVALID_INDEX_DROP_SQL,
+  },
+  // The internal dashboard's Sold and Cancelled listing filters. Appended,
+  // never inserted: the migration order is load-bearing and pinned.
+  {
+    name: 'woc_market_ops_closed_created',
+    createSql: WOC_MARKET_OPS_CLOSED_INDEX_SQL,
+    checkSql: WOC_MARKET_OPS_CLOSED_INVALID_INDEX_CHECK_SQL,
+    dropSql: WOC_MARKET_OPS_CLOSED_INVALID_INDEX_DROP_SQL,
   },
 ];

--- a/server/internal.ts
+++ b/server/internal.ts
@@ -97,7 +97,15 @@ export async function handleInternalApi(
  * exists on the role-gated /admin/api surface with its own audit trail, and
  * moving one here would move it out from under that.
  */
-const LISTING_STATUSES = ['active', 'ending', 'settling', 'closed', 'all'] as const;
+const LISTING_STATUSES = [
+  'active',
+  'ending',
+  'settling',
+  'closed',
+  'sold',
+  'cancelled',
+  'all',
+] as const;
 const OFFER_STATUSES = ['pending', 'accepted', 'declined', 'withdrawn', 'expired', 'all'] as const;
 
 const OPS_DAY_MS = 24 * 60 * 60 * 1000;

--- a/server/woc_market.ts
+++ b/server/woc_market.ts
@@ -43,6 +43,7 @@ import type {
 } from './woc_market_economy_types';
 import { pruneWocLocalLedgers, wocBackedOffIds, wocParkRow } from './woc_market_local_ledgers';
 import type { WocStuckCustodyClasses } from './woc_market_monitor_types';
+import type * as WocOps from './woc_market_ops';
 import type { WocMarketReadCache } from './woc_market_read_cache';
 import { WOC_MARKET_BROWSE_CACHE_MAX_PAGE } from './woc_market_read_cache';
 import {
@@ -563,12 +564,12 @@ export interface WocMarketDb {
   markCustodyRefBooked(custodyRef: string): Promise<void>;
   opsListings(q: {
     realm: string;
-    status: 'active' | 'ending' | 'settling' | 'closed' | 'all';
+    status: WocOps.WocOpsListingStatus;
     fromMs: number;
     toMs: number;
     page: number;
     pageSize: number;
-  }): Promise<{ rows: WocListingRow[]; hasMore: boolean }>;
+  }): Promise<{ rows: WocOps.WocOpsListingRow[]; hasMore: boolean }>;
   opsP2pTrades(q: {
     realm: string;
     status: WocDirectedOfferStatus | 'all';
@@ -576,7 +577,7 @@ export interface WocMarketDb {
     toMs: number;
     page: number;
     pageSize: number;
-  }): Promise<{ rows: WocOpsP2pTradeRow[]; hasMore: boolean }>;
+  }): Promise<{ rows: WocOps.WocOpsP2pTradeRow[]; hasMore: boolean }>;
   /** The claim row for a ref (booked flag plus rail intents), or null when
    *  no claim exists. What the resume paths consult when a claim is not fresh:
    *  booked means done; a grant intent parks; a mail intent may resume only
@@ -1173,12 +1174,6 @@ export { BOND_PAYOUT_BUDGET_MS, WOC_MARKET_ME_READOUT_DEADLINE_MS } from './woc_
 /** Per-arm counts for one sweep pass, so a wedged marketplace is visible: a
  *  silent idle pass and a permanently starved backlog look identical without
  *  it. An arm returning a FULL batch is the "backlog is not draining" signal. */
-/** A directed offer plus the outcome it reached, for the operator p2p view. */
-export interface WocOpsP2pTradeRow extends WocDirectedOfferRow {
-  settledAmountBase: string | null;
-  txSignature: string | null;
-}
-
 // The sweep's pass-accounting vocabulary lives in woc_market_sweep_types.ts
 // (the ratchet's leaf-types pattern); the trio keeps this import path.
 export type {
@@ -2289,12 +2284,12 @@ export class WocMarketService {
    * dashboard cannot ask one realm's process about another's.
    */
   async opsListings(q: {
-    status: 'active' | 'ending' | 'settling' | 'closed' | 'all';
+    status: WocOps.WocOpsListingStatus;
     fromMs: number;
     toMs: number;
     page: number;
     pageSize: number;
-  }): Promise<{ rows: WocListingRow[]; hasMore: boolean }> {
+  }): Promise<{ rows: WocOps.WocOpsListingRow[]; hasMore: boolean }> {
     return this.deps.db.opsListings({ ...q, realm: this.cfg.realm });
   }
 
@@ -2304,7 +2299,7 @@ export class WocMarketService {
     toMs: number;
     page: number;
     pageSize: number;
-  }): Promise<{ rows: WocOpsP2pTradeRow[]; hasMore: boolean }> {
+  }): Promise<{ rows: WocOps.WocOpsP2pTradeRow[]; hasMore: boolean }> {
     return this.deps.db.opsP2pTrades({ ...q, realm: this.cfg.realm });
   }
 

--- a/server/woc_market_db.ts
+++ b/server/woc_market_db.ts
@@ -36,13 +36,13 @@ import type {
   WocListingResolution,
   WocListingRow,
   WocMarketDb,
-  WocOpsP2pTradeRow,
   WocSaleRow,
   WocSellerProfile,
   WocSettlementRow,
   WocStrikeRow,
   WocStuckCustodyClasses,
 } from './woc_market';
+import type { WocOpsListingRow, WocOpsListingStatus, WocOpsP2pTradeRow } from './woc_market_ops';
 import type { WocBidStatus, WocSettlementState } from './woc_market_rules';
 import {
   WOC_MARKET_ABANDON_EXEMPT_FAIL_REASONS,
@@ -1631,19 +1631,25 @@ export class PgWocMarketDb implements WocMarketDb {
    */
   async opsListings(q: {
     realm: string;
-    status: 'active' | 'ending' | 'settling' | 'closed' | 'all';
+    status: WocOpsListingStatus;
     fromMs: number;
     toMs: number;
     page: number;
     pageSize: number;
-  }): Promise<{ rows: WocListingRow[]; hasMore: boolean }> {
+  }): Promise<{ rows: WocOpsListingRow[]; hasMore: boolean }> {
     const where: string[] = ['realm = $1', 'directed_buyer_account IS NULL'];
     const params: unknown[] = [q.realm];
     params.push(new Date(q.fromMs));
     where.push(`created_at >= $${params.length}`);
     params.push(new Date(q.toMs));
     where.push(`created_at <= $${params.length}`);
-    if (q.status !== 'all') {
+    if (q.status === 'sold' || q.status === 'cancelled') {
+      // Literals, not bound lifecycle values: they align with the partial
+      // woc_market_ops_closed_created index predicate and let Postgres prove
+      // the index applies before it sees a parameter value.
+      where.push("status = 'closed'");
+      where.push(`resolution = '${q.status}'`);
+    } else if (q.status !== 'all') {
       params.push(q.status);
       where.push(`status = $${params.length}`);
     }
@@ -1654,15 +1660,34 @@ export class PgWocMarketDb implements WocMarketDb {
     // range can be far wider than a player's.
     params.push(pageSize + 1, offset);
     const res = await this.pool.query(
-      `SELECT ${LISTING_COLS}
-         FROM woc_market_listings
-        WHERE ${where.join(' AND ')}
-        ORDER BY created_at DESC, id DESC
-        LIMIT $${params.length - 1} OFFSET $${params.length}`,
+      `WITH listing_page AS MATERIALIZED (
+         SELECT ${LISTING_COLS}
+           FROM woc_market_listings
+          WHERE ${where.join(' AND ')}
+          ORDER BY created_at DESC, id DESC
+          LIMIT $${params.length - 1} OFFSET $${params.length}
+       )
+       SELECT p.*,
+              s.buyer_account AS sale_buyer_account,
+              s.buyer_name AS sale_buyer_name,
+              s.created_at AS sold_at
+         FROM listing_page p
+         LEFT JOIN woc_market_sales s
+           ON p.status = 'closed' AND p.resolution = 'sold'
+          AND s.listing_id = p.id AND s.realm = p.realm AND s.excluded = false
+        ORDER BY p.created_at DESC, p.id DESC`,
       params,
     );
     const hasMore = res.rows.length > pageSize;
-    return { rows: (hasMore ? res.rows.slice(0, pageSize) : res.rows).map(toListing), hasMore };
+    const rows = (hasMore ? res.rows.slice(0, pageSize) : res.rows).map(
+      (row): WocOpsListingRow => ({
+        ...toListing(row),
+        buyerAccount: row.sale_buyer_account ?? null,
+        buyerName: row.sale_buyer_name ?? null,
+        soldAtMs: msOrNull(row.sold_at),
+      }),
+    );
+    return { rows, hasMore };
   }
 
   /**

--- a/server/woc_market_db.ts
+++ b/server/woc_market_db.ts
@@ -1644,11 +1644,12 @@ export class PgWocMarketDb implements WocMarketDb {
     params.push(new Date(q.toMs));
     where.push(`created_at <= $${params.length}`);
     if (q.status === 'sold' || q.status === 'cancelled') {
-      // Literals, not bound lifecycle values: they align with the partial
-      // woc_market_ops_closed_created index predicate and let Postgres prove
-      // the index applies before it sees a parameter value.
+      // Keep the partial-index predicate literal so Postgres can prove that
+      // woc_market_ops_closed_created applies. Resolution is an index key,
+      // not part of that predicate, and remains safely bound.
       where.push("status = 'closed'");
-      where.push(`resolution = '${q.status}'`);
+      params.push(q.status);
+      where.push(`resolution = $${params.length}`);
     } else if (q.status !== 'all') {
       params.push(q.status);
       where.push(`status = $${params.length}`);
@@ -1659,6 +1660,9 @@ export class PgWocMarketDb implements WocMarketDb {
     // window count re-reads the whole matching set on every page, and an ops
     // range can be far wider than a player's.
     params.push(pageSize + 1, offset);
+    // Only standing sale provenance is operator-visible. A voided sale is
+    // retained with excluded=true for audit, but deliberately maps to a null
+    // buyer/sold-at here (and therefore N/A in the dashboard).
     const res = await this.pool.query(
       `WITH listing_page AS MATERIALIZED (
          SELECT ${LISTING_COLS}
@@ -1672,9 +1676,15 @@ export class PgWocMarketDb implements WocMarketDb {
               s.buyer_name AS sale_buyer_name,
               s.created_at AS sold_at
          FROM listing_page p
-         LEFT JOIN woc_market_sales s
-           ON p.status = 'closed' AND p.resolution = 'sold'
-          AND s.listing_id = p.id AND s.realm = p.realm AND s.excluded = false
+         LEFT JOIN LATERAL (
+           SELECT sale.buyer_account, sale.buyer_name, sale.created_at
+             FROM woc_market_sales sale
+            WHERE p.status = 'closed' AND p.resolution = 'sold'
+              AND sale.listing_id = p.id
+              AND sale.realm = p.realm
+              AND sale.excluded = false
+            LIMIT 1
+         ) s ON true
         ORDER BY p.created_at DESC, p.id DESC`,
       params,
     );

--- a/server/woc_market_ops.ts
+++ b/server/woc_market_ops.ts
@@ -1,0 +1,16 @@
+import type { WocDirectedOfferRow, WocListingLifecycle, WocListingRow } from './woc_market';
+
+export type WocOpsListingStatus = WocListingLifecycle | 'sold' | 'cancelled' | 'all';
+
+/** A public listing plus sale provenance for the internal operator view. */
+export interface WocOpsListingRow extends WocListingRow {
+  buyerAccount: number | null;
+  buyerName: string | null;
+  soldAtMs: number | null;
+}
+
+/** A directed offer plus the outcome it reached, for the operator p2p view. */
+export interface WocOpsP2pTradeRow extends WocDirectedOfferRow {
+  settledAmountBase: string | null;
+  txSignature: string | null;
+}

--- a/server/woc_market_ops_listings_index.ts
+++ b/server/woc_market_ops_listings_index.ts
@@ -1,0 +1,30 @@
+// Concurrent-index SQL for the internal dashboard's Sold and Cancelled
+// exchange-listing filters (PgWocMarketDb.opsListings).
+//
+// The read is equality on realm and resolution, bounded by created_at and
+// ordered by created_at DESC, id DESC. Public listings only: directed rows
+// belong to the P2P view. Closed listings have configurable retention, and a
+// zero retention setting keeps them forever, so a result LIMIT alone cannot
+// bound the scan or sort work.
+//
+// CONCURRENTLY, never boot DDL: this is a live table. A transactional index
+// build during a rolling restart would block listing lifecycle writes for the
+// duration of the retained-history scan.
+
+export const WOC_MARKET_OPS_CLOSED_INDEX_SQL = `
+CREATE INDEX CONCURRENTLY IF NOT EXISTS woc_market_ops_closed_created
+  ON woc_market_listings(realm, resolution, created_at DESC, id DESC)
+  WHERE directed_buyer_account IS NULL AND status = 'closed';
+`;
+
+// IF NOT EXISTS accepts an invalid carcass left by an interrupted concurrent
+// build, so the boot migration repairs it before trying the create again.
+export const WOC_MARKET_OPS_CLOSED_INVALID_INDEX_CHECK_SQL = `
+SELECT 1
+  FROM pg_index i
+ WHERE i.indexrelid = to_regclass('woc_market_ops_closed_created')
+   AND NOT i.indisvalid
+`;
+
+export const WOC_MARKET_OPS_CLOSED_INVALID_INDEX_DROP_SQL =
+  'DROP INDEX CONCURRENTLY IF EXISTS woc_market_ops_closed_created';

--- a/tests/monolith_budget.test.ts
+++ b/tests/monolith_budget.test.ts
@@ -398,7 +398,9 @@ const MONOLITHS: MonolithRow[] = [
     // (quote legs, price/estimate readouts, WocMarketEconomy) moved to
     // woc_market_economy_types.ts (the monitor-types pattern), paying for the
     // desktopHandoff registrar dep and its four registration call sites.
-    ceiling: 3929,
+    // Down 3929 -> 3924: the operator listing and p2p row vocabulary moved to
+    // woc_market_ops.ts instead of growing this coordinator.
+    ceiling: 3924,
     seam: 'a woc_market_<thing>.ts sibling behind WocMarketDeps (the drift-warn split is the template)',
   },
   {

--- a/tests/schema_wiring.test.ts
+++ b/tests/schema_wiring.test.ts
@@ -689,6 +689,7 @@ describe('ensureSchema wires every schema module at boot', () => {
       'chat_violations_retention_created',
       'bank_ledger_account_recent',
       'woc_market_sales_seller',
+      'woc_market_ops_closed_created',
     ]);
     const guildPrefix = CONCURRENT_INDEX_MIGRATIONS.find(
       (m) => m.name === 'guilds_realm_lower_name_prefix',
@@ -781,6 +782,19 @@ describe('ensureSchema wires every schema module at boot', () => {
     expect(wocSalesSeller?.checkSql).toContain("to_regclass('woc_market_sales_seller')");
     expect(wocSalesSeller?.dropSql).toBe(
       'DROP INDEX CONCURRENTLY IF EXISTS woc_market_sales_seller',
+    );
+    const wocOpsClosed = CONCURRENT_INDEX_MIGRATIONS.find(
+      (m) => m.name === 'woc_market_ops_closed_created',
+    );
+    expect(wocOpsClosed?.createSql).toContain(
+      'ON woc_market_listings(realm, resolution, created_at DESC, id DESC)',
+    );
+    expect(wocOpsClosed?.createSql).toContain(
+      "WHERE directed_buyer_account IS NULL AND status = 'closed'",
+    );
+    expect(wocOpsClosed?.checkSql).toContain("to_regclass('woc_market_ops_closed_created')");
+    expect(wocOpsClosed?.dropSql).toBe(
+      'DROP INDEX CONCURRENTLY IF EXISTS woc_market_ops_closed_created',
     );
   });
 

--- a/tests/server/helpers/fake_woc_market_db.ts
+++ b/tests/server/helpers/fake_woc_market_db.ts
@@ -31,7 +31,6 @@ import type {
   WocListingResolution,
   WocListingRow,
   WocMarketDb,
-  WocOpsP2pTradeRow,
   WocSaleRow,
   WocSellerProfile,
   WocSettlementRow,
@@ -39,6 +38,11 @@ import type {
   WocStuckCustodyClasses,
 } from '../../../server/woc_market';
 import { SETTLED_OFFER_GRACE_MS } from '../../../server/woc_market_db';
+import type {
+  WocOpsListingRow,
+  WocOpsListingStatus,
+  WocOpsP2pTradeRow,
+} from '../../../server/woc_market_ops';
 import type { WocBidStatus, WocSettlementState } from '../../../server/woc_market_rules';
 import {
   WOC_MARKET_ABANDON_EXEMPT_FAIL_REASONS,
@@ -360,12 +364,12 @@ export class FakeWocMarketDb implements WocMarketDb {
    *  INCLUSIVE at both ends, and status narrowed unless 'all'. */
   async opsListings(q: {
     realm: string;
-    status: 'active' | 'ending' | 'settling' | 'closed' | 'all';
+    status: WocOpsListingStatus;
     fromMs: number;
     toMs: number;
     page: number;
     pageSize: number;
-  }): Promise<{ rows: WocListingRow[]; hasMore: boolean }> {
+  }): Promise<{ rows: WocOpsListingRow[]; hasMore: boolean }> {
     const matched = [...this.listings.values()]
       .filter(
         (r) =>
@@ -373,7 +377,10 @@ export class FakeWocMarketDb implements WocMarketDb {
           r.directedBuyerAccount === null &&
           r.createdAtMs >= q.fromMs &&
           r.createdAtMs <= q.toMs &&
-          (q.status === 'all' || r.status === q.status),
+          (q.status === 'all' ||
+            (q.status === 'sold' || q.status === 'cancelled'
+              ? r.status === 'closed' && r.resolution === q.status
+              : r.status === q.status)),
       )
       .sort((a, b) => b.createdAtMs - a.createdAtMs || b.id - a.id);
     const pageSize = Math.min(Math.max(1, q.pageSize), 200);
@@ -381,7 +388,18 @@ export class FakeWocMarketDb implements WocMarketDb {
     const page = matched.slice(offset, offset + pageSize + 1);
     const hasMore = page.length > pageSize;
     return {
-      rows: (hasMore ? page.slice(0, pageSize) : page).map((r) => this.listingOut(r)),
+      rows: (hasMore ? page.slice(0, pageSize) : page).map((r) => {
+        const sale =
+          r.status === 'closed' && r.resolution === 'sold'
+            ? [...this.sales.values()].find((s) => s.listingId === r.id && !s.excluded)
+            : undefined;
+        return {
+          ...this.listingOut(r),
+          buyerAccount: sale?.buyerAccount ?? null,
+          buyerName: sale?.buyerName ?? null,
+          soldAtMs: sale?.atMs ?? null,
+        };
+      }),
       hasMore,
     };
   }

--- a/tests/server/internal.test.ts
+++ b/tests/server/internal.test.ts
@@ -2338,6 +2338,14 @@ describe('the dashboard ops reads: filters and the default window', () => {
     expect((seen[0] as { status: string }).status).toBe('active');
   });
 
+  it('passes sold and cancelled listing display categories through', async () => {
+    await hit('/internal/woc-market/listings', { status: 'sold' });
+    expect((seen[0] as { status: string }).status).toBe('sold');
+    seen = [];
+    await hit('/internal/woc-market/listings', { status: 'cancelled' });
+    expect((seen[0] as { status: string }).status).toBe('cancelled');
+  });
+
   it('caps the page size, so a caller cannot ask for an unbounded read', async () => {
     await hit('/internal/woc-market/listings', { pageSize: '100000' });
     expect((seen[0] as { pageSize: number }).pageSize).toBe(200);

--- a/tests/server/woc_market_directed_sql.test.ts
+++ b/tests/server/woc_market_directed_sql.test.ts
@@ -801,6 +801,113 @@ describe('the operator reads behind the internal dashboard', () => {
     expect(text).not.toContain('status = $4');
   });
 
+  it('pages before joining sale provenance and filters sold or cancelled by resolution', async () => {
+    for (const status of ['sold', 'cancelled'] as const) {
+      const { pool, sql } = recordingPool();
+      await new PgWocMarketDb(pool).opsListings({
+        realm: REALM,
+        status,
+        fromMs: 1_000,
+        toMs: 2_000,
+        page: 3,
+        pageSize: 50,
+      });
+      const [text] = sql();
+      expect(text).toContain('WITH listing_page AS MATERIALIZED');
+      expect(text).toContain("status = 'closed'");
+      expect(text).toContain(`resolution = '${status}'`);
+      expect(text).toContain('LIMIT $4 OFFSET $5');
+      expect(text).toContain('LEFT JOIN woc_market_sales s');
+      expect(text).toContain("p.status = 'closed' AND p.resolution = 'sold'");
+      expect(text.indexOf('LIMIT $4 OFFSET $5')).toBeLessThan(
+        text.indexOf('LEFT JOIN woc_market_sales s'),
+      );
+      expect(sql()).toHaveLength(1);
+    }
+  });
+
+  it('maps buyer provenance onto sold listings and leaves non-sold rows unavailable', async () => {
+    const rows = [
+      {
+        id: 7,
+        realm: REALM,
+        seller_account: 1,
+        seller_character: 2,
+        seller_name: 'Seller',
+        seller_wallet: 'seller-wallet',
+        item: { itemId: 'ember_blade', count: 1 },
+        item_id: 'ember_blade',
+        quality: 'epic',
+        format: 'buy_now',
+        start_cents: 100,
+        reserve_cents: null,
+        buy_now_cents: 500,
+        offer_next: false,
+        status: 'closed',
+        resolution: 'sold',
+        item_disposed: true,
+        current_bid_cents: null,
+        current_bid_id: null,
+        ends_at: new Date(1_000),
+        base_ends_at: new Date(1_000),
+        buy_now_lock_account: null,
+        buy_now_lock_expires: null,
+        created_at: new Date(500),
+        directed_buyer_account: null,
+        cancel_requested_at: null,
+        sale_buyer_account: 44,
+        sale_buyer_name: 'Buyer',
+        sold_at: new Date(900),
+      },
+      {
+        id: 6,
+        realm: REALM,
+        seller_account: 1,
+        seller_character: 2,
+        seller_name: 'Seller',
+        seller_wallet: 'seller-wallet',
+        item: { itemId: 'ash_totem', count: 1 },
+        item_id: 'ash_totem',
+        quality: 'epic',
+        format: 'auction',
+        start_cents: 100,
+        reserve_cents: null,
+        buy_now_cents: null,
+        offer_next: false,
+        status: 'closed',
+        resolution: 'cancelled',
+        item_disposed: true,
+        current_bid_cents: null,
+        current_bid_id: null,
+        ends_at: new Date(1_000),
+        base_ends_at: new Date(1_000),
+        buy_now_lock_account: null,
+        buy_now_lock_expires: null,
+        created_at: new Date(400),
+        directed_buyer_account: null,
+        cancel_requested_at: null,
+        sale_buyer_account: null,
+        sale_buyer_name: null,
+        sold_at: null,
+      },
+    ];
+    const query = vi.fn(async () => ({ rows, rowCount: rows.length }));
+    const result = await new PgWocMarketDb({ query } as unknown as Pool).opsListings({
+      realm: REALM,
+      status: 'all',
+      fromMs: 0,
+      toMs: 1_000,
+      page: 0,
+      pageSize: 50,
+    });
+    expect(
+      result.rows.map((row) => [row.id, row.buyerAccount, row.buyerName, row.soldAtMs]),
+    ).toEqual([
+      [7, 44, 'Buyer', 900],
+      [6, null, null, null],
+    ]);
+  });
+
   it('reads p2p trades from OFFERS, so failed attempts are visible', async () => {
     // Sourcing from sales would show the successes and silently omit every
     // declined, withdrawn, expired or unpaid attempt, which is usually the half

--- a/tests/server/woc_market_directed_sql.test.ts
+++ b/tests/server/woc_market_directed_sql.test.ts
@@ -803,7 +803,7 @@ describe('the operator reads behind the internal dashboard', () => {
 
   it('pages before joining sale provenance and filters sold or cancelled by resolution', async () => {
     for (const status of ['sold', 'cancelled'] as const) {
-      const { pool, sql } = recordingPool();
+      const { pool, sql, params } = recordingPool();
       await new PgWocMarketDb(pool).opsListings({
         realm: REALM,
         status,
@@ -815,13 +815,15 @@ describe('the operator reads behind the internal dashboard', () => {
       const [text] = sql();
       expect(text).toContain('WITH listing_page AS MATERIALIZED');
       expect(text).toContain("status = 'closed'");
-      expect(text).toContain(`resolution = '${status}'`);
-      expect(text).toContain('LIMIT $4 OFFSET $5');
-      expect(text).toContain('LEFT JOIN woc_market_sales s');
+      expect(text).toContain('resolution = $4');
+      expect(params()[0]?.[3]).toBe(status);
+      expect(text).toContain('LIMIT $5 OFFSET $6');
+      expect(text).toContain('LEFT JOIN LATERAL');
+      expect(text).toContain('FROM woc_market_sales sale');
       expect(text).toContain("p.status = 'closed' AND p.resolution = 'sold'");
-      expect(text.indexOf('LIMIT $4 OFFSET $5')).toBeLessThan(
-        text.indexOf('LEFT JOIN woc_market_sales s'),
-      );
+      expect(text).toContain('sale.excluded = false');
+      expect(text).toContain('LIMIT 1');
+      expect(text.indexOf('LIMIT $5 OFFSET $6')).toBeLessThan(text.indexOf('LEFT JOIN LATERAL'));
       expect(sql()).toHaveLength(1);
     }
   });

--- a/tests/woc_market_plan_pins_pg_integration.test.ts
+++ b/tests/woc_market_plan_pins_pg_integration.test.ts
@@ -283,6 +283,74 @@ describeDb('woc market plan-class pins against real Postgres', () => {
     }
   }, 20_000);
 
+  it('operator sold and cancelled pages use the closed-listing index before the bounded sale join', async () => {
+    const realm = 'plans-ops-listings';
+    await pool.query(
+      `INSERT INTO woc_market_listings (
+         realm, seller_account, seller_character, seller_name, seller_wallet,
+         item, item_id, quality, format, start_cents, buy_now_cents,
+         offer_next, status, resolution, item_disposed, ends_at, base_ends_at,
+         created_at)
+       SELECT $1, 10001, 24000 + g, 'OS' || g, 'w-os-' || g,
+              '{"itemId":"crown_of_embers","count":1}'::jsonb, 'crown_of_embers',
+              'epic', 'buy_now', 500, 1000, false, 'closed',
+              CASE WHEN g % 2 = 0 THEN 'sold' ELSE 'cancelled' END,
+              true, now() - interval '1 hour', now() - interval '1 hour',
+              now() - (g || ' seconds')::interval
+         FROM generate_series(1, 1200) g`,
+      [realm],
+    );
+    await pool.query(
+      `INSERT INTO woc_market_sales (
+         realm, listing_id, item_id, item, price_cents, amount_base,
+         seller_account, buyer_account, seller_name, buyer_name, created_at)
+       SELECT realm, id, item_id, item, 1000, '1000000000',
+              seller_account, 10002, seller_name, 'PlanBuyer', created_at
+         FROM woc_market_listings
+        WHERE realm = $1 AND resolution = 'sold'`,
+      [realm],
+    );
+    await pool.query('ANALYZE woc_market_listings');
+    await pool.query('ANALYZE woc_market_sales');
+
+    for (const status of ['sold', 'cancelled'] as const) {
+      take();
+      const page = await marketDb.opsListings({
+        realm,
+        status,
+        fromMs: 0,
+        toMs: Date.now() + 60_000,
+        page: 0,
+        pageSize: 200,
+      });
+      expect(page.hasMore, status).toBe(true);
+      expect(page.rows, status).toHaveLength(200);
+      expect(
+        page.rows.every((row) => row.resolution === status),
+        `${status} filter is resolution-exclusive`,
+      ).toBe(true);
+      if (status === 'sold') {
+        expect(page.rows.every((row) => row.buyerAccount === 10002)).toBe(true);
+        expect(page.rows.every((row) => row.soldAtMs !== null)).toBe(true);
+      } else {
+        expect(page.rows.every((row) => row.buyerAccount === null)).toBe(true);
+        expect(page.rows.every((row) => row.soldAtMs === null)).toBe(true);
+      }
+
+      const [ops] = take();
+      const plan = await planOf(ops.text, ops.values);
+      expect(plan, status).not.toMatch(/Seq Scan on woc_market_listings/);
+      expect(plan, status).toContain('woc_market_ops_closed_created');
+      expect(plan, status).not.toMatch(/Seq Scan on woc_market_sales/);
+      if (status === 'sold') expect(plan).toContain('woc_market_sales_listing_once');
+      // A MATERIALIZED CTE does not export pathkeys, so Postgres may sort the
+      // at-most-201-row joined result once. A second Sort would mean the
+      // listing page stopped riding the ordered index.
+      const sortNodes = plan.split('\n').filter((line) => /(?:^|->)\s*Sort\s+\(/.test(line)).length;
+      expect(sortNodes, status).toBeLessThanOrEqual(1);
+    }
+  }, 20_000);
+
   it('the five stuck-readout classes are index-reachable end to end', async () => {
     take();
     await marketDb.stuckCustodyReadout('plans-readout', Date.now() - 600_000, 10, 1000, 0);

--- a/tests/woc_market_plan_pins_pg_integration.test.ts
+++ b/tests/woc_market_plan_pins_pg_integration.test.ts
@@ -15,9 +15,9 @@
 // 5,000 offers, ANALYZEs, and EXPLAINs at NATURAL costs, proving the planner
 // PREFERS the account indexes at a scale where the old shape seq-scanned.
 //
-// The pins assert plan CLASS (which index, no seq scan, no sort), anchored to
-// the captured query, never plan text: row estimates and node flavors may
-// drift across Postgres versions, index reachability must not.
+// The pins assert plan CLASS (which index, no seq scan, bounded joins),
+// anchored to the captured query, never costs or row estimates: those details
+// may drift across Postgres versions, index reachability must not.
 import { Pool } from 'pg';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { PgWocMarketDb } from '../server/woc_market_db';
@@ -310,6 +310,37 @@ describeDb('woc market plan-class pins against real Postgres', () => {
         WHERE realm = $1 AND resolution = 'sold'`,
       [realm],
     );
+    const voidedListing = await pool.query(
+      `INSERT INTO woc_market_listings (
+         realm, seller_account, seller_character, seller_name, seller_wallet,
+         item, item_id, quality, format, start_cents, buy_now_cents,
+         offer_next, status, resolution, item_disposed, ends_at, base_ends_at,
+         created_at)
+       VALUES ($1, 10001, 25201, 'VoidedSeller', 'w-voided',
+               '{"itemId":"crown_of_embers","count":1}'::jsonb, 'crown_of_embers',
+               'epic', 'buy_now', 500, 1000, false, 'closed', 'sold', true,
+               now() - interval '1 hour', now() - interval '1 hour', now())
+       RETURNING id, item, item_id, seller_account, seller_name, created_at`,
+      [realm],
+    );
+    const voided = voidedListing.rows[0];
+    const voidedListingId = Number(voided.id);
+    await pool.query(
+      `INSERT INTO woc_market_sales (
+         realm, listing_id, item_id, item, price_cents, amount_base,
+         seller_account, buyer_account, seller_name, buyer_name, excluded, created_at)
+       VALUES ($1, $2, $3, $4, 1000, '1000000000', $5, 10003, $6,
+               'VoidedBuyer', true, $7)`,
+      [
+        realm,
+        voidedListingId,
+        voided.item_id,
+        voided.item,
+        voided.seller_account,
+        voided.seller_name,
+        voided.created_at,
+      ],
+    );
     await pool.query('ANALYZE woc_market_listings');
     await pool.query('ANALYZE woc_market_sales');
 
@@ -330,8 +361,15 @@ describeDb('woc market plan-class pins against real Postgres', () => {
         `${status} filter is resolution-exclusive`,
       ).toBe(true);
       if (status === 'sold') {
-        expect(page.rows.every((row) => row.buyerAccount === 10002)).toBe(true);
-        expect(page.rows.every((row) => row.soldAtMs !== null)).toBe(true);
+        const excludedSale = page.rows.find((row) => row.id === voidedListingId);
+        expect(excludedSale).toMatchObject({
+          buyerAccount: null,
+          buyerName: null,
+          soldAtMs: null,
+        });
+        const standingSales = page.rows.filter((row) => row.id !== voidedListingId);
+        expect(standingSales.every((row) => row.buyerAccount === 10002)).toBe(true);
+        expect(standingSales.every((row) => row.soldAtMs !== null)).toBe(true);
       } else {
         expect(page.rows.every((row) => row.buyerAccount === null)).toBe(true);
         expect(page.rows.every((row) => row.soldAtMs === null)).toBe(true);
@@ -342,12 +380,12 @@ describeDb('woc market plan-class pins against real Postgres', () => {
       expect(plan, status).not.toMatch(/Seq Scan on woc_market_listings/);
       expect(plan, status).toContain('woc_market_ops_closed_created');
       expect(plan, status).not.toMatch(/Seq Scan on woc_market_sales/);
-      if (status === 'sold') expect(plan).toContain('woc_market_sales_listing_once');
-      // A MATERIALIZED CTE does not export pathkeys, so Postgres may sort the
-      // at-most-201-row joined result once. A second Sort would mean the
-      // listing page stopped riding the ordered index.
-      const sortNodes = plan.split('\n').filter((line) => /(?:^|->)\s*Sort\s+\(/.test(line)).length;
-      expect(sortNodes, status).toBeLessThanOrEqual(1);
+      if (status === 'sold') {
+        expect(plan).toContain('Nested Loop');
+        expect(plan).toContain('woc_market_sales_listing_once');
+        expect(plan).toMatch(/Index Cond: \(listing_id = p\.id\)/);
+        expect(plan).not.toContain('Hash Right Join');
+      }
     }
   }, 20_000);
 


### PR DESCRIPTION
## Summary

- expose buyer account, buyer name, and sold timestamp on internal exchange-listing reads
- add distinct sold and cancelled operator filters
- page listing rows before joining sale provenance
- add a concurrent partial index for closed public listing history
- add structural, route, mapping, schema, and disposable-Postgres plan coverage

## Type of change

- [x] Feature: new functionality
- [x] Refactor or performance (no behavior change)
- [x] Tests

## How was this tested?

- Commands:
  - `pnpm exec vitest run tests/monolith_budget.test.ts tests/server/internal.test.ts tests/server/woc_market_directed_sql.test.ts tests/schema_wiring.test.ts tests/woc_market_plan_pins_pg_integration.test.ts` — 250 passed, 12 PostgreSQL cases skipped because `TEST_DATABASE_URL` is unavailable
  - `pnpm exec tsc --noEmit` — passed
  - pre-push QA floor — 151 passed, 3 environment-skipped; type, guard, lint, and copy checks green
- Manual steps: N/A; this PR supplies the internal API consumed by the separate dashboard PR.

## Checklist

### Quality

- [x] Decisive tests were added for the changed behavior.
- [ ] Full gate: the unchanged release base reproduces the existing `ci_leg_runner` subprocess-tail failure. The branch-specific test and pre-push floors are green.

### Localization

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` files committed.
- [x] No generated files were hand-edited.

## Runtime follow-up

The disposable PostgreSQL plan test is committed but could not run locally without `TEST_DATABASE_URL`. CI should verify both filters use `woc_market_ops_closed_created` and the sold provenance lookup uses `woc_market_sales_listing_once`.