### PR TITLE
fix(pet): refuse to attack or acquire a mob mid-evade

### DIFF
--- a/src/sim/combat/damage.ts
+++ b/src/sim/combat/damage.ts
@@ -32,6 +32,7 @@ import { weaponHand } from '../equipment_rules';
 import { emitIgnivarRaidNarrativeOnDeath } from '../ignivar_raid_lore';
 import { lockNormalDungeonResetOnBossKill, spawnBossExitPortal } from '../instances/dungeons';
 import { spawnWidowHatchlingOnEggDeath } from '../mob/egg_hatchling';
+import { isEvadingWildMob } from '../mob/evade_immunity';
 import { grantAbilityDevotion } from '../paladin_devotion';
 import { snapshotPetOnOwnerDeath } from '../pet/pet_owner_revive';
 import { pvpDamageMultiplier } from '../pvp';
@@ -241,7 +242,7 @@ export function dealDamage(
   // reflect ticks stay silent so a dotted evader does not spam a word per tick.
   // The early return keeps every downstream effect off: no threat, no combat
   // entry, no stealth break, no tap.
-  if (target.kind === 'mob' && target.aiState === 'evade' && target.ownerId === null) {
+  if (isEvadingWildMob(target)) {
     if (direct && source) {
       ctx.emit({
         type: 'damage',

--- a/src/sim/mob/evade_immunity.ts
+++ b/src/sim/mob/evade_immunity.ts
@@ -1,0 +1,24 @@
+// A wild mob mid-evade (leashed home, walking back to spawn after breaking combat)
+// is damage/threat-immune: combat/damage.ts's dealDamage voids any hit that lands
+// on one regardless. Acquiring or keeping one as a target just wastes an attack on
+// a mob that cannot be hurt, so Sim.enterCombat/aggroMob, the player's own
+// auto-attack engage in combat/auto_attack.ts, the pet command surface in
+// pet/pet_commands.ts, the AI target picker in pet/pet_ai.ts, and
+// warlock_pet_skills.ts all refuse to acquire or keep one. An owned mob (a
+// player's own pet) is exempt: it runs pet AI, not wild-mob leash recovery, and
+// never legitimately carries this state.
+//
+// NOT yet consulted by every attacker-side entry point in the sim: a player's own
+// direct-cast pet-redirect abilities (hunter Pack Command in
+// combat/hunter_packlord.ts, warlock Reap in combat/necromancy.ts) still let the
+// swing fire and rely on dealDamage's void downstream, the same shipped precedent
+// combat/auto_attack.ts's own engage gate follows for a player's ordinary attack.
+// Extending the guard there is a deliberate follow-up, not an oversight here.
+//
+// Pure leaf: no SimContext, draws no rng, reads only Entity fields.
+
+import type { Entity } from '../types';
+
+export function isEvadingWildMob(target: Entity): boolean {
+  return target.kind === 'mob' && target.aiState === 'evade' && target.ownerId === null;
+}

--- a/src/sim/pet/pet_ai.ts
+++ b/src/sim/pet/pet_ai.ts
@@ -19,11 +19,16 @@
 // mobSwing/dealDamage/moveToward/updateRangedPetAttack callees the dispatcher calls)
 // are preserved exactly so the parity gate's full-state trace AND rng draw-order log
 // stay byte-identical. The in-place Entity mutation is intentional (the refactor's
-// immutability waiver). One DELIBERATE post-extraction behavior change rides on
-// top of the verbatim move: petRangedAttack now rolls isMobSpellResisted before
+// immutability waiver). Two DELIBERATE post-extraction behavior changes ride on
+// top of the verbatim move. (1) petRangedAttack now rolls isMobSpellResisted before
 // its crit roll (player pet bolts were resist-immune by omission, unlike every
 // other spell path), with the pet_ai parity golden re-minted for the extra draw
-// in the same PR; every other draw position is still the verbatim move. The shared movement/combat entry points (updateRangedPetAttack,
+// in the same PR. (2) a pet can no longer acquire, or keep attacking, a mob mid-evade
+// (isEvadingWildMob, mob/evade_immunity.ts): the mobSwing draws that used to fire
+// every swing interval against such a target (always voided by dealDamage's own
+// evade-immunity gate downstream) are now skipped outright, with no golden re-mint,
+// because no parity scenario exercises a pet against an evading mob. Every other
+// draw position is still the verbatim move. The shared movement/combat entry points (updateRangedPetAttack,
 // mobSwing, applyTaunt, moveToward), the pet-management helpers (syncPetAspect,
 // despawnPersistentPet), and the stat/predicate helpers (effectiveAttackPower,
 // isHostileTo, isStunned, isRooted, moveSpeedMult, swingIntervalMult, mobCanSwim,
@@ -39,6 +44,7 @@ import { packlordPetHasteMultiplier } from '../combat/hunter_packlord';
 import { hunterPetDamageMultiplier } from '../combat/hunter_shared';
 import { isMobSpellResisted } from '../combat/spell_resist';
 import { MOBS } from '../data';
+import { isEvadingWildMob } from '../mob/evade_immunity';
 import { questGateBlocksAggro } from '../mob/quest_gated_aggro';
 import { isTrivialTo } from '../mob/targeting';
 import { findPlayerPath, PLAYER_BODY_RADIUS } from '../pathfind';
@@ -130,9 +136,18 @@ export function updatePet(ctx: SimContext, pet: Entity): void {
   if (!travelling) pullNearbyMobs(ctx, pet);
 
   let target = pet.aggroTargetId !== null ? (ctx.entities.get(pet.aggroTargetId) ?? null) : null;
+  // isEvadingWildMob (mob/evade_immunity.ts) drops a mob mid-evade (leashed home,
+  // walking back to spawn) exactly like dealDamage already voids any hit on one:
+  // most visibly, a raid boss sets aiState 'evade' the instant a wipe empties the
+  // room (encounters/ignivar.ts), but its aggroTargetId/threat-table entry can
+  // still name a player who has not been pruned from the hate table yet. Before
+  // this guard, the moment that player's pet was restored on revive (with the
+  // owner given no chance to react: the pet comes back already fighting), the
+  // stale match alone made the pet lunge at the "boss" mid-reset.
   if (
     target &&
     (target.dead ||
+      isEvadingWildMob(target) ||
       !ctx.isHostileTo(pet, target) ||
       !petCanSeeTarget(target) ||
       petQuestGateBlocksTarget(ctx, pet, target))
@@ -248,6 +263,7 @@ function updateWaterJetChannel(ctx: SimContext, pet: Entity): boolean {
     ctx.isStunned(pet) ||
     !target ||
     target.dead ||
+    isEvadingWildMob(target) ||
     !ctx.isHostileTo(pet, target) ||
     petQuestGateBlocksTarget(ctx, pet, target) ||
     !petCanSeeTarget(target) ||
@@ -626,7 +642,7 @@ export function petPickTarget(ctx: SimContext, pet: Entity, owner: Entity): Enti
   // grid visits the pet itself at distance 0). We keep the inner dist2d rather than the
   // callback's squared d2 to avoid a units mismatch silently changing the radius.
   ctx.grid.forEachInRadius(pet.pos.x, pet.pos.z, PET_ASSIST_RANGE, (m) => {
-    if (m.id === pet.id || m.dead || !ctx.isHostileTo(pet, m)) return;
+    if (m.id === pet.id || m.dead || isEvadingWildMob(m) || !ctx.isHostileTo(pet, m)) return;
     if (petQuestGateBlocksTarget(ctx, pet, m)) return;
     if (!petCanSeeTarget(m)) return;
     const engagingUs =

--- a/src/sim/pet/pet_commands.ts
+++ b/src/sim/pet/pet_commands.ts
@@ -28,7 +28,13 @@
 // entity-iteration order and guards are unchanged. In-place Entity mutation
 // (`pet.hp = ...`, `pet.auras = pet.auras.filter(...)`, `m.threat.delete(...)`,
 // `r.meta.lastActiveTick = ...`, `delvePetStash.set/delete`) is intentional under
-// the refactor's immutability waiver.
+// the refactor's immutability waiver. ONE DELIBERATE post-extraction exception: an
+// evade check (isEvadingWildMob, mob/evade_immunity.ts) on petAttack/petTaunt/
+// petWaterJet/petSpecial now refuses a mob mid-evade outright, so the mobSwing/
+// Water Jet channel/petRangedAttack impact draws that command would otherwise arm
+// on a later tick (always voided downstream by dealDamage's own evade-immunity
+// gate) never fire. No golden re-mint: no parity scenario drives a pet command
+// against an evading mob.
 //
 // `src/sim`-pure: no DOM/Three/render/ui/game/net imports, no Math.random/Date.now
 // (enforced by tests/architecture.test.ts). data/entity/threat/types are imported
@@ -41,6 +47,7 @@ import { isTemporaryNecromancyUndead } from '../combat/necromancy';
 import { ABILITIES, DUNGEON_X_THRESHOLD, ITEMS, isDelvePos, MOBS } from '../data';
 import { createMob } from '../entity';
 import { consumeSelectedInventorySlot } from '../item_copy_ref';
+import { isEvadingWildMob } from '../mob/evade_immunity';
 import { questGateBlocksAggro } from '../mob/quest_gated_aggro';
 import type { PetState, PlayerMeta } from '../sim';
 import type { SimContext } from '../sim_context';
@@ -637,7 +644,7 @@ export function petAttack(ctx: SimContext, pid?: number): void {
     return;
   }
   const target = r.e.targetId !== null ? ctx.entities.get(r.e.targetId) : null;
-  if (!target || target.dead || !ctx.isHostileTo(pets[0], target)) {
+  if (!target || target.dead || isEvadingWildMob(target) || !ctx.isHostileTo(pets[0], target)) {
     ctx.error(r.e.id, 'Your pet needs a hostile target.');
     return;
   }
@@ -677,7 +684,13 @@ export function petTaunt(ctx: SimContext, pid?: number): void {
       : r.e.targetId !== null
         ? (ctx.entities.get(r.e.targetId) ?? null)
         : null;
-  if (target?.kind !== 'mob' || target.dead || !target.hostile || target.ownerId !== null) {
+  if (
+    target?.kind !== 'mob' ||
+    target.dead ||
+    !target.hostile ||
+    target.ownerId !== null ||
+    isEvadingWildMob(target)
+  ) {
     ctx.error(r.e.id, 'Your pet needs a hostile target.');
     return;
   }
@@ -702,7 +715,7 @@ export function petWaterJet(ctx: SimContext, pid?: number): void {
   const jet = pet ? MOBS[pet.templateId]?.petRanged?.jet : undefined;
   if (!pet || !jet || pet.dead || pet.castingAbility || pet.petTauntTimer > 0) return;
   const target = r.e.targetId !== null ? ctx.entities.get(r.e.targetId) : null;
-  if (!target || target.dead || !ctx.isHostileTo(pet, target)) return;
+  if (!target || target.dead || isEvadingWildMob(target) || !ctx.isHostileTo(pet, target)) return;
   if (questGateBlocksAggro(ctx.players, target, pet)) return;
   const range = MOBS[pet.templateId]?.petRanged?.range ?? 0;
   if (dist2d(pet.pos, target.pos) > range) return;
@@ -732,7 +745,7 @@ export function petSpecial(ctx: SimContext, pid?: number): void {
   if (ctx.isStunned(pet)) return;
   if (!templateHasPetSpecial(pet.templateId) || (pet.petSkillTimer ?? 0) > 0) return;
   const target = r.e.targetId !== null ? ctx.entities.get(r.e.targetId) : null;
-  if (!target || target.dead || !ctx.isHostileTo(pet, target)) {
+  if (!target || target.dead || isEvadingWildMob(target) || !ctx.isHostileTo(pet, target)) {
     ctx.error(r.e.id, 'Your pet needs a hostile target.');
     return;
   }

--- a/src/sim/pet/warlock_pet_skills.ts
+++ b/src/sim/pet/warlock_pet_skills.ts
@@ -1,9 +1,15 @@
 // Signature Warlock-pet utility kept outside the general pet dispatcher.
 // The data lives on MobTemplate; this module owns the movement-authority and
 // boss-immunity boundary for Gloomshade's anti-kite chain.
+//
+// useRangedActive refuses a mob mid-evade (isEvadingWildMob, mob/evade_immunity.ts),
+// same as canChainPull's own pre-existing aiState check just above it: this
+// deliberately skips the launcher's downstream projectile draws (resist/crit/
+// damage) against a target dealDamage would void the hit on anyway.
 
 import { isPullEligible } from '../combat/pull_eligibility';
 import { MOBS } from '../data';
+import { isEvadingWildMob } from '../mob/evade_immunity';
 import { PLAYER_BODY_RADIUS } from '../pathfind';
 import type { SimContext } from '../sim_context';
 import { type Aura, dist2d, type Entity } from '../types';
@@ -101,7 +107,7 @@ function useRangedActive(
 ): boolean {
   const ranged = MOBS[pet.templateId]?.petRanged;
   if (!ranged?.active || !ranged.ability || !ranged.name) return false;
-  if (target.dead || !ctx.isHostileTo(pet, target)) return false;
+  if (target.dead || isEvadingWildMob(target) || !ctx.isHostileTo(pet, target)) return false;
   if (dist2d(pet.pos, target.pos) > ranged.range || !ctx.hasLineOfSight(pet, target)) return false;
   pet.facing = Math.atan2(target.pos.x - pet.pos.x, target.pos.z - pet.pos.z);
   launchRanged(ctx, pet, target, ranged);

--- a/tests/evade_immunity.test.ts
+++ b/tests/evade_immunity.test.ts
@@ -4,6 +4,9 @@
 // risk-free kill, which also breaks the classic reset contract.
 import { describe, expect, it } from 'vitest';
 import { dealDamage } from '../src/sim/combat/damage';
+import { MOBS } from '../src/sim/data';
+import { createMob, createPlayer } from '../src/sim/entity';
+import { isEvadingWildMob } from '../src/sim/mob/evade_immunity';
 import { Sim } from '../src/sim/sim';
 import type { Entity } from '../src/sim/types';
 import { dist2d } from '../src/sim/types';
@@ -294,5 +297,41 @@ describe('an evading mob that cannot path home recovers instead of getting stuck
     expect(reset).toBe(true);
     // it walked home under its own power (no snap needed): well within ~20yd of spawn
     expect(dist2d(mob.pos, mob.spawnPos)).toBeLessThan(0.5);
+  });
+});
+
+// Direct unit test for the pure leaf (no SimContext, no rng) extracted from the
+// dealDamage check above: isEvadingWildMob is now the single shared predicate every
+// attacker-side entry point (dealDamage here, plus pet_ai.ts, pet_commands.ts, and
+// warlock_pet_skills.ts) consults before newly engaging or continuing to attack a
+// mob mid-evade, so a pet can no longer lunge at one either.
+describe('isEvadingWildMob (the pure leaf behind the immunity above)', () => {
+  const POS = { x: 0, y: 0, z: 0 };
+
+  it('is true only for a wild mob whose aiState is evade', () => {
+    const mob = createMob(1, MOBS.forest_wolf, 5, POS);
+    mob.aiState = 'evade';
+    expect(isEvadingWildMob(mob)).toBe(true);
+  });
+
+  it('is false for the same mob in any non-evade aiState', () => {
+    const mob = createMob(1, MOBS.forest_wolf, 5, POS);
+    for (const state of ['idle', 'chase', 'attack', 'flee', 'dead'] as const) {
+      mob.aiState = state;
+      expect(isEvadingWildMob(mob)).toBe(false);
+    }
+  });
+
+  it('is false for an owned mob (a pet), even if its aiState happens to read evade', () => {
+    const mob = createMob(1, MOBS.forest_wolf, 5, POS);
+    mob.aiState = 'evade';
+    mob.ownerId = 42; // owned mobs run pet AI, never legitimately carry this state
+    expect(isEvadingWildMob(mob)).toBe(false);
+  });
+
+  it('is false for a player, regardless of aiState', () => {
+    const player = createPlayer(1, 'hunter', POS, 'Aleph');
+    player.aiState = 'evade';
+    expect(isEvadingWildMob(player)).toBe(false);
   });
 });

--- a/tests/pet_ai.test.ts
+++ b/tests/pet_ai.test.ts
@@ -379,6 +379,77 @@ describe('pet_ai module (P1a) — direct unit tests', () => {
     petFollow(sim.ctx, pet, owner);
     expect(pet.petPath).toEqual([]);
   });
+
+  // Bug: a defensive/aggressive pet kept fighting (and could newly acquire) a mob
+  // that is mid-evade: leashed home, damage/threat-immune, and untargetable by every
+  // other combat entry point (enterCombat/aggroMob on Sim, the player's own auto-attack
+  // engage in combat/auto_attack.ts, dealDamage's evade-immunity gate). Worst case: a
+  // raid boss sets aiState 'evade' the instant a wipe empties the room (see
+  // encounters/ignivar.ts), but its aggroTargetId/threat entry can still name a player
+  // who has not been pruned yet. The moment that player's pet is restored on revive, a
+  // stale aggroTargetId match made the pet lunge at the "boss" with the owner given no
+  // chance to react (the pet comes back already fighting). Pet AI must honor the same
+  // evade exclusion every other attack path already does.
+  it('drops the current target and returns to heel the instant it starts evading, at zero rng cost', () => {
+    const { sim, pid, owner } = world();
+    const pet = adopt(sim, pid);
+    pet.petMode = 'defensive';
+    const target = wildHostile(sim, [pet.id]);
+    isolate(sim, [pid, pet.id, target.id]);
+    place(owner, 0, 30);
+    place(pet, owner.pos.x + 20, owner.pos.z);
+    place(target, pet.pos.x + 1, pet.pos.z); // in melee range of the pet
+    pet.aggroTargetId = target.id;
+    pet.inCombat = true;
+    pet.autoAttack = true;
+    target.aiState = 'evade'; // the raid boss just wiped the room and is walking home
+    syncGrid(sim);
+    const d0 = dist2d(pet.pos, owner.pos);
+    let draws = 0;
+    sim.rng.setObserver(() => draws++);
+    updatePet(sim.ctx, pet);
+    sim.rng.setObserver(null);
+    expect(pet.aggroTargetId).toBeNull();
+    expect(pet.inCombat).toBe(false);
+    expect(pet.autoAttack).toBe(false);
+    expect(dist2d(pet.pos, owner.pos)).toBeLessThan(d0); // fell through to the heel arm
+    // The old (pre-fix) path swung at the evading target every interval: dealDamage
+    // voided the hit downstream, but Sim.mobSwing still drew rng for the roll first.
+    // Dropping the target before any swing means this tick costs nothing.
+    expect(draws).toBe(0);
+  });
+
+  it('cancels an in-progress Water Jet channel the instant its target starts evading', () => {
+    const { sim, pid, owner } = world();
+    const pet = adopt(sim, pid);
+    const target = wildHostile(sim, [pet.id]);
+    pet.templateId = 'water_elemental';
+    pet.petMode = 'defensive';
+    pet.aggroTargetId = target.id;
+    isolate(sim, [pid, pet.id, target.id]);
+    place(owner, 0, 0);
+    place(pet, 1, 0);
+    place(target, 10, 0);
+    startWaterJet(sim.ctx, pet, target, {
+      total: 30,
+      duration: 4,
+      interval: 1,
+      slow: 0.6,
+      cooldown: 8,
+    });
+    expect(pet.channeling).toBe(true);
+    sim.drainEvents();
+
+    target.aiState = 'evade';
+    updatePet(sim.ctx, pet);
+    expect(pet.castingAbility).toBeNull();
+    expect(pet.channeling).toBe(false);
+    expect(
+      sim
+        .drainEvents()
+        .some((e) => e.type === 'spellfx' && e.fx === 'bubbleBeam' && e.duration === 0),
+    ).toBe(true); // the same cancel-fx arm a normal out-of-range break uses
+  });
 });
 
 describe('pet proximity pull: a pet drags idle wild mobs like its owner', () => {
@@ -568,6 +639,25 @@ describe('petPickTarget: grid scan preserves the selection contract', () => {
     syncGrid(sim);
     // The mob is well outside a 50yd query centered on the owner; it is selected only
     // because the scan is centered on pet.pos. Guards against a pet.pos -> owner.pos slip.
+    expect(petPickTarget(sim.ctx, pet, owner)?.id).toBe(mob.id);
+  });
+
+  it('never selects an evading mob, even when engagingUs would otherwise admit it', () => {
+    const { sim, pid, owner } = world();
+    const pet = adopt(sim, pid);
+    pet.petMode = 'defensive';
+    const mob = wildHostile(sim, [pet.id]);
+    isolate(sim, [pid, pet.id, mob.id]);
+    place(owner, 0, 0);
+    place(pet, 0, 0);
+    place(mob, 5, 0);
+    mob.aggroTargetId = owner.id; // stale engagingUs signal (a wiped boss's last target)
+    mob.aiState = 'evade'; // ...but the mob is mid-reset: immune, not a real threat
+    syncGrid(sim);
+    expect(petPickTarget(sim.ctx, pet, owner)).toBeNull();
+    // control: the same mob IS selected once it drops out of evade
+    mob.aiState = 'chase';
+    syncGrid(sim);
     expect(petPickTarget(sim.ctx, pet, owner)?.id).toBe(mob.id);
   });
 

--- a/tests/pet_commands_module.test.ts
+++ b/tests/pet_commands_module.test.ts
@@ -161,6 +161,102 @@ describe('pet_commands module (P1b)', () => {
     expect(egg.threat.has(pet.id)).toBe(true);
   });
 
+  // A mob mid-evade (leashed home, walking back to spawn) is damage/threat-immune
+  // (dealDamage's evade gate); the manual pet-command surface must refuse to newly
+  // engage one exactly like pet AI does (pet_ai.ts petPickTarget/updatePet), or a
+  // player pointing their pet at what looks like an idle boss right after a wipe
+  // still writes a durable threat-table entry onto it.
+  it('refuses petAttack against an evading mob, and works once it stops evading', () => {
+    const { sim, hid, hunter } = hunterWorld(1312);
+    summonPet(sim.ctx, hunter, 'forest_wolf');
+    const pet = petOf(sim.ctx, hid) as AnyEntity;
+    const target = spawnWolf(sim, pet);
+    hunter.targetId = target.id;
+    target.aiState = 'evade';
+
+    petAttack(sim.ctx, hid);
+    expect(pet.aggroTargetId).toBeNull();
+    expect(pet.inCombat).toBe(false);
+    expect(target.threat.has(pet.id)).toBe(false);
+
+    target.aiState = 'idle';
+    petAttack(sim.ctx, hid);
+    expect(pet.aggroTargetId).toBe(target.id);
+    expect(pet.inCombat).toBe(true);
+    expect(target.threat.has(pet.id)).toBe(true);
+  });
+
+  it('refuses petTaunt against an evading mob, and works once it stops evading', () => {
+    const { sim, hid, hunter } = hunterWorld(1313);
+    summonPet(sim.ctx, hunter, 'forest_wolf');
+    const pet = petOf(sim.ctx, hid) as AnyEntity;
+    const target = spawnWolf(sim, pet);
+    hunter.targetId = target.id;
+    target.aiState = 'evade';
+
+    petTaunt(sim.ctx, hid);
+    expect(pet.aggroTargetId).toBeNull();
+    expect(pet.inCombat).toBe(false);
+    expect(target.threat.has(pet.id)).toBe(false);
+    expect(target.forcedTargetId).not.toBe(pet.id);
+
+    target.aiState = 'idle';
+    petTaunt(sim.ctx, hid);
+    expect(pet.aggroTargetId).toBe(target.id);
+    expect(pet.inCombat).toBe(true);
+    expect(target.threat.has(pet.id)).toBe(true);
+  });
+
+  it('refuses petWaterJet against an evading mob, and works once it stops evading', () => {
+    const { sim, hid, hunter } = hunterWorld(1314);
+    summonPet(sim.ctx, hunter, 'forest_wolf');
+    const pet = petOf(sim.ctx, hid) as AnyEntity;
+    pet.templateId = 'water_elemental'; // the only family with a Water Jet
+    const target = spawnWolf(sim, pet);
+    hunter.targetId = target.id;
+    target.aiState = 'evade';
+
+    petWaterJet(sim.ctx, hid);
+    expect(pet.aggroTargetId).toBeNull();
+    expect(pet.castingAbility).not.toBe('water_jet');
+
+    target.aiState = 'idle';
+    petWaterJet(sim.ctx, hid);
+    expect(pet.aggroTargetId).toBe(target.id);
+    expect(pet.castingAbility).toBe('water_jet');
+  });
+
+  it('refuses petSpecial against an evading mob, and works once it stops evading', () => {
+    const { sim, hid, hunter } = hunterWorld(1315);
+    summonPet(sim.ctx, hunter, 'forest_wolf');
+    const pet = petOf(sim.ctx, hid) as AnyEntity;
+    pet.templateId = 'emberkin'; // ranged-active signature skill (petRanged.active)
+    const target = spawnWolf(sim, pet);
+    target.pos.z = pet.pos.z + 12; // inside the felbolt's range
+    target.prevPos = { ...target.pos };
+    hunter.targetId = target.id;
+    target.aiState = 'evade';
+    sim.drainEvents();
+
+    // useWarlockPetSkill would already refuse an evading target on its own arms
+    // (canChainPull's aiState check, useRangedActive's new one), silently. This
+    // function's own guard is what turns that silence into a real player-facing
+    // toast instead of a no-op button press.
+    petSpecial(sim.ctx, hid);
+    expect(pet.aggroTargetId).toBeNull();
+    expect(pet.petSkillTimer ?? 0).toBe(0);
+    expect(
+      sim
+        .drainEvents()
+        .some((e) => e.type === 'error' && e.text === 'Your pet needs a hostile target.'),
+    ).toBe(true);
+
+    target.aiState = 'idle';
+    petSpecial(sim.ctx, hid);
+    expect(pet.aggroTargetId).toBe(target.id);
+    expect(pet.petSkillTimer).toBeGreaterThan(0);
+  });
+
   it('preserves an explicit autocast preference and defaults legacy pet state safely', () => {
     const sim = new Sim({
       seed: 131,

--- a/tests/warlock_pet_skills.test.ts
+++ b/tests/warlock_pet_skills.test.ts
@@ -102,6 +102,22 @@ describe('Warlock pet signature skills', () => {
     );
   });
 
+  it('refuses the ranged-active signature skill against an evading mob', () => {
+    const { sim, owner, pet, target } = rig('emberkin');
+    owner.targetId = target.id;
+    target.aiState = 'evade'; // leashed home mid-reset: damage/threat-immune
+
+    expect(useWarlockPetSkill(sim.ctx, pet, target, petRangedAttack)).toBe(false);
+    expect(pet.petSkillTimer ?? 0).toBe(0);
+    expect(sim.drainEvents().some((e) => e.type === 'spellfx' && e.sourceId === pet.id)).toBe(
+      false,
+    );
+
+    target.aiState = 'idle'; // control: works once it stops evading
+    expect(useWarlockPetSkill(sim.ctx, pet, target, petRangedAttack)).toBe(true);
+    expect(pet.petSkillTimer).toBe(8);
+  });
+
   it('only auto-casts a signature skill while its pet-bar autocast is armed', () => {
     const disabled = rig('emberkin');
     disabled.pet.petAutoSkill = false;


### PR DESCRIPTION
## Summary

Hunter and warlock pets in defensive (and aggressive) mode could acquire, or keep
attacking, a mob that is currently `aiState === 'evade'`: leashed home, damage/threat
immune, walking back to spawn after breaking combat. Several combat entry points in the
sim already refuse to newly engage an evading mob (`Sim.enterCombat`/`aggroMob`, the
player's own auto-attack *engage* gate in `combat/auto_attack.ts`, `dealDamage`'s
evade-immunity gate in `combat/damage.ts`), but nothing on the pet side ever consulted
`aiState` at all: not target acquisition, not target retention, not the manual
pet-command surface, not the warlock pet's signature skill.

The worst-case consequence is exactly the reported bug: a raid boss sets
`aiState = 'evade'` the instant a full-room wipe empties the encounter (see
`encounters/ignivar.ts` `updateIgnivarEncounter`), but its `aggroTargetId`/threat-table
entry can still name a player who has not been pruned from the hate table yet (a low
threat entry that is never the "best" candidate is never visited by the pruning scan).
The moment that player's pet is restored on revive, the stale match alone was enough to
make a defensive pet lunge at the "boss" mid-reset, with the owner given no chance to
react (the pet comes back already fighting, and pet stance can't be re-issued fast
enough to head it off).

### Fix

Extracted the shared predicate into its own pure leaf, `src/sim/mob/evade_immunity.ts`
(`isEvadingWildMob`), mirroring the exact condition `dealDamage`'s evade-immunity gate
already used (`combat/damage.ts` now imports it too, a pure move with no behavior
change). Wired it into every pet-side entry point that reads or writes a target:

- `pet/pet_ai.ts`: `updatePet`'s target-validity re-check, `petPickTarget`'s
  candidate scan, `updateWaterJetChannel`'s cancel check
- `pet/pet_commands.ts`: the four manual pet-bar commands (`petAttack`, `petTaunt`,
  `petWaterJet`, `petSpecial`), which otherwise still wrote a durable threat-table
  entry or forced target onto an evading mob even with the AI-side fix in place
- `pet/warlock_pet_skills.ts`: `useRangedActive` (its sibling `canChainPull` already
  had an equivalent, broader check)

`pullNearbyMobs` needed no change: it already requires `aiState === 'idle'`, mutually
exclusive with `'evade'`.

**Deliberately out of scope**, left as follow-ups rather than folded into this fix:
- `src/sim/delves/companion.ts:105,111` (`updateDelveCompanion`) has the identical gap,
  but a delve companion is a different subsystem from a hunter/warlock pet.
- `src/sim/combat/hunter_packlord.ts:219` (Pack Command) and
  `src/sim/combat/necromancy.ts:531,553` (Reap) can still redirect a pet/undead at an
  evading target for one tick before the pet-AI guard drops it on the next tick; neither
  writes a durable threat entry, so the residue is a wasted swing and one stray tick of
  `inCombat`, matching the same "allowed to fire, voided downstream" precedent
  `combat/auto_attack.ts`'s own engage gate already follows for a player's ordinary
  attack.

One accepted, documented side effect: dropping an evading target now skips the
`mobSwing`/channel/projectile rng draws that used to fire against it every interval
(always voided by `dealDamage` downstream anyway). This is a deliberate draw-order
change, noted in the touched modules' PRIME DIRECTIVE headers; `tests/parity` stays
green with no golden re-mint, because no parity scenario drives a pet against an
evading mob.

```mermaid
flowchart TD
    A[Raid wipe: the room empties] --> B["boss.aiState becomes 'evade'\n(aggroTargetId / a threat entry can still name a player)"]
    B --> C[That player revives near the boss]
    C --> D[Their pet is restored, defensive mode]
    D --> E{Pet-side code reads the stale mob state}
    E -->|"Before: aiState never checked"| F[Pet acquires or keeps the boss as its target]
    F --> G[Pet swings at the evading boss]
    E -->|"After: isEvadingWildMob guard"| H[Target dropped / never acquired]
    H --> I[Pet heels, stays passive]
```

## Related issues

N/A, reported directly (defensive pets randomly attacking without provocation, worst
right after reviving near a raid boss mid-reset).

## Type of change

- [x] Bug fix
- [x] Tests

## How was this tested?

- Commands:
  - `npx vitest run tests/evade_immunity.test.ts tests/pet_ai.test.ts tests/pet_commands_module.test.ts tests/warlock_pet_skills.test.ts` (96 tests, all pass)
  - `npx tsc --noEmit`
  - `npx vitest run tests/architecture.test.ts` (sim purity guard, 112/112)
  - `npx vitest run tests/parity` (golden-trace rng-draw-order gate; green with no
    golden re-mint)
  - `npx @biomejs/biome check` on all changed files (0 errors, 0 format diffs)
  - `node scripts/gate_select.mjs` (all 12 steps green)
- Manual steps:
  - Reproduced the bug with failing tests first (a defensive pet mid-fight against a
    target that flips to `aiState: 'evade'` keeps attacking it; the four manual pet
    commands and the warlock ranged-active skill likewise succeed against a fabricated
    evading target), confirmed each failed for the stated reason, then applied the
    smallest fix that turns them green.
  - Verified test non-vacuity by mutation: reverting the guard at each of the 8 call
    sites individually turns exactly the matching test(s) red, including the pre-existing
    `dealDamage` evade-immunity suite (proving the `combat/damage.ts` substitution is a
    faithful move, not a rewrite).

## Screenshots / recordings

N/A. This is a pure `src/sim/` targeting-logic change (pet target acquisition and
retention); it has no render/HUD/CSS surface to capture, per the template's own "remove
this section for non-UI changes" guidance.

---

## Checklist

### Quality

- [x] **The gate passes.** `node scripts/gate_select.mjs` is green. Added/extended tests
      at all 8 guarded call sites, each pairing a refusal assertion with a "works once it
      stops evading" control arm.

### Cross-platform

- ~~Tested on desktop and mobile.~~ N/A, no UI surface.
- ~~Accessible.~~ N/A, no UI surface.

### Localization (i18n)

- [x] N/A. No new player-visible string; the refusal arms reuse the existing
      `'Your pet needs a hostile target.'` literal, already matched in `src/ui/sim_i18n.ts`.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not
      enabled in any production path.
- [x] I didn't hand-edit generated files.
