### PR TITLE
fix(scripts): read the ferry landing from the sim in the tutorial E2E

### DIFF
--- a/scripts/tutorial_island_e2e.mjs
+++ b/scripts/tutorial_island_e2e.mjs
@@ -121,7 +121,6 @@ await page.screenshot({ path: 'tmp/tutorial-island-arrival.png' });
 // displaces to (FERRY_BELL_TOWN_LANDING), never copied here: the coordinates
 // have moved once already, and a second copy would just go stale again.
 const returned = await page.evaluate(async () => {
-  const { FERRY_BELL_TOWN_LANDING } = await import('/src/sim/interactions/ferry_bell.ts');
   const sim = window.__game.sim;
   const p = sim.entities.get(sim.playerId);
   const bell = [...sim.entities.values()].find(
@@ -131,6 +130,9 @@ const returned = await page.evaluate(async () => {
   p.pos.x = bell.pos.x + 1;
   p.pos.z = bell.pos.z;
   sim.pickUpObject(bell.id);
+  // Imported after the bell lookup, so a missing bell still reports itself
+  // rather than surfacing as a dev-server import failure.
+  const { FERRY_BELL_TOWN_LANDING } = await import('/src/sim/interactions/ferry_bell.ts');
   return { pos: { ...p.pos }, landing: { ...FERRY_BELL_TOWN_LANDING } };
 });
 console.log('after bell:', returned);

--- a/scripts/tutorial_island_e2e.mjs
+++ b/scripts/tutorial_island_e2e.mjs
@@ -116,9 +116,12 @@ await sleep(6000);
 await page.screenshot({ path: 'tmp/tutorial-island-arrival.png' });
 
 // The return trip: ring the Old Pier's ferry bell (a clicked object, never a
-// walk-in trigger) and assert the crossing sets the player down in Eastbrook
-// town beside the spawn square.
-const returned = await page.evaluate(() => {
+// walk-in trigger) and assert the crossing sets the player down on the harbor
+// town's dock road. The landing spot is read from the sim module the sim itself
+// displaces to (FERRY_BELL_TOWN_LANDING), never copied here: the coordinates
+// have moved once already, and a second copy would just go stale again.
+const returned = await page.evaluate(async () => {
+  const { FERRY_BELL_TOWN_LANDING } = await import('/src/sim/interactions/ferry_bell.ts');
   const sim = window.__game.sim;
   const p = sim.entities.get(sim.playerId);
   const bell = [...sim.entities.values()].find(
@@ -128,12 +131,15 @@ const returned = await page.evaluate(() => {
   p.pos.x = bell.pos.x + 1;
   p.pos.z = bell.pos.z;
   sim.pickUpObject(bell.id);
-  return { pos: { ...p.pos } };
+  return { pos: { ...p.pos }, landing: { ...FERRY_BELL_TOWN_LANDING } };
 });
 console.log('after bell:', returned);
 if (returned.error) throw new Error(returned.error);
-if (!(Math.abs(returned.pos.x - 4) < 2 && Math.abs(returned.pos.z + 6) < 2)) {
-  throw new Error('ferry bell did not land in Eastbrook town');
+const { pos: landed, landing } = returned;
+if (!(Math.abs(landed.x - landing.x) < 2 && Math.abs(landed.z - landing.z) < 2)) {
+  throw new Error(
+    `ferry bell did not land at the harbor town landing (${landing.x}, ${landing.z}); got (${landed.x}, ${landed.z})`,
+  );
 }
 
 // The first homecoming points out the town's twin bell (a possible misclick


### PR DESCRIPTION
## Summary

`scripts/tutorial_island_e2e.mjs` threw on a clean checkout, right after
`island arrival: Odo welcome note shown`. The return-trip assertion still
checked the pre-f36793814c landing spot:

```js
if (!(Math.abs(returned.pos.x - 4) < 2 && Math.abs(returned.pos.z + 6) < 2))
```

f36793814c ("fix(tutorial): land the ferry at the harbor town and hold the
loading screen across the crossing", 2026-08-23) moved the landing to the
harbor town's dock road. The authoritative constant is
`FERRY_BELL_TOWN_LANDING = { x: -4.5, z: -101.5, facing: -0.87 }` in
`src/sim/interactions/ferry_bell.ts`; the script was last touched 2026-08-14
and never followed.

The fix reads that constant in the page through the dev server rather than
keeping a second copy of the coordinates here (the `await import('/src/sim/...ts')`
pattern several other browser scripts already use, e.g. `rock_collision_visibility_shot.mjs`
and `drowned_litany_shots.mjs`). The spot has moved once already; a hardcoded
copy would just go stale again. The tolerance stays at 2 yards, and the
failure message now prints expected vs actual.

## Related issues

N/A

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [ ] Tests
- [x] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npm run dev`, then `GAME_URL=http://localhost:5176 node scripts/tutorial_island_e2e.mjs`
    (this machine already had :5173 in use by another worktree). Green end to end:
    `after bell: { pos: { x: -4.5, y: -0.79, z: -101.5 }, landing: { x: -4.5, z: -101.5, facing: -0.87 } }`
    then `E2E OK: greeting, ferry, chain head, bell home, twin-bell hint shown`.
    Confirmed the old assertion would still fail against that position.
  - `npx tsc --noEmit`: clean.
  - `npx @biomejs/biome check` on the committed (LF) file content: clean.
  - `npx vitest related --run scripts/tutorial_island_e2e.mjs tests/architecture.test.ts tests/fenbridge_town_assets.test.ts`.
- Manual steps: watched the run's screenshots in `tmp/` for the arrival and the
  twin-bell hint.

Note on the local gate: this clone has `core.autocrlf=true`, so the working copy
is CRLF while `biome.json` pins `lineEnding: "lf"`. That reds the changed-files
biome step, the `architecture` control-byte scan, and the fenbridge byte-hash
pins on an untouched tree as well; I reproduced each with my change stashed, so
none of them are from this diff. CI checks out LF and is the real signal here.

## Screenshots / recordings

N/A, no player-visible change (test tooling only).

---

## Checklist

### Quality

- [x] **The gate passes.** See the CRLF note above: everything that covers this
      diff is green, and the failures reproduce identically on a clean tree.

### Cross-platform

- ~Tested on desktop and mobile~ N/A, no UI.
- ~Accessible~ N/A, no UI.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
