### PR TITLE
fix(guild-bank): refuse consuming another officer's unsettled work at dispatch

### DIFF
--- a/docs/guild-bank/state.md
+++ b/docs/guild-bank/state.md
@@ -1234,7 +1234,20 @@ the deployment premise the cache bust and the single-writer narrowing both rest 
   backstop SEED the log under the gate (`seedUnflushed` in
   `tests/guild_bank_persistence.test.ts`); the gate's own pins are
   `tests/guild_bank_settle_gate.test.ts` and the gate describe block in the persistence
-  suite. Metered as `unsettled_refused` (rate, never presence). The holder flush is
-  DAMPED (`GUILD_BOOK_FLUSH_COOLDOWN_MS`, one flush per holder per window, shared with
-  the refusal arm's retry flush): a refusal costs its sender only an op-guard token, so
-  an undamped fan-out would let one officer force a save per dirty guildmate per refusal.
+  suite. Metered as `unsettled_refused` (rate, never presence). Review hardening
+  (2026-09-02): (a) EDIT AUTHORITY FIRST: a read-only member view (`canEdit` false) never
+  reaches the gate, so a plain member can buy neither an incident nor a flush; (b) the
+  gate reads a per-guild HOLDER INDEX with each holder's contribution cached
+  (`server/guild_book_holders.ts` GuildBookHolderIndex: touch on every op, resync after
+  every commit and rollback, dropGuild on disband, dropSession on leave), never a
+  realm-wide session scan per op, and a cached contribution is invalidated, never
+  patched (a commit that consumed one entry while an op pushed another keeps the log
+  LENGTH and changes its contents); (c) the refusal flush reaches only the holders whose
+  contribution FEEDS the refused dependency (`GuildBookDependency`: the exact identity,
+  the arm's item id, copper, or the ladder), at most `GUILD_BOOK_FLUSH_FAN_OUT_MAX` of
+  them, through the background-permit save, with ONE flush queued or running per holder
+  and a single re-arm behind it (`requestGuildBookFlush`), shared with the refusal arm's
+  retry flush; (d) the gate mirrors the sim's admissibility checks (floored count within
+  the stack, positive safe-integer amount within the treasury, a priced rung the
+  treasury covers) and passes every inadmissible shape through unjudged, so a request
+  the sim refuses anyway can never buy a refusal, an incident, or a flush.

--- a/docs/guild-bank/state.md
+++ b/docs/guild-bank/state.md
@@ -825,7 +825,10 @@ not preventing one. Concretely:
   is TRANSIENT: their commit is what makes the replay applicable and it lands
   within an autosave interval. Nothing is consumed, and the marks and log are
   exactly as they were. It is metered as `escrow_refused_retry`, deliberately
-  NOT as `escrow_save_failed`: nothing failed.
+  NOT as `escrow_save_failed`: nothing failed. Since the unsettled gate
+  (2026-09-02, "Known gotchas" below) an ordinary two-officer session never
+  reaches this arm: the consume that would have created the dependency is
+  refused at dispatch instead, so the arm is the backstop, not the path.
 - When no session can ever make the missing value durable (or the retries run
   out after `GameServer.GUILD_BANK_DEFICIT_MAX_SKIPS`), the session's live
   state is ABANDONED: its own book ops come back off the live book, it is
@@ -993,9 +996,10 @@ What remains accepted:
     and refetches the listing, and a 200 with `audited: false` says the item went but its
     moderation row did not.
 - Guild bank incidents are metered (2026-08-03): `woc_guild_bank_incidents_total{kind}`
-  over the fixed ELEVEN `GUILD_BANK_INCIDENTS` (escrow_save_failed, escrow_refused_retry,
+  over the fixed TWELVE `GUILD_BANK_INCIDENTS` (escrow_save_failed, escrow_refused_retry,
   save_fenced_out, escrow_quarantined, reconcile, book_unloaded, ledger_write_failed,
-  counterparty_orphan, counterparty_unstamped, log_read_failed, create_fee_unpaid)
+  counterparty_orphan, counterparty_unstamped, log_read_failed, create_fee_unpaid,
+  unsettled_refused)
   through the `gameMetricsCounters` seam,
   pre-registered at zero. Guild id stays in the loud log and is never a metric label.
   Each counter sits BESIDE its log, never instead of it.
@@ -1013,7 +1017,9 @@ What remains accepted:
   `counterparty_orphan`, `counterparty_unstamped` and the legacy-cardinality
   `create_fee_unpaid` are single-sample defects and are PAGE-worthy on `> 0`; the current
   atomic paid-create path cannot emit the latter, so any new sample implies mixed-release
-  traffic or an invariant breach. `escrow_refused_retry` is alert-worthy on its RATE,
+  traffic or an invariant breach. `unsettled_refused` (the dispatch-time gate refusing a
+  consume of another session's not-yet-durable work, 2026-09-02) and
+  `escrow_refused_retry` are alert-worthy on their RATE,
   not its presence: it is ordinary two-officer concurrency on a healthy realm, so alert on
   a sustained rise (or a rate that tracks ONE guild), which is the shape that means a book
   is failing to converge rather than two officers sharing it. `escrow_save_failed`,
@@ -1209,3 +1215,23 @@ the deployment premise the cache bust and the single-writer narrowing both rest 
   tab (a client without the def cannot evaluate the pipe's four refusal dimensions,
   and a refused copy strands dormant), which is now an explicit arm with its own pin
   rather than a side effect of the two bank modes being exclusive.
+- The unsettled gate (2026-09-02, `server/guild_bank_settle_gate.ts`, wired through
+  `server/guild_bank_op_coordinator.ts` before admission): a withdraw, gold withdraw, or
+  rung purchase may consume only durable value plus the acting session's OWN unflushed
+  deposits. Another session's not-yet-durable deposit is UNSETTLED: the op is refused
+  with the `guild.bankSettling` notice and that session is flushed on the spot, so the
+  retry lands a round trip later. Why: the retry/rollback arm honours only a ONE-WAY
+  dependency, and the old note that "only ladder rungs can deadlock both replays" was
+  true for one fungible and false for two item identities. On 2026-09-01 (prod guild
+  294) two officers swapped spider legs for venom glands inside one autosave window;
+  each replay was short on the other's key, the retry bound rolled BOTH back
+  (disconnected as "taken over"), and the per-session reverts of an already-consumed
+  deposit CLAMPED on the live book, leaving a phantom 20-stack that quarantined every
+  later withdrawer of it until the realm restarted. With the gate a log carries only
+  deposits, removals of settled copies, and rungs on a settled ladder, so
+  `handleGuildBankEscrowRefusal` (now `server/guild_bank_escrow_refusal.ts` behind a
+  GameServer port) is the backstop for unusable rows and tampering. Tests that need the
+  backstop SEED the log under the gate (`seedUnflushed` in
+  `tests/guild_bank_persistence.test.ts`); the gate's own pins are
+  `tests/guild_bank_settle_gate.test.ts` and the gate describe block in the persistence
+  suite. Metered as `unsettled_refused` (rate, never presence).

--- a/docs/guild-bank/state.md
+++ b/docs/guild-bank/state.md
@@ -1234,4 +1234,7 @@ the deployment premise the cache bust and the single-writer narrowing both rest 
   backstop SEED the log under the gate (`seedUnflushed` in
   `tests/guild_bank_persistence.test.ts`); the gate's own pins are
   `tests/guild_bank_settle_gate.test.ts` and the gate describe block in the persistence
-  suite. Metered as `unsettled_refused` (rate, never presence).
+  suite. Metered as `unsettled_refused` (rate, never presence). The holder flush is
+  DAMPED (`GUILD_BOOK_FLUSH_COOLDOWN_MS`, one flush per holder per window, shared with
+  the refusal arm's retry flush): a refusal costs its sender only an op-guard token, so
+  an undamped fan-out would let one officer force a save per dirty guildmate per refusal.

--- a/server/game.ts
+++ b/server/game.ts
@@ -266,6 +266,7 @@ import {
   type GuildBankOpGuardState,
 } from './guild_bank_op_guard';
 import {
+  GUILD_BOOK_FLUSH_COOLDOWN_MS,
   type GuildBankOpRequest,
   guildBookHolders,
   unsettledGuildBook,
@@ -1209,6 +1210,10 @@ export interface ClientSession extends MovementInputSessionState {
   // only bounds how long a session waits for the other officer's commit before
   // it is rolled back and disconnected instead.
   guildBankDeficitSkips: Map<number, number>;
+  // When this session was last flushed as a guild book HOLDER (the unsettled
+  // gate's refusal, the escrow refusal's retry arm); flushGuildBookHolders
+  // damps on it. Zero until the first flush.
+  guildBookFlushedAtMs: number;
   // Set once this session's book work can never become durable and its live
   // state has therefore been abandoned. A quarantined session persists
   // NOTHING, ever again: its character half is the half that would carry the
@@ -3845,6 +3850,7 @@ export class GameServer {
       bankLedgerSaveScheduled: false,
       unflushedGuildBankOps: new Map(),
       guildBankDeficitSkips: new Map(),
+      guildBookFlushedAtMs: 0,
       escrowQuarantined: false,
       inFlightGuildBankOps: new Map(),
       ignoredIds: new Set(),
@@ -5158,12 +5164,18 @@ export class GameServer {
   // guild's book another session is waiting on: the unsettled gate's refusal
   // and the escrow refusal's retry arm both call it, so the retry lands a
   // round trip later rather than an autosave interval later. Never a
-  // departing session (its leave flush is already in flight).
+  // departing session (its leave flush is already in flight), and never the
+  // same holder twice inside GUILD_BOOK_FLUSH_COOLDOWN_MS: a refusal costs its
+  // sender only an op-guard token, so an undamped fan-out would let one
+  // officer force a save per dirty guildmate per refusal.
   private flushGuildBookHolders(guildId: number, except: ClientSession): void {
+    const now = Date.now();
     const holders = guildBookHolders(this.sessionsByCharacterId.values(), guildId, except, {
       includeLeaving: false,
     });
     for (const s of holders) {
+      if (now - s.guildBookFlushedAtMs < GUILD_BOOK_FLUSH_COOLDOWN_MS) continue;
+      s.guildBookFlushedAtMs = now;
       void this.saveCharacter(s).catch((err) =>
         console.error(`guild bank deficit flush failed for ${s.name}:`, err),
       );

--- a/server/game.ts
+++ b/server/game.ts
@@ -117,7 +117,7 @@ import { recordOnlineSample } from './admin_db';
 import { type AdminGuildBankView, adminGuildBankView } from './admin_guild_bank_view';
 import { offensiveName } from './auth';
 import type { BackgroundDbGate } from './background_db_gate';
-import { type GuildBankLedgerOp, recordGuildBankEscrowRollback } from './bank_ledger';
+import type { GuildBankLedgerOp } from './bank_ledger';
 import type { BankLedgerProjectionSurface } from './bank_ledger_admission';
 import { BankLedgerGrowthLimitExceeded } from './bank_ledger_growth_budget';
 import {
@@ -255,6 +255,7 @@ import { mergedPrsForLogin } from './github_contributors';
 import { githubForAccount } from './github_db';
 import { groundTelegraphWireJson, groundTelegraphWorld } from './ground_telegraph_wire';
 import { forEachGuarded, runGuarded } from './guarded_iter';
+import { handleGuildBankEscrowRefusal as handleEscrowRefusal } from './guild_bank_escrow_refusal';
 import { createGuildBankLazyLoader, type GuildBankLazyLoader } from './guild_bank_lazy_loader';
 import { bustGuildBankLog, GUILD_BANK_LOG_VISIBLE_OPS } from './guild_bank_log';
 import { deliverGuildBankLog } from './guild_bank_log_delivery';
@@ -264,6 +265,11 @@ import {
   createGuildBankOpGuard,
   type GuildBankOpGuardState,
 } from './guild_bank_op_guard';
+import {
+  type GuildBankOpRequest,
+  guildBookHolders,
+  unsettledGuildBook,
+} from './guild_bank_settle_gate';
 import {
   collectGuildBankDeltas,
   // Imported from the module that DEFINES it, never through ./db: every test
@@ -5121,135 +5127,46 @@ export class GameServer {
   // round trip instead of an autosave interval.
   static readonly GUILD_BANK_DEFICIT_MAX_SKIPS = 2;
 
-  // The escrow REFUSAL arm. The book half could not be replayed onto durable
-  // truth, so the whole transaction rolled back and this save persisted
-  // NOTHING: not the books, not the character. That is the invariant the
-  // feature rests on, stated as a rule rather than as a residue:
-  //
-  //   If the book half cannot be applied, the character half must not commit.
-  //
-  // Carrying the shortfall and recording it was the alternative, and it is a
-  // two-account money printer: officer A deposits without flushing, officer B
-  // withdraws, B's character half commits while the book half does not, then A
-  // gets itself fenced (an ordinary re-login) so nothing will ever make A's
-  // deposit durable. B keeps the copper, A's stake comes back, repeatable on
-  // demand. Refusing removes it: B's purse can never durably gain what the
-  // book never durably lost.
-  //
-  // Two outcomes:
-  // - RETRY, while another session still holds unflushed work for the guild:
-  //   their commit is what makes this replay applicable, and it lands within
-  //   an autosave interval. Nothing is consumed; the marks and the log are
-  //   exactly as they were.
-  // - ROLL BACK, when no other session holds unflushed work (so nothing will
-  //   ever make the missing value durable) or the retries ran out. This
-  //   session's live state is abandoned: its own book ops come back off the
-  //   live book, it is QUARANTINED so it can never persist again, one
-  //   aggregate anomaly row records the incident, and it is disconnected to
-  //   reload from its durable row. Everything it did since its last successful
-  //   save is lost, which is exactly what a lease fence-out already does, and
-  //   it conserves precisely because none of it was ever durable.
+  // The escrow REFUSAL arm lives in server/guild_bank_escrow_refusal.ts (its
+  // design note is there); this is the GameServer seam it runs behind. The
+  // holder flush it shares with the dispatch-time unsettled gate is
+  // flushGuildBookHolders below.
   private handleGuildBankEscrowRefusal(
     session: ClientSession,
     results: readonly GuildBankWriteResult[],
-    // True when this is the LAST save this session will ever get (the leave
-    // flush, or the shutdown flush's second pass). There is no later retry to
-    // wait for, so the refusal is resolved now rather than left to a save that
-    // will never come: otherwise the session would tear down with its progress
-    // discarded and no log line and no ledger row to say why.
     final = false,
   ): void {
-    let quarantine = false;
-    for (const result of results) {
-      if (result.written) continue;
-      const guildId = result.guildId;
-      let anotherSessionDirty = false;
-      for (const s of this.sessionsByCharacterId.values()) {
-        // A quarantined or departing session's marks are NOT a reason to wait:
-        // it will never commit them, so counting it would burn every retry
-        // (blocking this session's character saves the whole time) before
-        // reaching the same rollback.
-        if (s === session || s.escrowQuarantined || s.left) continue;
-        if (s.dirtyGuildBanks.has(guildId)) {
-          anotherSessionDirty = true;
-          break;
-        }
-      }
-      const skips = (session.guildBankDeficitSkips.get(guildId) ?? 0) + 1;
-      const canResolve =
-        !final &&
-        anotherSessionDirty &&
-        !result.rowUnusable &&
-        skips < GameServer.GUILD_BANK_DEFICIT_MAX_SKIPS;
-      if (canResolve) {
-        // ORDINARY CONCURRENCY, not a failure: another officer of this guild
-        // holds unflushed work, their commit is what makes this replay
-        // applicable, and the flush below makes that a round trip rather than
-        // an autosave interval. Nothing was consumed and nothing is lost, so
-        // it gets its own counter kind: sharing escrow_save_failed made that
-        // counter unusable for `> 0` alerting. Counted per GUILD, the unit the
-        // retry applies to.
-        gameMetricsCounters().guildBankIncident('escrow_refused_retry');
-        session.guildBankDeficitSkips.set(guildId, skips);
-        // Do not wait out an autosave interval: FLUSH the sessions whose
-        // unflushed work this replay is waiting on, so the retry lands a round
-        // trip later rather than 30 seconds later. This is what keeps the
-        // blocked window (during which THIS character persists nothing at all,
-        // including progress that has nothing to do with the guild bank) to
-        // the shortest it can be, and it is why the skip bound is small.
-        //
-        // Only on the FIRST refusal: if that flush is itself refused it will
-        // flush back, and an unbounded ping-pong of fire-and-forget saves
-        // between two mutually-stuck sessions is worse than the wait it saves.
-        if (skips > 1) continue;
-        for (const s of this.sessionsByCharacterId.values()) {
-          if (s === session || s.escrowQuarantined || s.left) continue;
-          if (!s.dirtyGuildBanks.has(guildId)) continue;
-          void this.saveCharacter(s).catch((err) =>
-            console.error(`guild bank deficit flush failed for ${s.name}:`, err),
-          );
-        }
-        continue;
-      }
-      const log = session.unflushedGuildBankOps.get(guildId) ?? [];
-      recordGuildBankEscrowRollback(session, guildId, log, result.deficit);
-      console.error(
-        `guild bank escrow rolled back for guild ${guildId} (character ${session.characterId}): ${
-          result.rowUnusable
-            ? 'the stored row is oversized or malformed, its live shadow vanished, or the merged book would cross the size bound, so it is preserved untouched'
-            : `${result.deficit?.kind} shortfall ${result.deficit?.shortfall} on ${result.deficit?.op}${result.deficit?.itemId ? ` (${result.deficit.itemId})` : ''}, and ${
-                anotherSessionDirty
-                  ? `it did not resolve within ${skips} escrow saves`
-                  : 'no other session holds unflushed work for this guild, so it never can'
-              }`
-        }. The session is quarantined and disconnected; nothing it did since its last save was durable, so nothing is lost that was.`,
+    handleEscrowRefusal(
+      {
+        maxDeficitSkips: GameServer.GUILD_BANK_DEFICIT_MAX_SKIPS,
+        sessions: () => this.sessionsByCharacterId.values(),
+        flushHolders: (guildId, except) => this.flushGuildBookHolders(guildId, except),
+        revertOwnGuildBookOps: (s, guildIds) => this.revertOwnGuildBookOps(s, guildIds),
+        kickSession: (s) => {
+          void this.kickSession(s, 'character taken over', 'guild bank escrow rollback');
+        },
+        recordIncident: (kind) => gameMetricsCounters().guildBankIncident(kind),
+        logError: (message) => console.error(message),
+      },
+      session,
+      results,
+      final,
+    );
+  }
+
+  // Fire-and-forget saves for the sessions whose unflushed work on this
+  // guild's book another session is waiting on: the unsettled gate's refusal
+  // and the escrow refusal's retry arm both call it, so the retry lands a
+  // round trip later rather than an autosave interval later. Never a
+  // departing session (its leave flush is already in flight).
+  private flushGuildBookHolders(guildId: number, except: ClientSession): void {
+    const holders = guildBookHolders(this.sessionsByCharacterId.values(), guildId, except, {
+      includeLeaving: false,
+    });
+    for (const s of holders) {
+      void this.saveCharacter(s).catch((err) =>
+        console.error(`guild bank deficit flush failed for ${s.name}:`, err),
       );
-      quarantine = true;
-    }
-    if (!quarantine) return;
-    // TERMINAL: this refusal will never resolve, so the save really did fail
-    // for good (character half included, nothing durable). That is what
-    // escrow_save_failed means, and it is booked here rather than at the throw
-    // site so a refusal that merely RETRIES never reaches it. Counted once per
-    // SAVE, matching the db-threw arm above.
-    gameMetricsCounters().guildBankIncident('escrow_save_failed');
-    // The terminal arm of the escrow design and the one an operator should
-    // alert on: a live session is being abandoned because its book half can
-    // never be replayed onto durable truth. Counted once per SESSION (the unit
-    // the remedy applies to; the per-guild reverts it triggers are counted as
-    // 'reconcile' inside revertOwnGuildBookOps), beside the loud log that
-    // carries the guild id and the deficit.
-    gameMetricsCounters().guildBankIncident('escrow_quarantined');
-    // The character half is the half that would carry the value the book half
-    // could not, so this session must never save again.
-    session.escrowQuarantined = true;
-    // Undo EVERY book this session dirtied, not only the refused one: the
-    // session as a whole is abandoned, so its deltas in a second guild's book
-    // are live value nobody will ever make durable, and another officer
-    // withdrawing that phantom value would be refused in turn.
-    this.revertOwnGuildBookOps(session, [...session.dirtyGuildBanks.keys()]);
-    if (!session.left) {
-      void this.kickSession(session, 'character taken over', 'guild bank escrow rollback');
     }
   }
 
@@ -5262,6 +5179,7 @@ export class GameServer {
     target: { pid: number } | { guildId: number; actorAccountId: number },
     op: GuildBankLedgerOp,
     run: () => void,
+    request?: GuildBankOpRequest,
   ): void {
     coordinateGuildBankOp(
       {
@@ -5271,6 +5189,16 @@ export class GameServer {
         bankLedgerNeedsSave: () => bankLedgerJournalNeedsSave(session.bankLedgerJournal.outbox),
         scheduleBankLedgerHighWaterSave: () => this.scheduleBankLedgerHighWaterSave(session),
         markGuildBankDirty: (guildId) => this.markGuildBankDirty(session, guildId),
+        // The unsettled gate's inputs: every OTHER live session's unflushed
+        // work on this book (a departing session's included, its leave flush
+        // has not committed yet), and the flush a refusal fires.
+        unsettledGuildBook: (guildId) =>
+          unsettledGuildBook(
+            guildBookHolders(this.sessionsByCharacterId.values(), guildId, session, {
+              includeLeaving: true,
+            }).map((s) => s.unflushedGuildBankOps.get(guildId) ?? []),
+          ),
+        flushUnsettledGuildBook: (guildId) => this.flushGuildBookHolders(guildId, session),
         recordGuildBankIncident: (kind) => gameMetricsCounters().guildBankIncident(kind),
         logError: (message) => console.error(message),
       },
@@ -5278,6 +5206,7 @@ export class GameServer {
       target,
       op,
       run,
+      request,
     );
   }
 
@@ -8124,8 +8053,12 @@ export class GameServer {
         if (!this.consumeGuildBankOp(session, receivedAtMs / 1000)) break;
         if (typeof msg.amount === 'number') {
           const amount = msg.amount;
-          this.runGuildBankOp(session, { pid }, 'withdraw_gold', () =>
-            sim.guildBankWithdrawGoldFor(pid, amount),
+          this.runGuildBankOp(
+            session,
+            { pid },
+            'withdraw_gold',
+            () => sim.guildBankWithdrawGoldFor(pid, amount),
+            { amount },
           );
         }
         break;
@@ -8144,8 +8077,12 @@ export class GameServer {
         if (typeof msg.slot === 'number') {
           const slot = msg.slot;
           const count = typeof msg.count === 'number' ? msg.count : undefined;
-          this.runGuildBankOp(session, { pid }, 'withdraw', () =>
-            sim.guildBankWithdrawFor(pid, slot, count),
+          this.runGuildBankOp(
+            session,
+            { pid },
+            'withdraw',
+            () => sim.guildBankWithdrawFor(pid, slot, count),
+            { slot, count },
           );
         }
         break;

--- a/server/game.ts
+++ b/server/game.ts
@@ -1206,9 +1206,7 @@ export interface ClientSession extends MovementInputSessionState {
   // only bounds how long a session waits for the other officer's commit before
   // it is rolled back and disconnected instead.
   guildBankDeficitSkips: Map<number, number>;
-  // The coalesced holder flush (server/guild_book_holders.ts
-  // requestGuildBookFlush): one flush queued or running per holder, one
-  // re-arm behind it.
+  // Coalesced holder flush state (server/guild_book_holders.ts).
   guildBookFlushInFlight: boolean;
   guildBookFlushRearm: boolean;
   // Set once this session's book work can never become durable and its live
@@ -1830,11 +1828,8 @@ export class GameServer {
   // One FIFO per character id: every durable LIVE-SESSION character write
   // rides it, so commit order is enqueue order (exceptions: server/CLAUDE.md).
   readonly characterSaveQueues = createKeyedSerialWriter<number>();
-  // Which sessions hold unflushed work on which guild's book, with each
-  // holder's unsettled contribution cached (server/guild_book_holders.ts).
-  // Maintained at every mark or log change: markGuildBankDirty (touch), the
-  // post-commit prefix consume and revertOwnGuildBookOps (resync),
-  // onGuildDisbanded (dropGuild), leave (dropSession).
+  // The per-guild holder index behind the unsettled gate
+  // (server/guild_book_holders.ts owns the maintenance contract).
   private readonly guildBookHolders = new GuildBookHolderIndex<ClientSession>();
   // Weapon-skin loadouts are whole-record replacements in their dedicated paid
   // state row. Keep one FIFO per account so rapid apply/detach commands cannot
@@ -5143,10 +5138,8 @@ export class GameServer {
   // round trip instead of an autosave interval.
   static readonly GUILD_BANK_DEFICIT_MAX_SKIPS = 2;
 
-  // The escrow REFUSAL arm lives in server/guild_bank_escrow_refusal.ts (its
-  // design note is there); this is the GameServer seam it runs behind. The
-  // holder flush it shares with the dispatch-time unsettled gate is
-  // flushGuildBookHolders below.
+  // The escrow REFUSAL arm (server/guild_bank_escrow_refusal.ts) behind its
+  // GameServer seam; it shares flushGuildBookHolders with the unsettled gate.
   private handleGuildBankEscrowRefusal(
     session: ClientSession,
     results: readonly GuildBankWriteResult[],
@@ -5172,14 +5165,9 @@ export class GameServer {
     );
   }
 
-  // Flush the holders whose unflushed work FEEDS the named dependency (never
-  // an unrelated holder), at most GUILD_BOOK_FLUSH_FAN_OUT_MAX of them, each
-  // through the background-permit save with one flush in flight per holder
-  // and a single re-arm behind it (server/guild_book_holders.ts). The
-  // unsettled gate's refusal and the escrow refusal's retry arm both call it,
-  // so the retry lands a round trip later rather than an autosave later; a
-  // refusal costs its sender only an op-guard token, so anything looser would
-  // let one officer stack saves on the realm's writer.
+  // Flush the holders feeding the named dependency, bounded and coalesced,
+  // through the background-permit save (server/guild_book_holders.ts): the
+  // gate's refusal and the escrow arm's retry both land here.
   private flushGuildBookHolders(
     guildId: number,
     except: ClientSession,

--- a/server/game.ts
+++ b/server/game.ts
@@ -265,12 +265,7 @@ import {
   createGuildBankOpGuard,
   type GuildBankOpGuardState,
 } from './guild_bank_op_guard';
-import {
-  GUILD_BOOK_FLUSH_COOLDOWN_MS,
-  type GuildBankOpRequest,
-  guildBookHolders,
-  unsettledGuildBook,
-} from './guild_bank_settle_gate';
+import type { GuildBankOpRequest, GuildBookDependency } from './guild_bank_settle_gate';
 import {
   collectGuildBankDeltas,
   // Imported from the module that DEFINES it, never through ./db: every test
@@ -280,6 +275,7 @@ import {
   type GuildBankWriteResult,
   loadGuildBanksIntoSim,
 } from './guild_bank_state';
+import { GuildBookHolderIndex, requestGuildBookFlush } from './guild_book_holders';
 import { createPaidGuildWithLeaderAtomic } from './guild_create_db';
 import { gameMetricsCounters, type WsDropCause } from './http/game_signals';
 import { bgWideInterestApplies, buildSharedInterestCandidates } from './interest_candidates';
@@ -1210,10 +1206,11 @@ export interface ClientSession extends MovementInputSessionState {
   // only bounds how long a session waits for the other officer's commit before
   // it is rolled back and disconnected instead.
   guildBankDeficitSkips: Map<number, number>;
-  // When this session was last flushed as a guild book HOLDER (the unsettled
-  // gate's refusal, the escrow refusal's retry arm); flushGuildBookHolders
-  // damps on it. Zero until the first flush.
-  guildBookFlushedAtMs: number;
+  // The coalesced holder flush (server/guild_book_holders.ts
+  // requestGuildBookFlush): one flush queued or running per holder, one
+  // re-arm behind it.
+  guildBookFlushInFlight: boolean;
+  guildBookFlushRearm: boolean;
   // Set once this session's book work can never become durable and its live
   // state has therefore been abandoned. A quarantined session persists
   // NOTHING, ever again: its character half is the half that would carry the
@@ -1833,6 +1830,12 @@ export class GameServer {
   // One FIFO per character id: every durable LIVE-SESSION character write
   // rides it, so commit order is enqueue order (exceptions: server/CLAUDE.md).
   readonly characterSaveQueues = createKeyedSerialWriter<number>();
+  // Which sessions hold unflushed work on which guild's book, with each
+  // holder's unsettled contribution cached (server/guild_book_holders.ts).
+  // Maintained at every mark or log change: markGuildBankDirty (touch), the
+  // post-commit prefix consume and revertOwnGuildBookOps (resync),
+  // onGuildDisbanded (dropGuild), leave (dropSession).
+  private readonly guildBookHolders = new GuildBookHolderIndex<ClientSession>();
   // Weapon-skin loadouts are whole-record replacements in their dedicated paid
   // state row. Keep one FIFO per account so rapid apply/detach commands cannot
   // commit on separate pool clients in reverse order and resurrect stale state.
@@ -2596,6 +2599,7 @@ export class GameServer {
           s.unflushedGuildBankOps.delete(guildId);
           s.guildBankDeficitSkips.delete(guildId);
         }
+        this.guildBookHolders.dropGuild(guildId);
       },
       // The disband guard's read, and the OPEN of the guild-delete window it
       // has to hold. Returns the LIVE sim book's holdings, or null (the guard
@@ -3850,7 +3854,8 @@ export class GameServer {
       bankLedgerSaveScheduled: false,
       unflushedGuildBankOps: new Map(),
       guildBankDeficitSkips: new Map(),
-      guildBookFlushedAtMs: 0,
+      guildBookFlushInFlight: false,
+      guildBookFlushRearm: false,
       escrowQuarantined: false,
       inFlightGuildBankOps: new Map(),
       ignoredIds: new Set(),
@@ -4333,6 +4338,7 @@ export class GameServer {
     }
     session.bankLedgerJournal.outbox.discard();
     this.sessionsByCharacterId.delete(session.characterId);
+    this.guildBookHolders.dropSession(session);
     storageRecovery.offline(session.characterId);
     // Release the per-character load lease so a fresh login (here or on another
     // process) can reload the character without waiting out the TTL. Order
@@ -4494,6 +4500,7 @@ export class GameServer {
     }
     if (!session.bankLedgerJournal.outbox.acknowledgeCommittedPrefix(snapshot, batches)) return;
     consumeCommittedGuildLedgerPrefix(session, guildCounts);
+    this.guildBookHolders.resync(session);
     visitGuildLedgerIdsForOps(batches, GUILD_BANK_LOG_VISIBLE_OPS, bustGuildBankLog);
   }
 
@@ -4827,6 +4834,7 @@ export class GameServer {
             session.guildBankDeficitSkips.delete(guildId);
           }
         }
+        this.guildBookHolders.resync(session);
         // The blob is durable: publish every unlock it contains. A rejected
         // save skips this (the throw propagates past it), leaving the ids
         // pending for the next save attempt (the 30s autosave, the next
@@ -5084,6 +5092,7 @@ export class GameServer {
   // Schedule a guild's book for the next fenced escrow save of this session.
   private markGuildBankDirty(session: ClientSession, guildId: number): void {
     session.dirtyGuildBanks.set(guildId, (session.dirtyGuildBanks.get(guildId) ?? 0) + 1);
+    this.guildBookHolders.touch(session, guildId);
   }
 
   // When this session's escrow can never commit again, its guild-book
@@ -5109,6 +5118,7 @@ export class GameServer {
       dead.dirtyGuildBanks.delete(guildId);
       dead.unflushedGuildBankOps.delete(guildId);
       dead.guildBankDeficitSkips.delete(guildId);
+      this.guildBookHolders.resync(dead);
       if (log.length === 0) continue;
       // Counted per GUILD, the unit the remedy applies to: reaching this at
       // all means a session that can never commit again held unflushed book
@@ -5145,8 +5155,10 @@ export class GameServer {
     handleEscrowRefusal(
       {
         maxDeficitSkips: GameServer.GUILD_BANK_DEFICIT_MAX_SKIPS,
-        sessions: () => this.sessionsByCharacterId.values(),
-        flushHolders: (guildId, except) => this.flushGuildBookHolders(guildId, except),
+        holders: (guildId, except) =>
+          this.guildBookHolders.holders(guildId, except, { includeLeaving: false }),
+        flushHolders: (guildId, except, dependency) =>
+          this.flushGuildBookHolders(guildId, except, dependency),
         revertOwnGuildBookOps: (s, guildIds) => this.revertOwnGuildBookOps(s, guildIds),
         kickSession: (s) => {
           void this.kickSession(s, 'character taken over', 'guild bank escrow rollback');
@@ -5160,24 +5172,24 @@ export class GameServer {
     );
   }
 
-  // Fire-and-forget saves for the sessions whose unflushed work on this
-  // guild's book another session is waiting on: the unsettled gate's refusal
-  // and the escrow refusal's retry arm both call it, so the retry lands a
-  // round trip later rather than an autosave interval later. Never a
-  // departing session (its leave flush is already in flight), and never the
-  // same holder twice inside GUILD_BOOK_FLUSH_COOLDOWN_MS: a refusal costs its
-  // sender only an op-guard token, so an undamped fan-out would let one
-  // officer force a save per dirty guildmate per refusal.
-  private flushGuildBookHolders(guildId: number, except: ClientSession): void {
-    const now = Date.now();
-    const holders = guildBookHolders(this.sessionsByCharacterId.values(), guildId, except, {
-      includeLeaving: false,
-    });
-    for (const s of holders) {
-      if (now - s.guildBookFlushedAtMs < GUILD_BOOK_FLUSH_COOLDOWN_MS) continue;
-      s.guildBookFlushedAtMs = now;
-      void this.saveCharacter(s).catch((err) =>
-        console.error(`guild bank deficit flush failed for ${s.name}:`, err),
+  // Flush the holders whose unflushed work FEEDS the named dependency (never
+  // an unrelated holder), at most GUILD_BOOK_FLUSH_FAN_OUT_MAX of them, each
+  // through the background-permit save with one flush in flight per holder
+  // and a single re-arm behind it (server/guild_book_holders.ts). The
+  // unsettled gate's refusal and the escrow refusal's retry arm both call it,
+  // so the retry lands a round trip later rather than an autosave later; a
+  // refusal costs its sender only an op-guard token, so anything looser would
+  // let one officer stack saves on the realm's writer.
+  private flushGuildBookHolders(
+    guildId: number,
+    except: ClientSession,
+    dependency: GuildBookDependency | null,
+  ): void {
+    for (const holder of this.guildBookHolders.contributors(guildId, except, dependency)) {
+      requestGuildBookFlush(holder, (s) =>
+        this.saveCharacterWithBackgroundPermit(s).catch((err) =>
+          console.error(`guild bank deficit flush failed for ${s.name}:`, err),
+        ),
       );
     }
   }
@@ -5201,16 +5213,12 @@ export class GameServer {
         bankLedgerNeedsSave: () => bankLedgerJournalNeedsSave(session.bankLedgerJournal.outbox),
         scheduleBankLedgerHighWaterSave: () => this.scheduleBankLedgerHighWaterSave(session),
         markGuildBankDirty: (guildId) => this.markGuildBankDirty(session, guildId),
-        // The unsettled gate's inputs: every OTHER live session's unflushed
-        // work on this book (a departing session's included, its leave flush
-        // has not committed yet), and the flush a refusal fires.
-        unsettledGuildBook: (guildId) =>
-          unsettledGuildBook(
-            guildBookHolders(this.sessionsByCharacterId.values(), guildId, session, {
-              includeLeaving: true,
-            }).map((s) => s.unflushedGuildBankOps.get(guildId) ?? []),
-          ),
-        flushUnsettledGuildBook: (guildId) => this.flushGuildBookHolders(guildId, session),
+        // The unsettled gate's inputs: every OTHER holder's cached
+        // contribution on this book (a departing session's included, its
+        // leave flush has not committed yet), and the flush a refusal fires.
+        unsettledGuildBook: (guildId) => this.guildBookHolders.unsettled(guildId, session),
+        flushUnsettledGuildBook: (guildId, dependency) =>
+          this.flushGuildBookHolders(guildId, session, dependency),
         recordGuildBankIncident: (kind) => gameMetricsCounters().guildBankIncident(kind),
         logError: (message) => console.error(message),
       },

--- a/server/guild_bank_escrow_refusal.ts
+++ b/server/guild_bank_escrow_refusal.ts
@@ -38,7 +38,7 @@
 
 import type { GuildBankOpDelta } from '../src/sim/guild_bank';
 import { recordGuildBankEscrowRollback } from './bank_ledger';
-import { guildBookHolders } from './guild_bank_settle_gate';
+import { deficitDependency, type GuildBookDependency } from './guild_bank_settle_gate';
 import type { GuildBankWriteResult } from './guild_bank_state';
 import type { GuildBankIncident } from './http/game_signals';
 
@@ -58,11 +58,16 @@ export interface EscrowRefusalHostPort<S extends EscrowRefusalSession> {
   /** GameServer.GUILD_BANK_DEFICIT_MAX_SKIPS: how many consecutive refusals
    *  one session tolerates for one guild before it is rolled back. */
   readonly maxDeficitSkips: number;
-  /** Every live session of the realm (the holder scan reads all of them). */
-  readonly sessions: () => Iterable<S>;
-  /** Fire-and-forget saves for the sessions whose unflushed work on this
-   *  book the refused replay is waiting on. */
-  readonly flushHolders: (guildId: number, except: S) => void;
+  /** The OTHER live, non-departing sessions holding unflushed work on this
+   *  guild's book (server/guild_book_holders.ts). */
+  readonly holders: (guildId: number, except: S) => readonly S[];
+  /** Flush the holders whose unflushed work FEEDS the refused dependency, so
+   *  the retry lands a round trip later (bounded and coalesced by the host). */
+  readonly flushHolders: (
+    guildId: number,
+    except: S,
+    dependency: GuildBookDependency | null,
+  ) => void;
   /** Undo exactly this session's own unflushed deltas on the live books. */
   readonly revertOwnGuildBookOps: (session: S, guildIds: number[]) => void;
   /** Disconnect the abandoned session so it reloads from its durable row. */
@@ -90,8 +95,7 @@ export function handleGuildBankEscrowRefusal<S extends EscrowRefusalSession>(
     // it will never commit them, so counting it would burn every retry
     // (blocking this session's character saves the whole time) before
     // reaching the same rollback.
-    const anotherSessionDirty =
-      guildBookHolders(host.sessions(), guildId, session, { includeLeaving: false }).length > 0;
+    const anotherSessionDirty = host.holders(guildId, session).length > 0;
     const skips = (session.guildBankDeficitSkips.get(guildId) ?? 0) + 1;
     const canResolve =
       !final && anotherSessionDirty && !result.rowUnusable && skips < host.maxDeficitSkips;
@@ -116,7 +120,7 @@ export function handleGuildBankEscrowRefusal<S extends EscrowRefusalSession>(
       // flush back, and an unbounded ping-pong of fire-and-forget saves
       // between two mutually-stuck sessions is worse than the wait it saves.
       if (skips > 1) continue;
-      host.flushHolders(guildId, session);
+      host.flushHolders(guildId, session, deficitDependency(result.deficit));
       continue;
     }
     const log = session.unflushedGuildBankOps.get(guildId) ?? [];

--- a/server/guild_bank_escrow_refusal.ts
+++ b/server/guild_bank_escrow_refusal.ts
@@ -1,0 +1,160 @@
+// The escrow REFUSAL arm, extracted from GameServer.saveCharacter's catch
+// (move-not-rewrite from server/game.ts; the host port below is the exact set
+// of GameServer seams the arm used). The book half could not be replayed onto
+// durable truth, so the whole transaction rolled back and this save persisted
+// NOTHING: not the books, not the character. That is the invariant the
+// feature rests on, stated as a rule rather than as a residue:
+//
+//   If the book half cannot be applied, the character half must not commit.
+//
+// Carrying the shortfall and recording it was the alternative, and it is a
+// two-account money printer: officer A deposits without flushing, officer B
+// withdraws, B's character half commits while the book half does not, then A
+// gets itself fenced (an ordinary re-login) so nothing will ever make A's
+// deposit durable. B keeps the copper, A's stake comes back, repeatable on
+// demand. Refusing removes it: B's purse can never durably gain what the
+// book never durably lost.
+//
+// Two outcomes:
+// - RETRY, while another session still holds unflushed work for the guild:
+//   their commit is what makes this replay applicable, and it lands within
+//   an autosave interval. Nothing is consumed; the marks and the log are
+//   exactly as they were.
+// - ROLL BACK, when no other session holds unflushed work (so nothing will
+//   ever make the missing value durable) or the retries ran out. This
+//   session's live state is abandoned: its own book ops come back off the
+//   live book, it is QUARANTINED so it can never persist again, one
+//   aggregate anomaly row records the incident, and it is disconnected to
+//   reload from its durable row. Everything it did since its last successful
+//   save is lost, which is exactly what a lease fence-out already does, and
+//   it conserves precisely because none of it was ever durable.
+//
+// Since the unsettled gate (server/guild_bank_settle_gate.ts) a session's
+// log can no longer carry a consume of another session's not-yet-durable
+// work, so an ordinary two-officer session never reaches this arm at all: it
+// is the BACKSTOP for a row that became unusable, a tampered book, or a
+// dependency the gate could not see. The retry bound below still matters
+// because a mutual dependency, once it exists, can never resolve.
+
+import type { GuildBankOpDelta } from '../src/sim/guild_bank';
+import { recordGuildBankEscrowRollback } from './bank_ledger';
+import { guildBookHolders } from './guild_bank_settle_gate';
+import type { GuildBankWriteResult } from './guild_bank_state';
+import type { GuildBankIncident } from './http/game_signals';
+
+/** The slice of a live session the refusal arm reads and writes
+ *  (structural, so GameServer's ClientSession satisfies it). */
+export interface EscrowRefusalSession {
+  readonly characterId: number;
+  readonly accountId: number;
+  escrowQuarantined: boolean;
+  readonly left: boolean;
+  readonly dirtyGuildBanks: Map<number, number>;
+  readonly unflushedGuildBankOps: Map<number, GuildBankOpDelta[]>;
+  readonly guildBankDeficitSkips: Map<number, number>;
+}
+
+export interface EscrowRefusalHostPort<S extends EscrowRefusalSession> {
+  /** GameServer.GUILD_BANK_DEFICIT_MAX_SKIPS: how many consecutive refusals
+   *  one session tolerates for one guild before it is rolled back. */
+  readonly maxDeficitSkips: number;
+  /** Every live session of the realm (the holder scan reads all of them). */
+  readonly sessions: () => Iterable<S>;
+  /** Fire-and-forget saves for the sessions whose unflushed work on this
+   *  book the refused replay is waiting on. */
+  readonly flushHolders: (guildId: number, except: S) => void;
+  /** Undo exactly this session's own unflushed deltas on the live books. */
+  readonly revertOwnGuildBookOps: (session: S, guildIds: number[]) => void;
+  /** Disconnect the abandoned session so it reloads from its durable row. */
+  readonly kickSession: (session: S) => void;
+  readonly recordIncident: (kind: GuildBankIncident) => void;
+  readonly logError: (message: string) => void;
+}
+
+export function handleGuildBankEscrowRefusal<S extends EscrowRefusalSession>(
+  host: EscrowRefusalHostPort<S>,
+  session: S,
+  results: readonly GuildBankWriteResult[],
+  // True when this is the LAST save this session will ever get (the leave
+  // flush, or the shutdown flush's second pass). There is no later retry to
+  // wait for, so the refusal is resolved now rather than left to a save that
+  // will never come: otherwise the session would tear down with its progress
+  // discarded and no log line and no ledger row to say why.
+  final = false,
+): void {
+  let quarantine = false;
+  for (const result of results) {
+    if (result.written) continue;
+    const guildId = result.guildId;
+    // A quarantined or departing session's marks are NOT a reason to wait:
+    // it will never commit them, so counting it would burn every retry
+    // (blocking this session's character saves the whole time) before
+    // reaching the same rollback.
+    const anotherSessionDirty =
+      guildBookHolders(host.sessions(), guildId, session, { includeLeaving: false }).length > 0;
+    const skips = (session.guildBankDeficitSkips.get(guildId) ?? 0) + 1;
+    const canResolve =
+      !final && anotherSessionDirty && !result.rowUnusable && skips < host.maxDeficitSkips;
+    if (canResolve) {
+      // ORDINARY CONCURRENCY, not a failure: another officer of this guild
+      // holds unflushed work, their commit is what makes this replay
+      // applicable, and the flush below makes that a round trip rather than
+      // an autosave interval. Nothing was consumed and nothing is lost, so
+      // it gets its own counter kind: sharing escrow_save_failed made that
+      // counter unusable for `> 0` alerting. Counted per GUILD, the unit the
+      // retry applies to.
+      host.recordIncident('escrow_refused_retry');
+      session.guildBankDeficitSkips.set(guildId, skips);
+      // Do not wait out an autosave interval: FLUSH the sessions whose
+      // unflushed work this replay is waiting on, so the retry lands a round
+      // trip later rather than 30 seconds later. This is what keeps the
+      // blocked window (during which THIS character persists nothing at all,
+      // including progress that has nothing to do with the guild bank) to
+      // the shortest it can be, and it is why the skip bound is small.
+      //
+      // Only on the FIRST refusal: if that flush is itself refused it will
+      // flush back, and an unbounded ping-pong of fire-and-forget saves
+      // between two mutually-stuck sessions is worse than the wait it saves.
+      if (skips > 1) continue;
+      host.flushHolders(guildId, session);
+      continue;
+    }
+    const log = session.unflushedGuildBankOps.get(guildId) ?? [];
+    recordGuildBankEscrowRollback(session, guildId, log, result.deficit);
+    host.logError(
+      `guild bank escrow rolled back for guild ${guildId} (character ${session.characterId}): ${
+        result.rowUnusable
+          ? 'the stored row is oversized or malformed, its live shadow vanished, or the merged book would cross the size bound, so it is preserved untouched'
+          : `${result.deficit?.kind} shortfall ${result.deficit?.shortfall} on ${result.deficit?.op}${result.deficit?.itemId ? ` (${result.deficit.itemId})` : ''}, and ${
+              anotherSessionDirty
+                ? `it did not resolve within ${skips} escrow saves`
+                : 'no other session holds unflushed work for this guild, so it never can'
+            }`
+      }. The session is quarantined and disconnected; nothing it did since its last save was durable, so nothing is lost that was.`,
+    );
+    quarantine = true;
+  }
+  if (!quarantine) return;
+  // TERMINAL: this refusal will never resolve, so the save really did fail
+  // for good (character half included, nothing durable). That is what
+  // escrow_save_failed means, and it is booked here rather than at the throw
+  // site so a refusal that merely RETRIES never reaches it. Counted once per
+  // SAVE, matching the db-threw arm in saveCharacter.
+  host.recordIncident('escrow_save_failed');
+  // The terminal arm of the escrow design and the one an operator should
+  // alert on: a live session is being abandoned because its book half can
+  // never be replayed onto durable truth. Counted once per SESSION (the unit
+  // the remedy applies to; the per-guild reverts it triggers are counted as
+  // 'reconcile' inside revertOwnGuildBookOps), beside the loud log that
+  // carries the guild id and the deficit.
+  host.recordIncident('escrow_quarantined');
+  // The character half is the half that would carry the value the book half
+  // could not, so this session must never save again.
+  session.escrowQuarantined = true;
+  // Undo EVERY book this session dirtied, not only the refused one: the
+  // session as a whole is abandoned, so its deltas in a second guild's book
+  // are live value nobody will ever make durable, and another officer
+  // withdrawing that phantom value would be refused in turn.
+  host.revertOwnGuildBookOps(session, [...session.dirtyGuildBanks.keys()]);
+  if (!session.left) host.kickSession(session);
+}

--- a/server/guild_bank_op_coordinator.ts
+++ b/server/guild_bank_op_coordinator.ts
@@ -21,6 +21,12 @@ import {
   counterpartySnapshot,
   stampCounterpartyDeltas,
 } from './guild_bank_counterparty';
+import {
+  type GuildBankOpRequest,
+  guildBankUnsettledRefusal,
+  isGuildBankGatedOp,
+  type UnsettledGuildBook,
+} from './guild_bank_settle_gate';
 
 export type GuildBankOpTarget =
   | { readonly pid: number }
@@ -55,7 +61,13 @@ export interface GuildBankOpHostPort {
   readonly bankLedgerNeedsSave: () => boolean;
   readonly scheduleBankLedgerHighWaterSave: () => void;
   readonly markGuildBankDirty: (guildId: number) => void;
-  readonly recordGuildBankIncident: (kind: 'counterparty_orphan') => void;
+  /** Every OTHER live session's unflushed work on this guild's book,
+   *  aggregated for the unsettled gate (server/guild_bank_settle_gate.ts). */
+  readonly unsettledGuildBook: (guildId: number) => UnsettledGuildBook;
+  /** Fire-and-forget saves for the sessions holding that work, so a refused
+   *  op's retry lands a round trip later rather than an autosave later. */
+  readonly flushUnsettledGuildBook: (guildId: number) => void;
+  readonly recordGuildBankIncident: (kind: 'counterparty_orphan' | 'unsettled_refused') => void;
   readonly logError: (message: string) => void;
 }
 
@@ -73,6 +85,8 @@ export function runGuildBankOp(
   target: GuildBankOpTarget,
   op: GuildBankLedgerOp,
   run: () => void,
+  // The op's client-supplied inputs, read by the unsettled gate only.
+  request: GuildBankOpRequest = {},
 ): void {
   const playerTarget = 'pid' in target;
   const actingGuildId = playerTarget
@@ -83,6 +97,30 @@ export function runGuildBankOp(
       host.sendPlayerNotice('The guild bank is closing. Try again in a moment.');
     }
     return;
+  }
+
+  // The unsettled gate (server/guild_bank_settle_gate.ts): a withdraw, a gold
+  // withdraw, or a rung purchase that would consume value another session has
+  // not made durable yet is refused BEFORE admission (nothing mutates, nothing
+  // is reserved, no row and no mark), and the holders are flushed so the
+  // retry lands a round trip later. Player targets only: the operator purge
+  // removes a dormant copy, which can only be durable. The notice is English
+  // on the wire, re-localized by the client matcher (src/ui/server_i18n.ts
+  // guild.bankSettling).
+  if (playerTarget && actingGuildId !== undefined && isGuildBankGatedOp(op)) {
+    const live = host.sim.guildBankInfoFor(target.pid);
+    const refusal =
+      live === null
+        ? null
+        : guildBankUnsettledRefusal(op, request, live, host.unsettledGuildBook(actingGuildId));
+    if (refusal !== null) {
+      host.recordGuildBankIncident('unsettled_refused');
+      host.sendPlayerNotice(
+        'The guild bank is still saving a recent change. Try again in a moment.',
+      );
+      host.flushUnsettledGuildBook(actingGuildId);
+      return;
+    }
   }
 
   const reservation = session.bankLedgerJournal.admission.tryReserve(2, 2, 'guild');

--- a/server/guild_bank_op_coordinator.ts
+++ b/server/guild_bank_op_coordinator.ts
@@ -23,6 +23,7 @@ import {
 } from './guild_bank_counterparty';
 import {
   type GuildBankOpRequest,
+  type GuildBookDependency,
   guildBankUnsettledRefusal,
   isGuildBankGatedOp,
   type UnsettledGuildBook,
@@ -64,9 +65,9 @@ export interface GuildBankOpHostPort {
   /** Every OTHER live session's unflushed work on this guild's book,
    *  aggregated for the unsettled gate (server/guild_bank_settle_gate.ts). */
   readonly unsettledGuildBook: (guildId: number) => UnsettledGuildBook;
-  /** Fire-and-forget saves for the sessions holding that work, so a refused
+  /** Flush the holders whose work FEEDS the refused dependency, so a refused
    *  op's retry lands a round trip later rather than an autosave later. */
-  readonly flushUnsettledGuildBook: (guildId: number) => void;
+  readonly flushUnsettledGuildBook: (guildId: number, dependency: GuildBookDependency) => void;
   readonly recordGuildBankIncident: (kind: 'counterparty_orphan' | 'unsettled_refused') => void;
   readonly logError: (message: string) => void;
 }
@@ -102,15 +103,19 @@ export function runGuildBankOp(
   // The unsettled gate (server/guild_bank_settle_gate.ts): a withdraw, a gold
   // withdraw, or a rung purchase that would consume value another session has
   // not made durable yet is refused BEFORE admission (nothing mutates, nothing
-  // is reserved, no row and no mark), and the holders are flushed so the
-  // retry lands a round trip later. Player targets only: the operator purge
-  // removes a dormant copy, which can only be durable. The notice is English
-  // on the wire, re-localized by the client matcher (src/ui/server_i18n.ts
+  // is reserved, no row and no mark), and the holders feeding that dependency
+  // are flushed so the retry lands a round trip later. Player targets only:
+  // the operator purge removes a dormant copy, which can only be durable.
+  // EDIT AUTHORITY FIRST: guildBankInfoFor hands every guild member a view,
+  // read-only for a plain member (canEdit false), whose op the sim refuses on
+  // rank; that view never reaches the gate, so a member can neither buy an
+  // incident nor force a holder flush. The notice is English on the wire,
+  // re-localized by the client matcher (src/ui/server_i18n.ts
   // guild.bankSettling).
   if (playerTarget && actingGuildId !== undefined && isGuildBankGatedOp(op)) {
     const live = host.sim.guildBankInfoFor(target.pid);
     const refusal =
-      live === null
+      live === null || !live.canEdit
         ? null
         : guildBankUnsettledRefusal(op, request, live, host.unsettledGuildBook(actingGuildId));
     if (refusal !== null) {
@@ -118,7 +123,7 @@ export function runGuildBankOp(
       host.sendPlayerNotice(
         'The guild bank is still saving a recent change. Try again in a moment.',
       );
-      host.flushUnsettledGuildBook(actingGuildId);
+      host.flushUnsettledGuildBook(actingGuildId, refusal);
       return;
     }
   }

--- a/server/guild_bank_settle_gate.ts
+++ b/server/guild_bank_settle_gate.ts
@@ -4,7 +4,7 @@
 // UNSETTLED: consuming it puts a replay dependency on that session into this
 // session's escrow log, and the escrow save honours only a ONE-WAY dependency
 // (its refusal arm flushes the other session and retries, see
-// server/game.ts handleGuildBankEscrowRefusal).
+// server/guild_bank_escrow_refusal.ts).
 //
 // Two sessions that each consumed the other's unsettled value can never
 // commit in any order. The 2026-09-01 production incident was exactly that
@@ -26,10 +26,12 @@
 // an officer reaches for a deposit made moments ago, and the host flushes the
 // depositor on the spot so the retry lands a round trip later.
 //
-// Pure: the host hands over the live book snapshot and the OTHER live
-// sessions' unflushed logs; nothing here touches a session or the sim.
+// Pure: the host hands over the live book snapshot and the OTHER holders'
+// contributions (server/guild_book_holders.ts keeps them indexed per guild and
+// cached per holder); nothing here touches a session or the sim.
 
 import {
+  type GuildBankDeltaDeficit,
   type GuildBankOpDelta,
   guildBankDeltaIdentityKey,
   guildBankRungsBought,
@@ -48,47 +50,34 @@ export function isGuildBankGatedOp(op: string): op is GuildBankGatedOp {
 }
 
 /** The client-supplied inputs of one op, as the dispatch site received them
- *  (already type-checked there; the gate re-validates the shapes it reads). */
+ *  (already type-checked there). The gate mirrors the sim's own admissibility
+ *  checks on them and passes every inadmissible shape through UNJUDGED, so a
+ *  request the sim is going to refuse anyway can never buy a refusal, an
+ *  incident, or a holder flush. */
 export interface GuildBankOpRequest {
   readonly slot?: number;
   readonly count?: number;
   readonly amount?: number;
 }
 
-export type GuildBankUnsettledKind = 'items' | 'copper' | 'ladder';
-
-/** How long after a holder was flushed the host must NOT flush it again, in
- *  milliseconds. The flush exists so a refused op's retry lands a round trip
- *  later, and one flush per holder buys exactly that; a second one inside
- *  the window would only stack a save behind one still in flight. The bound
- *  it gives: a refusal costs its sender no more than an op-guard token, so
- *  without it one officer refusing at the guard's rate could force a save per
- *  dirty guildmate per refusal. With it, the fan-out is at most one extra save
- *  per holder per window, whoever is refusing and however often. */
-export const GUILD_BOOK_FLUSH_COOLDOWN_MS = 1_000;
-
-/** What OTHER sessions' unflushed logs still hold on one guild's book: the
- *  part of the live book durable truth may not have when the acting session's
- *  replay runs.
+/** One holder's contribution to a book's unsettled value: its OWN net per
+ *  identity key and net treasury copper, positives only, plus whether it holds
+ *  a ladder rung. The sum over holders is what the gate judges against.
  *
- *  Summed PER SESSION, positives only. A commit is atomic per session, so the
- *  worst durable base for the acting replay is every net-REMOVING holder
- *  already committed (durable lowered) and every net-DEPOSITING holder not
- *  yet committed (its copies still unsettled): `live - sum over holders of
- *  max(0, holder's net)`. Netting one holder's withdrawal against another
- *  holder's deposit would hide the deposit (holder C's withdraw of 10 cancels
- *  holder B's deposit of 10, and the acting officer takes B's copies ungated),
- *  which is the same two-identity cycle the gate exists to refuse, one officer
- *  removed. */
-export interface UnsettledGuildBook {
-  /** Per identity key (the escrow replay's three-dimensional key): the sum
-   *  over holders of each holder's POSITIVE net copies (deposits minus its own
-   *  removals, floored at zero). */
+ *  Positives only, PER HOLDER: a commit is atomic per session, so the worst
+ *  durable base for the acting replay is every net-REMOVING holder already
+ *  committed (durable lowered) and every net-DEPOSITING holder not yet
+ *  committed (its copies still unsettled). Netting one holder's withdrawal
+ *  against another holder's deposit would hide the deposit (holder C's
+ *  withdraw of 10 cancels holder B's deposit of 10, and the acting officer
+ *  takes B's copies ungated), which is the same two-identity cycle the gate
+ *  exists to refuse, one officer removed. */
+export interface GuildBookContribution {
+  /** Per identity key (the escrow replay's three-dimensional key). */
   readonly items: ReadonlyMap<string, number>;
-  /** The sum over holders of each holder's POSITIVE net treasury copper the
-   *  replay would MOVE. open_bank is excluded (rung 0 is purse-paid and the
-   *  applier never moves it), buy_slots is included (its charge left the
-   *  treasury). */
+  /** Net treasury copper the replay would MOVE. open_bank is excluded (rung 0
+   *  is purse-paid and the applier never moves it), buy_slots is included (its
+   *  charge left the treasury). */
   readonly copper: number;
   /** True while any slot op is outstanding: a rung replays only onto the exact
    *  ladder position its witness names, so a rung bought on top of an
@@ -96,39 +85,99 @@ export interface UnsettledGuildBook {
   readonly ladder: boolean;
 }
 
-export function unsettledGuildBook(
-  logs: Iterable<readonly GuildBankOpDelta[]>,
+/** The sum of the OTHER holders' contributions on one guild's book. */
+export type UnsettledGuildBook = GuildBookContribution;
+
+export const SETTLED_BOOK: UnsettledGuildBook = { items: new Map(), copper: 0, ladder: false };
+
+export function holderContribution(log: readonly GuildBankOpDelta[]): GuildBookContribution {
+  const own = new Map<string, number>();
+  let copper = 0;
+  let ladder = false;
+  for (const d of log) {
+    if (d.op === 'open_bank' || d.op === 'buy_slots') {
+      ladder = true;
+      if (d.op === 'buy_slots') copper += Number(d.copperDelta) || 0;
+      continue;
+    }
+    if (d.op === 'deposit_gold' || d.op === 'withdraw_gold') {
+      copper += Number(d.copperDelta) || 0;
+      continue;
+    }
+    if (typeof d.itemId !== 'string' || d.itemId === '') continue;
+    const count = Math.max(0, Math.floor(Number(d.count)) || 0);
+    if (count === 0) continue;
+    const key = guildBankDeltaIdentityKey(d);
+    own.set(key, (own.get(key) ?? 0) + (d.op === 'deposit' ? count : -count));
+  }
+  const items = new Map<string, number>();
+  for (const [key, net] of own) if (net > 0) items.set(key, net);
+  return { items, copper: Math.max(0, copper), ladder };
+}
+
+export function sumContributions(
+  contributions: Iterable<GuildBookContribution>,
 ): UnsettledGuildBook {
   const items = new Map<string, number>();
   let copper = 0;
   let ladder = false;
-  for (const log of logs) {
-    // One holder's own net, keyed like the replay; only its positive part
-    // joins the total (see the interface note).
-    const own = new Map<string, number>();
-    let ownCopper = 0;
-    for (const d of log) {
-      if (d.op === 'open_bank' || d.op === 'buy_slots') {
-        ladder = true;
-        if (d.op === 'buy_slots') ownCopper += Number(d.copperDelta) || 0;
-        continue;
-      }
-      if (d.op === 'deposit_gold' || d.op === 'withdraw_gold') {
-        ownCopper += Number(d.copperDelta) || 0;
-        continue;
-      }
-      if (typeof d.itemId !== 'string' || d.itemId === '') continue;
-      const count = Math.max(0, Math.floor(Number(d.count)) || 0);
-      if (count === 0) continue;
-      const key = guildBankDeltaIdentityKey(d);
-      own.set(key, (own.get(key) ?? 0) + (d.op === 'deposit' ? count : -count));
-    }
-    for (const [key, net] of own) {
-      if (net > 0) items.set(key, (items.get(key) ?? 0) + net);
-    }
-    if (ownCopper > 0) copper += ownCopper;
+  for (const c of contributions) {
+    for (const [key, net] of c.items) items.set(key, (items.get(key) ?? 0) + net);
+    copper += c.copper;
+    ladder = ladder || c.ladder;
   }
   return { items, copper, ladder };
+}
+
+/** Convenience for callers holding raw logs (tests, the unit pins). */
+export function unsettledGuildBook(
+  logs: Iterable<readonly GuildBankOpDelta[]>,
+): UnsettledGuildBook {
+  const contributions: GuildBookContribution[] = [];
+  for (const log of logs) contributions.push(holderContribution(log));
+  return sumContributions(contributions);
+}
+
+/** What a refused op would have consumed, named so the host flushes ONLY the
+ *  holders whose work feeds it. `items` names the exact identity the gate
+ *  matched; `items_of` is the escrow refusal arm's coarser view (its deficit
+ *  carries an item id and no payload). */
+export type GuildBookDependency =
+  | { readonly kind: 'items'; readonly key: string }
+  | { readonly kind: 'items_of'; readonly itemId: string }
+  | { readonly kind: 'copper' }
+  | { readonly kind: 'ladder' };
+
+export function contributesTo(c: GuildBookContribution, dep: GuildBookDependency): boolean {
+  switch (dep.kind) {
+    case 'items':
+      return (c.items.get(dep.key) ?? 0) > 0;
+    case 'items_of': {
+      const prefix = `${dep.itemId}|`;
+      for (const [key, net] of c.items) if (net > 0 && key.startsWith(prefix)) return true;
+      return false;
+    }
+    case 'copper':
+      return c.copper > 0;
+    case 'ladder':
+      return c.ladder;
+  }
+}
+
+/** The escrow refusal arm's deficit, as a dependency the flush can filter on. */
+export function deficitDependency(
+  deficit: GuildBankDeltaDeficit | null,
+): GuildBookDependency | null {
+  if (!deficit) return null;
+  switch (deficit.kind) {
+    case 'missing_items':
+      return deficit.itemId ? { kind: 'items_of', itemId: deficit.itemId } : null;
+    case 'treasury_underflow':
+    case 'treasury_overflow':
+      return { kind: 'copper' };
+    case 'ladder_behind':
+      return { kind: 'ladder' };
+  }
 }
 
 /** The identity the replay would match this slot's copies on. */
@@ -140,78 +189,53 @@ function slotIdentityKey(slot: InvSlot): string {
   });
 }
 
-/** Why the op must be refused, or null when it may run. `live` is the acting
- *  player's book snapshot (guildBankInfoFor); `unsettled` aggregates every
- *  OTHER live session's unflushed log for the same guild. A shape the sim
- *  would refuse anyway (a bad slot, a non-positive amount) passes through
- *  unjudged so the sim's own refusal and wording stay authoritative. */
+/** The dependency the op must be refused for, or null when it may run.
+ *  `live` is the acting player's EDITABLE book snapshot (guildBankInfoFor with
+ *  canEdit; the host never calls this for a read-only view); `unsettled` sums
+ *  every OTHER holder's contribution for the same guild.
+ *
+ *  Every shape the sim refuses on its own passes through unjudged: the same
+ *  count and amount rules as src/sim/bank.ts moveBetweenContainers and
+ *  src/sim/guild_bank.ts (a plain stack takes a floored count within the
+ *  stack, an instanced stack moves whole, an amount is a positive safe
+ *  integer within the treasury, a rung has a table price the treasury
+ *  covers), so the sim's refusal and wording stay authoritative and an
+ *  inadmissible request never buys a refusal, an incident, or a flush. */
 export function guildBankUnsettledRefusal(
   op: GuildBankGatedOp,
   request: GuildBankOpRequest,
   live: GuildBankInfo,
   unsettled: UnsettledGuildBook,
-): GuildBankUnsettledKind | null {
+): GuildBookDependency | null {
   if (op === 'withdraw') {
     const slot = Number.isInteger(request.slot) ? live.slots[request.slot as number] : undefined;
     if (!slot) return null;
-    // An instanced stack moves whole; a plain stack moves the asked count or,
-    // with none asked, the whole stack (src/sim/bank.ts moveBetweenContainers).
     const want = slot.instance
       ? slot.count
       : request.count === undefined
         ? slot.count
         : Math.floor(request.count);
-    if (!(want > 0)) return null;
+    if (!(want > 0) || want > slot.count) return null;
     const key = slotIdentityKey(slot);
     const others = unsettled.items.get(key) ?? 0;
-    // Others' net REMOVALS only lower the live count, which the sim already
-    // bounds the withdraw by; only their net deposits are copies durable truth
-    // lacks.
     if (others <= 0) return null;
     let held = 0;
     for (const s of live.slots) if (slotIdentityKey(s) === key) held += s.count;
-    return want > held - others ? 'items' : null;
+    return want > held - others ? { kind: 'items', key } : null;
   }
   if (op === 'withdraw_gold') {
-    const amount = Math.floor(Number(request.amount));
-    if (!(amount > 0) || unsettled.copper <= 0) return null;
-    return amount > live.treasury - unsettled.copper ? 'copper' : null;
+    const amount = request.amount;
+    if (typeof amount !== 'number' || !Number.isSafeInteger(amount) || amount <= 0) return null;
+    if (amount > live.treasury || unsettled.copper <= 0) return null;
+    return amount > live.treasury - unsettled.copper ? { kind: 'copper' } : null;
   }
   // buy_slots: the ladder is strictly ordered, so ANY outstanding rung blocks
   // the next; rung 0 (open_bank) is purse-paid and moves no treasury copper,
   // rungs 1+ charge the treasury the table price and answer to the copper rule.
-  if (unsettled.ladder) return 'ladder';
-  if (guildBankRungsBought(live.purchasedSlots) === 0 || unsettled.copper <= 0) return null;
-  const price = live.nextExpansionPrice ?? 0;
-  return price > live.treasury - unsettled.copper ? 'copper' : null;
-}
-
-/** The slice of a live session the holder selection reads (structural, so
- *  GameServer's ClientSession satisfies it without the type dragging the
- *  whole class in). */
-export interface GuildBookHolderSession {
-  readonly escrowQuarantined: boolean;
-  readonly left: boolean;
-  readonly dirtyGuildBanks: ReadonlyMap<number, number>;
-}
-
-/** Sessions other than `except` whose unflushed log still holds work on this
- *  guild's book. A quarantined session is never a holder: its work was undone
- *  on the live book the moment it was quarantined. A LEAVING session's work is
- *  still on the live book until its leave flush commits, so the gate counts it
- *  (`includeLeaving: true`); the escrow refusal arm does not, because a
- *  departing session is neither one to wait on nor one to flush again. */
-export function guildBookHolders<S extends GuildBookHolderSession>(
-  sessions: Iterable<S>,
-  guildId: number,
-  except: S,
-  opts: { readonly includeLeaving: boolean },
-): S[] {
-  const holders: S[] = [];
-  for (const s of sessions) {
-    if (s === except || s.escrowQuarantined) continue;
-    if (s.left && !opts.includeLeaving) continue;
-    if (s.dirtyGuildBanks.has(guildId)) holders.push(s);
-  }
-  return holders;
+  const price = live.nextExpansionPrice;
+  if (price === null) return null;
+  if (unsettled.ladder) return { kind: 'ladder' };
+  if (guildBankRungsBought(live.purchasedSlots) === 0) return null;
+  if (price > live.treasury || unsettled.copper <= 0) return null;
+  return price > live.treasury - unsettled.copper ? { kind: 'copper' } : null;
 }

--- a/server/guild_bank_settle_gate.ts
+++ b/server/guild_bank_settle_gate.ts
@@ -57,15 +57,38 @@ export interface GuildBankOpRequest {
 
 export type GuildBankUnsettledKind = 'items' | 'copper' | 'ladder';
 
+/** How long after a holder was flushed the host must NOT flush it again, in
+ *  milliseconds. The flush exists so a refused op's retry lands a round trip
+ *  later, and one flush per holder buys exactly that; a second one inside
+ *  the window would only stack a save behind one still in flight. The bound
+ *  it gives: a refusal costs its sender no more than an op-guard token, so
+ *  without it one officer refusing at the guard's rate could force a save per
+ *  dirty guildmate per refusal. With it, the fan-out is at most one extra save
+ *  per holder per window, whoever is refusing and however often. */
+export const GUILD_BOOK_FLUSH_COOLDOWN_MS = 1_000;
+
 /** What OTHER sessions' unflushed logs still hold on one guild's book: the
- *  part of the live book durable truth does not have yet. */
+ *  part of the live book durable truth may not have when the acting session's
+ *  replay runs.
+ *
+ *  Summed PER SESSION, positives only. A commit is atomic per session, so the
+ *  worst durable base for the acting replay is every net-REMOVING holder
+ *  already committed (durable lowered) and every net-DEPOSITING holder not
+ *  yet committed (its copies still unsettled): `live - sum over holders of
+ *  max(0, holder's net)`. Netting one holder's withdrawal against another
+ *  holder's deposit would hide the deposit (holder C's withdraw of 10 cancels
+ *  holder B's deposit of 10, and the acting officer takes B's copies ungated),
+ *  which is the same two-identity cycle the gate exists to refuse, one officer
+ *  removed. */
 export interface UnsettledGuildBook {
-  /** Net copies per identity key (deposits minus removals), the same
-   *  three-dimensional key the escrow replay matches on. */
+  /** Per identity key (the escrow replay's three-dimensional key): the sum
+   *  over holders of each holder's POSITIVE net copies (deposits minus its own
+   *  removals, floored at zero). */
   readonly items: ReadonlyMap<string, number>;
-  /** Net treasury copper the replay would MOVE. open_bank is excluded (rung 0
-   *  is purse-paid and the applier never moves it), buy_slots is included (its
-   *  charge left the treasury). */
+  /** The sum over holders of each holder's POSITIVE net treasury copper the
+   *  replay would MOVE. open_bank is excluded (rung 0 is purse-paid and the
+   *  applier never moves it), buy_slots is included (its charge left the
+   *  treasury). */
   readonly copper: number;
   /** True while any slot op is outstanding: a rung replays only onto the exact
    *  ladder position its witness names, so a rung bought on top of an
@@ -80,22 +103,30 @@ export function unsettledGuildBook(
   let copper = 0;
   let ladder = false;
   for (const log of logs) {
+    // One holder's own net, keyed like the replay; only its positive part
+    // joins the total (see the interface note).
+    const own = new Map<string, number>();
+    let ownCopper = 0;
     for (const d of log) {
       if (d.op === 'open_bank' || d.op === 'buy_slots') {
         ladder = true;
-        if (d.op === 'buy_slots') copper += Number(d.copperDelta) || 0;
+        if (d.op === 'buy_slots') ownCopper += Number(d.copperDelta) || 0;
         continue;
       }
       if (d.op === 'deposit_gold' || d.op === 'withdraw_gold') {
-        copper += Number(d.copperDelta) || 0;
+        ownCopper += Number(d.copperDelta) || 0;
         continue;
       }
       if (typeof d.itemId !== 'string' || d.itemId === '') continue;
       const count = Math.max(0, Math.floor(Number(d.count)) || 0);
       if (count === 0) continue;
       const key = guildBankDeltaIdentityKey(d);
-      items.set(key, (items.get(key) ?? 0) + (d.op === 'deposit' ? count : -count));
+      own.set(key, (own.get(key) ?? 0) + (d.op === 'deposit' ? count : -count));
     }
+    for (const [key, net] of own) {
+      if (net > 0) items.set(key, (items.get(key) ?? 0) + net);
+    }
+    if (ownCopper > 0) copper += ownCopper;
   }
   return { items, copper, ladder };
 }

--- a/server/guild_bank_settle_gate.ts
+++ b/server/guild_bank_settle_gate.ts
@@ -1,0 +1,186 @@
+// The UNSETTLED gate for guild bank ops. A session may take out of the live
+// book only what durable truth already holds plus what its OWN unflushed log
+// put in. Value another session deposited but has not yet made durable is
+// UNSETTLED: consuming it puts a replay dependency on that session into this
+// session's escrow log, and the escrow save honours only a ONE-WAY dependency
+// (its refusal arm flushes the other session and retries, see
+// server/game.ts handleGuildBankEscrowRefusal).
+//
+// Two sessions that each consumed the other's unsettled value can never
+// commit in any order. The 2026-09-01 production incident was exactly that
+// shape: officer A deposited spider legs and took B's venom glands, B
+// deposited the venom glands and took A's spider legs, all inside one autosave
+// window. Each replay was short on the key the other held, the retry bound
+// rolled both back, both were disconnected as "taken over", and the
+// per-session reverts of an already-consumed deposit clamped on the live book
+// and left a PHANTOM stack that rolled back every officer who withdrew it
+// until the realm restarted. The design note that only ladder rungs could
+// deadlock was true for ONE fungible (gold: one of two nets is always
+// non-negative); it is false as soon as two item identities are involved.
+//
+// Refusing the consume HERE, at the dispatch boundary, makes that whole class
+// unreachable in ordinary play: a log can then only carry deposits (always
+// applicable), removals of settled copies, and rungs bought on a settled
+// ladder, so a replay refusal and the rollback behind it become the backstop
+// they were meant to be. The cost is one "try again in a moment" notice when
+// an officer reaches for a deposit made moments ago, and the host flushes the
+// depositor on the spot so the retry lands a round trip later.
+//
+// Pure: the host hands over the live book snapshot and the OTHER live
+// sessions' unflushed logs; nothing here touches a session or the sim.
+
+import {
+  type GuildBankOpDelta,
+  guildBankDeltaIdentityKey,
+  guildBankRungsBought,
+} from '../src/sim/guild_bank';
+import type { InvSlot } from '../src/sim/types';
+import type { GuildBankInfo } from '../src/world_api';
+
+/** The ops the gate judges. Deposits are never gated: a deposit replays onto
+ *  any base. The operator purge is not gated either: it removes only a
+ *  DORMANT copy the deposit pipe refuses, which can only be durable. */
+export const GUILD_BANK_GATED_OPS = ['withdraw', 'withdraw_gold', 'buy_slots'] as const;
+export type GuildBankGatedOp = (typeof GUILD_BANK_GATED_OPS)[number];
+
+export function isGuildBankGatedOp(op: string): op is GuildBankGatedOp {
+  return (GUILD_BANK_GATED_OPS as readonly string[]).includes(op);
+}
+
+/** The client-supplied inputs of one op, as the dispatch site received them
+ *  (already type-checked there; the gate re-validates the shapes it reads). */
+export interface GuildBankOpRequest {
+  readonly slot?: number;
+  readonly count?: number;
+  readonly amount?: number;
+}
+
+export type GuildBankUnsettledKind = 'items' | 'copper' | 'ladder';
+
+/** What OTHER sessions' unflushed logs still hold on one guild's book: the
+ *  part of the live book durable truth does not have yet. */
+export interface UnsettledGuildBook {
+  /** Net copies per identity key (deposits minus removals), the same
+   *  three-dimensional key the escrow replay matches on. */
+  readonly items: ReadonlyMap<string, number>;
+  /** Net treasury copper the replay would MOVE. open_bank is excluded (rung 0
+   *  is purse-paid and the applier never moves it), buy_slots is included (its
+   *  charge left the treasury). */
+  readonly copper: number;
+  /** True while any slot op is outstanding: a rung replays only onto the exact
+   *  ladder position its witness names, so a rung bought on top of an
+   *  unsettled one can never apply first. */
+  readonly ladder: boolean;
+}
+
+export function unsettledGuildBook(
+  logs: Iterable<readonly GuildBankOpDelta[]>,
+): UnsettledGuildBook {
+  const items = new Map<string, number>();
+  let copper = 0;
+  let ladder = false;
+  for (const log of logs) {
+    for (const d of log) {
+      if (d.op === 'open_bank' || d.op === 'buy_slots') {
+        ladder = true;
+        if (d.op === 'buy_slots') copper += Number(d.copperDelta) || 0;
+        continue;
+      }
+      if (d.op === 'deposit_gold' || d.op === 'withdraw_gold') {
+        copper += Number(d.copperDelta) || 0;
+        continue;
+      }
+      if (typeof d.itemId !== 'string' || d.itemId === '') continue;
+      const count = Math.max(0, Math.floor(Number(d.count)) || 0);
+      if (count === 0) continue;
+      const key = guildBankDeltaIdentityKey(d);
+      items.set(key, (items.get(key) ?? 0) + (d.op === 'deposit' ? count : -count));
+    }
+  }
+  return { items, copper, ladder };
+}
+
+/** The identity the replay would match this slot's copies on. */
+function slotIdentityKey(slot: InvSlot): string {
+  return guildBankDeltaIdentityKey({
+    itemId: slot.itemId,
+    instance: slot.instance ?? null,
+    craftedRecipeId: slot.craftedRecipeId ?? null,
+  });
+}
+
+/** Why the op must be refused, or null when it may run. `live` is the acting
+ *  player's book snapshot (guildBankInfoFor); `unsettled` aggregates every
+ *  OTHER live session's unflushed log for the same guild. A shape the sim
+ *  would refuse anyway (a bad slot, a non-positive amount) passes through
+ *  unjudged so the sim's own refusal and wording stay authoritative. */
+export function guildBankUnsettledRefusal(
+  op: GuildBankGatedOp,
+  request: GuildBankOpRequest,
+  live: GuildBankInfo,
+  unsettled: UnsettledGuildBook,
+): GuildBankUnsettledKind | null {
+  if (op === 'withdraw') {
+    const slot = Number.isInteger(request.slot) ? live.slots[request.slot as number] : undefined;
+    if (!slot) return null;
+    // An instanced stack moves whole; a plain stack moves the asked count or,
+    // with none asked, the whole stack (src/sim/bank.ts moveBetweenContainers).
+    const want = slot.instance
+      ? slot.count
+      : request.count === undefined
+        ? slot.count
+        : Math.floor(request.count);
+    if (!(want > 0)) return null;
+    const key = slotIdentityKey(slot);
+    const others = unsettled.items.get(key) ?? 0;
+    // Others' net REMOVALS only lower the live count, which the sim already
+    // bounds the withdraw by; only their net deposits are copies durable truth
+    // lacks.
+    if (others <= 0) return null;
+    let held = 0;
+    for (const s of live.slots) if (slotIdentityKey(s) === key) held += s.count;
+    return want > held - others ? 'items' : null;
+  }
+  if (op === 'withdraw_gold') {
+    const amount = Math.floor(Number(request.amount));
+    if (!(amount > 0) || unsettled.copper <= 0) return null;
+    return amount > live.treasury - unsettled.copper ? 'copper' : null;
+  }
+  // buy_slots: the ladder is strictly ordered, so ANY outstanding rung blocks
+  // the next; rung 0 (open_bank) is purse-paid and moves no treasury copper,
+  // rungs 1+ charge the treasury the table price and answer to the copper rule.
+  if (unsettled.ladder) return 'ladder';
+  if (guildBankRungsBought(live.purchasedSlots) === 0 || unsettled.copper <= 0) return null;
+  const price = live.nextExpansionPrice ?? 0;
+  return price > live.treasury - unsettled.copper ? 'copper' : null;
+}
+
+/** The slice of a live session the holder selection reads (structural, so
+ *  GameServer's ClientSession satisfies it without the type dragging the
+ *  whole class in). */
+export interface GuildBookHolderSession {
+  readonly escrowQuarantined: boolean;
+  readonly left: boolean;
+  readonly dirtyGuildBanks: ReadonlyMap<number, number>;
+}
+
+/** Sessions other than `except` whose unflushed log still holds work on this
+ *  guild's book. A quarantined session is never a holder: its work was undone
+ *  on the live book the moment it was quarantined. A LEAVING session's work is
+ *  still on the live book until its leave flush commits, so the gate counts it
+ *  (`includeLeaving: true`); the escrow refusal arm does not, because a
+ *  departing session is neither one to wait on nor one to flush again. */
+export function guildBookHolders<S extends GuildBookHolderSession>(
+  sessions: Iterable<S>,
+  guildId: number,
+  except: S,
+  opts: { readonly includeLeaving: boolean },
+): S[] {
+  const holders: S[] = [];
+  for (const s of sessions) {
+    if (s === except || s.escrowQuarantined) continue;
+    if (s.left && !opts.includeLeaving) continue;
+    if (s.dirtyGuildBanks.has(guildId)) holders.push(s);
+  }
+  return holders;
+}

--- a/server/guild_bank_state.ts
+++ b/server/guild_bank_state.ts
@@ -157,7 +157,7 @@ export function loadGuildBanksIntoSim(
 // escrow transaction rolls back, character row included: writing what durable
 // truth could cover while the paired character half commits mints exactly the
 // difference, and recording that is a receipt for a mint rather than a
-// mitigation. The caller retries; see server/game.ts
+// mitigation. The caller retries; see server/guild_bank_escrow_refusal.ts
 // handleGuildBankEscrowRefusal for what happens when a retry can never win.
 export function mergeGuildBankRow(
   durableRaw: unknown,

--- a/server/guild_book_holders.ts
+++ b/server/guild_book_holders.ts
@@ -1,0 +1,231 @@
+// The per-guild HOLDER INDEX behind the unsettled gate and the escrow refusal
+// arm: which live sessions hold unflushed work on which guild's book, with
+// each holder's contribution (server/guild_bank_settle_gate.ts
+// holderContribution) cached until its log changes. The gate used to walk
+// every live session per gated op and fold every matching log; at the realm
+// session cap and the op guard's rate that is tens of millions of session
+// probes per second, so the index is maintained at the four places a mark or
+// a log changes instead:
+//
+//   touch(session, guild)   an op landed (the mark was set, the log grew)
+//   resync(session)         a save committed (a prefix was consumed, a mark
+//                           may have cleared) or a rollback undid the log
+//   dropGuild(guild)        the guild disbanded (every mark cleared)
+//   dropSession(session)    the session left the realm
+//
+// A cached contribution is invalidated (never patched) on touch and resync,
+// and recomputed lazily from the live log on the next read. Anything less
+// exact is unsafe: a commit that consumed one entry while an op pushed
+// another leaves the log the same LENGTH with different contents, and a
+// length-keyed cache would then report the old deposit as unsettled and the
+// new one as settled, which is exactly the consume the gate exists to refuse.
+//
+// The same module owns the flush coalescing: one flush in flight per holder
+// (queued or running, however long the per-character save queue holds it),
+// with a single re-arm behind it that fires only if the holder still carries
+// work when the flush settles. Refusals cost their sender one op-guard token,
+// so anything looser lets one officer stack saves on a dirty guildmate.
+
+import type { GuildBankOpDelta } from '../src/sim/guild_bank';
+import {
+  contributesTo,
+  type GuildBookContribution,
+  type GuildBookDependency,
+  holderContribution,
+  SETTLED_BOOK,
+  sumContributions,
+  type UnsettledGuildBook,
+} from './guild_bank_settle_gate';
+
+/** The slice of a live session the index reads (structural, so GameServer's
+ *  ClientSession satisfies it without the type dragging the whole class in). */
+export interface GuildBookHolderSession {
+  readonly escrowQuarantined: boolean;
+  readonly left: boolean;
+  readonly dirtyGuildBanks: ReadonlyMap<number, number>;
+  readonly unflushedGuildBankOps: ReadonlyMap<number, readonly GuildBankOpDelta[]>;
+}
+
+/** How many holders one refusal may flush. The contributing filter normally
+ *  leaves one; the bound is the ceiling for a book many officers are feeding
+ *  at once, so a refusal can never fan out across a whole online guild. */
+export const GUILD_BOOK_FLUSH_FAN_OUT_MAX = 4;
+
+export class GuildBookHolderIndex<S extends GuildBookHolderSession> {
+  // guild -> holder -> cached contribution, null while stale.
+  private readonly byGuild = new Map<number, Map<S, GuildBookContribution | null>>();
+  private readonly bySession = new Map<S, Set<number>>();
+
+  /** An op landed on this guild's book for this session: index it and drop
+   *  its cached contribution. */
+  touch(session: S, guildId: number): void {
+    let holders = this.byGuild.get(guildId);
+    if (!holders) {
+      holders = new Map();
+      this.byGuild.set(guildId, holders);
+    }
+    holders.set(session, null);
+    let guilds = this.bySession.get(session);
+    if (!guilds) {
+      guilds = new Set();
+      this.bySession.set(session, guilds);
+    }
+    guilds.add(guildId);
+  }
+
+  /** The session's marks or logs changed outside an op (a commit consumed a
+   *  prefix, a rollback undid the log): keep it indexed where it is still
+   *  dirty with a stale contribution, drop it where it is not. */
+  resync(session: S): void {
+    const guilds = this.bySession.get(session);
+    if (!guilds) return;
+    for (const guildId of [...guilds]) {
+      if (session.dirtyGuildBanks.has(guildId)) {
+        this.byGuild.get(guildId)?.set(session, null);
+        continue;
+      }
+      this.remove(session, guildId, guilds);
+    }
+  }
+
+  /** The guild disbanded: every session's mark for it cleared. */
+  dropGuild(guildId: number): void {
+    const holders = this.byGuild.get(guildId);
+    if (!holders) return;
+    for (const session of holders.keys()) {
+      const guilds = this.bySession.get(session);
+      guilds?.delete(guildId);
+      if (guilds && guilds.size === 0) this.bySession.delete(session);
+    }
+    this.byGuild.delete(guildId);
+  }
+
+  /** The session left the realm. */
+  dropSession(session: S): void {
+    const guilds = this.bySession.get(session);
+    if (!guilds) return;
+    for (const guildId of [...guilds]) this.remove(session, guildId, guilds);
+  }
+
+  /** Sessions other than `except` holding unflushed work on this guild's
+   *  book. A quarantined session is never a holder: its work was undone on the
+   *  live book the moment it was quarantined. A LEAVING session's work is
+   *  still on the live book until its leave flush commits, so the gate counts
+   *  it (`includeLeaving: true`); the escrow refusal arm does not, because a
+   *  departing session is neither one to wait on nor one to flush again. */
+  holders(guildId: number, except: S | null, opts: { readonly includeLeaving: boolean }): S[] {
+    const out: S[] = [];
+    const holders = this.byGuild.get(guildId);
+    if (!holders) return out;
+    for (const session of holders.keys()) {
+      if (session === except || session.escrowQuarantined) continue;
+      if (session.left && !opts.includeLeaving) continue;
+      if (!session.dirtyGuildBanks.has(guildId)) continue;
+      out.push(session);
+    }
+    return out;
+  }
+
+  /** The sum of every OTHER holder's contribution on this guild's book, the
+   *  gate's input. Leaving sessions included: their work is live until their
+   *  leave flush commits. */
+  unsettled(guildId: number, except: S | null): UnsettledGuildBook {
+    const holders = this.byGuild.get(guildId);
+    if (!holders) return SETTLED_BOOK;
+    const contributions: GuildBookContribution[] = [];
+    for (const session of this.holders(guildId, except, { includeLeaving: true })) {
+      contributions.push(this.contribution(holders, session, guildId));
+    }
+    return contributions.length === 0 ? SETTLED_BOOK : sumContributions(contributions);
+  }
+
+  /** The holders a refusal should flush: the ones whose work FEEDS the named
+   *  dependency (every holder when none is named), never a leaving or
+   *  quarantined one, and at most `max` of them. */
+  contributors(
+    guildId: number,
+    except: S | null,
+    dependency: GuildBookDependency | null,
+    max = GUILD_BOOK_FLUSH_FAN_OUT_MAX,
+  ): S[] {
+    const out: S[] = [];
+    const holders = this.byGuild.get(guildId);
+    if (!holders) return out;
+    for (const session of this.holders(guildId, except, { includeLeaving: false })) {
+      if (out.length >= max) break;
+      if (
+        dependency === null ||
+        contributesTo(this.contribution(holders, session, guildId), dependency)
+      ) {
+        out.push(session);
+      }
+    }
+    return out;
+  }
+
+  /** How many guilds have at least one indexed holder (a leak pin for tests). */
+  get size(): number {
+    return this.byGuild.size;
+  }
+
+  private contribution(
+    holders: Map<S, GuildBookContribution | null>,
+    session: S,
+    guildId: number,
+  ): GuildBookContribution {
+    let cached = holders.get(session) ?? null;
+    if (cached === null) {
+      cached = holderContribution(session.unflushedGuildBankOps.get(guildId) ?? []);
+      holders.set(session, cached);
+    }
+    return cached;
+  }
+
+  private remove(session: S, guildId: number, guilds: Set<number>): void {
+    const holders = this.byGuild.get(guildId);
+    holders?.delete(session);
+    if (holders && holders.size === 0) this.byGuild.delete(guildId);
+    guilds.delete(guildId);
+    if (guilds.size === 0) this.bySession.delete(session);
+  }
+}
+
+/** The flush state a holder session carries. */
+export interface GuildBookFlushSession {
+  guildBookFlushInFlight: boolean;
+  guildBookFlushRearm: boolean;
+  readonly left: boolean;
+  readonly escrowQuarantined: boolean;
+  readonly dirtyGuildBanks: ReadonlyMap<number, number>;
+}
+
+/** Flush one holder, coalesced: while a flush is queued or running for it,
+ *  a further request only arms ONE follow-up, which fires when the flush
+ *  settles and only if the holder still carries work then. `save` must never
+ *  reject (the host wraps its own logging around the real save). */
+export function requestGuildBookFlush<S extends GuildBookFlushSession>(
+  session: S,
+  save: (session: S) => Promise<unknown>,
+): void {
+  if (session.left || session.escrowQuarantined) return;
+  if (session.guildBookFlushInFlight) {
+    session.guildBookFlushRearm = true;
+    return;
+  }
+  session.guildBookFlushInFlight = true;
+  session.guildBookFlushRearm = false;
+  void save(session).then(
+    () => settle(session, save),
+    () => settle(session, save),
+  );
+}
+
+function settle<S extends GuildBookFlushSession>(
+  session: S,
+  save: (session: S) => Promise<unknown>,
+): void {
+  session.guildBookFlushInFlight = false;
+  const again = session.guildBookFlushRearm;
+  session.guildBookFlushRearm = false;
+  if (again && session.dirtyGuildBanks.size > 0) requestGuildBookFlush(session, save);
+}

--- a/server/http/game_signals.ts
+++ b/server/http/game_signals.ts
@@ -163,6 +163,12 @@ export const GUILD_BANK_INCIDENTS = [
   // creation commits the guild and fee in one transaction, so a new sample is
   // a single-sample mixed-release or invariant defect and remains page-worthy.
   'create_fee_unpaid',
+  // The dispatch-time unsettled gate (server/guild_bank_settle_gate.ts)
+  // refused a withdraw, gold withdraw, or rung purchase that would have
+  // consumed another session's not-yet-durable work, and flushed that
+  // session instead. Ordinary two-officer concurrency, like
+  // escrow_refused_retry before it: watch its RATE, never its presence.
+  'unsettled_refused',
 ] as const;
 
 /** One of the fixed eleven guild-bank incident kinds. */

--- a/server/http/game_signals.ts
+++ b/server/http/game_signals.ts
@@ -171,7 +171,7 @@ export const GUILD_BANK_INCIDENTS = [
   'unsettled_refused',
 ] as const;
 
-/** One of the fixed eleven guild-bank incident kinds. */
+/** One of the fixed twelve guild-bank incident kinds. */
 export type GuildBankIncident = (typeof GUILD_BANK_INCIDENTS)[number];
 
 /** The marketplace escrow-queue outcomes (the per-character save FIFO's

--- a/server/linkdead.ts
+++ b/server/linkdead.ts
@@ -27,8 +27,9 @@ export interface LinkdeadSessionView {
   // re-acquires).
   left: boolean;
   // True once this session's guild bank escrow was ROLLED BACK: its live state
-  // was abandoned and it can never persist again (server/game.ts
-  // handleGuildBankEscrowRefusal). RESUMING it would hand the player a session
+  // was abandoned and it can never persist again
+  // (server/guild_bank_escrow_refusal.ts handleGuildBankEscrowRefusal).
+  // RESUMING it would hand the player a session
   // that plays normally and saves NOTHING, forever, with no error and no
   // signal: silent unbounded data loss, which is far worse than the reconnect
   // refusal below. The refused client retries into the fresh-join arm and

--- a/src/sim/guild_bank.ts
+++ b/src/sim/guild_bank.ts
@@ -539,7 +539,7 @@ export function applyGuildBankDeltasTo(
       // later rung cannot commit before the rung under it) and would charge
       // the treasury for a grant the inverse then declines to undo, so it is
       // refused too. The save retries once the other officer commits, and is
-      // rolled back if they never can (server/game.ts
+      // rolled back if they never can (server/guild_bank_escrow_refusal.ts
       // handleGuildBankEscrowRefusal).
       if (book.purchasedSlots !== d.purchasedSlotsBefore) {
         return {
@@ -662,7 +662,9 @@ export function revertGuildBankDeltasTo(
  *  the inverse match on. EXPORTED so the server's log compactor
  *  (server/guild_bank_op_log.ts) nets on exactly this key rather than a second
  *  copy that could disagree about a payload's canonical form. */
-export function guildBankDeltaIdentityKey(d: GuildBankOpDelta): string {
+export function guildBankDeltaIdentityKey(
+  d: Pick<GuildBankOpDelta, 'itemId' | 'instance' | 'craftedRecipeId'>,
+): string {
   return `${d.itemId ?? ''}|${canonicalJson(d.instance ?? null)}|${d.craftedRecipeId ?? ''}`;
 }
 

--- a/src/ui/server_i18n.newlocales.ts
+++ b/src/ui/server_i18n.newlocales.ts
@@ -85,6 +85,7 @@ export const SERVER_NEW = {
     'guild.createFee': 'K založení cechu potřebuješ {amount} zlata.',
     'guild.bankNotEmpty': 'Před rozpuštěním cechu musí být cechovní banka vyprázdněna.',
     'guild.bankClosing': 'Cechovní banka se zavírá. Zkus to za chvíli znovu.',
+    'guild.bankSettling': 'Cechovní banka stále ukládá nedávnou změnu. Zkus to za chvíli znovu.',
     'guild.notInYours': '{name} není ve tvém cechu.',
     'guild.nowRank': '{name} má nyní hodnost {rank}.',
     'guild.onlyGmChangeRanks': 'Hodnosti může měnit jen vůdce cechu.',
@@ -222,6 +223,8 @@ export const SERVER_NEW = {
     'guild.createFee': 'Du skal bruge {amount} guld for at grundlægge en lavsforening.',
     'guild.bankNotEmpty': 'Lavsforeningens bank skal tømmes, før lavsforeningen kan opløses.',
     'guild.bankClosing': 'Lavsforeningens bank lukker. Prøv igen om et øjeblik.',
+    'guild.bankSettling':
+      'Lavsforeningens bank gemmer stadig en nylig ændring. Prøv igen om et øjeblik.',
     'guild.notInYours': '{name} er ikke i din lavsforening.',
     'guild.nowRank': '{name} er nu {rank}.',
     'guild.onlyGmChangeRanks': 'Kun Lavsmesteren kan ændre rangordener.',
@@ -360,6 +363,7 @@ export const SERVER_NEW = {
     'guild.createFee': 'Kamu membutuhkan {amount} emas untuk mendirikan guild.',
     'guild.bankNotEmpty': 'Bank guild harus dikosongkan sebelum guild dapat dibubarkan.',
     'guild.bankClosing': 'Bank guild sedang ditutup. Coba lagi sebentar lagi.',
+    'guild.bankSettling': 'Bank guild masih menyimpan perubahan terbaru. Coba lagi sebentar lagi.',
     'guild.notInYours': '{name} tidak ada dalam guild-mu.',
     'guild.nowRank': '{name} sekarang menjadi {rank}.',
     'guild.onlyGmChangeRanks': 'Hanya Guild Master yang boleh mengubah pangkat.',
@@ -499,6 +503,8 @@ export const SERVER_NEW = {
     'guild.createFee': 'Je hebt {amount} goud nodig om een gilde te stichten.',
     'guild.bankNotEmpty': 'De gildebank moet leeg zijn voordat de gilde kan worden opgeheven.',
     'guild.bankClosing': 'De gildebank sluit. Probeer het zo meteen opnieuw.',
+    'guild.bankSettling':
+      'De gildebank slaat nog een recente wijziging op. Probeer het zo meteen opnieuw.',
     'guild.notInYours': '{name} zit niet in je gilde.',
     'guild.nowRank': '{name} is nu {rank}.',
     'guild.onlyGmChangeRanks': 'Alleen de Gildemeester mag rangen wijzigen.',
@@ -642,6 +648,7 @@ export const SERVER_NEW = {
     'guild.bankNotEmpty':
       'Bank gildii musi zostać opróżniony, zanim gildia będzie mogła zostać rozwiązana.',
     'guild.bankClosing': 'Bank gildii jest zamykany. Spróbuj ponownie za chwilę.',
+    'guild.bankSettling': 'Bank gildii wciąż zapisuje niedawną zmianę. Spróbuj ponownie za chwilę.',
     'guild.notInYours': '{name} nie należy do twojej gildii.',
     'guild.nowRank': '{name} ma teraz rangę {rank}.',
     'guild.onlyGmChangeRanks': 'Tylko Mistrz Gildii może zmieniać rangi.',
@@ -782,6 +789,8 @@ export const SERVER_NEW = {
     'guild.createFee': 'Du behöver {amount} guld för att grunda ett gille.',
     'guild.bankNotEmpty': 'Gillesbanken måste tömmas innan gillet kan upplösas.',
     'guild.bankClosing': 'Gillesbanken stänger. Försök igen om ett ögonblick.',
+    'guild.bankSettling':
+      'Gillesbanken sparar fortfarande en nyligen gjord ändring. Försök igen om ett ögonblick.',
     'guild.notInYours': '{name} är inte med i ditt gille.',
     'guild.nowRank': '{name} är nu {rank}.',
     'guild.onlyGmChangeRanks': 'Endast gillesmästaren kan ändra rang.',
@@ -919,6 +928,8 @@ export const SERVER_NEW = {
     'guild.createFee': 'Lonca kurmak için {amount} altın gerekir.',
     'guild.bankNotEmpty': 'Lonca dağıtılmadan önce lonca bankası boşaltılmalıdır.',
     'guild.bankClosing': 'Lonca bankası kapanıyor. Birazdan tekrar dene.',
+    'guild.bankSettling':
+      'Lonca bankası hâlâ yakın zamandaki bir değişikliği kaydediyor. Birazdan tekrar dene.',
     'guild.notInYours': '{name} loncanda değil.',
     'guild.nowRank': '{name} artık {rank}.',
     'guild.onlyGmChangeRanks': 'Yalnızca Lonca Lideri rütbeleri değiştirebilir.',
@@ -1059,6 +1070,8 @@ export const SERVER_NEW = {
     'guild.bankNotEmpty':
       'Ngân khố bang hội phải được dọn sạch trước khi bang hội có thể bị giải tán.',
     'guild.bankClosing': 'Ngân hàng bang hội đang đóng. Hãy thử lại sau giây lát.',
+    'guild.bankSettling':
+      'Ngân hàng bang hội vẫn đang lưu một thay đổi gần đây. Hãy thử lại sau giây lát.',
     'guild.notInYours': '{name} không ở trong bang hội của bạn.',
     'guild.nowRank': '{name} giờ là {rank}.',
     'guild.onlyGmChangeRanks': 'Chỉ Bang Chủ mới có thể thay đổi cấp bậc.',

--- a/src/ui/server_i18n.newlocales.ts
+++ b/src/ui/server_i18n.newlocales.ts
@@ -86,6 +86,7 @@ export const SERVER_NEW = {
     'guild.bankNotEmpty': 'Před rozpuštěním cechu musí být cechovní banka vyprázdněna.',
     'guild.bankClosing': 'Cechovní banka se zavírá. Zkus to za chvíli znovu.',
     'guild.bankSettling': 'Cechovní banka stále ukládá nedávnou změnu. Zkus to za chvíli znovu.',
+    'guild.bankBusy': 'Jsi zaneprázdněn. Zkus to za chvíli znovu.',
     'guild.notInYours': '{name} není ve tvém cechu.',
     'guild.nowRank': '{name} má nyní hodnost {rank}.',
     'guild.onlyGmChangeRanks': 'Hodnosti může měnit jen vůdce cechu.',
@@ -225,6 +226,7 @@ export const SERVER_NEW = {
     'guild.bankClosing': 'Lavsforeningens bank lukker. Prøv igen om et øjeblik.',
     'guild.bankSettling':
       'Lavsforeningens bank gemmer stadig en nylig ændring. Prøv igen om et øjeblik.',
+    'guild.bankBusy': 'Du er optaget. Prøv igen om et øjeblik.',
     'guild.notInYours': '{name} er ikke i din lavsforening.',
     'guild.nowRank': '{name} er nu {rank}.',
     'guild.onlyGmChangeRanks': 'Kun Lavsmesteren kan ændre rangordener.',
@@ -364,6 +366,7 @@ export const SERVER_NEW = {
     'guild.bankNotEmpty': 'Bank guild harus dikosongkan sebelum guild dapat dibubarkan.',
     'guild.bankClosing': 'Bank guild sedang ditutup. Coba lagi sebentar lagi.',
     'guild.bankSettling': 'Bank guild masih menyimpan perubahan terbaru. Coba lagi sebentar lagi.',
+    'guild.bankBusy': 'Kamu sedang sibuk. Coba lagi sebentar lagi.',
     'guild.notInYours': '{name} tidak ada dalam guild-mu.',
     'guild.nowRank': '{name} sekarang menjadi {rank}.',
     'guild.onlyGmChangeRanks': 'Hanya Guild Master yang boleh mengubah pangkat.',
@@ -505,6 +508,7 @@ export const SERVER_NEW = {
     'guild.bankClosing': 'De gildebank sluit. Probeer het zo meteen opnieuw.',
     'guild.bankSettling':
       'De gildebank slaat nog een recente wijziging op. Probeer het zo meteen opnieuw.',
+    'guild.bankBusy': 'Je bent bezig. Probeer het zo meteen opnieuw.',
     'guild.notInYours': '{name} zit niet in je gilde.',
     'guild.nowRank': '{name} is nu {rank}.',
     'guild.onlyGmChangeRanks': 'Alleen de Gildemeester mag rangen wijzigen.',
@@ -649,6 +653,7 @@ export const SERVER_NEW = {
       'Bank gildii musi zostać opróżniony, zanim gildia będzie mogła zostać rozwiązana.',
     'guild.bankClosing': 'Bank gildii jest zamykany. Spróbuj ponownie za chwilę.',
     'guild.bankSettling': 'Bank gildii wciąż zapisuje niedawną zmianę. Spróbuj ponownie za chwilę.',
+    'guild.bankBusy': 'Jesteś zajęty. Spróbuj ponownie za chwilę.',
     'guild.notInYours': '{name} nie należy do twojej gildii.',
     'guild.nowRank': '{name} ma teraz rangę {rank}.',
     'guild.onlyGmChangeRanks': 'Tylko Mistrz Gildii może zmieniać rangi.',
@@ -791,6 +796,7 @@ export const SERVER_NEW = {
     'guild.bankClosing': 'Gillesbanken stänger. Försök igen om ett ögonblick.',
     'guild.bankSettling':
       'Gillesbanken sparar fortfarande en nyligen gjord ändring. Försök igen om ett ögonblick.',
+    'guild.bankBusy': 'Du är upptagen. Försök igen om ett ögonblick.',
     'guild.notInYours': '{name} är inte med i ditt gille.',
     'guild.nowRank': '{name} är nu {rank}.',
     'guild.onlyGmChangeRanks': 'Endast gillesmästaren kan ändra rang.',
@@ -930,6 +936,7 @@ export const SERVER_NEW = {
     'guild.bankClosing': 'Lonca bankası kapanıyor. Birazdan tekrar dene.',
     'guild.bankSettling':
       'Lonca bankası hâlâ yakın zamandaki bir değişikliği kaydediyor. Birazdan tekrar dene.',
+    'guild.bankBusy': 'Meşgulsün. Birazdan tekrar dene.',
     'guild.notInYours': '{name} loncanda değil.',
     'guild.nowRank': '{name} artık {rank}.',
     'guild.onlyGmChangeRanks': 'Yalnızca Lonca Lideri rütbeleri değiştirebilir.',
@@ -1072,6 +1079,7 @@ export const SERVER_NEW = {
     'guild.bankClosing': 'Ngân hàng bang hội đang đóng. Hãy thử lại sau giây lát.',
     'guild.bankSettling':
       'Ngân hàng bang hội vẫn đang lưu một thay đổi gần đây. Hãy thử lại sau giây lát.',
+    'guild.bankBusy': 'Bạn đang bận. Hãy thử lại sau giây lát.',
     'guild.notInYours': '{name} không ở trong bang hội của bạn.',
     'guild.nowRank': '{name} giờ là {rank}.',
     'guild.onlyGmChangeRanks': 'Chỉ Bang Chủ mới có thể thay đổi cấp bậc.',

--- a/src/ui/server_i18n.ts
+++ b/src/ui/server_i18n.ts
@@ -85,6 +85,7 @@ export const DICT: Record<string, Record<string, string>> = {
     // refused, because anything banked in that gap would be destroyed with the
     // row. Two DB round trips wide.
     'guild.bankClosing': 'The guild bank is closing. Try again in a moment.',
+    'guild.bankSettling': 'The guild bank is still saving a recent change. Try again in a moment.',
     'guild.onlyOfficersInvite': 'Only officers and the Guild Master may invite.',
     'guild.alreadyInThis': 'You are already in the guild.',
     'guild.mustBeOnline': '{name} must be online to be invited.',
@@ -237,6 +238,7 @@ export const DICT: Record<string, Record<string, string>> = {
     'guild.createFee': 'You need {amount} gold to found a guild.',
     'guild.bankNotEmpty': 'The guild bank must be emptied before the guild can be disbanded.',
     'guild.bankClosing': 'The guild bank is closing. Try again in a moment.',
+    'guild.bankSettling': 'The guild bank is still saving a recent change. Try again in a moment.',
     'guild.onlyOfficersInvite': 'Only officers and the Guild Master may invite.',
     'guild.alreadyInThis': 'You are already in the guild.',
     'guild.mustBeOnline': '{name} must be online to be invited.',
@@ -379,6 +381,8 @@ export const DICT: Record<string, Record<string, string>> = {
       'El banco de hermandad debe vaciarse antes de poder disolver la hermandad.',
     'guild.bankClosing':
       'El banco de hermandad se está cerrando. Inténtalo de nuevo en un momento.',
+    'guild.bankSettling':
+      'El banco de hermandad aún está guardando un cambio reciente. Inténtalo de nuevo en un momento.',
     'guild.onlyOfficersInvite': 'Solo los oficiales y el Maestro de hermandad pueden invitar.',
     'guild.alreadyInThis': 'Ya perteneces a la hermandad.',
     'guild.mustBeOnline': '{name} debe estar conectado para ser invitado.',
@@ -525,6 +529,8 @@ export const DICT: Record<string, Record<string, string>> = {
       'El banco de hermandad debe vaciarse antes de poder disolver la hermandad.',
     'guild.bankClosing':
       'El banco de hermandad se está cerrando. Inténtalo de nuevo en un momento.',
+    'guild.bankSettling':
+      'El banco de hermandad aún está guardando un cambio reciente. Inténtalo de nuevo en un momento.',
     'guild.onlyOfficersInvite': 'Solo los oficiales y el Maestro de hermandad pueden invitar.',
     'guild.alreadyInThis': 'Ya perteneces a la hermandad.',
     'guild.mustBeOnline': '{name} debe estar conectado para poder ser invitado.',
@@ -671,6 +677,8 @@ export const DICT: Record<string, Record<string, string>> = {
     'guild.bankNotEmpty':
       'La banque de guilde doit être vidée avant que la guilde puisse être dissoute.',
     'guild.bankClosing': 'La banque de guilde est en cours de fermeture. Réessaie dans un instant.',
+    'guild.bankSettling':
+      'La banque de guilde enregistre encore une modification récente. Réessaie dans un instant.',
     'guild.onlyOfficersInvite': 'Seuls les officiers et le maître de guilde peuvent inviter.',
     'guild.alreadyInThis': 'Vous appartenez déjà à cette guilde.',
     'guild.mustBeOnline': '{name} doit être en ligne pour être invité.',
@@ -817,6 +825,8 @@ export const DICT: Record<string, Record<string, string>> = {
     'guild.bankNotEmpty':
       'La banque de guilde doit être vidée avant que la guilde puisse être dissoute.',
     'guild.bankClosing': 'La banque de guilde est en cours de fermeture. Réessaie dans un instant.',
+    'guild.bankSettling':
+      'La banque de guilde enregistre encore une modification récente. Réessaie dans un instant.',
     'guild.onlyOfficersInvite': 'Seuls les officiers et le maître de guilde peuvent inviter.',
     'guild.alreadyInThis': 'Vous faites déjà partie de la guilde.',
     'guild.mustBeOnline': '{name} doit être en ligne pour être invité.',
@@ -958,6 +968,8 @@ export const DICT: Record<string, Record<string, string>> = {
     'guild.bankNotEmpty':
       'La banca di gilda deve essere svuotata prima di poter sciogliere la gilda.',
     'guild.bankClosing': 'La banca di gilda si sta chiudendo. Riprova tra un momento.',
+    'guild.bankSettling':
+      'La banca di gilda sta ancora salvando una modifica recente. Riprova tra un momento.',
     'guild.onlyOfficersInvite': 'Solo gli ufficiali e il Maestro di Gilda possono invitare.',
     'guild.alreadyInThis': 'Fai già parte della gilda.',
     'guild.mustBeOnline': '{name} deve essere connesso per essere invitato.',
@@ -1104,6 +1116,8 @@ export const DICT: Record<string, Record<string, string>> = {
     'guild.bankNotEmpty':
       'Die Gildenbank muss geleert werden, bevor die Gilde aufgelöst werden kann.',
     'guild.bankClosing': 'Die Gildenbank wird geschlossen. Versuche es gleich noch einmal.',
+    'guild.bankSettling':
+      'Die Gildenbank speichert noch eine kürzliche Änderung. Versuche es gleich noch einmal.',
     'guild.onlyOfficersInvite': 'Nur Offiziere und der Gildenmeister können einladen.',
     'guild.alreadyInThis': 'Ihr seid bereits in der Gilde.',
     'guild.mustBeOnline': '{name} muss online sein, um eingeladen zu werden.',
@@ -1242,6 +1256,7 @@ export const DICT: Record<string, Record<string, string>> = {
     'guild.createFee': '创建公会需要{amount}金币。',
     'guild.bankNotEmpty': '必须先清空公会银行才能解散公会。',
     'guild.bankClosing': '公会银行正在关闭。请稍后再试。',
+    'guild.bankSettling': '公会银行仍在保存最近的一次变动。请稍后再试。',
     'guild.onlyOfficersInvite': '只有官员和会长才能邀请成员。',
     'guild.alreadyInThis': '你已经在该公会中了。',
     'guild.mustBeOnline': '{name}必须在线才能被邀请。',
@@ -1376,6 +1391,7 @@ export const DICT: Record<string, Record<string, string>> = {
     'guild.createFee': '建立公會需要 {amount} 金幣。',
     'guild.bankNotEmpty': '必須先清空公會銀行才能解散公會。',
     'guild.bankClosing': '公會銀行正在關閉。請稍後再試。',
+    'guild.bankSettling': '公會銀行仍在儲存最近的一次變動。請稍後再試。',
     'guild.onlyOfficersInvite': '只有幹部和會長才能邀請成員。',
     'guild.alreadyInThis': '你已經是這個公會的成員。',
     'guild.mustBeOnline': '{name} 必須在線上才能被邀請。',
@@ -1511,6 +1527,8 @@ export const DICT: Record<string, Record<string, string>> = {
     'guild.createFee': '길드를 창설하려면 {amount} 골드가 필요합니다.',
     'guild.bankNotEmpty': '길드를 해산하려면 먼저 길드 은행을 비워야 합니다.',
     'guild.bankClosing': '길드 은행이 닫히는 중입니다. 잠시 후 다시 시도하세요.',
+    'guild.bankSettling':
+      '길드 은행이 아직 최근 변경 사항을 저장하는 중입니다. 잠시 후 다시 시도하세요.',
     'guild.onlyOfficersInvite': '장교와 길드장만 초대할 수 있습니다.',
     'guild.alreadyInThis': '이미 해당 길드에 가입되어 있습니다.',
     'guild.mustBeOnline': '{name}님을 초대하려면 접속 중이어야 합니다.',
@@ -1647,6 +1665,8 @@ export const DICT: Record<string, Record<string, string>> = {
     'guild.createFee': 'ギルドを設立するには{amount}ゴールドが必要です。',
     'guild.bankNotEmpty': 'ギルドを解散するには、先にギルド銀行を空にする必要があります。',
     'guild.bankClosing': 'ギルド銀行は閉鎖中です。しばらくしてからもう一度お試しください。',
+    'guild.bankSettling':
+      'ギルド銀行は最近の変更をまだ保存中です。しばらくしてからもう一度お試しください。',
     'guild.onlyOfficersInvite': '招待できるのはオフィサーとギルドマスターのみです。',
     'guild.alreadyInThis': 'あなたはすでにこのギルドに所属しています。',
     'guild.mustBeOnline': '{name}を招待するには、相手がオンラインである必要があります。',
@@ -1791,6 +1811,8 @@ export const DICT: Record<string, Record<string, string>> = {
     'guild.bankNotEmpty':
       'O banco da guilda deve ser esvaziado antes que a guilda possa ser dissolvida.',
     'guild.bankClosing': 'O banco da guilda está fechando. Tente novamente em um momento.',
+    'guild.bankSettling':
+      'O banco da guilda ainda está salvando uma alteração recente. Tente novamente em um momento.',
     'guild.onlyOfficersInvite': 'Apenas oficiais e o Mestre da Guilda podem convidar.',
     'guild.alreadyInThis': 'Você já está na guilda.',
     'guild.mustBeOnline': '{name} precisa estar online para ser convidado.',
@@ -1931,6 +1953,8 @@ export const DICT: Record<string, Record<string, string>> = {
     'guild.createFee': 'Чтобы основать гильдию, вам нужно {amount} золота.',
     'guild.bankNotEmpty': 'Прежде чем распустить гильдию, необходимо опустошить гильдейский банк.',
     'guild.bankClosing': 'Гильдейский банк закрывается. Попробуйте ещё раз через мгновение.',
+    'guild.bankSettling':
+      'Гильдейский банк ещё сохраняет недавнее изменение. Попробуйте ещё раз через мгновение.',
     'guild.onlyOfficersInvite': 'Приглашать могут только офицеры и глава гильдии.',
     'guild.alreadyInThis': 'Вы уже состоите в этой гильдии.',
     'guild.mustBeOnline': '{name} должен(на) быть в сети, чтобы получить приглашение.',

--- a/src/ui/server_i18n.ts
+++ b/src/ui/server_i18n.ts
@@ -86,6 +86,7 @@ export const DICT: Record<string, Record<string, string>> = {
     // row. Two DB round trips wide.
     'guild.bankClosing': 'The guild bank is closing. Try again in a moment.',
     'guild.bankSettling': 'The guild bank is still saving a recent change. Try again in a moment.',
+    'guild.bankBusy': 'You are busy. Try again in a moment.',
     'guild.onlyOfficersInvite': 'Only officers and the Guild Master may invite.',
     'guild.alreadyInThis': 'You are already in the guild.',
     'guild.mustBeOnline': '{name} must be online to be invited.',
@@ -239,6 +240,7 @@ export const DICT: Record<string, Record<string, string>> = {
     'guild.bankNotEmpty': 'The guild bank must be emptied before the guild can be disbanded.',
     'guild.bankClosing': 'The guild bank is closing. Try again in a moment.',
     'guild.bankSettling': 'The guild bank is still saving a recent change. Try again in a moment.',
+    'guild.bankBusy': 'You are busy. Try again in a moment.',
     'guild.onlyOfficersInvite': 'Only officers and the Guild Master may invite.',
     'guild.alreadyInThis': 'You are already in the guild.',
     'guild.mustBeOnline': '{name} must be online to be invited.',
@@ -383,6 +385,7 @@ export const DICT: Record<string, Record<string, string>> = {
       'El banco de hermandad se está cerrando. Inténtalo de nuevo en un momento.',
     'guild.bankSettling':
       'El banco de hermandad aún está guardando un cambio reciente. Inténtalo de nuevo en un momento.',
+    'guild.bankBusy': 'Estás ocupado. Inténtalo de nuevo en un momento.',
     'guild.onlyOfficersInvite': 'Solo los oficiales y el Maestro de hermandad pueden invitar.',
     'guild.alreadyInThis': 'Ya perteneces a la hermandad.',
     'guild.mustBeOnline': '{name} debe estar conectado para ser invitado.',
@@ -531,6 +534,7 @@ export const DICT: Record<string, Record<string, string>> = {
       'El banco de hermandad se está cerrando. Inténtalo de nuevo en un momento.',
     'guild.bankSettling':
       'El banco de hermandad aún está guardando un cambio reciente. Inténtalo de nuevo en un momento.',
+    'guild.bankBusy': 'Estás ocupado. Inténtalo de nuevo en un momento.',
     'guild.onlyOfficersInvite': 'Solo los oficiales y el Maestro de hermandad pueden invitar.',
     'guild.alreadyInThis': 'Ya perteneces a la hermandad.',
     'guild.mustBeOnline': '{name} debe estar conectado para poder ser invitado.',
@@ -679,6 +683,7 @@ export const DICT: Record<string, Record<string, string>> = {
     'guild.bankClosing': 'La banque de guilde est en cours de fermeture. Réessaie dans un instant.',
     'guild.bankSettling':
       'La banque de guilde enregistre encore une modification récente. Réessaie dans un instant.',
+    'guild.bankBusy': 'Tu es occupé. Réessaie dans un instant.',
     'guild.onlyOfficersInvite': 'Seuls les officiers et le maître de guilde peuvent inviter.',
     'guild.alreadyInThis': 'Vous appartenez déjà à cette guilde.',
     'guild.mustBeOnline': '{name} doit être en ligne pour être invité.',
@@ -827,6 +832,7 @@ export const DICT: Record<string, Record<string, string>> = {
     'guild.bankClosing': 'La banque de guilde est en cours de fermeture. Réessaie dans un instant.',
     'guild.bankSettling':
       'La banque de guilde enregistre encore une modification récente. Réessaie dans un instant.',
+    'guild.bankBusy': 'Tu es occupé. Réessaie dans un instant.',
     'guild.onlyOfficersInvite': 'Seuls les officiers et le maître de guilde peuvent inviter.',
     'guild.alreadyInThis': 'Vous faites déjà partie de la guilde.',
     'guild.mustBeOnline': '{name} doit être en ligne pour être invité.',
@@ -970,6 +976,7 @@ export const DICT: Record<string, Record<string, string>> = {
     'guild.bankClosing': 'La banca di gilda si sta chiudendo. Riprova tra un momento.',
     'guild.bankSettling':
       'La banca di gilda sta ancora salvando una modifica recente. Riprova tra un momento.',
+    'guild.bankBusy': 'Sei occupato. Riprova tra un momento.',
     'guild.onlyOfficersInvite': 'Solo gli ufficiali e il Maestro di Gilda possono invitare.',
     'guild.alreadyInThis': 'Fai già parte della gilda.',
     'guild.mustBeOnline': '{name} deve essere connesso per essere invitato.',
@@ -1118,6 +1125,7 @@ export const DICT: Record<string, Record<string, string>> = {
     'guild.bankClosing': 'Die Gildenbank wird geschlossen. Versuche es gleich noch einmal.',
     'guild.bankSettling':
       'Die Gildenbank speichert noch eine kürzliche Änderung. Versuche es gleich noch einmal.',
+    'guild.bankBusy': 'Du bist beschäftigt. Versuche es gleich noch einmal.',
     'guild.onlyOfficersInvite': 'Nur Offiziere und der Gildenmeister können einladen.',
     'guild.alreadyInThis': 'Ihr seid bereits in der Gilde.',
     'guild.mustBeOnline': '{name} muss online sein, um eingeladen zu werden.',
@@ -1257,6 +1265,7 @@ export const DICT: Record<string, Record<string, string>> = {
     'guild.bankNotEmpty': '必须先清空公会银行才能解散公会。',
     'guild.bankClosing': '公会银行正在关闭。请稍后再试。',
     'guild.bankSettling': '公会银行仍在保存最近的一次变动。请稍后再试。',
+    'guild.bankBusy': '你正忙着。请稍后再试。',
     'guild.onlyOfficersInvite': '只有官员和会长才能邀请成员。',
     'guild.alreadyInThis': '你已经在该公会中了。',
     'guild.mustBeOnline': '{name}必须在线才能被邀请。',
@@ -1392,6 +1401,7 @@ export const DICT: Record<string, Record<string, string>> = {
     'guild.bankNotEmpty': '必須先清空公會銀行才能解散公會。',
     'guild.bankClosing': '公會銀行正在關閉。請稍後再試。',
     'guild.bankSettling': '公會銀行仍在儲存最近的一次變動。請稍後再試。',
+    'guild.bankBusy': '你正在忙。請稍後再試。',
     'guild.onlyOfficersInvite': '只有幹部和會長才能邀請成員。',
     'guild.alreadyInThis': '你已經是這個公會的成員。',
     'guild.mustBeOnline': '{name} 必須在線上才能被邀請。',
@@ -1529,6 +1539,7 @@ export const DICT: Record<string, Record<string, string>> = {
     'guild.bankClosing': '길드 은행이 닫히는 중입니다. 잠시 후 다시 시도하세요.',
     'guild.bankSettling':
       '길드 은행이 아직 최근 변경 사항을 저장하는 중입니다. 잠시 후 다시 시도하세요.',
+    'guild.bankBusy': '지금은 바쁩니다. 잠시 후 다시 시도하세요.',
     'guild.onlyOfficersInvite': '장교와 길드장만 초대할 수 있습니다.',
     'guild.alreadyInThis': '이미 해당 길드에 가입되어 있습니다.',
     'guild.mustBeOnline': '{name}님을 초대하려면 접속 중이어야 합니다.',
@@ -1667,6 +1678,7 @@ export const DICT: Record<string, Record<string, string>> = {
     'guild.bankClosing': 'ギルド銀行は閉鎖中です。しばらくしてからもう一度お試しください。',
     'guild.bankSettling':
       'ギルド銀行は最近の変更をまだ保存中です。しばらくしてからもう一度お試しください。',
+    'guild.bankBusy': '現在は操作中です。しばらくしてからもう一度お試しください。',
     'guild.onlyOfficersInvite': '招待できるのはオフィサーとギルドマスターのみです。',
     'guild.alreadyInThis': 'あなたはすでにこのギルドに所属しています。',
     'guild.mustBeOnline': '{name}を招待するには、相手がオンラインである必要があります。',
@@ -1813,6 +1825,7 @@ export const DICT: Record<string, Record<string, string>> = {
     'guild.bankClosing': 'O banco da guilda está fechando. Tente novamente em um momento.',
     'guild.bankSettling':
       'O banco da guilda ainda está salvando uma alteração recente. Tente novamente em um momento.',
+    'guild.bankBusy': 'Você está ocupado. Tente novamente em um momento.',
     'guild.onlyOfficersInvite': 'Apenas oficiais e o Mestre da Guilda podem convidar.',
     'guild.alreadyInThis': 'Você já está na guilda.',
     'guild.mustBeOnline': '{name} precisa estar online para ser convidado.',
@@ -1955,6 +1968,7 @@ export const DICT: Record<string, Record<string, string>> = {
     'guild.bankClosing': 'Гильдейский банк закрывается. Попробуйте ещё раз через мгновение.',
     'guild.bankSettling':
       'Гильдейский банк ещё сохраняет недавнее изменение. Попробуйте ещё раз через мгновение.',
+    'guild.bankBusy': 'Вы заняты. Попробуйте ещё раз через мгновение.',
     'guild.onlyOfficersInvite': 'Приглашать могут только офицеры и глава гильдии.',
     'guild.alreadyInThis': 'Вы уже состоите в этой гильдии.',
     'guild.mustBeOnline': '{name} должен(на) быть в сети, чтобы получить приглашение.',

--- a/tests/audit_conservation_property.test.ts
+++ b/tests/audit_conservation_property.test.ts
@@ -634,6 +634,25 @@ interface World {
 // biome-ignore lint/suspicious/noExplicitAny: the harness spans private seams (dispatch, saveCharacter, reconcile)
 const priv = (server: GameServer): any => server as any;
 
+/** Servers of earlier worlds whose fire-and-forget holder flushes (the
+ *  unsettled gate's refusal flushes the depositor on the spot) may still sit
+ *  on a per-character save queue. The fake durable store is keyed by the SAME
+ *  guild and character ids across worlds, so a late commit from an old
+ *  server would land in the NEXT world's rows as a phantom durable prefix (an
+ *  opening replayed onto a ladder already at 24, a deposit applied twice).
+ *  Drain them before a new world is built; bounded so a stuck queue fails
+ *  the run instead of hanging it. */
+const straggleWatch: GameServer[] = [];
+async function drainStragglingSaves(): Promise<void> {
+  for (const server of straggleWatch) {
+    for (let spin = 0; server.characterSaveQueues.pendingKeys() > 0; spin++) {
+      if (spin > 2_000) throw new Error('a previous world never drained its save queues');
+      await new Promise((r) => setTimeout(r, 0));
+    }
+  }
+  straggleWatch.length = 0;
+}
+
 function fakeWs(): unknown {
   return {
     readyState: 1,
@@ -686,7 +705,9 @@ async function makeWorld(): Promise<World> {
   // "Worker exited unexpectedly" failure). The per-test beforeEach clear
   // stays for the suites that assert against a fresh history.
   vi.clearAllMocks();
+  await drainStragglingSaves();
   const server = new GameServer();
+  straggleWatch.push(server);
   const actors: Actor[] = [];
   for (const characterId of [1, 2]) {
     const session = server.join(

--- a/tests/audit_cur_conservation.test.ts
+++ b/tests/audit_cur_conservation.test.ts
@@ -304,6 +304,29 @@ async function settle(): Promise<void> {
 const dispatch = (server: GameServer, session: ClientSession, msg: Record<string, unknown>) =>
   priv(server).dispatchMessage(session, { t: 'cmd', ...msg }, JSON.stringify(msg), 0);
 
+/** Dispatch one op with `hidden` sessions invisible to the dispatch-time
+ *  unsettled gate (server/guild_bank_settle_gate.ts): they read as quarantined
+ *  for the duration, so the gate sees no holder and the op lands through the
+ *  real coordinator exactly as every op did before the gate. The
+ *  consume-then-fence probes below pin the refusal/rollback machinery UNDER
+ *  the gate, which ordinary dispatch can no longer reach. */
+function dispatchUnderGate(
+  server: GameServer,
+  session: ClientSession,
+  msg: Record<string, unknown>,
+  hidden: readonly ClientSession[],
+): void {
+  const was = hidden.map((h) => h.escrowQuarantined);
+  for (const h of hidden) h.escrowQuarantined = true;
+  try {
+    dispatch(server, session, msg);
+  } finally {
+    hidden.forEach((h, n) => {
+      h.escrowQuarantined = was[n] ?? false;
+    });
+  }
+}
+
 const purse = (server: GameServer, session: ClientSession): number =>
   server.sim.players.get(session.pid)?.copper ?? -1;
 
@@ -441,13 +464,16 @@ describe("another officer's save can no longer launder an unflushed deposit into
 // itself fenced (an ordinary re-login) so nothing will ever make A's deposit
 // durable. B kept the value; A's stake came back.
 //
-// It is now impossible by construction: B's save cannot commit its character
-// half, because the book half it is paired with cannot be replayed onto
-// durable truth, so the whole transaction rolls back. B retries while A is
-// still around to make the deposit durable, and once A is gone B's live state
-// is abandoned wholesale: its own book ops come off the live book, it is
-// quarantined so it can never persist, and it reloads from a durable row that
-// never saw the withdrawal.
+// It is now impossible by construction, twice over. First line: the
+// dispatch-time unsettled gate (server/guild_bank_settle_gate.ts) refuses B's
+// consume of A's not-yet-durable deposit outright, so B never holds the value
+// (the last probe below). Backstop, reached here by hiding A from the gate:
+// B's save cannot commit its character half, because the book half it is
+// paired with cannot be replayed onto durable truth, so the whole transaction
+// rolls back. B retries while A is still around to make the deposit durable,
+// and once A is gone B's live state is abandoned wholesale: its own book ops
+// come off the live book, it is quarantined so it can never persist, and it
+// reloads from a durable row that never saw the withdrawal.
 // ---------------------------------------------------------------------------
 describe('consume-then-fence can no longer duplicate across two accounts', () => {
   it("refuses the consumer's save and rolls it back rather than minting", async () => {
@@ -471,7 +497,9 @@ describe('consume-then-fence can no longer duplicate across two accounts', () =>
     if (!aMeta) throw new Error('missing meta');
     const idx = aMeta.inventory.findIndex((s) => s.itemId === 'wolf_fang');
     dispatch(server, a, { cmd: 'guild_bank_deposit', slot: idx, count: 4 });
-    dispatch(server, b, { cmd: 'guild_bank_withdraw', slot: 0, count: 4 });
+    // The consume itself is what the gate refuses now; hide A to reach the
+    // backstop this probe pins.
+    dispatchUnderGate(server, b, { cmd: 'guild_bank_withdraw', slot: 0, count: 4 }, [a]);
     expect(countFangs({ inventory: server.sim.players.get(b.pid)?.inventory })).toBe(4);
 
     // A fences itself out (an ordinary re-login), so A's deposit will never be
@@ -533,7 +561,7 @@ describe('consume-then-fence can no longer duplicate across two accounts', () =>
       stamp(server, b);
       const start = durablePurse(1) + durablePurse(2);
       dispatch(server, a, { cmd: 'guild_bank_deposit_gold', amount: 400_000 });
-      dispatch(server, b, { cmd: 'guild_bank_withdraw_gold', amount: 400_000 });
+      dispatchUnderGate(server, b, { cmd: 'guild_bank_withdraw_gold', amount: 400_000 }, [a]);
       dbMock.setFence(1);
       const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
       const err = vi.spyOn(console, 'error').mockImplementation(() => {});
@@ -545,6 +573,58 @@ describe('consume-then-fence can no longer duplicate across two accounts', () =>
         durablePurse(1) + durablePurse(2) + (dbMock.durableBooks.get(GUILD_ID) as Book).treasury;
       expect(`round ${round}: ${end - start}`).toBe(`round ${round}: 0`);
     }
+  });
+
+  it('the unsettled gate refuses the consume at dispatch, so the fence-out strands nothing', async () => {
+    // The first line of defense: through ordinary dispatch B never holds A's
+    // not-yet-durable fangs at all, A's fence-out simply lifts its own deposit
+    // off the live book, B stays clean and saves normally, and no anomaly row
+    // is ever written.
+    dbMock.durableBooks.clear();
+    dbMock.durableChars.clear();
+    dbMock.setFence(null);
+    const server = new GameServer();
+    const a = joinServer(server, 1, 'GateA');
+    const b = joinServer(server, 2, 'GateB');
+    await settle();
+    server.sim.loadGuildBank(GUILD_ID, { treasury: 0, inventory: [], purchasedSlots: 24 });
+    dbMock.durableBooks.set(GUILD_ID, { treasury: 0, inventory: [], purchasedSlots: 24 });
+    officer(server, a, 10_000);
+    officer(server, b, 10_000);
+    server.sim.addItem('wolf_fang', 4, a.pid);
+    await priv(server).saveCharacter(a);
+    await priv(server).saveCharacter(b);
+    stamp(server, a);
+    stamp(server, b);
+    const aMeta = server.sim.players.get(a.pid);
+    if (!aMeta) throw new Error('missing meta');
+    const idx = aMeta.inventory.findIndex((s) => s.itemId === 'wolf_fang');
+    dispatch(server, a, { cmd: 'guild_bank_deposit', slot: idx, count: 4 });
+    dispatch(server, b, { cmd: 'guild_bank_withdraw', slot: 0, count: 4 });
+    // Refused: B holds nothing, the book still holds A's four, B has no book ops.
+    expect(countFangs({ inventory: server.sim.players.get(b.pid)?.inventory })).toBe(0);
+    expect(countFangs({ inventory: server.sim.guildBanks.get(GUILD_ID)?.inventory })).toBe(4);
+    expect(b.dirtyGuildBanks.size).toBe(0);
+    // The refusal flushed A; let that land, then fence A out and save both.
+    await settle();
+    dbMock.setFence(1);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+    await priv(server).saveCharacter(a);
+    stamp(server, b);
+    await priv(server).saveCharacter(b);
+    warn.mockRestore();
+    err.mockRestore();
+    expect(b.escrowQuarantined).toBe(false);
+    // Four fangs, in exactly one durable place, whatever A's flush managed
+    // before the fence: A's bags or the book, never both and never B.
+    const bookFangs = countFangs({
+      inventory: (dbMock.durableBooks.get(GUILD_ID) as Book).inventory,
+    });
+    expect(countFangs(dbMock.durableChars.get(1)) + bookFangs).toBe(4);
+    expect(countFangs(dbMock.durableChars.get(2))).toBe(0);
+    await bankLedgerIdle();
+    expect(capturedLedgerRows().filter((row) => row.op === 'escrow_deficit')).toEqual([]);
   });
 });
 

--- a/tests/guild_bank_persistence.test.ts
+++ b/tests/guild_bank_persistence.test.ts
@@ -2645,15 +2645,18 @@ describe('the unsettled gate (server/guild_bank_settle_gate.ts) at the real disp
     expect(durableBook()).toEqual({ treasury: 0, inventory: [], purchasedSlots: 24 });
   });
 
-  it("a departing officer's deposit stays unsettled until their leave flush lands, and is never flushed again", () => {
+  it("a departing officer's deposit stays unsettled until their leave flush lands, and only the staying holder is flushed", async () => {
     const server = new GameServer();
     const aJoin = joinServer(server, 1, 'Stayer');
     const a = aJoin.session;
     const b = joinServer(server, 2, 'Leaver').session;
+    const c = joinServer(server, 3, 'Holder').session;
     officerSetup(server, a, 0);
     secondOfficer(server, b);
+    secondOfficer(server, c);
     server.sim.addItem('spider_leg', 20, b.pid);
     dispatch(server, b, { cmd: 'guild_bank_deposit', slot: bagIndex(server, b.pid, 'spider_leg') });
+    dispatch(server, c, { cmd: 'guild_bank_deposit_gold', amount: 5_000 }); // C: an unrelated holder
     // The window between leave() and the leave flush's commit: B's deposit is
     // on the live book, not durable, and B's own flush is already in flight.
     b.left = true;
@@ -2661,8 +2664,85 @@ describe('the unsettled gate (server/guild_bank_settle_gate.ts) at the real disp
     dispatch(server, a, { cmd: 'guild_bank_withdraw', slot: bookIndex(server, 'spider_leg') });
     expect(notices(aJoin.sent)).toContain(NOTICE);
     expect(bookCount(server, 'spider_leg')).toBe(20);
+    // The positive control: the staying holder IS flushed by that refusal...
+    await vi.waitFor(() => expect(c.dirtyGuildBanks.size).toBe(0));
+    // ...and the departing one is not (its mark survives, no save was queued
+    // for it): only C's character id reached the escrow save.
     expect(b.dirtyGuildBanks.has(GUILD_ID)).toBe(true);
-    expect(dbMock.saveCharacterAndGuildBankState).not.toHaveBeenCalled();
+    const saved = dbMock.saveCharacterAndGuildBankState.mock.calls.map((call) => call[0]);
+    expect(saved).toEqual([3]);
+  });
+
+  it("three officers: one holder's uncommitted withdrawal never hides another holder's deposit", async () => {
+    // Durable truth holds 10 spider legs. B deposits 10 more (unsettled), C
+    // withdraws 10 (settled copies, so C's gate passes). A single cross-holder
+    // net would read 0 and let A take B's copies; per-session positives keep
+    // B's 10 unsettled until B commits.
+    const server = new GameServer();
+    const aJoin = joinServer(server, 1, 'Taker');
+    const a = aJoin.session;
+    const b = joinServer(server, 2, 'Depositor').session;
+    const cJoin = joinServer(server, 3, 'Remover');
+    const c = cJoin.session;
+    officerSetup(server, a, 0);
+    secondOfficer(server, b);
+    secondOfficer(server, c);
+    liveBook(server).inventory.push({ itemId: 'spider_leg', count: 10 });
+    durableBooks.set(GUILD_ID, {
+      treasury: 0,
+      inventory: [{ itemId: 'spider_leg', count: 10 }],
+      purchasedSlots: 24,
+    });
+    server.sim.addItem('spider_leg', 10, b.pid);
+    dispatch(server, b, { cmd: 'guild_bank_deposit', slot: bagIndex(server, b.pid, 'spider_leg') });
+    expect(bookCount(server, 'spider_leg')).toBe(20);
+    dispatch(server, c, {
+      cmd: 'guild_bank_withdraw',
+      slot: bookIndex(server, 'spider_leg'),
+      count: 10,
+    });
+    expect(notices(cJoin.sent)).not.toContain(NOTICE);
+    expect(bookCount(server, 'spider_leg')).toBe(10);
+    // The 10 left on the live book are B's: A is refused, and B is flushed.
+    dispatch(server, a, { cmd: 'guild_bank_withdraw', slot: bookIndex(server, 'spider_leg') });
+    expect(notices(aJoin.sent)).toContain(NOTICE);
+    expect(bookCount(server, 'spider_leg')).toBe(10);
+    await vi.waitFor(() => expect(b.dirtyGuildBanks.size).toBe(0));
+    restamp(server, a, c);
+    // B's deposit is durable now; C's withdrawal is still unsettled but it is
+    // a REMOVAL, so it hides nothing: A's retry passes and every save lands.
+    dispatch(server, a, { cmd: 'guild_bank_withdraw', slot: bookIndex(server, 'spider_leg') });
+    expect(notices(aJoin.sent).filter((text) => text === NOTICE)).toHaveLength(1);
+    expect(bookCount(server, 'spider_leg')).toBe(0);
+    expect(await priv(server).saveCharacter(c)).toBe(true);
+    expect(await priv(server).saveCharacter(a)).toBe(true);
+    expect(a.escrowQuarantined).toBe(false);
+    expect(c.escrowQuarantined).toBe(false);
+    expect(durableBook()).toEqual({ treasury: 0, inventory: [], purchasedSlots: 24 });
+    expect(server.sim.serializeGuildBank(GUILD_ID)).toEqual(durableBook());
+  });
+
+  it('the holder flush is DAMPED: refusals inside the cooldown never stack a second save', async () => {
+    const server = new GameServer();
+    const aJoin = joinServer(server, 1, 'Spammer');
+    const a = aJoin.session;
+    const b = joinServer(server, 2, 'Holder').session;
+    officerSetup(server, a, 0);
+    secondOfficer(server, b);
+    server.sim.addItem('spider_leg', 20, b.pid);
+    dispatch(server, b, { cmd: 'guild_bank_deposit', slot: bagIndex(server, b.pid, 'spider_leg') });
+    dbMock.saveCharacterAndGuildBankState.mockClear();
+    // Three refusals back to back, well inside GUILD_BOOK_FLUSH_COOLDOWN_MS.
+    for (let n = 0; n < 3; n++) {
+      dispatch(server, a, { cmd: 'guild_bank_withdraw', slot: bookIndex(server, 'spider_leg') });
+    }
+    expect(notices(aJoin.sent).filter((text) => text === NOTICE)).toHaveLength(3);
+    await vi.waitFor(() => expect(b.dirtyGuildBanks.size).toBe(0));
+    // ONE save for the holder, not three: the fan-out is bounded per holder
+    // per window, whatever the refusal rate.
+    const saved = dbMock.saveCharacterAndGuildBankState.mock.calls.map((call) => call[0]);
+    expect(saved).toEqual([2]);
+    expect(b.guildBookFlushedAtMs).toBeGreaterThan(0);
   });
 });
 

--- a/tests/guild_bank_persistence.test.ts
+++ b/tests/guild_bank_persistence.test.ts
@@ -204,6 +204,30 @@ function officerSetup(server: GameServer, session: ClientSession, treasury = 100
 const dispatch = (server: GameServer, session: ClientSession, msg: Record<string, unknown>) =>
   priv(server).dispatchMessage(session, { t: 'cmd', ...msg }, JSON.stringify(msg), 0);
 
+/** Dispatch one op with `hidden` sessions invisible to the dispatch-time
+ *  unsettled gate (server/guild_bank_settle_gate.ts): they read as quarantined
+ *  for the duration, so the gate sees no holder and the op lands through the
+ *  REAL coordinator (journal, log, mark) exactly as every op did before the
+ *  gate. The tests that use it pin the refusal/rollback machinery UNDER the
+ *  gate, which ordinary dispatch can no longer reach: a dependency the gate
+ *  could not see is the shape the backstop exists for. */
+function dispatchUnderGate(
+  server: GameServer,
+  session: ClientSession,
+  msg: Record<string, unknown>,
+  hidden: readonly ClientSession[],
+): void {
+  const was = hidden.map((s) => s.escrowQuarantined);
+  for (const s of hidden) s.escrowQuarantined = true;
+  try {
+    dispatch(server, session, msg);
+  } finally {
+    hidden.forEach((s, n) => {
+      s.escrowQuarantined = was[n] ?? false;
+    });
+  }
+}
+
 type CapturedLedgerEffects = {
   batches?: readonly { rows?: readonly Record<string, unknown>[] }[];
 };
@@ -2124,13 +2148,16 @@ describe('the guild_create fee gate + the create/disband hooks', () => {
     expect(priv(server).social.tx.beginGuildBankDelete(GUILD_ID)).toEqual({ copper: 0, items: 0 });
   });
 
-  // Two officers alternating LADDER rungs is the only shape that can deadlock
-  // both replays at once: gold and items cannot, because the live book never
-  // goes below zero, so at least one session's net is non-negative and lands
-  // (and the flush a refusal fires then unblocks the other). A rung, by
-  // contrast, replays only onto the exact position its witness names, so
-  // officer A's rung waits on officer B's opening while officer B's next rung
-  // waits on officer A's.
+  // Two officers alternating LADDER rungs: officer A's rung waits on officer
+  // B's opening while officer B's next rung waits on officer A's, so neither
+  // replay can ever apply first. (This used to be described as the ONLY shape
+  // that can deadlock both replays, gold and items being unable to: true for
+  // one fungible, false for two item identities, which is the 2026-09-01
+  // production incident the unsettled gate now refuses at dispatch; see the
+  // gate's own describe block below.) The gate refuses a rung on top of an
+  // unsettled one, so the deadlock is SEEDED under it: B's opening and both
+  // gold deposits go through dispatch (never gated), the two rungs are
+  // dispatched with the other officer hidden from the gate.
   function ladderDeadlock(server: GameServer, a: ClientSession, b: ClientSession): void {
     officerSetup(server, a, 0);
     durableBooks.set(GUILD_ID, { treasury: 0, inventory: [], purchasedSlots: 0 });
@@ -2149,10 +2176,12 @@ describe('the guild_create fee gate + the create/disband hooks', () => {
     dispatch(server, b, { cmd: 'guild_bank_buy_slots' }); // B opens, 0 -> 24
     stampBoth();
     dispatch(server, a, { cmd: 'guild_bank_deposit_gold', amount: 25_000 });
-    dispatch(server, a, { cmd: 'guild_bank_buy_slots' }); // A buys rung 1, 24 -> 30
+    // A buys rung 1, 24 -> 30, on top of B's unsettled opening.
+    dispatchUnderGate(server, a, { cmd: 'guild_bank_buy_slots' }, [b]);
     stampBoth();
     dispatch(server, b, { cmd: 'guild_bank_deposit_gold', amount: 50_000 });
-    dispatch(server, b, { cmd: 'guild_bank_buy_slots' }); // B buys rung 2, 30 -> 36
+    // B buys rung 2, 30 -> 36, on top of A's unsettled rung.
+    dispatchUnderGate(server, b, { cmd: 'guild_bank_buy_slots' }, [a]);
     stampBoth();
     expect(server.sim.guildBanks.get(GUILD_ID)?.purchasedSlots).toBe(36);
     // Neither log can be replayed: A's rung needs the ladder at exactly 24
@@ -2225,7 +2254,10 @@ describe('the guild_create fee gate + the create/disband hooks', () => {
     bMeta.copper = 500_000;
     dispatch(server, b, { cmd: 'guild_bank_deposit_gold', amount: 40_000 });
     server.sim.setPlayerGuildMembership(a.pid, { guildId: GUILD_ID, rank: 'officer' });
-    dispatch(server, a, { cmd: 'guild_bank_withdraw_gold', amount: 40_000 });
+    // A's withdraw of B's unsettled copper is exactly what the dispatch-time
+    // gate now refuses, so it is dispatched with B hidden from the gate to
+    // reach the refusal arm.
+    dispatchUnderGate(server, a, { cmd: 'guild_bank_withdraw_gold', amount: 40_000 }, [b]);
     const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     await priv(server).saveCharacter(a); // refused, and flushes B
     await vi.waitFor(() => expect(b.dirtyGuildBanks.size).toBe(0));
@@ -2435,6 +2467,204 @@ function recordingIncidents(): { sink: GameMetricsCounters; kinds: GuildBankInci
     },
   };
 }
+
+describe('the unsettled gate (server/guild_bank_settle_gate.ts) at the real dispatch seam', () => {
+  afterEach(() => {
+    setGameMetricsCounters(noopGameMetricsCounters);
+  });
+
+  // English on the wire; the client matcher re-localizes it (guild.bankSettling).
+  const NOTICE = 'The guild bank is still saving a recent change. Try again in a moment.';
+  /** Every player-facing error line a fake socket received. */
+  const notices = (sent: unknown[]): string[] =>
+    sent.flatMap((frame) => {
+      const f = frame as { t?: string; list?: { type?: string; text?: string }[] };
+      if (f.t !== 'events') return [];
+      return (f.list ?? []).filter((e) => e.type === 'error').map((e) => e.text ?? '');
+    });
+  /** A second officer of the same guild at the banker, with copper. */
+  function secondOfficer(server: GameServer, b: ClientSession): void {
+    moveToBanker(server, b.pid);
+    stampMember(server, b, 'officer');
+    const meta = server.sim.players.get(b.pid);
+    if (!meta) throw new Error('missing meta');
+    meta.copper = 500_000;
+  }
+  /** Re-seat the officer stamps after any await: the join's async social load
+   *  lands there and re-stamps from the (mocked, empty) social read, exactly
+   *  why the ladder tests above call stampBoth() between their steps. */
+  const restamp = (server: GameServer, ...sessions: ClientSession[]): void => {
+    for (const s of sessions) {
+      server.sim.setPlayerGuildMembership(s.pid, { guildId: GUILD_ID, rank: 'officer' });
+    }
+  };
+  const bagIndex = (server: GameServer, pid: number, itemId: string): number => {
+    const idx = server.sim.players.get(pid)?.inventory.findIndex((s) => s.itemId === itemId) ?? -1;
+    if (idx < 0) throw new Error(`${itemId} is not in the bags of ${pid}`);
+    return idx;
+  };
+  const liveBook = (server: GameServer) => {
+    const book = server.sim.guildBanks.get(GUILD_ID);
+    if (!book) throw new Error('missing book');
+    return book;
+  };
+  const bookIndex = (server: GameServer, itemId: string): number => {
+    const idx = liveBook(server).inventory.findIndex((s) => s.itemId === itemId);
+    if (idx < 0) throw new Error(`${itemId} is not in the book`);
+    return idx;
+  };
+  const bookCount = (server: GameServer, itemId: string): number =>
+    liveBook(server)
+      .inventory.filter((s) => s.itemId === itemId)
+      .reduce((n, s) => n + s.count, 0);
+  const durableBags = (characterId: number) =>
+    (durableChars.get(characterId) as { inventory?: { itemId: string; count: number }[] })
+      ?.inventory ?? [];
+
+  it('the 2026-09-01 shape: two officers swapping two materials inside one save window quarantine nobody and strand nothing', async () => {
+    const server = new GameServer();
+    const aJoin = joinServer(server, 1, 'Legs');
+    const bJoin = joinServer(server, 2, 'Glands');
+    const a = aJoin.session;
+    const b = bJoin.session;
+    officerSetup(server, a, 0);
+    secondOfficer(server, b);
+    server.sim.addItem('spider_leg', 20, a.pid);
+    server.sim.addItem('venom_gland', 20, b.pid);
+    dispatch(server, a, { cmd: 'guild_bank_deposit', slot: bagIndex(server, a.pid, 'spider_leg') });
+    dispatch(server, b, {
+      cmd: 'guild_bank_deposit',
+      slot: bagIndex(server, b.pid, 'venom_gland'),
+    });
+    expect(bookCount(server, 'spider_leg')).toBe(20);
+    expect(bookCount(server, 'venom_gland')).toBe(20);
+    const rec = recordingIncidents();
+    setGameMetricsCounters(rec.sink);
+    // B reaches for A's not-yet-durable spider legs: refused at dispatch, the
+    // book untouched, B's log still only its own deposit and its mark
+    // unchanged, the notice sent, and A flushed on the spot.
+    const bSeq = b.dirtyGuildBanks.get(GUILD_ID);
+    dispatch(server, b, { cmd: 'guild_bank_withdraw', slot: bookIndex(server, 'spider_leg') });
+    expect(notices(bJoin.sent)).toContain(NOTICE);
+    expect(bookCount(server, 'spider_leg')).toBe(20);
+    expect(b.unflushedGuildBankOps.get(GUILD_ID)?.map((d) => d.op)).toEqual(['deposit']);
+    expect(b.dirtyGuildBanks.get(GUILD_ID)).toBe(bSeq);
+    expect(rec.kinds).toEqual(['unsettled_refused']);
+    await vi.waitFor(() => expect(a.dirtyGuildBanks.size).toBe(0));
+    restamp(server, a, b);
+    // A reaches for B's venom glands: the mirror image, and B is flushed.
+    dispatch(server, a, { cmd: 'guild_bank_withdraw', slot: bookIndex(server, 'venom_gland') });
+    expect(notices(aJoin.sent)).toContain(NOTICE);
+    await vi.waitFor(() => expect(b.dirtyGuildBanks.size).toBe(0));
+    restamp(server, a, b);
+    // Both stacks are settled now: the retries land, and so do both saves.
+    dispatch(server, b, { cmd: 'guild_bank_withdraw', slot: bookIndex(server, 'spider_leg') });
+    dispatch(server, a, { cmd: 'guild_bank_withdraw', slot: bookIndex(server, 'venom_gland') });
+    expect(await priv(server).saveCharacter(a)).toBe(true);
+    expect(await priv(server).saveCharacter(b)).toBe(true);
+    expect(a.escrowQuarantined).toBe(false);
+    expect(b.escrowQuarantined).toBe(false);
+    expect(rec.kinds).toEqual(['unsettled_refused', 'unsettled_refused']);
+    // The swap went through durably, and the live book equals the durable
+    // one: no phantom stack survives for the next officer to trip over.
+    expect(durableBook()).toEqual({ treasury: 0, inventory: [], purchasedSlots: 24 });
+    expect(server.sim.serializeGuildBank(GUILD_ID)).toEqual(durableBook());
+    expect(durableBags(1)).toContainEqual(
+      expect.objectContaining({ itemId: 'venom_gland', count: 20 }),
+    );
+    expect(durableBags(2)).toContainEqual(
+      expect.objectContaining({ itemId: 'spider_leg', count: 20 }),
+    );
+  });
+
+  it('a gold withdraw beyond the settled treasury is refused and lands after the flush; one within it passes at once', async () => {
+    const server = new GameServer();
+    const aJoin = joinServer(server, 1, 'Taker');
+    const a = aJoin.session;
+    const b = joinServer(server, 2, 'Giver').session;
+    officerSetup(server, a, 100_000);
+    secondOfficer(server, b);
+    dispatch(server, b, { cmd: 'guild_bank_deposit_gold', amount: 40_000 });
+    // 100_000 is settled: it passes even while B's 40_000 is not.
+    dispatch(server, a, { cmd: 'guild_bank_withdraw_gold', amount: 100_000 });
+    expect(notices(aJoin.sent)).not.toContain(NOTICE);
+    expect(liveBook(server).treasury).toBe(40_000);
+    // The remaining 40_000 is B's unsettled deposit: refused, and B flushed.
+    dispatch(server, a, { cmd: 'guild_bank_withdraw_gold', amount: 40_000 });
+    expect(notices(aJoin.sent)).toContain(NOTICE);
+    expect(liveBook(server).treasury).toBe(40_000);
+    await vi.waitFor(() => expect(b.dirtyGuildBanks.size).toBe(0));
+    restamp(server, a);
+    dispatch(server, a, { cmd: 'guild_bank_withdraw_gold', amount: 40_000 });
+    expect(liveBook(server).treasury).toBe(0);
+    expect(await priv(server).saveCharacter(a)).toBe(true);
+    expect(a.escrowQuarantined).toBe(false);
+    expect(durableBook()).toEqual({ treasury: 0, inventory: [], purchasedSlots: 24 });
+    expect(durableChars.get(1)?.copper).toBe(640_000);
+  });
+
+  it("a rung bought on top of another officer's unsettled rung is refused, never deadlocked", async () => {
+    const server = new GameServer();
+    const aJoin = joinServer(server, 1, 'RungA');
+    const a = aJoin.session;
+    const b = joinServer(server, 2, 'OpenerB').session;
+    officerSetup(server, a, 0);
+    durableBooks.set(GUILD_ID, { treasury: 0, inventory: [], purchasedSlots: 0 });
+    liveBook(server).purchasedSlots = 0; // unopened, matching the durable row
+    secondOfficer(server, b);
+    dispatch(server, b, { cmd: 'guild_bank_buy_slots' }); // B opens, 0 -> 24, unsettled
+    expect(liveBook(server).purchasedSlots).toBe(24);
+    dispatch(server, a, { cmd: 'guild_bank_deposit_gold', amount: 100_000 });
+    dispatch(server, a, { cmd: 'guild_bank_buy_slots' }); // refused: B's opening is unsettled
+    expect(notices(aJoin.sent)).toContain(NOTICE);
+    expect(liveBook(server).purchasedSlots).toBe(24);
+    await vi.waitFor(() => expect(b.dirtyGuildBanks.size).toBe(0));
+    restamp(server, a);
+    dispatch(server, a, { cmd: 'guild_bank_buy_slots' });
+    expect(liveBook(server).purchasedSlots).toBe(30);
+    expect(await priv(server).saveCharacter(a)).toBe(true);
+    expect(a.escrowQuarantined).toBe(false);
+    expect(durableBook()).toEqual(expect.objectContaining({ purchasedSlots: 30 }));
+  });
+
+  it('a session may take back its OWN unsettled deposit while another officer is dirty on the book', async () => {
+    const server = new GameServer();
+    const aJoin = joinServer(server, 1, 'Own');
+    const a = aJoin.session;
+    const b = joinServer(server, 2, 'Bystander').session;
+    officerSetup(server, a, 0);
+    secondOfficer(server, b);
+    server.sim.addItem('spider_leg', 20, a.pid);
+    dispatch(server, a, { cmd: 'guild_bank_deposit', slot: bagIndex(server, a.pid, 'spider_leg') });
+    dispatch(server, b, { cmd: 'guild_bank_deposit_gold', amount: 5_000 });
+    dispatch(server, a, { cmd: 'guild_bank_withdraw', slot: bookIndex(server, 'spider_leg') });
+    expect(notices(aJoin.sent)).not.toContain(NOTICE);
+    expect(bookCount(server, 'spider_leg')).toBe(0);
+    expect(await priv(server).saveCharacter(a)).toBe(true);
+    expect(a.escrowQuarantined).toBe(false);
+    expect(durableBook()).toEqual({ treasury: 0, inventory: [], purchasedSlots: 24 });
+  });
+
+  it("a departing officer's deposit stays unsettled until their leave flush lands, and is never flushed again", () => {
+    const server = new GameServer();
+    const aJoin = joinServer(server, 1, 'Stayer');
+    const a = aJoin.session;
+    const b = joinServer(server, 2, 'Leaver').session;
+    officerSetup(server, a, 0);
+    secondOfficer(server, b);
+    server.sim.addItem('spider_leg', 20, b.pid);
+    dispatch(server, b, { cmd: 'guild_bank_deposit', slot: bagIndex(server, b.pid, 'spider_leg') });
+    // The window between leave() and the leave flush's commit: B's deposit is
+    // on the live book, not durable, and B's own flush is already in flight.
+    b.left = true;
+    dbMock.saveCharacterAndGuildBankState.mockClear();
+    dispatch(server, a, { cmd: 'guild_bank_withdraw', slot: bookIndex(server, 'spider_leg') });
+    expect(notices(aJoin.sent)).toContain(NOTICE);
+    expect(bookCount(server, 'spider_leg')).toBe(20);
+    expect(b.dirtyGuildBanks.has(GUILD_ID)).toBe(true);
+    expect(dbMock.saveCharacterAndGuildBankState).not.toHaveBeenCalled();
+  });
+});
 
 describe('guild bank incident counters at their real emission sites', () => {
   afterEach(() => {
@@ -2681,7 +2911,12 @@ describe('guild bank incident counters at their real emission sites', () => {
     expect(other.dirtyGuildBanks.has(GUILD_ID)).toBe(true);
     // This officer consumes value durable truth does not hold yet, so its own
     // escrow replay is refused until the other one commits.
-    dispatch(server, session, { cmd: 'guild_bank_withdraw_gold', amount: 120_000 });
+    // The dispatch-time gate now refuses exactly this consume, so it is
+    // dispatched with the other officer hidden from the gate to reach the
+    // refusal arm.
+    dispatchUnderGate(server, session, { cmd: 'guild_bank_withdraw_gold', amount: 120_000 }, [
+      other,
+    ]);
     const rec = recordingIncidents();
     setGameMetricsCounters(rec.sink);
     await priv(server).saveCharacter(session);

--- a/tests/guild_bank_persistence.test.ts
+++ b/tests/guild_bank_persistence.test.ts
@@ -2829,6 +2829,44 @@ describe('the unsettled gate (server/guild_bank_settle_gate.ts) at the real disp
     expect(saved).toHaveLength(GUILD_BOOK_FLUSH_FAN_OUT_MAX);
     expect(holders.filter((h) => h.dirtyGuildBanks.size > 0)).toHaveLength(1);
   });
+
+  it('the holder index follows a commit, a leave, and a disband at the server seams, and agrees with a full scan', async () => {
+    const server = new GameServer();
+    const a = joinServer(server, 1, 'IdxA').session;
+    const b = joinServer(server, 2, 'IdxB').session;
+    const c = joinServer(server, 3, 'IdxC').session;
+    officerSetup(server, a, 0);
+    secondOfficer(server, b);
+    secondOfficer(server, c);
+    const index = priv(server).guildBookHolders as {
+      holders(g: number, e: ClientSession | null, o: { includeLeaving: boolean }): ClientSession[];
+      readonly size: number;
+    };
+    const holders = () => index.holders(GUILD_ID, null, { includeLeaving: true });
+    // The oracle: the index must say exactly what a scan of every live
+    // session says, so a mark or log site that forgets the index shows here.
+    const scan = () =>
+      [...(priv(server).sessionsByCharacterId.values() as Iterable<ClientSession>)].filter(
+        (s) => !s.escrowQuarantined && s.dirtyGuildBanks.has(GUILD_ID),
+      );
+    dispatch(server, a, { cmd: 'guild_bank_deposit_gold', amount: 1_000 });
+    dispatch(server, b, { cmd: 'guild_bank_deposit_gold', amount: 1_000 });
+    dispatch(server, c, { cmd: 'guild_bank_deposit_gold', amount: 1_000 });
+    expect(holders()).toEqual([a, b, c]);
+    expect(holders()).toEqual(scan());
+    // A commit releases A's mark: gone from the index.
+    expect(await priv(server).saveCharacter(a)).toBe(true);
+    expect(holders()).toEqual([b, c]);
+    expect(holders()).toEqual(scan());
+    // A leave tears B down (its leave flush lands first): dropped.
+    await server.leave(b, 'test disconnect');
+    expect(holders()).toEqual([c]);
+    expect(holders()).toEqual(scan());
+    // A disband drops the guild entirely.
+    priv(server).social.tx.onGuildDisbanded(GUILD_ID);
+    expect(holders()).toEqual([]);
+    expect(index.size).toBe(0);
+  });
 });
 
 describe('guild bank incident counters at their real emission sites', () => {

--- a/tests/guild_bank_persistence.test.ts
+++ b/tests/guild_bank_persistence.test.ts
@@ -80,6 +80,7 @@ import {
   mergeGuildBankRow,
   nettedReplayRescueCount,
 } from '../server/guild_bank_state';
+import { GUILD_BOOK_FLUSH_FAN_OUT_MAX } from '../server/guild_book_holders';
 import {
   type GameMetricsCounters,
   type GuildBankIncident,
@@ -2655,15 +2656,17 @@ describe('the unsettled gate (server/guild_bank_settle_gate.ts) at the real disp
     secondOfficer(server, b);
     secondOfficer(server, c);
     server.sim.addItem('spider_leg', 20, b.pid);
+    server.sim.addItem('spider_leg', 20, c.pid);
     dispatch(server, b, { cmd: 'guild_bank_deposit', slot: bagIndex(server, b.pid, 'spider_leg') });
-    dispatch(server, c, { cmd: 'guild_bank_deposit_gold', amount: 5_000 }); // C: an unrelated holder
+    // C feeds the same dependency (the flush reaches only contributing holders).
+    dispatch(server, c, { cmd: 'guild_bank_deposit', slot: bagIndex(server, c.pid, 'spider_leg') });
     // The window between leave() and the leave flush's commit: B's deposit is
     // on the live book, not durable, and B's own flush is already in flight.
     b.left = true;
     dbMock.saveCharacterAndGuildBankState.mockClear();
     dispatch(server, a, { cmd: 'guild_bank_withdraw', slot: bookIndex(server, 'spider_leg') });
     expect(notices(aJoin.sent)).toContain(NOTICE);
-    expect(bookCount(server, 'spider_leg')).toBe(20);
+    expect(bookCount(server, 'spider_leg')).toBe(40);
     // The positive control: the staying holder IS flushed by that refusal...
     await vi.waitFor(() => expect(c.dirtyGuildBanks.size).toBe(0));
     // ...and the departing one is not (its mark survives, no save was queued
@@ -2722,7 +2725,7 @@ describe('the unsettled gate (server/guild_bank_settle_gate.ts) at the real disp
     expect(server.sim.serializeGuildBank(GUILD_ID)).toEqual(durableBook());
   });
 
-  it('the holder flush is DAMPED: refusals inside the cooldown never stack a second save', async () => {
+  it('the holder flush is COALESCED: refusals while a flush is queued or running never stack a second save', async () => {
     const server = new GameServer();
     const aJoin = joinServer(server, 1, 'Spammer');
     const a = aJoin.session;
@@ -2732,17 +2735,99 @@ describe('the unsettled gate (server/guild_bank_settle_gate.ts) at the real disp
     server.sim.addItem('spider_leg', 20, b.pid);
     dispatch(server, b, { cmd: 'guild_bank_deposit', slot: bagIndex(server, b.pid, 'spider_leg') });
     dbMock.saveCharacterAndGuildBankState.mockClear();
-    // Three refusals back to back, well inside GUILD_BOOK_FLUSH_COOLDOWN_MS.
+    // Three refusals back to back while the first flush is still queued.
     for (let n = 0; n < 3; n++) {
       dispatch(server, a, { cmd: 'guild_bank_withdraw', slot: bookIndex(server, 'spider_leg') });
     }
     expect(notices(aJoin.sent).filter((text) => text === NOTICE)).toHaveLength(3);
     await vi.waitFor(() => expect(b.dirtyGuildBanks.size).toBe(0));
-    // ONE save for the holder, not three: the fan-out is bounded per holder
-    // per window, whatever the refusal rate.
+    // ONE save for the holder, not three: the flush is one in flight per
+    // holder with a single re-arm, and the re-arm finds the holder clean.
     const saved = dbMock.saveCharacterAndGuildBankState.mock.calls.map((call) => call[0]);
     expect(saved).toEqual([2]);
-    expect(b.guildBookFlushedAtMs).toBeGreaterThan(0);
+    expect(b.guildBookFlushInFlight).toBe(false);
+    expect(b.guildBookFlushRearm).toBe(false);
+  });
+
+  it('a plain member with unsettled work in the book is refused by the sim, never by the gate', async () => {
+    // A read-only view never reaches the gate: no notice from it, no
+    // incident, and no holder flush a member could force.
+    const server = new GameServer();
+    const aJoin = joinServer(server, 1, 'Depositor');
+    const a = aJoin.session;
+    const mJoin = joinServer(server, 2, 'Member');
+    const m = mJoin.session;
+    officerSetup(server, a, 0);
+    moveToBanker(server, m.pid);
+    stampMember(server, m, 'member');
+    server.sim.addItem('spider_leg', 20, a.pid);
+    dispatch(server, a, { cmd: 'guild_bank_deposit', slot: bagIndex(server, a.pid, 'spider_leg') });
+    const rec = recordingIncidents();
+    setGameMetricsCounters(rec.sink);
+    dbMock.saveCharacterAndGuildBankState.mockClear();
+    dispatch(server, m, { cmd: 'guild_bank_withdraw', slot: bookIndex(server, 'spider_leg') });
+    expect(notices(mJoin.sent)).not.toContain(NOTICE);
+    expect(bookCount(server, 'spider_leg')).toBe(20);
+    expect(rec.kinds).toEqual([]);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(dbMock.saveCharacterAndGuildBankState).not.toHaveBeenCalled();
+    expect(a.dirtyGuildBanks.has(GUILD_ID)).toBe(true);
+  });
+
+  it('a refusal flushes ONLY the holder whose work feeds it, never an unrelated holder', async () => {
+    const server = new GameServer();
+    const aJoin = joinServer(server, 1, 'Taker');
+    const a = aJoin.session;
+    const legs = joinServer(server, 2, 'LegsHolder').session;
+    const copper = joinServer(server, 3, 'CopperHolder').session;
+    officerSetup(server, a, 0);
+    secondOfficer(server, legs);
+    secondOfficer(server, copper);
+    server.sim.addItem('spider_leg', 20, legs.pid);
+    dispatch(server, legs, {
+      cmd: 'guild_bank_deposit',
+      slot: bagIndex(server, legs.pid, 'spider_leg'),
+    });
+    dispatch(server, copper, { cmd: 'guild_bank_deposit_gold', amount: 5_000 });
+    dbMock.saveCharacterAndGuildBankState.mockClear();
+    dispatch(server, a, { cmd: 'guild_bank_withdraw', slot: bookIndex(server, 'spider_leg') });
+    expect(notices(aJoin.sent)).toContain(NOTICE);
+    await vi.waitFor(() => expect(legs.dirtyGuildBanks.size).toBe(0));
+    const saved = dbMock.saveCharacterAndGuildBankState.mock.calls.map((call) => call[0]);
+    expect(saved).toEqual([2]);
+    expect(copper.dirtyGuildBanks.has(GUILD_ID)).toBe(true);
+  });
+
+  it('a refusal flushes at most GUILD_BOOK_FLUSH_FAN_OUT_MAX holders, however many feed it', async () => {
+    const server = new GameServer();
+    const aJoin = joinServer(server, 1, 'Taker');
+    const a = aJoin.session;
+    officerSetup(server, a, 0);
+    const holders: ClientSession[] = [];
+    for (let n = 0; n < GUILD_BOOK_FLUSH_FAN_OUT_MAX + 1; n++) {
+      const h = joinServer(server, 10 + n, `Holder${n}`).session;
+      secondOfficer(server, h);
+      server.sim.addItem('spider_leg', 4, h.pid);
+      dispatch(server, h, {
+        cmd: 'guild_bank_deposit',
+        slot: bagIndex(server, h.pid, 'spider_leg'),
+      });
+      holders.push(h);
+    }
+    expect(bookCount(server, 'spider_leg')).toBe(4 * holders.length);
+    dbMock.saveCharacterAndGuildBankState.mockClear();
+    dispatch(server, a, { cmd: 'guild_bank_withdraw', slot: bookIndex(server, 'spider_leg') });
+    expect(notices(aJoin.sent)).toContain(NOTICE);
+    await vi.waitFor(() =>
+      expect(holders.filter((h) => h.dirtyGuildBanks.size === 0)).toHaveLength(
+        GUILD_BOOK_FLUSH_FAN_OUT_MAX,
+      ),
+    );
+    await Promise.resolve();
+    const saved = dbMock.saveCharacterAndGuildBankState.mock.calls.map((call) => call[0]);
+    expect(saved).toHaveLength(GUILD_BOOK_FLUSH_FAN_OUT_MAX);
+    expect(holders.filter((h) => h.dirtyGuildBanks.size > 0)).toHaveLength(1);
   });
 });
 

--- a/tests/guild_bank_settle_gate.test.ts
+++ b/tests/guild_bank_settle_gate.test.ts
@@ -11,7 +11,7 @@ import {
   isGuildBankGatedOp,
   unsettledGuildBook,
 } from '../server/guild_bank_settle_gate';
-import type { GuildBankOpDelta } from '../src/sim/guild_bank';
+import { type GuildBankOpDelta, guildBankDeltaIdentityKey } from '../src/sim/guild_bank';
 import type { InvSlot } from '../src/sim/types';
 import type { GuildBankInfo } from '../src/world_api';
 
@@ -51,7 +51,7 @@ const refusal = (
 ) => guildBankUnsettledRefusal(op, request, live, unsettledGuildBook(logs));
 
 describe('unsettledGuildBook (what other sessions have not made durable)', () => {
-  it('nets item deltas per identity key, deposits minus removals, across every log', () => {
+  it('nets item deltas per identity key WITHIN each log, then sums the positive nets', () => {
     const u = unsettledGuildBook([
       [deposit('spider_leg', 20), withdraw('spider_leg', 5)],
       [deposit('spider_leg', 3), delta({ op: 'admin_purge', itemId: 'spider_leg', count: 1 })],
@@ -65,6 +65,20 @@ describe('unsettledGuildBook (what other sessions have not made durable)', () =>
     expect(u.ladder).toBe(false);
   });
 
+  it("never lets one holder's removal hide another holder's deposit (per-session positives)", () => {
+    // Holder B deposited 10, holder C withdrew 10 (of the durable copies): a
+    // single net would read 0 and wave the acting officer through onto B's
+    // unsettled copies. C's commit lowers durable, B's may never land.
+    const u = unsettledGuildBook([[deposit('spider_leg', 10)], [withdraw('spider_leg', 10)]]);
+    expect(u.items.get(guildBankDeltaIdentityKey(deposit('spider_leg', 1)))).toBe(10);
+    // The same for copper: B's deposit stays unsettled whatever C withdrew.
+    const g = unsettledGuildBook([[gold(10_000)], [gold(-10_000)]]);
+    expect(g.copper).toBe(10_000);
+    // A holder that is net-negative on its own contributes nothing.
+    const n = unsettledGuildBook([[deposit('spider_leg', 4), withdraw('spider_leg', 9)]]);
+    expect(n.items.size).toBe(0);
+  });
+
   it('keeps the three identity dimensions apart (instance payload and craft provenance)', () => {
     const u = unsettledGuildBook([
       [deposit('iron_ore', 5, { instance: { signer: 'BigDamage' } })],
@@ -75,11 +89,11 @@ describe('unsettledGuildBook (what other sessions have not made durable)', () =>
     for (const net of u.items.values()) expect(net).toBe(5);
   });
 
-  it('nets treasury copper the replay would move: gold both ways and buy_slots, never open_bank', () => {
+  it('nets treasury copper the replay would move within a log: gold both ways and buy_slots, never open_bank', () => {
     const u = unsettledGuildBook([
-      [gold(40_000), gold(-15_000)],
-      [delta({ op: 'open_bank', copperDelta: -10_000, purchasedSlotsAfter: 24 })],
       [
+        gold(40_000),
+        gold(-15_000),
         delta({
           op: 'buy_slots',
           copperDelta: -5_000,
@@ -87,6 +101,7 @@ describe('unsettledGuildBook (what other sessions have not made durable)', () =>
           purchasedSlotsAfter: 30,
         }),
       ],
+      [delta({ op: 'open_bank', copperDelta: -10_000, purchasedSlotsAfter: 24 })],
     ]);
     expect(u.copper).toBe(20_000);
     expect(u.ladder).toBe(true);

--- a/tests/guild_bank_settle_gate.test.ts
+++ b/tests/guild_bank_settle_gate.test.ts
@@ -1,14 +1,20 @@
-// The unsettled gate, unit: what OTHER sessions' unflushed logs make
-// unsettled on a book, and which withdraws / gold withdraws / rung purchases
-// that refuses. The server-level pins (the 2026-09-01 two-material swap, the
-// flush, the counter, the notice) live in tests/guild_bank_persistence.test.ts.
+// The unsettled gate, unit: what one holder's log contributes, how holders
+// sum, which withdraws / gold withdraws / rung purchases that refuses (and
+// which inadmissible shapes it leaves to the sim), and the dependency a
+// refusal names for the flush. The server-level pins (the 2026-09-01
+// two-material swap, the flush, the counter, the notice) live in
+// tests/guild_bank_persistence.test.ts; the holder index and the coalesced
+// flush in tests/guild_book_holders.test.ts.
 import { describe, expect, it } from 'vitest';
 import {
+  contributesTo,
+  deficitDependency,
   GUILD_BANK_GATED_OPS,
   type GuildBankOpRequest,
   guildBankUnsettledRefusal,
-  guildBookHolders,
+  holderContribution,
   isGuildBankGatedOp,
+  sumContributions,
   unsettledGuildBook,
 } from '../server/guild_bank_settle_gate';
 import { type GuildBankOpDelta, guildBankDeltaIdentityKey } from '../src/sim/guild_bank';
@@ -31,8 +37,19 @@ const withdraw = (itemId: string, count: number, extra: Partial<GuildBankOpDelta
   delta({ op: 'withdraw', itemId, count, ...extra });
 const gold = (copperDelta: number) =>
   delta({ op: copperDelta > 0 ? 'deposit_gold' : 'withdraw_gold', copperDelta });
+const keyOf = (itemId: string, extra: Partial<GuildBankOpDelta> = {}) =>
+  guildBankDeltaIdentityKey({
+    itemId,
+    instance: extra.instance ?? null,
+    craftedRecipeId: extra.craftedRecipeId ?? null,
+  });
 
-function book(slots: InvSlot[], treasury = 0, purchasedSlots = 24): GuildBankInfo {
+function book(
+  slots: InvSlot[],
+  treasury = 0,
+  purchasedSlots = 24,
+  overrides: Partial<GuildBankInfo> = {},
+): GuildBankInfo {
   return {
     treasury,
     slots,
@@ -40,6 +57,7 @@ function book(slots: InvSlot[], treasury = 0, purchasedSlots = 24): GuildBankInf
     purchasedSlots,
     nextExpansionPrice: purchasedSlots === 0 ? 10_000 : 50_000,
     canEdit: true,
+    ...overrides,
   };
 }
 
@@ -50,33 +68,35 @@ const refusal = (
   logs: readonly (readonly GuildBankOpDelta[])[],
 ) => guildBankUnsettledRefusal(op, request, live, unsettledGuildBook(logs));
 
-describe('unsettledGuildBook (what other sessions have not made durable)', () => {
-  it('nets item deltas per identity key WITHIN each log, then sums the positive nets', () => {
-    const u = unsettledGuildBook([
-      [deposit('spider_leg', 20), withdraw('spider_leg', 5)],
-      [deposit('spider_leg', 3), delta({ op: 'admin_purge', itemId: 'spider_leg', count: 1 })],
-      [deposit('venom_gland', 7)],
+describe('holderContribution and the sum over holders', () => {
+  it('nets item deltas per identity key within a log and keeps the positive nets', () => {
+    const c = holderContribution([
+      deposit('spider_leg', 20),
+      withdraw('spider_leg', 5),
+      deposit('venom_gland', 7),
+      withdraw('wolf_fang', 3),
+      delta({ op: 'admin_purge', itemId: 'venom_gland', count: 1 }),
     ]);
-    expect([...u.items.entries()]).toEqual([
-      [expect.stringContaining('spider_leg'), 17],
-      [expect.stringContaining('venom_gland'), 7],
+    expect([...c.items.entries()]).toEqual([
+      [keyOf('spider_leg'), 15],
+      [keyOf('venom_gland'), 6],
     ]);
-    expect(u.copper).toBe(0);
-    expect(u.ladder).toBe(false);
+    expect(c.copper).toBe(0);
+    expect(c.ladder).toBe(false);
   });
 
-  it("never lets one holder's removal hide another holder's deposit (per-session positives)", () => {
+  it("never lets one holder's removal hide another holder's deposit (positives per holder)", () => {
     // Holder B deposited 10, holder C withdrew 10 (of the durable copies): a
     // single net would read 0 and wave the acting officer through onto B's
     // unsettled copies. C's commit lowers durable, B's may never land.
     const u = unsettledGuildBook([[deposit('spider_leg', 10)], [withdraw('spider_leg', 10)]]);
-    expect(u.items.get(guildBankDeltaIdentityKey(deposit('spider_leg', 1)))).toBe(10);
-    // The same for copper: B's deposit stays unsettled whatever C withdrew.
+    expect(u.items.get(keyOf('spider_leg'))).toBe(10);
     const g = unsettledGuildBook([[gold(10_000)], [gold(-10_000)]]);
     expect(g.copper).toBe(10_000);
     // A holder that is net-negative on its own contributes nothing.
-    const n = unsettledGuildBook([[deposit('spider_leg', 4), withdraw('spider_leg', 9)]]);
+    const n = holderContribution([deposit('spider_leg', 4), withdraw('spider_leg', 9), gold(-5)]);
     expect(n.items.size).toBe(0);
+    expect(n.copper).toBe(0);
   });
 
   it('keeps the three identity dimensions apart (instance payload and craft provenance)', () => {
@@ -90,34 +110,42 @@ describe('unsettledGuildBook (what other sessions have not made durable)', () =>
   });
 
   it('nets treasury copper the replay would move within a log: gold both ways and buy_slots, never open_bank', () => {
-    const u = unsettledGuildBook([
-      [
-        gold(40_000),
-        gold(-15_000),
-        delta({
-          op: 'buy_slots',
-          copperDelta: -5_000,
-          purchasedSlotsBefore: 24,
-          purchasedSlotsAfter: 30,
-        }),
-      ],
-      [delta({ op: 'open_bank', copperDelta: -10_000, purchasedSlotsAfter: 24 })],
+    const c = holderContribution([
+      gold(40_000),
+      gold(-15_000),
+      delta({
+        op: 'buy_slots',
+        copperDelta: -5_000,
+        purchasedSlotsBefore: 24,
+        purchasedSlotsAfter: 30,
+      }),
     ]);
-    expect(u.copper).toBe(20_000);
-    expect(u.ladder).toBe(true);
+    expect(c.copper).toBe(20_000);
+    expect(c.ladder).toBe(true);
+    const opened = holderContribution([
+      delta({ op: 'open_bank', copperDelta: -10_000, purchasedSlotsAfter: 24 }),
+    ]);
+    expect(opened.copper).toBe(0);
+    expect(opened.ladder).toBe(true);
+    expect(sumContributions([c, opened])).toEqual({
+      items: new Map(),
+      copper: 20_000,
+      ladder: true,
+    });
   });
 
   it('ignores a malformed item delta rather than keying on it', () => {
-    const u = unsettledGuildBook([[deposit('', 5), withdraw('wolf_fang', Number.NaN)]]);
-    expect(u.items.size).toBe(0);
+    const c = holderContribution([deposit('', 5), withdraw('wolf_fang', Number.NaN)]);
+    expect(c.items.size).toBe(0);
   });
 });
 
 describe('guildBankUnsettledRefusal: withdraws', () => {
   const live = book([{ itemId: 'spider_leg', count: 20 }]);
+  const legs = { kind: 'items', key: keyOf('spider_leg') } as const;
 
-  it("refuses a withdraw of another session's unsettled stack", () => {
-    expect(refusal('withdraw', { slot: 0 }, live, [[deposit('spider_leg', 20)]])).toBe('items');
+  it("refuses a withdraw of another session's unsettled stack, naming the identity", () => {
+    expect(refusal('withdraw', { slot: 0 }, live, [[deposit('spider_leg', 20)]])).toEqual(legs);
   });
 
   it('passes the same withdraw once nothing is unsettled (the stack is durable)', () => {
@@ -133,10 +161,13 @@ describe('guildBankUnsettledRefusal: withdraws', () => {
     ]);
     const logs = [[deposit('spider_leg', 20)]];
     expect(refusal('withdraw', { slot: 0, count: 10 }, two, logs)).toBeNull();
-    expect(refusal('withdraw', { slot: 0, count: 11 }, two, logs)).toBe('items');
+    expect(refusal('withdraw', { slot: 0, count: 11 }, two, logs)).toEqual(legs);
     // No count asked means the whole stack.
     expect(refusal('withdraw', { slot: 1 }, two, logs)).toBeNull();
-    expect(refusal('withdraw', { slot: 0 }, two, logs)).toBe('items');
+    expect(refusal('withdraw', { slot: 0 }, two, logs)).toEqual(legs);
+    // The sim floors a fractional count, so the gate judges the floor.
+    expect(refusal('withdraw', { slot: 0, count: 10.9 }, two, logs)).toBeNull();
+    expect(refusal('withdraw', { slot: 0, count: 11.1 }, two, logs)).toEqual(legs);
   });
 
   it("is blind to another session's unsettled REMOVAL (the live count already reflects it)", () => {
@@ -150,7 +181,7 @@ describe('guildBankUnsettledRefusal: withdraws', () => {
       refusal('withdraw', { slot: 0 }, signed, [
         [deposit('iron_ore', 5, { instance: { signer: 'BigDamage' } })],
       ]),
-    ).toBe('items');
+    ).toEqual({ kind: 'items', key: keyOf('iron_ore', { instance: { signer: 'BigDamage' } }) });
     const crafted = book([{ itemId: 'iron_ore', count: 5, craftedRecipeId: 'smelt_iron' }]);
     expect(refusal('withdraw', { slot: 0 }, crafted, [[deposit('iron_ore', 5)]])).toBeNull();
   });
@@ -158,15 +189,22 @@ describe('guildBankUnsettledRefusal: withdraws', () => {
   it('treats an instanced stack as moving whole, whatever count was asked', () => {
     const signed = book([{ itemId: 'iron_ore', count: 5, instance: { signer: 'BigDamage' } }]);
     const logs = [[deposit('iron_ore', 5, { instance: { signer: 'BigDamage' } })]];
-    expect(refusal('withdraw', { slot: 0, count: 1 }, signed, logs)).toBe('items');
+    expect(refusal('withdraw', { slot: 0, count: 1 }, signed, logs)).toMatchObject({
+      kind: 'items',
+    });
   });
 
-  it('passes a shape the sim refuses itself (a missing slot, a bad count) unjudged', () => {
+  it('passes every shape the sim refuses itself unjudged (missing slot, bad or over-stack count)', () => {
     const logs = [[deposit('spider_leg', 20)]];
     expect(refusal('withdraw', { slot: 7 }, live, logs)).toBeNull();
     expect(refusal('withdraw', { slot: -1 }, live, logs)).toBeNull();
     expect(refusal('withdraw', { slot: 0.5 }, live, logs)).toBeNull();
     expect(refusal('withdraw', { slot: 0, count: 0 }, live, logs)).toBeNull();
+    expect(refusal('withdraw', { slot: 0, count: -3 }, live, logs)).toBeNull();
+    expect(refusal('withdraw', { slot: 0, count: Number.NaN }, live, logs)).toBeNull();
+    // Over the stack: moveBetweenContainers refuses it as 'invalid'.
+    expect(refusal('withdraw', { slot: 0, count: 21 }, live, logs)).toBeNull();
+    expect(refusal('withdraw', { slot: 0, count: Number.MAX_SAFE_INTEGER }, live, logs)).toBeNull();
     expect(refusal('withdraw', {}, live, logs)).toBeNull();
   });
 });
@@ -176,7 +214,7 @@ describe('guildBankUnsettledRefusal: gold and ladder rungs', () => {
     const live = book([], 140_000);
     const logs = [[gold(40_000)]];
     expect(refusal('withdraw_gold', { amount: 100_000 }, live, logs)).toBeNull();
-    expect(refusal('withdraw_gold', { amount: 100_001 }, live, logs)).toBe('copper');
+    expect(refusal('withdraw_gold', { amount: 100_001 }, live, logs)).toEqual({ kind: 'copper' });
   });
 
   it("is blind to another session's unsettled gold WITHDRAW", () => {
@@ -184,18 +222,22 @@ describe('guildBankUnsettledRefusal: gold and ladder rungs', () => {
     expect(refusal('withdraw_gold', { amount: 60_000 }, live, [[gold(-40_000)]])).toBeNull();
   });
 
-  it('passes a non-positive or malformed amount unjudged', () => {
+  it('passes every amount the sim refuses itself unjudged (non-positive, fractional, unsafe, over the treasury)', () => {
     const live = book([], 40_000);
     const logs = [[gold(40_000)]];
     expect(refusal('withdraw_gold', { amount: 0 }, live, logs)).toBeNull();
     expect(refusal('withdraw_gold', { amount: -5 }, live, logs)).toBeNull();
+    expect(refusal('withdraw_gold', { amount: 100.5 }, live, logs)).toBeNull();
+    expect(refusal('withdraw_gold', { amount: Number.NaN }, live, logs)).toBeNull();
+    expect(refusal('withdraw_gold', { amount: 2 ** 53 }, live, logs)).toBeNull();
+    expect(refusal('withdraw_gold', { amount: 40_001 }, live, logs)).toBeNull();
     expect(refusal('withdraw_gold', {}, live, logs)).toBeNull();
   });
 
   it('refuses a rung purchase while any rung is unsettled (the ladder is strictly ordered)', () => {
     const live = book([], 500_000, 24);
     const opened = [[delta({ op: 'open_bank', copperDelta: -10_000, purchasedSlotsAfter: 24 })]];
-    expect(refusal('buy_slots', {}, live, opened)).toBe('ladder');
+    expect(refusal('buy_slots', {}, live, opened)).toEqual({ kind: 'ladder' });
     expect(refusal('buy_slots', {}, live, [])).toBeNull();
   });
 
@@ -203,10 +245,57 @@ describe('guildBankUnsettledRefusal: gold and ladder rungs', () => {
     // Rung 1+ costs nextExpansionPrice (50_000 here) from the treasury.
     const live = book([], 60_000, 24);
     expect(refusal('buy_slots', {}, live, [[gold(10_000)]])).toBeNull();
-    expect(refusal('buy_slots', {}, live, [[gold(10_001)]])).toBe('copper');
+    expect(refusal('buy_slots', {}, live, [[gold(10_001)]])).toEqual({ kind: 'copper' });
     // Rung 0 opens the bank from the acting officer's own purse: no copper rule.
     const unopened = book([], 0, 0);
     expect(refusal('buy_slots', {}, unopened, [[gold(10_000)]])).toBeNull();
+  });
+
+  it('passes a rung the sim refuses itself unjudged (ladder finished, treasury short of the price)', () => {
+    const done = book([], 500_000, 24, { nextExpansionPrice: null });
+    expect(refusal('buy_slots', {}, done, [[gold(10_000)]])).toBeNull();
+    const poor = book([], 40_000, 24);
+    expect(refusal('buy_slots', {}, poor, [[gold(10_000)]])).toBeNull();
+  });
+});
+
+describe('the dependency a refusal names, and who feeds it', () => {
+  it('contributesTo matches the exact identity, any identity of an item, copper, or the ladder', () => {
+    const c = holderContribution([
+      deposit('iron_ore', 5, { instance: { signer: 'BigDamage' } }),
+      gold(1),
+      delta({ op: 'open_bank', copperDelta: -10_000, purchasedSlotsAfter: 24 }),
+    ]);
+    const signedKey = keyOf('iron_ore', { instance: { signer: 'BigDamage' } });
+    expect(contributesTo(c, { kind: 'items', key: signedKey })).toBe(true);
+    expect(contributesTo(c, { kind: 'items', key: keyOf('iron_ore') })).toBe(false);
+    expect(contributesTo(c, { kind: 'items_of', itemId: 'iron_ore' })).toBe(true);
+    expect(contributesTo(c, { kind: 'items_of', itemId: 'iron' })).toBe(false);
+    expect(contributesTo(c, { kind: 'copper' })).toBe(true);
+    expect(contributesTo(c, { kind: 'ladder' })).toBe(true);
+    const plain = holderContribution([withdraw('wolf_fang', 2)]);
+    expect(contributesTo(plain, { kind: 'copper' })).toBe(false);
+    expect(contributesTo(plain, { kind: 'ladder' })).toBe(false);
+    expect(contributesTo(plain, { kind: 'items_of', itemId: 'wolf_fang' })).toBe(false);
+  });
+
+  it('maps the escrow refusal deficit onto the same dependency vocabulary', () => {
+    const base = { op: 'withdraw' as const, shortfall: 1, copperDelta: 0 };
+    expect(deficitDependency({ ...base, kind: 'missing_items', itemId: 'spider_leg' })).toEqual({
+      kind: 'items_of',
+      itemId: 'spider_leg',
+    });
+    expect(deficitDependency({ ...base, kind: 'missing_items', itemId: null })).toBeNull();
+    expect(deficitDependency({ ...base, kind: 'treasury_underflow', itemId: null })).toEqual({
+      kind: 'copper',
+    });
+    expect(deficitDependency({ ...base, kind: 'treasury_overflow', itemId: null })).toEqual({
+      kind: 'copper',
+    });
+    expect(deficitDependency({ ...base, kind: 'ladder_behind', itemId: null })).toEqual({
+      kind: 'ladder',
+    });
+    expect(deficitDependency(null)).toBeNull();
   });
 });
 
@@ -216,34 +305,5 @@ describe('the gated op set', () => {
     for (const op of ['deposit', 'deposit_gold', 'open_bank', 'admin_purge']) {
       expect(isGuildBankGatedOp(op)).toBe(false);
     }
-  });
-});
-
-describe('guildBookHolders (which sessions hold unflushed work on a book)', () => {
-  const session = (
-    dirty: number[],
-    flags: { escrowQuarantined?: boolean; left?: boolean } = {},
-  ) => ({
-    escrowQuarantined: flags.escrowQuarantined ?? false,
-    left: flags.left ?? false,
-    dirtyGuildBanks: new Map(dirty.map((g) => [g, 1])),
-  });
-
-  it('returns every other session with a dirty mark on the guild, never the caller or a quarantined one', () => {
-    const me = session([9]);
-    const holder = session([9]);
-    const otherGuild = session([10]);
-    const quarantined = session([9], { escrowQuarantined: true });
-    const holders = guildBookHolders([me, holder, otherGuild, quarantined], 9, me, {
-      includeLeaving: false,
-    });
-    expect(holders).toEqual([holder]);
-  });
-
-  it('counts a departing session only when asked to (the gate does, the refusal arm does not)', () => {
-    const me = session([]);
-    const leaving = session([9], { left: true });
-    expect(guildBookHolders([me, leaving], 9, me, { includeLeaving: false })).toEqual([]);
-    expect(guildBookHolders([me, leaving], 9, me, { includeLeaving: true })).toEqual([leaving]);
   });
 });

--- a/tests/guild_bank_settle_gate.test.ts
+++ b/tests/guild_bank_settle_gate.test.ts
@@ -1,0 +1,234 @@
+// The unsettled gate, unit: what OTHER sessions' unflushed logs make
+// unsettled on a book, and which withdraws / gold withdraws / rung purchases
+// that refuses. The server-level pins (the 2026-09-01 two-material swap, the
+// flush, the counter, the notice) live in tests/guild_bank_persistence.test.ts.
+import { describe, expect, it } from 'vitest';
+import {
+  GUILD_BANK_GATED_OPS,
+  type GuildBankOpRequest,
+  guildBankUnsettledRefusal,
+  guildBookHolders,
+  isGuildBankGatedOp,
+  unsettledGuildBook,
+} from '../server/guild_bank_settle_gate';
+import type { GuildBankOpDelta } from '../src/sim/guild_bank';
+import type { InvSlot } from '../src/sim/types';
+import type { GuildBankInfo } from '../src/world_api';
+
+const delta = (partial: Partial<GuildBankOpDelta> & { op: GuildBankOpDelta['op'] }) => ({
+  itemId: null,
+  count: null,
+  instance: null,
+  craftedRecipeId: null,
+  copperDelta: 0,
+  purchasedSlotsBefore: 0,
+  purchasedSlotsAfter: 0,
+  ...partial,
+});
+const deposit = (itemId: string, count: number, extra: Partial<GuildBankOpDelta> = {}) =>
+  delta({ op: 'deposit', itemId, count, ...extra });
+const withdraw = (itemId: string, count: number, extra: Partial<GuildBankOpDelta> = {}) =>
+  delta({ op: 'withdraw', itemId, count, ...extra });
+const gold = (copperDelta: number) =>
+  delta({ op: copperDelta > 0 ? 'deposit_gold' : 'withdraw_gold', copperDelta });
+
+function book(slots: InvSlot[], treasury = 0, purchasedSlots = 24): GuildBankInfo {
+  return {
+    treasury,
+    slots,
+    capacity: purchasedSlots,
+    purchasedSlots,
+    nextExpansionPrice: purchasedSlots === 0 ? 10_000 : 50_000,
+    canEdit: true,
+  };
+}
+
+const refusal = (
+  op: (typeof GUILD_BANK_GATED_OPS)[number],
+  request: GuildBankOpRequest,
+  live: GuildBankInfo,
+  logs: readonly (readonly GuildBankOpDelta[])[],
+) => guildBankUnsettledRefusal(op, request, live, unsettledGuildBook(logs));
+
+describe('unsettledGuildBook (what other sessions have not made durable)', () => {
+  it('nets item deltas per identity key, deposits minus removals, across every log', () => {
+    const u = unsettledGuildBook([
+      [deposit('spider_leg', 20), withdraw('spider_leg', 5)],
+      [deposit('spider_leg', 3), delta({ op: 'admin_purge', itemId: 'spider_leg', count: 1 })],
+      [deposit('venom_gland', 7)],
+    ]);
+    expect([...u.items.entries()]).toEqual([
+      [expect.stringContaining('spider_leg'), 17],
+      [expect.stringContaining('venom_gland'), 7],
+    ]);
+    expect(u.copper).toBe(0);
+    expect(u.ladder).toBe(false);
+  });
+
+  it('keeps the three identity dimensions apart (instance payload and craft provenance)', () => {
+    const u = unsettledGuildBook([
+      [deposit('iron_ore', 5, { instance: { signer: 'BigDamage' } })],
+      [deposit('iron_ore', 5)],
+      [deposit('iron_ore', 5, { craftedRecipeId: 'smelt_iron' })],
+    ]);
+    expect(u.items.size).toBe(3);
+    for (const net of u.items.values()) expect(net).toBe(5);
+  });
+
+  it('nets treasury copper the replay would move: gold both ways and buy_slots, never open_bank', () => {
+    const u = unsettledGuildBook([
+      [gold(40_000), gold(-15_000)],
+      [delta({ op: 'open_bank', copperDelta: -10_000, purchasedSlotsAfter: 24 })],
+      [
+        delta({
+          op: 'buy_slots',
+          copperDelta: -5_000,
+          purchasedSlotsBefore: 24,
+          purchasedSlotsAfter: 30,
+        }),
+      ],
+    ]);
+    expect(u.copper).toBe(20_000);
+    expect(u.ladder).toBe(true);
+  });
+
+  it('ignores a malformed item delta rather than keying on it', () => {
+    const u = unsettledGuildBook([[deposit('', 5), withdraw('wolf_fang', Number.NaN)]]);
+    expect(u.items.size).toBe(0);
+  });
+});
+
+describe('guildBankUnsettledRefusal: withdraws', () => {
+  const live = book([{ itemId: 'spider_leg', count: 20 }]);
+
+  it("refuses a withdraw of another session's unsettled stack", () => {
+    expect(refusal('withdraw', { slot: 0 }, live, [[deposit('spider_leg', 20)]])).toBe('items');
+  });
+
+  it('passes the same withdraw once nothing is unsettled (the stack is durable)', () => {
+    expect(refusal('withdraw', { slot: 0 }, live, [])).toBeNull();
+    expect(refusal('withdraw', { slot: 0 }, live, [[deposit('venom_gland', 20)]])).toBeNull();
+  });
+
+  it('lets a PARTIAL withdraw through while it fits inside the settled copies', () => {
+    // 30 live copies across two stacks, 20 of them unsettled: 10 are settled.
+    const two = book([
+      { itemId: 'spider_leg', count: 20 },
+      { itemId: 'spider_leg', count: 10 },
+    ]);
+    const logs = [[deposit('spider_leg', 20)]];
+    expect(refusal('withdraw', { slot: 0, count: 10 }, two, logs)).toBeNull();
+    expect(refusal('withdraw', { slot: 0, count: 11 }, two, logs)).toBe('items');
+    // No count asked means the whole stack.
+    expect(refusal('withdraw', { slot: 1 }, two, logs)).toBeNull();
+    expect(refusal('withdraw', { slot: 0 }, two, logs)).toBe('items');
+  });
+
+  it("is blind to another session's unsettled REMOVAL (the live count already reflects it)", () => {
+    expect(refusal('withdraw', { slot: 0 }, live, [[withdraw('spider_leg', 20)]])).toBeNull();
+  });
+
+  it('matches on the full identity: a differently signed or crafted copy is a different key', () => {
+    const signed = book([{ itemId: 'iron_ore', count: 5, instance: { signer: 'BigDamage' } }]);
+    expect(refusal('withdraw', { slot: 0 }, signed, [[deposit('iron_ore', 5)]])).toBeNull();
+    expect(
+      refusal('withdraw', { slot: 0 }, signed, [
+        [deposit('iron_ore', 5, { instance: { signer: 'BigDamage' } })],
+      ]),
+    ).toBe('items');
+    const crafted = book([{ itemId: 'iron_ore', count: 5, craftedRecipeId: 'smelt_iron' }]);
+    expect(refusal('withdraw', { slot: 0 }, crafted, [[deposit('iron_ore', 5)]])).toBeNull();
+  });
+
+  it('treats an instanced stack as moving whole, whatever count was asked', () => {
+    const signed = book([{ itemId: 'iron_ore', count: 5, instance: { signer: 'BigDamage' } }]);
+    const logs = [[deposit('iron_ore', 5, { instance: { signer: 'BigDamage' } })]];
+    expect(refusal('withdraw', { slot: 0, count: 1 }, signed, logs)).toBe('items');
+  });
+
+  it('passes a shape the sim refuses itself (a missing slot, a bad count) unjudged', () => {
+    const logs = [[deposit('spider_leg', 20)]];
+    expect(refusal('withdraw', { slot: 7 }, live, logs)).toBeNull();
+    expect(refusal('withdraw', { slot: -1 }, live, logs)).toBeNull();
+    expect(refusal('withdraw', { slot: 0.5 }, live, logs)).toBeNull();
+    expect(refusal('withdraw', { slot: 0, count: 0 }, live, logs)).toBeNull();
+    expect(refusal('withdraw', {}, live, logs)).toBeNull();
+  });
+});
+
+describe('guildBankUnsettledRefusal: gold and ladder rungs', () => {
+  it('refuses a gold withdraw that exceeds the settled treasury', () => {
+    const live = book([], 140_000);
+    const logs = [[gold(40_000)]];
+    expect(refusal('withdraw_gold', { amount: 100_000 }, live, logs)).toBeNull();
+    expect(refusal('withdraw_gold', { amount: 100_001 }, live, logs)).toBe('copper');
+  });
+
+  it("is blind to another session's unsettled gold WITHDRAW", () => {
+    const live = book([], 60_000);
+    expect(refusal('withdraw_gold', { amount: 60_000 }, live, [[gold(-40_000)]])).toBeNull();
+  });
+
+  it('passes a non-positive or malformed amount unjudged', () => {
+    const live = book([], 40_000);
+    const logs = [[gold(40_000)]];
+    expect(refusal('withdraw_gold', { amount: 0 }, live, logs)).toBeNull();
+    expect(refusal('withdraw_gold', { amount: -5 }, live, logs)).toBeNull();
+    expect(refusal('withdraw_gold', {}, live, logs)).toBeNull();
+  });
+
+  it('refuses a rung purchase while any rung is unsettled (the ladder is strictly ordered)', () => {
+    const live = book([], 500_000, 24);
+    const opened = [[delta({ op: 'open_bank', copperDelta: -10_000, purchasedSlotsAfter: 24 })]];
+    expect(refusal('buy_slots', {}, live, opened)).toBe('ladder');
+    expect(refusal('buy_slots', {}, live, [])).toBeNull();
+  });
+
+  it('refuses a treasury-paid rung the settled treasury cannot cover, but never a purse-paid opening', () => {
+    // Rung 1+ costs nextExpansionPrice (50_000 here) from the treasury.
+    const live = book([], 60_000, 24);
+    expect(refusal('buy_slots', {}, live, [[gold(10_000)]])).toBeNull();
+    expect(refusal('buy_slots', {}, live, [[gold(10_001)]])).toBe('copper');
+    // Rung 0 opens the bank from the acting officer's own purse: no copper rule.
+    const unopened = book([], 0, 0);
+    expect(refusal('buy_slots', {}, unopened, [[gold(10_000)]])).toBeNull();
+  });
+});
+
+describe('the gated op set', () => {
+  it('gates withdraws, gold withdraws, and rung purchases; never deposits or the operator purge', () => {
+    expect([...GUILD_BANK_GATED_OPS]).toEqual(['withdraw', 'withdraw_gold', 'buy_slots']);
+    for (const op of ['deposit', 'deposit_gold', 'open_bank', 'admin_purge']) {
+      expect(isGuildBankGatedOp(op)).toBe(false);
+    }
+  });
+});
+
+describe('guildBookHolders (which sessions hold unflushed work on a book)', () => {
+  const session = (
+    dirty: number[],
+    flags: { escrowQuarantined?: boolean; left?: boolean } = {},
+  ) => ({
+    escrowQuarantined: flags.escrowQuarantined ?? false,
+    left: flags.left ?? false,
+    dirtyGuildBanks: new Map(dirty.map((g) => [g, 1])),
+  });
+
+  it('returns every other session with a dirty mark on the guild, never the caller or a quarantined one', () => {
+    const me = session([9]);
+    const holder = session([9]);
+    const otherGuild = session([10]);
+    const quarantined = session([9], { escrowQuarantined: true });
+    const holders = guildBookHolders([me, holder, otherGuild, quarantined], 9, me, {
+      includeLeaving: false,
+    });
+    expect(holders).toEqual([holder]);
+  });
+
+  it('counts a departing session only when asked to (the gate does, the refusal arm does not)', () => {
+    const me = session([]);
+    const leaving = session([9], { left: true });
+    expect(guildBookHolders([me, leaving], 9, me, { includeLeaving: false })).toEqual([]);
+    expect(guildBookHolders([me, leaving], 9, me, { includeLeaving: true })).toEqual([leaving]);
+  });
+});

--- a/tests/guild_book_holders.test.ts
+++ b/tests/guild_book_holders.test.ts
@@ -1,0 +1,286 @@
+// The per-guild holder index behind the unsettled gate and the coalesced
+// holder flush (server/guild_book_holders.ts), unit. The index replaces the
+// realm-wide session scan the gate first shipped with; the pins here are the
+// maintenance contract (touch / resync / dropGuild / dropSession), the cache
+// invalidation trap the module note names, the contributing-only bounded
+// flush selection, and the one-in-flight-one-rearm flush.
+import { describe, expect, it, vi } from 'vitest';
+import {
+  GUILD_BOOK_FLUSH_FAN_OUT_MAX,
+  GuildBookHolderIndex,
+  requestGuildBookFlush,
+} from '../server/guild_book_holders';
+import { type GuildBankOpDelta, guildBankDeltaIdentityKey } from '../src/sim/guild_bank';
+
+const delta = (partial: Partial<GuildBankOpDelta> & { op: GuildBankOpDelta['op'] }) => ({
+  itemId: null,
+  count: null,
+  instance: null,
+  craftedRecipeId: null,
+  copperDelta: 0,
+  purchasedSlotsBefore: 0,
+  purchasedSlotsAfter: 0,
+  ...partial,
+});
+const deposit = (itemId: string, count: number) => delta({ op: 'deposit', itemId, count });
+const withdraw = (itemId: string, count: number) => delta({ op: 'withdraw', itemId, count });
+const gold = (copperDelta: number) =>
+  delta({ op: copperDelta > 0 ? 'deposit_gold' : 'withdraw_gold', copperDelta });
+const keyOf = (itemId: string) =>
+  guildBankDeltaIdentityKey({ itemId, instance: null, craftedRecipeId: null });
+
+interface FakeSession {
+  name: string;
+  escrowQuarantined: boolean;
+  left: boolean;
+  dirtyGuildBanks: Map<number, number>;
+  unflushedGuildBankOps: Map<number, GuildBankOpDelta[]>;
+  guildBookFlushInFlight: boolean;
+  guildBookFlushRearm: boolean;
+}
+
+function session(name: string): FakeSession {
+  return {
+    name,
+    escrowQuarantined: false,
+    left: false,
+    dirtyGuildBanks: new Map(),
+    unflushedGuildBankOps: new Map(),
+    guildBookFlushInFlight: false,
+    guildBookFlushRearm: false,
+  };
+}
+
+/** Land an op on a session the way the coordinator does: mark, log, touch. */
+function land(
+  index: GuildBookHolderIndex<FakeSession>,
+  s: FakeSession,
+  guildId: number,
+  ...deltas: GuildBankOpDelta[]
+): void {
+  s.dirtyGuildBanks.set(guildId, (s.dirtyGuildBanks.get(guildId) ?? 0) + 1);
+  const log = s.unflushedGuildBankOps.get(guildId) ?? [];
+  log.push(...deltas);
+  s.unflushedGuildBankOps.set(guildId, log);
+  index.touch(s, guildId);
+}
+
+/** Commit a prefix the way the post-commit consume does: splice, maybe clear
+ *  the mark, resync. */
+function commit(
+  index: GuildBookHolderIndex<FakeSession>,
+  s: FakeSession,
+  guildId: number,
+  count: number,
+): void {
+  const log = s.unflushedGuildBankOps.get(guildId) ?? [];
+  log.splice(0, count);
+  if (log.length === 0) {
+    s.unflushedGuildBankOps.delete(guildId);
+    s.dirtyGuildBanks.delete(guildId);
+  }
+  index.resync(s);
+}
+
+describe('GuildBookHolderIndex: maintenance', () => {
+  it('indexes a holder on touch, sums its contribution, and forgets it once its mark clears', () => {
+    const index = new GuildBookHolderIndex<FakeSession>();
+    const a = session('a');
+    const me = session('me');
+    land(index, a, 9, deposit('spider_leg', 20));
+    expect(index.holders(9, me, { includeLeaving: false })).toEqual([a]);
+    expect(index.unsettled(9, me).items.get(keyOf('spider_leg'))).toBe(20);
+    expect(index.size).toBe(1);
+    commit(index, a, 9, 1);
+    expect(index.holders(9, me, { includeLeaving: false })).toEqual([]);
+    expect(index.unsettled(9, me).items.size).toBe(0);
+    expect(index.size).toBe(0);
+  });
+
+  it('never counts the acting session itself, a quarantined holder, or (unless asked) a leaving one', () => {
+    const index = new GuildBookHolderIndex<FakeSession>();
+    const me = session('me');
+    const quarantined = session('q');
+    const leaving = session('l');
+    land(index, me, 9, deposit('spider_leg', 5));
+    land(index, quarantined, 9, deposit('spider_leg', 5));
+    land(index, leaving, 9, deposit('spider_leg', 5));
+    quarantined.escrowQuarantined = true;
+    leaving.left = true;
+    expect(index.holders(9, me, { includeLeaving: false })).toEqual([]);
+    expect(index.holders(9, me, { includeLeaving: true })).toEqual([leaving]);
+    // The gate counts the leaving holder's work; the flush never targets it.
+    expect(index.unsettled(9, me).items.get(keyOf('spider_leg'))).toBe(5);
+    expect(index.contributors(9, me, { kind: 'items', key: keyOf('spider_leg') })).toEqual([]);
+  });
+
+  it('invalidates, never patches: a commit that consumed one entry while an op pushed another keeps the length and changes the contents', () => {
+    const index = new GuildBookHolderIndex<FakeSession>();
+    const a = session('a');
+    const me = session('me');
+    land(index, a, 9, deposit('spider_leg', 10));
+    // Warm the cache on the old log.
+    expect(index.unsettled(9, me).items.get(keyOf('spider_leg'))).toBe(10);
+    // The deposit commits (prefix consumed) while a NEW op lands: same log
+    // length, different contents.
+    const log = a.unflushedGuildBankOps.get(9);
+    if (!log) throw new Error('missing log');
+    log.splice(0, 1);
+    index.resync(a);
+    land(index, a, 9, deposit('venom_gland', 10));
+    expect(a.unflushedGuildBankOps.get(9)).toHaveLength(1);
+    const u = index.unsettled(9, me);
+    expect(u.items.get(keyOf('spider_leg'))).toBeUndefined();
+    expect(u.items.get(keyOf('venom_gland'))).toBe(10);
+  });
+
+  it('resync after a rollback, dropGuild on a disband, and dropSession on a leave all forget the holder', () => {
+    const index = new GuildBookHolderIndex<FakeSession>();
+    const me = session('me');
+    const a = session('a');
+    const b = session('b');
+    const c = session('c');
+    land(index, a, 9, gold(1_000));
+    land(index, b, 9, gold(1_000));
+    land(index, c, 9, gold(1_000));
+    land(index, c, 10, gold(1_000));
+    // A rolled back: its marks are gone before the resync.
+    a.dirtyGuildBanks.clear();
+    a.unflushedGuildBankOps.clear();
+    index.resync(a);
+    expect(index.holders(9, me, { includeLeaving: false })).toEqual([b, c]);
+    index.dropSession(c);
+    expect(index.holders(9, me, { includeLeaving: false })).toEqual([b]);
+    expect(index.holders(10, me, { includeLeaving: false })).toEqual([]);
+    index.dropGuild(9);
+    expect(index.holders(9, me, { includeLeaving: false })).toEqual([]);
+    expect(index.size).toBe(0);
+  });
+
+  it('sums each holder POSITIVE net per key and copper (a removal never hides a deposit)', () => {
+    const index = new GuildBookHolderIndex<FakeSession>();
+    const me = session('me');
+    const b = session('b');
+    const c = session('c');
+    land(index, b, 9, deposit('spider_leg', 10), gold(10_000));
+    land(index, c, 9, withdraw('spider_leg', 10), gold(-10_000));
+    const u = index.unsettled(9, me);
+    expect(u.items.get(keyOf('spider_leg'))).toBe(10);
+    expect(u.copper).toBe(10_000);
+  });
+});
+
+describe('GuildBookHolderIndex.contributors: the flush selection', () => {
+  function rig() {
+    const index = new GuildBookHolderIndex<FakeSession>();
+    const me = session('me');
+    const legs = session('legs');
+    const glands = session('glands');
+    const copper = session('copper');
+    const rung = session('rung');
+    land(index, legs, 9, deposit('spider_leg', 20));
+    land(index, glands, 9, deposit('venom_gland', 20));
+    land(index, copper, 9, gold(50_000));
+    land(index, rung, 9, delta({ op: 'open_bank', copperDelta: -10_000, purchasedSlotsAfter: 24 }));
+    return { index, me, legs, glands, copper, rung };
+  }
+
+  it('selects only the holders whose work feeds the dependency', () => {
+    const { index, me, legs, glands, copper, rung } = rig();
+    expect(index.contributors(9, me, { kind: 'items', key: keyOf('spider_leg') })).toEqual([legs]);
+    expect(index.contributors(9, me, { kind: 'items_of', itemId: 'venom_gland' })).toEqual([
+      glands,
+    ]);
+    expect(index.contributors(9, me, { kind: 'copper' })).toEqual([copper]);
+    expect(index.contributors(9, me, { kind: 'ladder' })).toEqual([rung]);
+    expect(index.contributors(9, me, { kind: 'items', key: keyOf('wolf_fang') })).toEqual([]);
+  });
+
+  it('flushes every holder when no dependency is named, bounded by the fan-out cap', () => {
+    const { index, me } = rig();
+    expect(index.contributors(9, me, null)).toHaveLength(4);
+    expect(index.contributors(9, me, null, 2)).toHaveLength(2);
+    expect(GUILD_BOOK_FLUSH_FAN_OUT_MAX).toBe(4);
+    // A fifth contributor stays behind the cap.
+    const fifth = session('fifth');
+    land(index, fifth, 9, gold(1));
+    expect(index.contributors(9, me, null)).toHaveLength(GUILD_BOOK_FLUSH_FAN_OUT_MAX);
+  });
+
+  it('never selects a leaving or quarantined holder even when it feeds the dependency', () => {
+    const { index, me, legs } = rig();
+    legs.left = true;
+    expect(index.contributors(9, me, { kind: 'items', key: keyOf('spider_leg') })).toEqual([]);
+    legs.left = false;
+    legs.escrowQuarantined = true;
+    expect(index.contributors(9, me, { kind: 'items', key: keyOf('spider_leg') })).toEqual([]);
+  });
+});
+
+describe('requestGuildBookFlush: one in flight, one re-arm', () => {
+  function deferred() {
+    let resolve: (() => void) | undefined;
+    const promise = new Promise<void>((r) => {
+      resolve = r;
+    });
+    return { promise, resolve: () => resolve?.() };
+  }
+
+  it('runs one save while further requests only arm a single follow-up', async () => {
+    const s = session('holder');
+    s.dirtyGuildBanks.set(9, 1);
+    const first = deferred();
+    const save = vi.fn(() => first.promise);
+    requestGuildBookFlush(s, save);
+    requestGuildBookFlush(s, save);
+    requestGuildBookFlush(s, save);
+    expect(save).toHaveBeenCalledTimes(1);
+    expect(s.guildBookFlushInFlight).toBe(true);
+    expect(s.guildBookFlushRearm).toBe(true);
+    // The flush settles with work still on the holder: exactly ONE more.
+    first.resolve();
+    await first.promise;
+    await Promise.resolve();
+    expect(save).toHaveBeenCalledTimes(2);
+    expect(s.guildBookFlushRearm).toBe(false);
+  });
+
+  it('does not re-arm once the holder is clean when the flush settles', async () => {
+    const s = session('holder');
+    s.dirtyGuildBanks.set(9, 1);
+    const first = deferred();
+    const save = vi.fn(() => {
+      // The save commits the holder's work.
+      s.dirtyGuildBanks.clear();
+      return first.promise;
+    });
+    requestGuildBookFlush(s, save);
+    requestGuildBookFlush(s, save);
+    first.resolve();
+    await first.promise;
+    await Promise.resolve();
+    expect(save).toHaveBeenCalledTimes(1);
+    expect(s.guildBookFlushInFlight).toBe(false);
+    expect(s.guildBookFlushRearm).toBe(false);
+  });
+
+  it('settles on a rejected save too, and never flushes a leaving or quarantined holder', async () => {
+    const s = session('holder');
+    s.dirtyGuildBanks.set(9, 1);
+    const save = vi.fn(() => Promise.reject(new Error('db down')));
+    requestGuildBookFlush(s, save);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(s.guildBookFlushInFlight).toBe(false);
+    const left = session('left');
+    left.left = true;
+    left.dirtyGuildBanks.set(9, 1);
+    const never = vi.fn(() => Promise.resolve());
+    requestGuildBookFlush(left, never);
+    const quarantined = session('q');
+    quarantined.escrowQuarantined = true;
+    quarantined.dirtyGuildBanks.set(9, 1);
+    requestGuildBookFlush(quarantined, never);
+    expect(never).not.toHaveBeenCalled();
+  });
+});

--- a/tests/monolith_budget.test.ts
+++ b/tests/monolith_budget.test.ts
@@ -578,13 +578,13 @@ const MONOLITHS: MonolithRow[] = [
     // Re-pinned to the exact merged count of the OSSBrain v0.41.0 base
     // merge: both parents had already ratcheted for their own work, so
     // the composite is the honest size. Exact count, zero slack.
-    // LOWERED 10641 -> 10578 by the guild bank unsettled gate (2026-09-02): the
+    // LOWERED 10641 -> 10590 by the guild bank unsettled gate (2026-09-02): the
     // escrow REFUSAL arm moved behind a GameServer port into
     // server/guild_bank_escrow_refusal.ts, and the gate itself landed in the op
     // coordinator (server/guild_bank_op_coordinator.ts) plus its own pure
     // module (server/guild_bank_settle_gate.ts), paying for the request
     // pass-through and the two port entries with room to spare. Zero margin.
-    ceiling: 10578,
+    ceiling: 10590,
     seam: 'a sibling server module; see the hot-path seams in server/CLAUDE.md',
   },
   {

--- a/tests/monolith_budget.test.ts
+++ b/tests/monolith_budget.test.ts
@@ -578,7 +578,7 @@ const MONOLITHS: MonolithRow[] = [
     // Re-pinned to the exact merged count of the OSSBrain v0.41.0 base
     // merge: both parents had already ratcheted for their own work, so
     // the composite is the honest size. Exact count, zero slack.
-    // LOWERED 10641 -> 10598 by the guild bank unsettled gate (2026-09-02): the
+    // LOWERED 10641 -> 10586 by the guild bank unsettled gate (2026-09-02): the
     // escrow REFUSAL arm moved behind a GameServer port into
     // server/guild_bank_escrow_refusal.ts, and the gate itself landed in the op
     // coordinator (server/guild_bank_op_coordinator.ts) plus its own pure
@@ -586,7 +586,7 @@ const MONOLITHS: MonolithRow[] = [
     // pass-through and the two port entries with room to spare; the review
     // hardening added the per-guild holder index hooks (touch, resync,
     // dropGuild, dropSession) and the coalesced flush fields. Zero margin.
-    ceiling: 10598,
+    ceiling: 10586,
     seam: 'a sibling server module; see the hot-path seams in server/CLAUDE.md',
   },
   {

--- a/tests/monolith_budget.test.ts
+++ b/tests/monolith_budget.test.ts
@@ -578,13 +578,15 @@ const MONOLITHS: MonolithRow[] = [
     // Re-pinned to the exact merged count of the OSSBrain v0.41.0 base
     // merge: both parents had already ratcheted for their own work, so
     // the composite is the honest size. Exact count, zero slack.
-    // LOWERED 10641 -> 10590 by the guild bank unsettled gate (2026-09-02): the
+    // LOWERED 10641 -> 10598 by the guild bank unsettled gate (2026-09-02): the
     // escrow REFUSAL arm moved behind a GameServer port into
     // server/guild_bank_escrow_refusal.ts, and the gate itself landed in the op
     // coordinator (server/guild_bank_op_coordinator.ts) plus its own pure
     // module (server/guild_bank_settle_gate.ts), paying for the request
-    // pass-through and the two port entries with room to spare. Zero margin.
-    ceiling: 10590,
+    // pass-through and the two port entries with room to spare; the review
+    // hardening added the per-guild holder index hooks (touch, resync,
+    // dropGuild, dropSession) and the coalesced flush fields. Zero margin.
+    ceiling: 10598,
     seam: 'a sibling server module; see the hot-path seams in server/CLAUDE.md',
   },
   {

--- a/tests/monolith_budget.test.ts
+++ b/tests/monolith_budget.test.ts
@@ -578,7 +578,13 @@ const MONOLITHS: MonolithRow[] = [
     // Re-pinned to the exact merged count of the OSSBrain v0.41.0 base
     // merge: both parents had already ratcheted for their own work, so
     // the composite is the honest size. Exact count, zero slack.
-    ceiling: 10641,
+    // LOWERED 10641 -> 10578 by the guild bank unsettled gate (2026-09-02): the
+    // escrow REFUSAL arm moved behind a GameServer port into
+    // server/guild_bank_escrow_refusal.ts, and the gate itself landed in the op
+    // coordinator (server/guild_bank_op_coordinator.ts) plus its own pure
+    // module (server/guild_bank_settle_gate.ts), paying for the request
+    // pass-through and the two port entries with room to spare. Zero margin.
+    ceiling: 10578,
     seam: 'a sibling server module; see the hot-path seams in server/CLAUDE.md',
   },
   {

--- a/tests/server/guild_bank_op_coordinator.test.ts
+++ b/tests/server/guild_bank_op_coordinator.test.ts
@@ -6,6 +6,7 @@ import {
   runGuildBankOp,
 } from '../../server/guild_bank_op_coordinator';
 import type { UnsettledGuildBook } from '../../server/guild_bank_settle_gate';
+import { guildBankDeltaIdentityKey } from '../../src/sim/guild_bank';
 import type { InvSlot } from '../../src/sim/types';
 import type { GuildBankInfo } from '../../src/world_api';
 
@@ -613,5 +614,103 @@ describe('guild-bank op coordinator', () => {
     expect(rig.failAfterMutation).toHaveBeenCalledWith(error);
     expect(rig.session.unflushedGuildBankOps.get(23)).toHaveLength(1);
     expect(rig.bankLedgerNeedsSave).not.toHaveBeenCalled();
+  });
+});
+
+describe('the unsettled gate (server/guild_bank_settle_gate.ts) inside the coordinator', () => {
+  const NOTICE = 'The guild bank is still saving a recent change. Try again in a moment.';
+  const legsKey = guildBankDeltaIdentityKey({
+    itemId: 'spider_leg',
+    instance: null,
+    craftedRecipeId: null,
+  });
+  const unsettledLegs = (): UnsettledGuildBook => ({
+    items: new Map([[legsKey, 20]]),
+    copper: 0,
+    ladder: false,
+  });
+
+  it('refuses an unsettled withdraw BEFORE admission: no reservation, no mutation, notice, flush, incident', () => {
+    const rig = makeRig();
+    rig.state.playerBook = book({ slots: [slot('spider_leg', 20)] });
+    rig.unsettledGuildBook.mockReturnValue(unsettledLegs());
+    const run = vi.fn();
+    runGuildBankOp(rig.host, rig.session, { pid: 5 }, 'withdraw', run, { slot: 0 });
+    expect(run).not.toHaveBeenCalled();
+    expect(rig.tryReserve).not.toHaveBeenCalled();
+    expect(rig.markGuildBankDirty).not.toHaveBeenCalled();
+    expect(rig.session.unflushedGuildBankOps.size).toBe(0);
+    expect(rig.unsettledGuildBook).toHaveBeenCalledWith(23);
+    expect(rig.sendPlayerNotice).toHaveBeenCalledWith(NOTICE);
+    expect(rig.flushUnsettledGuildBook).toHaveBeenCalledWith(23);
+    expect(rig.recordGuildBankIncident).toHaveBeenCalledWith('unsettled_refused');
+  });
+
+  it('passes a settled withdraw through to admission and the mutation, with no notice and no flush', () => {
+    const rig = makeRig();
+    rig.state.playerBook = book({ slots: [slot('spider_leg', 20)] });
+    const run = vi.fn(() => {
+      // The withdraw moves the stack from the book into the acting bags.
+      rig.state.playerBook = book();
+      if (rig.state.meta) rig.state.meta.inventory = [slot('spider_leg', 20)];
+    });
+    runGuildBankOp(rig.host, rig.session, { pid: 5 }, 'withdraw', run, { slot: 0 });
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(rig.tryReserve).toHaveBeenCalledTimes(1);
+    expect(rig.markGuildBankDirty).toHaveBeenCalledWith(23);
+    expect(rig.sendPlayerNotice).not.toHaveBeenCalled();
+    expect(rig.flushUnsettledGuildBook).not.toHaveBeenCalled();
+    expect(rig.recordGuildBankIncident).not.toHaveBeenCalledWith('unsettled_refused');
+  });
+
+  it('never gates a deposit or an operator purge, whatever is unsettled', () => {
+    const rig = makeRig();
+    rig.state.playerBook = book({ slots: [slot('spider_leg', 20)] });
+    rig.state.guildBook = book({ slots: [slot('spider_leg', 20)] });
+    rig.unsettledGuildBook.mockReturnValue({
+      items: new Map([[legsKey, 20]]),
+      copper: 50_000,
+      ladder: true,
+    });
+    const deposit = vi.fn();
+    runGuildBankOp(rig.host, rig.session, { pid: 5 }, 'deposit', deposit, { slot: 0 });
+    expect(deposit).toHaveBeenCalledTimes(1);
+    const purge = vi.fn();
+    runGuildBankOp(
+      rig.host,
+      rig.session,
+      { guildId: 41, actorAccountId: 97 },
+      'admin_purge',
+      purge,
+      { slot: 0 },
+    );
+    expect(purge).toHaveBeenCalledTimes(1);
+    expect(rig.unsettledGuildBook).not.toHaveBeenCalled();
+    expect(rig.sendPlayerNotice).not.toHaveBeenCalled();
+    expect(rig.flushUnsettledGuildBook).not.toHaveBeenCalled();
+  });
+
+  it('never gates an operator target even on a gated op (the purge carrier is only a carrier)', () => {
+    const rig = makeRig();
+    rig.state.guildBook = book({ slots: [slot('spider_leg', 20)] });
+    rig.unsettledGuildBook.mockReturnValue(unsettledLegs());
+    const run = vi.fn();
+    runGuildBankOp(rig.host, rig.session, { guildId: 41, actorAccountId: 97 }, 'withdraw', run, {
+      slot: 0,
+    });
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(rig.unsettledGuildBook).not.toHaveBeenCalled();
+    expect(rig.sendPlayerNotice).not.toHaveBeenCalled();
+  });
+
+  it('leaves a withdraw with no live book (not at a banker) to the sim, unjudged', () => {
+    const rig = makeRig();
+    rig.state.playerBook = null;
+    rig.unsettledGuildBook.mockReturnValue(unsettledLegs());
+    const run = vi.fn();
+    runGuildBankOp(rig.host, rig.session, { pid: 5 }, 'withdraw', run, { slot: 0 });
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(rig.sendPlayerNotice).not.toHaveBeenCalled();
+    expect(rig.flushUnsettledGuildBook).not.toHaveBeenCalled();
   });
 });

--- a/tests/server/guild_bank_op_coordinator.test.ts
+++ b/tests/server/guild_bank_op_coordinator.test.ts
@@ -642,8 +642,25 @@ describe('the unsettled gate (server/guild_bank_settle_gate.ts) inside the coord
     expect(rig.session.unflushedGuildBankOps.size).toBe(0);
     expect(rig.unsettledGuildBook).toHaveBeenCalledWith(23);
     expect(rig.sendPlayerNotice).toHaveBeenCalledWith(NOTICE);
-    expect(rig.flushUnsettledGuildBook).toHaveBeenCalledWith(23);
+    expect(rig.flushUnsettledGuildBook).toHaveBeenCalledWith(23, { kind: 'items', key: legsKey });
     expect(rig.recordGuildBankIncident).toHaveBeenCalledWith('unsettled_refused');
+  });
+
+  it('never gates a READ-ONLY view: a plain member buys neither an incident nor a flush', () => {
+    // guildBankInfoFor hands every member a view; only officer-plus get
+    // canEdit. The sim refuses the member's op on rank, and the gate must not
+    // run first (it would count an incident and flush a holder for a request
+    // that can never succeed).
+    const rig = makeRig();
+    rig.state.playerBook = book({ slots: [slot('spider_leg', 20)], canEdit: false });
+    rig.unsettledGuildBook.mockReturnValue(unsettledLegs());
+    const run = vi.fn();
+    runGuildBankOp(rig.host, rig.session, { pid: 5 }, 'withdraw', run, { slot: 0 });
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(rig.unsettledGuildBook).not.toHaveBeenCalled();
+    expect(rig.sendPlayerNotice).not.toHaveBeenCalled();
+    expect(rig.flushUnsettledGuildBook).not.toHaveBeenCalled();
+    expect(rig.recordGuildBankIncident).not.toHaveBeenCalledWith('unsettled_refused');
   });
 
   it('passes a settled withdraw through to admission and the mutation, with no notice and no flush', () => {

--- a/tests/server/guild_bank_op_coordinator.test.ts
+++ b/tests/server/guild_bank_op_coordinator.test.ts
@@ -5,6 +5,7 @@ import {
   type GuildBankOpSessionPort,
   runGuildBankOp,
 } from '../../server/guild_bank_op_coordinator';
+import type { UnsettledGuildBook } from '../../server/guild_bank_settle_gate';
 import type { InvSlot } from '../../src/sim/types';
 import type { GuildBankInfo } from '../../src/world_api';
 
@@ -48,6 +49,10 @@ function makeRig() {
   const bankLedgerNeedsSave = vi.fn(() => false);
   const scheduleBankLedgerHighWaterSave = vi.fn();
   const markGuildBankDirty = vi.fn();
+  const unsettledGuildBook = vi.fn(
+    (): UnsettledGuildBook => ({ items: new Map(), copper: 0, ladder: false }),
+  );
+  const flushUnsettledGuildBook = vi.fn();
   const recordGuildBankIncident = vi.fn();
   const logError = vi.fn();
   const host: GuildBankOpHostPort = {
@@ -57,6 +62,8 @@ function makeRig() {
     bankLedgerNeedsSave,
     scheduleBankLedgerHighWaterSave,
     markGuildBankDirty,
+    unsettledGuildBook,
+    flushUnsettledGuildBook,
     recordGuildBankIncident,
     logError,
   };
@@ -84,6 +91,8 @@ function makeRig() {
     bankLedgerNeedsSave,
     scheduleBankLedgerHighWaterSave,
     markGuildBankDirty,
+    unsettledGuildBook,
+    flushUnsettledGuildBook,
     recordGuildBankIncident,
     logError,
   };

--- a/tests/server/http/game_metrics.test.ts
+++ b/tests/server/http/game_metrics.test.ts
@@ -958,6 +958,7 @@ describe('registerGameStateMetrics: throughput counters via the returned sink', 
       // Legacy cardinality: the current atomic path cannot create an unpaid
       // guild, so any new sample is a mixed-release/invariant defect.
       'create_fee_unpaid',
+      'unsettled_refused',
     ]);
 
     // Scrape BEFORE any increment: an alert rule cannot fire on a series that

--- a/tests/server_i18n.test.ts
+++ b/tests/server_i18n.test.ts
@@ -1,3 +1,5 @@
+import fs from 'node:fs';
+import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { GUILD_CREATION_FEE_COPPER } from '../src/sim/guild_bank';
 import { ensureLocaleLoaded, setLanguage, supportedLanguages } from '../src/ui/i18n';
@@ -49,6 +51,7 @@ describe('server-sent message localization', () => {
     // literal and these matchers ships English to every locale.
     'You need 1 gold to found a guild.',
     'The guild bank must be emptied before the guild can be disbanded.',
+    'You are busy. Try again in a moment.',
     'The guild bank is still saving a recent change. Try again in a moment.',
     // guildCreate's screened-name refusal (guild.nameNotAllowed): emitted from
     // server/social.ts, which the S3 guard does not scan, so the emit literal
@@ -338,6 +341,42 @@ describe('localizeServerDuration maps formatDuration output (via the filter-mute
       expect(localizeServerText(input), `es duration ${c.duration}`).toBe(
         `Estás silenciado y no puedes chatear durante ${c.es} más.`,
       );
+    }
+    setLanguage('en');
+  });
+});
+
+// The S3 emit scanner (tests/localization_fixes.test.ts) reads server/game.ts
+// only, and the guild bank op coordinator emits its own player notices
+// (host.sendPlayerNotice literals) from a sibling module, so those literals
+// would drift from the matcher unguarded. Pin them here: every literal the
+// coordinator emits must be recognized and must not stay English.
+describe('guild bank op coordinator notices stay matchable', () => {
+  const src = fs.readFileSync(
+    path.resolve(process.cwd(), 'server/guild_bank_op_coordinator.ts'),
+    'utf8',
+  );
+  const literals = [...src.matchAll(/sendPlayerNotice\(\s*'((?:[^'\\]|\\.)*)'/g)].map((m) => m[1]);
+
+  it('finds the coordinator notices, the unsettled gate refusal included', () => {
+    expect(literals).toContain(
+      'The guild bank is still saving a recent change. Try again in a moment.',
+    );
+    expect(literals).toContain('The guild bank is closing. Try again in a moment.');
+    expect(literals).toContain('You are busy. Try again in a moment.');
+  });
+
+  it('localizes every coordinator notice in every non-English locale', async () => {
+    for (const lang of supportedLanguages) {
+      await ensureLocaleLoaded(lang);
+      setLanguage(lang);
+      for (const text of literals) {
+        const out = localizeServerText(text);
+        expect(out, `${lang}: "${text}" should be recognized`).not.toBeNull();
+        if (lang !== 'en' && lang !== 'en_CA') {
+          expect(out, `${lang}: "${text}" should not stay English`).not.toBe(text);
+        }
+      }
     }
     setLanguage('en');
   });

--- a/tests/server_i18n.test.ts
+++ b/tests/server_i18n.test.ts
@@ -49,6 +49,7 @@ describe('server-sent message localization', () => {
     // literal and these matchers ships English to every locale.
     'You need 1 gold to found a guild.',
     'The guild bank must be emptied before the guild can be disbanded.',
+    'The guild bank is still saving a recent change. Try again in a moment.',
     // guildCreate's screened-name refusal (guild.nameNotAllowed): emitted from
     // server/social.ts, which the S3 guard does not scan, so the emit literal
     // is pinned to the EXACT matcher here like the tiers above.


### PR DESCRIPTION
## Summary

Players reported "Your character was taken over by another session" whenever they touched the guild bank (Discord, 2026-09-02 morning NZ). That message is the escrow refusal arm's kick: the character save carrying the guild book was refused and the session was quarantined and disconnected.

**What happened on prod (guild 294, Legio X Equestris, 2026-09-01 21:44 to 22:24 UTC, six incidents):**

1. Two officers swapped two different materials through the bank inside one 30 s autosave window: A deposited 20 spider legs and took B's 20 venom glands; B deposited the venom glands and took A's spider legs.
2. Each session's escrow replay was short on the key the OTHER session's not-yet-durable deposit held. The refusal arm honours only a one-way dependency (flush the other officer, retry), so both retries were refused again, the retry bound rolled BOTH sessions back, and both were kicked as "taken over". Ledger evidence: the two `escrow_deficit` rows at 21:44:25 (`venom_gland -20` for 94262, `spider_leg -20` for 98358), five ledger ids consumed and rolled back in the same second, and the server log lines `missing_items shortfall 20 on withdraw (spider_leg)`.
3. The rollback then left a phantom stack: reverting A's deposit found the copies already withdrawn (the revert clamps), and reverting B's withdraw granted 20 spider legs back onto the live book with nothing durable behind them. Every later withdraw of that stack (21:46, 21:58, 22:04, 22:24, "no other session holds unflushed work for this guild, so it never can") quarantined the withdrawer, and the revert put the phantom back. That is the "anytime I touch the bank" report. The phantom lives until the realm process restarts (deploying this fix restarts it).

The design note in the tests ("only ladder rungs can deadlock both replays; gold and items cannot") was true for one fungible and false for two item identities.

**The fix: an unsettled gate at dispatch.** A withdraw, gold withdraw, or rung purchase may consume only durable value plus the acting session's OWN unflushed deposits. Another session's not-yet-durable work is UNSETTLED: the op is refused before admission (nothing mutates, no ledger reservation, no mark) with a new notice, "The guild bank is still saving a recent change. Try again in a moment.", and the holder session is flushed on the spot so the retry lands a round trip later. With the gate a log can only carry deposits (always applicable), removals of settled copies, and rungs on a settled ladder, so a replay refusal (and the rollback behind it) becomes the backstop it was meant to be, reachable only through an unusable row or tampering.

- `server/guild_bank_settle_gate.ts` (new, pure): the unsettled aggregation (per identity key nets, copper excluding purse-paid `open_bank`, outstanding ladder rungs), the refusal decision, and the holder selection. A departing session's work counts as unsettled until its leave flush lands, but it is never flushed again.
- `server/guild_bank_op_coordinator.ts`: the gate runs before admission for player targets; two new host callbacks; the op request (slot/count/amount) is passed through from the three dispatch sites.
- `server/guild_bank_escrow_refusal.ts` (new): the escrow refusal arm moved out of `server/game.ts` behind a GameServer port (move-not-rewrite), sharing the holder flush with the gate. `game.ts` shrinks by 51 lines net (after the damping field and its init) and `tests/monolith_budget.test.ts` pins the new zero-margin ceiling.
- `server/http/game_signals.ts`: new incident kind `unsettled_refused` (rate signal, like `escrow_refused_retry`).
- i18n: `guild.bankSettling` in `src/ui/server_i18n.ts` and `server_i18n.newlocales.ts`, filled in every locale (M16), plus the matcher sample.
- `docs/guild-bank/state.md`: the finding and the gate, in the refusal design note, the incident kinds, and Known gotchas.
- `src/sim/guild_bank.ts`: `guildBankDeltaIdentityKey` accepts the three identity fields (type widening only, no behavior change).

**Review follow-ups (second commit):**

- The unsettled total sums each holder's POSITIVE net, never one net across holders: a commit is atomic per session, so holder C's uncommitted withdrawal must not hide holder B's uncommitted deposit (that would re-admit the cycle one officer removed). Pinned with a three-officer test.
- The refusal-triggered holder flush is damped (`GUILD_BOOK_FLUSH_COOLDOWN_MS`, one flush per holder per window, shared with the escrow arm's retry flush): a refusal costs its sender only an op-guard token, so an undamped fan-out would let one officer force a save per dirty guildmate per refusal. Pinned.
- Coordinator-level pins: refusal happens BEFORE admission (no reservation, no mutation), operator targets and a missing live book are never gated.
- A new emit-to-matcher pin over the coordinator's `sendPlayerNotice` literals (the S3 scanner reads only `server/game.ts`) caught the pre-existing unlocalized "You are busy. Try again in a moment." admission notice (also emitted by `server/paid_guild_creation.ts` and `server/social.ts`); it is now `guild.bankBusy`, filled in every locale.

**Review hardening (third and fourth commits, 867ed4cd9f and 8b376ea4f1):**

- Edit authority first: the gate runs only on an editable view (`live.canEdit`); a plain member's read-only view goes straight to the Sim's rank refusal and can buy neither an incident nor a flush.
- No realm-wide scan: `server/guild_book_holders.ts` keeps a per-guild holder index with each holder's contribution cached and invalidated (never patched) at every mark or log change (touch on op, resync after commit and rollback, dropGuild on disband, dropSession on leave). Per gated op the cost is O(holders of that guild).
- Bounded, gated flush: only the holders whose contribution feeds the refused dependency, at most `GUILD_BOOK_FLUSH_FAN_OUT_MAX`, through the background-permit save; one flush queued or running per holder with a single re-arm (`requestGuildBookFlush`).
- The gate mirrors the Sim's admissibility checks (floored count within the stack, positive safe-integer amount within the treasury, a priced rung the treasury covers) and passes every inadmissible shape through unjudged.
- The persistence suite pins the holder index at the real server seams (commit, leave, disband) and against a full session scan.
- `tests/audit_conservation_property.test.ts` now drains a previous world's pending holder flushes before building the next: its fake durable store is shared across worlds by guild and character id, and a straggling flush replayed an already durable bank opening into the next seed (surfaced by the permit path's extra microtask ticks; not a production hazard).

## Type of change

- [x] Bug fix
- [x] Refactor or performance (no behavior change): the refusal arm extraction
- [x] Tests
- [x] Documentation

## How was this tested?

- Reviewers dispatched over the diff: `qa-checklist`, `server-hot-path-reviewer`, `test-coverage-auditor`; every blocking and should-fix finding is addressed in the second commit (per-session nets, flush damping, the coordinator-level and departing-holder pins, the emit-to-matcher pin). Left as noted follow-ups: a memoized unsettled aggregation for the pathological all-saves-stalled state (the op guard bounds it today), and a flush fan-out counter.
- Commands:
  - `npx vitest run tests/guild_bank_settle_gate.test.ts tests/guild_bank_persistence.test.ts tests/server/guild_bank_op_coordinator.test.ts tests/server/http/game_metrics.test.ts tests/server_i18n.test.ts tests/localization_fixes.test.ts tests/i18n_completeness.test.ts tests/monolith_budget.test.ts tests/architecture.test.ts` (green)
  - `npx tsc --noEmit` (clean)
  - `GATE_SELECT_BASE=origin/release/v0.41.2 node scripts/gate_select.mjs`
- RED/GREEN: the new persistence test "the 2026-09-01 shape: two officers swapping two materials inside one save window quarantine nobody and strand nothing" fails with the coordinator change stashed (B's withdraw goes through, no notice, both sessions end up quarantined) and passes with it.
- Tests reworked: the backstop tests that used to construct a cross-session consume through plain dispatch (`ladderDeadlock`, "a refusal FLUSHES what it is waiting on", "counts escrow_refused_retry", and the two consume-then-fence probes in `tests/audit_cur_conservation.test.ts`, which CI shard 1 caught on the first push) now dispatch with the other officer hidden from the gate (`dispatchUnderGate`), so the retry bound, the leave-flush resolution, the refusal counters, and the fence-out rollback stay pinned; the conservation suite also gained the gate's own probe of the exploit shape.
- Manual steps: none (server-side; prod evidence above is from the live `bank_ledger` table and the game container log).

## Operational note

The phantom spider leg stack in guild 294's live book persists until the realm process restarts; the deploy of this change clears it (the boot reload rebuilds the live book from the durable row, which never held it). Nobody lost durable items or copper: every quarantined session reloaded from its last committed save.

---

## Checklist

### Quality

- [x] **The gate passes.** CI is green on every check (classify, lint, PR checks, browser tests, both long-sim arms, all eight test shards) at 48c70f6458 on the release/v0.41.2 base. Local `node scripts/gate_select.mjs` on the dev box: every stage before vitest green; the vitest stage there crashes on the known local-only jsdom admin-suite `ECONNREFUSED localhost:3000` noise under disk pressure, so CI is the bar. Every suite the change touches is green standalone (commands above).

### Cross-platform

- [x] No `IWorld` change, no wire change; the notice rides the existing server-text matcher (`src/ui/server_i18n.ts`).

### Content and i18n

- [x] New server-sent player string added in English and filled in every locale (M16), `tests/localization_fixes.test.ts` and `tests/server_i18n.test.ts` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R1PWGohNjidFb4egv4VtZR
