### PR TITLE
fix(desktop): no Linux PRIME offload when the NVIDIA card drives the screen

### DIFF
--- a/docs/desktop-release.md
+++ b/docs/desktop-release.md
@@ -620,8 +620,12 @@ product exist. Coding and merge stay dark-safe without those credentials.
    never an `appendSwitch` call in the running process.
    `main.cjs` therefore calls `relaunchForLinuxPrime` as the very first thing it
    does (before crash reporting, logging, or any window): on a HYBRID Linux
-   machine (two or more GPUs under `/sys/class/drm`; single-GPU machines are left
-   completely untouched), it re-execs the app with the PRIME variables baked into
+   machine (two or more GPUs under `/sys/class/drm` whose display card, the one
+   sysfs marks `boot_vga`, is not the NVIDIA one; single-GPU machines, and desktops
+   where the NVIDIA card already drives the screen next to an enabled integrated
+   GPU, are left completely untouched: on the latter the offload env fails every
+   EGL display type and Chromium disables the GPU for the session), it re-execs
+   the app with the PRIME variables baked into
    the new process's environment from birth plus `--ozone-platform=x11` appended
    to argv, and the original process exits immediately. The spawn source is
    `$APPIMAGE` (the outer AppImage file, the same source electron-updater restarts

--- a/electron/gpu_preference.cjs
+++ b/electron/gpu_preference.cjs
@@ -96,6 +96,11 @@ const nodePath = require('node:path');
 //         initialise ("Invalid visual ID requested"), the GPU process exits three times and
 //         Chromium disables the GPU for the session (measured 2026-08-28 on an Intel ARL
 //         iGPU + RTX 3090 desktop under X11: no WebGL at all).
+//         Known limit: the check keys on the NVIDIA vendor only. The analogous AMD desktop
+//         (an AMD card on the screen, an iGPU left enabled) still takes the offload path,
+//         where DRI_PRIME=1 points rendering at the other device: it mis-selects rather
+//         than crashing, exactly as under the old two-card rule, and PCI vendor ids cannot
+//         tell an AMD dGPU from an AMD APU, so the fatal NVIDIA case is the scope.
 //     (b) APPIMAGE-AWARE SPAWN SOURCE: in an AppImage, process.execPath points INSIDE the
 //         runtime's FUSE mount, and that mount's daemon is the runtime process, which
 //         unmounts and exits the moment its child (this process) exits; a child spawned from

--- a/electron/gpu_preference.cjs
+++ b/electron/gpu_preference.cjs
@@ -1,5 +1,9 @@
 const { execFileSync: nodeExecFileSync, spawn: nodeSpawn } = require('node:child_process');
-const { existsSync: nodeExistsSync, readdirSync: nodeReaddirSync } = require('node:fs');
+const {
+  existsSync: nodeExistsSync,
+  readdirSync: nodeReaddirSync,
+  readFileSync: nodeReadFileSync,
+} = require('node:fs');
 const nodePath = require('node:path');
 
 // Force the app onto the discrete (high-performance) GPU on hybrid systems, with ZERO
@@ -82,9 +86,16 @@ const nodePath = require('node:path');
 //     caller must invoke this and, if it returns true, exit immediately without creating any
 //     window or spawning the GPU process itself. Four constraints shape the details:
 //     (a) HYBRID-GATED: the relaunch only happens when /sys/class/drm exposes two or more
-//         GPUs (isLinuxHybridGpu). A single-GPU machine gets neither the extra spawn nor a
+//         GPUs AND the card that drives the display (sysfs boot_vga) is not the NVIDIA one
+//         (isLinuxHybridGpu). A single-GPU machine gets neither the extra spawn nor a
 //         forced --ozone-platform=x11 (which would silently move native-Wayland players onto
 //         XWayland for no benefit, and would strand a Wayland-only setup with no XWayland).
+//         A DESKTOP with an integrated GPU left enabled next to the NVIDIA card that runs
+//         the screen is not hybrid territory either: the offload env there makes the NVIDIA
+//         EGL render beside a screen it already owns, every EGL display type fails to
+//         initialise ("Invalid visual ID requested"), the GPU process exits three times and
+//         Chromium disables the GPU for the session (measured 2026-08-28 on an Intel ARL
+//         iGPU + RTX 3090 desktop under X11: no WebGL at all).
 //     (b) APPIMAGE-AWARE SPAWN SOURCE: in an AppImage, process.execPath points INSIDE the
 //         runtime's FUSE mount, and that mount's daemon is the runtime process, which
 //         unmounts and exits the moment its child (this process) exits; a child spawned from
@@ -308,20 +319,48 @@ function shouldRelaunchForLinuxPrime(env, argv, fileExists = nodeExistsSync) {
   return Object.keys(buildLinuxPrimeEnv(env, fileExists)).length > 0;
 }
 
+const NVIDIA_PCI_VENDOR = '0x10de';
+
+/** The card that drives the display, per sysfs: `boot_vga` is 1 on the VGA device the
+ *  firmware brought up the screen on. Null when no card says so or the files are
+ *  unreadable (a headless box, an exotic sandbox). */
+function linuxDisplayCardVendor(cards, readFile) {
+  for (const card of cards) {
+    try {
+      const bootVga = String(readFile(`/sys/class/drm/${card}/device/boot_vga`, 'utf8')).trim();
+      if (bootVga !== '1') continue;
+      return String(readFile(`/sys/class/drm/${card}/device/vendor`, 'utf8'))
+        .trim()
+        .toLowerCase();
+    } catch {
+      // This card has no PCI attributes (a virtual or platform device): not the one.
+    }
+  }
+  return null;
+}
+
 /**
- * True when /sys/class/drm exposes two or more GPU card devices, the hybrid-graphics case
- * this whole lever exists for. Needs no Electron API (getGPUInfo needs app ready, far too
- * late to decide a relaunch), so it can run at the very top of main. On any read failure
- * (exotic sandbox, no /sys) it returns false: when we cannot tell, we impose neither the
- * extra spawn nor a forced X11 backend on the player. `readdir` is injectable for tests.
+ * True when /sys/class/drm exposes two or more GPU card devices AND the card that drives
+ * the display is not the NVIDIA one: the hybrid-graphics case this whole lever exists for
+ * (an integrated GPU on the screen, the NVIDIA card idle until offloaded onto). When the
+ * NVIDIA card already runs the screen (a desktop with its iGPU left enabled, boot_vga on
+ * the 0x10de device) the offload env is not only useless but fatal to the GPU process,
+ * so that machine reads as not hybrid. Needs no Electron API (getGPUInfo needs app ready,
+ * far too late to decide a relaunch), so it can run at the very top of main. On a
+ * /sys/class/drm read failure (exotic sandbox, no /sys) it returns false: when we cannot
+ * tell, we impose neither the extra spawn nor a forced X11 backend on the player. When
+ * only the boot_vga files are unreadable, the two-card rule decides as it always has.
+ * `readdir` and `readFile` are injectable for tests.
  */
-function isLinuxHybridGpu(readdir = nodeReaddirSync) {
+function isLinuxHybridGpu(readdir = nodeReaddirSync, readFile = nodeReadFileSync) {
+  let cards;
   try {
-    const cards = readdir('/sys/class/drm').filter((name) => /^card\d+$/.test(name));
-    return cards.length >= 2;
+    cards = readdir('/sys/class/drm').filter((name) => /^card\d+$/.test(name));
   } catch {
     return false;
   }
+  if (cards.length < 2) return false;
+  return linuxDisplayCardVendor(cards, readFile) !== NVIDIA_PCI_VENDOR;
 }
 
 /**

--- a/electron/gpu_preference.d.cts
+++ b/electron/gpu_preference.d.cts
@@ -14,7 +14,10 @@ export function buildLinuxPrimeEnv(
   fileExists?: (path: string) => boolean,
 ): Record<string, string>;
 export function hasExplicitOzonePlatformArg(argv?: string[]): boolean;
-export function isLinuxHybridGpu(readdir?: (path: string) => string[]): boolean;
+export function isLinuxHybridGpu(
+  readdir?: (path: string) => string[],
+  readFile?: (path: string, encoding: 'utf8') => string,
+): boolean;
 export function shouldRelaunchForLinuxPrime(
   env?: Record<string, string | undefined>,
   argv?: string[],

--- a/tests/electron_gpu_preference.test.ts
+++ b/tests/electron_gpu_preference.test.ts
@@ -349,13 +349,84 @@ describe('hasExplicitOzonePlatformArg', () => {
   });
 });
 
+/** A fake sysfs: which card the firmware brought the screen up on, and each
+ *  card's PCI vendor; a card absent from the map has no PCI attributes. */
+function sysfs(cards: Record<string, { vendor: string; bootVga: '0' | '1' }>) {
+  return (path: string, encoding: 'utf8'): string => {
+    expect(encoding).toBe('utf8');
+    const match = /^\/sys\/class\/drm\/(card\d+)\/device\/(boot_vga|vendor)$/.exec(path);
+    const card = match ? cards[match[1]] : undefined;
+    if (!match || !card) throw new Error(`ENOENT ${path}`);
+    return `${match[2] === 'vendor' ? card.vendor : card.bootVga}\n`;
+  };
+}
+
+const INTEL = '0x8086';
+const NVIDIA = '0x10de';
+const AMD = '0x1002';
+
 describe('isLinuxHybridGpu', () => {
-  it('is true when /sys/class/drm exposes two or more card devices', () => {
+  it('is true on a laptop whose integrated GPU drives the screen next to an NVIDIA card', () => {
     const readdir = (path: string) => {
       expect(path).toBe('/sys/class/drm');
       return ['card0', 'card0-eDP-1', 'card1', 'renderD128', 'renderD129', 'version'];
     };
-    expect(isLinuxHybridGpu(readdir)).toBe(true);
+    const laptop = sysfs({
+      card0: { vendor: INTEL, bootVga: '1' },
+      card1: { vendor: NVIDIA, bootVga: '0' },
+    });
+    expect(isLinuxHybridGpu(readdir, laptop)).toBe(true);
+  });
+
+  it('is false on a desktop where the NVIDIA card already drives the screen', () => {
+    // An Intel ARL iGPU left enabled next to an RTX 3090 on the screen
+    // (measured 2026-08-28): the offload env there fails every EGL display
+    // type ("Invalid visual ID requested") and Chromium disables the GPU.
+    const desktop = sysfs({
+      card1: { vendor: INTEL, bootVga: '0' },
+      card2: { vendor: NVIDIA, bootVga: '1' },
+    });
+    expect(isLinuxHybridGpu(() => ['card1', 'card2', 'renderD128', 'renderD129'], desktop)).toBe(
+      false,
+    );
+  });
+
+  it('keeps an AMD APU plus NVIDIA laptop, and an all-AMD hybrid, on the offload path', () => {
+    const cards = () => ['card0', 'card1'];
+    expect(
+      isLinuxHybridGpu(
+        cards,
+        sysfs({ card0: { vendor: AMD, bootVga: '1' }, card1: { vendor: NVIDIA, bootVga: '0' } }),
+      ),
+    ).toBe(true);
+    expect(
+      isLinuxHybridGpu(
+        cards,
+        sysfs({ card0: { vendor: AMD, bootVga: '1' }, card1: { vendor: AMD, bootVga: '0' } }),
+      ),
+    ).toBe(true);
+  });
+
+  it('falls back to the two-card rule when no card claims the screen or the files are unreadable', () => {
+    const cards = () => ['card0', 'card1'];
+    expect(
+      isLinuxHybridGpu(
+        cards,
+        sysfs({ card0: { vendor: INTEL, bootVga: '0' }, card1: { vendor: NVIDIA, bootVga: '0' } }),
+      ),
+    ).toBe(true);
+    expect(
+      isLinuxHybridGpu(cards, () => {
+        throw new Error('EACCES');
+      }),
+    ).toBe(true);
+    // A card without PCI attributes (a virtual device) is skipped, not fatal.
+    expect(
+      isLinuxHybridGpu(
+        () => ['card0', 'card1', 'card2'],
+        sysfs({ card2: { vendor: NVIDIA, bootVga: '1' } }),
+      ),
+    ).toBe(false);
   });
 
   it('is false on a single-GPU machine (render nodes and connectors do not count)', () => {

--- a/tests/electron_gpu_preference.test.ts
+++ b/tests/electron_gpu_preference.test.ts
@@ -350,14 +350,17 @@ describe('hasExplicitOzonePlatformArg', () => {
 });
 
 /** A fake sysfs: which card the firmware brought the screen up on, and each
- *  card's PCI vendor; a card absent from the map has no PCI attributes. */
-function sysfs(cards: Record<string, { vendor: string; bootVga: '0' | '1' }>) {
+ *  card's PCI vendor; a card absent from the map has no PCI attributes, a card
+ *  without `vendor` has an unreadable vendor file. */
+function sysfs(cards: Record<string, { vendor?: string; bootVga: '0' | '1' }>) {
   return (path: string, encoding: 'utf8'): string => {
     expect(encoding).toBe('utf8');
     const match = /^\/sys\/class\/drm\/(card\d+)\/device\/(boot_vga|vendor)$/.exec(path);
     const card = match ? cards[match[1]] : undefined;
     if (!match || !card) throw new Error(`ENOENT ${path}`);
-    return `${match[2] === 'vendor' ? card.vendor : card.bootVga}\n`;
+    if (match[2] === 'boot_vga') return `${card.bootVga}\n`;
+    if (card.vendor === undefined) throw new Error(`EACCES ${path}`);
+    return `${card.vendor}\n`;
   };
 }
 
@@ -427,6 +430,14 @@ describe('isLinuxHybridGpu', () => {
         sysfs({ card2: { vendor: NVIDIA, bootVga: '1' } }),
       ),
     ).toBe(false);
+    // boot_vga claims the screen but the vendor file is unreadable: that card is skipped
+    // and the two-card rule decides.
+    expect(
+      isLinuxHybridGpu(
+        cards,
+        sysfs({ card0: { bootVga: '1' }, card1: { vendor: NVIDIA, bootVga: '0' } }),
+      ),
+    ).toBe(true);
   });
 
   it('is false on a single-GPU machine (render nodes and connectors do not count)', () => {


### PR DESCRIPTION
## Summary

Some Linux desktops keep the processor's integrated graphics enabled next to their NVIDIA card; the desktop app mistook them for hybrid laptops, applied the laptop-style GPU offload, and ended up with no graphics acceleration at all, so the game could not start.

On Linux the desktop shell decides "hybrid graphics" by counting cards under `/sys/class/drm`
(`isLinuxHybridGpu` in `electron/gpu_preference.cjs`): two or more, and it re-execs the app with
the NVIDIA PRIME offload env plus `--ozone-platform=x11`. A desktop with its integrated GPU left
enabled next to the NVIDIA card that runs the screen also has two cards, and there the offload
env is fatal to Chromium's GPU process: every EGL display type fails to initialise with
`eglInitialize: Invalid visual ID requested`, the GPU process exits three times, and Chromium
disables the GPU for the session. The game then has no WebGL context at all ("Could not start
the renderer"). Every Linux player on such a desktop hits this in the packaged app.

The predicate now also reads which card the firmware brought the screen up on (sysfs
`boot_vga`, no X or Electron API needed) and answers false when that card is the NVIDIA one.
A laptop with an Intel or AMD integrated GPU on the screen keeps the offload path, an all-AMD
hybrid keeps it, and unreadable `boot_vga` files fall back to the two-card rule. The dev loop
(`scripts/electron-dev.mjs`) shares the predicate. The PRIME section of `docs/desktop-release.md`
states the new rule.

Reproduced on an Intel ARL iGPU (`boot_vga=0`) plus RTX 3090 (`boot_vga=1`, the X11 "Source
Output" provider) desktop: with the offload env the GPU process dies at init; without it the
same machine runs on the 3090 (`opengl: enabled_on`, `webgl: enabled`, adapter `0x10de` active).

## Related issues

N/A (found while running the desktop client locally for the first time on that machine).

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [x] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `GATE_SELECT_BASE=upstream/release/v0.41.0 node scripts/gate_select.mjs`: PASS, all 12 steps
    (17962 vitest tests, the browser suite, tsc, builds).
  - `npx vitest run tests/electron_gpu_preference.test.ts tests/electron_shell_startup.test.ts`:
    104 tests, green. New cases drive `isLinuxHybridGpu` with a fake sysfs (`readdir` and
    `readFile` injected): an Intel-on-screen laptop (true), an NVIDIA-on-screen desktop (false),
    AMD APU plus NVIDIA and all-AMD hybrids (true), no card claiming the screen or unreadable
    files (the two-card rule), a card without PCI attributes (skipped, not fatal).
- Manual steps:
  - On the affected desktop, before the fix: `npm run electron:dev` logs
    `running as PRIME-relaunched child`, then `GPU access is disabled due to frequent crashes`
    and the renderer error; the terminal (`ELECTRON_ENABLE_LOGGING=1`) shows the three
    `ANGLE Display::initialize error 12289: Invalid visual ID requested` failures.
  - After the fix: no PRIME relaunch line, `opengl: enabled_on`, `webgl: enabled`, the game runs
    on the 3090. `node -e 'console.log(require("./electron/gpu_preference.cjs").isLinuxHybridGpu())'`
    answers false on that machine.

## Screenshots / recordings

N/A (no UI change).

---

## Checklist

### Quality

- [x] **The gate passes.** `node scripts/gate_select.mjs` is green (or `npm run gate` for
      the full suite). I added or updated decisive
      tests for changed behavior and recorded any manual checks above.

### Cross-platform

- ~Tested on desktop and mobile.~ Linux desktop shell only; no viewport or input change.
- ~Accessible.~ No UI added or edited.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.