### PR TITLE
fix(build): pin media asset extensions as binary in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,3 +11,20 @@ src/ui/i18n.catalog/translation_keys.generated.ts linguist-generated
 # Windows batch scripts keep their CRLF endings: exempt from text conversion so an
 # LF-normalized checkout (core.autocrlf=input) neither flags nor rewrites them.
 *.bat -text
+
+# Media assets are binary, always. Git's text heuristic samples only the first
+# block of a file, and a Radiance HDR (pure-ASCII header, no NUL in the sample)
+# passes as text: with core.autocrlf=true a fresh Windows checkout smudged the
+# evergarden env HDRs from LF to CRLF (+4 bytes each), build_media_manifest.mjs
+# hashed the smudged bytes, and the gate's manifest freshness step failed on
+# src/render/assets/manifest.generated.ts. Pin every extension in the manifest
+# script's MEDIA_EXTENSIONS set, not just the ones the heuristic misses today
+# (welded by tests/media_gitattributes.test.ts).
+*.glb binary
+*.fbx binary
+*.hdr binary
+*.jpg binary
+*.jpeg binary
+*.png binary
+*.webp binary
+*.ktx2 binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -19,7 +19,12 @@ src/ui/i18n.catalog/translation_keys.generated.ts linguist-generated
 # hashed the smudged bytes, and the gate's manifest freshness step failed on
 # src/render/assets/manifest.generated.ts. Pin every extension in the manifest
 # script's MEDIA_EXTENSIONS set, not just the ones the heuristic misses today
-# (welded by tests/media_gitattributes.test.ts).
+# (welded by tests/media_gitattributes.test.ts). These rules only apply at
+# checkout: a Windows clone made before they landed still has the smudged
+# bytes on disk (git status stays clean, nothing re-smudges them). Heal it by
+# deleting the affected files and re-checking them out:
+#   rm public/env/evergarden_day_1k.hdr public/env/evergarden_day_2k.hdr
+#   git checkout -- public/env
 *.glb binary
 *.fbx binary
 *.hdr binary

--- a/tests/media_gitattributes.test.ts
+++ b/tests/media_gitattributes.test.ts
@@ -1,0 +1,41 @@
+// Git's text heuristic samples only the first block of a file, so a media asset
+// with a pure-ASCII header (a Radiance .hdr) can pass as text. On a fresh
+// Windows checkout with core.autocrlf=true that smudged two env HDRs from LF to
+// CRLF, build_media_manifest.mjs hashed the smudged bytes, and the gate's
+// manifest freshness step failed on src/render/assets/manifest.generated.ts.
+//
+// The fix is a `binary` .gitattributes pin per media extension. This suite
+// welds that pin list to the manifest script's MEDIA_EXTENSIONS set, re-read
+// from source each run so a new media extension cannot land without its pin.
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const root = path.join(__dirname, '..');
+const gitattributes = readFileSync(path.join(root, '.gitattributes'), 'utf8');
+const manifestSource = readFileSync(path.join(root, 'scripts/build_media_manifest.mjs'), 'utf8');
+
+function manifestMediaExtensions(): string[] {
+  const block = manifestSource.match(/const MEDIA_EXTENSIONS = new Set\(\[([\s\S]*?)\]\)/);
+  if (!block) throw new Error('MEDIA_EXTENSIONS set not found in scripts/build_media_manifest.mjs');
+  const exts = [...block[1].matchAll(/'\.([a-z0-9]+)'/g)].map((m) => m[1]);
+  if (exts.length === 0) throw new Error('MEDIA_EXTENSIONS set parsed empty');
+  return exts;
+}
+
+function binaryPinnedExtensions(): Set<string> {
+  const pinned = new Set<string>();
+  for (const line of gitattributes.split('\n')) {
+    const m = line.match(/^\*\.([a-z0-9]+)\s+binary\s*$/);
+    if (m) pinned.add(m[1]);
+  }
+  return pinned;
+}
+
+describe('media .gitattributes binary pins', () => {
+  it('pins every MEDIA_EXTENSIONS entry as binary', () => {
+    const pinned = binaryPinnedExtensions();
+    const missing = manifestMediaExtensions().filter((ext) => !pinned.has(ext));
+    expect(missing, 'add `*.<ext> binary` to .gitattributes for each').toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

On a fresh Windows checkout with `core.autocrlf=true`, git's text heuristic misclassifies `public/env/evergarden_day_1k.hdr` and `public/env/evergarden_day_2k.hdr` as text: they are Radiance HDR files whose first block is a pure-ASCII header, so the heuristic sees no NUL byte and smudges every LF to CRLF at checkout (+4 bytes each). `scripts/build_media_manifest.mjs` then hashes the smudged bytes, so the manifest freshness step of `node scripts/gate_select.mjs` fails on `src/render/assets/manifest.generated.ts` (hash mismatch for those two entries) on every fresh Windows worktree.

This PR pins every extension in the manifest script's `MEDIA_EXTENSIONS` set (`glb`, `fbx`, `hdr`, `jpg`, `jpeg`, `png`, `webp`, `ktx2`) as `binary` in `.gitattributes`. The other extensions are already binary-detected by the heuristic today, but pinning them removes the dependence on content sniffing entirely, so a future asset with an ASCII-leading header cannot regress the same way. A new pin test, `tests/media_gitattributes.test.ts`, re-reads `MEDIA_EXTENSIONS` from the script source each run and fails if any entry lacks its `binary` pin, so a new media extension cannot land without one.

No committed blobs change: the two HDR blobs in the index were always the correct LF bytes (2097202 and 8388659 bytes); only the working-tree smudge was wrong.

## Type of change

- [x] Bug fix
- [x] Build, CI, or tooling
- [x] Tests

## How was this tested?

- Commands:
  - Reproduced on a fresh worktree of `release/v0.42.0` with `core.autocrlf=true`: `git ls-files --eol public` showed the two HDRs as `i/lf w/crlf`, on-disk sizes 2097206 and 8388663 (4 bytes over the blob sizes).
  - After adding the rules: deleted both HDRs, `git checkout --` them, confirmed on-disk sizes match `git cat-file -s` exactly (2097202 and 8388659) and `git ls-files --eol` reports `attr/-text`.
  - `node scripts/build_media_manifest.mjs generate` now produces a manifest content-identical to the committed `src/render/assets/manifest.generated.ts` (the freshness step passes).
  - `npx vitest run tests/media_gitattributes.test.ts` passes; `npx tsc --noEmit` and `npx @biomejs/biome check` on the new test pass.
  - `node scripts/gate_select.mjs`: every step passed except the vitest step, which fell back to the full suite (a `.gitattributes` change is outside the planner's selection reasoning). The full suite is red on this native Windows dev machine for pre-existing environmental reasons unrelated to this diff: parallel-run contention timeouts on heavy sim suites (they pass standalone), Windows temp-dir EPERM and unprivileged-symlink errors in the audit tooling suites, path-separator assumptions, and Linux-targeted electron suites. I verified the sampled failing suites fail identically on the untouched base checkout without this change, and that the ones that timed out under load (`fenbridge_town_assets`, `priest_vespers`) pass standalone on this branch. The pre-push QA floor (tsc, guard tests, changed-files biome, copy scan) is green, and the manifest/asset-adjacent suites (`media_duplicate_prune`, `visual_manifest`, `asset_pipeline`, `glb_assets`, `sky_ktx2_assets`, `architecture`) all pass on this branch.
- Manual steps: N/A beyond the above.

Note for Windows contributors: this machine's initial full-suite run also surfaced that the golden-master fixtures under `tests/server/fixtures/` byte-mismatch when checked out with `core.autocrlf=true` (the repo assumes LF-normalized checkouts). That is the same disease class as this fix but a separate, larger change (pinning `eol=lf` on byte-compared text fixtures); deliberately not bundled here.

---

## Checklist

### Quality

- [x] **The gate passes** through the manifest freshness step; the full-suite vitest fallback is red locally only from pre-existing Windows CRLF checkout noise, verified identical on the pristine base (details above). I added decisive tests for the changed behavior and recorded the manual checks above.

### Cross-platform

- ~Tested on desktop and mobile.~ N/A: no UI change.
- ~Accessible.~ N/A: no UI change.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files such as `src/render/assets/manifest.generated.ts`. They're regenerated by the build.

Generated with [Claude Code](https://claude.com/claude-code)
