### PR TITLE
fix: make Emberward heroic-only

### DIFF
--- a/src/sim/content/dungeons.ts
+++ b/src/sim/content/dungeons.ts
@@ -132,16 +132,10 @@ export const DUNGEON_MOBS: Record<string, MobTemplate> = {
       { itemId: 'thundershock_treads', chance: 0.07, rollGroup: 'varkhul_offset' },
       { itemId: 'springwarden_sabatons', chance: 0.07, rollGroup: 'varkhul_offset' },
       { itemId: 'orb_of_the_last_spring', chance: 0.15, rollGroup: 'varkhul_offset' },
-      { itemId: 'cinder_of_the_first_design', chance: 0.12, rollGroup: 'varkhul_offset' },
-      // The legendary shield rides INSIDE the feet-and-held group at the
-      // kingsbane_last_oath 3 percent precedent (each group is an exclusive
-      // partition summing to exactly 1.00): the cinder, its off-hand
-      // slot-mate, pays the 0.03 while the orb sits back at its full 0.15.
-      // Forgebreaker deliberately does NOT drop here: the maintainer is
-      // routing it through the crafting professions (2026-08-30), so the
-      // item stays defined (dev-give, reliquary pending) with no loot row
-      // until its recipe chain lands.
-      { itemId: 'varkhul_emberward', chance: 0.03, rollGroup: 'varkhul_offset' },
+      { itemId: 'cinder_of_the_first_design', chance: 0.15, rollGroup: 'varkhul_offset' },
+      // Neither legendary drops on Normal. Emberward's 3 percent roll lives
+      // in Varkhul's heroic-only shield group; Forgebreaker remains reserved
+      // for the crafting professions until its recipe chain lands.
       { itemId: 'seal_of_the_forgewall', chance: 0.25, rollGroup: 'varkhul_rings' },
       { itemId: 'band_of_marked_strikes', chance: 0.25, rollGroup: 'varkhul_rings' },
       { itemId: 'circle_of_cinders', chance: 0.25, rollGroup: 'varkhul_rings' },

--- a/src/sim/content/heroic_loot.ts
+++ b/src/sim/content/heroic_loot.ts
@@ -778,8 +778,16 @@ export const HEROIC_BOSS_LOOT: Record<string, LootEntry[]> = {
     { itemId: 'sigil_anvil_chest', chance: 0.34, rollGroup: 'varkhul_h_sigil_robe' },
     { itemId: 'sigil_ember_chest', chance: 0.33, rollGroup: 'varkhul_h_sigil_robe' },
     { itemId: 'sigil_tempest_chest', chance: 0.33, rollGroup: 'varkhul_h_sigil_robe' },
-    { itemId: 'bulwark_of_the_inner_crucible', chance: 0.5, rollGroup: 'varkhul_h_shields' },
-    { itemId: 'ember_wardens_barrier', chance: 0.5, rollGroup: 'varkhul_h_shields' },
+    // Emberward shares the existing shield partition so its 3 percent chance
+    // adds no heroic RNG draw. The two epic outcomes split the remaining 97
+    // percent evenly, and the group still guarantees exactly one shield.
+    {
+      itemId: 'bulwark_of_the_inner_crucible',
+      chance: 0.485,
+      rollGroup: 'varkhul_h_shields',
+    },
+    { itemId: 'ember_wardens_barrier', chance: 0.485, rollGroup: 'varkhul_h_shields' },
+    { itemId: 'varkhul_emberward', chance: 0.03, rollGroup: 'varkhul_h_shields' },
     { itemId: 'heart_of_the_end_greatblade', chance: 0.34, rollGroup: 'varkhul_h_weapon' },
     { itemId: 'forgefire_spire', chance: 0.33, rollGroup: 'varkhul_h_weapon' },
     { itemId: 'staff_of_the_last_spring', chance: 0.33, rollGroup: 'varkhul_h_weapon' },

--- a/src/sim/content/ignivar_drops.ts
+++ b/src/sim/content/ignivar_drops.ts
@@ -1,28 +1,13 @@
-// The two legendary drops from the Ignivar raid (Varkhul the Forgefather),
-// LIVE on Varkhul's normal table (dungeons.ts, 3 percent each, the
-// kingsbane_last_oath precedent) since the loot PR's launch wiring. Their
-// realized item level from Varkhul's own boss level is 33 (source 20 +
-// legendary 10 + raid 3), the same kingsbane tier the handover authored
-// against, so the numbers below stand re-derived and budget-true as
-// written:
-// - forgebreaker: primary stats round(44 * TWOHAND_STAT_MULT 1.3) = 57; the
-//   authored 55-82 at speed 3.6 is 19.03 dps, within rounding of the
-//   weaponDpsBudget(33) * TWOHAND_DPS_MULT 1.15 target (19.09).
-// - emberward: primary stats round(33 * 1.9 * SLOT_STAT_MULT.offhand 0.75 *
-//   STAT_PER_ILVL 0.7) = 33; blockValue/armor extrapolate the shield ladder
-//   (buckler 6 / wallshield 14 / bonewrought 30 at epic ilvl 29) one tier up.
-// With the wiring live, itemLevel() resolves 33 for both, the budget sweeps
-// cover them, and their Reliquary rows sit on the conquerors_varkhul page
-// (the same-change unit the old tripwire pin enforced).
+// Varkhul's two authored legendaries have separate acquisition routes.
+// Emberward drops at 3 percent from the heroic-only shield partition and is
+// catalogued on Varkhul's heroic Reliquary page. Forgebreaker remains defined
+// for development and item-budget coverage while its crafting route is
+// pending; it has no boss-loot or Reliquary row yet.
 import type { ItemDef } from '../types';
 
-/** Handover placeholders not yet on any loot table, as a set: gear pickers
- *  that argmax over the whole ITEMS table (the PBE boost BiS kit) must skip
- *  anything a player cannot actually obtain yet, and table membership is the
- *  reliable test for that (the source index misses vendor/quest paths, so
- *  "no derivable source" is not). EMPTY today: the Varkhul pair went live
- *  with the launch wiring; the next handover item stages here the same
- *  way. */
+/** Handover placeholders excluded from whole-catalog gear pickers. Empty on
+ *  this release line: Emberward is obtainable from Heroic Varkhul, while
+ *  Forgebreaker remains below the live melee-kit winners on score. */
 export const IGNIVAR_DROP_PLACEHOLDER_IDS: ReadonlySet<string> = new Set([]);
 
 export const IGNIVAR_DROP_ITEMS: Record<string, ItemDef> = {

--- a/src/sim/content/reliquary.ts
+++ b/src/sim/content/reliquary.ts
@@ -726,6 +726,7 @@ export const RELIQUARY_HEROIC_GEAR = {
   varkhul_forgefather_of_the_last_flame: [
     'bulwark_of_the_inner_crucible',
     'ember_wardens_barrier',
+    'varkhul_emberward',
     'heart_of_the_end_greatblade',
     'forgefire_spire',
     'staff_of_the_last_spring',
@@ -1584,13 +1585,10 @@ export const RELIQUARY_PAGES: readonly ReliquaryPageDef[] = freezePageTable([
   // growth and the measured autosave cost per catalogued id; if the sets
   // earn a prestige surface it should be an authored per-lineage page shape
   // (the honor-stock precedent), a curator decision recorded for the
-  // maintainer. The two Varkhul legendaries
-  // (varkhul_forgebreaker, varkhul_emberward) are deliberately ABSENT: no
-  // live table awards either yet (IGNIVAR_DROP_PLACEHOLDER_IDS,
-  // content/ignivar_drops.ts), and an unearnable slot must never sit on a
-  // conquerors page (it would dead-end col_reliquary_conquerors, the pin in
-  // tests/reliquary_content.test.ts); their page rows land with the drop
-  // wiring, as the ignivar_drops.ts contract records.
+  // maintainer. Emberward is catalogued on Varkhul's heroic page because its
+  // 3 percent roll is heroic-only. Forgebreaker remains absent while its
+  // crafting route is pending; an unearnable slot must never sit on a
+  // conquerors page because it would dead-end col_reliquary_conquerors.
   {
     id: 'conquerors_ignivar',
     shelf: 'conquerors',
@@ -1634,15 +1632,12 @@ export const RELIQUARY_PAGES: readonly ReliquaryPageDef[] = freezePageTable([
     name: 'The Inner Crucible',
     desc: 'Epic spoils claimed from Varkhul, Forgefather of the Last Flame.',
     clearSource: { kind: 'dungeon', dungeonId: 'ignivar_inner_crucible', difficulty: 'normal' },
-    // The wing's one boss drops every relic on the page, including the
-    // legendary shield (the kingsbane 3 percent precedent; see
-    // content/ignivar_drops.ts). Forgebreaker is deliberately NOT paged:
-    // the maintainer pulled it from the loot table to route it through the
-    // crafting professions (2026-08-30), and a relic page row requires a
-    // conquerable source; it re-pages with its recipe chain.
+    // The wing's one boss drops every normal relic on the page. Emberward is
+    // heroic-only and lives on the heroic page below. Forgebreaker is not
+    // paged while its crafting route is pending; a relic row requires a live
+    // source, so it pages with its recipe chain.
     sourceDefault: fromBoss('varkhul_forgefather_of_the_last_flame'),
     relics: items(
-      'varkhul_emberward',
       'orb_of_the_last_spring',
       'cinder_of_the_first_design',
       'seal_of_the_forgewall',

--- a/tests/ignivar_loot.test.ts
+++ b/tests/ignivar_loot.test.ts
@@ -375,7 +375,7 @@ describe('ignivar loot: the boss drop tables', () => {
     for (const [name, group] of groups) expect(group.sum, name).toBeCloseTo(1, 6);
   });
 
-  it('Varkhul pays two sigil slots, the feet-and-held group, a ring, copper, and the legendary shield', () => {
+  it('Varkhul pays two sigil slots, the feet-and-held group, a ring, and copper on Normal', () => {
     const loot = MOBS.varkhul_forgefather_of_the_last_flame.loot ?? [];
     expect(loot[0]).toMatchObject({ copper: 200000, chance: 1 });
     const groups = groupsOf(loot);
@@ -385,22 +385,16 @@ describe('ignivar loot: the boss drop tables', () => {
       'varkhul_offset',
       'varkhul_rings',
     ]);
-    // The shield rides inside the feet-and-held group at the kingsbane 3
-    // percent precedent, paid for by its off-hand slot-mate the cinder.
-    // Forgebreaker is deliberately ABSENT: the maintainer pulled it from the
-    // table to route it through the crafting professions (2026-08-30); the
-    // orb sits back at its full 0.15 and the partition stays exactly 1.00.
+    // Neither legendary belongs to the normal table. Emberward is a
+    // heroic-only Varkhul drop, while Forgebreaker remains reserved for the
+    // crafting professions. The two held offhands keep their full 0.15
+    // slices and the partition stays exactly 1.00.
     const legendaryRows = loot.filter(
       (r) => 'itemId' in r && String(r.itemId).startsWith('varkhul_'),
     );
-    expect(legendaryRows.map((r) => ('itemId' in r ? r.itemId : ''))).toEqual([
-      'varkhul_emberward',
-    ]);
-    for (const row of legendaryRows) {
-      expect(row).toMatchObject({ chance: 0.03, rollGroup: 'varkhul_offset' });
-    }
+    expect(legendaryRows).toEqual([]);
     const offset = groups.get('varkhul_offset');
-    expect(offset?.ids.length).toBe(13); // 10 feet + both held offhands + the shield
+    expect(offset?.ids.length).toBe(12); // 10 feet + both held offhands
     expect(offset?.ids).toContain('orb_of_the_last_spring');
     expect(offset?.ids).toContain('cinder_of_the_first_design');
     for (const id of offset?.ids ?? []) {
@@ -427,7 +421,7 @@ describe('ignivar loot: the boss drop tables', () => {
     expect(tuning?.finalBossId).toBe('varkhul_forgefather_of_the_last_flame');
   });
 
-  it('Heroic appends pay the Robe sigil on both bosses and the shields on Varkhul', () => {
+  it('Heroic appends pay the Robe sigil on both bosses and Emberward in Varkhul shields', () => {
     const ignivar = HEROIC_BOSS_LOOT.ignivar_herald_of_the_last_flame ?? [];
     const varkhul = HEROIC_BOSS_LOOT.varkhul_forgefather_of_the_last_flame ?? [];
     const ignivarGroups = groupsOf(ignivar);
@@ -445,7 +439,12 @@ describe('ignivar loot: the boss drop tables', () => {
     expect(varkhulGroups.get('varkhul_h_shields')?.ids).toEqual([
       'bulwark_of_the_inner_crucible',
       'ember_wardens_barrier',
+      'varkhul_emberward',
     ]);
+    expect(varkhul.find((entry) => entry.itemId === 'varkhul_emberward')).toMatchObject({
+      chance: 0.03,
+      rollGroup: 'varkhul_h_shields',
+    });
     for (const groups of [ignivarGroups, varkhulGroups])
       for (const [name, group] of groups) expect(group.sum, name).toBeCloseTo(1, 6);
   });

--- a/tests/loot_roll.test.ts
+++ b/tests/loot_roll.test.ts
@@ -102,6 +102,32 @@ describe('loot_roll: rollLoot producer (drop-rate determinism)', () => {
     expect(rate).toBeLessThan(0.08);
   });
 
+  it('awards Emberward only when Varkhul belongs to a heroic instance', () => {
+    const rollVarkhul = (heroic: boolean): string[] => {
+      const sim = makeSim(123);
+      const pid = sim.addPlayer('warrior', 'Looter');
+      const meta = playerMeta(sim, pid);
+      const template = MOBS.varkhul_forgefather_of_the_last_flame;
+      const mob = createMob(-1, template, template.minLevel, { x: 0, y: 0, z: 0 });
+      if (heroic) {
+        sim.ctx.instances.push({
+          id: -1,
+          dungeonId: 'ignivar_inner_crucible',
+          difficulty: 'heroic',
+          partyKey: 'test-party',
+          mobIds: [mob.id],
+        } as unknown as (typeof sim.ctx.instances)[number]);
+      }
+      const nextSpy = vi.spyOn(sim.ctx.rng, 'next').mockReturnValue(0.99);
+      rollLoot(sim.ctx, mob, meta);
+      nextSpy.mockRestore();
+      return (mob.loot?.items ?? []).map((slot) => slot.itemId);
+    };
+
+    expect(rollVarkhul(false)).not.toContain('varkhul_emberward');
+    expect(rollVarkhul(true)).toContain('varkhul_emberward');
+  });
+
   // Reproduces the raid-loot duplicate bug: Nythraxis has 4 independent rollGroups
   // (2 helm slots, 2 shoulder slots) and several items (e.g. soulflame_mantle,
   // crownforged_dreadhelm, nighttalon_crown/shoulderguards) appear in every one of

--- a/tests/reliquary_content.test.ts
+++ b/tests/reliquary_content.test.ts
@@ -429,8 +429,9 @@ describe('Reliquary Conqueror catalog structure', () => {
     // moved instead of only that the sum did. The four Crucible raid pages
     // add 41 slots (17 + 3 + 16 + 5) on top of the 375 measured before them,
     // and the raid's flawless title joins the titles page, plus the two
-    // Varkhul legendaries at the launch wiring: 419; then 418 when the
-    // maintainer pulled Forgebreaker to route it through crafting.
+    // Varkhul legendary slots reached 419; then 418 when the maintainer
+    // pulled Forgebreaker to route it through crafting. Moving Emberward
+    // from Varkhul's normal page to its heroic page keeps the total fixed.
     expect(
       slots,
       `slot total moved; per page: ${RELIQUARY_PAGES.map((p) => `${p.id}=${p.relics.length}`).join(', ')}`,
@@ -1567,7 +1568,7 @@ const EQUALITY_PAGES: Record<string, { pageId: string; floor: number }> = {
   // sigil redemption tokens by kind; the token-liveness arm below proves the
   // filter excludes something real.
   ignivar_raid_arena: { pageId: 'conquerors_ignivar', floor: 17 },
-  ignivar_inner_crucible: { pageId: 'conquerors_varkhul', floor: 16 },
+  ignivar_inner_crucible: { pageId: 'conquerors_varkhul', floor: 15 },
 };
 
 describe('Reliquary dungeon and raid pages derive from live mob loot', () => {
@@ -1609,24 +1610,30 @@ describe('Reliquary dungeon and raid pages derive from live mob loot', () => {
     }
   });
 
-  it('the Varkhul legendaries: the shield drops and pages, Forgebreaker is craft-pending', () => {
-    // The 2026-08-30 landed state: Emberward drops from Varkhul's normal
-    // table (3 percent, the kingsbane precedent) and sits on the
-    // conquerors_varkhul page. Forgebreaker is deliberately OFF the table
-    // and OFF the pages: the maintainer is routing it through the crafting
-    // professions, and a relic page row requires a conquerable source. This
-    // pin holds drop and page membership as one unit in BOTH directions:
-    // re-wiring the drop without re-paging (or vice versa) reds here, and
-    // so does the recipe chain landing without flipping this pin.
+  it('the Varkhul legendaries: Emberward is Heroic-only and Forgebreaker is craft-pending', () => {
+    // Emberward's drop and museum route move as one unit: it is absent from
+    // Varkhul's normal table and page, present in the heroic append and page,
+    // and remains catalogued globally. Forgebreaker is deliberately off both
+    // tables and pages while its crafting route is pending.
+    const normalLootIds = (MOBS.varkhul_forgefather_of_the_last_flame.loot ?? []).map(
+      (entry) => entry.itemId,
+    );
+    const heroicLootIds = (
+      HEROIC_BOSS_LOOT.varkhul_forgefather_of_the_last_flame ?? []
+    ).map((entry) => entry.itemId);
     expect(IGNIVAR_DROP_PLACEHOLDER_IDS.size).toBe(0);
     expect(isCataloguedRelicItem('varkhul_emberward')).toBe(true);
-    expect(dungeonRarePlusLootIds('ignivar_inner_crucible').includes('varkhul_emberward')).toBe(
-      true,
+    expect(normalLootIds).not.toContain('varkhul_emberward');
+    expect(heroicLootIds).toContain('varkhul_emberward');
+    expect(itemRelicIds(RELIQUARY_PAGES_BY_ID.conquerors_varkhul)).not.toContain(
+      'varkhul_emberward',
+    );
+    expect(itemRelicIds(RELIQUARY_PAGES_BY_ID.conquerors_varkhul_heroic)).toContain(
+      'varkhul_emberward',
     );
     expect(isCataloguedRelicItem('varkhul_forgebreaker')).toBe(false);
-    expect(dungeonRarePlusLootIds('ignivar_inner_crucible').includes('varkhul_forgebreaker')).toBe(
-      false,
-    );
+    expect(normalLootIds).not.toContain('varkhul_forgebreaker');
+    expect(heroicLootIds).not.toContain('varkhul_forgebreaker');
   });
 
   it('the mob walk really reaches boss-summoned adds', () => {


### PR DESCRIPTION
## Summary
- remove Emberward from Varkhul normal loot and restore Cinder of the First Design to 15%
- add Emberward at 3% to the existing Heroic Varkhul shield partition without adding an RNG draw
- move Emberward to the Heroic Reliquary page and pin Normal versus Heroic behavior with regression tests

## Test plan
- `pnpm exec vitest run tests/loot_roll.test.ts tests/ignivar_loot.test.ts tests/reliquary_content.test.ts tests/server/pbe_boost.test.ts` (209 passed)
- `pnpm exec tsc --noEmit`
- `pnpm run ci:changed`
- `pnpm run gate` reached and passed artifact freshness, malware scanning, and changed-file lint; the long full-suite stage was still running when the PR was requested immediately