### PR TITLE
fix(instances): make heroic Ignivar claims survive the forge-lift door

### DIFF
--- a/src/sim/content/dungeon_difficulty.ts
+++ b/src/sim/content/dungeon_difficulty.ts
@@ -1,4 +1,8 @@
-import { IGNIVAR_FORGE_APPROACH_ID, IGNIVAR_MOLTEN_ASSEMBLY_ID } from '../ignivar_raid_ids';
+import {
+  IGNIVAR_FORGE_APPROACH_ID,
+  IGNIVAR_LIFT_ROOM_ID,
+  IGNIVAR_MOLTEN_ASSEMBLY_ID,
+} from '../ignivar_raid_ids';
 import type { DungeonDifficulty } from '../types';
 
 // The participation token awarded directly to every eligible player when a
@@ -256,7 +260,21 @@ export const NORMAL_DUNGEON_TUNING: Record<string, NormalDungeonTuning> = {
 // they must not carry final-boss rewards or lockouts. Keeping them outside
 // HEROIC_DUNGEON_TUNING scopes the pressure pass to the two preboss spawn
 // lists and prevents Varkhul's encounter summons from inheriting it.
+// The forge lift rides here too, for ELIGIBILITY only: it is the raid
+// chain's first room and its only overworld door, so it must sit in
+// HEROIC_DUNGEON_IDS or claimDifficultyForDungeon clamps a heroic
+// selection to normal at the keep door and every deeper room inherits
+// that clamped claim. The lift spawns nothing, so its factors stay 1.
 export const HEROIC_MOB_TUNING: Record<string, HeroicMobTuning> = {
+  [IGNIVAR_LIFT_ROOM_ID]: {
+    id: IGNIVAR_LIFT_ROOM_ID,
+    difficulty: 'heroic',
+    level: 22,
+    healthMultiplier: 1,
+    damageMultiplier: 1,
+    addDamageMultiplier: 1,
+    armorMultiplier: 1,
+  },
   [IGNIVAR_FORGE_APPROACH_ID]: {
     id: IGNIVAR_FORGE_APPROACH_ID,
     difficulty: 'heroic',

--- a/tests/dungeon_difficulty.test.ts
+++ b/tests/dungeon_difficulty.test.ts
@@ -9,6 +9,7 @@ import { HEROIC_DUNGEON_TUNING, HEROIC_MARK_ITEM_ID } from '../src/sim/content/d
 import { DUNGEON_MOBS } from '../src/sim/content/dungeons';
 import { TEMPLE_DUNGEON_MOBS } from '../src/sim/content/temple';
 import { DUNGEONS, ITEMS, MOBS } from '../src/sim/data';
+import { IGNIVAR_RAID_ROOM_IDS } from '../src/sim/ignivar_raid_ids';
 import {
   applyDungeonMobTuning,
   claimDifficultyForDungeon,
@@ -140,8 +141,21 @@ describe('claimDifficultyForDungeon', () => {
     expect(claimDifficultyForDungeon('gravewyrm_sanctum', 'heroic')).toBe('heroic');
     expect(claimDifficultyForDungeon('nythraxis_boss_arena', 'heroic')).toBe('heroic');
     expect(claimDifficultyForDungeon('ignivar_raid_arena', 'heroic')).toBe('heroic');
-    // The chain's door room: a clamp here silently normalizes the whole raid.
-    expect(claimDifficultyForDungeon('ignivar_forge_lift', 'heroic')).toBe('heroic');
+    // Derived door-room guard: the Ignivar chain's difficulty is decided at
+    // whichever room carries the overworld walk-up door (the chain head), and
+    // a clamp there silently normalizes the whole raid (the v0.41.0 bug: the
+    // door moved to the forge lift, which had no tuning record, and the
+    // hardcoded id pins above stayed green). Deriving from the live room list
+    // makes this fail on its own the next time the entrance moves.
+    for (const roomId of IGNIVAR_RAID_ROOM_IDS) {
+      if (DUNGEONS[roomId].overworldDoor === false) continue;
+      expect(claimDifficultyForDungeon(roomId, 'heroic'), `${roomId} is a door room`).toBe(
+        'heroic',
+      );
+    }
+    // The chain HEAD decides the claim every deeper room inherits, so it stays
+    // pinned even if a future layout gives it no overworld door.
+    expect(claimDifficultyForDungeon(IGNIVAR_RAID_ROOM_IDS[0], 'heroic')).toBe('heroic');
     expect(claimDifficultyForDungeon('ignivar_forge_approach', 'heroic')).toBe('heroic');
     expect(claimDifficultyForDungeon('ignivar_molten_assembly', 'heroic')).toBe('heroic');
     expect(claimDifficultyForDungeon('ignivar_inner_crucible', 'heroic')).toBe('heroic');

--- a/tests/dungeon_difficulty.test.ts
+++ b/tests/dungeon_difficulty.test.ts
@@ -8,7 +8,7 @@ import { describe, expect, it } from 'vitest';
 import { HEROIC_DUNGEON_TUNING, HEROIC_MARK_ITEM_ID } from '../src/sim/content/dungeon_difficulty';
 import { DUNGEON_MOBS } from '../src/sim/content/dungeons';
 import { TEMPLE_DUNGEON_MOBS } from '../src/sim/content/temple';
-import { ITEMS, MOBS } from '../src/sim/data';
+import { DUNGEONS, ITEMS, MOBS } from '../src/sim/data';
 import {
   applyDungeonMobTuning,
   claimDifficultyForDungeon,
@@ -56,6 +56,11 @@ describe('heroic tuning data contract', () => {
       'sunken_bastion',
       'wildheart_basin',
     ]);
+    // The lift record is eligibility-only, and that premise holds only while
+    // the room spawns nothing: its factors are all 1, so the day a spawn is
+    // added to the lift, its heroic tuning becomes a real balance statement
+    // and needs authored numbers like its siblings.
+    expect(DUNGEONS.ignivar_forge_lift.spawns).toEqual([]);
     expect(
       Object.fromEntries(Object.values(HEROIC_DUNGEON_TUNING).map((t) => [t.id, t.finalBossId])),
     ).toEqual({
@@ -135,6 +140,8 @@ describe('claimDifficultyForDungeon', () => {
     expect(claimDifficultyForDungeon('gravewyrm_sanctum', 'heroic')).toBe('heroic');
     expect(claimDifficultyForDungeon('nythraxis_boss_arena', 'heroic')).toBe('heroic');
     expect(claimDifficultyForDungeon('ignivar_raid_arena', 'heroic')).toBe('heroic');
+    // The chain's door room: a clamp here silently normalizes the whole raid.
+    expect(claimDifficultyForDungeon('ignivar_forge_lift', 'heroic')).toBe('heroic');
     expect(claimDifficultyForDungeon('ignivar_forge_approach', 'heroic')).toBe('heroic');
     expect(claimDifficultyForDungeon('ignivar_molten_assembly', 'heroic')).toBe('heroic');
     expect(claimDifficultyForDungeon('ignivar_inner_crucible', 'heroic')).toBe('heroic');

--- a/tests/dungeon_difficulty.test.ts
+++ b/tests/dungeon_difficulty.test.ts
@@ -39,12 +39,16 @@ const SYNTHETIC: MobTemplate = {
 };
 
 describe('heroic tuning data contract', () => {
-  it('covers the five five-player dungeons plus all three raid arenas and final bosses', () => {
+  it('covers the five five-player dungeons plus the raid rooms (the Ignivar chain door-first) and final bosses', () => {
+    // The forge lift is the Ignivar chain's overworld door: it must be
+    // heroic-eligible or the whole chain's claim clamps to normal there
+    // (tests/ignivar_heroic_entry.test.ts drives the real door path).
     expect([...HEROIC_DUNGEON_IDS].sort()).toEqual([
       'drowned_temple',
       'gravewyrm_sanctum',
       'hollow_crypt',
       'ignivar_forge_approach',
+      'ignivar_forge_lift',
       'ignivar_inner_crucible',
       'ignivar_molten_assembly',
       'ignivar_raid_arena',

--- a/tests/ignivar_heroic_entry.test.ts
+++ b/tests/ignivar_heroic_entry.test.ts
@@ -1,0 +1,71 @@
+// The heroic claim through the REAL Ignivar door path (no dev bypass): the
+// overworld keep door claims the forge lift, and every deeper room inherits
+// that first claim's difficulty. The lift must therefore be heroic-eligible
+// in HEROIC_DUNGEON_IDS, or claimDifficultyForDungeon silently clamps the
+// whole chain to normal (the v0.41.0 regression: the forge-lift became the
+// chain's first room without a heroic tuning record, and every suite entered
+// deeper rooms through the dev arm, the one path that skips the clamp).
+import { describe, expect, it } from 'vitest';
+import { IGNIVAR_LIFT_RIDE_SECONDS } from '../src/sim/ignivar_forge_lift';
+import { IGNIVAR_FORGE_APPROACH_ID, IGNIVAR_LIFT_ROOM_ID } from '../src/sim/ignivar_raid_ids';
+import { enterDungeon } from '../src/sim/instances/dungeons';
+import { type InstanceSlot, type PlayerMeta, Sim } from '../src/sim/sim';
+import type { DungeonDifficulty } from '../src/sim/types';
+
+// A production-shaped sim: no devCommands, so every door decision below runs
+// the live-server branch of enterDungeon (bypass stays false throughout).
+function raidSim(): { sim: Sim; lead: PlayerMeta } {
+  const sim = new Sim({ seed: 42, playerClass: 'warrior', autoEquip: false, noPlayer: true });
+  const leadPid = sim.addPlayer('warrior', 'Lead');
+  const lead = sim.players.get(leadPid)!;
+  for (let i = 0; i < 4; i += 1) {
+    const pid = sim.addPlayer('mage', `M${i}`);
+    sim.partyInvite(pid, lead.entityId);
+    sim.partyAccept(pid);
+  }
+  sim.convertPartyToRaid(lead.entityId);
+  if (sim.ctx.partyOf(lead.entityId)?.raid !== true) throw new Error('test raid did not form');
+  return { sim, lead };
+}
+
+function liveClaim(sim: Sim, dungeonId: string): InstanceSlot {
+  const claim = sim.instances.find(
+    (inst) => inst.dungeonId === dungeonId && inst.partyKey !== null,
+  );
+  if (!claim) throw new Error(`no live claim for ${dungeonId}`);
+  return claim;
+}
+
+// Walk the whole production path for one difficulty selection: the keep door
+// onto the lift, the ride (the gate swaps open at the 1 Hz instance sweep),
+// then the opened gate into the Halls. Returns the two claims' difficulties.
+function walkIntoHalls(selected: DungeonDifficulty): {
+  lift: DungeonDifficulty;
+  halls: DungeonDifficulty;
+} {
+  const { sim, lead } = raidSim();
+  if (selected === 'heroic') sim.setDungeonDifficulty('heroic', lead.entityId);
+  if (!enterDungeon(sim.ctx, IGNIVAR_LIFT_ROOM_ID, lead.entityId)) {
+    throw new Error('lift entry failed');
+  }
+  const lift = liveClaim(sim, IGNIVAR_LIFT_ROOM_ID).difficulty;
+  for (let i = 0; i < 20 * (IGNIVAR_LIFT_RIDE_SECONDS + 2); i += 1) sim.tick();
+  if (!enterDungeon(sim.ctx, IGNIVAR_FORGE_APPROACH_ID, lead.entityId)) {
+    throw new Error('Halls entry through the opened lift gate failed');
+  }
+  return { lift, halls: liveClaim(sim, IGNIVAR_FORGE_APPROACH_ID).difficulty };
+}
+
+describe('the Ignivar raid claims the selected difficulty through the real door', () => {
+  it('a heroic selection claims a heroic lift, and the Halls inherit it', () => {
+    const { lift, halls } = walkIntoHalls('heroic');
+    expect(lift).toBe('heroic');
+    expect(halls).toBe('heroic');
+  });
+
+  it('the default selection still claims normal all the way in', () => {
+    const { lift, halls } = walkIntoHalls('normal');
+    expect(lift).toBe('normal');
+    expect(halls).toBe('normal');
+  });
+});

--- a/tests/ignivar_heroic_entry.test.ts
+++ b/tests/ignivar_heroic_entry.test.ts
@@ -6,11 +6,12 @@
 // chain's first room without a heroic tuning record, and every suite entered
 // deeper rooms through the dev arm, the one path that skips the clamp).
 import { describe, expect, it } from 'vitest';
+import { HEROIC_MOB_TUNING } from '../src/sim/content/dungeon_difficulty';
 import { IGNIVAR_LIFT_RIDE_SECONDS } from '../src/sim/ignivar_forge_lift';
 import { IGNIVAR_FORGE_APPROACH_ID, IGNIVAR_LIFT_ROOM_ID } from '../src/sim/ignivar_raid_ids';
 import { enterDungeon } from '../src/sim/instances/dungeons';
 import { type InstanceSlot, type PlayerMeta, Sim } from '../src/sim/sim';
-import type { DungeonDifficulty } from '../src/sim/types';
+import type { DungeonDifficulty, Entity } from '../src/sim/types';
 
 // A production-shaped sim: no devCommands, so every door decision below runs
 // the live-server branch of enterDungeon (bypass stays false throughout).
@@ -36,12 +37,21 @@ function liveClaim(sim: Sim, dungeonId: string): InstanceSlot {
   return claim;
 }
 
+function drainedErrors(sim: Sim): string[] {
+  return (sim.drainEvents() as { type: string; text?: string }[])
+    .filter((event) => event.type === 'error')
+    .map((event) => event.text ?? '');
+}
+
 // Walk the whole production path for one difficulty selection: the keep door
 // onto the lift, the ride (the gate swaps open at the 1 Hz instance sweep),
-// then the opened gate into the Halls. Returns the two claims' difficulties.
+// then the opened gate into the Halls. Returns the two claims' difficulties
+// plus the Halls trash so the caller can assert the transform actually landed.
 function walkIntoHalls(selected: DungeonDifficulty): {
   lift: DungeonDifficulty;
   halls: DungeonDifficulty;
+  hallsMobs: Entity[];
+  errors: string[];
 } {
   const { sim, lead } = raidSim();
   if (selected === 'heroic') sim.setDungeonDifficulty('heroic', lead.entityId);
@@ -50,21 +60,35 @@ function walkIntoHalls(selected: DungeonDifficulty): {
   }
   const lift = liveClaim(sim, IGNIVAR_LIFT_ROOM_ID).difficulty;
   for (let i = 0; i < 20 * (IGNIVAR_LIFT_RIDE_SECONDS + 2); i += 1) sim.tick();
+  sim.drainEvents();
   if (!enterDungeon(sim.ctx, IGNIVAR_FORGE_APPROACH_ID, lead.entityId)) {
     throw new Error('Halls entry through the opened lift gate failed');
   }
-  return { lift, halls: liveClaim(sim, IGNIVAR_FORGE_APPROACH_ID).difficulty };
+  const halls = liveClaim(sim, IGNIVAR_FORGE_APPROACH_ID);
+  const hallsMobs = halls.mobIds
+    .map((id) => sim.entities.get(id))
+    .filter((mob): mob is Entity => mob !== undefined);
+  return { lift, halls: halls.difficulty, hallsMobs, errors: drainedErrors(sim) };
 }
 
 describe('the Ignivar raid claims the selected difficulty through the real door', () => {
   it('a heroic selection claims a heroic lift, and the Halls inherit it', () => {
-    const { lift, halls } = walkIntoHalls('heroic');
+    const { lift, halls, hallsMobs, errors } = walkIntoHalls('heroic');
+    expect(errors).toEqual([]);
     expect(lift).toBe('heroic');
     expect(halls).toBe('heroic');
+    // The observable half of the claim: the Halls trash really spawned
+    // through the heroic transform (every heroic mob pins to the tuning
+    // level; the deeper rooms take their difficulty from the same
+    // ignivarSourceClaim line this hop exercises).
+    expect(hallsMobs.length).toBeGreaterThan(0);
+    const heroicLevel = HEROIC_MOB_TUNING[IGNIVAR_FORGE_APPROACH_ID].level;
+    for (const mob of hallsMobs) expect(mob.level).toBe(heroicLevel);
   });
 
   it('the default selection still claims normal all the way in', () => {
-    const { lift, halls } = walkIntoHalls('normal');
+    const { lift, halls, errors } = walkIntoHalls('normal');
+    expect(errors).toEqual([]);
     expect(lift).toBe('normal');
     expect(halls).toBe('normal');
   });

--- a/tests/ignivar_heroic_entry.test.ts
+++ b/tests/ignivar_heroic_entry.test.ts
@@ -55,12 +55,18 @@ function walkIntoHalls(selected: DungeonDifficulty): {
 } {
   const { sim, lead } = raidSim();
   if (selected === 'heroic') sim.setDungeonDifficulty('heroic', lead.entityId);
+  // The difficulty toggle confirms through the toast channel; drain the setup
+  // noise so the per-hop error capture below covers only the walk-in itself.
+  sim.drainEvents();
   if (!enterDungeon(sim.ctx, IGNIVAR_LIFT_ROOM_ID, lead.entityId)) {
     throw new Error('lift entry failed');
   }
+  // Capture errors per hop: a single drain at the end would let the drain
+  // before the Halls hop silently discard anything the lift hop refused with.
+  const errors = drainedErrors(sim);
   const lift = liveClaim(sim, IGNIVAR_LIFT_ROOM_ID).difficulty;
   for (let i = 0; i < 20 * (IGNIVAR_LIFT_RIDE_SECONDS + 2); i += 1) sim.tick();
-  sim.drainEvents();
+  errors.push(...drainedErrors(sim));
   if (!enterDungeon(sim.ctx, IGNIVAR_FORGE_APPROACH_ID, lead.entityId)) {
     throw new Error('Halls entry through the opened lift gate failed');
   }
@@ -68,7 +74,8 @@ function walkIntoHalls(selected: DungeonDifficulty): {
   const hallsMobs = halls.mobIds
     .map((id) => sim.entities.get(id))
     .filter((mob): mob is Entity => mob !== undefined);
-  return { lift, halls: halls.difficulty, hallsMobs, errors: drainedErrors(sim) };
+  errors.push(...drainedErrors(sim));
+  return { lift, halls: halls.difficulty, hallsMobs, errors };
 }
 
 describe('the Ignivar raid claims the selected difficulty through the real door', () => {


### PR DESCRIPTION
## Summary

Heroic difficulty silently did not work for the Ignivar raid on prod (build 0.41.0): every recorded Ignivar fight is normal-difficulty, while Nythraxis records both. Root cause: the v0.41.0 forge-lift change (db21be1e46) made ignivar_forge_lift the raid chain's first room and its only overworld door, but never added it to a heroic tuning table. HEROIC_DUNGEON_IDS is built from those tables, so claimDifficultyForDungeon clamped a heroic selection to normal at the keep door, and every deeper room inherited that clamped claim (ignivarSourceClaim wins in enterDungeon). No error was shown to players.

The fix adds an eligibility-only HEROIC_MOB_TUNING record for the lift: the room spawns nothing, so all factors stay 1 and its level pins to the heroic-standard 22. The lift only needs to exist in the id set.

Why no suite caught it: every Ignivar test entered rooms with devBypass = true, the one branch that reads the unclamped selection. The new regression test walks the production path instead: a real raid group, the real keep door with no dev bypass, the 9 second lift ride until the gate swaps open at the 1 Hz sweep, then the opened gate into the Halls, asserting the heroic claim on both rooms (plus the normal-selection mirror).

A coverage review pass then hardened the test: it also asserts the observable transform (the Halls trash spawns at the heroic tuning level), pins claimDifficultyForDungeon for the lift directly, pins the lift-spawns-nothing premise the inert record rests on, and asserts the walk-in drains no error events.

Known follow-up, out of scope here: the claim/selection mismatch notice in enterDungeon is gated off for raid rooms, so a raid that boards the lift on Normal and then flips the selector to Heroic still gets a silent Normal chain (the pre-existing behavior class, now only reachable mid-claim). That wants a raid-shaped notice or an explicit ruling.

## Type of change

- [x] Bug fix

## How was this tested?

- Commands:
  - npx vitest run tests/ignivar_heroic_entry.test.ts (new; fails on base with expected 'normal' to be 'heroic', green with the fix)
  - npx vitest run tests/dungeon_difficulty.test.ts tests/ignivar_weekly_lockout.test.ts (39 tests green)
  - npx tsc --noEmit (clean)
  - node scripts/gate_select.mjs: every step green except 9 vitest failures in 4 files (ci_stall_rerun, ci_shard_plan, bank_sockets, battleground) that are native-Windows environment artifacts (spawn npx/grep ENOENT, backslash path separators in scan guards), unrelated to this diff. CI on Linux is the authoritative check.
- Manual steps: none beyond the sim-driven regression test; the test drives the exact door path a live raid takes.

## Checklist

### Quality

- [x] **The gate passes.** Green apart from the Windows-host environment failures noted above; decisive regression coverage added for the changed behavior.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or .env committed, and ALLOW_DEV_COMMANDS is not enabled in any production path.
- [x] I didn't hand-edit generated files.

Generated with [Claude Code](https://claude.com/claude-code)
