### PR TITLE
fix(raids): move tier vendor outside entrance

### DIFF
--- a/src/sim/content/dungeons.ts
+++ b/src/sim/content/dungeons.ts
@@ -28,7 +28,6 @@ import type {
   MobTemplate,
 } from '../types';
 import { HEROIC_FINALE_COPPER, NYTHRAXIS_HEROIC_COPPER } from './dungeon_difficulty';
-import { CRUCIBLE_VENDOR_NPC_ID } from './ignivar_loot';
 import {
   IGNIVAR_LORE_OBJECTS,
   IGNIVAR_MAELIN_NPC_ID,
@@ -1531,9 +1530,6 @@ export const DUNGEON_DEFS: Record<string, DungeonDef> = {
     npcs: [
       { npcId: IGNIVAR_MAELIN_NPC_ID, x: 0, z: -47 },
       { npcId: IGNIVAR_MAELIN_PROJECTION_NPC_ID, x: 0, z: 48 },
-      // The sigil-redemption vendor beside the raid entrance (APPEND-only:
-      // instance entity ids allocate in list order).
-      { npcId: CRUCIBLE_VENDOR_NPC_ID, x: 6, z: -47 },
     ],
     objects: [
       {

--- a/src/sim/content/ignivar_loot.ts
+++ b/src/sim/content/ignivar_loot.ts
@@ -3304,6 +3304,14 @@ export const IGNIVAR_ART_PENDING_ITEM_IDS: readonly string[] = [];
 // token serves its three classes and each class picks its spec's set.
 export const CRUCIBLE_VENDOR_NPC_ID = 'crucible_quartermaster';
 
+// Reserved so this overworld service NPC does not shift the sequential entity
+// ids pinned by replay parity. The other reserved NPC singletons occupy
+// 1_000_000_000 through 1_000_000_002.
+export const CRUCIBLE_VENDOR_ENTITY_ID = 1_000_000_003;
+
+/** Overworld entrance position, separate from the inert dynamic NPC definition. */
+export const CRUCIBLE_VENDOR_ENTRANCE_POS = { x: 510.5, z: 2242.5 } as const;
+
 export interface CrucibleVendorOffer {
   itemId: string;
   sigilId: string;
@@ -3465,8 +3473,11 @@ export const IGNIVAR_VENDOR_NPCS: Record<string, NpcDef> = {
     id: CRUCIBLE_VENDOR_NPC_ID,
     name: 'Quartermaster Bronn Emberward',
     title: 'Crucible Quartermaster',
-    pos: { x: 506.5, z: 2237 },
+    // Dynamic definitions remain inert so the generic placement collider veto
+    // cannot suppress nearby raid-entrance structures or terrain edits.
+    pos: { x: 0, z: 0 },
     facing: Math.PI,
+    dynamic: true,
     color: 0xb3702d,
     questIds: [],
     crucibleVendor: true,

--- a/src/sim/content/ignivar_loot.ts
+++ b/src/sim/content/ignivar_loot.ts
@@ -3457,24 +3457,20 @@ export const CRUCIBLE_VENDOR_STOCK: readonly CrucibleVendorOffer[] = [
   { itemId: 'grovespring_legs', sigilId: 'sigil_anvil_legs' },
 ];
 
-// The Crucible Quartermaster herself. Dynamic on the Maelin pattern
-// (content/ignivar_raid_lore.ts): the overworld bootstrap never places her;
-// the Halls of the First Tempering lists her in its `npcs` array beside the
-// raid entrance. The crucibleVendor flag routes her dialog to the sigil shop.
+// The Crucible Quartermaster herself, stationed outside the Forgefather's
+// Isle keep door so raiders can redeem sigils without entering an instance.
+// The crucibleVendor flag routes her dialog to the sigil shop.
 export const IGNIVAR_VENDOR_NPCS: Record<string, NpcDef> = {
   [CRUCIBLE_VENDOR_NPC_ID]: {
     id: CRUCIBLE_VENDOR_NPC_ID,
     name: 'Quartermaster Bronn Emberward',
     title: 'Crucible Quartermaster',
-    // Dynamic NPCs use an authored instance-local spawn; this placeholder is
-    // never read by the overworld placement loop.
-    pos: { x: 0, z: 0 },
-    facing: 0,
+    pos: { x: 506.5, z: 2237 },
+    facing: Math.PI,
     color: 0xb3702d,
     questIds: [],
     crucibleVendor: true,
     greeting:
       'The forge marks its own. Bring me a sigil from the Crucible and I will fit you for war.',
-    dynamic: true,
   },
 };

--- a/src/sim/data.ts
+++ b/src/sim/data.ts
@@ -446,8 +446,8 @@ export const NPCS: Record<string, NpcDef> = {
   // for the same insertion-order stability reason as the realms above.
   ...PROVING_SHORE_NPCS,
   ...IGNIVAR_RAID_LORE_NPCS,
-  // The Crucible Quartermaster (dynamic: true, spawned by the raid's approach
-  // room), appended after the lore NPCs for insertion-order stability.
+  // The Crucible Quartermaster at the raid's overworld entrance, appended
+  // after the lore NPCs for insertion-order stability.
   ...IGNIVAR_VENDOR_NPCS,
   // The Spirit Healer template (dynamic: true, so the ctor's surface-placement
   // loop skips it). Kept in NPCS so the online client and world_entity_i18n can

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -157,6 +157,11 @@ import { ensureWarriorStance } from './combat/warrior_stances';
 // the PlayerMeta interface + the power-up catalog the fiestaMatchInfo accessor reads.
 import { type AugmentSpecial, type AugmentTier, POWERUPS_BY_ID } from './content/augments';
 import { applyTalentMods } from './content/classes';
+import {
+  CRUCIBLE_VENDOR_ENTITY_ID,
+  CRUCIBLE_VENDOR_ENTRANCE_POS,
+  CRUCIBLE_VENDOR_NPC_ID,
+} from './content/ignivar_loot';
 import { DEFAULT_MOUNT, type MountKey } from './content/mounts';
 import { GATHERING_PROFESSION_IDS, type GatheringProfessionId } from './content/professions';
 import { PROVING_SHORE_ARRIVAL } from './content/proving_shore';
@@ -2300,6 +2305,21 @@ export class Sim {
       if (kole) {
         const safe = this.findSafePos(kole.pos.x, kole.pos.z, waterLevel() + 0.6);
         spawnWarfareQuartermaster(this.ctx, kole, safe);
+      }
+    }
+
+    // Quartermaster Bronn Emberward at the Crucible entrance: spawn after
+    // world generation under a reserved id so replay entity ids remain stable.
+    {
+      const bronn = worldContent.npcs[CRUCIBLE_VENDOR_NPC_ID];
+      if (bronn && !this.entities.has(CRUCIBLE_VENDOR_ENTITY_ID)) {
+        const safe = this.findSafePos(
+          CRUCIBLE_VENDOR_ENTRANCE_POS.x,
+          CRUCIBLE_VENDOR_ENTRANCE_POS.z,
+          waterLevel() + 0.6,
+        );
+        const npc = createNpc(CRUCIBLE_VENDOR_ENTITY_ID, bronn, this.groundPos(safe.x, safe.z));
+        this.addEntity(npc);
       }
     }
 

--- a/tests/crucible_vendor.test.ts
+++ b/tests/crucible_vendor.test.ts
@@ -5,6 +5,7 @@
 
 import { describe, expect, it } from 'vitest';
 import {
+  CRUCIBLE_VENDOR_ENTITY_ID,
   CRUCIBLE_VENDOR_NPC_ID,
   CRUCIBLE_VENDOR_STOCK,
   IGNIVAR_VENDOR_NPCS,
@@ -52,7 +53,8 @@ describe('crucible quartermaster: spawn and dialog routing', () => {
     expect(npc.dungeonId).toBeNull();
     expect(Math.hypot(npc.pos.x - 503.05, npc.pos.z - 2243.7)).toBeLessThanOrEqual(15);
     expect(IGNIVAR_VENDOR_NPCS[CRUCIBLE_VENDOR_NPC_ID].crucibleVendor).toBe(true);
-    expect(IGNIVAR_VENDOR_NPCS[CRUCIBLE_VENDOR_NPC_ID].dynamic).not.toBe(true);
+    expect(npc.id).toBe(CRUCIBLE_VENDOR_ENTITY_ID);
+    expect(IGNIVAR_VENDOR_NPCS[CRUCIBLE_VENDOR_NPC_ID].dynamic).toBe(true);
   });
 });
 

--- a/tests/crucible_vendor.test.ts
+++ b/tests/crucible_vendor.test.ts
@@ -17,25 +17,19 @@ import { buildCrucibleVendorView } from '../src/ui/hud/vendor/crucible_vendor_vi
 type AnySim = Sim & Record<string, any>;
 type AnyEntity = Entity & Record<string, any>;
 
-// The vendor is a dynamic NPC spawned inside the raid's approach room, so the
-// buy-path tests enter through the /dev practice-raid door like
-// tests/ignivar_dev_raid.test.ts.
-function raidSim(playerClass: 'warrior' | 'mage' = 'warrior'): AnySim {
-  const sim = new Sim({
+function vendorSim(playerClass: 'warrior' | 'mage' = 'warrior'): AnySim {
+  return new Sim({
     seed: 2786,
     playerClass,
     autoEquip: true,
-    devCommands: true,
   }) as AnySim;
-  sim.chat('/dev ignivarraid');
-  return sim;
 }
 
 function vendorEntity(sim: AnySim): AnyEntity {
   const npc = [...sim.entities.values()].find(
     (e: AnyEntity) => e.kind === 'npc' && e.templateId === CRUCIBLE_VENDOR_NPC_ID,
   );
-  if (!npc) throw new Error('Crucible Quartermaster did not spawn in the approach room');
+  if (!npc) throw new Error('Crucible Quartermaster did not spawn outside the raid entrance');
   return npc as AnyEntity;
 }
 
@@ -52,18 +46,19 @@ function errorTexts(sim: AnySim): string[] {
 }
 
 describe('crucible quartermaster: spawn and dialog routing', () => {
-  it('spawns in the approach room with the crucibleVendor dialog flag', () => {
-    const sim = raidSim();
+  it('spawns in the overworld at the raid entrance with the crucibleVendor dialog flag', () => {
+    const sim = vendorSim();
     const npc = vendorEntity(sim);
-    expect(npc).toBeTruthy();
+    expect(npc.dungeonId).toBeNull();
+    expect(Math.hypot(npc.pos.x - 503.05, npc.pos.z - 2243.7)).toBeLessThanOrEqual(15);
     expect(IGNIVAR_VENDOR_NPCS[CRUCIBLE_VENDOR_NPC_ID].crucibleVendor).toBe(true);
-    expect(IGNIVAR_VENDOR_NPCS[CRUCIBLE_VENDOR_NPC_ID].dynamic).toBe(true);
+    expect(IGNIVAR_VENDOR_NPCS[CRUCIBLE_VENDOR_NPC_ID].dynamic).not.toBe(true);
   });
 });
 
 describe('crucible quartermaster: buy path', () => {
   it('debits the matching sigil and grants the set piece', () => {
-    const sim = raidSim('warrior');
+    const sim = vendorSim('warrior');
     standAtVendor(sim);
     sim.addItem('sigil_anvil_helmet', 2, sim.playerId);
     sim.drainEvents();
@@ -80,7 +75,7 @@ describe('crucible quartermaster: buy path', () => {
   });
 
   it('redemptions repeat: each buy debits exactly one sigil from the stack', () => {
-    const sim = raidSim('warrior');
+    const sim = vendorSim('warrior');
     standAtVendor(sim);
     sim.addItem('sigil_anvil_helmet', 3, sim.playerId);
     sim.drainEvents();
@@ -93,7 +88,7 @@ describe('crucible quartermaster: buy path', () => {
   });
 
   it('refuses without the matching sigil (a different slot sigil does not pay)', () => {
-    const sim = raidSim('warrior');
+    const sim = vendorSim('warrior');
     standAtVendor(sim);
     sim.addItem('sigil_anvil_gloves', 1, sim.playerId);
     sim.drainEvents();
@@ -108,7 +103,7 @@ describe('crucible quartermaster: buy path', () => {
   it("refuses another class's piece even with the right sigil in hand", () => {
     // A warrior holds an Anvil helm sigil; Aetherweave is the mage set in the
     // same Anvil group, so only the class gate stands between them.
-    const sim = raidSim('warrior');
+    const sim = vendorSim('warrior');
     standAtVendor(sim);
     sim.addItem('sigil_anvil_helmet', 1, sim.playerId);
     sim.drainEvents();
@@ -121,7 +116,7 @@ describe('crucible quartermaster: buy path', () => {
   });
 
   it('refuses items that are not in the redemption stock', () => {
-    const sim = raidSim('warrior');
+    const sim = vendorSim('warrior');
     standAtVendor(sim);
     sim.drainEvents();
 
@@ -132,7 +127,7 @@ describe('crucible quartermaster: buy path', () => {
   });
 
   it('refuses out of range, before any debit', () => {
-    const sim = raidSim('warrior');
+    const sim = vendorSim('warrior');
     // Still at the room entry, not at the vendor.
     const npc = vendorEntity(sim);
     const p = sim.player as AnyEntity;
@@ -150,7 +145,7 @@ describe('crucible quartermaster: buy path', () => {
   });
 
   it('checks bag space BEFORE the debit so a full-bags refusal keeps the sigil', () => {
-    const sim = raidSim('warrior');
+    const sim = vendorSim('warrior');
     standAtVendor(sim);
     sim.addItem('sigil_anvil_helmet', 1, sim.playerId);
     // Fill every remaining slot with unstackable items.

--- a/tests/crucible_vendor_online.test.ts
+++ b/tests/crucible_vendor_online.test.ts
@@ -5,11 +5,8 @@
 // buy-path outcome over handleMessage (sigil debit, set-piece grant), the
 // routed vendor response frame, and the ClientWorld inventory mirror.
 //
-// The fixture enters the raid approach room through the /dev practice-raid
-// door exactly like the sim-direct suite (the Crucible Quartermaster is a
-// dynamic NPC that only exists there), so the server sim is built with
-// ALLOW_DEV_COMMANDS set for the setup chat command only; crucible_buy itself
-// is an ordinary player command with no dev gating.
+// The fixture moves the player to the quartermaster at the overworld raid
+// entrance; crucible_buy is an ordinary player command with no dev gating.
 import { describe, expect, it, vi } from 'vitest';
 
 // Mock the db layer so the live GameServer suite needs no Postgres (the
@@ -66,30 +63,17 @@ import {
 const SET_PIECE = 'slagbreaker_helmet';
 const SIGIL = 'sigil_anvil_helmet';
 
-/** A GameServer whose sim was built with dev commands enabled, so the fixture
- *  can enter the raid approach room where the quartermaster spawns. The env
- *  var is restored immediately after construction: Sim.devCommands latches at
- *  construction time, and nothing under test reads the variable afterwards. */
 function raidServer(): GameServer {
-  const previous = process.env.ALLOW_DEV_COMMANDS;
-  process.env.ALLOW_DEV_COMMANDS = '1';
-  try {
-    return new GameServer();
-  } finally {
-    if (previous === undefined) delete process.env.ALLOW_DEV_COMMANDS;
-    else process.env.ALLOW_DEV_COMMANDS = previous;
-  }
+  return new GameServer();
 }
 
-/** Join a session, stage the practice raid, and stand the player at the
- *  Crucible Quartermaster in the approach room. */
+/** Join a session and stand the player at the overworld raid quartermaster. */
 function joinAtQuartermaster(server: GameServer, fc: FakeClient): ClientSession {
   const session = joinServer(server, fc, 1, 'Redeemer');
-  server.sim.chat('/dev ignivarraid', session.pid);
   const vendor = [...server.sim.entities.values()].find(
     (e) => e.kind === 'npc' && e.templateId === CRUCIBLE_VENDOR_NPC_ID,
   );
-  if (!vendor) throw new Error('Crucible Quartermaster did not spawn in the approach room');
+  if (!vendor) throw new Error('Crucible Quartermaster did not spawn outside the raid entrance');
   const player = server.sim.entities.get(session.pid);
   if (!player) throw new Error('joined player missing');
   player.pos = { x: vendor.pos.x + 1, y: player.pos.y, z: vendor.pos.z };
@@ -112,7 +96,7 @@ describe('crucible_buy over the GameServer wire', () => {
     const fc = fakeWs();
     const session = joinAtQuartermaster(server, fc);
     server.sim.addItem(SIGIL, 2, session.pid);
-    routeTick(server); // drain the join/dev-staging noise before the buy
+    routeTick(server); // drain the join noise before the buy
     broadcast(server);
     fc.sent.length = 0;
 
@@ -187,7 +171,6 @@ describe('crucible_buy over the GameServer wire', () => {
     const server = raidServer();
     const fc = fakeWs();
     const session = joinServer(server, fc, 1, 'Farbuyer');
-    server.sim.chat('/dev ignivarraid', session.pid);
     const vendor = [...server.sim.entities.values()].find(
       (e) => e.kind === 'npc' && e.templateId === CRUCIBLE_VENDOR_NPC_ID,
     );

--- a/tests/ignivar_raid_lore.test.ts
+++ b/tests/ignivar_raid_lore.test.ts
@@ -116,8 +116,6 @@ describe('Ignivar raid lore content', () => {
     expect(DUNGEONS[IGNIVAR_FORGE_APPROACH_ID].npcs).toEqual([
       { npcId: IGNIVAR_MAELIN_NPC_ID, x: 0, z: -47 },
       { npcId: IGNIVAR_MAELIN_PROJECTION_NPC_ID, x: 0, z: 48 },
-      // The sigil-redemption vendor beside the entrance (content/ignivar_loot.ts).
-      { npcId: 'crucible_quartermaster', x: 6, z: -47 },
     ]);
     expect(DUNGEONS[IGNIVAR_RAID_ARENA_ID].npcs).toEqual([
       { npcId: IGNIVAR_MAELIN_PROJECTION_NPC_ID, x: 10, z: 24, facing: Math.PI },

--- a/tests/ignivar_raid_progression.test.ts
+++ b/tests/ignivar_raid_progression.test.ts
@@ -134,7 +134,6 @@ describe('Ignivar raid progression', () => {
     expect(claim.npcIds.map((id) => sim.entities.get(id)?.templateId)).toEqual([
       IGNIVAR_MAELIN_NPC_ID,
       IGNIVAR_MAELIN_PROJECTION_NPC_ID,
-      'crucible_quartermaster',
     ]);
     const gate = claim.objectIds
       .map((id) => sim.entities.get(id))
@@ -310,7 +309,6 @@ describe('Ignivar raid progression', () => {
     expect(npcTemplatesByRoom.get(IGNIVAR_FORGE_APPROACH_ID)).toEqual([
       IGNIVAR_MAELIN_NPC_ID,
       IGNIVAR_MAELIN_PROJECTION_NPC_ID,
-      'crucible_quartermaster',
     ]);
     expect(npcTemplatesByRoom.get(IGNIVAR_RAID_ARENA_ID)).toEqual([
       IGNIVAR_MAELIN_PROJECTION_NPC_ID,


### PR DESCRIPTION
## Summary

- moves Quartermaster Bronn Emberward from the Halls of the First Tempering to the overworld beside the Forgefather Isle keep entrance
- removes the quartermaster from the raid instance NPC list
- keeps sigil redemption working through direct simulation and the live server wire without dev-command staging

## Type of change

- [x] Bug fix
- [x] Tests

## How was this tested?

- `npm test -- --run tests/crucible_vendor.test.ts tests/crucible_vendor_online.test.ts tests/ignivar_raid_lore.test.ts` (25 passed)
- `npx vitest run tests/architecture.test.ts tests/localization_fixes.test.ts` (156 passed, 3 skipped)
- `npx tsc --noEmit`
- `GATE_SELECT_BASE=origin/release/v0.41.1 npm run ci:changed`
- `npm run security:gate`
- archive-dependent rerun after restoring the full checkout: 75 passed across the five screenshot and asset contract suites that had failed under sparse checkout

Manual runtime inspection placed the collision-adjusted NPC about 3.2 yards outside the keep door, clear of the 2-yard automatic entrance trigger and within the 7-yard vendor range.

`node scripts/gate_select.mjs` was started with the release base. Artifact freshness, malware scanning, and changed-file formatting passed, but the broad always-run Vitest floor produced unrelated contention failures and sparse-checkout asset failures. The run was stopped after failures were established; the sparse asset failures passed after the full checkout was restored.

## Checklist

- [x] Decisive tests cover the changed behavior
- [x] No player-visible strings were added
- [x] No secrets, credentials, or production dev commands were added
- [x] Generated files were not hand-edited