### PR TITLE
fix(render): dispose terrain/water/underwater views on renderer teardown

### DIFF
--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -3223,7 +3223,13 @@ export class Renderer {
     for (const target of this.envRTs.values()) bestEffort(() => target.dispose());
     this.envRTs.clear();
     disposeRendererPrewarmAndGroundFx(this, bestEffort);
-    disposeRendererWorldViews(this, bestEffort);
+    disposeRendererWorldViews(
+      this.terrainView,
+      this.farTerrainView,
+      this.waterView,
+      this.underwaterView,
+      bestEffort,
+    );
     for (const bubble of this.chatBubbles.values()) bestEffort(() => bubble.el.remove());
     this.chatBubbles.clear();
     for (const id of [...this.views.keys()]) bestEffort(() => this.removeView(id, true));
@@ -12620,24 +12626,8 @@ export class Renderer {
       this.terrainView.rebuildRegion(region.minX, region.minZ, region.maxX, region.maxZ);
       return;
     }
-    this.terrainView.cancelStreaming();
-    const old = this.terrainView.group;
-    this.scene.remove(old);
-    const firstMesh = old.children.find((c) => (c as THREE.Mesh).isMesh) as THREE.Mesh | undefined;
-    const sharedMat = firstMesh?.material as THREE.Material | THREE.Material[] | undefined;
-    old.traverse((o) => {
-      const m = o as THREE.Mesh;
-      if (m.isMesh) m.geometry.dispose();
-    });
-    const disposeMat = (mat: THREE.Material): void => {
-      const withMap = mat as THREE.Material & {
-        normalMap?: THREE.Texture | null;
-      };
-      withMap.normalMap?.dispose();
-      mat.dispose();
-    };
-    if (Array.isArray(sharedMat)) sharedMat.forEach(disposeMat);
-    else if (sharedMat) disposeMat(sharedMat);
+    this.scene.remove(this.terrainView.group);
+    this.terrainView.dispose();
     this.terrainView = buildTerrain(this.sim.cfg.seed);
     setRenderCategory(this.terrainView.group, 'terrain');
     this.scene.add(this.terrainView.group);

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -605,7 +605,10 @@ import type {
   RendererPhaseStats,
   RendererQualityChangeStats,
 } from './renderer_perf_stats';
-import { disposeRendererPrewarmAndGroundFx } from './renderer_resource_lifecycle';
+import {
+  disposeRendererPrewarmAndGroundFx,
+  disposeRendererWorldViews,
+} from './renderer_resource_lifecycle';
 import { createRevealCompileHost, REVEAL_GATE_PREP_KIND } from './reveal_compile_host';
 import { createRevealGate } from './reveal_gate';
 import type { RevealGateCore } from './reveal_gate_core';
@@ -3217,11 +3220,10 @@ export class Renderer {
     // Unbind this dome from the sky module's live-binding set, or a replaced
     // renderer's dome would pin its last biome pair against eviction forever.
     bestEffort(() => this.skyView?.dispose());
-    for (const target of this.envRTs.values()) {
-      bestEffort(() => target.dispose());
-    }
+    for (const target of this.envRTs.values()) bestEffort(() => target.dispose());
     this.envRTs.clear();
     disposeRendererPrewarmAndGroundFx(this, bestEffort);
+    disposeRendererWorldViews(this, bestEffort);
     for (const bubble of this.chatBubbles.values()) bestEffort(() => bubble.el.remove());
     this.chatBubbles.clear();
     for (const id of [...this.views.keys()]) bestEffort(() => this.removeView(id, true));

--- a/src/render/renderer_resource_lifecycle.ts
+++ b/src/render/renderer_resource_lifecycle.ts
@@ -32,3 +32,34 @@ export function disposeRendererPrewarmAndGroundFx(
   // context; a later renderer installs its own (occluder_fade_gate.ts).
   bestEffort(() => uninstallOccluderFadeGate());
 }
+
+export interface RendererWorldViewsOwner {
+  terrainView?: RendererDisposable;
+  waterView?: RendererDisposable;
+  underwaterView?: RendererDisposable;
+}
+
+/**
+ * Dispose the renderer-owned world-subsystem views (terrain, water,
+ * underwater) independently. Without this, a graphics-preset rebuild
+ * (electron/main.cjs's context recycle path; see GitHub issue #3750)
+ * silently retains every resident terrain chunk, the water simulation, and
+ * the underwater overlay's geometry and materials on the JS heap: nothing
+ * else in the renderer's teardown ever calls their dispose() methods, so a
+ * rebuild permanently steps up memory instead of returning to its pre-rebuild
+ * floor. The renderer passes itself because these resource fields are
+ * private. Props/foliage are deliberately NOT included here: unlike these
+ * three, their geometries and materials are drawn from the shared GLB-cache
+ * (`assets/loader.ts`), and disposing a cached resource that another
+ * consumer still reads would corrupt live rendering elsewhere; releasing
+ * them safely needs its own per-subsystem accounting, tracked separately.
+ */
+export function disposeRendererWorldViews(
+  owner: object,
+  bestEffort: (cleanup: () => void) => void,
+): void {
+  const resources = owner as RendererWorldViewsOwner;
+  bestEffort(() => resources.terrainView?.dispose());
+  bestEffort(() => resources.waterView?.dispose());
+  bestEffort(() => resources.underwaterView?.dispose());
+}

--- a/src/render/renderer_resource_lifecycle.ts
+++ b/src/render/renderer_resource_lifecycle.ts
@@ -33,33 +33,37 @@ export function disposeRendererPrewarmAndGroundFx(
   bestEffort(() => uninstallOccluderFadeGate());
 }
 
-export interface RendererWorldViewsOwner {
-  terrainView?: RendererDisposable;
-  waterView?: RendererDisposable;
-  underwaterView?: RendererDisposable;
-}
-
 /**
- * Dispose the renderer-owned world-subsystem views (terrain, water,
- * underwater) independently. Without this, a graphics-preset rebuild
- * (electron/main.cjs's context recycle path; see GitHub issue #3750)
- * silently retains every resident terrain chunk, the water simulation, and
- * the underwater overlay's geometry and materials on the JS heap: nothing
- * else in the renderer's teardown ever calls their dispose() methods, so a
- * rebuild permanently steps up memory instead of returning to its pre-rebuild
- * floor. The renderer passes itself because these resource fields are
- * private. Props/foliage are deliberately NOT included here: unlike these
- * three, their geometries and materials are drawn from the shared GLB-cache
- * (`assets/loader.ts`), and disposing a cached resource that another
- * consumer still reads would corrupt live rendering elsewhere; releasing
- * them safely needs its own per-subsystem accounting, tracked separately.
+ * Dispose the renderer-owned world-subsystem views (terrain, far terrain,
+ * water, underwater) independently. Without this, a graphics-preset rebuild
+ * (`src/main.ts` wiring `shutdownRenderer`/`recycleContext` into
+ * `GraphicsRebuildCoordinator`, `src/render/context_recycle.ts` driving the
+ * `WEBGL_lose_context` cycle; see GitHub issue #3750) silently retains every
+ * resident terrain chunk, the far-vista tiles, the water simulation, and the
+ * underwater overlay's geometry and materials on the JS heap: nothing else in
+ * the renderer's teardown ever calls their dispose() methods, so a rebuild
+ * permanently steps up memory instead of returning to its pre-rebuild floor.
+ * `FarTerrainView.dispose()` also flips its own `cancelled` flag, so this is
+ * what stops its idle-paced tile build from allocating against the dead
+ * renderer, the same role `cancelTerrainStreaming()` plays for the near
+ * layer. Typed parameters, not a duck-typed owner cast: a call site passes
+ * `this.<field>` directly, so a renamed field fails `tsc`, not a silent
+ * dispose-nothing. Props/foliage are deliberately NOT included here: unlike
+ * these four, their geometries and materials are drawn from the shared
+ * GLB-cache (`assets/loader.ts`), and disposing a cached resource that
+ * another consumer still reads would corrupt live rendering elsewhere;
+ * releasing them safely needs its own per-subsystem accounting, tracked
+ * separately.
  */
 export function disposeRendererWorldViews(
-  owner: object,
+  terrainView: RendererDisposable | undefined,
+  farTerrainView: RendererDisposable | undefined,
+  waterView: RendererDisposable | undefined,
+  underwaterView: RendererDisposable | undefined,
   bestEffort: (cleanup: () => void) => void,
 ): void {
-  const resources = owner as RendererWorldViewsOwner;
-  bestEffort(() => resources.terrainView?.dispose());
-  bestEffort(() => resources.waterView?.dispose());
-  bestEffort(() => resources.underwaterView?.dispose());
+  bestEffort(() => terrainView?.dispose());
+  bestEffort(() => farTerrainView?.dispose());
+  bestEffort(() => waterView?.dispose());
+  bestEffort(() => underwaterView?.dispose());
 }

--- a/src/render/terrain.ts
+++ b/src/render/terrain.ts
@@ -1787,6 +1787,16 @@ export interface TerrainView {
    * abandoned zone builds keep running on a setTimeout chain.
    */
   cancelStreaming(): void;
+  /**
+   * Terminal teardown: releases every resident chunk regardless of zone
+   * (removes each mesh from `group` and disposes its geometry), plus the
+   * shared terrain material and its per-instance normal map. Call once, when
+   * this view is being discarded for good (renderer shutdown); a later
+   * ensureZone/unloadZone on a disposed view has nothing left to build on.
+   * The normal map and material are built fresh per `buildTerrain` call
+   * (never shared with another view), so disposing them here is safe.
+   */
+  dispose(): void;
 }
 
 export function buildTerrain(seed: number, priorityPoint?: { x: number; z: number }): TerrainView {
@@ -2290,6 +2300,15 @@ export function buildTerrain(seed: number, priorityPoint?: { x: number; z: numbe
     cancelStreaming(): void {
       cancelled = true;
       disposeZoneBuildPool();
+    },
+    dispose(): void {
+      cancelled = true;
+      disposeZoneBuildPool();
+      for (const chunk of chunks) group.remove(chunk.mesh);
+      for (const chunk of chunks) chunk.mesh.geometry.dispose();
+      chunks.length = 0;
+      mat.dispose();
+      normalTex?.dispose();
     },
     unloadZone(zone: ZoneDef): void {
       // A zone with an in-flight ensureZone is not resident yet (it only

--- a/tests/renderer_resource_lifecycle.test.ts
+++ b/tests/renderer_resource_lifecycle.test.ts
@@ -74,12 +74,17 @@ describe('renderer resource lifecycle', () => {
   // Regression for the graphics-rebuild heap leak (GitHub issue #3750):
   // disposeRendererResources() never called these views' own dispose()
   // methods, so a renderer swap permanently retained the previous
-  // terrain/water/underwater GPU resources on the JS heap.
+  // terrain/far-terrain/water/underwater GPU resources on the JS heap.
   describe('disposeRendererWorldViews', () => {
-    it('disposes terrain, water, and underwater independently, each other failing', () => {
+    it('disposes terrain, far terrain, water, and underwater independently, each other failing', () => {
       const terrainView = {
         dispose: vi.fn(() => {
           throw new Error('terrain');
+        }),
+      };
+      const farTerrainView = {
+        dispose: vi.fn(() => {
+          throw new Error('far terrain');
         }),
       };
       const waterView = { dispose: vi.fn() };
@@ -97,12 +102,13 @@ describe('renderer resource lifecycle', () => {
         }
       };
 
-      disposeRendererWorldViews({ terrainView, waterView, underwaterView }, bestEffort);
+      disposeRendererWorldViews(terrainView, farTerrainView, waterView, underwaterView, bestEffort);
 
       expect(terrainView.dispose).toHaveBeenCalledOnce();
+      expect(farTerrainView.dispose).toHaveBeenCalledOnce();
       expect(waterView.dispose).toHaveBeenCalledOnce();
       expect(underwaterView.dispose).toHaveBeenCalledOnce();
-      expect(errors).toHaveLength(2);
+      expect(errors).toHaveLength(3);
     });
 
     it('tolerates a view that has not been constructed yet', () => {
@@ -117,10 +123,7 @@ describe('renderer resource lifecycle', () => {
       };
 
       expect(() =>
-        disposeRendererWorldViews(
-          { terrainView: undefined, waterView, underwaterView: undefined },
-          bestEffort,
-        ),
+        disposeRendererWorldViews(undefined, undefined, waterView, undefined, bestEffort),
       ).not.toThrow();
 
       expect(waterView.dispose).toHaveBeenCalledOnce();

--- a/tests/renderer_resource_lifecycle.test.ts
+++ b/tests/renderer_resource_lifecycle.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
-import { disposeRendererPrewarmAndGroundFx } from '../src/render/renderer_resource_lifecycle';
+import {
+  disposeRendererPrewarmAndGroundFx,
+  disposeRendererWorldViews,
+} from '../src/render/renderer_resource_lifecycle';
 
 describe('renderer resource lifecycle', () => {
   it('keeps every renderer-owned VFX owner independent at the lifecycle seam', () => {
@@ -66,5 +69,62 @@ describe('renderer resource lifecycle', () => {
     expect(vfx.dispose).toHaveBeenCalledOnce();
     expect(abilityVfxFx.dispose).toHaveBeenCalledOnce();
     expect(errors).toHaveLength(1);
+  });
+
+  // Regression for the graphics-rebuild heap leak (GitHub issue #3750):
+  // disposeRendererResources() never called these views' own dispose()
+  // methods, so a renderer swap permanently retained the previous
+  // terrain/water/underwater GPU resources on the JS heap.
+  describe('disposeRendererWorldViews', () => {
+    it('disposes terrain, water, and underwater independently, each other failing', () => {
+      const terrainView = {
+        dispose: vi.fn(() => {
+          throw new Error('terrain');
+        }),
+      };
+      const waterView = { dispose: vi.fn() };
+      const underwaterView = {
+        dispose: vi.fn(() => {
+          throw new Error('underwater');
+        }),
+      };
+      const errors: unknown[] = [];
+      const bestEffort = (cleanup: () => void): void => {
+        try {
+          cleanup();
+        } catch (error) {
+          errors.push(error);
+        }
+      };
+
+      disposeRendererWorldViews({ terrainView, waterView, underwaterView }, bestEffort);
+
+      expect(terrainView.dispose).toHaveBeenCalledOnce();
+      expect(waterView.dispose).toHaveBeenCalledOnce();
+      expect(underwaterView.dispose).toHaveBeenCalledOnce();
+      expect(errors).toHaveLength(2);
+    });
+
+    it('tolerates a view that has not been constructed yet', () => {
+      const waterView = { dispose: vi.fn() };
+      const errors: unknown[] = [];
+      const bestEffort = (cleanup: () => void): void => {
+        try {
+          cleanup();
+        } catch (error) {
+          errors.push(error);
+        }
+      };
+
+      expect(() =>
+        disposeRendererWorldViews(
+          { terrainView: undefined, waterView, underwaterView: undefined },
+          bestEffort,
+        ),
+      ).not.toThrow();
+
+      expect(waterView.dispose).toHaveBeenCalledOnce();
+      expect(errors).toHaveLength(0);
+    });
   });
 });

--- a/tests/terrain_streaming.test.ts
+++ b/tests/terrain_streaming.test.ts
@@ -235,6 +235,83 @@ describe('progressive terrain build', () => {
     expect(terrain.group.children).toHaveLength(0);
   });
 
+  // The macro normal DataTexture only exists on the splat tier
+  // (hasTerrainSplatAssets() true), which mockEmptyAssetLoads() can never
+  // reach: its loader promises never resolve. Regression for the same
+  // issue #3750 gap on the resource the doc comment argues hardest for:
+  // buildSplatMaterial binds this texture as normalMap, so releasing the
+  // chunk geometries and the shared material is not enough on its own.
+  describe('macro normal-map lifecycle (splat tier)', () => {
+    afterEach(() => {
+      vi.unstubAllGlobals();
+      vi.doUnmock('../src/render/assets/loader');
+      vi.doUnmock('../src/render/textures');
+    });
+
+    it('dispose releases the macro normal-map DataTexture when the splat tier built one', async () => {
+      vi.resetModules();
+      // buildSplatAlbedoArray fails soft (neutral-grey fill per layer) with
+      // no 2D context, so a real canvas is not needed to prove the
+      // DataTexture it creates gets released.
+      vi.stubGlobal('document', {
+        createElement: (tag: string) => {
+          if (tag !== 'canvas') throw new Error(`unexpected document.createElement(${tag})`);
+          return { getContext: () => null };
+        },
+      });
+      vi.doMock('../src/render/assets/loader', () => ({
+        loadGltf: vi.fn(() => new Promise(() => {})),
+        loadKtx2Texture: vi.fn(() => Promise.resolve(new THREE.Texture())),
+        loadTexture: vi.fn(() => Promise.resolve(new THREE.Texture())),
+        releaseGltf: vi.fn(),
+      }));
+      const texture = (): THREE.DataTexture => {
+        const data = new Uint8Array([255, 255, 255, 255]);
+        const tex = new THREE.DataTexture(data, 1, 1, THREE.RGBAFormat);
+        tex.needsUpdate = true;
+        return tex;
+      };
+      vi.doMock('../src/render/textures', () => ({
+        groundDetailTexture: vi.fn(texture),
+        groundSplatMaps: vi.fn(() => ({
+          grass: texture(),
+          dirt: texture(),
+          rock: texture(),
+          sand: texture(),
+          mud: texture(),
+          snow: texture(),
+        })),
+        macroNoiseTexture: vi.fn(texture),
+        skyTexture: vi.fn(texture),
+        waterNormalish: vi.fn(texture),
+        waterNormalMaps: vi.fn(() => [texture(), texture()]),
+      }));
+
+      const gfx = await import('../src/render/gfx');
+      gfx.activateGfxProfile({
+        settings: { ...gfx.GFX, terrainSplat: true },
+        fingerprint: '',
+        forcedTier: null,
+        softwareRendering: false,
+        epoch: 0,
+      });
+
+      const { buildTerrain, hasTerrainSplatAssets, prepareTerrainProfileAssets } = await import(
+        '../src/render/terrain'
+      );
+      await prepareTerrainProfileAssets(gfx.GFX);
+      expect(hasTerrainSplatAssets()).toBe(true);
+
+      const disposeSpy = vi.spyOn(THREE.DataTexture.prototype, 'dispose');
+      const terrain = buildTerrain(20061);
+      expect(disposeSpy).not.toHaveBeenCalled();
+
+      terrain.dispose();
+
+      expect(disposeSpy).toHaveBeenCalledOnce();
+    });
+  });
+
   it('cancelStreaming stops an in-flight zone build from ever completing', async () => {
     vi.resetModules();
     mockEmptyAssetLoads();

--- a/tests/terrain_streaming.test.ts
+++ b/tests/terrain_streaming.test.ts
@@ -187,6 +187,54 @@ describe('progressive terrain build', () => {
     expect(terrain.isZoneLoaded(zone.id)).toBe(false);
   });
 
+  // Regression for the graphics-rebuild heap leak (GitHub issue #3750): a
+  // renderer swap tore the old TerrainView down without ever releasing its
+  // resident chunk geometries or shared material, so every rebuild
+  // permanently retained the whole previous zone's terrain on the JS heap.
+  // dispose() is the terminal teardown disposeRendererResources() now calls.
+  it('dispose releases every resident chunk regardless of zone, plus the shared material', async () => {
+    vi.resetModules();
+    mockEmptyAssetLoads();
+    const { buildTerrain } = await import('../src/render/terrain');
+    const { zoneAt } = await import('../src/sim/data');
+
+    const terrain = buildTerrain(20061);
+    const zone = zoneAt(0, 0);
+    const neighbor = zoneAt(0, 300);
+    const firstTask = terrain.ensureZone(zone);
+    await vi.runAllTimersAsync();
+    await firstTask;
+    const neighborTask = terrain.ensureZone(neighbor);
+    await vi.runAllTimersAsync();
+    await neighborTask;
+
+    expect(terrain.group.children.length).toBeGreaterThan(0);
+    const meshes = terrain.group.children as THREE.Mesh[];
+    const geometrySpies = meshes.map((mesh) => vi.spyOn(mesh.geometry, 'dispose'));
+    // Every chunk mesh shares the ONE material buildTerrain built (see
+    // terrain.ts's `new THREE.Mesh(geo, mat)`), so dispose() must release it
+    // exactly once, not per chunk.
+    const sharedMaterial = meshes[0].material as THREE.Material;
+    expect(meshes.every((mesh) => mesh.material === sharedMaterial)).toBe(true);
+    const materialSpy = vi.spyOn(sharedMaterial, 'dispose');
+
+    terrain.dispose();
+
+    for (const spy of geometrySpies) expect(spy).toHaveBeenCalledOnce();
+    expect(materialSpy).toHaveBeenCalledOnce();
+    expect(terrain.group.children).toHaveLength(0);
+  });
+
+  it('dispose on a view with nothing built does not throw', async () => {
+    vi.resetModules();
+    mockEmptyAssetLoads();
+    const { buildTerrain } = await import('../src/render/terrain');
+
+    const terrain = buildTerrain(20061);
+    expect(() => terrain.dispose()).not.toThrow();
+    expect(terrain.group.children).toHaveLength(0);
+  });
+
   it('cancelStreaming stops an in-flight zone build from ever completing', async () => {
     vi.resetModules();
     mockEmptyAssetLoads();


### PR DESCRIPTION
## Summary

A graphics-preset rebuild (`GraphicsRebuildCoordinator` recycling the WebGL2
context) tears the old `Renderer` down through `disposeRendererResources()`,
but that teardown never called `WaterView.dispose()` or
`UnderwaterView.dispose()` (both already implemented and working),
`FarTerrainView.dispose()` (also implemented, but wired only into the
editor's `rebuildTerrain`), and `TerrainView` had no `dispose()` at all.
Every rebuild therefore permanently retains the previous zone's terrain
chunks, the far-vista tiles, and the water simulation on the JS heap.

```mermaid
sequenceDiagram
    participant Player
    participant Coordinator as GraphicsRebuildCoordinator
    participant Old as Renderer (old)
    participant New as Renderer (new)
    participant Heap as JS heap

    Player->>Coordinator: change graphics preset
    Coordinator->>Old: shutdown()
    activate Old
    Note over Old: beginRendererShutdown()<br/>disposeRendererResources()
    Old->>Heap: dispose views, VFX, character pool...
    rect rgb(255, 230, 230)
      Note over Old,Heap: BEFORE THIS FIX<br/>terrainView / farTerrainView / waterView /<br/>underwaterView never disposed: chunks, far tiles,<br/>water sim, and materials stay heap-resident
    end
    deactivate Old
    Coordinator->>New: buildRenderer() on the recycled context
    New-->>Player: world re-streams in
    Note over Heap: heap floor steps UP,<br/>never returns (issue #3750)

    rect rgb(230, 255, 230)
      Note over Old,Heap: AFTER THIS FIX<br/>disposeRendererWorldViews() calls<br/>terrainView.dispose() (new)<br/>farTerrainView.dispose() (now wired in)<br/>waterView.dispose() / underwaterView.dispose()<br/>(already existed)
    end
```

This closes one of the teardown gaps GitHub issue #3750 documents. It is
good teardown hygiene worth having on its own, but it does not by itself
establish that it explains the issue's full measured heap growth: three's
`BufferGeometry.dispose()` releases GPU buffers but leaves the CPU-side
attribute arrays on the heap until the last reference drops, which is what
removing these views from the scene graph and releasing their chunks/tiles
now does. The issue's acceptance criteria (a `WeakRef` release test, five
cycles with no monotonic growth, telemetry separating a rebuild from a
driver-side context loss) are untouched by this PR, and it makes no claim
about the "ghost windows" symptom some players report.

## Related issues

Closes one documented teardown gap flagged by
levy-street/world-of-claudecraft#3750 (does not fully close it: props/foliage
disposal is explicitly out of scope here, see below).

## Fix

- `src/render/terrain.ts`: adds `TerrainView.dispose()`. Releases every
  resident chunk regardless of owning zone (removes each mesh from `group`
  and disposes its geometry), plus the shared terrain material and its
  per-instance normal map (both built fresh per `buildTerrain()` call, never
  shared with another view, so disposing them here is safe).
- `src/render/renderer_resource_lifecycle.ts`: adds `disposeRendererWorldViews()`,
  a small dependency-injected helper (mirroring the existing
  `disposeRendererPrewarmAndGroundFx()` in the same file) that best-effort
  disposes `terrainView`, `farTerrainView`, `waterView`, and `underwaterView`
  independently, so one throwing doesn't block the others. It takes each view
  as a typed parameter rather than a duck-typed `owner: object` cast, so a
  renamed view field fails `tsc` instead of silently disposing nothing.
  `farTerrainView` is included because `FarTerrainView.dispose()` also flips
  its own `cancelled` flag, so this is what stops its idle-paced tile build
  from allocating against the dead renderer during a rebuild, the same role
  `cancelTerrainStreaming()` plays for the near layer.
- `src/render/renderer.ts`: wires the new helper into
  `disposeRendererResources()`, right beside the existing prewarm/ground-FX
  disposal call, passing `this.terrainView`, `this.farTerrainView`,
  `this.waterView`, and `this.underwaterView` directly. Also folds the
  editor-only `rebuildTerrain`'s hand-rolled chunk/material/normal-map
  disposal into `this.terrainView.dispose()` (the same recipe now lives in
  one place instead of two).

**Deliberately out of scope:** props and foliage. Unlike terrain/water,
their geometries and materials are drawn from the shared GLB-cache
(`assets/loader.ts`), and disposing a cached resource another live consumer
still reads would corrupt rendering elsewhere (`src/render/CLAUDE.md`: "Never
`dispose()` a shared GLB-cache texture that may still be drawn"). Closing that
part of #3750 needs its own per-subsystem accounting and is left as follow-up
work; this PR only touches instance-owned resources that are safe to
unconditionally dispose.

## Type of change

- [x] Bug fix
- [ ] Feature: new functionality
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change

## How was this tested?

- Commands:
  - `npx tsc --noEmit`
  - `npx vitest run tests/terrain_streaming.test.ts tests/renderer_resource_lifecycle.test.ts tests/monolith_budget.test.ts tests/architecture.test.ts tests/renderer_lifecycle.test.ts tests/graphics_overhaul_integration.test.ts` (all green;
    `renderer_lifecycle.test.ts` reads `renderer.ts` as source text, so `vitest related`
    would not select it from this diff, per review feedback)
  - `npx @biomejs/biome check <changed files>` (clean)
- New/updated tests, test-first where the fix was new behavior:
  - `tests/terrain_streaming.test.ts`: `dispose releases every resident chunk
    regardless of zone, plus the shared material` (unchanged from round 1) plus
    a new `macro normal-map lifecycle (splat tier)` describe block: forces the
    splat tier (`hasTerrainSplatAssets()` true, which the file's shared
    `mockEmptyAssetLoads()` helper can never reach on its own) and asserts
    `dispose()` releases the macro normal DataTexture the splat material
    binds as `normalMap`, the one resource the previous round's test never
    covered.
  - `tests/renderer_resource_lifecycle.test.ts`: `disposeRendererWorldViews`
    describe block now covers `farTerrainView` alongside the other three
    views, and calls the function with its new typed positional arguments.
- Manual steps: not run against a live browser this pass (time-constrained);
  the fix is unit-verified end to end through the injected-dependency seam
  `disposeRendererResources()` already uses for this exact purpose.

## Screenshots / recordings

N/A: this is a memory-lifecycle fix inside the renderer's teardown path, with
no player-visible visual change (same textures, same geometry, same frame
output before and after a rebuild; only what gets released afterward
differs).

---

## Checklist

### Quality

- [x] Decisive tests added for the changed behavior (see above). Full
      `node scripts/gate_select.mjs` was not run locally this pass
      (time-constrained); tsc, the architecture/monolith-budget guard suite,
      biome on changed files, and the specific affected test files (including
      `renderer_lifecycle.test.ts`, which the selective gate would not pick
      up on its own) are all green.

### Cross-platform

- [ ] Tested on desktop and mobile. N/A: no UI surface changed.
- [ ] Accessible. N/A: no UI surface changed.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS`
      is not enabled in any production path.
- [x] I didn't hand-edit generated files.
