### PR TITLE
feat(combat): queue ability presses in the GCD tail (WotLK-style spell queue)

### DIFF
--- a/src/sim/combat/affliction_sentence_queue.ts
+++ b/src/sim/combat/affliction_sentence_queue.ts
@@ -1,8 +1,13 @@
-import { CAST_QUEUE_WINDOW_SEC } from '../types';
-
 const NEEDLE_OF_FATE_ID = 'needle_of_fate';
 const SENTENCE_ID = 'sentence';
 
+// Sentence is Hexcraft's release and may already be queued behind the cast or
+// GCD that produced its final Thread. Repeated generator or release presses
+// must not overwrite the queued release (the one deliberate exception to the
+// queue's last-press-wins rule); a press of any OTHER ability still replaces
+// it like any queued slot. The GCD-tail buffering itself is the general spell
+// queue in casting_lifecycle.ts (it absorbed the Sentence-only buffer that
+// used to live here).
 export function shouldPreserveQueuedSentence(
   queuedAbilityId: string | null,
   requestedAbilityId: string,
@@ -11,8 +16,4 @@ export function shouldPreserveQueuedSentence(
     queuedAbilityId === SENTENCE_ID &&
     (requestedAbilityId === NEEDLE_OF_FATE_ID || requestedAbilityId === SENTENCE_ID)
   );
-}
-
-export function shouldBufferSentenceDuringGcd(abilityId: string, gcdRemaining: number): boolean {
-  return abilityId === SENTENCE_ID && gcdRemaining > 0 && gcdRemaining <= CAST_QUEUE_WINDOW_SEC;
 }

--- a/src/sim/combat/casting_lifecycle.ts
+++ b/src/sim/combat/casting_lifecycle.ts
@@ -1826,7 +1826,10 @@ export function castAbility(
   }
 
   if (!ability.offGcd) p.gcdRemaining = Math.max(p.gcdRemaining, gcd);
-  dropStaleHeldPressOnCommit(p, ability);
+  // A blink-through press is an escape weave DURING the cast in progress
+  // (Flickerstep is on-GCD but slips past the busy guard); it must not eat
+  // the follow-up queued behind that cast.
+  if (!blinkThrough) dropStaleHeldPressOnCommit(p, ability);
   const instantResolved = ability.empowerStages
     ? { ...res, empowerLevel: ability.empowerStages }
     : res;

--- a/src/sim/combat/casting_lifecycle.ts
+++ b/src/sim/combat/casting_lifecycle.ts
@@ -89,10 +89,7 @@ import {
   consumeFateThreadsForDrain,
   gainDoom,
 } from './affliction';
-import {
-  shouldBufferSentenceDuringGcd,
-  shouldPreserveQueuedSentence,
-} from './affliction_sentence_queue';
+import { shouldPreserveQueuedSentence } from './affliction_sentence_queue';
 import {
   hasUnbreakableMovementLock,
   isInStasis,
@@ -718,6 +715,20 @@ export function releaseEmpoweredAbility(ctx: SimContext, abilityId: string, pid?
   fireQueuedCast(ctx, p);
 }
 
+// An accepted on-GCD press is the player's latest intent: it discards any
+// stale GCD-held queued press still in the slot. Reachable only via the
+// one-tick gap after the GCD expires (gcdRemaining zeroes in updateTimers,
+// AFTER the updateCasting retry arm ran), where a fresh press passes the GCD
+// gate before the retry can fire the slot; without this clear the stale press
+// fires when the fresh cast completes. Off-GCD weaves never touch the slot,
+// and the normal queued fire is unaffected (fireQueuedCast empties the slot
+// before calling back in).
+function dropStaleHeldPressOnCommit(p: Entity, ability: AbilityDef): void {
+  if (ability.offGcd) return;
+  p.queuedCastAbility = null;
+  p.queuedCastAim = null;
+}
+
 // Consumes the single-slot spell queue (see CAST_QUEUE_WINDOW_SEC), firing the
 // queued ability exactly as a fresh castAbility press. A cast shorter than the
 // flat GCD (the common hasted case) can complete before the GCD armed at its
@@ -1002,11 +1013,17 @@ export function castAbility(
   // in when the GCD is still running, so this early return only fires for a
   // same-tick player press racing the GCD, not for a queued follow-up.
   if (!ability.offGcd && p.gcdRemaining > 0 && !blinkThrough) {
-    if (shouldBufferSentenceDuringGcd(abilityId, p.gcdRemaining)) {
+    // WotLK-style GCD-tail queue: a press inside the final CAST_QUEUE_WINDOW_SEC
+    // of a bare GCD loads the same single slot the cast-tail queue uses
+    // (last-press-wins), and the updateCasting retry arm fires it the tick the
+    // GCD clears. This generalizes the Sentence-only buffer that previously
+    // lived here; the Sentence preserve guard above still keeps a queued
+    // release from being overwritten by generator spam.
+    if (p.gcdRemaining <= CAST_QUEUE_WINDOW_SEC) {
       p.queuedCastAbility = abilityId;
       p.queuedCastAim = aim ?? null;
     }
-    return; // silent, classic spams this
+    return; // an earlier press stays silent, classic spams this
   }
   const togglingOff = isToggleBuff(ability) && p.auras.some((a) => a.id === ability.id);
   // sharedCooldownIds generalizes the release's shaman-shock special case (it
@@ -1755,6 +1772,7 @@ export function castAbility(
       consumeFateThreadsForDrain(ctx, p, target, channelDuration);
     }
     p.gcdRemaining = Math.max(p.gcdRemaining, gcd);
+    dropStaleHeldPressOnCommit(p, ability);
     if (ability.id === 'rain_of_fire') {
       const center = ability.selfCentered ? p.pos : (p.castAim ?? p.pos);
       const radius = res.effects.find((effect) => effect.type === 'aoeDamage')?.radius;
@@ -1802,11 +1820,13 @@ export function castAbility(
     p.castTotal = stretchedCastTime;
     p.castRemaining = stretchedCastTime;
     p.gcdRemaining = Math.max(p.gcdRemaining, gcd);
+    dropStaleHeldPressOnCommit(p, ability);
     ctx.emit({ type: 'castStart', entityId: p.id, ability: ability.id, time: stretchedCastTime });
     return;
   }
 
   if (!ability.offGcd) p.gcdRemaining = Math.max(p.gcdRemaining, gcd);
+  dropStaleHeldPressOnCommit(p, ability);
   const instantResolved = ability.empowerStages
     ? { ...res, empowerLevel: ability.empowerStages }
     : res;

--- a/src/sim/combat/casting_lifecycle.ts
+++ b/src/sim/combat/casting_lifecycle.ts
@@ -721,8 +721,10 @@ export function releaseEmpoweredAbility(ctx: SimContext, abilityId: string, pid?
 // AFTER the updateCasting retry arm ran), where a fresh press passes the GCD
 // gate before the retry can fire the slot; without this clear the stale press
 // fires when the fresh cast completes. Off-GCD weaves never touch the slot,
-// and the normal queued fire is unaffected (fireQueuedCast empties the slot
-// before calling back in).
+// and neither does a blink-through commit (excluded at its call site: the
+// escape weave leaves the cast in progress, and therefore the follow-up
+// queued behind it, untouched). The normal queued fire is unaffected
+// (fireQueuedCast empties the slot before calling back in).
 function dropStaleHeldPressOnCommit(p: Entity, ability: AbilityDef): void {
   if (ability.offGcd) return;
   p.queuedCastAbility = null;

--- a/src/sim/obs.ts
+++ b/src/sim/obs.ts
@@ -237,6 +237,10 @@ export function encodeObs(sim: Sim): number[] {
       requiredAuraReady &&
       afflictionEyeReady &&
       dominionReady &&
+      // Deliberately ignores the GCD-tail queue: a press inside the final
+      // CAST_QUEUE_WINDOW_SEC of the GCD reports not-ready yet still queues
+      // and fires. The queued slot is not observed; policies see it only
+      // through the next transition.
       (known.def.offGcd || p.gcdRemaining <= 0);
     obs.push(ready ? 1 : 0);
     obs.push(known.def.cooldown > 0 ? cd / known.def.cooldown : 0);

--- a/src/sim/professions/session_teardown.ts
+++ b/src/sim/professions/session_teardown.ts
@@ -18,12 +18,19 @@
 // (teleports that should break a spell keep their own rules), and delegated
 // to the one cancelCast on the seam, which already clears the queued-spell
 // slot and every hidden session field. Draw-free on every path.
+// The GCD-held queued press is the one exception to spell neutrality: a
+// stored press must not survive a displacement (it would fire ticks later at
+// the destination, with a clamped stale aim for a ground-target press), so
+// the slot is dropped on every displacement while a live spell cast stays
+// untouched.
 
 import type { SimContext } from '../sim_context';
 import { type Entity, isNonSpellCast } from '../types';
 
 export function cancelProfessionSessionOnDisplacement(ctx: SimContext, e: Entity): void {
   if (e.kind !== 'player') return;
+  e.queuedCastAbility = null;
+  e.queuedCastAim = null;
   if (!isNonSpellCast(e.castingAbility)) return;
   ctx.cancelCast(e);
 }

--- a/src/sim/social/fiesta_bots.ts
+++ b/src/sim/social/fiesta_bots.ts
@@ -276,7 +276,10 @@ function driveFiestaBot(sim: Sim, pid: number): void {
   // busy." (#1360's single-slot spell queue applies to every castAbility caller,
   // bots included); this is intended, not an accidental behavior change, and it stays
   // deterministic since bot presses derive from tickCount/pid, not rng.
-  if (sim.tickCount % 24 === pid % 24) {
+  // A bare-GCD press is skipped: it would load the GCD-tail queue and silently
+  // tighten bot cadence past the pre-queue tuning, so bots keep the classic
+  // press-when-the-GCD-is-clear rhythm the practice arena was balanced around.
+  if (sim.tickCount % 24 === pid % 24 && (e.castingAbility !== null || e.gcdRemaining <= 0)) {
     const ability = pickBotAbility(meta);
     if (ability) sim.castAbility(ability, pid);
   }

--- a/tests/affliction_sentence_queue.test.ts
+++ b/tests/affliction_sentence_queue.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import {
-  shouldBufferSentenceDuringGcd,
-  shouldPreserveQueuedSentence,
-} from '../src/sim/combat/affliction_sentence_queue';
+import { shouldPreserveQueuedSentence } from '../src/sim/combat/affliction_sentence_queue';
 import { CAST_QUEUE_WINDOW_SEC } from '../src/sim/types';
 
+// The Sentence-only GCD buffer this module used to carry was absorbed by the
+// general GCD-tail spell queue (casting_lifecycle.ts); what remains here is the
+// preserve rule, the one deliberate exception to the queue's last-press-wins.
 describe('Affliction Sentence queue policy', () => {
   it('uses the classic 0.4 second queue window', () => {
     expect(CAST_QUEUE_WINDOW_SEC).toBe(0.4);
@@ -16,12 +16,5 @@ describe('Affliction Sentence queue policy', () => {
     expect(shouldPreserveQueuedSentence('sentence', 'drain_life')).toBe(false);
     expect(shouldPreserveQueuedSentence('needle_of_fate', 'needle_of_fate')).toBe(false);
     expect(shouldPreserveQueuedSentence(null, 'needle_of_fate')).toBe(false);
-  });
-
-  it('buffers Sentence only inside the final GCD queue window', () => {
-    expect(shouldBufferSentenceDuringGcd('sentence', CAST_QUEUE_WINDOW_SEC)).toBe(true);
-    expect(shouldBufferSentenceDuringGcd('sentence', CAST_QUEUE_WINDOW_SEC + 0.01)).toBe(false);
-    expect(shouldBufferSentenceDuringGcd('sentence', 0)).toBe(false);
-    expect(shouldBufferSentenceDuringGcd('needle_of_fate', CAST_QUEUE_WINDOW_SEC)).toBe(false);
   });
 });

--- a/tests/combat_casting_lifecycle.test.ts
+++ b/tests/combat_casting_lifecycle.test.ts
@@ -1089,10 +1089,13 @@ describe('casting_lifecycle: GCD-tail queue (WotLK-style spell queue)', () => {
     spawnTarget(sim, p, 1, 2); // dz 2: inside melee range for the hamstring press
     castAbility(sim.ctx, 'hamstring', p.id); // instant on-GCD press arms the GCD
     expect(p.gcdRemaining).toBeGreaterThan(0);
+    while (p.gcdRemaining > CAST_QUEUE_WINDOW_SEC) sim.tick();
+    castAbility(sim.ctx, 'hamstring', p.id); // load the slot: a held press to protect
+    expect(p.queuedCastAbility).toBe('hamstring');
 
     castAbility(sim.ctx, 'berserker_rage', p.id); // offGcd: bypasses the GCD outright
-    expect(p.queuedCastAbility).toBeNull();
     expect(p.cooldowns.has('berserker_rage')).toBe(true); // it fired now, not later
+    expect(p.queuedCastAbility).toBe('hamstring'); // and the held press is undisturbed
   });
 
   it('pins the exact window boundary: gcdRemaining at the window queues, just above drops', () => {

--- a/tests/combat_casting_lifecycle.test.ts
+++ b/tests/combat_casting_lifecycle.test.ts
@@ -1192,6 +1192,23 @@ describe('casting_lifecycle: GCD-tail queue (WotLK-style spell queue)', () => {
     expect(p.queuedCastAbility).toBe('smite');
   });
 
+  it('a blink-through escape press never eats the queued follow-up', () => {
+    const { sim, p, meta } = makeSim('mage', 40);
+    spawnTarget(sim, p);
+    meta.talentMods.global.blinkCast = 1; // Flickerstep: blink slips through mid-cast
+    castAbility(sim.ctx, 'fireball', p.id);
+    while (p.castRemaining > CAST_QUEUE_WINDOW_SEC) sim.tick();
+    castAbility(sim.ctx, 'fireball', p.id);
+    expect(p.queuedCastAbility).toBe('fireball');
+
+    // The escape weave: an on-GCD instant committing THROUGH the busy guard.
+    // It relocates the mage but must leave both the cast in progress and the
+    // follow-up queued behind that cast untouched.
+    castAbility(sim.ctx, 'blink', p.id);
+    expect(p.castingAbility).toBe('fireball');
+    expect(p.queuedCastAbility).toBe('fireball');
+  });
+
   it('death clears a GCD-held slot so it never fires posthumously', () => {
     const { sim, p, meta } = makeSim('priest', 40);
     spawnTarget(sim, p);

--- a/tests/combat_casting_lifecycle.test.ts
+++ b/tests/combat_casting_lifecycle.test.ts
@@ -1005,6 +1005,209 @@ describe('casting_lifecycle: spell queue (#1360)', () => {
   });
 });
 
+describe('casting_lifecycle: GCD-tail queue (WotLK-style spell queue)', () => {
+  // The general arm of the queue: a press during the final CAST_QUEUE_WINDOW_SEC
+  // of a bare GCD (no cast in flight) loads the same single slot the cast-tail
+  // queue uses, and the updateCasting retry arm fires it the tick the GCD clears.
+
+  it('queues an instant pressed inside the GCD tail and fires it the moment the GCD clears', () => {
+    const { sim, p } = makeSim('priest', 40);
+    spawnTarget(sim, p);
+    castAbility(sim.ctx, 'shadow_word_pain', p.id); // instant: arms the GCD, no cast in flight
+    expect(p.castingAbility).toBeNull();
+    expect(p.gcdRemaining).toBeGreaterThan(CAST_QUEUE_WINDOW_SEC);
+
+    while (p.gcdRemaining > CAST_QUEUE_WINDOW_SEC) sim.tick();
+    castAbility(sim.ctx, 'shadow_word_pain', p.id); // pressed inside the GCD tail
+    expect(p.queuedCastAbility).toBe('shadow_word_pain');
+    expect(p.gcdRemaining).toBeGreaterThan(0); // held, not fired through the GCD
+
+    while (p.queuedCastAbility) sim.tick(); // retried every tick until the GCD clears
+    expect(p.queuedCastAbility).toBeNull();
+    // The held press fired as a fresh cast the tick the GCD cleared: a NEW full
+    // GCD is armed, which an unfired (dropped) press could never produce.
+    expect(p.gcdRemaining).toBeGreaterThan(CAST_QUEUE_WINDOW_SEC);
+  });
+
+  it('stays silent and unqueued on a press earlier than the queue window (classic spam)', () => {
+    const { sim, p } = makeSim('priest', 40);
+    spawnTarget(sim, p);
+    castAbility(sim.ctx, 'shadow_word_pain', p.id);
+    expect(p.gcdRemaining).toBeGreaterThan(CAST_QUEUE_WINDOW_SEC); // well outside the tail
+
+    const events: Array<Record<string, any>> = [];
+    const orig = (sim as any).emit.bind(sim);
+    (sim as any).emit = (e: Record<string, any>) => {
+      events.push(e);
+      orig(e);
+    };
+    castAbility(sim.ctx, 'smite', p.id); // early press: dropped, silently
+    expect(p.queuedCastAbility).toBeNull();
+    expect(p.castingAbility).toBeNull();
+    expect(events.some((e) => e.type === 'error')).toBe(false);
+  });
+
+  it('a later press inside the GCD tail overwrites the earlier one (last-press-wins)', () => {
+    const { sim, p } = makeSim('priest', 40);
+    spawnTarget(sim, p);
+    // Half hp: the queued heal is meaningful, and the priest survives the
+    // aggroed wolf chewing on them through the GCD-wait ticks below.
+    p.hp = Math.max(1, Math.floor(p.maxHp / 2));
+    castAbility(sim.ctx, 'shadow_word_pain', p.id);
+    while (p.gcdRemaining > CAST_QUEUE_WINDOW_SEC) sim.tick();
+
+    castAbility(sim.ctx, 'lesser_heal', p.id);
+    expect(p.queuedCastAbility).toBe('lesser_heal');
+    castAbility(sim.ctx, 'smite', p.id); // a distinct second press replaces the queued slot
+    expect(p.queuedCastAbility).toBe('smite'); // not 'lesser_heal': proves overwrite, not keep-first
+  });
+
+  it('re-runs the full gate set when the held press fires: a press whose mana is gone refuses', () => {
+    const { sim, p } = makeSim('priest', 40);
+    spawnTarget(sim, p);
+    castAbility(sim.ctx, 'shadow_word_pain', p.id);
+    while (p.gcdRemaining > CAST_QUEUE_WINDOW_SEC) sim.tick();
+    castAbility(sim.ctx, 'smite', p.id);
+    expect(p.queuedCastAbility).toBe('smite');
+
+    p.resource = 0; // the mana the press was made with is gone before the GCD clears
+    const events: Array<Record<string, any>> = [];
+    const orig = (sim as any).emit.bind(sim);
+    (sim as any).emit = (e: Record<string, any>) => {
+      events.push(e);
+      orig(e);
+    };
+    let n = 0;
+    while (p.queuedCastAbility && n++ < 100) sim.tick();
+    expect(p.queuedCastAbility).toBeNull(); // slot consumed by the refused fire, not stuck
+    expect(p.castingAbility).toBeNull(); // the cast never started
+    expect(events.some((e) => e.type === 'error' && e.text === 'Not enough mana!')).toBe(true);
+  });
+
+  it('an off-GCD ability pressed during the GCD fires immediately and never touches the queue', () => {
+    const { sim, p } = makeSim('warrior', 40);
+    spawnTarget(sim, p, 1, 2); // dz 2: inside melee range for the hamstring press
+    castAbility(sim.ctx, 'hamstring', p.id); // instant on-GCD press arms the GCD
+    expect(p.gcdRemaining).toBeGreaterThan(0);
+
+    castAbility(sim.ctx, 'berserker_rage', p.id); // offGcd: bypasses the GCD outright
+    expect(p.queuedCastAbility).toBeNull();
+    expect(p.cooldowns.has('berserker_rage')).toBe(true); // it fired now, not later
+  });
+
+  it('pins the exact window boundary: gcdRemaining at the window queues, just above drops', () => {
+    const { sim, p } = makeSim('priest', 40);
+    spawnTarget(sim, p);
+    castAbility(sim.ctx, 'shadow_word_pain', p.id);
+    p.gcdRemaining = CAST_QUEUE_WINDOW_SEC + 0.01;
+    castAbility(sim.ctx, 'smite', p.id);
+    expect(p.queuedCastAbility).toBeNull(); // just above the window: classic silent drop
+    p.gcdRemaining = CAST_QUEUE_WINDOW_SEC;
+    castAbility(sim.ctx, 'smite', p.id);
+    expect(p.queuedCastAbility).toBe('smite'); // exactly the window edge queues
+  });
+
+  it('carries the queued aim point through the GCD arm to the fired ground-targeted cast', () => {
+    const { sim, p } = makeSim('mage', 20);
+    sim.setSpec('fire'); // Flamestrike is a DPS-spec ability (Chronomancy gating)
+    spawnTarget(sim, p);
+    // A bare GCD tail with no cast in flight (the GCD source is irrelevant here;
+    // what this pins is that the GCD arm stores and carries the aim point).
+    p.gcdRemaining = CAST_QUEUE_WINDOW_SEC;
+    expect(p.castingAbility).toBeNull();
+
+    const aim = { x: p.pos.x + 5, z: p.pos.z + 5 };
+    castAbility(sim.ctx, 'flamestrike', p.id, aim);
+    expect(p.queuedCastAbility).toBe('flamestrike');
+    expect(p.queuedCastAim).toEqual(aim);
+
+    while (p.queuedCastAbility) sim.tick();
+    expect(p.castingAbility).toBe('flamestrike'); // the held press fired as a fresh cast
+    expect(p.castAim?.x).toBe(aim.x);
+    expect(p.castAim?.z).toBe(aim.z);
+  });
+
+  it('a silence landing during the hold refuses the queued press at fire time', () => {
+    const { sim, p } = makeSim('priest', 40);
+    spawnTarget(sim, p);
+    castAbility(sim.ctx, 'shadow_word_pain', p.id);
+    while (p.gcdRemaining > CAST_QUEUE_WINDOW_SEC) sim.tick();
+    castAbility(sim.ctx, 'smite', p.id);
+    expect(p.queuedCastAbility).toBe('smite');
+
+    p.auras.push({
+      id: 'test_silence',
+      name: 'Test Silence',
+      kind: 'silence',
+      remaining: 10,
+      duration: 10,
+      value: 0,
+      sourceId: p.id,
+      school: 'shadow',
+    });
+    const events: Array<Record<string, any>> = [];
+    const orig = (sim as any).emit.bind(sim);
+    (sim as any).emit = (e: Record<string, any>) => {
+      events.push(e);
+      orig(e);
+    };
+    let n = 0;
+    while (p.queuedCastAbility && n++ < 100) sim.tick();
+    expect(p.queuedCastAbility).toBeNull(); // slot consumed by the refused fire, not stuck
+    expect(p.castingAbility).toBeNull(); // the silenced press never started
+    expect(events.some((e) => e.type === 'error' && e.text === 'You are silenced!')).toBe(true);
+  });
+
+  it('a fresh press landing in the one-tick gap after the GCD clears discards the stale held press', () => {
+    const { sim, p } = makeSim('priest', 40);
+    spawnTarget(sim, p);
+    p.hp = Math.max(1, Math.floor(p.maxHp / 2));
+    castAbility(sim.ctx, 'shadow_word_pain', p.id);
+    while (p.gcdRemaining > CAST_QUEUE_WINDOW_SEC) sim.tick();
+    castAbility(sim.ctx, 'smite', p.id);
+    expect(p.queuedCastAbility).toBe('smite');
+
+    // The gap: gcdRemaining zeroes in updateTimers AFTER the updateCasting retry
+    // arm ran that tick, so a fresh press can see a clear GCD while the slot is
+    // still loaded. The fresh press is the newest intent: it must win outright.
+    p.gcdRemaining = 0;
+    castAbility(sim.ctx, 'lesser_heal', p.id);
+    expect(p.castingAbility).toBe('lesser_heal'); // the fresh press started casting now
+    expect(p.queuedCastAbility).toBeNull(); // and the stale smite press was discarded
+
+    while (p.castingAbility) sim.tick();
+    expect(p.castingAbility).toBeNull(); // nothing fired behind the completed heal
+  });
+
+  it('a non-Sentence press inside the tail replaces a GCD-held Sentence (last-press-wins)', () => {
+    const { sim, p } = makeSim('priest', 40);
+    spawnTarget(sim, p);
+    castAbility(sim.ctx, 'shadow_word_pain', p.id);
+    while (p.gcdRemaining > CAST_QUEUE_WINDOW_SEC) sim.tick();
+    // A held Sentence, loaded by hand (only a warlock can press it for real).
+    // The preserve guard shields it from needle_of_fate/sentence presses only.
+    p.queuedCastAbility = 'sentence';
+    p.queuedCastAim = null;
+    castAbility(sim.ctx, 'smite', p.id);
+    expect(p.queuedCastAbility).toBe('smite');
+  });
+
+  it('death clears a GCD-held slot so it never fires posthumously', () => {
+    const { sim, p, meta } = makeSim('priest', 40);
+    spawnTarget(sim, p);
+    castAbility(sim.ctx, 'shadow_word_pain', p.id);
+    while (p.gcdRemaining > CAST_QUEUE_WINDOW_SEC) sim.tick();
+    castAbility(sim.ctx, 'smite', p.id);
+    expect(p.queuedCastAbility).toBe('smite'); // held against a bare GCD, no cast in flight
+
+    handleDeath(sim.ctx, p, null);
+    expect(p.queuedCastAbility).toBeNull();
+    expect(p.queuedCastAim).toBeNull();
+    for (let i = 0; i < 20; i++) updateCasting(sim.ctx, p, meta);
+    expect(p.castingAbility).toBeNull(); // nothing fired after death
+  });
+});
+
 describe('casting_lifecycle: force-stop clears drop the queued slot', () => {
   it('death (handleDeath) clears a queued press', () => {
     const { sim, p } = makeSim('mage', 12);

--- a/tests/professions_session_teardown.test.ts
+++ b/tests/professions_session_teardown.test.ts
@@ -127,6 +127,26 @@ describe('the shared displacement helper', () => {
     }
   });
 
+  it('drops a GCD-held queued press while leaving a live spell cast untouched', () => {
+    const sim = makeSim();
+    const pid = sim.playerId;
+    const p = sim.entities.get(pid);
+    if (!p) throw new Error('missing entity');
+    // A stored press must not survive a displacement: it would fire ticks
+    // later at the destination (with a clamped stale aim for a ground-target
+    // press). A live spell cast keeps its own teleport rules.
+    p.castingAbility = 'fireball';
+    p.castRemaining = 2;
+    p.queuedCastAbility = 'flamestrike';
+    p.queuedCastAim = { x: 10, z: 20 };
+    cancelProfessionSessionOnDisplacement(sim.ctx, p);
+    expect(p.queuedCastAbility).toBeNull();
+    expect(p.queuedCastAim).toBeNull();
+    expect(p.castingAbility).toBe('fireball');
+    p.castingAbility = null;
+    p.castRemaining = 0;
+  });
+
   it('the gather timer survives the cancel (nothing was spent)', () => {
     const sim = makeSim();
     const pid = sim.playerId;


### PR DESCRIPTION
## Summary

Generalizes the single-slot spell queue (#1360) to the bare GCD: a press inside the final 0.4s (CAST_QUEUE_WINDOW_SEC) of a running GCD now loads the same queued slot the cast-tail queue uses and fires the tick the GCD clears, last-press-wins. This is the WotLK-era SpellQueueWindow behavior (and what TBC Classic shipped): rotation cadence becomes latency-neutral instead of rewarding low ping, with no throughput gain for a perfect spammer (a spam press already lands within one 50ms tick of the GCD clearing).

Design decisions, discussed and settled beforehand:
- Last-press-wins replacement: the most recent press inside the window is the intent. The one exception stays: a GCD-held Sentence is preserved against needle_of_fate/sentence spam (the existing Hexcraft guard), while any other press replaces it like any queued slot.
- Presses earlier than the window keep the classic silent drop.
- Off-GCD abilities bypass the queue entirely and never disturb a held slot.
- The Sentence-only GCD buffer (shouldBufferSentenceDuringGcd) is absorbed by the general rule and removed; its preserve-guard sibling stays.

Hardening that came out of the sim review:
- An accepted on-GCD press drops any stale GCD-held slot at its commit point, closing the one-tick-gap misfire (a press landing right after the GCD zeroes but before the retry arm could start a cast with the old press still loaded, which then fired when that cast completed).
- Displacements (the shared teleport teardown hook) drop a GCD-held slot, so a stored press never fires ticks later at a teleport destination with a stale clamped aim.
- Fiesta practice bots skip bare-GCD presses, keeping bot cadence exactly at the pre-queue tuning instead of silently gaining DPS.
- The RL obs ready flag deliberately keeps ignoring the queued slot (documented at the flag); env dynamics change only in that a tail press now has a delayed effect.

Balance note: this is not perfectly class-neutral. Casters already had queuing off cast tails; the new arm mostly benefits instant-heavy melee rotations (rogue included) for ordinary and high-ping players, worth a few percent of realized cadence. Expect a small melee-side parse bump after this ships, an artifact of the input pipeline, not organic drift.

## Type of change

- [x] Feature: new functionality

## How was this tested?

- Commands:
  - New pins in tests/combat_casting_lifecycle.test.ts (describe: GCD-tail queue): queue-and-fire on GCD clear, early-press silent drop, last-press-wins overwrite, exact window boundary, aim carry on the GCD arm, gate re-run at fire time (mana gone), silence landing during the hold, one-tick-gap stale-press discard, non-Sentence press replacing a held Sentence, death clearing a held slot. Plus a displacement pin in tests/professions_session_teardown.test.ts.
  - npx vitest run tests/combat_casting_lifecycle.test.ts tests/professions_session_teardown.test.ts tests/fiesta_bots.test.ts tests/affliction.test.ts tests/affliction_sentence_queue.test.ts: 177/177 green.
  - npx tsc --noEmit: clean. Biome on changed files: clean (warnings only, pre-existing style).
  - tests/parity: goldens byte-identical; every trace-mismatch assertion that completed passed across three local runs. The only local failures were roving 20s/90s timeouts under heavy core contention (another worktree's vitest was live); zero toEqual mismatches. The scenario drivers only press with the GCD clear, so the new arm draws nothing in any recorded scenario. Treat the CI run as the clean-machine parity verdict.
- Manual steps: none required (no UI change).

## Checklist

### Quality
- [x] The gate passes locally per above; CI is the arbiter for the contention-flaky parity timeouts.

### Localization (i18n)
- [x] N/A. This PR adds no player-visible strings (queued presses that fail at fire time surface only pre-existing matched error lines).

### Hygiene
- [x] No secrets, no generated files touched.