### PR TITLE
fix(sim): put the shaman mass resurrection on the Chronomancy cooldown

### DIFF
--- a/src/sim/content/classes.ts
+++ b/src/sim/content/classes.ts
@@ -4756,6 +4756,13 @@ export const ABILITIES: Record<string, AbilityDef> = {
     description:
       'Heal a friendly target for $d, then jump to up to 2 allies within 12 yards. Each jump heals for 50% of the previous target. Each ally reached consumes your remaining Mending Current and immediately heals for 125% of the amount consumed. The initial heal increases with Spell Power. (Spiritmend signature)',
   },
+  // ---- Spiritmend out-of-combat mass resurrection, the Chronomancy
+  // collective_reversal twin. The five-minute cooldown is the real throttle:
+  // requiresOutOfCombat alone is not one, because a backline healer who never draws
+  // aggro drops combat mid-fight the moment combatTimer passes the 5s linger (see the
+  // engagedPids pass in sim.ts), so a zero-cooldown mass rez could be chained
+  // repeatedly inside a single encounter. Kept equal to collective_reversal so the two
+  // mass rezzes cannot be played against each other; both are pinned to that equality.
   ancestor_return: {
     id: 'ancestor_return',
     name: "Ancestors' Return",
@@ -4764,7 +4771,7 @@ export const ABILITIES: Record<string, AbilityDef> = {
     learnLevel: 20,
     cost: 250,
     castTime: 7,
-    cooldown: 0,
+    cooldown: 300,
     range: 0,
     school: 'nature',
     requiresTarget: false,

--- a/tests/owned_class_approved_followups.test.ts
+++ b/tests/owned_class_approved_followups.test.ts
@@ -299,13 +299,64 @@ describe('approved Spiritmend group revive follow-up', () => {
       specs: ['restoration'],
       learnLevel: 20,
       castTime: 7,
+      cooldown: 300,
       requiresTarget: false,
       requiresOutOfCombat: true,
     });
+    // Same invariant the Chronomancy twin (collective_reversal) pins, for the same
+    // reason: requiresOutOfCombat is not a throttle on its own, because a healer who
+    // never draws aggro drops combat mid-fight once combatTimer passes the 5s linger.
+    // The cooldown is what stops a mass rez from being chained inside one encounter,
+    // so it must outlast a cast plus the linger the caster waits out to become
+    // eligible again.
+    const def = ABILITIES.ancestor_return;
+    expect(def.cooldown).toBeGreaterThan(def.castTime + 5);
+    expect(def.cooldown).toBe(ABILITIES.collective_reversal.cooldown);
     expect(ABILITIES.ancestor_return.effects).toContainEqual({
       type: 'massResurrectGroup',
       hpFrac: 0.3,
     });
+  });
+
+  it('refuses a second mass revive while the cooldown runs, even fully out of combat', () => {
+    const sim = new Sim({ seed: 4471, playerClass: 'shaman' });
+    sim.setPlayerLevel(20);
+    expect(sim.setSpec('restoration')).toBe(true);
+    const fallenId = sim.addPlayer('warrior', 'Fallen Twice');
+    sim.partyInvite(fallenId, sim.playerId);
+    sim.partyAccept(fallenId);
+    const fallen = sim.entities.get(fallenId) as Entity;
+    killAt(fallen, sim.player.pos.x + 2, sim.player.pos.z);
+    sim.player.resource = sim.player.maxResource;
+
+    sim.castAbility('ancestor_return');
+    expect(sim.player.castingAbility).toBe('ancestor_return');
+    advance(sim, 7.05);
+    expect(sim.player.castingAbility).toBeNull();
+    sim.respondToResurrection(true, fallen.id);
+    expect(fallen.dead).toBe(false);
+
+    const remaining = sim.player.cooldowns.get('ancestor_return') ?? 0;
+    expect(remaining).toBeGreaterThan(290);
+    expect(remaining).toBeLessThanOrEqual(300);
+
+    // The same member dies again and the shaman is unambiguously out of combat with a
+    // full mana pool: only the cooldown may refuse this cast.
+    killAt(fallen, sim.player.pos.x + 2, sim.player.pos.z);
+    sim.player.inCombat = false;
+    sim.player.combatTimer = 99;
+    sim.player.resource = sim.player.maxResource;
+    const mana = sim.player.resource;
+    sim.castAbility('ancestor_return');
+    expect(sim.player.castingAbility).toBeNull();
+    expect(sim.player.resource).toBe(mana);
+    expect(fallen.dead).toBe(true);
+
+    // Clearing only the cooldown lets the identical cast start, proving the refusal
+    // above was the cooldown and not the out-of-combat or dead-member gate.
+    sim.player.cooldowns.delete('ancestor_return');
+    sim.castAbility('ancestor_return');
+    expect(sim.player.castingAbility).toBe('ancestor_return');
   });
 
   it('offers every dead group member a resurrection and leaves strangers alone', () => {


### PR DESCRIPTION
## Summary

Ancestors' Return (`ancestor_return`, Spiritmend shaman) shipped at `cooldown: 0`, while its identical mage twin Collective Reversal (`collective_reversal`, Chronomancy) carries `cooldown: 300`. Both are 7 second, 250 mana, `requiresOutOfCombat` untargeted casts with the same `massResurrectGroup` effect at `hpFrac: 0.3`, so the asymmetry looks unintended.

The comment above the mage twin already spells out why the cooldown is the real throttle:

> The five-minute cooldown is the real throttle: requiresOutOfCombat alone is not one, because a backline caster who never draws aggro drops combat mid-fight the moment combatTimer passes the 5s linger (see the engagedPids pass in sim.ts), so a zero-cooldown mass rez could be chained repeatedly inside a single encounter.

That reasoning applies verbatim to the shaman version, which had no cooldown to do the throttling. A resto shaman could wait out the 5 second combat linger, cast the 7 second mass rez, and repeat with no cooldown inside one boss fight.

This matters most for raids: the Ignivar door already carries an anti-zerg combat lockout that bars any outside entrant, living or ghost, while a claimed room still has a living engaged mob. That rule stops the raid walking back in mid-fight, but a chainable mass rez stands the raid back up in place, which is the same outcome by another route.

`ancestor_return.cooldown` moves 0 to 300, matching the twin, and the two are now pinned to that equality so they cannot drift apart again.

## Scope

Pre-existing on `release/v0.41.0`; not a regression from any open PR. Verified byte-identical on the release tip and on the Ignivar raid branch (#3655), so this is deliberately a standalone fix off the release branch rather than a rider on the raid.

No tooltip or i18n change: the spellbook renders cost, cast time, and cooldown from the live ability def (`src/ui/spellbook_window.ts` packs them per known ability), which is why the mage twin's description does not mention its own cooldown either. `npm run wiki:content` regenerates `src/guide/content.generated.ts` with no diff, so generated guide content is unaffected.

## Related issues

Part of the v0.41.0 cycle.

## Type of change

- [x] Fix: bug fix

## How was this tested?

Test-first, and the test reproduces the exploit rather than just pinning a constant:

- `refuses a second mass revive while the cooldown runs, even fully out of combat` casts the rez, confirms it lands and sets the cooldown (>290, <=300), then kills the same member again, forces the shaman fully out of combat with a full mana pool, and asserts the recast is refused with no mana spent. It then clears **only** the cooldown and asserts the identical cast starts, proving the refusal was the cooldown and not the out-of-combat or dead-member gate.
- The content pin gains `cooldown: 300`, the shared invariant `cooldown > castTime + 5` (it must outlast a cast plus the combat linger), and an equality pin against `collective_reversal.cooldown`.
- Both failed before the change: the content pin on `cooldown: 0`, and the behavior test on `expected 0 to be greater than 290`.

Commands:

- `npx vitest run` over `owned_class_approved_followups`, `shaman_class_spec_kits`, `owned_class_default_bars`, `collective_reversal`, `resurrection_reach`, `guide_key_coverage`, `skill_icons`: 7 files, 76 tests, all green.
- `npx tsc --noEmit` clean; biome clean on both changed files.
- `GATE_SELECT_BASE=origin/release/v0.41.0 node scripts/gate_select.mjs`: 38,100 tests passing. Two red files, both TIMEOUTS rather than assertions, and both unrelated to this change: `tests/ci_shard_plan.test.ts` (20s bound) and `tests/sfx_export_core.test.ts` (90s bound), on a 38.5k-test parallel run on a loaded machine. Re-run in isolation at `--testTimeout=180000` they pass, 2 files / 80 tests / exit 0.

---

## Checklist

### Quality

- [x] **The gate passes.** See above.
- [x] Bug fixed test-first: failing test that exercises the real code path, then the smallest change that turns it green.

### Localization (i18n)

- [x] No new or changed player-visible strings. The cooldown renders from the ability def through the existing spellbook path.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] Generated files were regenerated by their owning build steps, not hand-edited (`npm run wiki:content`, no diff).
