### PR TITLE
fix(sim): show Mister Crabs summon lines only to the summoner

### DIFF
--- a/src/sim/encounters/quest_summon.ts
+++ b/src/sim/encounters/quest_summon.ts
@@ -18,7 +18,11 @@ export function summonQuestMob(
   // instead of queueing behind a stranger's. Omitted, the guard stays
   // site-wide, the original Nythraxis behavior. hardDespawnSeconds gives a
   // summon a fixed lifetime that combat and retargeting cannot clear.
-  opts?: { perOwner?: boolean; hardDespawnSeconds?: number },
+  // announceOwnerOnly scopes the awaken line and the opening yell to the
+  // summoner (pid-scoped personal events) instead of a world-visible log:
+  // right for a per-owner summon on a shared site, where a stranger's chat
+  // would otherwise fill with someone else's private quest beat.
+  opts?: { perOwner?: boolean; hardDespawnSeconds?: number; announceOwnerOnly?: boolean },
 ): void {
   const existing = [...ctx.entities.values()].some(
     (e) =>
@@ -52,11 +56,28 @@ export function summonQuestMob(
     return Math.abs(mob.pos.x - origin.x) < 120 && Math.abs(mob.pos.z - origin.z) < 250;
   });
   if (inst) inst.mobIds.push(mob.id);
-  ctx.emit({ type: 'log', text: `${template.name} awakens!`, color: '#ff6666' });
-  emitQuestMobDialogue(ctx, templateId, mob.id);
+  const announcePid = opts?.announceOwnerOnly ? ownerPid : undefined;
+  if (announcePid === undefined) {
+    ctx.emit({ type: 'log', text: `${template.name} awakens!`, color: '#ff6666' });
+  } else {
+    ctx.emit({
+      type: 'log',
+      text: `${template.name} awakens!`,
+      color: '#ff6666',
+      pid: announcePid,
+    });
+  }
+  emitQuestMobDialogue(ctx, templateId, mob.id, announcePid);
 }
 
-export function emitQuestMobDialogue(ctx: SimContext, templateId: string, entityId: number): void {
+// pid (when set) makes the yell a personal event delivered only to that player;
+// omitted, it stays a world-visible log anchored to the yelling entity.
+export function emitQuestMobDialogue(
+  ctx: SimContext,
+  templateId: string,
+  entityId: number,
+  pid?: number,
+): void {
   const text =
     templateId === 'fallen_captain_aldren'
       ? 'Fallen Captain Aldren yells, "None shall disturb the king\'s rest! For Thornpeak!"'
@@ -67,5 +88,7 @@ export function emitQuestMobDialogue(ctx: SimContext, templateId: string, entity
           : templateId === 'mister_crabs'
             ? 'Mister Crabs yells, "MINE! The pearl is mine, and mine she stays!"'
             : null;
-  if (text) ctx.emit({ type: 'log', text, color: '#ff9999', entityId });
+  if (!text) return;
+  if (pid === undefined) ctx.emit({ type: 'log', text, color: '#ff9999', entityId });
+  else ctx.emit({ type: 'log', text, color: '#ff9999', entityId, pid });
 }

--- a/src/sim/interactions/crab_summon.ts
+++ b/src/sim/interactions/crab_summon.ts
@@ -80,6 +80,8 @@ export function useBrinyLure(ctx: SimContext, player: Entity, meta: PlayerMeta):
     CRAB_MOB_ID,
     { x: CRAB_SUMMON_SITE.x, y: 0, z: CRAB_SUMMON_SITE.z },
     meta.entityId,
-    { perOwner: true, hardDespawnSeconds: CRAB_DESPAWN_SECONDS },
+    // announceOwnerOnly: each summon is a private quest beat on a shared
+    // island, so the awaken line and the yell reach only the summoner.
+    { perOwner: true, hardDespawnSeconds: CRAB_DESPAWN_SECONDS, announceOwnerOnly: true },
   );
 }

--- a/tests/crab_summon.test.ts
+++ b/tests/crab_summon.test.ts
@@ -290,6 +290,51 @@ describe('the Mother of Pearl chain in a real sim', () => {
     expect(sim.entities.has(second.id)).toBe(false);
   });
 
+  it('announces the summon only to the summoner, never the whole shore', () => {
+    const sim = makeSim();
+    startQuest(sim);
+    teleportTo(sim, CRAB_SUMMON_SITE.x, CRAB_SUMMON_SITE.z);
+    sim.drainEvents();
+    sim.useItem(LURE_ITEM_ID);
+    const logs = sim
+      .drainEvents()
+      .filter((e): e is Extract<SimEvent, { type: 'log' }> => e.type === 'log');
+    const awaken = logs.find((e) => e.text === 'Mister Crabs awakens!');
+    const yell = logs.find((e) =>
+      e.text.startsWith('Mister Crabs yells, "MINE! The pearl is mine'),
+    );
+    if (!awaken || !yell) throw new Error('Expected the awaken line and the opening yell');
+    // Both summon lines are personal (pid-scoped) events: the server delivers
+    // them only to the summoner's session, so a shared island never fills
+    // everyone's chat with someone else's private quest beat.
+    expect(awaken.pid).toBe(sim.playerId);
+    expect(yell.pid).toBe(sim.playerId);
+    // The yell keeps its entity anchor so the chat bubble still points at him.
+    expect(yell.entityId).toBe(requireLiveBoss(sim).id);
+  });
+
+  it('keeps the default summon announcement world-visible (the Nythraxis beats)', () => {
+    const sim = makeSim();
+    sim.drainEvents();
+    // A summon WITHOUT announceOwnerOnly (the graveside ambush shape) still
+    // broadcasts: those beats happen inside the summoner's own instance.
+    summonQuestMob(
+      sim.ctx,
+      CRAB_MOB_ID,
+      { x: CRAB_SUMMON_SITE.x, y: 0, z: CRAB_SUMMON_SITE.z },
+      -1,
+      {
+        perOwner: true,
+      },
+    );
+    const logs = sim
+      .drainEvents()
+      .filter((e): e is Extract<SimEvent, { type: 'log' }> => e.type === 'log');
+    const awaken = logs.find((e) => e.text === 'Mister Crabs awakens!');
+    if (!awaken) throw new Error('Expected the awaken line');
+    expect(awaken.pid).toBeUndefined();
+  });
+
   it('stays silent for a player who never took the quest', () => {
     const sim = makeSim();
     // No quest, standing right at the pool with a lure smuggled into bags:

--- a/tests/crab_summon.test.ts
+++ b/tests/crab_summon.test.ts
@@ -331,8 +331,15 @@ describe('the Mother of Pearl chain in a real sim', () => {
       .drainEvents()
       .filter((e): e is Extract<SimEvent, { type: 'log' }> => e.type === 'log');
     const awaken = logs.find((e) => e.text === 'Mister Crabs awakens!');
-    if (!awaken) throw new Error('Expected the awaken line');
+    const yell = logs.find((e) =>
+      e.text.startsWith('Mister Crabs yells, "MINE! The pearl is mine'),
+    );
+    if (!awaken || !yell) throw new Error('Expected the awaken line and the opening yell');
     expect(awaken.pid).toBeUndefined();
+    // The yell is pinned on its own: the pid-less branch of emitQuestMobDialogue
+    // must stay world-visible AND keep its entity anchor for the chat bubble.
+    expect(yell.pid).toBeUndefined();
+    expect(yell.entityId).toBe(requireLiveBoss(sim).id);
   });
 
   it('stays silent for a player who never took the quest', () => {


### PR DESCRIPTION
## Summary

When Mister Crabs is summoned at the Proving Shore tide pool, the "Mister Crabs awakens!" line and his opening yell were world-visible log events, so every player near the shared island saw someone else's private quest beat in chat. This scopes both lines to the summoner.

`summonQuestMob` (src/sim/encounters/quest_summon.ts) gains an `announceOwnerOnly` option: when set, the awaken line and the `emitQuestMobDialogue` yell are emitted as pid-scoped personal events, which the server delivers only to the summoner's session. The yell keeps its `entityId` anchor so the chat bubble still points at the boss. The Briny Lure summon (src/sim/interactions/crab_summon.ts) passes the option; the Nythraxis graveside summons do not, so their broadcasts are unchanged. Both strings are byte-identical to before, so the existing sim_i18n matchers cover them with no catalog change.

## Type of change

- [x] Bug fix

## How was this tested?

- Commands:
  - `npx vitest run tests/crab_summon.test.ts` (13 passed, including two new cases: the crab's summon lines carry the summoner's pid, and a default summon stays world-visible)
  - `npx vitest run tests/localization_fixes.test.ts` (S3 guard green; emit text unchanged)
  - `npx tsc --noEmit`, changed-files biome, and the parity suite (all failures on the local Windows box were load timeouts that reproduce identically on the untouched base commit; no trace mismatches)
- Manual steps: ran the dev client against a local authoritative server, two accounts at the tide pool; the summoner's chat shows both lines, the bystander sees the crab spawn with no chat lines.

---

## Checklist

### Quality

- [x] **The gate passes.** Pre-push floor (typecheck, guard tests, lint, copy rules) green locally; decisive tests added for the changed behavior. Full-suite verdict via CI (known environmental reds on the local Windows machine).

### Localization (i18n)

- [x] Player-facing text emitted from `src/sim/` is re-localized at the client boundary (existing matchers; emit strings unchanged), and `npx vitest run tests/localization_fixes.test.ts` passes.
- [x] N/A otherwise. This PR adds no new player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] No generated files hand-edited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
