### PR TITLE
fix(ui): don't auto-attack when casting Rune of Power

### DIFF
--- a/src/ui/hud/action_bar/attack_on_ability.ts
+++ b/src/ui/hud/action_bar/attack_on_ability.ts
@@ -170,6 +170,10 @@ export function abilityStartsAutoAttack(effects: AbilityEffect[]): boolean {
   let damaging = false;
   for (const e of effects) {
     if (e.type === 'aoeRoot' && e.breakOnDamage !== undefined) return false;
+    // A groundAoE with allyBuffPct is a FRIENDLY zone (Rune of Power): its min/max
+    // are ignored by the sim (see the AbilityEffect comment), so it deals no damage
+    // and must not be classified as an attack.
+    if (e.type === 'groundAoE' && e.allyBuffPct !== undefined) continue;
     const cls = EFFECT_CLASS[e.type];
     if (cls === 'breakCC') return false;
     if (

--- a/tests/attack_on_ability.test.ts
+++ b/tests/attack_on_ability.test.ts
@@ -33,6 +33,18 @@ describe('abilityStartsAutoAttack', () => {
     expect(abilityStartsAutoAttack(effectsOf('hour_of_judgment'))).toBe(false);
   });
 
+  it('does not engage on a friendly groundAoE ally buff (Rune of Power)', () => {
+    // Rune of Power's groundAoE carries allyBuffPct with min/max both 0 (no damage,
+    // "min/max are ignored" per its AbilityEffect comment): it must not be classified
+    // as an attack, or the "Attack on Ability Use" QoL engages a white swing (and can
+    // pull a hostile mob) on a purely defensive/support cast that has no target.
+    expect(abilityStartsAutoAttack(effectsOf('rune_of_power'))).toBe(false);
+  });
+
+  it('still engages on a damaging groundAoE with no allyBuffPct rider (Blizzard)', () => {
+    expect(abilityStartsAutoAttack(effectsOf('blizzard'))).toBe(true);
+  });
+
   it('does not engage on pure crowd control', () => {
     expect(abilityStartsAutoAttack(effectsOf('polymorph'))).toBe(false); // polymorph only
     expect(abilityStartsAutoAttack(effectsOf('sap'))).toBe(false); // incapacitate only


### PR DESCRIPTION
## Summary

Casting Rune of Power (mage choice-row talent) engaged the player's white-swing
auto-attack against whatever hostile mob was currently targeted, which could pull it
mid-encounter (boss pull, unexpected aggro).

Root cause: the "Attack on Ability Use" QoL setting decides whether a cast should also
engage auto-attack by classifying every `groundAoE` ability effect as a damaging attack
(`EFFECT_CLASS.groundAoE = 'damage'` in `attack_on_ability.ts`). Rune of Power's effect is
a `groundAoE` too, but it is a purely FRIENDLY ally-buff zone: it sets `allyBuffPct` and
`min: 0, max: 0`, and the effect's own doc comment on `AbilityEffect` already says
"min/max are ignored" for that variant. `abilityStartsAutoAttack` never checked for that
rider, so it always classified Rune of Power as an attack and engaged auto-attack on cast.

## Fix

```mermaid
flowchart TD
    A["Cast Rune of Power<br/>(groundAoE, allyBuffPct: 0.1, min:0/max:0)"] --> B{abilityStartsAutoAttack}
    B -->|before| C["groundAoE ⇒ always 'damage'"]
    C --> D["startAutoAttack(pid)"]
    D --> E["Aggro + white swing vs<br/>current target"]
    E --> F["Unexpected pull<br/>(boss encounter, etc.)"]

    B -->|after| G{"effect.type === 'groundAoE'<br/>&& allyBuffPct !== undefined?"}
    G -->|yes| H["skip: no damage classification"]
    G -->|no, e.g. Blizzard| I["groundAoE ⇒ 'damage' (unchanged)"]
    H --> J["No auto-attack engage"]
    I --> D
```

`abilityStartsAutoAttack` (`src/ui/hud/action_bar/attack_on_ability.ts`) now skips a
`groundAoE` effect when it carries `allyBuffPct`, since that variant never deals damage.
A damaging `groundAoE` with no `allyBuffPct` rider (e.g. Blizzard) is unaffected and still
correctly engages auto-attack.

## Related issues

N/A (reported directly by a player: "Right now Rune of Power triggers auto attack which
can be unexpected and causes boss pull and whatnot").

## Type of change

- [x] Bug fix

## How was this tested?

- Commands:
  - `npx vitest run tests/attack_on_ability.test.ts` (added two cases: Rune of Power no
    longer engages auto-attack; Blizzard, a damaging groundAoE with no `allyBuffPct`,
    still does)
  - `npx tsc --noEmit`
  - `npx @biomejs/biome check --write src/ui/hud/action_bar/attack_on_ability.ts tests/attack_on_ability.test.ts`
  - `GATE_SELECT_BASE=upstream/release/v0.41.0 node scripts/gate_select.mjs` (PASS: all 12
    steps green)

## Screenshots / recordings

N/A. This is a pure behavioral/logic fix in a DOM-free pure core
(`abilityStartsAutoAttack`); no markup, styling, or rendered HUD state changes as a
result. See the mermaid diagram above for the decision-flow before/after instead.

---

## Checklist

### Quality

- [x] **The gate passes.** `node scripts/gate_select.mjs` is green. Added decisive tests
      for the changed behavior.

### Cross-platform

- [x] N/A. No DOM/CSS change; the fix is a pure boolean classification used identically
      on desktop and mobile.
- [x] N/A. No UI markup change.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not
      enabled in any production path.
- [x] I didn't hand-edit generated files.
