### PR TITLE
fix(sim): keep bag position stable across item swaps

### DIFF
--- a/src/sim/bags.ts
+++ b/src/sim/bags.ts
@@ -31,7 +31,9 @@
 
 import { freePoolSlots, type PoolCapacity, poolCapacityOf, totalPoolCapacity } from './bag_pools';
 import { ITEMS } from './data';
+import { insertInventoryEntryAtPlacement } from './inventory_order';
 import {
+  consumeNewestInventoryUnit,
   consumeSelectedInventorySlot,
   newestMatchingSlot,
   selectedInventorySlot,
@@ -41,6 +43,7 @@ import { isMaterialItemId } from './material_ids';
 import type { SimContext } from './sim_context';
 import {
   cloneItemInstancePayload,
+  type InventoryPlacement,
   type InvSlot,
   type ItemDef,
   type ItemInstancePayload,
@@ -255,10 +258,12 @@ export function addStacked(
   count: number,
   instance?: ItemInstancePayload,
   craftedRecipeId?: string,
+  placement?: InventoryPlacement,
 ): void {
   const def = ITEMS[itemId];
   const stack = stackSizeOf(def);
   let remaining = count;
+  let nextPlacement = placement;
   for (const s of inventory) {
     if (remaining <= 0) return;
     if (
@@ -271,6 +276,7 @@ export function addStacked(
     const take = Math.min(stack - s.count, remaining);
     s.count += take;
     remaining -= take;
+    nextPlacement = undefined;
   }
   const mergeable = isMergeableInstancePayload(instance);
   while (remaining > 0) {
@@ -281,7 +287,8 @@ export function addStacked(
       ? { itemId, count: take, instance: cloneItemInstancePayload(instance) }
       : { itemId, count: take };
     if (craftedRecipeId !== undefined) slot.craftedRecipeId = craftedRecipeId;
-    inventory.push(slot);
+    insertInventoryEntryAtPlacement(inventory, slot, nextPlacement);
+    nextPlacement = undefined;
     remaining -= take;
   }
 }
@@ -480,21 +487,27 @@ export function equipBag(
     ctx.error(meta.entityId, 'That bag cannot be equipped while it carries a special property.');
     return;
   }
-  // A named slot consumes exactly that copy; an id-only call keeps the legacy
-  // newest-first walk (ctx.removeItem) untouched. Both consumers stay
-  // tri-state-aware even though the peek above already refused every
-  // legitimate case: a silent no-op keeps a future divergence between the
-  // peek and consume halves from equipping a bag AND leaving its source copy
-  // behind (item_copy_ref.ts's own "branch on all three" contract).
+  // A named slot consumes exactly that copy. An occupied id-only swap uses the
+  // same newest-first selection with placement capture; an empty socket keeps
+  // ctx.removeItem. The selected consumer is tri-state: this branch rules out
+  // undefined, and null is rechecked after the peek so future divergence cannot
+  // equip a bag while leaving its source copy behind.
+  let placement: InventoryPlacement | undefined;
   if (slotIndex !== undefined) {
     // No onInventoryChangedForQuests here: the shared call below already fires for
     // both arms, and running it twice re-evaluated collect objectives on one equip.
-    if (consumeSelectedInventorySlot(meta.inventory, itemId, slotIndex) === null) return;
+    const consumed = consumeSelectedInventorySlot(meta.inventory, itemId, slotIndex);
+    if (consumed === null) return;
+    placement = consumed.placement;
+  } else if (old && peeked && peeked.count >= 1) {
+    // Bypass ctx.removeItem deliberately so the returned bag can inherit this position.
+    placement = consumeNewestInventoryUnit(meta.inventory, itemId).placement;
+    ctx.onInventoryChangedForQuests(meta);
   } else {
     ctx.removeItem(itemId, 1, meta.entityId);
   }
 
-  if (old) addStacked(meta.inventory, old, 1);
+  if (old) addStacked(meta.inventory, old, 1, undefined, undefined, placement);
   meta.bags[target] = itemId;
   ctx.onInventoryChangedForQuests(meta);
   ctx.emit({ type: 'log', text: `Equipped ${def.name}.`, color: '#8f8', pid: meta.entityId });

--- a/src/sim/bank_sockets.ts
+++ b/src/sim/bank_sockets.ts
@@ -35,11 +35,13 @@ import { BANK_BAG_SOCKETS, bumpBankWireRev, nearBanker, nearBankerTemplateId } f
 import { ITEMS } from './data';
 import * as deedsMod from './deeds';
 import {
+  consumeNewestInventoryUnit,
   consumeSelectedInventorySlot,
   newestMatchingSlot,
   selectedInventorySlot,
 } from './item_copy_ref';
 import type { SimContext } from './sim_context';
+import type { InventoryPlacement } from './types';
 
 const inRange = (socket: number): boolean =>
   Number.isInteger(socket) && socket >= 0 && socket < BANK_BAG_SOCKETS;
@@ -159,19 +161,26 @@ export function bankSocketBag(
     ctx.error(meta.entityId, 'That bag cannot be socketed while it carries a special property.');
     return;
   }
-  // A named slot consumes exactly that copy; an id-only call keeps the legacy
-  // newest-first walk (ctx.removeItem) untouched. Tri-state-aware like
-  // equipBag: a silent no-op keeps a peek/consume divergence from socketing a
-  // bag AND leaving its source copy behind.
+  const old = meta.bank.socketBags[target];
+  // A named slot consumes exactly that copy. An occupied id-only swap uses the
+  // same newest-first selection with placement capture; an empty socket keeps
+  // ctx.removeItem. The selected consumer is tri-state: this branch rules out
+  // undefined, and null is rechecked after the peek so a divergence cannot
+  // socket a bag while leaving its source copy behind.
+  let placement: InventoryPlacement | undefined;
   if (slotIndex !== undefined) {
-    if (consumeSelectedInventorySlot(meta.inventory, itemId, slotIndex) === null) return;
+    const consumed = consumeSelectedInventorySlot(meta.inventory, itemId, slotIndex);
+    if (consumed === null) return;
+    placement = consumed.placement;
+  } else if (old) {
+    placement = consumeNewestInventoryUnit(meta.inventory, itemId).placement;
+    ctx.onInventoryChangedForQuests(meta);
   } else {
     ctx.removeItem(itemId, 1, meta.entityId);
   }
-  const old = meta.bank.socketBags[target];
   // Raw addStacked, never the addItem hub (module header: a swap is a
   // movement, and the hub would inflate reliquary obtain tallies).
-  if (old) addStacked(meta.inventory, old, 1);
+  if (old) addStacked(meta.inventory, old, 1, undefined, undefined, placement);
   meta.bank.socketBags[target] = itemId;
   bumpBankWireRev(meta);
   ctx.onInventoryChangedForQuests(meta);

--- a/src/sim/inventory_order.ts
+++ b/src/sim/inventory_order.ts
@@ -15,10 +15,27 @@
 // Pure leaf: no SimContext, no rng, no clock. The sim's move command and the HUD's grid
 // both call this, so what the player drags onto is what the server rearranges.
 
-import type { InvSlot } from './types';
+import type { InventoryPlacement, InvSlot } from './types';
 
 /** A laid-out bag: one entry per cell, null where the cell is empty. */
 export type BagCells = (InvSlot | null)[];
+
+/** Insert a swap replacement before the stack that followed its removed item,
+ *  so it inherits the vacated dense cell even when intervening removals shift the array. */
+export function insertInventoryEntryAtPlacement(
+  inventory: InvSlot[],
+  entry: InvSlot,
+  placement?: InventoryPlacement,
+): void {
+  if (!placement) {
+    inventory.push(entry);
+    return;
+  }
+  if (placement.slotHint !== undefined) entry.slot = placement.slotHint;
+  const anchorIndex = placement.anchor === null ? -1 : inventory.indexOf(placement.anchor);
+  if (anchorIndex < 0) inventory.push(entry);
+  else inventory.splice(anchorIndex, 0, entry);
+}
 
 /** Place every stack into a cell. A stack's `slot` is honored when it is a real, free
  *  cell of this bag; every other stack (and every stack whose hint was unusable) falls

--- a/src/sim/item_copy_ref.ts
+++ b/src/sim/item_copy_ref.ts
@@ -19,11 +19,10 @@
 // that slot, and a pin re-checked mid-cast catches a bag that shifted underneath.
 //
 // This module is that mechanism, lifted out so every surface can share it. Both
-// halves are MOVES, byte-identical to the private originals they replace
+// halves preserve the selection and payload behavior of the private originals
 // (`consumeSelectedInventorySlot` and `disenchantVictimPin` from
-// professions/enchanting.ts, `consumeEquippedInventoryUnit` from items.ts), because
-// the golden-trace parity gate drives equip / discard / sell / use and an id-only
-// call must stay bit-for-bit what it was. The extraction is the rule of three:
+// professions/enchanting.ts, `consumeEquippedInventoryUnit` from items.ts). A removed
+// stack now also reports its additive placement. The extraction is the rule of three:
 // enchanting had it, items.ts had a near-copy of the fallback half, and the gear
 // loadout is the third caller.
 //
@@ -48,7 +47,21 @@
 // the refusal has to happen EARLIER than the consume, so the composed helper was
 // removed rather than left as documented-but-unused advice.
 
-import { cloneItemInstancePayload, type InventoryUnit, type InvSlot } from './types';
+import {
+  cloneItemInstancePayload,
+  type InventoryPlacement,
+  type InventoryUnitWithPlacement,
+  type InvSlot,
+} from './types';
+
+export function inventoryPlacementForRemovedStack(
+  inventory: readonly InvSlot[],
+  index: number,
+  slot: Pick<InvSlot, 'slot'>,
+): InventoryPlacement {
+  const anchor = inventory[index] ?? null;
+  return slot.slot === undefined ? { anchor } : { anchor, slotHint: slot.slot };
+}
 
 /** Stable, order-independent JSON, so a pin does not depend on key insertion
  *  order. Moved verbatim from professions/enchanting.ts. */
@@ -101,8 +114,23 @@ export function itemCopyPin(slot: InvSlot | undefined): string {
 export function consumeSelectedInventorySlot(
   inventory: InvSlot[],
   itemId: string,
+  slotIndex: number,
+): InventoryUnitWithPlacement | null;
+export function consumeSelectedInventorySlot(
+  inventory: InvSlot[],
+  itemId: string,
+  slotIndex: undefined,
+): undefined;
+export function consumeSelectedInventorySlot(
+  inventory: InvSlot[],
+  itemId: string,
   slotIndex: number | undefined,
-): InventoryUnit | undefined | null {
+): InventoryUnitWithPlacement | undefined | null;
+export function consumeSelectedInventorySlot(
+  inventory: InvSlot[],
+  itemId: string,
+  slotIndex: number | undefined,
+): InventoryUnitWithPlacement | undefined | null {
   if (slotIndex === undefined) return undefined;
   if (!Number.isInteger(slotIndex) || slotIndex < 0 || slotIndex >= inventory.length) return null;
   const slot = inventory[slotIndex];
@@ -111,24 +139,30 @@ export function consumeSelectedInventorySlot(
     slot.instance && slot.count > 1 ? cloneItemInstancePayload(slot.instance) : slot.instance;
   const craftedRecipeId = slot.craftedRecipeId;
   slot.count -= 1;
-  if (slot.count <= 0) inventory.splice(slotIndex, 1);
-  return { instance, craftedRecipeId };
+  let placement: InventoryPlacement | undefined;
+  if (slot.count <= 0) {
+    inventory.splice(slotIndex, 1);
+    placement = inventoryPlacementForRemovedStack(inventory, slotIndex, slot);
+  }
+  return { instance, craftedRecipeId, ...(placement ? { placement } : {}) };
 }
 
 /**
  * The legacy fallback: consume the NEWEST matching copy (highest bag index down).
  *
- * This is the historical guess, kept exactly as it was and deliberately NOT
- * improved. Every id-only caller still reaches it, including callers no UI can
+ * This keeps the historical selection order deliberately unchanged. Every id-only
+ * caller still reaches it, including callers no UI can
  * fix (`server/pbe_boost.ts` auto-gears by bare item id), and the parity goldens
  * drive equip / discard / sell / use through it, so any change here forks the
  * world. New surfaces should pass a selection instead of relying on this.
  *
- * Moved verbatim from `consumeEquippedInventoryUnit` (items.ts), parameterized on
- * the inventory array rather than PlayerMeta so it composes with the selected
- * walk above and needs no meta in a test.
+ * It takes the inventory array rather than PlayerMeta so it composes with the
+ * selected walk above and needs no meta in a test.
  */
-export function consumeNewestInventoryUnit(inventory: InvSlot[], itemId: string): InventoryUnit {
+export function consumeNewestInventoryUnit(
+  inventory: InvSlot[],
+  itemId: string,
+): InventoryUnitWithPlacement {
   for (let i = inventory.length - 1; i >= 0; i--) {
     const slot = inventory[i];
     if (slot.itemId !== itemId) continue;
@@ -136,8 +170,12 @@ export function consumeNewestInventoryUnit(inventory: InvSlot[], itemId: string)
       slot.instance && slot.count > 1 ? cloneItemInstancePayload(slot.instance) : slot.instance;
     const craftedRecipeId = slot.craftedRecipeId;
     slot.count -= 1;
-    if (slot.count <= 0) inventory.splice(i, 1);
-    return { instance, craftedRecipeId };
+    let placement: InventoryPlacement | undefined;
+    if (slot.count <= 0) {
+      inventory.splice(i, 1);
+      placement = inventoryPlacementForRemovedStack(inventory, i, slot);
+    }
+    return { instance, craftedRecipeId, ...(placement ? { placement } : {}) };
   }
   return { instance: undefined, craftedRecipeId: undefined };
 }
@@ -147,9 +185,9 @@ export function consumeNewestInventoryUnit(inventory: InvSlot[], itemId: string)
  * bag index down), SAME match predicate, but returns the live slot rather than
  * taking a unit from it. For a caller that must inspect the copy an id-only
  * command would consume BEFORE committing to consume it (equipBag's bag-payload
- * refusal, bags.ts, #2837): peeking through this function rather than a
- * bespoke walk is what keeps it locked to the real selection `ctx.removeItem`
- * (`Sim.removeItem`) makes, instead of drifting into its own guess.
+ * refusal, bags.ts, #2837), this preserves the historical newest-first selection.
+ * Empty-socket equipBag pairs the peek with `ctx.removeItem`; occupied swaps use
+ * `consumeNewestInventoryUnit` so the removed position is available.
  *
  * THE ONE PRECONDITION, stated because a caller that misses it destroys items.
  * This agrees with `Sim.removeItem` only when the newest matching slot holds

--- a/src/sim/items.ts
+++ b/src/sim/items.ts
@@ -45,7 +45,7 @@ import {
 import { formatMoney } from './format_money';
 import { useBrinyLure } from './interactions/crab_summon';
 import { throwFirebottleAtNearestHut } from './interactions/firebottle_hut';
-import { moveStackToCell } from './inventory_order';
+import { insertInventoryEntryAtPlacement, moveStackToCell } from './inventory_order';
 import { sortInventoryStacks } from './inventory_sort';
 import {
   consumeNewestInventoryUnit,
@@ -71,7 +71,9 @@ import {
   type Entity,
   type EquipSlot,
   INTERACT_RANGE,
+  type InventoryPlacement,
   type InventoryUnit,
+  type InventoryUnitWithPlacement,
   type InvSlot,
   type ItemDef,
   type ItemInstancePayload,
@@ -124,19 +126,24 @@ function returnEquippedItemToBags(
   meta: PlayerMeta,
   itemId: string,
   payload?: ItemInstancePayload,
+  placement?: InventoryPlacement,
 ): void {
   const craftedRecipeId = payload?.craftedRecipeId;
   const instance = payload ? payloadWithoutCraftedRecipeId(payload) : undefined;
   if (instance || craftedRecipeId !== undefined) {
-    meta.inventory.push({
-      itemId,
-      count: 1,
-      ...(instance ? { instance } : {}),
-      ...(craftedRecipeId === undefined ? {} : { craftedRecipeId }),
-    });
+    insertInventoryEntryAtPlacement(
+      meta.inventory,
+      {
+        itemId,
+        count: 1,
+        ...(instance ? { instance } : {}),
+        ...(craftedRecipeId === undefined ? {} : { craftedRecipeId }),
+      },
+      placement,
+    );
     return;
   }
-  addItemSilent(itemId, 1, meta);
+  addItemSilent(itemId, 1, meta, undefined, undefined, placement);
 }
 
 function canReturnEquippedItemToBags(
@@ -546,8 +553,8 @@ export function equipItem(
   // flagged, warning that "a future picker UI should not assume the enchanted copy
   // is always favored". It is no longer the only option: a caller that knows which
   // copy the player meant passes slotIndex and gets exactly it. The id-only walk
-  // stays byte-identical for the callers that cannot (server/pbe_boost.ts, the RL
-  // host, the parity goldens).
+  // keeps the historical newest-first selection for callers that cannot
+  // (server/pbe_boost.ts, the RL host, the parity goldens).
   // A named slot equips exactly that copy. This is the surface the whole feature
   // exists for: with a plain and an enchanted copy of one piece, the legacy walk
   // takes whichever is NEWEST, so looting a plain duplicate silently benches your
@@ -558,7 +565,7 @@ export function equipItem(
   // An invalid selection refuses rather than falling back, because equipping the
   // wrong copy is silent: the piece looks right in the paperdoll and simply
   // carries none of the stats the player expected.
-  let consumed: InventoryUnit;
+  let consumed: InventoryUnitWithPlacement;
   if (slotIndex !== undefined) {
     const taken = consumeSelectedInventorySlot(meta.inventory, itemId, slotIndex);
     // Unreachable in practice: the early gate above refuses an invalid selection
@@ -579,7 +586,7 @@ export function equipItem(
     // silently drop the enchant; worn kinds are 1-per-slot, so the
     // identical-payload merge arm of addItemInstance could
     // never apply here anyway).
-    returnEquippedItemToBags(meta, old, oldInstance);
+    returnEquippedItemToBags(meta, old, oldInstance, consumed.placement);
   }
   if (displacedId) {
     returnEquippedItemToBags(meta, displacedId, displacedInstance);
@@ -1533,6 +1540,7 @@ function addItemSilent(
   meta: PlayerMeta,
   instance?: ItemInstancePayload,
   craftedRecipeId?: string,
+  placement?: InventoryPlacement,
 ): void {
-  addStacked(meta.inventory, itemId, count, instance, craftedRecipeId);
+  addStacked(meta.inventory, itemId, count, instance, craftedRecipeId, placement);
 }

--- a/src/sim/professions/enchanting.ts
+++ b/src/sim/professions/enchanting.ts
@@ -60,7 +60,12 @@ import { ENCHANTS, type EnchantDef } from '../content/enchants';
 import { ENCHANT_FAMILY_CAST_DURATION_SEC } from '../content/professions';
 import { ITEMS } from '../data';
 import { recalcPlayerStats } from '../entity';
-import { consumeSelectedInventorySlot, itemCopyPin } from '../item_copy_ref';
+import { insertInventoryEntryAtPlacement } from '../inventory_order';
+import {
+  consumeSelectedInventorySlot,
+  inventoryPlacementForRemovedStack,
+  itemCopyPin,
+} from '../item_copy_ref';
 import { requiredLevelFor } from '../item_level_req';
 import {
   consumePlayerVaultStock,
@@ -83,7 +88,9 @@ import {
   ENCHANT_CAST_ID,
   type Entity,
   type EquipSlot,
+  type InventoryPlacement,
   type InventoryUnit,
+  type InventoryUnitWithPlacement,
   type InvSlot,
   type ItemDef,
   type ItemInstancePayload,
@@ -196,7 +203,7 @@ export function replaceVictimIndex(inventory: readonly InvSlot[], itemId: string
 export function consumeEnchantedVictim(
   inventory: InvSlot[],
   itemId: string,
-): InventoryUnit | undefined {
+): InventoryUnitWithPlacement | undefined {
   const i = replaceVictimIndex(inventory, itemId);
   if (i < 0) return undefined;
   const s = inventory[i];
@@ -204,8 +211,12 @@ export function consumeEnchantedVictim(
   const payload = survives && s.instance ? cloneItemInstancePayload(s.instance) : s.instance;
   const craftedRecipeId = s.craftedRecipeId;
   s.count -= 1;
-  if (s.count <= 0) inventory.splice(i, 1);
-  return { instance: payload, craftedRecipeId };
+  let placement: InventoryPlacement | undefined;
+  if (s.count <= 0) {
+    inventory.splice(i, 1);
+    placement = inventoryPlacementForRemovedStack(inventory, i, s);
+  }
+  return { instance: payload, craftedRecipeId, ...(placement ? { placement } : {}) };
 }
 
 /** Eligible for disenchant: same eligibility as plain salvage (an equippable
@@ -1031,6 +1042,26 @@ function resolveApplyEnchantWorn(
   return enchantSuccess(itemId, enchantId, vaultDraws);
 }
 
+function reinsertMintedInventoryReplacement(
+  meta: PlayerMeta,
+  itemId: string,
+  replacement: ItemInstancePayload,
+  placement: InventoryPlacement | undefined,
+  inventoryLengthBeforeMint: number,
+): void {
+  if (!placement) return;
+  const minted = meta.inventory[inventoryLengthBeforeMint];
+  // Sim.addItemInstance keeps the caller's payload object for the first minted unit.
+  if (
+    meta.inventory.length === inventoryLengthBeforeMint + 1 &&
+    minted?.itemId === itemId &&
+    minted.instance === replacement
+  ) {
+    meta.inventory.splice(inventoryLengthBeforeMint, 1);
+    insertInventoryEntryAtPlacement(meta.inventory, minted, placement);
+  }
+}
+
 /** The #2415 bagged replace arm: resolve one CONFIRMED apply onto the pinned
  *  already-enchanted victim copy of `itemId` (replaceVictimIndex: the
  *  highest-index enchanted copy, the same end-first order every remover in
@@ -1161,12 +1192,21 @@ function resolveReplaceEnchantBagged(
   // movement: this re-mints the player's OWN copy in place, the same reason
   // silent + callerLogs are set, so it is not a new acquisition for the
   // Reliquary tally either (re-enchanting a relic must not raise its count).
-  ctx.addItemInstance(itemId, replacedEnchantPayloadFor(consumed.instance, enchant), pid, 1, {
+  const replacement = replacedEnchantPayloadFor(consumed.instance, enchant);
+  const inventoryLengthBeforeMint = meta.inventory.length;
+  ctx.addItemInstance(itemId, replacement, pid, 1, {
     silent: true,
     callerLogs: true,
     craftedRecipeId: consumed.craftedRecipeId,
     movement: true,
   });
+  reinsertMintedInventoryReplacement(
+    meta,
+    itemId,
+    replacement,
+    consumed.placement,
+    inventoryLengthBeforeMint,
+  );
   // Quality-tiered gain: the applied enchant's reagent-derived tier, exactly
   // like the plain arms (also stamps the shared throttle).
   grantEnchantingSkill(ctx, meta, enchantGainTier(enchant));
@@ -1315,7 +1355,7 @@ export function resolveApplyEnchant(
   // The minted payload: the consumed copy's markers plus the enchant's
   // additive bonus and marker (enchantedPayloadFor above, shared with the
   // capacity gate).
-  const merged = enchantedPayloadFor(consumed?.instance, enchant);
+  const merged = enchantedPayloadFor(consumed.instance, enchant);
   // silent + callerLogs: the enchantResult event fires its own dedicated cue
   // (audio.enchant in src/game/audio.ts) and logs the one enchant line. This
   // mint re-grants the player's OWN copy, so the hub's "You receive:" line
@@ -1329,12 +1369,22 @@ export function resolveApplyEnchant(
   // loop the player runs entirely on their own gear.
   // movement: the plain apply arm re-mints the player's own copy too (see the
   // replace arm above), so it is a relocation, not an acquisition.
+  const inventoryLengthBeforeMint = meta?.inventory.length;
   ctx.addItemInstance(itemId, merged, pid, 1, {
     silent: true,
     callerLogs: true,
-    craftedRecipeId: consumed?.craftedRecipeId,
+    craftedRecipeId: consumed.craftedRecipeId,
     movement: true,
   });
+  if (meta && inventoryLengthBeforeMint !== undefined) {
+    reinsertMintedInventoryReplacement(
+      meta,
+      itemId,
+      merged,
+      consumed.placement,
+      inventoryLengthBeforeMint,
+    );
+  }
   // Quality-tiered gain: the applied enchant's reagent-derived tier.
   if (meta) grantEnchantingSkill(ctx, meta, enchantGainTier(enchant));
   return enchantSuccess(itemId, enchantId, vaultDraws);

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -274,7 +274,7 @@ import type { GuildBankState, GuildMembership } from './guild_bank';
 import * as guildBankMod from './guild_bank';
 import * as interaction from './interaction';
 import type { ExtractOutcome, ExtractRef } from './inventory_extract';
-import { foldNamedSlotTarget } from './item_copy_ref';
+import { foldNamedSlotTarget, inventoryPlacementForRemovedStack } from './item_copy_ref';
 import {
   boundCraftedRecipeIdOnLoad,
   sanitizeItemInstancePayloadOnLoad,
@@ -754,7 +754,7 @@ import {
   FAERIE_FIRE_ARMOR_PCT,
   GCD,
   type HonorArenaDailyState,
-  type InventoryUnit,
+  type InventoryUnitWithPlacement,
   type InvSlot,
   type ItemInstancePayload,
   isConsuming,
@@ -8830,24 +8830,24 @@ export class Sim {
     return n;
   }
 
-  // Removal counterpart to countEnchantableItem above: prefers plain fungible
-  // stacks (matching removeFungibleItem's ordering within that subset) and only
-  // reaches for an instanced-but-unenchanted copy once no fungible copy is left.
-  // Never removes an already-enchanted copy (isEnchantedInstance). Returns one
-  // InventoryUnit per unit actually consumed, from BOTH passes, so a caller
-  // applying an enchant can merge a crafted copy's signer/masterwork/legacy
-  // rolled.quality into the freshly-enchanted instance instead of silently
-  // dropping them (#1712 round-3 review) AND can re-stamp the plain-stack
-  // craftedRecipeId marker on the copy it mints. Pass 1 (plain stacks) used to
-  // report nothing at all, which is precisely how enchanting a common crafted
-  // item laundered its disenchant-gate provenance: a plain crafted stack keeps
-  // its marker on the SLOT, not in an `instance`, so a payload-only return had
-  // nowhere to put it.
-  removeEnchantableItem(itemId: string, count: number, pid?: number): InventoryUnit[] {
-    const consumed: InventoryUnit[] = [];
+  // Plain stacks remain preferred so a special copy is consumed only when needed.
+  // Returned units preserve both provenance channels and any vacated placement.
+  // Already-enchanted copies are never removed (isEnchantedInstance).
+  // #1712 plain crafted stacks keep their marker on the slot, so payload-only returns cannot carry it.
+  removeEnchantableItem(itemId: string, count: number, pid?: number): InventoryUnitWithPlacement[] {
+    const consumed: InventoryUnitWithPlacement[] = [];
     const r = this.resolve(pid);
     if (!r) return consumed;
     const { meta } = r;
+    const recordPlacement = (index: number, slot: InvSlot, take: number): void => {
+      meta.inventory.splice(index, 1);
+      if (take <= 0) return;
+      consumed[consumed.length - 1].placement = inventoryPlacementForRemovedStack(
+        meta.inventory,
+        index,
+        slot,
+      );
+    };
     // Pass 1: plain fungible stacks only, same order removeFungibleItem uses.
     for (let i = meta.inventory.length - 1; i >= 0 && count > 0; i--) {
       const s = meta.inventory[i];
@@ -8858,7 +8858,7 @@ export class Sim {
       }
       s.count -= take;
       count -= take;
-      if (s.count <= 0) meta.inventory.splice(i, 1);
+      if (s.count <= 0) recordPlacement(i, s, take);
     }
     // Pass 2: instanced copies that are not already enchanted. Per-unit
     // returns with the same clone-on-survival rule removeItem follows: the
@@ -8877,7 +8877,7 @@ export class Sim {
       }
       s.count -= take;
       count -= take;
-      if (s.count <= 0) meta.inventory.splice(i, 1);
+      if (s.count <= 0) recordPlacement(i, s, take);
     }
     this.ctx.onInventoryChangedForQuests(meta);
     return consumed;

--- a/src/sim/sim_context.ts
+++ b/src/sim/sim_context.ts
@@ -60,7 +60,7 @@ import type {
   ErrorReason,
   EscortRunState,
   GatherNodeDef,
-  InventoryUnit,
+  InventoryUnitWithPlacement,
   ItemInstancePayload,
   PendingResurrection,
   PlayerClass,
@@ -640,7 +640,7 @@ export interface SimContextCallbacks {
   // masterwork bonus into the freshly-enchanted instance instead of dropping
   // them, and can re-stamp the craft marker a plain crafted stack carries on
   // the slot rather than in a payload.
-  removeEnchantableItem(itemId: string, count: number, pid?: number): InventoryUnit[];
+  removeEnchantableItem(itemId: string, count: number, pid?: number): InventoryUnitWithPlacement[];
   completeQuestForDev(questId: string, pid?: number): boolean;
   completeCurrentQuestsForDev(pid?: number): number;
 

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -1302,6 +1302,11 @@ export interface InvSlot {
   slot?: number;
 }
 
+export interface InventoryPlacement {
+  anchor: InvSlot | null;
+  slotHint?: number;
+}
+
 // A shallow `{ ...slot }` aliases `instance` between the live slot and a
 // serialized/loaded copy; see cloneItemInstancePayload above (shared with the
 // equipped-instance map, src/sim/professions/enchanting.ts) for why that is
@@ -1328,6 +1333,10 @@ export interface InventoryUnit {
   instance: ItemInstancePayload | undefined;
   craftedRecipeId: string | undefined;
 }
+
+export type InventoryUnitWithPlacement = InventoryUnit & {
+  placement?: InventoryPlacement;
+};
 
 export interface LootSlot extends InvSlot {
   // Quest corpse loot can be personal: each listed player can take one copy.

--- a/tests/bags.test.ts
+++ b/tests/bags.test.ts
@@ -81,6 +81,44 @@ describe('stack sizes and stacking math', () => {
     ]);
   });
 
+  it('addStacked prefers an existing merge and drops the supplied placement', () => {
+    const anchor: InvSlot = { itemId: 'spring_water', count: 1 };
+    const inv: InvSlot[] = [{ itemId: 'baked_bread', count: 19 }, anchor];
+
+    addStacked(inv, 'baked_bread', 2, undefined, undefined, {
+      anchor,
+      slotHint: 9,
+    });
+
+    expect(inv).toEqual([
+      { itemId: 'baked_bread', count: 20 },
+      { itemId: 'spring_water', count: 1 },
+      { itemId: 'baked_bread', count: 1 },
+    ]);
+    expect(inv.at(-1)?.slot).toBeUndefined();
+  });
+
+  it('addStacked inserts non-merging gear before the supplied anchor', () => {
+    const anchor: InvSlot = { itemId: 'cryptbone_helm', count: 1 };
+    const inv: InvSlot[] = [
+      { itemId: 'baked_bread', count: 1 },
+      anchor,
+      { itemId: 'spring_water', count: 1 },
+    ];
+
+    addStacked(inv, 'cryptbone_helm', 1, undefined, undefined, {
+      anchor,
+      slotHint: 10,
+    });
+
+    expect(inv).toEqual([
+      { itemId: 'baked_bread', count: 1 },
+      { itemId: 'cryptbone_helm', count: 1, slot: 10 },
+      anchor,
+      { itemId: 'spring_water', count: 1 },
+    ]);
+  });
+
   it('each copy of an unstackable item takes its own slot', () => {
     const inv: InvSlot[] = [];
     addStacked(inv, 'worn_sword', 3);

--- a/tests/bank_sockets.test.ts
+++ b/tests/bank_sockets.test.ts
@@ -18,7 +18,7 @@
 import { readdirSync, readFileSync, statSync } from 'node:fs';
 import { join, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { stackSizeOf } from '../src/sim/bags';
 import {
   BANK_BAG_SOCKETS,
@@ -480,6 +480,44 @@ describe('bankSocketBag', () => {
     expect(m.inventory.filter((s) => s.itemId === GENERAL_6).length).toBe(1);
     expect(m.inventory.length).toBe(carriedLen);
     expect(holdings(sim)).toEqual(before);
+  });
+
+  it.each([
+    ['named stack', true],
+    ['newest stack', false],
+  ] as const)('returns an occupied socket bag to the vacated %s position', (_label, named) => {
+    const sim = simWithSockets(1);
+    const m = meta(sim);
+    m.bank.socketBags[0] = GENERAL_6;
+    m.inventory.length = 0;
+    m.inventory.push(
+      { itemId: BREAD, count: 1 },
+      { itemId: GENERAL_16, count: 1, slot: 10 },
+      { itemId: ORE, count: 1 },
+    );
+
+    sim.bankSocketBag(GENERAL_16, 0, named ? { slotIndex: 1 } : undefined);
+
+    expect(m.bank.socketBags[0]).toBe(GENERAL_16);
+    expect(m.inventory.map((slot) => slot.itemId)).toEqual([BREAD, GENERAL_6, ORE]);
+    expect(m.inventory[1]?.slot).toBe(10);
+  });
+
+  it.each([
+    ['empty socket', false, false, 2],
+    ['occupied id-only socket', true, false, 2],
+    ['occupied named-slot socket', true, true, 1],
+  ] as const)('notifies quests for the %s arm', (_label, occupied, named, expectedCalls) => {
+    const sim = simWithSockets(1);
+    const m = meta(sim);
+    m.bank.socketBags[0] = occupied ? GENERAL_6 : null;
+    m.inventory.length = 0;
+    m.inventory.push({ itemId: GENERAL_16, count: 1 });
+    const notify = vi.spyOn(sim.ctx, 'onInventoryChangedForQuests');
+
+    sim.bankSocketBag(GENERAL_16, 0, named ? { slotIndex: 0 } : undefined);
+
+    expect(notify).toHaveBeenCalledTimes(expectedCalls);
   });
 
   it('refuses with no open unlocked socket (zero unlocked, and all occupied)', () => {

--- a/tests/inventory_order.test.ts
+++ b/tests/inventory_order.test.ts
@@ -8,7 +8,12 @@
 // claiming one cell all still lay out deterministically, with no stack lost or cloned.
 
 import { describe, expect, it } from 'vitest';
-import { cellOfIndex, layoutBagCells, moveStackToCell } from '../src/sim/inventory_order';
+import {
+  cellOfIndex,
+  insertInventoryEntryAtPlacement,
+  layoutBagCells,
+  moveStackToCell,
+} from '../src/sim/inventory_order';
 import { Sim } from '../src/sim/sim';
 import type { InvSlot } from '../src/sim/types';
 
@@ -56,6 +61,44 @@ describe('layoutBagCells', () => {
   it('an old save with no slots at all lays out exactly as it always did', () => {
     const inv = [stack('a'), stack('b'), stack('c')];
     expect(ids(layoutBagCells(inv, 5))).toEqual(['a', 'b', 'c', null, null]);
+  });
+});
+
+describe('insertInventoryEntryAtPlacement', () => {
+  it('inserts before the surviving anchor and restores the visual hint', () => {
+    const anchor = stack('last');
+    const inventory = [stack('first'), anchor];
+
+    insertInventoryEntryAtPlacement(inventory, stack('replacement'), {
+      anchor,
+      slotHint: 6,
+    });
+
+    expect(inventory).toEqual([stack('first'), stack('replacement', 6), anchor]);
+  });
+
+  it('appends when placement is absent, at the tail, or its anchor disappeared', () => {
+    const missingAnchor = stack('missing');
+    const inventory = [stack('first')];
+
+    insertInventoryEntryAtPlacement(inventory, stack('absent'));
+    insertInventoryEntryAtPlacement(inventory, stack('tail'), {
+      anchor: null,
+      slotHint: 7,
+    });
+    expect(inventory.at(-1)?.slot).toBe(7);
+    insertInventoryEntryAtPlacement(inventory, stack('missing-anchor'), {
+      anchor: missingAnchor,
+      slotHint: 8,
+    });
+    expect(inventory.at(-1)?.slot).toBe(8);
+
+    expect(inventory.map((slot) => slot.itemId)).toEqual([
+      'first',
+      'absent',
+      'tail',
+      'missing-anchor',
+    ]);
   });
 });
 

--- a/tests/inventory_swap_position.test.ts
+++ b/tests/inventory_swap_position.test.ts
@@ -1,0 +1,396 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ENCHANTS } from '../src/sim/content/enchants';
+import { layoutBagCells } from '../src/sim/inventory_order';
+import { resolveApplyEnchant } from '../src/sim/professions/enchanting';
+import { Sim } from '../src/sim/sim';
+import type { InvSlot } from '../src/sim/types';
+
+const OLD_HELM = 'cryptbone_helm';
+const NEW_HELM = 'roadwardens_helm';
+const OLD_RING = 'seal_of_the_nine_oaths';
+const NEW_RING = 'nielas_coldlight_band';
+const ONE_HAND = 'eastbrook_arming_sword';
+const TWO_HAND = 'eastbrook_greatsword';
+const OFFHAND = 'eastbrook_buckler';
+const OLD_BAG = 'linen_pouch';
+const NEW_BAG = 'wolfhide_satchel';
+const ENCHANTED_SWORD = 'eastbrook_arming_sword';
+const OLD_ENCHANT = 'enchant_weapon_might';
+const NEW_ENCHANT = 'enchant_weapon_agility';
+const NEW_ENCHANT_DUST_COUNT = ENCHANTS[NEW_ENCHANT].reagents.find(
+  (reagent) => reagent.itemId === 'arcane_dust',
+)!.count;
+
+function makeSim(): Sim {
+  const sim = new Sim({ seed: 17, playerClass: 'warrior', autoEquip: false });
+  sim.setPlayerLevel(20);
+  sim.inventory.length = 0;
+  sim.drainEvents();
+  return sim;
+}
+
+function itemIds(inventory: readonly InvSlot[]): string[] {
+  return inventory.map((slot) => slot.itemId);
+}
+
+function cellIds(inventory: readonly InvSlot[], capacity = 16): Array<string | null> {
+  return layoutBagCells(inventory, capacity).map((slot) => slot?.itemId ?? null);
+}
+
+function swappedCells(
+  before: readonly (string | null)[],
+  outgoing: string,
+  replacement: string,
+): Array<string | null> {
+  return before.map((itemId) => (itemId === outgoing ? replacement : itemId));
+}
+
+describe('inventory replacement position stability', () => {
+  it('returns equipped gear to the named stack index and hinted cell', () => {
+    const sim = makeSim();
+    sim.equipment.helmet = OLD_HELM;
+    const originalRolled = { stats: { sta: 3 } };
+    sim.equipmentInstances.helmet = { signer: 'Original owner', rolled: originalRolled };
+    sim.inventory.push(
+      { itemId: 'baked_bread', count: 2 },
+      { itemId: NEW_HELM, count: 1, slot: 9 },
+      { itemId: 'spring_water', count: 2 },
+    );
+    const beforeOrder = itemIds(sim.inventory);
+    const beforeCells = cellIds(sim.inventory);
+
+    sim.equipItem(NEW_HELM, { slotIndex: 1 });
+
+    expect(sim.equipment.helmet).toBe(NEW_HELM);
+    expect(itemIds(sim.inventory)).toEqual([beforeOrder[0], OLD_HELM, beforeOrder[2]]);
+    expect(sim.inventory[1]?.slot).toBe(9);
+    expect(sim.inventory[1]?.instance?.signer).toBe('Original owner');
+    expect(sim.inventory[1]?.instance?.rolled).toBe(originalRolled);
+    expect(cellIds(sim.inventory)).toEqual(swappedCells(beforeCells, NEW_HELM, OLD_HELM));
+  });
+
+  it('returns craftedRecipeId-only gear at the vacated position', () => {
+    const sim = makeSim();
+    sim.equipment.helmet = OLD_HELM;
+    sim.equipmentInstances.helmet = { craftedRecipeId: 'recipe_test_helm' };
+    sim.inventory.push(
+      { itemId: 'baked_bread', count: 1 },
+      { itemId: NEW_HELM, count: 1, slot: 4 },
+      { itemId: 'spring_water', count: 1 },
+    );
+
+    sim.equipItem(NEW_HELM, { slotIndex: 1 });
+
+    expect(sim.inventory[1]).toEqual({
+      itemId: OLD_HELM,
+      count: 1,
+      craftedRecipeId: 'recipe_test_helm',
+      slot: 4,
+    });
+  });
+
+  it('keeps click-to-equip through useItem position-stable', () => {
+    const sim = makeSim();
+    sim.equipment.helmet = OLD_HELM;
+    sim.inventory.push(
+      { itemId: 'baked_bread', count: 1 },
+      { itemId: NEW_HELM, count: 1, slot: 6 },
+      { itemId: 'spring_water', count: 1 },
+    );
+
+    sim.useItem(NEW_HELM, { slotIndex: 1 });
+
+    expect(itemIds(sim.inventory)).toEqual(['baked_bread', OLD_HELM, 'spring_water']);
+    expect(sim.inventory[1]?.slot).toBe(6);
+  });
+
+  it('keeps an aimed ring swap through equipItemToSlot position-stable', () => {
+    const sim = makeSim();
+    sim.equipment.ring2 = OLD_RING;
+    sim.inventory.push(
+      { itemId: 'baked_bread', count: 1 },
+      { itemId: NEW_RING, count: 1, slot: 11 },
+      { itemId: 'spring_water', count: 1 },
+    );
+
+    sim.equipItemToSlot(NEW_RING, 'ring2', { slotIndex: 1 });
+
+    expect(sim.equipment.ring2).toBe(NEW_RING);
+    expect(itemIds(sim.inventory)).toEqual(['baked_bread', OLD_RING, 'spring_water']);
+    expect(sim.inventory[1]?.slot).toBe(11);
+  });
+
+  it('captures the newest-unit fallback position when no slot index is supplied', () => {
+    const sim = makeSim();
+    sim.equipment.helmet = OLD_HELM;
+    sim.inventory.push(
+      { itemId: 'baked_bread', count: 1 },
+      { itemId: NEW_HELM, count: 1, slot: 8 },
+      { itemId: 'spring_water', count: 1 },
+    );
+
+    sim.equipItem(NEW_HELM);
+
+    expect(itemIds(sim.inventory)).toEqual(['baked_bread', OLD_HELM, 'spring_water']);
+    expect(sim.inventory[1]?.slot).toBe(8);
+  });
+
+  it('places the old main hand at the vacated index and appends a displaced offhand', () => {
+    const sim = makeSim();
+    sim.equipment.mainhand = ONE_HAND;
+    sim.equipment.offhand = OFFHAND;
+    sim.inventory.push(
+      { itemId: 'baked_bread', count: 1 },
+      { itemId: TWO_HAND, count: 1, slot: 7 },
+      { itemId: 'spring_water', count: 1 },
+    );
+
+    sim.equipItem(TWO_HAND, { slotIndex: 1 });
+
+    expect(sim.equipment.mainhand).toBe(TWO_HAND);
+    expect(sim.equipment.offhand).toBeUndefined();
+    expect(itemIds(sim.inventory)).toEqual(['baked_bread', ONE_HAND, 'spring_water', OFFHAND]);
+    expect(sim.inventory[1]?.slot).toBe(7);
+    expect([sim.equipment.mainhand, ...itemIds(sim.inventory)].sort()).toEqual(
+      [TWO_HAND, ONE_HAND, OFFHAND, 'baked_bread', 'spring_water'].sort(),
+    );
+  });
+
+  it.each([
+    ['named stack', true],
+    ['newest stack', false],
+  ] as const)('returns an occupied socket bag to the vacated %s position', (_label, named) => {
+    const sim = makeSim();
+    sim.bags[0] = OLD_BAG;
+    sim.inventory.push(
+      { itemId: 'baked_bread', count: 1 },
+      { itemId: NEW_BAG, count: 1, slot: 10 },
+      { itemId: 'spring_water', count: 1 },
+    );
+
+    sim.equipBag(NEW_BAG, 0, named ? { slotIndex: 1 } : undefined);
+
+    expect(sim.bags[0]).toBe(NEW_BAG);
+    expect(itemIds(sim.inventory)).toEqual(['baked_bread', OLD_BAG, 'spring_water']);
+    expect(sim.inventory[1]?.slot).toBe(10);
+  });
+
+  it.each([
+    ['empty socket', false, false, 2],
+    ['occupied id-only socket', true, false, 2],
+    ['occupied named-slot socket', true, true, 1],
+  ] as const)('notifies quests for the %s arm', (_label, occupied, named, expectedCalls) => {
+    const sim = makeSim();
+    if (occupied) sim.bags[0] = OLD_BAG;
+    sim.inventory.push({ itemId: NEW_BAG, count: 1 });
+    const notify = vi.spyOn(sim.ctx, 'onInventoryChangedForQuests');
+
+    sim.equipBag(NEW_BAG, 0, named ? { slotIndex: 0 } : undefined);
+
+    expect(notify).toHaveBeenCalledTimes(expectedCalls);
+  });
+
+  it('appends the old bag when the id-only source stack survives consumption', () => {
+    const sim = makeSim();
+    sim.bags[0] = OLD_BAG;
+    sim.inventory.push(
+      { itemId: 'baked_bread', count: 1 },
+      { itemId: NEW_BAG, count: 2, slot: 10 },
+      { itemId: 'spring_water', count: 1 },
+    );
+
+    sim.equipBag(NEW_BAG, 0);
+
+    expect(sim.inventory[1]).toEqual({ itemId: NEW_BAG, count: 1, slot: 10 });
+    expect(sim.inventory.at(-1)).toEqual({ itemId: OLD_BAG, count: 1 });
+    expect(itemIds(sim.inventory)).toEqual(['baked_bread', NEW_BAG, 'spring_water', OLD_BAG]);
+  });
+
+  it('keeps a confirmed bagged enchant remint at the victim index and hint', () => {
+    const sim = makeSim();
+    sim.inventory.push(
+      { itemId: 'baked_bread', count: 1 },
+      {
+        itemId: ENCHANTED_SWORD,
+        count: 1,
+        slot: 12,
+        instance: { enchant: OLD_ENCHANT, rolled: { stats: { str: 2 } } },
+      },
+      { itemId: 'spring_water', count: 1 },
+      { itemId: 'arcane_dust', count: 5 },
+    );
+
+    const result = resolveApplyEnchant(
+      sim.ctx,
+      sim.playerId,
+      ENCHANTED_SWORD,
+      NEW_ENCHANT,
+      undefined,
+      true,
+    );
+
+    expect(result.ok).toBe(true);
+    expect(itemIds(sim.inventory)).toEqual(['baked_bread', ENCHANTED_SWORD, 'spring_water']);
+    expect(sim.inventory[1]?.slot).toBe(12);
+    expect(sim.inventory[1]?.instance?.enchant).toBe(NEW_ENCHANT);
+  });
+
+  it.each([
+    ['unhinted', undefined],
+    ['hinted', 12],
+  ] as const)(
+    'keeps a confirmed %s enchant remint before its anchor after a lower reagent stack is spent',
+    (_label, slot) => {
+      const sim = makeSim();
+      sim.inventory.push(
+        { itemId: 'arcane_dust', count: NEW_ENCHANT_DUST_COUNT },
+        { itemId: 'baked_bread', count: 1 },
+        {
+          itemId: ENCHANTED_SWORD,
+          count: 1,
+          ...(slot === undefined ? {} : { slot }),
+          instance: { enchant: OLD_ENCHANT, rolled: { stats: { str: 2 } } },
+        },
+        { itemId: 'spring_water', count: 1 },
+      );
+
+      const result = resolveApplyEnchant(
+        sim.ctx,
+        sim.playerId,
+        ENCHANTED_SWORD,
+        NEW_ENCHANT,
+        undefined,
+        true,
+      );
+
+      expect(result.ok).toBe(true);
+      expect(itemIds(sim.inventory)).toEqual(['baked_bread', ENCHANTED_SWORD, 'spring_water']);
+      expect(sim.inventory[1]?.slot).toBe(slot);
+      expect(sim.inventory[1]?.instance?.enchant).toBe(NEW_ENCHANT);
+    },
+  );
+
+  it('keeps a first-time bagged enchant at the victim index and hint', () => {
+    const sim = makeSim();
+    sim.inventory.push(
+      { itemId: 'baked_bread', count: 1 },
+      { itemId: ENCHANTED_SWORD, count: 1, slot: 11 },
+      { itemId: 'spring_water', count: 1 },
+      { itemId: 'arcane_dust', count: 5 },
+    );
+
+    const result = resolveApplyEnchant(sim.ctx, sim.playerId, ENCHANTED_SWORD, NEW_ENCHANT);
+
+    expect(result.ok).toBe(true);
+    expect(itemIds(sim.inventory)).toEqual(['baked_bread', ENCHANTED_SWORD, 'spring_water']);
+    expect(sim.inventory[1]?.slot).toBe(11);
+    expect(sim.inventory[1]?.instance?.enchant).toBe(NEW_ENCHANT);
+  });
+
+  it('keeps a first-time instanced enchant at the victim index and hint', () => {
+    const sim = makeSim();
+    sim.inventory.push(
+      { itemId: 'baked_bread', count: 1 },
+      {
+        itemId: ENCHANTED_SWORD,
+        count: 1,
+        slot: 11,
+        instance: { signer: 'Crafter', rolled: { masterwork: true, stats: { str: 2 } } },
+      },
+      { itemId: 'spring_water', count: 1 },
+      { itemId: 'arcane_dust', count: 5 },
+    );
+
+    const result = resolveApplyEnchant(sim.ctx, sim.playerId, ENCHANTED_SWORD, NEW_ENCHANT);
+
+    expect(result.ok).toBe(true);
+    expect(itemIds(sim.inventory)).toEqual(['baked_bread', ENCHANTED_SWORD, 'spring_water']);
+    expect(sim.inventory[1]?.slot).toBe(11);
+    expect(sim.inventory[1]?.instance).toMatchObject({
+      enchant: NEW_ENCHANT,
+      signer: 'Crafter',
+      rolled: { masterwork: true },
+    });
+  });
+
+  it.each([
+    ['plain', undefined],
+    ['instanced', { signer: 'Crafter', rolled: { masterwork: true, stats: { str: 2 } } }],
+  ] as const)(
+    'keeps a first-time %s enchant before its anchor after a lower reagent stack is spent',
+    (_label, instance) => {
+      const sim = makeSim();
+      sim.inventory.push(
+        { itemId: 'arcane_dust', count: NEW_ENCHANT_DUST_COUNT },
+        { itemId: 'baked_bread', count: 1 },
+        {
+          itemId: ENCHANTED_SWORD,
+          count: 1,
+          slot: 11,
+          ...(instance === undefined ? {} : { instance }),
+        },
+        { itemId: 'spring_water', count: 1 },
+      );
+
+      const result = resolveApplyEnchant(sim.ctx, sim.playerId, ENCHANTED_SWORD, NEW_ENCHANT);
+
+      expect(result.ok).toBe(true);
+      expect(itemIds(sim.inventory)).toEqual(['baked_bread', ENCHANTED_SWORD, 'spring_water']);
+      expect(sim.inventory[1]?.slot).toBe(11);
+      expect(sim.inventory[1]?.instance).toMatchObject({
+        enchant: NEW_ENCHANT,
+        ...(instance === undefined ? {} : { signer: 'Crafter', rolled: { masterwork: true } }),
+      });
+    },
+  );
+
+  it('keeps the existing compaction when equipment has no returned item', () => {
+    const sim = makeSim();
+    sim.inventory.push(
+      { itemId: 'baked_bread', count: 1 },
+      { itemId: NEW_HELM, count: 1, slot: 9 },
+      { itemId: 'spring_water', count: 1 },
+    );
+
+    sim.equipItem(NEW_HELM, { slotIndex: 1 });
+
+    expect(itemIds(sim.inventory)).toEqual(['baked_bread', 'spring_water']);
+    expect(sim.inventory.every((slot) => slot.slot !== 9)).toBe(true);
+  });
+
+  it('keeps every other derived cell fixed in an unhinted mixed bag', () => {
+    const sim = makeSim();
+    sim.equipment.helmet = OLD_HELM;
+    sim.inventory.push(
+      { itemId: 'baked_bread', count: 1, slot: 5 },
+      { itemId: NEW_HELM, count: 1 },
+      { itemId: 'spring_water', count: 1 },
+      { itemId: 'minor_healing_potion', count: 1, slot: 8 },
+    );
+    const beforeCells = cellIds(sim.inventory);
+
+    sim.equipItem(NEW_HELM, { slotIndex: 1 });
+
+    expect(cellIds(sim.inventory)).toEqual(swappedCells(beforeCells, NEW_HELM, OLD_HELM));
+    expect(sim.inventory[1]?.slot).toBeUndefined();
+  });
+
+  it('inherits the same replacement position through a gear loadout swap', () => {
+    const sim = makeSim();
+    sim.equipment.helmet = NEW_HELM;
+    const saved = sim.saveLoadout('Stable bags', [], sim.playerId, undefined, true);
+    expect(saved).toBeGreaterThanOrEqual(0);
+    sim.equipment.helmet = OLD_HELM;
+    sim.inventory.push(
+      { itemId: 'baked_bread', count: 1 },
+      { itemId: NEW_HELM, count: 1, slot: 13 },
+      { itemId: 'spring_water', count: 1 },
+    );
+
+    expect(sim.switchLoadout(saved)).toBe(true);
+
+    expect(sim.equipment.helmet).toBe(NEW_HELM);
+    expect(itemIds(sim.inventory)).toEqual(['baked_bread', OLD_HELM, 'spring_water']);
+    expect(sim.inventory[1]?.slot).toBe(13);
+  });
+});

--- a/tests/item_copy_ref.test.ts
+++ b/tests/item_copy_ref.test.ts
@@ -14,6 +14,7 @@ import {
   consumeNewestInventoryUnit,
   consumeSelectedInventorySlot,
   foldNamedSlotTarget,
+  inventoryPlacementForRemovedStack,
   itemCopyPin,
   newestMatchingSlot,
   selectedInventorySlot,
@@ -142,6 +143,20 @@ describe('consumeSelectedInventorySlot: the tri-state', () => {
     expect(unit?.instance).toEqual({ enchantId: 'power' });
     expect(unit?.instance).not.toBe(inv[0].instance);
   });
+
+  it('captures the following stack and visual hint only when removal vacates the slot', () => {
+    const following = plain('boots');
+    const removed: InvSlot[] = [plain('bread'), { ...plain('girdle'), slot: 7 }, following];
+
+    const consumed = consumeSelectedInventorySlot(removed, 'girdle', 1);
+
+    expect(consumed?.placement).toEqual({ anchor: following, slotHint: 7 });
+    expect(removed).toEqual([plain('bread'), following]);
+
+    const surviving: InvSlot[] = [{ ...plain('girdle', 2), slot: 7 }];
+    expect(consumeSelectedInventorySlot(surviving, 'girdle', 0)?.placement).toBeUndefined();
+    expect(surviving).toEqual([{ ...plain('girdle'), slot: 7 }]);
+  });
 });
 
 describe('consumeNewestInventoryUnit: the legacy fallback, unchanged', () => {
@@ -163,6 +178,36 @@ describe('consumeNewestInventoryUnit: the legacy fallback, unchanged', () => {
       craftedRecipeId: undefined,
     });
     expect(inv).toHaveLength(1);
+  });
+
+  it('captures the following stack when removal vacates the newest match', () => {
+    const following = plain('bread');
+    const inv = [{ ...plain('girdle'), slot: 9 }, following, plain('boots')];
+
+    const consumed = consumeNewestInventoryUnit(inv, 'girdle');
+
+    expect(consumed.placement).toEqual({ anchor: following, slotHint: 9 });
+    expect(consumed.placement?.anchor).toBe(following);
+  });
+
+  it('omits placement when the newest matching stack survives', () => {
+    const inv = [plain('bread'), { ...plain('girdle', 2), slot: 9 }];
+
+    expect(consumeNewestInventoryUnit(inv, 'girdle').placement).toBeUndefined();
+    expect(inv).toEqual([plain('bread'), { ...plain('girdle'), slot: 9 }]);
+  });
+});
+
+describe('inventoryPlacementForRemovedStack', () => {
+  it('captures the stack now at the vacated index or null at the tail', () => {
+    const following = plain('boots');
+    const inventory = [plain('bread'), following];
+
+    expect(inventoryPlacementForRemovedStack(inventory, 1, {})).toEqual({ anchor: following });
+    expect(inventoryPlacementForRemovedStack(inventory, 2, { slot: 11 })).toEqual({
+      anchor: null,
+      slotHint: 11,
+    });
   });
 });
 

--- a/tests/professions_enchanting.test.ts
+++ b/tests/professions_enchanting.test.ts
@@ -1791,6 +1791,7 @@ describe('replaceVictimIndex / consumeEnchantedVictim (the shared victim walk)',
     const consumed = consumeEnchantedVictim(stacked, GEAR);
     expect(stacked).toHaveLength(1);
     expect(stacked[0].count).toBe(1);
+    expect(consumed?.placement).toBeUndefined();
     // Clone-on-survival: mutating the returned payload never reaches the
     // surviving stack's shared payload (the removeEnchantableItem contract).
     consumed!.instance!.rolled!.stats!.str = 99;


### PR DESCRIPTION
## Summary

**Cause:** interacting with a bag item that gets replaced by another item reshuffled the whole bag. Equipping a piece of gear returned the previously worn piece to the end of the bag instead of the slot the new piece came from, and every stack after the vacated slot slid one cell over. The same splice-then-append shape existed for bag socket swaps (whose doc comment already promised slot-stable behavior that was never implemented), bank socket swaps, two-hand equips that displace an offhand, gear loadout switches, and enchanting a bagged item.

**Root cause:** the consume helpers (`consumeSelectedInventorySlot`, `consumeNewestInventoryUnit`, `consumeEnchantedVictim`, `Sim.removeEnchantableItem`) splice the emptied stack out of the dense inventory array and the return paths (`returnEquippedItemToBags`, `addStacked`, `ctx.addItemInstance`) push the replacement with no cell hint, so `layoutBagCells` re-derives the grid from the compacted order.

**How it works now:** when a consume removes a stack, it records an `InventoryPlacement`: the stack's `slot` cell hint plus an anchor, the `InvSlot` object that shifted into the vacated dense index (null for a tail removal). The replacement item is inserted back at the anchor's current index (re-derived with `indexOf` at insert time, so intervening mutations such as the enchant reagent draw cannot stale it) and inherits the cell hint. Every other stack keeps its cell, in hand-arranged and untouched bags alike. Fallbacks preserve the old append behavior when the source stack survives or the anchor is gone. Only the directly swapped item is repositioned: a displaced offhand and plain adds still append.

Sim-only change shared by all three hosts (offline, server, RL env): no IWorld facet change, no wire shape change (`InvSlot.slot` was already persisted and wired), no UI change, no new strings. Note for reviewers: bag order on swap commands changes identically on every host; no observation shape or env action reaches the reordering path, but the RL `eat_drink` first-match scan is order-sensitive if an equip action is ever added to the action set.

## Type of change

- [x] Bug fix

## How was this tested?

- Commands:
  - `node scripts/gate_select.mjs` green locally (typecheck, selected tests, changed-files biome, builds).
  - `GAME_REPO=$PWD npx vitest run tests/inventory_swap_position.test.ts` (new suite: every swap path asserts the dense index, the inherited `slot` hint, and the derived `layoutBagCells` cells).
  - Targeted suites: `item_copy_ref`, `inventory_order`, `items`, `equip_target_slot`, `bags`, `bank_sockets`, `professions_enchanting`, `professions_enchanting_commands`, `loadout_gear_swap`, `architecture`, `monolith_budget`, `world_api_parity`, and the full `tests/parity` golden traces, all green.
- Review depth: three independent review passes plus a mutation-testing audit (29 mutants) over the new suites; all surviving-mutant gaps were closed with decisive assertions (append fallback keeps the cell hint, partial-merge overflow placement, quest-notify call counts per socket-swap arm, first-time enchant with a fully consumed reagent stack below the victim).
- Manual steps: none required; the behavior is pinned at the `layoutBagCells` cell level, which is exactly what the bags window renders.

## Checklist

### Quality

- [x] **The gate passes.** `node scripts/gate_select.mjs` is green and decisive tests cover the changed behavior.

### Cross-platform

- ~Tested on desktop and mobile.~ N/A: no UI code changed; the bags window renders the same derived cells.
- ~Accessible.~ N/A: no UI added or edited.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files.

## Follow-up

None required; bank socket swaps were included after review flagged them as the structural twin of bag socket swaps.
