### PR TITLE
fix(sim): weekly raid rooms re-admit their own kill's raiders for loot and corpse runs

### DIFF
--- a/src/sim/instances/dungeons.ts
+++ b/src/sim/instances/dungeons.ts
@@ -86,12 +86,12 @@ export const RAID_REQUIRED_DUNGEON_IDS: ReadonlySet<string> = new Set([
 // how long a corpse run has to make it back. Every other claim state (still
 // being fought, or freed and reclaimed at a new difficulty) keeps the
 // shorter, standard timeout so an abandoned attempt frees its slot promptly.
-// Deliberately HEROIC-ONLY: clearedBy is the only cheap "the final boss is
-// genuinely dead" signal that exists today (lockToHeroicClaim, stamped only
-// from the heroic mark payout), so a normal-difficulty or raid final-boss
-// kill still relies on the shorter INSTANCE_EMPTY_TIMEOUT alone. Extending
-// this further would need its own finalBossDeadAt-style marker on every
-// InstanceSlot, not just the heroic ledger; out of scope here.
+// clearedBy is the cheap "the final boss is genuinely dead" signal: heroic
+// kills stamp it via lockToHeroicClaim, and the weekly raid rooms' NORMAL
+// kills stamp it via awardHeroicMarks' weekly arm, so both take this longer
+// grace. An ordinary normal-difficulty kill stamps nothing and still relies
+// on the shorter INSTANCE_EMPTY_TIMEOUT alone; extending that further would
+// need its own finalBossDeadAt-style marker on every InstanceSlot.
 export const INSTANCE_CLEARED_EMPTY_TIMEOUT = 15 * 60;
 
 export function instanceKeyFor(ctx: SimContext, pid: number): string {
@@ -529,6 +529,19 @@ export function enterDungeon(
   }
   const corpseRunClaim = defeatedNythraxisCorpseRunClaim(ctx, key, r.e);
   const returningForLoot = inst !== undefined && corpseRunClaim === inst;
+  // The cleared-run door exception, the heroic idiom extended to the weekly
+  // rooms: the live claim this kill's own lock came from stays re-enterable
+  // for loot and corpse runs once its final boss is down. raidReturnKeys
+  // holds exactly that kill's participants who actually entered, on the
+  // DURABLE key, so a relog after a wipe cannot strand a raider outside
+  // their own cleared claim; a player locked by an EARLIER run still cannot
+  // walk into someone else's cleared claim, and a claim whose boss is up is
+  // a fresh farm no locked player may join.
+  const returningToClearedClaim =
+    WEEKLY_LOCKOUT_RAID_ROOMS.has(dungeonId) &&
+    inst !== undefined &&
+    !finalBossAlive(ctx, inst) &&
+    inst.raidReturnKeys.has(durableMemberKey(ctx, r.meta.entityId));
   // The raid rooms keep their at-the-door lockout, scoped to the difficulty
   // actually being entered: the live claim's when one exists, else the current
   // selection. A loot-eligible ghost may return to its party's defeated live
@@ -537,17 +550,6 @@ export function enterDungeon(
   if (DAILY_LOCKOUT_RAID_ROOMS.has(dungeonId) || WEEKLY_LOCKOUT_RAID_ROOMS.has(dungeonId)) {
     const doorDifficulty = inst?.difficulty ?? difficulty;
     const lockId = doorDifficulty === 'heroic' ? heroicLockoutId(dungeonId) : dungeonId;
-    // The cleared-run door exception, the heroic idiom extended to the weekly
-    // rooms: the live claim this kill's own lock came from stays re-enterable
-    // for loot and corpse runs once its final boss is down. clearedBy holds
-    // exactly that kill's participants, so a player locked by an EARLIER run
-    // still cannot walk into someone else's cleared claim, and a claim whose
-    // boss is up is a fresh farm no locked player may join.
-    const returningToClearedClaim =
-      WEEKLY_LOCKOUT_RAID_ROOMS.has(dungeonId) &&
-      inst !== undefined &&
-      !finalBossAlive(ctx, inst) &&
-      inst.clearedBy.has(r.meta.entityId);
     if (isRaidLocked(ctx, r.meta, lockId) && !returningForLoot && !returningToClearedClaim) {
       ctx.error(
         r.meta.entityId,
@@ -571,6 +573,7 @@ export function enterDungeon(
     inst &&
     inst.difficulty === 'heroic' &&
     !returningForLoot &&
+    !returningToClearedClaim &&
     isRaidLocked(ctx, r.meta, heroicLockoutId(dungeonId)) &&
     (finalBossAlive(ctx, inst) || !inst.clearedBy.has(r.meta.entityId))
   ) {
@@ -937,6 +940,7 @@ function claimInstance(
   inst.claimedAt = ctx.time;
   inst.clearedBy = new Set();
   inst.enteredBy = new Set();
+  inst.raidReturnKeys = new Set();
   inst.raidBossWelcomeKeys = new Set();
   inst.combatExitMemory = new Map();
   const origin = instanceOriginOf(inst);
@@ -1049,6 +1053,7 @@ function freeInstance(ctx: SimContext, inst: InstanceSlot): void {
   inst.claimedAt = undefined;
   inst.clearedBy = new Set();
   inst.enteredBy = new Set();
+  inst.raidReturnKeys = new Set();
   inst.raidBossWelcomeKeys = new Set();
   inst.combatExitMemory = new Map();
 }
@@ -1184,12 +1189,24 @@ export function instanceLockoutMetas(ctx: SimContext, inst: InstanceSlot): Playe
   return out;
 }
 
+// The durable per-player membership key for a claim's session ledgers: the
+// server's stable character id when present (it survives the relog or
+// character-select Take Over that mints a new entity id), the entity id for
+// offline and sim-only callers (the raidBossWelcomeKeys idiom).
+function durableMemberKey(ctx: SimContext, entityId: number): string {
+  const characterId = ctx.players.get(entityId)?.characterId;
+  return characterId === undefined ? `entity:${entityId}` : `character:${characterId}`;
+}
+
 // Stamp one player's heroic daily lockout for this claim. A player whose lock
 // FIRST lands with this kill also joins the claim's `clearedBy` set: the
 // heroic door's cleared-run exception (enterDungeon) admits only them, so a
 // player locked by an EARLIER run can never treat someone else's cleared claim
 // as their own loot run (corpse loot rights ride the tapper's current party,
-// so an open door would hand them the epics too).
+// so an open door would hand them the epics too). Participants who actually
+// stepped through the door also mint a durable raidReturnKeys entry, the key
+// the weekly rooms' door exception reads (a parked alt the lockout strikes
+// without pay never entered, so it earns no return key either).
 function lockToHeroicClaim(
   ctx: SimContext,
   inst: InstanceSlot,
@@ -1197,7 +1214,12 @@ function lockToHeroicClaim(
   lockedUntil: number,
 ): void {
   const lockId = heroicLockoutId(inst.dungeonId);
-  if (!isRaidLocked(ctx, meta, lockId)) inst.clearedBy.add(meta.entityId);
+  if (!isRaidLocked(ctx, meta, lockId)) {
+    inst.clearedBy.add(meta.entityId);
+    if (inst.enteredBy.has(meta.entityId)) {
+      inst.raidReturnKeys.add(durableMemberKey(ctx, meta.entityId));
+    }
+  }
   meta.raidLockouts.set(lockId, lockedUntil);
 }
 
@@ -1241,7 +1263,13 @@ export function awardHeroicMarks(ctx: SimContext, mob: Entity, recipients: Playe
       for (const meta of lockoutRecipients.values()) {
         // The cleared-run door exception admits exactly this kill's own
         // participants back for loot and corpse runs (the heroic idiom).
-        if (!isRaidLocked(ctx, meta, inst.dungeonId)) inst.clearedBy.add(meta.entityId);
+        // Only players who actually entered mint the durable return key.
+        if (!isRaidLocked(ctx, meta, inst.dungeonId)) {
+          inst.clearedBy.add(meta.entityId);
+          if (inst.enteredBy.has(meta.entityId)) {
+            inst.raidReturnKeys.add(durableMemberKey(ctx, meta.entityId));
+          }
+        }
         meta.raidLockouts.set(inst.dungeonId, lockedUntil);
       }
     }
@@ -1338,8 +1366,15 @@ export function updateInstances(ctx: SimContext): void {
       inst.emptyFor = 0;
     } else {
       inst.emptyFor += 1;
-      const emptyTimeout =
-        inst.clearedBy.size > 0 ? INSTANCE_CLEARED_EMPTY_TIMEOUT : INSTANCE_EMPTY_TIMEOUT;
+      // The Ignivar rooms free as a whole family, so a bossless room's shorter
+      // empty timeout must not reap a sibling's cleared claim (and its boss
+      // corpse) out from under the loot-and-corpse-run grace window: any
+      // cleared claim in the family extends the grace to all of it.
+      const clearedGrace =
+        inst.clearedBy.size > 0 ||
+        (isIgnivarRaidRoom(inst.dungeonId) &&
+          ignivarRaidClaimsForKey(ctx, inst.partyKey).some((claim) => claim.clearedBy.size > 0));
+      const emptyTimeout = clearedGrace ? INSTANCE_CLEARED_EMPTY_TIMEOUT : INSTANCE_EMPTY_TIMEOUT;
       if (inst.emptyFor >= emptyTimeout) {
         if (isIgnivarRaidRoom(inst.dungeonId)) {
           for (const claim of ignivarRaidClaimsForKey(ctx, inst.partyKey)) {

--- a/src/sim/instances/dungeons.ts
+++ b/src/sim/instances/dungeons.ts
@@ -74,7 +74,10 @@ const RAID_ALLOWED_DUNGEON_IDS = new Set([
   'nythraxis_boss_arena',
   ...IGNIVAR_RAID_ROOM_IDS,
 ]);
-const RAID_REQUIRED_DUNGEON_IDS = new Set(['nythraxis_boss_arena', ...IGNIVAR_RAID_ROOM_IDS]);
+export const RAID_REQUIRED_DUNGEON_IDS: ReadonlySet<string> = new Set([
+  'nythraxis_boss_arena',
+  ...IGNIVAR_RAID_ROOM_IDS,
+]);
 // A claim whose final boss is already dead (inst.clearedBy is non-empty) idles
 // this much longer than INSTANCE_EMPTY_TIMEOUT before the reaper frees it: a
 // clean kill that wipes the whole party, with nobody left to resurrect, must
@@ -299,6 +302,14 @@ export const WEEKLY_LOCKOUT_RAID_ROOMS: ReadonlySet<string> = new Set([
   'ignivar_inner_crucible',
 ]);
 
+// The raid boss rooms that keep the realm-DAILY boundary, by the same explicit
+// maintainer ruling. Every raid-tier room with a final boss must appear in
+// exactly one of these two sets: the at-the-door lock check below reads their
+// union, and the guard in tests/ignivar_weekly_lockout.test.ts fails any new
+// raid boss room that names neither, so a future room cannot silently ship on
+// an undeclared boundary.
+export const DAILY_LOCKOUT_RAID_ROOMS: ReadonlySet<string> = new Set(['nythraxis_boss_arena']);
+
 // The reset boundary a final-boss kill in this dungeon locks until: the weekly
 // boundary for the raid rooms above, the realm-daily boundary everywhere else.
 function finalBossLockedUntil(ctx: SimContext, dungeonId: string): number {
@@ -518,14 +529,26 @@ export function enterDungeon(
   }
   const corpseRunClaim = defeatedNythraxisCorpseRunClaim(ctx, key, r.e);
   const returningForLoot = inst !== undefined && corpseRunClaim === inst;
-  // Nythraxis keeps its at-the-door lockout, scoped to the difficulty actually
-  // being entered: the live claim's when one exists, else the current selection.
-  // A loot-eligible ghost may return to its party's defeated live claim for the
-  // normal corpse-run resurrection, but the lockout still bars every fresh claim.
-  if (dungeonId === 'nythraxis_boss_arena' || WEEKLY_LOCKOUT_RAID_ROOMS.has(dungeonId)) {
+  // The raid rooms keep their at-the-door lockout, scoped to the difficulty
+  // actually being entered: the live claim's when one exists, else the current
+  // selection. A loot-eligible ghost may return to its party's defeated live
+  // claim for the normal corpse-run resurrection, but the lockout still bars
+  // every fresh claim.
+  if (DAILY_LOCKOUT_RAID_ROOMS.has(dungeonId) || WEEKLY_LOCKOUT_RAID_ROOMS.has(dungeonId)) {
     const doorDifficulty = inst?.difficulty ?? difficulty;
     const lockId = doorDifficulty === 'heroic' ? heroicLockoutId(dungeonId) : dungeonId;
-    if (isRaidLocked(ctx, r.meta, lockId) && !returningForLoot) {
+    // The cleared-run door exception, the heroic idiom extended to the weekly
+    // rooms: the live claim this kill's own lock came from stays re-enterable
+    // for loot and corpse runs once its final boss is down. clearedBy holds
+    // exactly that kill's participants, so a player locked by an EARLIER run
+    // still cannot walk into someone else's cleared claim, and a claim whose
+    // boss is up is a fresh farm no locked player may join.
+    const returningToClearedClaim =
+      WEEKLY_LOCKOUT_RAID_ROOMS.has(dungeonId) &&
+      inst !== undefined &&
+      !finalBossAlive(ctx, inst) &&
+      inst.clearedBy.has(r.meta.entityId);
+    if (isRaidLocked(ctx, r.meta, lockId) && !returningForLoot && !returningToClearedClaim) {
       ctx.error(
         r.meta.entityId,
         doorDifficulty === 'heroic'
@@ -549,7 +572,7 @@ export function enterDungeon(
     inst.difficulty === 'heroic' &&
     !returningForLoot &&
     isRaidLocked(ctx, r.meta, heroicLockoutId(dungeonId)) &&
-    (heroicFinalBossAlive(ctx, inst) || !inst.clearedBy.has(r.meta.entityId))
+    (finalBossAlive(ctx, inst) || !inst.clearedBy.has(r.meta.entityId))
   ) {
     ctx.error(r.meta.entityId, `You are locked to Heroic ${dungeon.name}.`);
     return false;
@@ -698,11 +721,12 @@ function isRaidLocked(ctx: SimContext, meta: PlayerMeta, dungeonId: string): boo
   return true;
 }
 
-// Is the claimed heroic instance's final boss still up? Gates the locked-player
-// door rule in enterDungeon: a cleared run (boss down, or its corpse already
-// swept) stays re-enterable for loot and corpse-runs; a run with the boss alive
-// is a fresh farm a locked player must not join.
-function heroicFinalBossAlive(ctx: SimContext, inst: InstanceSlot): boolean {
+// Is the claimed instance's final boss still up? Difficulty-agnostic (the
+// tuning table names the final boss for both difficulties). Gates the
+// locked-player door rules in enterDungeon: a cleared run (boss down, or its
+// corpse already swept) stays re-enterable for loot and corpse-runs; a run
+// with the boss alive is a fresh farm a locked player must not join.
+function finalBossAlive(ctx: SimContext, inst: InstanceSlot): boolean {
   const tuning = HEROIC_DUNGEON_TUNING[inst.dungeonId];
   if (!tuning) return false;
   for (const id of inst.mobIds) {

--- a/src/sim/instances/instance_slot.ts
+++ b/src/sim/instances/instance_slot.ts
@@ -20,6 +20,7 @@ export function freshInstanceSlot(dungeonId: string, slot: number): InstanceSlot
     resetAvailableAt: 0,
     clearedBy: new Set(),
     enteredBy: new Set(),
+    raidReturnKeys: new Set(),
     raidBossWelcomeKeys: new Set(),
     combatExitMemory: new Map(),
   };

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -1178,6 +1178,13 @@ export interface InstanceSlot {
   // when they actually entered this run: a door-camper or a member parked in
   // town takes the lockout without turning roster membership into mailed income.
   enteredBy: Set<number>;
+  // Durable-character (or offline-entity) identities of THIS kill's own locked
+  // participants who actually stepped through the door: the weekly raid rooms'
+  // cleared-run door exception re-admits exactly these for loot and corpse
+  // runs. Durable-keyed (the raidBossWelcomeKeys idiom) so the relog that
+  // mints a new entity id after a wipe cannot strand a raider outside their
+  // own cleared claim. Session-only, cleared with the claim.
+  raidReturnKeys: Set<string>;
   // Durable-character or offline-entity identities that already heard this
   // claim's first-entry raid-boss welcome. Session-only and cleared with the
   // claim so a relog cannot replay it while a fresh instance can.

--- a/tests/deeds_sites_pin.test.ts
+++ b/tests/deeds_sites_pin.test.ts
@@ -86,6 +86,7 @@ function encounterInstance(
     resetAvailableAt: 0,
     clearedBy: new Set(),
     enteredBy: new Set(),
+    raidReturnKeys: new Set(),
     raidBossWelcomeKeys: new Set(),
     combatExitMemory: new Map(),
   };

--- a/tests/dungeons.test.ts
+++ b/tests/dungeons.test.ts
@@ -2783,7 +2783,7 @@ describe('dungeons: a cleared heroic claim outlives the ordinary empty-timeout',
     expect(inst.partyKey, 'freed once the extended grace elapses').toBeNull();
   });
 
-  it('a normal-difficulty run never earns the extended grace (clearedBy is heroic-only)', () => {
+  it('an ordinary normal-difficulty run never earns the extended grace (no clearedBy stamp)', () => {
     const sim = makeSim();
     const pid = sim.addPlayer('warrior', 'Solo');
     enterDungeon(sim.ctx, 'hollow_crypt', pid);

--- a/tests/ignivar_weekly_lockout.test.ts
+++ b/tests/ignivar_weekly_lockout.test.ts
@@ -4,9 +4,18 @@
 // through a real Sim's ctx settle hub and the real enterDungeon door, the
 // deeds_sites_pin harness idiom.
 import { describe, expect, it } from 'vitest';
+import { HEROIC_DUNGEON_TUNING } from '../src/sim/content/dungeon_difficulty';
 import { DUNGEONS, instanceOrigin, MOBS } from '../src/sim/data';
 import { createMob } from '../src/sim/entity';
-import { enterDungeon, heroicLockoutId } from '../src/sim/instances/dungeons';
+import {
+  DAILY_LOCKOUT_RAID_ROOMS,
+  enterDungeon,
+  heroicLockoutId,
+  instanceKeyFor,
+  leaveDungeon,
+  RAID_REQUIRED_DUNGEON_IDS,
+  WEEKLY_LOCKOUT_RAID_ROOMS,
+} from '../src/sim/instances/dungeons';
 import { type InstanceSlot, type PlayerMeta, Sim } from '../src/sim/sim';
 import type { DungeonDifficulty, Entity, Vec3 } from '../src/sim/types';
 
@@ -190,5 +199,93 @@ describe('the door: a locked player cannot mint a fresh raid claim', () => {
     lead.raidLockouts.set('ignivar_raid_arena', Math.floor(sim.time * 1000) - 1);
     expect(enterDungeon(sim.ctx, 'ignivar_raid_arena', lead.entityId, true)).toBe(true);
     expect(lead.raidLockouts.has('ignivar_raid_arena')).toBe(false);
+  });
+});
+
+// A real claimed run through the real door: enter, find the claim and its own
+// final boss, kill it via the real stamping path, then exercise re-entry.
+function clearedClaimRun(sim: Sim, lead: PlayerMeta): { inst: InstanceSlot; boss: Entity } {
+  expect(enterDungeon(sim.ctx, 'ignivar_raid_arena', lead.entityId, true)).toBe(true);
+  const key = instanceKeyFor(sim.ctx, lead.entityId);
+  const inst = sim.ctx.instances.find(
+    (i) => i.dungeonId === 'ignivar_raid_arena' && i.partyKey === key,
+  )!;
+  expect(inst).toBeDefined();
+  const finalBossId = HEROIC_DUNGEON_TUNING.ignivar_raid_arena.finalBossId;
+  const boss = inst.mobIds
+    .map((id) => sim.entities.get(id))
+    .find((e): e is Entity => e !== undefined && e.templateId === finalBossId)!;
+  expect(boss).toBeDefined();
+  boss.hp = 0;
+  boss.dead = true;
+  sim.ctx.awardHeroicMarks(boss, [lead]);
+  expect(lead.raidLockouts.has('ignivar_raid_arena')).toBe(true);
+  expect(inst.clearedBy.has(lead.entityId)).toBe(true);
+  return { inst, boss };
+}
+
+describe('the cleared-run door exception on the weekly rooms', () => {
+  it('a participant who steps out after the kill re-enters the cleared claim for loot', () => {
+    const sim = makeSim();
+    const lead = raidLeader(sim);
+    clearedClaimRun(sim, lead);
+    expect(leaveDungeon(sim.ctx, lead.entityId)).toBe(true);
+    expect(enterDungeon(sim.ctx, 'ignivar_raid_arena', lead.entityId, true)).toBe(true);
+  });
+
+  it('a released ghost locked by its own kill walks back in to resurrect', () => {
+    const sim = makeSim();
+    const lead = raidLeader(sim);
+    const { inst } = clearedClaimRun(sim, lead);
+    const e = entityOf(sim, lead);
+    const corpsePos = { ...e.pos };
+    expect(leaveDungeon(sim.ctx, lead.entityId)).toBe(true);
+    e.dead = true;
+    e.ghost = true;
+    e.corpsePos = corpsePos;
+    e.corpseInstanceId = inst.exitId;
+    expect(enterDungeon(sim.ctx, 'ignivar_raid_arena', lead.entityId, true)).toBe(true);
+  });
+
+  it('a player locked by an earlier run is still barred from someone else cleared claim', () => {
+    const sim = makeSim();
+    const lead = raidLeader(sim);
+    clearedClaimRun(sim, lead);
+    // Late joins the raid AFTER the kill, carrying a lock from an earlier run:
+    // not in this claim's clearedBy, so the door must still refuse the ferry.
+    const latePid = sim.addPlayer('mage', 'Late');
+    sim.partyInvite(latePid, lead.entityId);
+    sim.partyAccept(latePid);
+    const late = sim.players.get(latePid)!;
+    late.raidLockouts.set('ignivar_raid_arena', Math.floor(sim.time * 1000) + WEEK_MS);
+    expect(enterDungeon(sim.ctx, 'ignivar_raid_arena', latePid, true)).toBe(false);
+  });
+});
+
+describe('every raid boss room declares its lockout boundary explicitly', () => {
+  it('raid rooms with a final boss sit in exactly one of the weekly/daily sets', () => {
+    for (const dungeonId of RAID_REQUIRED_DUNGEON_IDS) {
+      const hasFinalBoss = HEROIC_DUNGEON_TUNING[dungeonId]?.finalBossId !== undefined;
+      const weekly = WEEKLY_LOCKOUT_RAID_ROOMS.has(dungeonId);
+      const daily = DAILY_LOCKOUT_RAID_ROOMS.has(dungeonId);
+      if (!hasFinalBoss) {
+        expect(weekly || daily, `${dungeonId} has no final boss, so no lockout set`).toBe(false);
+        continue;
+      }
+      expect(
+        weekly !== daily,
+        `${dungeonId} must declare weekly or daily lockout, exactly one`,
+      ).toBe(true);
+    }
+  });
+
+  it('the two sets never overlap and name only raid-tier rooms', () => {
+    for (const dungeonId of WEEKLY_LOCKOUT_RAID_ROOMS) {
+      expect(DAILY_LOCKOUT_RAID_ROOMS.has(dungeonId), dungeonId).toBe(false);
+      expect(RAID_REQUIRED_DUNGEON_IDS.has(dungeonId), dungeonId).toBe(true);
+    }
+    for (const dungeonId of DAILY_LOCKOUT_RAID_ROOMS) {
+      expect(RAID_REQUIRED_DUNGEON_IDS.has(dungeonId), dungeonId).toBe(true);
+    }
   });
 });

--- a/tests/ignivar_weekly_lockout.test.ts
+++ b/tests/ignivar_weekly_lockout.test.ts
@@ -11,13 +11,16 @@ import {
   DAILY_LOCKOUT_RAID_ROOMS,
   enterDungeon,
   heroicLockoutId,
+  INSTANCE_CLEARED_EMPTY_TIMEOUT,
   instanceKeyFor,
   leaveDungeon,
   RAID_REQUIRED_DUNGEON_IDS,
+  updateInstances,
   WEEKLY_LOCKOUT_RAID_ROOMS,
 } from '../src/sim/instances/dungeons';
 import { type InstanceSlot, type PlayerMeta, Sim } from '../src/sim/sim';
 import type { DungeonDifficulty, Entity, Vec3 } from '../src/sim/types';
+import { INSTANCE_EMPTY_TIMEOUT } from '../src/sim/types';
 
 const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -62,6 +65,7 @@ function encounterInstance(
     slot: 0,
     partyKey: 'party:lockout-test',
     mobIds: [boss.id],
+    raidReturnKeys: new Set(),
     raidBossWelcomeKeys: new Set(),
     npcIds: [],
     objectIds: [],
@@ -221,19 +225,43 @@ function clearedClaimRun(sim: Sim, lead: PlayerMeta): { inst: InstanceSlot; boss
   sim.ctx.awardHeroicMarks(boss, [lead]);
   expect(lead.raidLockouts.has('ignivar_raid_arena')).toBe(true);
   expect(inst.clearedBy.has(lead.entityId)).toBe(true);
+  // Offline members key by entity id; only the entrant minted a return key.
+  expect(inst.raidReturnKeys.has(`entity:${lead.entityId}`)).toBe(true);
   return { inst, boss };
+}
+
+// The file's ctx.error capture idiom, shared by the refusal pins below.
+function captureErrors(sim: Sim): string[] {
+  const errors: string[] = [];
+  const restore = sim.ctx.error;
+  sim.ctx.error = (pid: number, text: string) => {
+    errors.push(text);
+    restore(pid, text);
+  };
+  return errors;
+}
+
+const ARENA_LOCK_ERROR = 'You are locked to Crucible of the Last Spring.';
+
+function arenaClaimsFor(sim: Sim, pid: number): InstanceSlot[] {
+  const key = instanceKeyFor(sim.ctx, pid);
+  return sim.ctx.instances.filter(
+    (i) => i.dungeonId === 'ignivar_raid_arena' && i.partyKey === key,
+  );
 }
 
 describe('the cleared-run door exception on the weekly rooms', () => {
   it('a participant who steps out after the kill re-enters the cleared claim for loot', () => {
     const sim = makeSim();
     const lead = raidLeader(sim);
-    clearedClaimRun(sim, lead);
+    const { inst } = clearedClaimRun(sim, lead);
     expect(leaveDungeon(sim.ctx, lead.entityId)).toBe(true);
     expect(enterDungeon(sim.ctx, 'ignivar_raid_arena', lead.entityId, true)).toBe(true);
+    // Back into the SAME claim: no parallel run was minted for a second loot pass.
+    expect(arenaClaimsFor(sim, lead.entityId)).toEqual([inst]);
   });
 
-  it('a released ghost locked by its own kill walks back in to resurrect', () => {
+  it('a released ghost locked by its own kill walks back through the door', () => {
     const sim = makeSim();
     const lead = raidLeader(sim);
     const { inst } = clearedClaimRun(sim, lead);
@@ -245,6 +273,62 @@ describe('the cleared-run door exception on the weekly rooms', () => {
     e.corpsePos = corpsePos;
     e.corpseInstanceId = inst.exitId;
     expect(enterDungeon(sim.ctx, 'ignivar_raid_arena', lead.entityId, true)).toBe(true);
+    expect(arenaClaimsFor(sim, lead.entityId)).toEqual([inst]);
+  });
+
+  it('a relog that mints a new entity id keeps the durable return key working', () => {
+    const sim = makeSim();
+    const lead = raidLeader(sim);
+    // The killer is a raid member with a durable character id, the server shape.
+    const memPid = sim.addPlayer('warrior', 'Mem', { characterId: 777 });
+    sim.partyInvite(memPid, lead.entityId);
+    sim.partyAccept(memPid);
+    const mem = sim.players.get(memPid)!;
+    expect(enterDungeon(sim.ctx, 'ignivar_raid_arena', memPid, true)).toBe(true);
+    const inst = arenaClaimsFor(sim, memPid)[0];
+    const finalBossId = HEROIC_DUNGEON_TUNING.ignivar_raid_arena.finalBossId;
+    const boss = inst.mobIds
+      .map((id) => sim.entities.get(id))
+      .find((e): e is Entity => e !== undefined && e.templateId === finalBossId)!;
+    boss.hp = 0;
+    boss.dead = true;
+    sim.ctx.awardHeroicMarks(boss, [mem]);
+    expect(inst.raidReturnKeys.has('character:777')).toBe(true);
+    expect(leaveDungeon(sim.ctx, memPid)).toBe(true);
+    // Relog: the old session's entity id is gone, the character id survives,
+    // and the durable lockout rides back in the way hydration restores it.
+    sim.removePlayer(memPid);
+    const backPid = sim.addPlayer('warrior', 'Mem', { characterId: 777 });
+    sim.partyInvite(backPid, lead.entityId);
+    sim.partyAccept(backPid);
+    const back = sim.players.get(backPid)!;
+    back.raidLockouts.set('ignivar_raid_arena', Math.floor(sim.time * 1000) + WEEK_MS);
+    expect(enterDungeon(sim.ctx, 'ignivar_raid_arena', backPid, true)).toBe(true);
+  });
+
+  it('a claim whose boss is back up is a fresh farm: the lockout still bars it', () => {
+    const sim = makeSim();
+    const lead = raidLeader(sim);
+    const { boss } = clearedClaimRun(sim, lead);
+    expect(leaveDungeon(sim.ctx, lead.entityId)).toBe(true);
+    boss.dead = false;
+    const errors = captureErrors(sim);
+    expect(enterDungeon(sim.ctx, 'ignivar_raid_arena', lead.entityId, true)).toBe(false);
+    expect(errors).toContain(ARENA_LOCK_ERROR);
+  });
+
+  it('a raid member who never entered takes the lockout but earns no return key', () => {
+    const sim = makeSim();
+    const lead = raidLeader(sim);
+    const { inst } = clearedClaimRun(sim, lead);
+    // The parked alt: locked with the roster (instanceLockoutMetas), but it
+    // never stepped through the door, so the cleared claim stays shut to it.
+    const parked = [...sim.players.values()].find((m) => m.name === 'M0')!;
+    expect(parked.raidLockouts.has('ignivar_raid_arena')).toBe(true);
+    expect(inst.raidReturnKeys.has(`entity:${parked.entityId}`)).toBe(false);
+    const errors = captureErrors(sim);
+    expect(enterDungeon(sim.ctx, 'ignivar_raid_arena', parked.entityId, true)).toBe(false);
+    expect(errors).toContain(ARENA_LOCK_ERROR);
   });
 
   it('a player locked by an earlier run is still barred from someone else cleared claim', () => {
@@ -252,13 +336,44 @@ describe('the cleared-run door exception on the weekly rooms', () => {
     const lead = raidLeader(sim);
     clearedClaimRun(sim, lead);
     // Late joins the raid AFTER the kill, carrying a lock from an earlier run:
-    // not in this claim's clearedBy, so the door must still refuse the ferry.
+    // no return key on this claim, so the door must still refuse the ferry.
     const latePid = sim.addPlayer('mage', 'Late');
     sim.partyInvite(latePid, lead.entityId);
     sim.partyAccept(latePid);
+    // The join must have landed, or the refusal below proves nothing.
+    expect(instanceKeyFor(sim.ctx, latePid)).toBe(instanceKeyFor(sim.ctx, lead.entityId));
     const late = sim.players.get(latePid)!;
     late.raidLockouts.set('ignivar_raid_arena', Math.floor(sim.time * 1000) + WEEK_MS);
+    const errors = captureErrors(sim);
     expect(enterDungeon(sim.ctx, 'ignivar_raid_arena', latePid, true)).toBe(false);
+    expect(errors).toContain(ARENA_LOCK_ERROR);
+  });
+});
+
+describe('the family reaper honors a cleared sibling claim', () => {
+  it('a bossless sibling room does not reap the cleared arena at the short timeout', () => {
+    const sim = makeSim();
+    const lead = raidLeader(sim);
+    // Claim the bossless front room first, then the arena, so the family holds
+    // two live claims under one party key.
+    expect(enterDungeon(sim.ctx, 'ignivar_forge_approach', lead.entityId, true)).toBe(true);
+    const key = instanceKeyFor(sim.ctx, lead.entityId);
+    const approach = sim.ctx.instances.find(
+      (i) => i.dungeonId === 'ignivar_forge_approach' && i.partyKey === key,
+    )!;
+    expect(approach).toBeDefined();
+    const { inst } = clearedClaimRun(sim, lead);
+    expect(leaveDungeon(sim.ctx, lead.entityId)).toBe(true);
+    // Past the SHORT timeout, the bossless approach used to free the whole
+    // family, cleared arena and boss corpse included; the cleared grace now
+    // extends to every sibling.
+    for (let i = 0; i <= INSTANCE_EMPTY_TIMEOUT + 1; i += 1) updateInstances(sim.ctx);
+    expect(inst.partyKey, 'cleared arena survives the short family timeout').toBe(key);
+    expect(approach.partyKey, 'sibling rides the same grace').toBe(key);
+    // Past the extended loot-recovery window, the family finally frees.
+    for (let i = 0; i <= INSTANCE_CLEARED_EMPTY_TIMEOUT + 1; i += 1) updateInstances(sim.ctx);
+    expect(inst.partyKey).toBeNull();
+    expect(approach.partyKey).toBeNull();
   });
 });
 
@@ -287,5 +402,17 @@ describe('every raid boss room declares its lockout boundary explicitly', () => 
     for (const dungeonId of DAILY_LOCKOUT_RAID_ROOMS) {
       expect(RAID_REQUIRED_DUNGEON_IDS.has(dungeonId), dungeonId).toBe(true);
     }
+  });
+
+  it('pins the shipped memberships, so a silent weekly/daily swap fails loudly here', () => {
+    // The guard loops above are structural; this floor is the literal anchor.
+    // NOTE: the guard's reach is exactly RAID_REQUIRED_DUNGEON_IDS, so a future
+    // raid-tier boss room must join that set (it must, for the raid-group door
+    // rule) before the declaration guard can see it.
+    expect([...WEEKLY_LOCKOUT_RAID_ROOMS].sort()).toEqual([
+      'ignivar_inner_crucible',
+      'ignivar_raid_arena',
+    ]);
+    expect([...DAILY_LOCKOUT_RAID_ROOMS]).toEqual(['nythraxis_boss_arena']);
   });
 });


### PR DESCRIPTION
## Summary

The weekly raid rooms' door refused every locked entrant outright, so the moment a boss died nobody could corpse-run back in or step out and return for loot: the clearedBy machinery both stamping arms populate for exactly that exception was unreachable. Found in the pre-3655 readiness audit; fix requested by the maintainer.

- The door now extends the heroic cleared-run idiom to the weekly rooms: a locked entrant is re-admitted when their party's live claim has its final boss down and the entrant holds this kill's return key.
- Return keys are DURABLE character keys (the raidBossWelcomeKeys idiom), so the relog after a wipe that mints a new entity id cannot strand a raider outside their own cleared claim.
- Return keys are minted only for participants who actually entered: a parked alt the lockout strikes without pay earns no door pass, and a player locked by an earlier run still cannot ferry into someone else's cleared claim. A claim whose boss is up stays barred.
- The cleared-claim reaper grace now extends across the Ignivar room family: the bossless front room's short empty timeout used to free the whole family (cleared arena and boss corpse included) at 5 minutes, silently cutting the documented 15-minute loot-recovery window to a third.
- New declaration guard: every raid-tier room with a final boss must sit in exactly one of WEEKLY_LOCKOUT_RAID_ROOMS / DAILY_LOCKOUT_RAID_ROOMS (new explicit daily set the door check reads), so a future raid boss room cannot silently ship on an undeclared boundary.

## Related issues

Part of the PR #3655 launch-readiness work (v0.41.0 cycle #3638).

NOTE for landing order: this touches src/sim/instances/dungeons.ts, same neighborhood as the Drakelands entrance stack (#3689); whichever lands second needs a trivial resync.

## Type of change

- [x] Bug fix

## How was this tested?

- Test-first: both re-entry arms were written RED against the old door (observed failing), then went green with the fix.
- tests/ignivar_weekly_lockout.test.ts grew from 8 to 17 tests: step-out-and-return, ghost walk-back, relog with durable character id, boss-back-up refusal, parked-alt refusal, anti-ferry refusal (error string pinned), same-claim identity on re-entry, the family reaper grace boundary, and the weekly/daily membership floor.
- Full neighbor battery green (dungeons, dungeon_difficulty, disconnect reset, dev raids, raid entry/flow/progression, nythraxis, deeds_sites_pin, parity goldens unchanged, architecture guard).
- npx tsc --noEmit clean; biome clean on changed files.
- Gate: all pre-vitest steps green; the vitest step's only failures across three runs were machine-contention timeouts (zero assertion failures), and every affected file passes standalone.
- Reviewed by the architecture-reviewer and test-coverage-auditor agents; all should-fix findings from both are addressed in the second commit.

## Checklist

### Quality

- [x] Sim change carries tests in the same change; parity goldens byte-identical.

### Localization (i18n)

- [x] No new player-visible strings (the two door refusal strings are pre-existing and unchanged).

### Hygiene

- [x] No secrets, no generated-file hand edits, no monolith growth (instances/dungeons.ts is not a ratcheted file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQa7ErUiBEpFYnhG1wyW64