### PR TITLE
fix(items): restore soulbound party trade flow

### DIFF
--- a/src/sim/loot/bop_trade_cleanup.ts
+++ b/src/sim/loot/bop_trade_cleanup.ts
@@ -1,0 +1,154 @@
+// Retires bind-on-pickup party-trade markers after they stop authorizing a
+// transfer, then restores ordinary stack behavior. The clock is supplied by
+// the caller so this leaf stays deterministic and host-neutral.
+
+import { stackSizeOf } from '../bags';
+import { ITEMS } from '../data';
+import { canStackInstancePayloads, isMergeableInstancePayload } from '../item_instance_merge';
+import { cloneItemInstancePayload, type InvSlot } from '../types';
+import { partyTradeActive, withoutPartyTradeMarker } from './bop_trade_window';
+
+export interface PartyTradeContainerOwner {
+  inventory: InvSlot[];
+  bank: { inventory: InvSlot[] };
+  vendorBuyback: InvSlot[];
+}
+
+export interface PartyTradeContainerChanges {
+  inventory: boolean;
+  bank: boolean;
+  buyback: boolean;
+}
+
+export interface PersistedPartyTradeContainers {
+  inventory: InvSlot[];
+  bank?: { inventory: InvSlot[] };
+  vendorBuyback?: InvSlot[];
+}
+
+function markerMustRetire(slot: InvSlot, nowMs: number): boolean {
+  if (!slot.instance?.partyTrade) return false;
+  return !partyTradeActive(slot.instance, nowMs);
+}
+
+function slotWithoutPartyTrade(slot: InvSlot): InvSlot {
+  const { instance: _instance, ...plain } = slot;
+  const instance = withoutPartyTradeMarker(slot.instance as NonNullable<InvSlot['instance']>);
+  return instance ? { ...plain, instance } : plain;
+}
+
+function freshSlot(source: InvSlot, count: number, keepPosition: boolean): InvSlot {
+  const slot: InvSlot = {
+    itemId: source.itemId,
+    count,
+    ...(source.instance ? { instance: cloneItemInstancePayload(source.instance) } : {}),
+    ...(source.craftedRecipeId === undefined ? {} : { craftedRecipeId: source.craftedRecipeId }),
+    ...(keepPosition && source.slot !== undefined ? { slot: source.slot } : {}),
+  };
+  return slot;
+}
+
+/**
+ * Returns the original array when no marker needs retirement. Otherwise it
+ * returns new slots with total counts conserved, unrelated payload fields
+ * preserved, and newly identical rows coalesced up to the live stack cap.
+ */
+export function normalizePartyTradeSlots(slots: InvSlot[], nowMs: number): InvSlot[] {
+  return normalizePartyTradeSlotsWithPolicy(slots, nowMs, true);
+}
+
+interface IndexedSlot {
+  sourceIndex: number;
+  splitIndex: number;
+  slot: InvSlot;
+}
+
+function normalizePartyTradeSlotsWithPolicy(
+  slots: InvSlot[],
+  nowMs: number,
+  restack: boolean,
+): InvSlot[] {
+  const retiring = slots.map((slot) => markerMustRetire(slot, nowMs));
+  if (!retiring.some(Boolean)) return slots;
+
+  // Seed the result with unaffected rows. Expired rows may fill those stacks,
+  // but two unrelated pre-existing partial stacks are never merged together.
+  const result: IndexedSlot[] = slots.flatMap((slot, sourceIndex) =>
+    retiring[sourceIndex] ? [] : [{ sourceIndex, splitIndex: 0, slot }],
+  );
+  for (let sourceIndex = 0; sourceIndex < slots.length; sourceIndex++) {
+    if (!retiring[sourceIndex]) continue;
+    const source = slotWithoutPartyTrade(slots[sourceIndex]);
+    let remaining = source.count;
+    const stackCap = stackSizeOf(ITEMS[source.itemId]);
+    const mergeable = isMergeableInstancePayload(source.instance);
+    if (restack && mergeable) {
+      for (const target of result) {
+        if (remaining <= 0) break;
+        if (
+          target.slot.itemId !== source.itemId ||
+          target.slot.craftedRecipeId !== source.craftedRecipeId ||
+          !canStackInstancePayloads(target.slot.instance, source.instance) ||
+          target.slot.count >= stackCap
+        ) {
+          continue;
+        }
+        const moved = Math.min(stackCap - target.slot.count, remaining);
+        target.slot = { ...target.slot, count: target.slot.count + moved };
+        remaining -= moved;
+      }
+    }
+    let splitIndex = 0;
+    while (remaining > 0) {
+      // A non-mergeable payload (for example a player-locked counted stack) is
+      // already one legal persisted row. Never fan it out into one row per unit.
+      const count = !restack || !mergeable ? remaining : Math.min(stackCap, remaining);
+      result.push({
+        sourceIndex,
+        splitIndex,
+        slot: freshSlot(source, count, splitIndex === 0),
+      });
+      splitIndex++;
+      remaining -= count;
+    }
+  }
+  result.sort((a, b) => a.sourceIndex - b.sourceIndex || a.splitIndex - b.splitIndex);
+  return result.map((entry) => entry.slot);
+}
+
+/** Normalize general persisted per-character item containers with one clock read. */
+export function normalizePartyTradeContainers(
+  owner: PartyTradeContainerOwner,
+  nowMs: number,
+): PartyTradeContainerChanges {
+  const inventory = normalizePartyTradeSlots(owner.inventory, nowMs);
+  const bank = normalizePartyTradeSlots(owner.bank.inventory, nowMs);
+  // Buyback is recency/index ordered and intentionally permits rows above the
+  // live stack cap. Strip only the marker; never reorder, split, or coalesce it.
+  const buyback = normalizePartyTradeSlotsWithPolicy(owner.vendorBuyback, nowMs, false);
+  const changes = {
+    inventory: inventory !== owner.inventory,
+    bank: bank !== owner.bank.inventory,
+    buyback: buyback !== owner.vendorBuyback,
+  };
+  owner.inventory = inventory;
+  owner.bank.inventory = bank;
+  owner.vendorBuyback = buyback;
+  return changes;
+}
+
+/** Normalize the optional JSONB container shape without growing Sim's save coordinator. */
+export function normalizePersistedPartyTradeContainers(
+  owner: PersistedPartyTradeContainers,
+  nowMs: number,
+): void {
+  const containers = {
+    inventory: owner.inventory,
+    bank: { inventory: owner.bank?.inventory ?? [] },
+    vendorBuyback: owner.vendorBuyback ?? [],
+  };
+  normalizePartyTradeContainers(containers, nowMs);
+  owner.inventory = containers.inventory;
+  if (owner.bank) owner.bank.inventory = containers.bank.inventory;
+  owner.vendorBuyback = containers.vendorBuyback;
+}

--- a/src/sim/loot/loot_roll.ts
+++ b/src/sim/loot/loot_roll.ts
@@ -348,6 +348,14 @@ export function rollLoot(
     }
   }
   if (copper > 0 || items.length > 0) {
+    if (items.some((slot) => ITEMS[slot.itemId]?.soulbound)) {
+      mob.lootPartyTradeEligibility = {
+        names: eligible.map((candidate) => candidate.name),
+        characterIds: eligible.flatMap((candidate) =>
+          candidate.characterId === undefined ? [] : [candidate.characterId],
+        ),
+      };
+    }
     mob.loot = { copper, items };
     mob.lootable = true;
     // start the owner-lock countdown: after LOOT_FFA_DELAY the tap opens to all.
@@ -505,6 +513,12 @@ export function killSnapshotEligibility(
   ctx: SimContext,
   mob: Entity,
 ): { names: string[]; characterIds: number[] } {
+  if (mob.lootPartyTradeEligibility) {
+    return {
+      names: [...mob.lootPartyTradeEligibility.names],
+      characterIds: [...mob.lootPartyTradeEligibility.characterIds],
+    };
+  }
   if (!mob.lootRecipientIds || mob.lootRecipientIds.length === 0) {
     return { names: [], characterIds: [] };
   }

--- a/src/sim/materials_vault.ts
+++ b/src/sim/materials_vault.ts
@@ -70,6 +70,7 @@ import {
   warnDroppedInstanceKeys,
 } from './item_instance_load';
 import { itemInstancePayloadsEqual } from './item_instance_merge';
+import { normalizePartyTradeSlots } from './loot/bop_trade_cleanup';
 import { materialItemIds } from './material_ids';
 import { sanitizeRiftGearInstance } from './rift/progression';
 import type { PlayerMeta } from './sim';
@@ -137,6 +138,24 @@ export function savedVaultState(state: MaterialsVaultState): SavedMaterialsVault
       : {}),
     upgrades: state.upgrades,
   };
+}
+
+/** Retire expired party-trade markers while keeping this module the sole vault writer. */
+export function normalizeVaultPartyTradeState(state: MaterialsVaultState, nowMs: number): boolean {
+  const special = normalizePartyTradeSlots(state.special, nowMs);
+  if (special === state.special) return false;
+  state.special = special;
+  return true;
+}
+
+/** Save-shape variant that preserves the absent-while-empty `special` contract. */
+export function normalizeSavedVaultPartyTradeState(
+  state: SavedMaterialsVaultState,
+  nowMs: number,
+): void {
+  if (!state.special) return;
+  const special = normalizePartyTradeSlots(state.special, nowMs);
+  if (special !== state.special) state.special = special;
 }
 
 /** True when a carried slot must retain its full identity in the vault. */

--- a/src/sim/mob/lifecycle.ts
+++ b/src/sim/mob/lifecycle.ts
@@ -56,6 +56,7 @@ export function respawnMob(ctx: SimContext, mob: Entity): void {
   mob.lootable = false;
   mob.loot = null;
   mob.lootRecipientIds = undefined;
+  mob.lootPartyTradeEligibility = undefined;
   mob.tappedById = null;
   mob.harvestClaimedBy = null;
   mob.ownerId = null;

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -304,6 +304,10 @@ import {
 } from './leaderboard_page';
 import { entityLineOfSightClear } from './line_of_sight_elevation';
 import type { Ante, PickAction } from './lockpick';
+import {
+  normalizePartyTradeContainers,
+  normalizePersistedPartyTradeContainers,
+} from './loot/bop_trade_cleanup';
 import { withoutPartyTradeMarker } from './loot/bop_trade_window';
 // L1: the loot-distribution layer (party-loot strategy, the rollLoot roller, copper
 // split, need-greed roll lifecycle, corpse-loot helpers) moved to ./loot/loot_roll.ts;
@@ -3067,6 +3071,9 @@ export class Sim {
       // save sanitizes to the empty locked vault): restoreVaultStateOnLoad owns the
       // whole-record replacement AND its vaultWireRev bump (the rationale sits there).
       vaultMod.restoreVaultStateOnLoad(meta, s.vault, droppedInstanceJunk, player.id);
+      const partyTradeNowMs = this.lockoutNowMs();
+      normalizePartyTradeContainers(meta, partyTradeNowMs);
+      vaultMod.normalizeVaultPartyTradeState(meta.vault, partyTradeNowMs);
       warnDroppedInstanceKeys(meta.name, droppedInstanceJunk);
       let questRevReset = false;
       for (const q of s.questLog) {
@@ -4084,6 +4091,12 @@ export class Sim {
         return reliquary ? { reliquary } : {};
       })(),
     };
+    // Retire expired BoP party-trade metadata at the existing per-character
+    // persistence boundary. This keeps saved JSON compact without adding a
+    // synchronized realm-wide container scan to the simulation tick.
+    const partyTradeNowMs = this.lockoutNowMs();
+    normalizePersistedPartyTradeContainers(state, partyTradeNowMs);
+    if (state.vault) vaultMod.normalizeSavedVaultPartyTradeState(state.vault, partyTradeNowMs);
     return sanitizeRemovedZone1Content(state).state;
   }
 

--- a/src/sim/social/trade.ts
+++ b/src/sim/social/trade.ts
@@ -27,7 +27,13 @@ import {
 import { partyTradeWindowAllows } from '../loot/bop_trade_window';
 import type { PlayerMeta, TradeSession } from '../sim';
 import type { SimContext } from '../sim_context';
-import { cloneItemInstancePayload, dist2d, type InvSlot, type ItemInstancePayload } from '../types';
+import {
+  cloneItemInstancePayload,
+  dist2d,
+  type InvSlot,
+  type ItemInstancePayload,
+  TICK_RATE,
+} from '../types';
 
 // A trade is only offered/kept while both parties are within this many yards;
 // the drift sweep cancels an open session once they wander past TRADE_RANGE + 4.
@@ -811,6 +817,8 @@ export function updateTradesAndInvites(ctx: SimContext): void {
   }
   // cancel trades when the parties drift apart
   const seen = new Set<TradeSession>();
+  const revalidatePartyTradeOffers = ctx.tickCount % TICK_RATE === 0;
+  const nowMs = revalidatePartyTradeOffers ? ctx.lockoutNowMs() : 0;
   for (const session of ctx.trades.values()) {
     if (seen.has(session)) continue;
     seen.add(session);
@@ -818,6 +826,19 @@ export function updateTradesAndInvites(ctx: SimContext): void {
     const eb = ctx.entities.get(session.b);
     if (!ea || !eb || dist2d(ea.pos, eb.pos) > TRADE_RANGE + 4 || ea.dead || eb.dead) {
       tradeCancel(ctx, session.a);
+      continue;
+    }
+    if (!revalidatePartyTradeOffers) continue;
+    for (const [pid, otherPid, offer] of [
+      [session.a, session.b, session.offerA],
+      [session.b, session.a, session.offerB],
+    ] as const) {
+      if (!offer.items.some((slot) => ITEMS[slot.itemId]?.soulbound)) continue;
+      if (offerCovered(ctx, offer.items, pid, otherPid, () => nowMs)) continue;
+      // Re-run the authoritative staging walk to remove only copies that are
+      // no longer valid. This also resets both acceptances, so a reconnecting
+      // client never sees an expired line as already agreed.
+      tradeSetOffer(ctx, offer.items, offer.copper, pid);
     }
   }
 }

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -4889,6 +4889,10 @@ export interface Entity extends ClientMirroredEntityFields {
   lootable: boolean;
   loot: CorpseLoot | null;
   lootRecipientIds?: number[];
+  /** Runtime-only stable identity for a soulbound drop's party-trade window.
+   *  Captured synchronously when loot rolls, so a later disconnect cannot
+   *  erase a kill-eligible character from the copy's transfer group. */
+  lootPartyTradeEligibility?: { names: string[]; characterIds: number[] };
   xpValue: number;
   // npc
   questIds: string[];

--- a/src/ui/bags_view.ts
+++ b/src/ui/bags_view.ts
@@ -173,7 +173,12 @@ export function bagItemAction(
    *  by the bank socket arm (bank sockets store bare ids, so a marked bag
    *  deposits instead). The vault preserves it, so it never blocks there. */
   craftedRecipeId?: string,
+  /** Host-clock verdict for the copy's marker. The server still authorizes the
+   *  recipient; this only prevents an expired client affordance. */
+  partyTradeWindowActive = instance?.partyTrade !== undefined,
 ): BagAction {
+  if (item.soulbound && mode.tradeOpen && instance?.partyTrade && partyTradeWindowActive)
+    return 'trade';
   if (item.soulbound && (mode.tradeOpen || mode.mailAttach || mode.marketSell || mode.vendorOpen))
     return 'transferBlockedSoulbound';
   if (mode.tradeOpen) return 'trade';
@@ -435,7 +440,10 @@ export function bagTooltipHintKey(
   /** The slot's crafting provenance marker, the bagItemAction twin: read only
    *  by the vaultDeposit arm. */
   craftedRecipeId?: string,
+  partyTradeWindowActive = instance?.partyTrade !== undefined,
 ): BagTooltipHintKey {
+  if (item.soulbound && mode.tradeOpen && instance?.partyTrade && partyTradeWindowActive)
+    return 'itemUi.tooltip.clickTradeOffer';
   if (item.soulbound && (mode.tradeOpen || mode.mailAttach || mode.marketSell || mode.vendorOpen))
     return 'hudChrome.itemSoulbound';
   if (mode.tradeOpen) return 'itemUi.tooltip.clickTradeOffer';

--- a/src/ui/bags_window.ts
+++ b/src/ui/bags_window.ts
@@ -1546,6 +1546,7 @@ export class BagsWindow {
       this.bagMode(),
       s.instance,
       s.craftedRecipeId,
+      this.partyTradeWindowActive(s.instance),
     );
     switch (action) {
       case 'transferBlockedSoulbound':
@@ -1715,6 +1716,7 @@ export class BagsWindow {
         mode,
         s.instance,
         s.craftedRecipeId,
+        this.partyTradeWindowActive(s.instance),
       );
       const extra = key ? `<div class="tt-sub">${esc(t(key))}</div>` : '';
       // Advertise the shift-click partial deposit on a splittable stack, the bank
@@ -1832,6 +1834,15 @@ export class BagsWindow {
       vaultDeposit: this.deps.isVaultBankTab(),
       petFeed: this.deps.pendingPetFeed(),
     };
+  }
+
+  private partyTradeWindowActive(instance: ItemInstancePayload | undefined): boolean {
+    const untilMs = instance?.partyTrade?.untilMs;
+    return (
+      typeof untilMs === 'number' &&
+      Number.isFinite(untilMs) &&
+      this.deps.world().partyTradeMsRemaining(untilMs) > 0
+    );
   }
 
   // Whether the action menu should open for this item. Offered ONLY in

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -6452,15 +6452,15 @@ export class Hud {
         )}</div>`;
       }
     }
-    // Bound-to-owner marker (marks and other soulbound tokens): shown like the
-    // classic "Soulbound" line so a player can see it cannot be traded or destroyed.
+    // Bound-to-owner marker: show that the item cannot be traded or destroyed.
     if (item.soulbound) {
       html += `<div class="tt-sub" style="color:var(--gold)">${esc(t('hudChrome.itemSoulbound'))}</div>`;
     }
-    // BoP party trade window: qualifies the Soulbound line above while this
-    // copy can still be traded to the players who shared its drop
-    // (item_instance_tooltip.ts owns the copy rules; the world owns the clock).
-    html += instancePartyTradeLine(instance, (untilMs) => this.sim.partyTradeMsRemaining(untilMs));
+    html += instancePartyTradeLine(
+      instance,
+      (untilMs) => this.sim.partyTradeMsRemaining(untilMs),
+      item.soulbound === true,
+    );
     // Maker's Bond lines (Professions 2.0): the commission
     // binds-on-first-trade warning or the bound lock, beside the def-level
     // soulbound line it parallels (item_instance_tooltip.ts owns the copy

--- a/src/ui/item_instance_tooltip.ts
+++ b/src/ui/item_instance_tooltip.ts
@@ -96,13 +96,16 @@ export function instanceBindingLines(
  *  IWorld.partyTradeMsRemaining, injected because only the world knows which
  *  clock `untilMs` was stamped from (tick-derived offline, epoch online);
  *  this builder stays a Node-testable pure string function. Renders nothing
- *  for an absent, malformed, or expired window, and never on WORN gear
+ *  for an absent, malformed, or expired window, for a definition that is no
+ *  longer soulbound, and never on WORN gear
  *  (equip strips the payload field, and wornTooltipInstance would trim it
  *  anyway). */
 export function instancePartyTradeLine(
   instance: ItemInstancePayload | undefined,
   msRemainingFor: (untilMs: number) => number,
+  soulbound = true,
 ): string {
+  if (!soulbound) return '';
   const untilMs = instance?.partyTrade?.untilMs;
   if (untilMs === undefined || !Number.isFinite(untilMs)) return '';
   const remainingMs = msRemainingFor(untilMs);

--- a/tests/bags_view.test.ts
+++ b/tests/bags_view.test.ts
@@ -319,6 +319,48 @@ describe('transfer-locked instanced copies (issue 1165)', () => {
 });
 
 describe('soulbound transfer affordances', () => {
+  const PARTY_WINDOW = {
+    partyTrade: { untilMs: 10_000, eligible: ['Alice', 'Bob'] },
+  };
+
+  it('stages a marked soulbound copy for player trade while keeping every anonymous pipe blocked', () => {
+    expect([
+      bagItemAction(ITEMS.mark, { ...NO_MODE, tradeOpen: true }, PARTY_WINDOW),
+      bagItemAction(ITEMS.mark, { ...NO_MODE, mailAttach: true }, PARTY_WINDOW),
+      bagItemAction(ITEMS.mark, { ...NO_MODE, marketSell: true }, PARTY_WINDOW),
+      bagItemAction(ITEMS.mark, { ...NO_MODE, vendorOpen: true }, PARTY_WINDOW),
+    ]).toEqual([
+      'trade',
+      'transferBlockedSoulbound',
+      'transferBlockedSoulbound',
+      'transferBlockedSoulbound',
+    ]);
+  });
+
+  it('advertises player trade only for a marked soulbound copy', () => {
+    expect([
+      bagTooltipHintKey(ITEMS.mark, { ...NO_MODE, tradeOpen: true }, PARTY_WINDOW),
+      bagTooltipHintKey(ITEMS.mark, { ...NO_MODE, mailAttach: true }, PARTY_WINDOW),
+      bagTooltipHintKey(ITEMS.mark, { ...NO_MODE, marketSell: true }, PARTY_WINDOW),
+      bagTooltipHintKey(ITEMS.mark, { ...NO_MODE, vendorOpen: true }, PARTY_WINDOW),
+    ]).toEqual([
+      'itemUi.tooltip.clickTradeOffer',
+      'hudChrome.itemSoulbound',
+      'hudChrome.itemSoulbound',
+      'hudChrome.itemSoulbound',
+    ]);
+  });
+
+  it('blocks the trade action and hint once the host clock says the marker expired', () => {
+    const tradeMode = { ...NO_MODE, tradeOpen: true };
+    expect(bagItemAction(ITEMS.mark, tradeMode, PARTY_WINDOW, undefined, false)).toBe(
+      'transferBlockedSoulbound',
+    );
+    expect(bagTooltipHintKey(ITEMS.mark, tradeMode, PARTY_WINDOW, undefined, false)).toBe(
+      'hudChrome.itemSoulbound',
+    );
+  });
+
   it('blocks trade, mail, market, and vendor clicks instead of staging a Heroic Mark transfer', () => {
     expect([
       bagItemAction(ITEMS.mark, { ...NO_MODE, tradeOpen: true }),

--- a/tests/bags_window_party_trade.test.ts
+++ b/tests/bags_window_party_trade.test.ts
@@ -1,0 +1,128 @@
+// @vitest-environment happy-dom
+// Drives the real bags painter through the player click that originally
+// rejected every soulbound copy before the authoritative trade path could see
+// its temporary party-trade marker.
+import { describe, expect, it } from 'vitest';
+import type { InvSlot } from '../src/sim/types';
+import { BagsWindow, type BagsWindowDeps } from '../src/ui/bags_window';
+import { ItemDragState } from '../src/ui/item_drag_state';
+import type { IWorld } from '../src/world_api';
+
+function clickHarness(
+  inventory: InvSlot[],
+  partyTradeMsRemaining = 1,
+): {
+  root: HTMLElement;
+  staged: string[];
+  errors: string[];
+} {
+  document.body.innerHTML = '';
+  const staged: string[] = [];
+  const errors: string[] = [];
+  const root = document.createElement('div');
+  document.body.appendChild(root);
+  const world = {
+    inventory,
+    bags: [null, null, null, null],
+    bagCapacity: 16,
+    copper: 0,
+    partyTradeMsRemaining: () => partyTradeMsRemaining,
+  } as unknown as IWorld;
+  const noop = (): void => {};
+  const deps: BagsWindowDeps = {
+    itemIcon: () => '<span class="item-icon"></span>',
+    moneyHtml: () => '',
+    itemTooltip: () => '',
+    attachTooltip: noop,
+    root: () => root,
+    world: () => world,
+    wocBalanceHtml: () => '',
+    claudiumLauncherHtml: () => '',
+    openClaudium: noop,
+    openWallet: noop,
+    hideTooltip: noop,
+    consumePeek: () => false,
+    cancelPetFeed: noop,
+    captureFocus: () => null,
+    restoreFocus: noop,
+    renderCharIfOpen: noop,
+    vendorOpen: () => false,
+    tradeOpen: () => true,
+    isMarketSell: () => false,
+    isMailAttach: () => false,
+    isBankOpen: () => false,
+    isPersonalBankTab: () => false,
+    isGuildBankTab: () => false,
+    isVaultBankTab: () => false,
+    pendingPetFeed: () => false,
+    closeVendor: noop,
+    closeBank: noop,
+    onClosed: noop,
+    addItemToTrade: (itemId) => staged.push(itemId),
+    stageMarketSell: noop,
+    stageMailParcel: noop,
+    insertItemChatLink: noop,
+    showError: (message) => errors.push(message),
+    setPendingPetFeed: noop,
+    resetPetBarSig: noop,
+    isHotbarItemId: () => false,
+    useGatherTool: () => false,
+    setDragAction: noop,
+    clearActionDropTargets: noop,
+    dragState: new ItemDragState(),
+    isTouchHud: () => false,
+    confirmVendorSell: () => true,
+    markEquipDropTargets: noop,
+    dropOnEquipSlot: noop,
+    dropOnActionSlot: noop,
+    dropOnActionRingSlot: noop,
+    openItemActionMenu: noop,
+  };
+  new BagsWindow(deps).render();
+  return { root, staged, errors };
+}
+
+function clickFirstCell(root: HTMLElement): void {
+  const cell = root.querySelector('button.bag-item');
+  expect(cell).not.toBeNull();
+  cell?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+}
+
+describe('bags party-trade click path', () => {
+  it('stages a windowed soulbound sigil instead of showing the Soulbound refusal', () => {
+    const { root, staged, errors } = clickHarness([
+      {
+        itemId: 'sigil_anvil_helmet',
+        count: 1,
+        instance: {
+          partyTrade: { untilMs: 10_000, eligible: ['Alice', 'Bob'] },
+        },
+      },
+    ]);
+
+    clickFirstCell(root);
+
+    expect(staged).toEqual(['sigil_anvil_helmet']);
+    expect(errors).toEqual([]);
+  });
+
+  it('shows the Soulbound refusal after the host clock expires the same marker', () => {
+    const { root, staged, errors } = clickHarness(
+      [
+        {
+          itemId: 'sigil_anvil_helmet',
+          count: 1,
+          instance: {
+            partyTrade: { untilMs: 10_000, eligible: ['Alice', 'Bob'] },
+          },
+        },
+      ],
+      0,
+    );
+
+    clickFirstCell(root);
+
+    expect(staged).toEqual([]);
+    expect(errors).toHaveLength(1);
+  });
+});

--- a/tests/bop_party_trade.test.ts
+++ b/tests/bop_party_trade.test.ts
@@ -7,7 +7,7 @@ import { describe, expect, it } from 'vitest';
 import { BOP_PARTY_TRADE_MS } from '../src/sim/loot/bop_trade_window';
 import { grantAwardedLootItem } from '../src/sim/loot/loot_roll';
 import { type PlayerMeta, Sim } from '../src/sim/sim';
-import type { ItemInstancePayload } from '../src/sim/types';
+import { type ItemInstancePayload, TICK_RATE } from '../src/sim/types';
 import { expectDefined } from './helpers/defined';
 
 const HELM = 'furyforged_warhelm'; // soulbound epic warrior PvP helmet
@@ -85,6 +85,34 @@ describe('BoP party trade window: the trade path', () => {
 
     expect(sim.countItem(HELM, alice)).toBe(1);
     expect(sim.countItem(HELM, bob)).toBe(0);
+  });
+
+  it('prunes a staged copy when its window expires and resets both acceptances', () => {
+    const { sim, alice, bob } = tradeSim();
+    const expiring = { partyTrade: { untilMs: 25, eligible: ['Alice', 'Bob'] } };
+    sim.addItemInstance(HELM, expiring, alice);
+    sim.addItemInstance(HELM, expiring, bob);
+    openTrade(sim, alice, bob);
+    sim.tradeSetOffer([{ itemId: HELM, count: 1 }], 0, alice);
+    sim.tradeSetOffer([{ itemId: HELM, count: 1 }], 0, bob);
+    const session = expectDefined(sim.ctx.trades.get(alice));
+    session.acceptedA = true;
+    session.acceptedB = true;
+
+    for (let i = 0; i < TICK_RATE - 1; i++) sim.tick();
+    expect(session.offerA.items).toHaveLength(1);
+    expect(session.offerB.items).toHaveLength(1);
+    expect(session.acceptedA).toBe(true);
+    expect(session.acceptedB).toBe(true);
+
+    sim.tick();
+
+    expect(session.offerA.items).toEqual([]);
+    expect(session.offerB.items).toEqual([]);
+    expect(session.acceptedA).toBe(false);
+    expect(session.acceptedB).toBe(false);
+    expect(sim.countItem(HELM, alice)).toBe(1);
+    expect(sim.countItem(HELM, bob)).toBe(1);
   });
 
   it('never offers a plain soulbound copy that carries no window at all', () => {

--- a/tests/bop_trade_cleanup.test.ts
+++ b/tests/bop_trade_cleanup.test.ts
@@ -1,0 +1,302 @@
+import { describe, expect, it } from 'vitest';
+import {
+  normalizePartyTradeContainers,
+  normalizePartyTradeSlots,
+} from '../src/sim/loot/bop_trade_cleanup';
+import {
+  normalizeSavedVaultPartyTradeState,
+  normalizeVaultPartyTradeState,
+} from '../src/sim/materials_vault';
+import { Sim } from '../src/sim/sim';
+import { type InvSlot, TICK_RATE } from '../src/sim/types';
+
+describe('bind-on-pickup party trade marker cleanup', () => {
+  it('retires expired sigil markers and restacks copies that are otherwise identical', () => {
+    const slots: InvSlot[] = [
+      {
+        itemId: 'sigil_anvil_helmet',
+        count: 1,
+        instance: { partyTrade: { untilMs: 100, eligible: ['Alice', 'Bob'] } },
+        slot: 4,
+      },
+      {
+        itemId: 'sigil_anvil_helmet',
+        count: 1,
+        instance: { partyTrade: { untilMs: 200, eligible: ['Alice', 'Bob'] } },
+        slot: 8,
+      },
+    ];
+
+    const normalized = normalizePartyTradeSlots(slots, 200);
+
+    expect(normalized).toEqual([{ itemId: 'sigil_anvil_helmet', count: 2, slot: 4 }]);
+    expect(slots).toHaveLength(2);
+    expect(slots[0].instance?.partyTrade).toBeDefined();
+  });
+
+  it('keeps active markers distinct and returns the original collection', () => {
+    const slots: InvSlot[] = [
+      {
+        itemId: 'sigil_anvil_helmet',
+        count: 1,
+        instance: { partyTrade: { untilMs: 201, eligible: ['Alice', 'Bob'] } },
+      },
+    ];
+
+    expect(normalizePartyTradeSlots(slots, 200)).toBe(slots);
+  });
+
+  it('preserves an active legacy marker on a currently tradable item for rollback safety', () => {
+    const slots: InvSlot[] = [
+      { itemId: 'heartspring_amulet', count: 1 },
+      {
+        itemId: 'heartspring_amulet',
+        count: 1,
+        instance: { partyTrade: { untilMs: 1_000, eligible: ['Alice', 'Bob'] } },
+      },
+    ];
+
+    expect(normalizePartyTradeSlots(slots, 0)).toBe(slots);
+  });
+
+  it('preserves unrelated payload fields and crafting provenance while restacking', () => {
+    const slots: InvSlot[] = [
+      {
+        itemId: 'sigil_anvil_helmet',
+        count: 1,
+        instance: {
+          signer: 'Alice',
+          partyTrade: { untilMs: 100, eligible: ['Alice', 'Bob'] },
+        },
+        craftedRecipeId: 'recipe_a',
+      },
+      {
+        itemId: 'sigil_anvil_helmet',
+        count: 1,
+        instance: {
+          signer: 'Alice',
+          partyTrade: { untilMs: 100, eligible: ['Alice', 'Bob'] },
+        },
+        craftedRecipeId: 'recipe_a',
+      },
+    ];
+
+    expect(normalizePartyTradeSlots(slots, 100)).toEqual([
+      {
+        itemId: 'sigil_anvil_helmet',
+        count: 2,
+        instance: { signer: 'Alice' },
+        craftedRecipeId: 'recipe_a',
+      },
+    ]);
+  });
+
+  it('keeps different crafting provenance and sibling payloads in separate rows', () => {
+    const expired = (craftedRecipeId: string, signer: string): InvSlot => ({
+      itemId: 'sigil_anvil_helmet',
+      count: 1,
+      instance: {
+        signer,
+        partyTrade: { untilMs: 100, eligible: ['Alice', 'Bob'] },
+      },
+      craftedRecipeId,
+    });
+
+    expect(
+      normalizePartyTradeSlots(
+        [expired('recipe_a', 'Alice'), expired('recipe_b', 'Alice'), expired('recipe_a', 'Bob')],
+        100,
+      ),
+    ).toHaveLength(3);
+  });
+
+  it('does not merge unrelated partial stacks when another item marker expires', () => {
+    const slots: InvSlot[] = [
+      { itemId: 'wolf_pelt', count: 2, slot: 1 },
+      {
+        itemId: 'sigil_anvil_helmet',
+        count: 1,
+        instance: { partyTrade: { untilMs: 100, eligible: ['Alice', 'Bob'] } },
+      },
+      { itemId: 'wolf_pelt', count: 3, slot: 7 },
+    ];
+
+    expect(normalizePartyTradeSlots(slots, 100)).toEqual([
+      { itemId: 'wolf_pelt', count: 2, slot: 1 },
+      { itemId: 'sigil_anvil_helmet', count: 1 },
+      { itemId: 'wolf_pelt', count: 3, slot: 7 },
+    ]);
+  });
+
+  it('preserves one counted non-mergeable row without increasing serialized bytes', () => {
+    const slots: InvSlot[] = [
+      {
+        itemId: 'sigil_anvil_helmet',
+        count: 20,
+        instance: {
+          locked: true,
+          partyTrade: { untilMs: 100, eligible: ['Alice', 'Bob'] },
+        },
+      },
+    ];
+
+    const normalized = normalizePartyTradeSlots(slots, 100);
+    expect(normalized).toEqual([
+      { itemId: 'sigil_anvil_helmet', count: 20, instance: { locked: true } },
+    ]);
+    expect(JSON.stringify(normalized).length).toBeLessThanOrEqual(JSON.stringify(slots).length);
+  });
+
+  it('splits a normalized stack at the live item cap and is idempotent', () => {
+    const slots: InvSlot[] = [
+      {
+        itemId: 'sigil_anvil_helmet',
+        count: 20,
+        instance: { partyTrade: { untilMs: 100, eligible: ['Alice', 'Bob'] } },
+      },
+      {
+        itemId: 'sigil_anvil_helmet',
+        count: 1,
+        instance: { partyTrade: { untilMs: 100, eligible: ['Alice', 'Bob'] } },
+      },
+    ];
+
+    const normalized = normalizePartyTradeSlots(slots, 100);
+    expect(normalized.map((slot) => slot.count)).toEqual([20, 1]);
+    expect(normalizePartyTradeSlots(normalized, 100)).toBe(normalized);
+  });
+
+  it('normalizes every persisted player item container through its owning boundary', () => {
+    const expired = (): InvSlot => ({
+      itemId: 'sigil_anvil_helmet',
+      count: 1,
+      instance: { partyTrade: { untilMs: 100, eligible: ['Alice', 'Bob'] } },
+    });
+    const owner = {
+      inventory: [expired()],
+      bank: { inventory: [expired()] },
+      vault: { stock: { copper_ore: 7 }, special: [expired()], upgrades: 2 },
+      vendorBuyback: [expired()],
+    };
+
+    expect(normalizePartyTradeContainers(owner, 100)).toEqual({
+      inventory: true,
+      bank: true,
+      buyback: true,
+    });
+    expect(normalizeVaultPartyTradeState(owner.vault, 100)).toBe(true);
+    expect(owner.vault.stock).toEqual({ copper_ore: 7 });
+    expect(owner.vault.upgrades).toBe(2);
+    expect(
+      [
+        ...owner.inventory,
+        ...owner.bank.inventory,
+        ...owner.vault.special,
+        ...owner.vendorBuyback,
+      ].every((slot) => slot.instance?.partyTrade === undefined),
+    ).toBe(true);
+  });
+
+  it('does not materialize an absent optional vault special list at save time', () => {
+    const vault = { stock: {}, upgrades: 0 };
+    normalizeSavedVaultPartyTradeState(vault, 100);
+    expect(vault).toEqual({ stock: {}, upgrades: 0 });
+  });
+
+  it('preserves buyback row order and oversized counts while stripping an expired marker', () => {
+    const expired: InvSlot = {
+      itemId: 'sigil_anvil_helmet',
+      count: 20,
+      instance: { partyTrade: { untilMs: 100, eligible: ['Alice', 'Bob'] } },
+    };
+    const owner = {
+      inventory: [],
+      bank: { inventory: [] },
+      vault: { special: [] },
+      vendorBuyback: [
+        { itemId: 'wolf_pelt', count: 40 },
+        expired,
+        { itemId: 'wolf_pelt', count: 60 },
+      ],
+    };
+
+    normalizePartyTradeContainers(owner, 100);
+
+    expect(owner.vendorBuyback).toEqual([
+      { itemId: 'wolf_pelt', count: 40 },
+      { itemId: 'sigil_anvil_helmet', count: 20 },
+      { itemId: 'wolf_pelt', count: 60 },
+    ]);
+  });
+
+  it('normalizes the saved character without a realm-wide tick sweep', () => {
+    const sim = new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+    const pid = sim.addPlayer('warrior', 'Alice');
+    const meta = sim.ctx.players.get(pid);
+    expect(meta).toBeDefined();
+    if (!meta) return;
+    const expired = (): InvSlot => ({
+      itemId: 'sigil_anvil_helmet',
+      count: 1,
+      instance: { partyTrade: { untilMs: 1, eligible: ['Alice', 'Bob'] } },
+    });
+    meta.inventory = [expired()];
+    meta.bank.inventory = [expired()];
+    meta.vault.special = [expired()];
+    meta.vendorBuyback = [expired()];
+    for (let i = 0; i < TICK_RATE; i++) sim.tick();
+
+    const saved = sim.serializeCharacter(pid);
+
+    expect(saved?.inventory[0].instance).toBeUndefined();
+    expect(saved?.bank?.inventory[0].instance).toBeUndefined();
+    expect(saved?.vault?.special?.[0].instance).toBeUndefined();
+    expect(saved?.vendorBuyback?.[0].instance).toBeUndefined();
+    expect(meta.inventory[0].instance?.partyTrade).toBeDefined();
+  });
+
+  it('retires and restacks expired persisted copies during load and resave', () => {
+    const seed = new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+    const seedPid = seed.addPlayer('warrior', 'Alice');
+    const state = seed.serializeCharacter(seedPid);
+    expect(state).toBeDefined();
+    if (!state) return;
+    state.inventory = [
+      {
+        itemId: 'sigil_anvil_helmet',
+        count: 1,
+        instance: { partyTrade: { untilMs: 1, eligible: ['Alice', 'Bob'] } },
+      },
+      {
+        itemId: 'sigil_anvil_helmet',
+        count: 1,
+        instance: { partyTrade: { untilMs: 2, eligible: ['Alice', 'Bob'] } },
+      },
+    ];
+    state.vault = {
+      stock: { copper_ore: 7 },
+      special: [
+        {
+          itemId: 'sigil_anvil_helmet',
+          count: 1,
+          instance: { partyTrade: { untilMs: 1, eligible: ['Alice', 'Bob'] } },
+        },
+      ],
+      upgrades: 2,
+    };
+    const loaded = new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+    loaded.tick();
+
+    const loadedPid = loaded.addPlayer('warrior', 'Alice', { state });
+    const meta = loaded.ctx.players.get(loadedPid);
+
+    expect(meta?.inventory).toEqual([{ itemId: 'sigil_anvil_helmet', count: 2 }]);
+    expect(meta?.vault).toEqual({
+      stock: { copper_ore: 7 },
+      special: [{ itemId: 'sigil_anvil_helmet', count: 1 }],
+      upgrades: 2,
+    });
+    const resaved = loaded.serializeCharacter(loadedPid);
+    expect(resaved?.inventory).toEqual([{ itemId: 'sigil_anvil_helmet', count: 2 }]);
+  });
+});

--- a/tests/item_instance_tooltip.test.ts
+++ b/tests/item_instance_tooltip.test.ts
@@ -421,11 +421,16 @@ describe('instancePartyTradeLine (the BoP party trade window line)', () => {
     ).toBe('');
   });
 
+  it('suppresses a legacy marker after the item definition becomes freely tradable', () => {
+    expect(instancePartyTradeLine(windowed, () => 3_600_000, false)).toBe('');
+  });
+
   it('composes in hud.itemTooltip right after the Soulbound line, before the bond lines', () => {
     const hud = readFileSync(new URL('../src/ui/hud.ts', import.meta.url), 'utf8');
     const soulbound = hud.indexOf("t('hudChrome.itemSoulbound')");
-    const partyTrade = hud.indexOf('instancePartyTradeLine(instance,');
+    const partyTrade = hud.indexOf('instancePartyTradeLine(');
     const binding = hud.indexOf('instanceBindingLines(instance, item.kind)');
+    expect(hud.slice(partyTrade, binding)).toContain('item.soulbound === true');
     expect(partyTrade).toBeGreaterThan(soulbound);
     expect(binding).toBeGreaterThan(partyTrade);
     expect(hud.indexOf('instancePartyTradeLine(', partyTrade + 1)).toBe(-1);

--- a/tests/loot_roll.test.ts
+++ b/tests/loot_roll.test.ts
@@ -8,6 +8,7 @@ import {
   awardSharedLootItem,
   CORPSE_INTERACT_GRACE_SECONDS,
   distributeLootCopper,
+  killSnapshotEligibility,
   lootRollGroupStatus,
   lootSlotVisibleTo,
   partyLootCandidatesForMob,
@@ -795,6 +796,30 @@ describe('loot_roll: heroic-append cross-group dedup arm', () => {
 });
 
 describe('loot_roll: bind-on-pickup party trade window on soulbound awards', () => {
+  it('keeps the exact drop group eligible when a member disconnects before distribution', () => {
+    const { sim, a, b, c } = partyOfThree();
+    playerMeta(sim, a).characterId = 101;
+    playerMeta(sim, b).characterId = 102;
+    playerMeta(sim, c).characterId = 103;
+    const mob = createMob(sim.nextId++, MOBS.ignivar_herald_of_the_last_flame, 20, {
+      x: 0,
+      y: 0,
+      z: 0,
+    });
+    mob.lootRecipientIds = [a, b, c];
+    rollLoot(sim.ctx, mob, playerMeta(sim, a), [
+      playerMeta(sim, a),
+      playerMeta(sim, b),
+      playerMeta(sim, c),
+    ]);
+    playerMeta(sim, b).leaving = true;
+
+    expect(killSnapshotEligibility(sim.ctx, mob)).toEqual({
+      names: ['Aaa', 'Bbb', 'Ccc'],
+      characterIds: [101, 102, 103],
+    });
+  });
+
   it('stamps the drop-moment candidate snapshot onto a need/greed win of a soulbound item', () => {
     const { sim, a, b, c } = partyOfThree();
     const mob = deadCorpse(sim, a, [a, b, c], {

--- a/tests/mob_lifecycle.test.ts
+++ b/tests/mob_lifecycle.test.ts
@@ -188,7 +188,7 @@ describe('mob_lifecycle module: respawnMob + despawnSummonedAdds', () => {
 // so the tapping player keeps a bounded, classic-faithful window before the loot
 // decays with the corpse. Both facets were previously unpinned.
 describe('mob_lifecycle module: un-looted corpse loot on respawn (issue #1539)', () => {
-  it('respawnMob wipes the reused corpse loot state (lootable/loot/tappedById/lootRecipientIds)', () => {
+  it('respawnMob wipes the reused corpse loot state and party-trade eligibility snapshot', () => {
     const sim = makeSim();
     const p = sim.player as any;
     const mob = spawn(sim, 'forest_wolf', 5, 40, 40);
@@ -200,6 +200,7 @@ describe('mob_lifecycle module: un-looted corpse loot on respawn (issue #1539)',
     mob.loot = { copper: 120, items: [{ itemId: 'wolf_pelt', count: 1 }] };
     mob.tappedById = p.id;
     mob.lootRecipientIds = [p.id];
+    mob.lootPartyTradeEligibility = { names: ['Tester'], characterIds: [101] };
 
     respawnMob(ctxOf(sim), mob);
 
@@ -207,6 +208,7 @@ describe('mob_lifecycle module: un-looted corpse loot on respawn (issue #1539)',
     expect(mob.loot).toBe(null);
     expect(mob.tappedById).toBe(null);
     expect(mob.lootRecipientIds).toBeUndefined();
+    expect(mob.lootPartyTradeEligibility).toBeUndefined();
   });
 
   it('the in-place respawn is deferred while the corpse is lootable, then wipes the loot when the corpse decays', () => {

--- a/tests/parity/coverage_c.test.ts
+++ b/tests/parity/coverage_c.test.ts
@@ -871,4 +871,12 @@ describe('coverage: each scenario fires its subsystem', () => {
     expect(notes.raiderCooldownReset).toBe(true);
     expect(notes.encounterReset).toBe(true);
   });
+
+  it('bop_party_trade_eligibility: a leaving drop-mate stays on the awarded copy', () => {
+    const rec = run('bop_party_trade_eligibility');
+    expect(rec.notes.eligibleCharacterIds).toEqual([101, 102]);
+    const alice = [...rec.sim.ctx.players.values()].find((meta) => meta.name === 'AliceParity');
+    const awarded = alice?.inventory.find((slot) => slot.itemId === 'sigil_anvil_helmet');
+    expect(awarded?.instance?.partyTrade?.eligibleIds).toEqual([101, 102]);
+  });
 });

--- a/tests/parity/golden/bop_party_trade_eligibility.json
+++ b/tests/parity/golden/bop_party_trade_eligibility.json
@@ -1,0 +1,1127 @@
+{
+  "scenario": "bop_party_trade_eligibility",
+  "seed": 1173,
+  "sampleEvery": 1,
+  "ticks": 0,
+  "coverage": [
+    "soulbound raid loot captures stable party-trade identity at roll time",
+    "a leaving member remains eligible during delayed distribution",
+    "class:warrior",
+    "class:mage"
+  ],
+  "draws": 8,
+  "drawDigest": "5b236bae",
+  "frames": [
+    {
+      "tick": 0,
+      "time": 0,
+      "nextId": 998,
+      "state": "5bc471b0",
+      "events": "741638a5",
+      "rng": {
+        "draws": 0,
+        "digest": "811c9dc5"
+      },
+      "label": "init",
+      "players": [],
+      "entities": []
+    },
+    {
+      "tick": 0,
+      "time": 0,
+      "nextId": 1001,
+      "state": "d74abbdd",
+      "events": "741638a5",
+      "rng": {
+        "draws": 8,
+        "digest": "5b236bae"
+      },
+      "label": "loot-identity-captured",
+      "players": [
+        {
+          "activeLoadout": -1,
+          "archetype": {},
+          "arena2v2Rating": 1500,
+          "arenaRating": 1500,
+          "bags": [
+            null,
+            null,
+            null,
+            null
+          ],
+          "bank": {
+            "socketBags": [
+              null,
+              null,
+              null,
+              null
+            ]
+          },
+          "bgRating": 1500,
+          "cls": "warrior",
+          "companionUpgrades": {},
+          "counters": {},
+          "craftSkills": {},
+          "deedStats": {
+            "counters": {},
+            "dungeonClears": {},
+            "itemsDiscovered": [
+              "baked_bread",
+              "eastbrook_buckler",
+              "recruit_tunic",
+              "worn_sword"
+            ]
+          },
+          "delveClears": {},
+          "delveDaily": {},
+          "entityId": 998,
+          "equipment": {
+            "chest": "recruit_tunic",
+            "mainhand": "worn_sword",
+            "offhand": "eastbrook_buckler"
+          },
+          "equipmentInstance": {},
+          "gatheringProficiency": {},
+          "heroicDaily": {},
+          "inventory": [
+            {
+              "count": 5,
+              "itemId": "baked_bread"
+            }
+          ],
+          "mailWelcomed": true,
+          "nodeHarvestReadyAt": {},
+          "recipesGrandfathered": true,
+          "reliquary": {
+            "counts": {},
+            "firstFind": {}
+          },
+          "talents": {
+            "rows": {}
+          },
+          "townFocus": {},
+          "vault": {
+            "stock": {}
+          }
+        },
+        {
+          "activeLoadout": -1,
+          "archetype": {},
+          "arena2v2Rating": 1500,
+          "arenaRating": 1500,
+          "bags": [
+            null,
+            null,
+            null,
+            null
+          ],
+          "bank": {
+            "socketBags": [
+              null,
+              null,
+              null,
+              null
+            ]
+          },
+          "bgRating": 1500,
+          "cls": "mage",
+          "companionUpgrades": {},
+          "counters": {},
+          "craftSkills": {},
+          "deedStats": {
+            "counters": {},
+            "dungeonClears": {},
+            "itemsDiscovered": [
+              "apprentice_robe",
+              "baked_bread",
+              "gnarled_staff",
+              "spring_water"
+            ]
+          },
+          "delveClears": {},
+          "delveDaily": {},
+          "entityId": 999,
+          "equipment": {
+            "chest": "apprentice_robe",
+            "mainhand": "gnarled_staff"
+          },
+          "equipmentInstance": {},
+          "gatheringProficiency": {},
+          "heroicDaily": {},
+          "inventory": [
+            {
+              "count": 5,
+              "itemId": "baked_bread"
+            },
+            {
+              "count": 5,
+              "itemId": "spring_water"
+            }
+          ],
+          "mailWelcomed": true,
+          "nodeHarvestReadyAt": {},
+          "recipesGrandfathered": true,
+          "reliquary": {
+            "counts": {},
+            "firstFind": {}
+          },
+          "talents": {
+            "rows": {}
+          },
+          "townFocus": {},
+          "vault": {
+            "stock": {}
+          }
+        }
+      ],
+      "entities": [
+        {
+          "aiState": "idle",
+          "attackPower": 46,
+          "auras": [
+            {
+              "duration": 3600,
+              "id": "battle_stance",
+              "kind": "battle_stance",
+              "name": "Battle Stance",
+              "remaining": 3600,
+              "school": "physical",
+              "sourceId": 998
+            }
+          ],
+          "blockChance": 0.05,
+          "blockValue": 6,
+          "combatTimer": 99,
+          "comboUntil": -1,
+          "critChance": 0.06,
+          "detonateTimer": "Infinity",
+          "dodgeChance": 0.06,
+          "fallStartY": -2,
+          "fiveSecondRule": 99,
+          "healPower": 5,
+          "hp": 100,
+          "id": 998,
+          "kind": "player",
+          "level": 1,
+          "lootFfaTimer": "Infinity",
+          "maxHp": 100,
+          "maxResource": 100,
+          "moveSpeed": 7,
+          "offhandItemId": "eastbrook_buckler",
+          "onGround": true,
+          "overpowerUntil": -1,
+          "petMode": "defensive",
+          "pos": {
+            "x": -94,
+            "y": -2,
+            "z": -58
+          },
+          "potionCooldownUntil": -1,
+          "resourceType": "rage",
+          "spawnPos": {
+            "x": -94,
+            "y": -2,
+            "z": -58
+          },
+          "spellPower": 5,
+          "stats": {
+            "agi": 20,
+            "armor": 144,
+            "int": 10,
+            "spi": 11,
+            "sta": 23,
+            "str": 23
+          },
+          "templateId": "warrior",
+          "weapon": {
+            "max": 5,
+            "min": 2,
+            "speed": 2
+          }
+        },
+        {
+          "aiState": "idle",
+          "attackPower": 10,
+          "combatTimer": 99,
+          "comboUntil": -1,
+          "critChance": 0.056,
+          "detonateTimer": "Infinity",
+          "dodgeChance": 0.056,
+          "fallStartY": -2,
+          "fiveSecondRule": 99,
+          "healPower": 13,
+          "hp": 54,
+          "id": 999,
+          "kind": "player",
+          "level": 1,
+          "lootFfaTimer": "Infinity",
+          "maxHp": 54,
+          "maxResource": 195,
+          "moveSpeed": 7,
+          "onGround": true,
+          "overpowerUntil": -1,
+          "petMode": "defensive",
+          "pos": {
+            "x": -94,
+            "y": -2,
+            "z": -58
+          },
+          "potionCooldownUntil": -1,
+          "resource": 195,
+          "resourceType": "mana",
+          "spawnPos": {
+            "x": -94,
+            "y": -2,
+            "z": -58
+          },
+          "spellPower": 13,
+          "stats": {
+            "agi": 12,
+            "armor": 57,
+            "int": 25,
+            "spi": 22,
+            "sta": 14,
+            "str": 10
+          },
+          "templateId": "mage",
+          "weapon": {
+            "max": 6,
+            "min": 3,
+            "speed": 2.9
+          }
+        },
+        {
+          "aiState": "idle",
+          "combatTimer": 99,
+          "comboUntil": -1,
+          "critChance": 0.05,
+          "detonateTimer": "Infinity",
+          "dodgeChance": 0.05,
+          "fallStartY": 0.413537,
+          "fiveSecondRule": 99,
+          "hostile": true,
+          "hp": 120000,
+          "id": 1000,
+          "kind": "mob",
+          "level": 20,
+          "loot": {
+            "copper": 112735,
+            "items": [
+              {
+                "count": 1,
+                "itemId": "sigil_ember_shoulder"
+              },
+              {
+                "count": 1,
+                "itemId": "sigil_tempest_gloves"
+              },
+              {
+                "count": 1,
+                "itemId": "ignivars_ember_choker"
+              },
+              {
+                "count": 1,
+                "itemId": "moonscorch_waistwrap"
+              },
+              {
+                "count": 1,
+                "itemId": "lastflame_core"
+              },
+              {
+                "count": 1,
+                "itemId": "lastflame_core"
+              }
+            ]
+          },
+          "lootFfaTimer": 60,
+          "lootPartyTradeEligibility": {
+            "characterIds": [
+              101,
+              102
+            ],
+            "names": [
+              "AliceParity",
+              "BobParity"
+            ]
+          },
+          "lootRecipientIds": [
+            998,
+            999
+          ],
+          "lootable": true,
+          "maxHp": 120000,
+          "moveSpeed": 7,
+          "onGround": true,
+          "overpowerUntil": -1,
+          "petMode": "defensive",
+          "pos": {
+            "x": 20,
+            "y": 0.413537,
+            "z": 22
+          },
+          "potionCooldownUntil": -1,
+          "spawnPos": {
+            "x": 20,
+            "y": 0.413537,
+            "z": 22
+          },
+          "stats": {
+            "armor": 798
+          },
+          "templateId": "ignivar_herald_of_the_last_flame",
+          "weapon": {
+            "max": 446,
+            "min": 286,
+            "speed": 2.6
+          }
+        }
+      ]
+    },
+    {
+      "tick": 0,
+      "time": 0,
+      "nextId": 1001,
+      "state": "7f5f7e07",
+      "events": "76b49129",
+      "rng": {
+        "draws": 8,
+        "digest": "5b236bae"
+      },
+      "label": "leaver-remains-eligible",
+      "players": [
+        {
+          "activeLoadout": -1,
+          "archetype": {},
+          "arena2v2Rating": 1500,
+          "arenaRating": 1500,
+          "bags": [
+            null,
+            null,
+            null,
+            null
+          ],
+          "bank": {
+            "socketBags": [
+              null,
+              null,
+              null,
+              null
+            ]
+          },
+          "bgRating": 1500,
+          "cls": "warrior",
+          "companionUpgrades": {},
+          "counters": {},
+          "craftSkills": {},
+          "deedStats": {
+            "counters": {},
+            "dungeonClears": {},
+            "itemsDiscovered": [
+              "baked_bread",
+              "eastbrook_buckler",
+              "recruit_tunic",
+              "sigil_anvil_helmet",
+              "worn_sword"
+            ],
+            "visited": [
+              "quality:epic"
+            ]
+          },
+          "delveClears": {},
+          "delveDaily": {},
+          "entityId": 998,
+          "equipment": {
+            "chest": "recruit_tunic",
+            "mainhand": "worn_sword",
+            "offhand": "eastbrook_buckler"
+          },
+          "equipmentInstance": {},
+          "gatheringProficiency": {},
+          "heroicDaily": {},
+          "inventory": [
+            {
+              "count": 5,
+              "itemId": "baked_bread"
+            },
+            {
+              "count": 1,
+              "instance": {
+                "partyTrade": {
+                  "eligible": [
+                    "AliceParity",
+                    "BobParity"
+                  ],
+                  "eligibleIds": [
+                    101,
+                    102
+                  ],
+                  "untilMs": 7200000
+                }
+              },
+              "itemId": "sigil_anvil_helmet"
+            }
+          ],
+          "mailWelcomed": true,
+          "nodeHarvestReadyAt": {},
+          "recipesGrandfathered": true,
+          "reliquary": {
+            "counts": {},
+            "firstFind": {}
+          },
+          "talents": {
+            "rows": {}
+          },
+          "townFocus": {},
+          "vault": {
+            "stock": {}
+          }
+        },
+        {
+          "activeLoadout": -1,
+          "archetype": {},
+          "arena2v2Rating": 1500,
+          "arenaRating": 1500,
+          "bags": [
+            null,
+            null,
+            null,
+            null
+          ],
+          "bank": {
+            "socketBags": [
+              null,
+              null,
+              null,
+              null
+            ]
+          },
+          "bgRating": 1500,
+          "cls": "mage",
+          "companionUpgrades": {},
+          "counters": {},
+          "craftSkills": {},
+          "deedStats": {
+            "counters": {},
+            "dungeonClears": {},
+            "itemsDiscovered": [
+              "apprentice_robe",
+              "baked_bread",
+              "gnarled_staff",
+              "spring_water"
+            ]
+          },
+          "delveClears": {},
+          "delveDaily": {},
+          "entityId": 999,
+          "equipment": {
+            "chest": "apprentice_robe",
+            "mainhand": "gnarled_staff"
+          },
+          "equipmentInstance": {},
+          "gatheringProficiency": {},
+          "heroicDaily": {},
+          "inventory": [
+            {
+              "count": 5,
+              "itemId": "baked_bread"
+            },
+            {
+              "count": 5,
+              "itemId": "spring_water"
+            }
+          ],
+          "leaving": true,
+          "mailWelcomed": true,
+          "nodeHarvestReadyAt": {},
+          "recipesGrandfathered": true,
+          "reliquary": {
+            "counts": {},
+            "firstFind": {}
+          },
+          "talents": {
+            "rows": {}
+          },
+          "townFocus": {},
+          "vault": {
+            "stock": {}
+          }
+        }
+      ],
+      "entities": [
+        {
+          "aiState": "idle",
+          "attackPower": 46,
+          "auras": [
+            {
+              "duration": 3600,
+              "id": "battle_stance",
+              "kind": "battle_stance",
+              "name": "Battle Stance",
+              "remaining": 3600,
+              "school": "physical",
+              "sourceId": 998
+            }
+          ],
+          "blockChance": 0.05,
+          "blockValue": 6,
+          "combatTimer": 99,
+          "comboUntil": -1,
+          "critChance": 0.06,
+          "detonateTimer": "Infinity",
+          "dodgeChance": 0.06,
+          "fallStartY": -2,
+          "fiveSecondRule": 99,
+          "healPower": 5,
+          "hp": 100,
+          "id": 998,
+          "kind": "player",
+          "level": 1,
+          "lootFfaTimer": "Infinity",
+          "maxHp": 100,
+          "maxResource": 100,
+          "moveSpeed": 7,
+          "offhandItemId": "eastbrook_buckler",
+          "onGround": true,
+          "overpowerUntil": -1,
+          "petMode": "defensive",
+          "pos": {
+            "x": -94,
+            "y": -2,
+            "z": -58
+          },
+          "potionCooldownUntil": -1,
+          "resourceType": "rage",
+          "spawnPos": {
+            "x": -94,
+            "y": -2,
+            "z": -58
+          },
+          "spellPower": 5,
+          "stats": {
+            "agi": 20,
+            "armor": 144,
+            "int": 10,
+            "spi": 11,
+            "sta": 23,
+            "str": 23
+          },
+          "templateId": "warrior",
+          "weapon": {
+            "max": 5,
+            "min": 2,
+            "speed": 2
+          }
+        },
+        {
+          "aiState": "idle",
+          "attackPower": 10,
+          "combatTimer": 99,
+          "comboUntil": -1,
+          "critChance": 0.056,
+          "detonateTimer": "Infinity",
+          "dodgeChance": 0.056,
+          "fallStartY": -2,
+          "fiveSecondRule": 99,
+          "healPower": 13,
+          "hp": 54,
+          "id": 999,
+          "kind": "player",
+          "level": 1,
+          "lootFfaTimer": "Infinity",
+          "maxHp": 54,
+          "maxResource": 195,
+          "moveSpeed": 7,
+          "onGround": true,
+          "overpowerUntil": -1,
+          "petMode": "defensive",
+          "pos": {
+            "x": -94,
+            "y": -2,
+            "z": -58
+          },
+          "potionCooldownUntil": -1,
+          "resource": 195,
+          "resourceType": "mana",
+          "spawnPos": {
+            "x": -94,
+            "y": -2,
+            "z": -58
+          },
+          "spellPower": 13,
+          "stats": {
+            "agi": 12,
+            "armor": 57,
+            "int": 25,
+            "spi": 22,
+            "sta": 14,
+            "str": 10
+          },
+          "templateId": "mage",
+          "weapon": {
+            "max": 6,
+            "min": 3,
+            "speed": 2.9
+          }
+        },
+        {
+          "aiState": "idle",
+          "combatTimer": 99,
+          "comboUntil": -1,
+          "critChance": 0.05,
+          "detonateTimer": "Infinity",
+          "dodgeChance": 0.05,
+          "fallStartY": 0.413537,
+          "fiveSecondRule": 99,
+          "hostile": true,
+          "hp": 120000,
+          "id": 1000,
+          "kind": "mob",
+          "level": 20,
+          "loot": {
+            "copper": 112735,
+            "items": [
+              {
+                "count": 1,
+                "itemId": "sigil_ember_shoulder"
+              },
+              {
+                "count": 1,
+                "itemId": "sigil_tempest_gloves"
+              },
+              {
+                "count": 1,
+                "itemId": "ignivars_ember_choker"
+              },
+              {
+                "count": 1,
+                "itemId": "moonscorch_waistwrap"
+              },
+              {
+                "count": 1,
+                "itemId": "lastflame_core"
+              },
+              {
+                "count": 1,
+                "itemId": "lastflame_core"
+              }
+            ]
+          },
+          "lootFfaTimer": 60,
+          "lootPartyTradeEligibility": {
+            "characterIds": [
+              101,
+              102
+            ],
+            "names": [
+              "AliceParity",
+              "BobParity"
+            ]
+          },
+          "lootRecipientIds": [
+            998,
+            999
+          ],
+          "lootable": true,
+          "maxHp": 120000,
+          "moveSpeed": 7,
+          "onGround": true,
+          "overpowerUntil": -1,
+          "petMode": "defensive",
+          "pos": {
+            "x": 20,
+            "y": 0.413537,
+            "z": 22
+          },
+          "potionCooldownUntil": -1,
+          "spawnPos": {
+            "x": 20,
+            "y": 0.413537,
+            "z": 22
+          },
+          "stats": {
+            "armor": 798
+          },
+          "templateId": "ignivar_herald_of_the_last_flame",
+          "weapon": {
+            "max": 446,
+            "min": 286,
+            "speed": 2.6
+          }
+        }
+      ]
+    },
+    {
+      "tick": 0,
+      "time": 0,
+      "nextId": 1001,
+      "state": "7f5f7e07",
+      "events": "741638a5",
+      "rng": {
+        "draws": 8,
+        "digest": "5b236bae"
+      },
+      "label": "final",
+      "players": [
+        {
+          "activeLoadout": -1,
+          "archetype": {},
+          "arena2v2Rating": 1500,
+          "arenaRating": 1500,
+          "bags": [
+            null,
+            null,
+            null,
+            null
+          ],
+          "bank": {
+            "socketBags": [
+              null,
+              null,
+              null,
+              null
+            ]
+          },
+          "bgRating": 1500,
+          "cls": "warrior",
+          "companionUpgrades": {},
+          "counters": {},
+          "craftSkills": {},
+          "deedStats": {
+            "counters": {},
+            "dungeonClears": {},
+            "itemsDiscovered": [
+              "baked_bread",
+              "eastbrook_buckler",
+              "recruit_tunic",
+              "sigil_anvil_helmet",
+              "worn_sword"
+            ],
+            "visited": [
+              "quality:epic"
+            ]
+          },
+          "delveClears": {},
+          "delveDaily": {},
+          "entityId": 998,
+          "equipment": {
+            "chest": "recruit_tunic",
+            "mainhand": "worn_sword",
+            "offhand": "eastbrook_buckler"
+          },
+          "equipmentInstance": {},
+          "gatheringProficiency": {},
+          "heroicDaily": {},
+          "inventory": [
+            {
+              "count": 5,
+              "itemId": "baked_bread"
+            },
+            {
+              "count": 1,
+              "instance": {
+                "partyTrade": {
+                  "eligible": [
+                    "AliceParity",
+                    "BobParity"
+                  ],
+                  "eligibleIds": [
+                    101,
+                    102
+                  ],
+                  "untilMs": 7200000
+                }
+              },
+              "itemId": "sigil_anvil_helmet"
+            }
+          ],
+          "mailWelcomed": true,
+          "nodeHarvestReadyAt": {},
+          "recipesGrandfathered": true,
+          "reliquary": {
+            "counts": {},
+            "firstFind": {}
+          },
+          "talents": {
+            "rows": {}
+          },
+          "townFocus": {},
+          "vault": {
+            "stock": {}
+          }
+        },
+        {
+          "activeLoadout": -1,
+          "archetype": {},
+          "arena2v2Rating": 1500,
+          "arenaRating": 1500,
+          "bags": [
+            null,
+            null,
+            null,
+            null
+          ],
+          "bank": {
+            "socketBags": [
+              null,
+              null,
+              null,
+              null
+            ]
+          },
+          "bgRating": 1500,
+          "cls": "mage",
+          "companionUpgrades": {},
+          "counters": {},
+          "craftSkills": {},
+          "deedStats": {
+            "counters": {},
+            "dungeonClears": {},
+            "itemsDiscovered": [
+              "apprentice_robe",
+              "baked_bread",
+              "gnarled_staff",
+              "spring_water"
+            ]
+          },
+          "delveClears": {},
+          "delveDaily": {},
+          "entityId": 999,
+          "equipment": {
+            "chest": "apprentice_robe",
+            "mainhand": "gnarled_staff"
+          },
+          "equipmentInstance": {},
+          "gatheringProficiency": {},
+          "heroicDaily": {},
+          "inventory": [
+            {
+              "count": 5,
+              "itemId": "baked_bread"
+            },
+            {
+              "count": 5,
+              "itemId": "spring_water"
+            }
+          ],
+          "leaving": true,
+          "mailWelcomed": true,
+          "nodeHarvestReadyAt": {},
+          "recipesGrandfathered": true,
+          "reliquary": {
+            "counts": {},
+            "firstFind": {}
+          },
+          "talents": {
+            "rows": {}
+          },
+          "townFocus": {},
+          "vault": {
+            "stock": {}
+          }
+        }
+      ],
+      "entities": [
+        {
+          "aiState": "idle",
+          "attackPower": 46,
+          "auras": [
+            {
+              "duration": 3600,
+              "id": "battle_stance",
+              "kind": "battle_stance",
+              "name": "Battle Stance",
+              "remaining": 3600,
+              "school": "physical",
+              "sourceId": 998
+            }
+          ],
+          "blockChance": 0.05,
+          "blockValue": 6,
+          "combatTimer": 99,
+          "comboUntil": -1,
+          "critChance": 0.06,
+          "detonateTimer": "Infinity",
+          "dodgeChance": 0.06,
+          "fallStartY": -2,
+          "fiveSecondRule": 99,
+          "healPower": 5,
+          "hp": 100,
+          "id": 998,
+          "kind": "player",
+          "level": 1,
+          "lootFfaTimer": "Infinity",
+          "maxHp": 100,
+          "maxResource": 100,
+          "moveSpeed": 7,
+          "offhandItemId": "eastbrook_buckler",
+          "onGround": true,
+          "overpowerUntil": -1,
+          "petMode": "defensive",
+          "pos": {
+            "x": -94,
+            "y": -2,
+            "z": -58
+          },
+          "potionCooldownUntil": -1,
+          "resourceType": "rage",
+          "spawnPos": {
+            "x": -94,
+            "y": -2,
+            "z": -58
+          },
+          "spellPower": 5,
+          "stats": {
+            "agi": 20,
+            "armor": 144,
+            "int": 10,
+            "spi": 11,
+            "sta": 23,
+            "str": 23
+          },
+          "templateId": "warrior",
+          "weapon": {
+            "max": 5,
+            "min": 2,
+            "speed": 2
+          }
+        },
+        {
+          "aiState": "idle",
+          "attackPower": 10,
+          "combatTimer": 99,
+          "comboUntil": -1,
+          "critChance": 0.056,
+          "detonateTimer": "Infinity",
+          "dodgeChance": 0.056,
+          "fallStartY": -2,
+          "fiveSecondRule": 99,
+          "healPower": 13,
+          "hp": 54,
+          "id": 999,
+          "kind": "player",
+          "level": 1,
+          "lootFfaTimer": "Infinity",
+          "maxHp": 54,
+          "maxResource": 195,
+          "moveSpeed": 7,
+          "onGround": true,
+          "overpowerUntil": -1,
+          "petMode": "defensive",
+          "pos": {
+            "x": -94,
+            "y": -2,
+            "z": -58
+          },
+          "potionCooldownUntil": -1,
+          "resource": 195,
+          "resourceType": "mana",
+          "spawnPos": {
+            "x": -94,
+            "y": -2,
+            "z": -58
+          },
+          "spellPower": 13,
+          "stats": {
+            "agi": 12,
+            "armor": 57,
+            "int": 25,
+            "spi": 22,
+            "sta": 14,
+            "str": 10
+          },
+          "templateId": "mage",
+          "weapon": {
+            "max": 6,
+            "min": 3,
+            "speed": 2.9
+          }
+        },
+        {
+          "aiState": "idle",
+          "combatTimer": 99,
+          "comboUntil": -1,
+          "critChance": 0.05,
+          "detonateTimer": "Infinity",
+          "dodgeChance": 0.05,
+          "fallStartY": 0.413537,
+          "fiveSecondRule": 99,
+          "hostile": true,
+          "hp": 120000,
+          "id": 1000,
+          "kind": "mob",
+          "level": 20,
+          "loot": {
+            "copper": 112735,
+            "items": [
+              {
+                "count": 1,
+                "itemId": "sigil_ember_shoulder"
+              },
+              {
+                "count": 1,
+                "itemId": "sigil_tempest_gloves"
+              },
+              {
+                "count": 1,
+                "itemId": "ignivars_ember_choker"
+              },
+              {
+                "count": 1,
+                "itemId": "moonscorch_waistwrap"
+              },
+              {
+                "count": 1,
+                "itemId": "lastflame_core"
+              },
+              {
+                "count": 1,
+                "itemId": "lastflame_core"
+              }
+            ]
+          },
+          "lootFfaTimer": 60,
+          "lootPartyTradeEligibility": {
+            "characterIds": [
+              101,
+              102
+            ],
+            "names": [
+              "AliceParity",
+              "BobParity"
+            ]
+          },
+          "lootRecipientIds": [
+            998,
+            999
+          ],
+          "lootable": true,
+          "maxHp": 120000,
+          "moveSpeed": 7,
+          "onGround": true,
+          "overpowerUntil": -1,
+          "petMode": "defensive",
+          "pos": {
+            "x": 20,
+            "y": 0.413537,
+            "z": 22
+          },
+          "potionCooldownUntil": -1,
+          "spawnPos": {
+            "x": 20,
+            "y": 0.413537,
+            "z": 22
+          },
+          "stats": {
+            "armor": 798
+          },
+          "templateId": "ignivar_herald_of_the_last_flame",
+          "weapon": {
+            "max": 446,
+            "min": 286,
+            "speed": 2.6
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/parity/scenarios.ts
+++ b/tests/parity/scenarios.ts
@@ -46,7 +46,12 @@ import {
 } from '../../src/sim/ignivar_raid_ids';
 import { enterDungeon } from '../../src/sim/instances/dungeons';
 import { solveLockActions } from '../../src/sim/lockpick';
-import type { PendingLootRoll } from '../../src/sim/loot/loot_roll';
+import {
+  grantAwardedLootItem,
+  killSnapshotEligibility,
+  type PendingLootRoll,
+  rollLoot,
+} from '../../src/sim/loot/loot_roll';
 import { RIFT_MECHANIC_SPACING_SEC } from '../../src/sim/mob/mechanic_spacing';
 import { PLAYER_BODY_RADIUS } from '../../src/sim/pathfind';
 import { startFishing } from '../../src/sim/professions/fishing';
@@ -6448,6 +6453,47 @@ function varkhulRaidTuning(): Scenario {
   };
 }
 
+function bopPartyTradeEligibility(): Scenario {
+  return {
+    name: 'bop_party_trade_eligibility',
+    coverage: [
+      'soulbound raid loot captures stable party-trade identity at roll time',
+      'a leaving member remains eligible during delayed distribution',
+      'class:warrior',
+      'class:mage',
+    ],
+    sampleEvery: 1,
+    build: () => new Sim({ seed: 1173, playerClass: 'warrior', noPlayer: true }),
+    drive(rec: Recorder) {
+      const sim = rec.sim;
+      const aliceId = sim.addPlayer('warrior', 'AliceParity', { characterId: 101 });
+      const bobId = sim.addPlayer('mage', 'BobParity', { characterId: 102 });
+      const alice = requireValue(sim.meta(aliceId), 'BoP parity Alice metadata');
+      const bob = requireValue(sim.meta(bobId), 'BoP parity Bob metadata');
+      const mob = createMob(sim.nextId++, MOBS.ignivar_herald_of_the_last_flame, 20, {
+        x: 20,
+        y: terrainHeight(20, 22, sim.cfg.seed),
+        z: 22,
+      }) as AnyEntity;
+      mob.lootRecipientIds = [aliceId, bobId];
+      sim.addEntity(mob);
+      rec.track(mob.id);
+
+      rollLoot(sim.ctx, mob, alice, [alice, bob]);
+      if (!mob.lootPartyTradeEligibility) {
+        throw new Error('BoP parity seed did not roll a soulbound Ignivar drop');
+      }
+      rec.snapshot('loot-identity-captured');
+
+      bob.leaving = true;
+      const eligibility = killSnapshotEligibility(sim.ctx, mob);
+      grantAwardedLootItem(sim.ctx, 'sigil_anvil_helmet', aliceId, eligibility);
+      rec.notes.eligibleCharacterIds = eligibility.characterIds;
+      rec.snapshot('leaver-remains-eligible');
+    },
+  };
+}
+
 export const SCENARIOS: Scenario[] = [
   soloWarrior(),
   soloMage(),
@@ -6529,4 +6575,5 @@ export const SCENARIOS: Scenario[] = [
   supportedElevationLineOfSight(),
   ignivarRaidTuning(),
   varkhulRaidTuning(),
+  bopPartyTradeEligibility(),
 ];


### PR DESCRIPTION
## Summary

- allow actively marked soulbound raid loot to be staged in player trades while preserving restrictions on other transfer paths
- snapshot kill-time party eligibility and prune expired offers while resetting trade acceptance
- retire expired trade metadata safely across persisted item containers and suppress stale tooltip text

## Test plan

- 11 focused Vitest files: 427 tests passed
- TypeScript typecheck passed
- changed-file CI gate passed
- pnpm audit completed with only known ignored advisories

## Gate note

The full gate passed its deterministic, generated-file, i18n, and malware stages. Its full-suite phase encountered unavailable localhost/Postgres services in this environment. The task-related material-vault regressions surfaced before that interruption were fixed, and the affected focused suites pass.