### PR TITLE
fix(sim): correct Mister Crabs lifecycle

### DIFF
--- a/src/sim/content/proving_shore.ts
+++ b/src/sim/content/proving_shore.ts
@@ -221,16 +221,15 @@ export const PROVING_SHORE_MOBS: Record<string, MobTemplate> = {
   // The old king of the shallows: the island's summon-only miniboss
   // (interactions/crab_summon.ts calls him out of the tide pool at the
   // strand's west end; no camp spawns him, the aldren idiom). Sized for a
-  // level 2 recruit fighting alone: a long meaty fight, never a lethal one.
-  // requiresQuestId keeps passers-by from griefing a summon they cannot be
-  // credited for.
+  // level 2 recruit fighting alone, with an owner tap that preserves the
+  // summoner's credit while allowing passers-by to help with the fight.
   mister_crabs: {
     id: 'mister_crabs',
     name: 'Mister Crabs',
     minLevel: 2,
     maxLevel: 2,
     family: 'beast',
-    hpBase: 70,
+    hpBase: 42,
     hpPerLevel: 0,
     // Harder per pinch than a scuttler (4 per 2.0s): the quest copy promises
     // it, and 6 per 2.4s is still a safe long fight for a level 2 recruit.
@@ -243,16 +242,18 @@ export const PROVING_SHORE_MOBS: Record<string, MobTemplate> = {
     moveSpeed: 6.2,
     aggroRadius: 10,
     canSwim: true,
-    requiresQuestId: 'q_ps_mother_of_pearl',
+    // Taming swaps a wild mob onto the ordinary pet respawn lifecycle, which
+    // would bypass this lure summon’s unconditional five-minute lifetime.
+    untameable: true,
     loot: [
       // Quest-gated like the pearl. The summon is repeatable while the quest
       // is active (the no-strand rule), which makes this a reviewed and
       // accepted micro-faucet: ~30 copper per full summon-kill cycle, well
       // under any economy ceiling, and it closes at the hand-in.
       { copper: 30, chance: 1, questId: 'q_ps_mother_of_pearl' },
-      // The prize, for quest holders only (LootEntry.questId): nobody else
-      // can even damage him (requiresQuestId above), so the pearl never
-      // rots on a corpse a stranger tapped.
+      // The prize remains for quest holders only (LootEntry.questId). Helpers
+      // may damage him, while the summon-time owner tap preserves the caller's
+      // corpse and kill credit.
       { itemId: 'ps_lustrous_pearl', chance: 1, questId: 'q_ps_mother_of_pearl' },
     ],
     scale: 1.7,

--- a/src/sim/encounters/quest_summon.ts
+++ b/src/sim/encounters/quest_summon.ts
@@ -16,8 +16,9 @@ export function summonQuestMob(
   // perOwner scopes the duplicate guard to THIS summoner's tap: on a shared
   // site (the island tide pool) every quest holder raises their own copy
   // instead of queueing behind a stranger's. Omitted, the guard stays
-  // site-wide, the original Nythraxis behavior.
-  opts?: { perOwner?: boolean },
+  // site-wide, the original Nythraxis behavior. hardDespawnSeconds gives a
+  // summon a fixed lifetime that combat and retargeting cannot clear.
+  opts?: { perOwner?: boolean; hardDespawnSeconds?: number },
 ): void {
   const existing = [...ctx.entities.values()].some(
     (e) =>
@@ -34,6 +35,14 @@ export function summonQuestMob(
   mob.facing = Math.PI;
   mob.prevFacing = mob.facing;
   mob.tappedById = ownerPid;
+  if (opts?.hardDespawnSeconds !== undefined) {
+    mob.hardDespawnTimer = opts.hardDespawnSeconds;
+    // A hard-lifetime summon was created by this script, not placed by a camp.
+    // Give it the established escort-wave lifecycle: death never schedules an
+    // ordinary wild respawn, and the corpse drops once its loot window decays.
+    mob.runScoped = true;
+    mob.summonedAdd = true;
+  }
   ctx.addEntity(mob);
   const owner = ctx.entities.get(ownerPid);
   if (owner && owner.kind === 'player' && !owner.dead) ctx.aggroMob(mob, owner, false);

--- a/src/sim/entity_roster.ts
+++ b/src/sim/entity_roster.ts
@@ -218,6 +218,10 @@ export function runDespawnDecay(ctx: SimContext): void {
       e.despawnTimer -= DT;
       if (e.despawnTimer <= 0) despawnIds.push(e.id);
     }
+    if (e.hardDespawnTimer !== undefined) {
+      e.hardDespawnTimer -= DT;
+      if (e.hardDespawnTimer <= 0 && despawnIds.at(-1) !== e.id) despawnIds.push(e.id);
+    }
     if (
       e.kind === 'mob' &&
       DAMAGE_IDLE_DESPAWN_MOB_IDS.has(e.templateId) &&

--- a/src/sim/interactions/crab_summon.ts
+++ b/src/sim/interactions/crab_summon.ts
@@ -19,6 +19,8 @@ export const CRAB_MOB_ID = 'mister_crabs';
 export const CRAB_SUMMON_SITE = { x: -398, z: -17 } as const;
 /** Must be standing AT the pool: the lesson is "go to the marked spot". */
 export const CRAB_SUMMON_RANGE = 8;
+/** A raised king returns to the shallows after five minutes, even mid-fight. */
+const CRAB_DESPAWN_SECONDS = 5 * 60;
 
 export type CrabSummonReason = 'notOnQuest' | 'questDone' | 'tooFar' | 'alreadyProwling';
 export type CrabSummonResult = { ok: true } | { ok: false; reason: CrabSummonReason };
@@ -78,6 +80,6 @@ export function useBrinyLure(ctx: SimContext, player: Entity, meta: PlayerMeta):
     CRAB_MOB_ID,
     { x: CRAB_SUMMON_SITE.x, y: 0, z: CRAB_SUMMON_SITE.z },
     meta.entityId,
-    { perOwner: true },
+    { perOwner: true, hardDespawnSeconds: CRAB_DESPAWN_SECONDS },
   );
 }

--- a/src/sim/pet/pet_commands.ts
+++ b/src/sim/pet/pet_commands.ts
@@ -309,6 +309,7 @@ export function tameError(ctx: SimContext, p: Entity, target: Entity): string | 
   if (target.kind !== 'mob' || !target.hostile) return 'You cannot tame that.';
   const template = MOBS[target.templateId];
   if (!template || !isTameableFamily(template.family)) return 'Only beasts can be tamed.';
+  if (template.untameable) return 'That beast is too strong to tame.';
   if (template.elite || template.boss || template.rare) return 'That beast is too strong to tame.';
   if (target.level > p.level) return 'That beast is too high level for you to tame.';
   if (target.spawnPos.x > DUNGEON_X_THRESHOLD) return 'You cannot tame dungeon creatures.';

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -1558,6 +1558,9 @@ export interface MobTemplate {
   componentTags?: string[];
   boss?: boolean;
   rare?: boolean;
+  // Explicit tame opt-out for ordinary beasts whose encounter lifecycle must
+  // not be replaced by the hunter pet respawn lifecycle.
+  untameable?: boolean;
   // World boss: a server-wide elite that spawns on a fixed cadence (not from a
   // CAMP), announces itself when it rises, and drops PERSONAL loot to every player
   // who damaged it (gated to once per day per boss). The spawn schedule + location
@@ -4875,6 +4878,9 @@ export interface Entity extends ClientMirroredEntityFields {
   // `tid` (#2513).
   harvestClaimedBy: number | null;
   despawnTimer?: number;
+  // An unconditional lifetime countdown. Unlike despawnTimer, combat, retargeting,
+  // and evade transitions never clear this timer.
+  hardDespawnTimer?: number;
   // Summoned quest add (e.g. a Broodmother-egg hatchling): seconds it survives out
   // of combat before despawning. updateMob starts the despawnTimer countdown when
   // the add leashes home and cancels it while the add is back in combat.

--- a/tests/crab_summon.test.ts
+++ b/tests/crab_summon.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from 'vitest';
 import { PROVING_SHORE_NPCS } from '../src/sim/content/proving_shore';
 import { MOBS, QUESTS } from '../src/sim/data';
 import { summonQuestMob } from '../src/sim/encounters/quest_summon';
+import { runDespawnDecay } from '../src/sim/entity_roster';
 import {
   CRAB_MOB_ID,
   CRAB_QUEST_ID,
@@ -15,11 +16,14 @@ import {
   crabSummonCheck,
   LURE_ITEM_ID,
 } from '../src/sim/interactions/crab_summon';
+import { completeTame, petOf, tameError } from '../src/sim/pet/pet_commands';
+import { isQuestGatedEntityHidden } from '../src/sim/quest_gated_entity';
 import { Sim } from '../src/sim/sim';
-import { ALL_CLASSES, type Entity, type SimEvent } from '../src/sim/types';
+import { ALL_CLASSES, type Entity, type SimEvent, TICK_RATE } from '../src/sim/types';
 
 const PEARL_ITEM_ID = 'ps_lustrous_pearl';
 const RING_ITEM_ID = 'mother_of_pearl';
+const FIVE_MINUTES_SECONDS = 5 * 60;
 
 function makeSim(seed = 4120): Sim {
   return new Sim({ seed, playerClass: 'warrior', autoEquip: true });
@@ -37,6 +41,12 @@ function liveBoss(sim: Sim): Entity | null {
   return null;
 }
 
+function requireLiveBoss(sim: Sim): Entity {
+  const boss = liveBoss(sim);
+  if (!boss) throw new Error('Expected a live Mister Crabs');
+  return boss;
+}
+
 function errorTexts(events: SimEvent[]): string[] {
   return events
     .filter((e): e is Extract<SimEvent, { type: 'error' }> => e.type === 'error')
@@ -46,7 +56,9 @@ function errorTexts(events: SimEvent[]): string[] {
 /** Clear the prerequisite and take the quest at Nel's watch (the real accept
  *  path, so the requiredItems grant runs). */
 function startQuest(sim: Sim): void {
-  sim.players.get(sim.playerId)!.questsDone.add('q_ps_shell_and_claw');
+  const meta = sim.players.get(sim.playerId);
+  if (!meta) throw new Error('Expected the primary player metadata');
+  meta.questsDone.add('q_ps_shell_and_claw');
   const nel = PROVING_SHORE_NPCS.tidewarden_nel.pos;
   teleportTo(sim, nel.x + 1, nel.z);
   sim.drainEvents();
@@ -105,11 +117,12 @@ describe('the Mother of Pearl chain in a real sim', () => {
     sim.drainEvents();
     sim.useItem(LURE_ITEM_ID);
 
-    const boss = liveBoss(sim);
-    expect(boss).toBeTruthy();
-    expect(boss!.hostile).toBe(true);
+    const boss = requireLiveBoss(sim);
+    expect(boss.hostile).toBe(true);
+    expect(boss.maxHp).toBe(42);
+    expect(boss.hp).toBe(42);
     // Tapped to the summoner, so nobody else can steal the credit.
-    expect(boss!.tappedById).toBe(sim.playerId);
+    expect(boss.tappedById).toBe(sim.playerId);
     // The lure is reusable: never consumed, so a wipe can always retry.
     expect(sim.countItem(LURE_ITEM_ID)).toBe(1);
     // A second use while he prowls warns instead of double-summoning.
@@ -117,10 +130,10 @@ describe('the Mother of Pearl chain in a real sim', () => {
     sim.useItem(LURE_ITEM_ID);
     expect(errorTexts(sim.drainEvents())).toContain('Mister Crabs already prowls the pool!');
 
-    sim.ctx.dealDamage(sim.player, boss!, 9_999, false, 'physical', null, 'hit');
-    expect(boss!.dead).toBe(true);
-    teleportTo(sim, boss!.pos.x, boss!.pos.z);
-    sim.lootCorpse(boss!.id);
+    sim.ctx.dealDamage(sim.player, boss, 9_999, false, 'physical', null, 'hit');
+    expect(boss.dead).toBe(true);
+    teleportTo(sim, boss.pos.x, boss.pos.z);
+    sim.lootCorpse(boss.id);
     expect(sim.countItem(PEARL_ITEM_ID)).toBe(1);
     expect(sim.questState(CRAB_QUEST_ID)).toBe('ready');
 
@@ -142,26 +155,139 @@ describe('the Mother of Pearl chain in a real sim', () => {
     expect(sim.equipment.ring1).toBe(RING_ITEM_ID);
   });
 
+  it('lets a non-questing player target and kill the summoner-owned crab', () => {
+    const sim = makeSim();
+    startQuest(sim);
+    teleportTo(sim, CRAB_SUMMON_SITE.x, CRAB_SUMMON_SITE.z);
+    sim.useItem(LURE_ITEM_ID);
+    const boss = requireLiveBoss(sim);
+    const helperPid = sim.addPlayer('mage', 'Helpful Stranger');
+    const helper = sim.entities.get(helperPid);
+    const helperMeta = sim.players.get(helperPid);
+    if (!helper || !helperMeta) throw new Error('Expected the helper player to join');
+    helper.pos.x = boss.pos.x;
+    helper.pos.z = boss.pos.z + 1;
+
+    expect(helperMeta.questLog.has(CRAB_QUEST_ID)).toBe(false);
+    expect(isQuestGatedEntityHidden(boss, helperMeta.questLog)).toBe(false);
+    expect(sim.ctx.isHostileTo(helper, boss)).toBe(true);
+    sim.targetEntity(boss.id, helperPid);
+    expect(helper.targetId).toBe(boss.id);
+
+    const hpBefore = boss.hp;
+    const dealt = sim.ctx.dealDamage(helper, boss, 1, false, 'physical', null, 'hit');
+    expect(dealt).toBeGreaterThan(0);
+    expect(boss.hp).toBeLessThan(hpBefore);
+    expect(boss.tappedById).toBe(sim.playerId);
+
+    sim.ctx.dealDamage(helper, boss, 9_999, false, 'physical', null, 'hit');
+    expect(boss.dead).toBe(true);
+    const progress = sim.questLog.get(CRAB_QUEST_ID);
+    if (!progress) throw new Error('Expected the summoner quest to stay active');
+    expect(progress.counts[0]).toBe(1);
+    teleportTo(sim, boss.pos.x, boss.pos.z);
+    sim.lootCorpse(boss.id);
+    expect(sim.countItem(PEARL_ITEM_ID)).toBe(1);
+    expect(sim.questState(CRAB_QUEST_ID)).toBe('ready');
+
+    // A scripted summon has no wild respawn scheduled. Advance its shortened
+    // corpse window through the real mob tick and prove it is dropped instead.
+    expect(boss.respawnTimer).toBe(Number.POSITIVE_INFINITY);
+    boss.corpseTimer = 1 / TICK_RATE;
+    sim.tick();
+    expect(sim.entities.has(boss.id)).toBe(false);
+  });
+
+  it('cannot be tamed into a permanent hunter pet that bypasses its lifetime', () => {
+    const sim = makeSim();
+    startQuest(sim);
+    teleportTo(sim, CRAB_SUMMON_SITE.x, CRAB_SUMMON_SITE.z);
+    sim.useItem(LURE_ITEM_ID);
+    const boss = requireLiveBoss(sim);
+    const hunterPid = sim.addPlayer('hunter', 'Crab Collector');
+    sim.setPlayerLevel(10, hunterPid);
+    const hunter = sim.entities.get(hunterPid);
+    if (!hunter) throw new Error('Expected the hunter player to join');
+
+    expect(tameError(sim.ctx, hunter, boss)).toBe('That beast is too strong to tame.');
+    completeTame(sim.ctx, hunter, boss);
+    expect(sim.entities.has(boss.id)).toBe(true);
+    expect(petOf(sim.ctx, hunterPid, true)).toBeNull();
+  });
+
+  it('despawns five minutes after the lure summons it', () => {
+    const sim = makeSim();
+    startQuest(sim);
+    teleportTo(sim, CRAB_SUMMON_SITE.x, CRAB_SUMMON_SITE.z);
+    sim.useItem(LURE_ITEM_ID);
+    const boss = requireLiveBoss(sim);
+
+    expect(boss.hardDespawnTimer).toBe(FIVE_MINUTES_SECONDS);
+    for (let i = 0; i < FIVE_MINUTES_SECONDS * TICK_RATE - 1; i++) {
+      runDespawnDecay(sim.ctx);
+    }
+    expect(sim.entities.has(boss.id)).toBe(true);
+    runDespawnDecay(sim.ctx);
+    expect(sim.entities.has(boss.id)).toBe(false);
+
+    sim.useItem(LURE_ITEM_ID);
+    const replacement = requireLiveBoss(sim);
+    expect(replacement.id).not.toBe(boss.id);
+  });
+
+  it('keeps the five-minute lifetime after the summoner dies and a helper takes aggro', () => {
+    const sim = makeSim();
+    startQuest(sim);
+    teleportTo(sim, CRAB_SUMMON_SITE.x, CRAB_SUMMON_SITE.z);
+    sim.useItem(LURE_ITEM_ID);
+    const boss = requireLiveBoss(sim);
+    const helperPid = sim.addPlayer('mage', 'Helpful Survivor');
+    const helper = sim.entities.get(helperPid);
+    if (!helper) throw new Error('Expected the helper player to join');
+    helper.pos.x = boss.pos.x;
+    helper.pos.z = boss.pos.z + 1;
+    sim.ctx.dealDamage(helper, boss, 1, false, 'physical', null, 'hit');
+
+    sim.ctx.dealDamage(boss, sim.player, 9_999, false, 'physical', null, 'hit');
+    expect(sim.player.dead).toBe(true);
+    expect(boss.aggroTargetId).toBe(helperPid);
+
+    for (let i = 0; i < FIVE_MINUTES_SECONDS * TICK_RATE; i++) {
+      runDespawnDecay(sim.ctx);
+    }
+    expect(sim.entities.has(boss.id)).toBe(false);
+  });
+
   it('lets an unlooted kill summon again, so the pearl can never strand', () => {
     const sim = makeSim();
     startQuest(sim);
     teleportTo(sim, CRAB_SUMMON_SITE.x, CRAB_SUMMON_SITE.z);
     sim.useItem(LURE_ITEM_ID);
-    const first = liveBoss(sim);
-    expect(first).toBeTruthy();
-    sim.ctx.dealDamage(sim.player, first!, 9_999, false, 'physical', null, 'hit');
-    expect(first!.dead).toBe(true);
+    const first = requireLiveBoss(sim);
+    sim.ctx.dealDamage(sim.player, first, 9_999, false, 'physical', null, 'hit');
+    expect(first.dead).toBe(true);
     // Kill credited but the pearl never looted (say the corpse faded): the
     // quest stays active, so the lure works again.
     expect(sim.questState(CRAB_QUEST_ID)).toBe('active');
     sim.useItem(LURE_ITEM_ID);
-    const second = liveBoss(sim);
-    expect(second).toBeTruthy();
-    expect(second!.id).not.toBe(first!.id);
+    const second = requireLiveBoss(sim);
+    expect(second.id).not.toBe(first.id);
     // The kill objective stays capped at its requirement across the rekill.
-    sim.ctx.dealDamage(sim.player, second!, 9_999, false, 'physical', null, 'hit');
-    const qp = sim.questLog.get(CRAB_QUEST_ID)!;
+    sim.ctx.dealDamage(sim.player, second, 9_999, false, 'physical', null, 'hit');
+    const qp = sim.questLog.get(CRAB_QUEST_ID);
+    if (!qp) throw new Error('Expected the summon quest progress');
     expect(qp.counts[0]).toBe(1);
+
+    // Summon-only corpses must have no ordinary one-minute wild-mob respawn
+    // scheduled. Move both decay windows to their last production tick: the
+    // summoned-add branch must drop them instead of reviving either copy.
+    expect(first.respawnTimer).toBe(Number.POSITIVE_INFINITY);
+    expect(second.respawnTimer).toBe(Number.POSITIVE_INFINITY);
+    first.corpseTimer = 1 / TICK_RATE;
+    second.corpseTimer = 1 / TICK_RATE;
+    sim.tick();
+    expect(sim.entities.has(first.id)).toBe(false);
+    expect(sim.entities.has(second.id)).toBe(false);
   });
 
   it('stays silent for a player who never took the quest', () => {
@@ -190,9 +316,11 @@ describe('the Mother of Pearl chain in a real sim', () => {
       -1,
       { perOwner: true },
     );
-    const strangers = liveBoss(sim);
-    expect(strangers).toBeTruthy();
-    expect(strangers!.tappedById).toBe(-1);
+    const strangers = requireLiveBoss(sim);
+    expect(strangers.tappedById).toBe(-1);
+    expect(strangers.hardDespawnTimer).toBeUndefined();
+    expect(strangers.runScoped).toBeUndefined();
+    expect(strangers.summonedAdd).toBe(false);
     // The player's own lure still works beside it.
     sim.drainEvents();
     sim.useItem(LURE_ITEM_ID);
@@ -207,13 +335,15 @@ describe('the Mother of Pearl chain in a real sim', () => {
     expect(errorTexts(sim.drainEvents())).toContain('Mister Crabs already prowls the pool!');
   });
 
-  it('pins the anti-grief and reward wiring on the content records', () => {
-    // Only quest holders can damage him (nobody can grief a summon), the
-    // pearl drops for quest holders only, and EVERY class is paid the same
-    // ring. Not three archetypes: the ring is the island's keepsake and the
-    // vehicle for its equip lesson, so a paladin or a druid used to finish
+  it('pins the public fight and reward wiring on the content records', () => {
+    // Anyone can help damage the summoner-owned crab, while the pearl remains
+    // quest-gated and EVERY class is paid the same ring. Not three archetypes:
+    // the ring is the island's keepsake and the vehicle for its equip lesson,
+    // so a paladin or a druid used to finish
     // the detour, be told to slide it on, and have no ring to slide.
-    expect(MOBS[CRAB_MOB_ID].requiresQuestId).toBe(CRAB_QUEST_ID);
+    expect(MOBS[CRAB_MOB_ID].hpBase).toBe(42);
+    expect(MOBS[CRAB_MOB_ID].requiresQuestId).toBeUndefined();
+    expect(MOBS[CRAB_MOB_ID].untameable).toBe(true);
     const pearlEntry = (MOBS[CRAB_MOB_ID].loot ?? []).find((l) => l.itemId === PEARL_ITEM_ID);
     expect(pearlEntry).toMatchObject({ chance: 1, questId: CRAB_QUEST_ID });
     expect(QUESTS[CRAB_QUEST_ID].itemRewards).toEqual(


### PR DESCRIPTION
## Summary

- reduce Mister Crabs health from 70 to 42, an exact 40% reduction
- allow non-questing players to target and help kill the summoner-owned crab while preserving summoner credit and quest loot
- hard-despawn each live lure summon after five minutes, including during combat
- make death terminal for lure summons so killed corpses decay instead of reviving on the ordinary 60-second world-mob timer
- prevent hunter taming from bypassing the encounter lifetime

## Root cause

Lure-created Mister Crabs entities were normal wild mobs. Death assigned the Proving Shore 60-second respawn timer, and the in-place respawn cleared the owner tap. Dead copies no longer blocked another lure summon, so old entities revived alongside replacement summons and accumulated at the tide pool.

Hard-lifetime quest summons now reuse the established script-spawn lifecycle: `runScoped` suppresses ordinary respawn scheduling and `summonedAdd` removes the corpse after its loot window.

## Test plan

- `npx vitest run tests/crab_summon.test.ts tests/summoned_add_respawn.test.ts tests/egg_hatchling.test.ts tests/entity_roster.test.ts tests/pet_commands_module.test.ts tests/nythraxis_bound_guardian_directions.test.ts` — 59 passed
- `npx tsc --noEmit` — passed
- explicit Biome check over all seven changed files — passed
- `pnpm audit --audit-level high` — completed; only two repository-ignored advisories
- generated artifact freshness and malware security gate — passed

The selective repository gate entered unrelated PostgreSQL characterization and raid/balance soak failures and was stopped after 30 minutes once it could no longer pass. Focused simulation, test-coverage, and cross-platform parity reviews reported ready.