### PR TITLE
fix(net): apply the staged OTA bundle instead of reloading the stale one

### DIFF
--- a/docs/ota-updates.md
+++ b/docs/ota-updates.md
@@ -52,25 +52,42 @@ The plugin itself is MPL-2.0; self-hosting is a documented, supported mode.
    boot (`src/main.ts`). A bundle that never confirms within the plugin's
    ready timeout is rolled back to the previous bundle automatically; that is
    the crash-safety net, do not remove the call. The same module carries the
-   other two duck-typed plugin calls the gate uses: `watchOtaUpdates`
-   (download progress/complete/failed listeners) and `applyPendingOtaUpdate`
-   (the plugin's `reload()`, an immediate WebView-reload apply).
+   other duck-typed plugin calls the gate uses: `watchOtaUpdates` (download
+   progress/complete/staged/failed listeners), `pendingOtaBundleId` (asks the
+   plugin, via `getNextBundle()` + `current()`, for a downloaded bundle it has
+   not switched to yet) and `applyPendingOtaUpdate` (the plugin's
+   `set({ id })`, an immediate switch-and-reload to a NAMED bundle).
+
+   The event order matters and the gate is built around it: the plugin emits
+   `downloadComplete` from inside its download routine, before it verifies the
+   bundle or records it as the next bundle, and `updateAvailable` once the
+   bundle is verified, one statement before that record is written (same
+   order on iOS and Android). A `reload()` issued on `downloadComplete`
+   therefore finds no pending bundle and reboots the stale client, which then
+   meets the incompatible-version rejection until the app is force-quit. So
+   the apply keys on `updateAvailable` and names the bundle through `set`.
 5. **The visible update gate.** `src/net/ota_update_gate.ts` (wired in
    `src/main.ts`, painted by `src/ui/ota_update_overlay.ts`) turns the silent
    default into a visible flow on the shells. Pre-world, a running download
    shows a modal with live percent progress and no cancel/dismiss action (a
    skipped update strands the player on a stale bundle headed for the
    incompatible-version dead end, so the gate holds until the update lands);
-   when the download completes and the player has not entered the world, the
-   staged bundle is applied immediately via `reload()` instead of waiting
-   for a backgrounding. When the server rejects a stale bundle's
-   world-layout epoch
+   once the plugin reports the download STAGED (`updateAvailable`) and the
+   player has not entered the world, the bundle is applied immediately via
+   `set({ id })` instead of waiting for a backgrounding (`downloadComplete`
+   alone only holds the screen; a completed download the plugin never stages
+   is released after a bounded grace window). A download can finish before
+   the JS context exists (cold start, or the context an earlier apply
+   reloaded) and no event replays, so the gate asks the plugin for an
+   already-staged bundle at install and applies that too. When the server
+   rejects a stale bundle's world-layout epoch
    (`ONLINE_WORLD_INCOMPATIBLE_MESSAGE`) while a download is in flight or
    staged, the gate replaces the dead-end fatal overlay: progress, then
    auto-apply, and the resume marker survives so the reload lands back in the
-   world on the new bundle. In-world sessions are never interrupted: the
-   overlay stays hidden and the apply falls back to the plugin's
-   apply-on-background behavior.
+   world on the new bundle; with nothing in flight it asks the plugin once
+   more and, finding a staged bundle, applies it out from under the fatal
+   overlay. In-world sessions are never interrupted: the overlay stays hidden
+   and the apply falls back to the plugin's apply-on-background behavior.
 
 Bandwidth economics: the update CHECK is a tiny JSON POST against the game
 server; the heavy zip download is served by the bundle host, so game-server
@@ -313,12 +330,17 @@ feed. Keep it scoped to the one bucket and rotate it on any suspicion.
   plus the delta channel: per-entry validation (all-or-nothing), the embedded
   `manifest` on offers, zip-only degradation, and the serialize-once body.
 - `tests/native_ota.test.ts`: the duck-typed plugin glue (`notifyAppReady`,
-  `watchOtaUpdates`, `applyPendingOtaUpdate`) plus source pins on the
-  `src/main.ts` wiring (boot confirm AND the gate install/disconnect arm),
-  `capacitor.config.ts` plugin block, and the `package.json` dependency.
+  `watchOtaUpdates` including the `updateAvailable` staged signal,
+  `pendingOtaBundleId` and its never-guess rules, `applyPendingOtaUpdate`
+  switching by id through `set` and refusing the running bundle) plus source
+  pins on the `src/main.ts` wiring (boot confirm AND the gate
+  install/disconnect arm), `capacitor.config.ts` plugin block, and the
+  `package.json` dependency.
 - `tests/ota_update_gate.test.ts`: the visible-gate state machine (progress,
-  auto-apply, in-world suppression, the incompatible-version
-  takeover and its fatal-mode dead ends).
+  the staged-keyed auto-apply and the regression it pins: no apply on
+  `downloadComplete` alone, the boot and rejection-time probes, the staging
+  grace window, in-world suppression, the incompatible-version takeover and
+  its fatal-mode dead ends).
 - `tests/ota_update_overlay.test.ts`: the overlay painter (mount/update in
   place, progressbar semantics, the no-cancel contract, fatal copy).
 - `tests/ota_publish.test.ts`: the publish planner (keys, URLs, manifest

--- a/docs/ota-updates.md
+++ b/docs/ota-updates.md
@@ -81,12 +81,14 @@ The plugin itself is MPL-2.0; self-hosting is a documented, supported mode.
    reloaded) and no event replays, so the gate asks the plugin for an
    already-staged bundle at install and applies that too. When the server
    rejects a stale bundle's world-layout epoch
-   (`ONLINE_WORLD_INCOMPATIBLE_MESSAGE`) while a download is in flight or
-   staged, the gate replaces the dead-end fatal overlay: progress, then
-   auto-apply, and the resume marker survives so the reload lands back in the
-   world on the new bundle; with nothing in flight it asks the plugin once
-   more and, finding a staged bundle, applies it out from under the fatal
-   overlay. In-world sessions are never interrupted: the overlay stays hidden
+   (`ONLINE_WORLD_INCOMPATIBLE_MESSAGE`), the gate claims the screen instead
+   of the dead-end fatal overlay: progress for a download in flight, then
+   auto-apply once staged; with nothing in flight it asks the plugin once
+   more, applies a staged bundle it finds, and hands the dead-end overlay
+   back only on a miss. The resume marker survives every apply (the dead-end
+   overlay is what clears it, and it paints only once there is provably
+   nothing to apply), so the reload lands back in the world on the new
+   bundle. In-world sessions are never interrupted: the overlay stays hidden
    and the apply falls back to the plugin's apply-on-background behavior.
 
 Bandwidth economics: the update CHECK is a tiny JSON POST against the game

--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -2,3 +2,7 @@
 
 - Backgrounded movement v2 sessions stop accruing playtime and daily-reward activity after
   their consumed input frames become stale.
+- Native shells (iOS and Android) apply an auto-downloaded OTA bundle the moment the
+  updater stages it instead of reloading the stale bundle on download completion, and
+  pick up a bundle staged before the app's JavaScript booted, so a player no longer
+  meets the "Game and server versions are incompatible" screen until they force-quit.

--- a/src/net/native_ota.ts
+++ b/src/net/native_ota.ts
@@ -3,7 +3,7 @@
 // The plugin's update machinery is native-side and config-driven
 // (capacitor.config.ts CapacitorUpdater: autoUpdate against our own
 // /api/ota/updates endpoint, stats disabled). The JS side is deliberately
-// thin, three duck-typed calls:
+// thin, a handful of duck-typed calls:
 // - notifyAppReady(): the ONE mandatory call. A freshly applied bundle that
 //   never reports ready within the plugin's appReadyTimeout is treated as
 //   broken and rolled back to the previous bundle on the next launch.
@@ -11,11 +11,26 @@
 //   boot never runs simply never confirms, and the rollback safety net fires.
 // - watchOtaUpdates(): subscribes to the native auto-updater's download
 //   lifecycle events so the boot gate (ota_update_gate.ts) can show real
-//   progress instead of the silent atBackground default.
-// - applyPendingOtaUpdate(): the plugin's reload(), which applies a fully
-//   downloaded (staged) bundle by reloading the WebView immediately, the
-//   same apply that normally waits for the next app backgrounding. On
-//   success the current JS context is destroyed mid-await.
+//   progress instead of the silent atBackground default, and learn the moment
+//   a finished download is actually STAGED (see below).
+// - pendingOtaBundleId(): asks the plugin whether it already holds a
+//   downloaded bundle it has not switched to. The download runs natively and
+//   can finish before this JS context existed (a cold start, or the context a
+//   previous apply reloaded), in which case no event will ever tell us.
+// - applyPendingOtaUpdate(): switches to a staged bundle NOW via the plugin's
+//   set({ id }), the same switch autoUpdate performs on the next app
+//   backgrounding. On success the WebView reloads and the current JS context
+//   is destroyed mid-await.
+//
+// Event ordering, which the gate is built around: the plugin emits
+// 'downloadComplete' from inside its download routine, BEFORE it verifies the
+// bundle and records it as the next bundle; 'updateAvailable' fires once the
+// bundle is verified, one statement before that record is written. So a
+// reload() issued on downloadComplete finds no pending bundle and reloads the
+// bundle already running, and the player boots into the same stale client
+// (then meets the incompatible-version rejection at the door). The apply
+// therefore keys on updateAvailable and names the bundle explicitly through
+// set({ id }) rather than trusting the plugin's next marker to be in place.
 //
 // Duck-typed off window.Capacitor.Plugins like native_app_update.ts (the
 // bridge injects every registered native plugin there), so the web bundle
@@ -42,41 +57,44 @@ interface CapacitorUpdaterReloadPlugin {
   reload(): Promise<unknown>;
 }
 
+interface CapacitorUpdaterSetPlugin {
+  set(options: { id: string }): Promise<unknown>;
+}
+
+interface CapacitorUpdaterBundleQueryPlugin {
+  getNextBundle(): Promise<unknown>;
+  current(): Promise<unknown>;
+}
+
 /** The global-scope shape the duck-typed plugin lookup reads; injectable for tests. */
 export interface OtaGlobalScope {
   Capacitor?: { Plugins?: Record<string, unknown> };
 }
 
-function updaterPlugin(scope: OtaGlobalScope): CapacitorUpdaterPlugin | null {
-  const plugin = scope.Capacitor?.Plugins?.CapacitorUpdater;
-  if (!plugin || typeof plugin !== 'object') return null;
-  const candidate = plugin as Partial<CapacitorUpdaterPlugin>;
-  return typeof candidate.notifyAppReady === 'function'
-    ? (candidate as CapacitorUpdaterPlugin)
-    : null;
-}
-
 // Separate capability lookups on purpose: each caller degrades to a no-op on
-// exactly the method IT needs, so an older or partially-injected plugin never
+// exactly the methods IT needs, so an older or partially-injected plugin never
 // breaks the unrelated calls (notifyAppReady must keep confirming even if
 // addListener were absent).
-function updaterEventsPlugin(scope: OtaGlobalScope): CapacitorUpdaterEventsPlugin | null {
+function updaterPluginWith<T extends object>(
+  scope: OtaGlobalScope,
+  methods: readonly string[],
+): T | null {
   const plugin = scope.Capacitor?.Plugins?.CapacitorUpdater;
   if (!plugin || typeof plugin !== 'object') return null;
-  const candidate = plugin as Partial<CapacitorUpdaterEventsPlugin>;
-  return typeof candidate.addListener === 'function'
-    ? (candidate as CapacitorUpdaterEventsPlugin)
-    : null;
+  const candidate = plugin as Record<string, unknown>;
+  return methods.every((method) => typeof candidate[method] === 'function') ? (plugin as T) : null;
 }
 
-function updaterReloadPlugin(scope: OtaGlobalScope): CapacitorUpdaterReloadPlugin | null {
-  const plugin = scope.Capacitor?.Plugins?.CapacitorUpdater;
-  if (!plugin || typeof plugin !== 'object') return null;
-  const candidate = plugin as Partial<CapacitorUpdaterReloadPlugin>;
-  return typeof candidate.reload === 'function'
-    ? (candidate as CapacitorUpdaterReloadPlugin)
-    : null;
-}
+const updaterPlugin = (scope: OtaGlobalScope) =>
+  updaterPluginWith<CapacitorUpdaterPlugin>(scope, ['notifyAppReady']);
+const updaterEventsPlugin = (scope: OtaGlobalScope) =>
+  updaterPluginWith<CapacitorUpdaterEventsPlugin>(scope, ['addListener']);
+const updaterReloadPlugin = (scope: OtaGlobalScope) =>
+  updaterPluginWith<CapacitorUpdaterReloadPlugin>(scope, ['reload']);
+const updaterSetPlugin = (scope: OtaGlobalScope) =>
+  updaterPluginWith<CapacitorUpdaterSetPlugin>(scope, ['set']);
+const updaterBundleQueryPlugin = (scope: OtaGlobalScope) =>
+  updaterPluginWith<CapacitorUpdaterBundleQueryPlugin>(scope, ['getNextBundle', 'current']);
 
 /**
  * Confirm the currently running OTA bundle as healthy. Returns true when the
@@ -104,7 +122,15 @@ export async function notifyOtaAppReady(
 /** The download-lifecycle callbacks the boot gate consumes; percent is 0..100. */
 export interface OtaUpdateHandlers {
   onProgress(percent: number): void;
+  /** The bytes are down ('downloadComplete'); the plugin is still verifying. */
   onComplete(): void;
+  /**
+   * The bundle is verified and about to be recorded as the next bundle
+   * ('updateAvailable'): the only signal an immediate apply may act on.
+   * bundleId is null when the payload carried none; the apply then asks the
+   * plugin for its next marker instead.
+   */
+  onStaged(bundleId: string | null): void;
   onFailed(): void;
 }
 
@@ -114,13 +140,33 @@ function coercePercent(event: unknown): number {
   return Math.max(0, Math.min(100, percent));
 }
 
+interface BundleRecord {
+  id: string;
+  status: string | null;
+}
+
+/** The `{ id, version, status, ... }` BundleInfo shape, read defensively. */
+function bundleRecordOf(value: unknown): BundleRecord | null {
+  if (!value || typeof value !== 'object') return null;
+  const { id, status } = value as { id?: unknown; status?: unknown };
+  if (typeof id !== 'string' || id.length === 0) return null;
+  return { id, status: typeof status === 'string' ? status : null };
+}
+
+/** Every plugin event that names a bundle wraps it as `{ bundle: BundleInfo }`. */
+function eventBundleId(event: unknown): string | null {
+  return bundleRecordOf((event as { bundle?: unknown } | null | undefined)?.bundle)?.id ?? null;
+}
+
 /**
  * Subscribe to the native updater's download events ('download' fires with a
- * percent throughout, 'downloadComplete'/'downloadFailed' close it out). The
- * native side downloads on its own in autoUpdate mode; this only OBSERVES so
- * the gate can paint progress. Returns an unsubscribe that also covers
- * listener handles that resolve late. Never throws: on web/desktop, a missing
- * plugin, or a bridge failure the handlers simply never fire.
+ * percent throughout, 'downloadComplete' when the bytes are down,
+ * 'updateAvailable' once the bundle is verified and being staged,
+ * 'downloadFailed' on any failure). The native side downloads on its own in
+ * autoUpdate mode; this only OBSERVES so the gate can paint progress and time
+ * its apply. Returns an unsubscribe that also covers listener handles that
+ * resolve late. Never throws: on web/desktop, a missing plugin, or a bridge
+ * failure the handlers simply never fire.
  */
 export function watchOtaUpdates(
   handlers: OtaUpdateHandlers,
@@ -157,6 +203,11 @@ export function watchOtaUpdates(
       plugin.addListener('download', (ev) => guarded(() => handlers.onProgress(coercePercent(ev)))),
     );
     track(plugin.addListener('downloadComplete', () => guarded(() => handlers.onComplete())));
+    track(
+      plugin.addListener('updateAvailable', (ev) =>
+        guarded(() => handlers.onStaged(eventBundleId(ev))),
+      ),
+    );
     track(plugin.addListener('downloadFailed', () => guarded(() => handlers.onFailed())));
   } catch (err) {
     console.warn('OTA listener registration failed', err);
@@ -173,31 +224,111 @@ export function watchOtaUpdates(
   };
 }
 
+/** Bundle statuses under which the plugin's next marker names nothing switchable. */
+const UNSWITCHABLE_STATUSES: ReadonlySet<string> = new Set([
+  'error',
+  'downloading',
+  'deleted',
+  'deleting',
+]);
+
 /**
- * Apply a staged (fully downloaded) OTA bundle NOW via the plugin's reload():
- * the same apply that autoUpdate performs on the next backgrounding, pulled
- * forward so the pre-game gate can finish visibly. On a real apply the
- * WebView reloads and this JS context is destroyed, usually mid-await; false
- * means the reload path was unavailable (web, plugin absent, bridge error)
- * and the caller should fall back to the background apply. Never throws.
+ * The id of a downloaded bundle the plugin has recorded as "next" but not
+ * switched to yet, or null. This is how a JS context learns about a download
+ * that finished before it existed (cold start; the context an earlier apply
+ * reloaded), since no event replays.
+ *
+ * Null whenever the answer cannot be PROVEN to be a different bundle: either
+ * query unavailable, no next marker, a marker in an unswitchable state, or a
+ * marker naming the running bundle. That last one is routine, not an error:
+ * set({ id }) leaves the next marker pointing at what is now current, and
+ * switching to the running bundle again would reload the app forever.
+ */
+export async function pendingOtaBundleId(
+  opts: { native?: boolean; scope?: OtaGlobalScope } = {},
+): Promise<string | null> {
+  const native = opts.native ?? NATIVE_APP;
+  if (!native) return null;
+  const scope = opts.scope ?? (window as unknown as OtaGlobalScope);
+  const plugin = updaterBundleQueryPlugin(scope);
+  if (!plugin) return null;
+  try {
+    const [nextRaw, currentRaw] = await Promise.all([plugin.getNextBundle(), plugin.current()]);
+    const next = bundleRecordOf(nextRaw);
+    if (!next || (next.status !== null && UNSWITCHABLE_STATUSES.has(next.status))) return null;
+    const current = bundleRecordOf((currentRaw as { bundle?: unknown } | null | undefined)?.bundle);
+    if (!current) return null;
+    return next.id === current.id ? null : next.id;
+  } catch (err) {
+    console.warn('OTA pending bundle query failed', err);
+    return null;
+  }
+}
+
+async function runningOtaBundleId(scope: OtaGlobalScope): Promise<string | null> {
+  const plugin = updaterBundleQueryPlugin(scope);
+  if (!plugin) return null;
+  try {
+    const currentRaw = await plugin.current();
+    return (
+      bundleRecordOf((currentRaw as { bundle?: unknown } | null | undefined)?.bundle)?.id ?? null
+    );
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Switch to a staged (downloaded and verified) OTA bundle NOW, the same
+ * switch autoUpdate performs on the next backgrounding, pulled forward so the
+ * pre-game gate can finish visibly. The bundle is named explicitly through
+ * the plugin's set({ id }): with `bundleId` (from the updateAvailable payload)
+ * when the caller has it, else whatever the plugin's own next marker names.
+ * set() switches the current bundle and reloads the WebView; the new bundle
+ * then confirms itself through notifyAppReady or the plugin rolls it back.
+ *
+ * On a real apply this JS context is destroyed, usually mid-await; false
+ * means nothing was switched (web, plugin absent, no staged bundle to name,
+ * the named bundle already running, bridge error) and the caller should fall
+ * back to the plugin's apply-on-background. Never throws.
+ *
+ * reload() is kept only as the fallback for a plugin without set(): it
+ * applies the plugin's next marker if that is already written and otherwise
+ * merely reloads the running bundle.
  */
 export async function applyPendingOtaUpdate(
-  opts: { native?: boolean; scope?: OtaGlobalScope } = {},
+  opts: { bundleId?: string | null; native?: boolean; scope?: OtaGlobalScope } = {},
 ): Promise<boolean> {
   const native = opts.native ?? NATIVE_APP;
   if (!native) return false;
   const scope = opts.scope ?? (window as unknown as OtaGlobalScope);
-  const plugin = updaterReloadPlugin(scope);
-  if (!plugin) return false;
+  const setPlugin = updaterSetPlugin(scope);
+  if (!setPlugin) {
+    const reloadPlugin = updaterReloadPlugin(scope);
+    if (!reloadPlugin) return false;
+    try {
+      await reloadPlugin.reload();
+      return true;
+    } catch (err) {
+      console.warn('OTA reload failed', err);
+      return false;
+    }
+  }
+  const bundleId = opts.bundleId ?? (await pendingOtaBundleId({ native, scope }));
+  if (!bundleId) return false;
+  // Never switch to the bundle already running: the plugin would reload the
+  // same code and this gate would meet the same staged id again on boot.
+  const running = await runningOtaBundleId(scope);
+  if (running !== null && running === bundleId) return false;
   try {
-    await plugin.reload();
+    await setPlugin.set({ id: bundleId });
     // Some bridges resolve the call in the same tick the reload tears the
     // context down, so a resolve here does NOT prove nothing happened. Treat
     // it as success: the worst case (plugin resolved but declined to reload)
     // degrades to the pre-existing apply-on-background behavior.
     return true;
   } catch (err) {
-    console.warn('OTA reload failed', err);
+    console.warn('OTA apply failed', err);
     return false;
   }
 }

--- a/src/net/ota_update_gate.ts
+++ b/src/net/ota_update_gate.ts
@@ -12,17 +12,27 @@
 //   an overlay shows live percent progress with no dismiss action (a skipped
 //   update leaves the player on a stale bundle headed for the
 //   incompatible-version dead end, so the gate holds until the update lands);
-//   when the download completes and the player has not entered the world, the
-//   staged bundle is applied immediately via a WebView reload instead of
-//   waiting for a backgrounding.
+//   once the plugin has STAGED the finished download and the player has not
+//   entered the world, the bundle is applied immediately via a WebView reload
+//   instead of waiting for a backgrounding.
 // - The incompatible-version rejection: when the server refuses the bundle's
 //   world-layout epoch and a download is in flight (or already staged), the
 //   dead-end fatal overlay is replaced by this gate in "fatal" mode: progress,
 //   then auto-apply (there is nothing playable behind it).
 //
+// "Staged" is load-bearing. The plugin emits downloadComplete before it has
+// verified the bundle or recorded it as the next bundle, so an apply issued on
+// that event switches to nothing and merely reloads the stale client (the
+// "still incompatible until I force-quit the app" report). The apply keys on
+// the later updateAvailable event, which names the verified bundle, and
+// switches to it by id. A download can also finish before this JS context
+// exists (cold start, or the context an earlier apply reloaded), and no event
+// replays, so the gate asks the plugin for an already-staged bundle at install
+// and again when the incompatible rejection lands with nothing in flight.
+//
 // In-world sessions are never interrupted: while body is game-active the
-// overlay stays hidden and a completed download falls back to the plugin's
-// own apply-on-background behavior.
+// overlay stays hidden and a staged download falls back to the plugin's own
+// apply-on-background behavior.
 //
 // Split on the reconnect_policy.ts pattern: pure, directly-testable state
 // functions (reduce/model/decide) plus one thin installer that wires them to
@@ -31,7 +41,7 @@
 // stays DOM-free.
 
 import { ONLINE_WORLD_INCOMPATIBLE_MESSAGE } from '../world_api';
-import { applyPendingOtaUpdate, watchOtaUpdates } from './native_ota';
+import { applyPendingOtaUpdate, pendingOtaBundleId, watchOtaUpdates } from './native_ota';
 import { NATIVE_APP } from './online';
 
 export type OtaGatePhase = 'idle' | 'downloading' | 'ready' | 'applying' | 'failed';
@@ -46,11 +56,20 @@ export interface OtaGateState {
    * applies the bundle the moment it is ready.
    */
   fatal: boolean;
+  /**
+   * The plugin has verified the download and recorded (or is recording) it as
+   * the next bundle. The only state an apply is allowed from: before it, there
+   * is nothing to switch to and a reload would boot the same stale client.
+   */
+  staged: boolean;
+  /** The staged bundle's id when the plugin named one; null means "ask the plugin". */
+  stagedId: string | null;
 }
 
 export type OtaGateEvent =
   | { type: 'progress'; percent: number }
   | { type: 'complete' }
+  | { type: 'staged'; bundleId: string | null }
   | { type: 'failed' }
   | { type: 'incompatible' }
   | { type: 'applying' };
@@ -63,7 +82,7 @@ export interface OtaOverlayModel {
 }
 
 export function initialOtaGateState(): OtaGateState {
-  return { phase: 'idle', percent: 0, fatal: false };
+  return { phase: 'idle', percent: 0, fatal: false, staged: false, stagedId: null };
 }
 
 export function reduceOtaGateEvent(state: OtaGateState, event: OtaGateEvent): OtaGateState {
@@ -76,8 +95,19 @@ export function reduceOtaGateEvent(state: OtaGateState, event: OtaGateEvent): Ot
     case 'complete':
       if (state.phase === 'applying') return state;
       return { ...state, phase: 'ready', percent: 100 };
-    case 'failed':
+    case 'staged':
       if (state.phase === 'applying') return state;
+      return {
+        ...state,
+        phase: 'ready',
+        percent: 100,
+        staged: true,
+        stagedId: event.bundleId ?? state.stagedId,
+      };
+    case 'failed':
+      // A bundle already staged outlives a later failure report: it is still
+      // the fix, and the plugin still applies it on the next backgrounding.
+      if (state.phase === 'applying' || state.staged) return state;
       return { ...state, phase: 'failed' };
     case 'incompatible':
       return { ...state, fatal: true };
@@ -93,16 +123,33 @@ export function otaOverlayModel(state: OtaGateState, inWorld: boolean): OtaOverl
   if (state.phase === 'downloading') {
     return { phase: 'downloading', percent: state.percent, fatal: state.fatal };
   }
-  // 'ready' renders as applying: the auto-apply decision below fires in the
-  // same event turn, so the player never sees a stalled "ready" state.
+  // 'ready' renders as applying: the plugin is verifying and staging the
+  // downloaded bundle, and the auto-apply fires the moment it reports staged,
+  // so the player never sees a stalled "ready" state.
   return { phase: 'applying', percent: 100, fatal: state.fatal };
 }
 
 export function shouldAutoApplyOta(state: OtaGateState, inWorld: boolean): boolean {
-  if (state.phase !== 'ready') return false;
+  if (state.phase !== 'ready' || !state.staged) return false;
   if (state.fatal) return true;
   return !inWorld;
 }
+
+/**
+ * How long a completed download may sit unverified before the gate stops
+ * holding the screen for it: after this, it asks the plugin once for a staged
+ * bundle and otherwise steps aside (the plugin's own apply-on-background is
+ * still armed). Verification is a checksum over the downloaded files, so
+ * anything near this long means the plugin is not going to stage it.
+ */
+export const OTA_STAGING_GRACE_MS = 30_000;
+
+export type OtaGateScheduler = (fn: () => void, ms: number) => () => void;
+
+const defaultSchedule: OtaGateScheduler = (fn, ms) => {
+  const handle = setTimeout(fn, ms);
+  return () => clearTimeout(handle);
+};
 
 export interface OtaUpdateGateDeps {
   overlay: {
@@ -121,6 +168,8 @@ export interface OtaUpdateGateDeps {
   native?: boolean;
   watch?: typeof watchOtaUpdates;
   apply?: typeof applyPendingOtaUpdate;
+  pending?: typeof pendingOtaBundleId;
+  schedule?: OtaGateScheduler;
   incompatibleReason?: string;
 }
 
@@ -128,7 +177,9 @@ export interface OtaUpdateGate {
   /**
    * Claim an ended session's disconnect reason: returns true (and takes over
    * the screen) only for the incompatible-version rejection while an update
-   * is downloading or staged. On false the caller shows its usual overlay.
+   * is downloading or staged. On false the caller shows its usual overlay;
+   * the gate still asks the plugin for a bundle it never heard about and,
+   * finding one, applies it out from under that overlay.
    */
   handleIncompatibleDisconnect(reason: string | undefined): boolean;
   /** Snapshot for tests/diagnostics. */
@@ -145,9 +196,12 @@ export function installOtaUpdateGate(deps: OtaUpdateGateDeps): OtaUpdateGate {
   if (!native) return INERT_GATE;
   const watch = deps.watch ?? watchOtaUpdates;
   const apply = deps.apply ?? applyPendingOtaUpdate;
+  const pending = deps.pending ?? pendingOtaBundleId;
+  const schedule = deps.schedule ?? defaultSchedule;
   const incompatibleReason = deps.incompatibleReason ?? ONLINE_WORLD_INCOMPATIBLE_MESSAGE;
 
   let state = initialOtaGateState();
+  let cancelStagingWatch: (() => void) | null = null;
 
   const paint = (): void => {
     const model = otaOverlayModel(state, deps.isInWorld());
@@ -155,17 +209,23 @@ export function installOtaUpdateGate(deps: OtaUpdateGateDeps): OtaUpdateGate {
     else deps.overlay.hide();
   };
 
+  const disarmStagingWatch = (): void => {
+    cancelStagingWatch?.();
+    cancelStagingWatch = null;
+  };
+
   const maybeApply = (): void => {
     if (!shouldAutoApplyOta(state, deps.isInWorld())) {
       paint();
       return;
     }
+    disarmStagingWatch();
     state = reduceOtaGateEvent(state, { type: 'applying' });
     paint();
-    void apply().then((applied) => {
+    void apply({ bundleId: state.stagedId }).then((applied) => {
       // On success the WebView reloads and this context is gone; reaching
-      // here with false means the reload path is unavailable (plugin absent
-      // or the bridge call failed).
+      // here with false means nothing was switched (plugin absent, no bundle
+      // to name, or the bridge call failed).
       if (applied) return;
       state = { ...state, phase: 'ready' };
       if (state.fatal) {
@@ -184,6 +244,42 @@ export function installOtaUpdateGate(deps: OtaUpdateGateDeps): OtaUpdateGate {
     });
   };
 
+  const onStaged = (bundleId: string | null): void => {
+    disarmStagingWatch();
+    state = reduceOtaGateEvent(state, { type: 'staged', bundleId });
+    maybeApply();
+  };
+
+  const onFailed = (): void => {
+    disarmStagingWatch();
+    const wasFatal = state.fatal;
+    state = reduceOtaGateEvent(state, { type: 'failed' });
+    paint();
+    if (wasFatal && state.phase === 'failed') deps.onFatalRecoveryFailed?.();
+  };
+
+  // Ask the plugin for a bundle this context never saw download. Anything it
+  // names is staged by definition (the plugin only records verified bundles).
+  const probeStaged = (onNone?: () => void): void => {
+    void pending().then((bundleId) => {
+      if (bundleId) onStaged(bundleId);
+      else onNone?.();
+    });
+  };
+
+  const armStagingWatch = (): void => {
+    disarmStagingWatch();
+    cancelStagingWatch = schedule(() => {
+      cancelStagingWatch = null;
+      if (state.phase !== 'ready' || state.staged) return;
+      probeStaged(() => {
+        // Re-check: the staged event may have landed while the probe ran.
+        if (state.phase !== 'ready' || state.staged) return;
+        onFailed();
+      });
+    }, OTA_STAGING_GRACE_MS);
+  };
+
   watch({
     onProgress: (percent) => {
       state = reduceOtaGateEvent(state, { type: 'progress', percent });
@@ -191,28 +287,42 @@ export function installOtaUpdateGate(deps: OtaUpdateGateDeps): OtaUpdateGate {
     },
     onComplete: () => {
       state = reduceOtaGateEvent(state, { type: 'complete' });
+      // Nothing to switch to yet: hold the screen ("applying") until the
+      // plugin reports the bundle staged, bounded by the grace window.
+      if (!state.staged) armStagingWatch();
       maybeApply();
     },
-    onFailed: () => {
-      const wasFatal = state.fatal;
-      state = reduceOtaGateEvent(state, { type: 'failed' });
-      paint();
-      if (wasFatal) deps.onFatalRecoveryFailed?.();
-    },
+    onStaged,
+    onFailed,
   });
+
+  // A download that finished before this context booted left no event to
+  // catch; the plugin's own record is the only trace.
+  probeStaged();
 
   return {
     handleIncompatibleDisconnect: (reason) => {
       if (reason !== incompatibleReason) return false;
-      // Only claim the recovery when an update is actually in flight or
-      // staged; with nothing to offer (no check answered yet, or the download
-      // already failed) the caller's overlay is the honest answer.
-      if (state.phase !== 'downloading' && state.phase !== 'ready' && state.phase !== 'applying') {
-        return false;
+      // Claim the recovery when an update is in flight or staged.
+      if (state.phase === 'downloading' || state.phase === 'ready' || state.phase === 'applying') {
+        state = reduceOtaGateEvent(state, { type: 'incompatible' });
+        maybeApply();
+        return true;
       }
+      // Nothing known in flight (no check answered yet, the download already
+      // failed, or it finished before this context existed). The caller's
+      // overlay is the honest answer NOW, but the plugin may still hold the
+      // fix: ask it, and on a hit take over in fatal mode. Fatal is set
+      // before the probe answers so the apply is unconditional (the session
+      // is dead either way) and the overlay carries the update-required copy.
+      // A successful apply reloads out from under the caller's overlay; a
+      // failed one hands back through onFatalRecoveryFailed, which the caller
+      // treats as a repaint. The flag also outlives a miss: a download that
+      // starts later (the plugin re-checks on foreground) paints and applies
+      // in fatal mode over the same dead end.
       state = reduceOtaGateEvent(state, { type: 'incompatible' });
-      maybeApply();
-      return true;
+      probeStaged();
+      return false;
     },
     state: () => state,
   };

--- a/src/net/ota_update_gate.ts
+++ b/src/net/ota_update_gate.ts
@@ -16,9 +16,11 @@
 //   entered the world, the bundle is applied immediately via a WebView reload
 //   instead of waiting for a backgrounding.
 // - The incompatible-version rejection: when the server refuses the bundle's
-//   world-layout epoch and a download is in flight (or already staged), the
-//   dead-end fatal overlay is replaced by this gate in "fatal" mode: progress,
-//   then auto-apply (there is nothing playable behind it).
+//   world-layout epoch, this gate claims the screen in "fatal" mode instead of
+//   the dead-end overlay: progress for a download in flight, then auto-apply
+//   once staged (there is nothing playable behind it). With nothing in flight
+//   it asks the plugin for a bundle staged before this context existed and
+//   hands the dead-end overlay back only on a miss.
 //
 // "Staged" is load-bearing. The plugin emits downloadComplete before it has
 // verified the bundle or recorded it as the next bundle, so an apply issued on
@@ -176,10 +178,13 @@ export interface OtaUpdateGateDeps {
 export interface OtaUpdateGate {
   /**
    * Claim an ended session's disconnect reason: returns true (and takes over
-   * the screen) only for the incompatible-version rejection while an update
-   * is downloading or staged. On false the caller shows its usual overlay;
-   * the gate still asks the plugin for a bundle it never heard about and,
-   * finding one, applies it out from under that overlay.
+   * the screen) for the incompatible-version rejection, false for any other
+   * reason, which the caller shows as usual. With an update downloading or
+   * staged the gate paints progress and applies; with nothing in flight it
+   * asks the plugin for a bundle it never heard about, applies a hit, and on
+   * a miss hands the screen back through onFatalRecoveryFailed. Claiming
+   * before the plugin answers keeps the caller's dead-end overlay, which
+   * clears the resume marker, off the screen until it is the truth.
    */
   handleIncompatibleDisconnect(reason: string | undefined): boolean;
   /** Snapshot for tests/diagnostics. */
@@ -300,29 +305,34 @@ export function installOtaUpdateGate(deps: OtaUpdateGateDeps): OtaUpdateGate {
   // catch; the plugin's own record is the only trace.
   probeStaged();
 
+  const isUpdateInFlight = (): boolean =>
+    state.phase === 'downloading' || state.phase === 'ready' || state.phase === 'applying';
+
   return {
     handleIncompatibleDisconnect: (reason) => {
       if (reason !== incompatibleReason) return false;
-      // Claim the recovery when an update is in flight or staged.
-      if (state.phase === 'downloading' || state.phase === 'ready' || state.phase === 'applying') {
-        state = reduceOtaGateEvent(state, { type: 'incompatible' });
+      state = reduceOtaGateEvent(state, { type: 'incompatible' });
+      if (isUpdateInFlight()) {
         maybeApply();
         return true;
       }
       // Nothing known in flight (no check answered yet, the download already
-      // failed, or it finished before this context existed). The caller's
-      // overlay is the honest answer NOW, but the plugin may still hold the
-      // fix: ask it, and on a hit take over in fatal mode. Fatal is set
-      // before the probe answers so the apply is unconditional (the session
-      // is dead either way) and the overlay carries the update-required copy.
-      // A successful apply reloads out from under the caller's overlay; a
-      // failed one hands back through onFatalRecoveryFailed, which the caller
-      // treats as a repaint. The flag also outlives a miss: a download that
-      // starts later (the plugin re-checks on foreground) paints and applies
-      // in fatal mode over the same dead end.
-      state = reduceOtaGateEvent(state, { type: 'incompatible' });
-      probeStaged();
-      return false;
+      // failed, or it finished before this context existed). The plugin may
+      // still hold the fix, so the screen is claimed NOW and the plugin asked.
+      // A hit applies in fatal mode (the session is dead either way) with the
+      // caller's resume marker intact, so the reload lands back in the world
+      // on the new bundle; a miss hands back through onFatalRecoveryFailed,
+      // whose dead-end overlay is what drops that marker, so it paints only
+      // once there is provably nothing to apply. Fatal outlives a miss: a
+      // download that starts later (the plugin re-checks on foreground)
+      // paints and applies in fatal mode over the same dead end.
+      probeStaged(() => {
+        // Re-check: a download may have started while the probe ran, and the
+        // gate then owns the screen through its own apply or failure paths.
+        if (isUpdateInFlight()) return;
+        deps.onFatalRecoveryFailed?.();
+      });
+      return true;
     },
     state: () => state,
   };

--- a/tests/native_ota.test.ts
+++ b/tests/native_ota.test.ts
@@ -228,10 +228,19 @@ describe('pendingOtaBundleId', () => {
   });
 
   it('is null when the plugin has no marker, however the bridge spells "none"', async () => {
-    for (const next of [undefined, null, {}, { id: '' }, 'builtin']) {
+    for (const next of [undefined, null, {}, { id: '' }]) {
       const scope = scopeWith(queryPlugin({ current: running('cur'), next }));
       await expect(pendingOtaBundleId({ native: true, scope })).resolves.toBeNull();
     }
+  });
+
+  it('names a revert to the shipped bundle too: set({ id: "builtin" }) is the plugin reset', async () => {
+    // The plugin records builtin as next when the store build overtakes the
+    // OTA channel; installNext() would switch to it on backgrounding anyway.
+    const scope = scopeWith(
+      queryPlugin({ current: running('cur'), next: { id: 'builtin', status: 'success' } }),
+    );
+    await expect(pendingOtaBundleId({ native: true, scope })).resolves.toBe('builtin');
   });
 
   it('is null when the running bundle cannot be read (never guess: a wrong apply reload-loops)', async () => {

--- a/tests/native_ota.test.ts
+++ b/tests/native_ota.test.ts
@@ -5,6 +5,7 @@ import {
   notifyOtaAppReady,
   type OtaGlobalScope,
   type OtaUpdateHandlers,
+  pendingOtaBundleId,
   watchOtaUpdates,
 } from '../src/net/native_ota';
 
@@ -55,6 +56,7 @@ function noopHandlers(overrides: Partial<OtaUpdateHandlers> = {}): OtaUpdateHand
   return {
     onProgress: () => {},
     onComplete: () => {},
+    onStaged: () => {},
     onFailed: () => {},
     ...overrides,
   };
@@ -78,12 +80,13 @@ function fakeEventsPlugin() {
 const flushMicrotasks = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
 
 describe('watchOtaUpdates', () => {
-  it('maps the three download-lifecycle events onto the handlers', async () => {
+  it('maps the four download-lifecycle events onto the handlers', async () => {
     const { plugin, listeners } = fakeEventsPlugin();
     const onProgress = vi.fn();
     const onComplete = vi.fn();
+    const onStaged = vi.fn();
     const onFailed = vi.fn();
-    watchOtaUpdates(noopHandlers({ onProgress, onComplete, onFailed }), {
+    watchOtaUpdates(noopHandlers({ onProgress, onComplete, onStaged, onFailed }), {
       native: true,
       scope: scopeWith(plugin),
     });
@@ -91,13 +94,26 @@ describe('watchOtaUpdates', () => {
       'download',
       'downloadComplete',
       'downloadFailed',
+      'updateAvailable',
     ]);
     listeners.get('download')?.({ percent: 37, bundle: { id: 'b' } });
     listeners.get('downloadComplete')?.({ bundle: { id: 'b' } });
+    listeners.get('updateAvailable')?.({ bundle: { id: 'b', version: '1.2.3' } });
     listeners.get('downloadFailed')?.({ version: '1.2.3' });
     expect(onProgress).toHaveBeenCalledWith(37);
     expect(onComplete).toHaveBeenCalledTimes(1);
+    expect(onStaged).toHaveBeenCalledWith('b');
     expect(onFailed).toHaveBeenCalledTimes(1);
+  });
+
+  it('a staged event without a usable bundle id still reports staged (id null)', () => {
+    const { plugin, listeners } = fakeEventsPlugin();
+    const onStaged = vi.fn();
+    watchOtaUpdates(noopHandlers({ onStaged }), { native: true, scope: scopeWith(plugin) });
+    listeners.get('updateAvailable')?.({});
+    listeners.get('updateAvailable')?.({ bundle: { id: '' } });
+    listeners.get('updateAvailable')?.(undefined);
+    expect(onStaged.mock.calls.map((c) => c[0])).toEqual([null, null, null]);
   });
 
   it('clamps and defaults malformed percent payloads', () => {
@@ -170,11 +186,131 @@ describe('watchOtaUpdates', () => {
   });
 });
 
+/** A plugin exposing the bundle queries, with the running bundle and the next marker scripted. */
+function queryPlugin(opts: { current?: unknown; next?: unknown; extra?: Record<string, unknown> }) {
+  return {
+    current: vi.fn(async () => opts.current),
+    getNextBundle: vi.fn(async () => opts.next),
+    ...opts.extra,
+  };
+}
+
+const running = (id: string) => ({
+  bundle: { id, version: '0.41.0', status: 'success' },
+  native: '59',
+});
+
+describe('pendingOtaBundleId', () => {
+  it('names the next bundle when it differs from the running one', async () => {
+    const scope = scopeWith(
+      queryPlugin({ current: running('cur'), next: { id: 'nxt', status: 'pending' } }),
+    );
+    await expect(pendingOtaBundleId({ native: true, scope })).resolves.toBe('nxt');
+    // A marker with no status field is still a recorded bundle.
+    const bare = scopeWith(queryPlugin({ current: running('cur'), next: { id: 'nxt' } }));
+    await expect(pendingOtaBundleId({ native: true, scope: bare })).resolves.toBe('nxt');
+  });
+
+  it('is null when the marker names the running bundle (the stale marker set() leaves behind)', async () => {
+    const scope = scopeWith(
+      queryPlugin({ current: running('same'), next: { id: 'same', status: 'success' } }),
+    );
+    await expect(pendingOtaBundleId({ native: true, scope })).resolves.toBeNull();
+  });
+
+  it('is null for a marker in an unswitchable state', async () => {
+    for (const status of ['error', 'downloading', 'deleted', 'deleting']) {
+      const scope = scopeWith(
+        queryPlugin({ current: running('cur'), next: { id: 'nxt', status } }),
+      );
+      await expect(pendingOtaBundleId({ native: true, scope })).resolves.toBeNull();
+    }
+  });
+
+  it('is null when the plugin has no marker, however the bridge spells "none"', async () => {
+    for (const next of [undefined, null, {}, { id: '' }, 'builtin']) {
+      const scope = scopeWith(queryPlugin({ current: running('cur'), next }));
+      await expect(pendingOtaBundleId({ native: true, scope })).resolves.toBeNull();
+    }
+  });
+
+  it('is null when the running bundle cannot be read (never guess: a wrong apply reload-loops)', async () => {
+    const malformed = scopeWith(
+      queryPlugin({ current: {}, next: { id: 'nxt', status: 'pending' } }),
+    );
+    await expect(pendingOtaBundleId({ native: true, scope: malformed })).resolves.toBeNull();
+    const noCurrent = scopeWith({ getNextBundle: vi.fn(async () => ({ id: 'nxt' })) });
+    await expect(pendingOtaBundleId({ native: true, scope: noCurrent })).resolves.toBeNull();
+  });
+
+  it('is null off native, without the plugin, and on a bridge error', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const plugin = queryPlugin({ current: running('cur'), next: { id: 'nxt' } });
+    await expect(
+      pendingOtaBundleId({ native: false, scope: scopeWith(plugin) }),
+    ).resolves.toBeNull();
+    expect(plugin.getNextBundle).not.toHaveBeenCalled();
+    await expect(pendingOtaBundleId({ native: true, scope: {} })).resolves.toBeNull();
+    const throwing = scopeWith({
+      current: vi.fn(async () => running('cur')),
+      getNextBundle: vi.fn(async () => {
+        throw new Error('bridge error');
+      }),
+    });
+    await expect(pendingOtaBundleId({ native: true, scope: throwing })).resolves.toBeNull();
+    warn.mockRestore();
+  });
+});
+
 describe('applyPendingOtaUpdate', () => {
-  it('reports success when the plugin accepted the reload call', async () => {
+  it('switches to the named bundle through set(), never reload()', async () => {
+    const set = vi.fn(async () => ({}));
+    const reload = vi.fn(async () => ({}));
+    const plugin = queryPlugin({ current: running('old'), extra: { set, reload } });
+    await expect(
+      applyPendingOtaUpdate({ bundleId: 'new', native: true, scope: scopeWith(plugin) }),
+    ).resolves.toBe(true);
+    expect(set).toHaveBeenCalledWith({ id: 'new' });
+    expect(reload).not.toHaveBeenCalled();
+    // The named bundle wins over the plugin's own marker.
+    expect(plugin.getNextBundle).not.toHaveBeenCalled();
+  });
+
+  it('refuses to re-apply the bundle already running', async () => {
+    const set = vi.fn(async () => ({}));
+    const plugin = queryPlugin({ current: running('same'), extra: { set } });
+    await expect(
+      applyPendingOtaUpdate({ bundleId: 'same', native: true, scope: scopeWith(plugin) }),
+    ).resolves.toBe(false);
+    expect(set).not.toHaveBeenCalled();
+  });
+
+  it('asks the plugin for its next marker when the caller has no id', async () => {
+    const set = vi.fn(async () => ({}));
+    const plugin = queryPlugin({
+      current: running('cur'),
+      next: { id: 'nxt', status: 'pending' },
+      extra: { set },
+    });
+    await expect(applyPendingOtaUpdate({ native: true, scope: scopeWith(plugin) })).resolves.toBe(
+      true,
+    );
+    expect(set).toHaveBeenCalledWith({ id: 'nxt' });
+  });
+
+  it('switches nothing when there is no staged bundle to name', async () => {
+    const set = vi.fn(async () => ({}));
+    const plugin = queryPlugin({ current: running('cur'), next: {}, extra: { set } });
+    await expect(applyPendingOtaUpdate({ native: true, scope: scopeWith(plugin) })).resolves.toBe(
+      false,
+    );
+    expect(set).not.toHaveBeenCalled();
+  });
+
+  it('falls back to reload() only when the plugin has no set()', async () => {
     const reload = vi.fn(async () => ({}));
     await expect(
-      applyPendingOtaUpdate({ native: true, scope: scopeWith({ reload }) }),
+      applyPendingOtaUpdate({ bundleId: 'new', native: true, scope: scopeWith({ reload }) }),
     ).resolves.toBe(true);
     expect(reload).toHaveBeenCalledTimes(1);
   });
@@ -183,6 +319,16 @@ describe('applyPendingOtaUpdate', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     await expect(applyPendingOtaUpdate({ native: false })).resolves.toBe(false);
     await expect(applyPendingOtaUpdate({ native: true, scope: {} })).resolves.toBe(false);
+    const set = vi.fn(async () => {
+      throw new Error('bridge error');
+    });
+    await expect(
+      applyPendingOtaUpdate({
+        bundleId: 'new',
+        native: true,
+        scope: scopeWith(queryPlugin({ current: running('old'), extra: { set } })),
+      }),
+    ).resolves.toBe(false);
     const reload = vi.fn(async () => {
       throw new Error('bridge error');
     });

--- a/tests/ota_update_gate.test.ts
+++ b/tests/ota_update_gate.test.ts
@@ -3,6 +3,7 @@ import type { OtaUpdateHandlers } from '../src/net/native_ota';
 import {
   initialOtaGateState,
   installOtaUpdateGate,
+  OTA_STAGING_GRACE_MS,
   type OtaGateState,
   type OtaOverlayModel,
   type OtaUpdateGateDeps,
@@ -19,14 +20,30 @@ function stateWith(overrides: Partial<OtaGateState>): OtaGateState {
 }
 
 describe('reduceOtaGateEvent', () => {
-  it('tracks a download through progress to ready', () => {
+  it('tracks a download through progress to ready, and staged marks it switchable', () => {
     let s = initialOtaGateState();
     s = reduceOtaGateEvent(s, { type: 'progress', percent: 12 });
     expect(s).toMatchObject({ phase: 'downloading', percent: 12 });
     s = reduceOtaGateEvent(s, { type: 'progress', percent: 80 });
     expect(s.percent).toBe(80);
     s = reduceOtaGateEvent(s, { type: 'complete' });
-    expect(s).toMatchObject({ phase: 'ready', percent: 100 });
+    // The bytes are down but the plugin has not verified or recorded them.
+    expect(s).toMatchObject({ phase: 'ready', percent: 100, staged: false, stagedId: null });
+    s = reduceOtaGateEvent(s, { type: 'staged', bundleId: 'b2' });
+    expect(s).toMatchObject({ phase: 'ready', percent: 100, staged: true, stagedId: 'b2' });
+  });
+
+  it('staged can arrive without a prior complete (a bundle found by the probe)', () => {
+    const s = reduceOtaGateEvent(initialOtaGateState(), { type: 'staged', bundleId: 'b7' });
+    expect(s).toMatchObject({ phase: 'ready', percent: 100, staged: true, stagedId: 'b7' });
+  });
+
+  it('a staged event without an id keeps any id already known', () => {
+    const known = stateWith({ phase: 'ready', staged: true, stagedId: 'b2' });
+    expect(reduceOtaGateEvent(known, { type: 'staged', bundleId: null }).stagedId).toBe('b2');
+    expect(
+      reduceOtaGateEvent(initialOtaGateState(), { type: 'staged', bundleId: null }),
+    ).toMatchObject({ staged: true, stagedId: null });
   });
 
   it('never demotes a ready or applying bundle on a trailing progress tick', () => {
@@ -35,7 +52,15 @@ describe('reduceOtaGateEvent', () => {
     const applying = stateWith({ phase: 'applying', percent: 100 });
     expect(reduceOtaGateEvent(applying, { type: 'progress', percent: 99 })).toBe(applying);
     expect(reduceOtaGateEvent(applying, { type: 'complete' })).toBe(applying);
+    expect(reduceOtaGateEvent(applying, { type: 'staged', bundleId: 'x' })).toBe(applying);
     expect(reduceOtaGateEvent(applying, { type: 'failed' })).toBe(applying);
+  });
+
+  it('a staged bundle outlives a later failure report', () => {
+    const staged = stateWith({ phase: 'ready', staged: true, stagedId: 'b2' });
+    expect(reduceOtaGateEvent(staged, { type: 'failed' })).toBe(staged);
+    const unstaged = stateWith({ phase: 'ready' });
+    expect(reduceOtaGateEvent(unstaged, { type: 'failed' }).phase).toBe('failed');
   });
 });
 
@@ -59,29 +84,51 @@ describe('otaOverlayModel', () => {
     expect(otaOverlayModel(fatal, true)).toMatchObject({ fatal: true });
   });
 
-  it('a ready bundle renders as applying (auto-apply fires in the same turn)', () => {
+  it('a ready bundle renders as applying, staged or not (the plugin is verifying it)', () => {
     expect(otaOverlayModel(stateWith({ phase: 'ready' }), false)).toMatchObject({
+      phase: 'applying',
+    });
+    expect(otaOverlayModel(stateWith({ phase: 'ready', staged: true }), false)).toMatchObject({
       phase: 'applying',
     });
   });
 });
 
 describe('shouldAutoApplyOta', () => {
-  it('applies a ready bundle pre-world, and always in fatal mode', () => {
-    expect(shouldAutoApplyOta(stateWith({ phase: 'ready' }), false)).toBe(true);
-    expect(shouldAutoApplyOta(stateWith({ phase: 'ready' }), true)).toBe(false);
-    expect(shouldAutoApplyOta(stateWith({ phase: 'ready', fatal: true }), true)).toBe(true);
+  it('applies only a STAGED ready bundle: pre-world, and always in fatal mode', () => {
+    const staged = stateWith({ phase: 'ready', staged: true });
+    expect(shouldAutoApplyOta(staged, false)).toBe(true);
+    expect(shouldAutoApplyOta(staged, true)).toBe(false);
+    expect(shouldAutoApplyOta({ ...staged, fatal: true }, true)).toBe(true);
     expect(shouldAutoApplyOta(stateWith({ phase: 'downloading' }), false)).toBe(false);
   });
+
+  it('never applies on downloadComplete alone: there is nothing to switch to yet', () => {
+    const unstaged = stateWith({ phase: 'ready' });
+    expect(shouldAutoApplyOta(unstaged, false)).toBe(false);
+    expect(shouldAutoApplyOta({ ...unstaged, fatal: true }, false)).toBe(false);
+  });
 });
+
+interface Timer {
+  fn: () => void;
+  ms: number;
+  cancelled: boolean;
+}
+
+type ApplyFn = NonNullable<OtaUpdateGateDeps['apply']>;
+type PendingFn = NonNullable<OtaUpdateGateDeps['pending']>;
 
 interface Rig {
   handlers: OtaUpdateHandlers;
   render: ReturnType<typeof vi.fn>;
   hide: ReturnType<typeof vi.fn>;
-  apply: ReturnType<typeof vi.fn>;
+  apply: ApplyFn;
+  pending: PendingFn;
   onFatalRecoveryFailed: ReturnType<typeof vi.fn>;
   gate: ReturnType<typeof installOtaUpdateGate>;
+  timers: Timer[];
+  fireTimers(): void;
   setInWorld(value: boolean): void;
 }
 
@@ -90,8 +137,12 @@ function makeRig(overrides: Partial<OtaUpdateGateDeps> = {}): Rig {
   let inWorld = false;
   const render = vi.fn();
   const hide = vi.fn();
-  const apply = vi.fn(async () => true);
+  // Overrides win, and the rig hands back the EFFECTIVE mocks so a test that
+  // scripts its own apply/pending can still assert on them.
+  const apply: ApplyFn = overrides.apply ?? vi.fn(async () => true);
+  const pending: PendingFn = overrides.pending ?? vi.fn(async () => null);
   const onFatalRecoveryFailed = vi.fn();
+  const timers: Timer[] = [];
   const gate = installOtaUpdateGate({
     native: true,
     watch: (h) => {
@@ -99,6 +150,14 @@ function makeRig(overrides: Partial<OtaUpdateGateDeps> = {}): Rig {
       return () => {};
     },
     apply,
+    pending,
+    schedule: (fn, ms) => {
+      const timer: Timer = { fn, ms, cancelled: false };
+      timers.push(timer);
+      return () => {
+        timer.cancelled = true;
+      };
+    },
     overlay: { render, hide },
     isInWorld: () => inWorld,
     onFatalRecoveryFailed,
@@ -110,8 +169,13 @@ function makeRig(overrides: Partial<OtaUpdateGateDeps> = {}): Rig {
     render,
     hide,
     apply,
+    pending,
     onFatalRecoveryFailed,
     gate,
+    timers,
+    fireTimers: () => {
+      for (const timer of timers.splice(0)) if (!timer.cancelled) timer.fn();
+    },
     setInWorld: (value) => {
       inWorld = value;
     },
@@ -121,13 +185,16 @@ function makeRig(overrides: Partial<OtaUpdateGateDeps> = {}): Rig {
 describe('installOtaUpdateGate', () => {
   it('is inert off the native shells', () => {
     const watch = vi.fn();
+    const pending = vi.fn();
     const gate = installOtaUpdateGate({
       native: false,
       watch,
+      pending,
       overlay: { render: vi.fn(), hide: vi.fn() },
       isInWorld: () => false,
     });
     expect(watch).not.toHaveBeenCalled();
+    expect(pending).not.toHaveBeenCalled();
     expect(gate.handleIncompatibleDisconnect(ONLINE_WORLD_INCOMPATIBLE_MESSAGE)).toBe(false);
   });
 
@@ -148,13 +215,17 @@ describe('installOtaUpdateGate', () => {
     rig.setInWorld(true);
     rig.handlers.onProgress(50);
     rig.handlers.onComplete();
+    rig.handlers.onStaged('b2');
     await flushMicrotasks();
     expect(rig.render).not.toHaveBeenCalled();
     expect(rig.hide).toHaveBeenCalled();
     expect(rig.apply).not.toHaveBeenCalled();
   });
 
-  it('applies a completed pre-world download immediately, painting the applying state', async () => {
+  it('holds the applying screen on downloadComplete and applies only once the bundle is staged', async () => {
+    // The regression this pins: applying on downloadComplete switched to
+    // nothing (the plugin had not recorded the bundle yet) and rebooted the
+    // same stale client, which then met the incompatible-version rejection.
     const rig = makeRig();
     rig.handlers.onProgress(90);
     rig.handlers.onComplete();
@@ -164,18 +235,49 @@ describe('installOtaUpdateGate', () => {
       fatal: false,
     });
     await flushMicrotasks();
+    expect(rig.apply).not.toHaveBeenCalled();
+    rig.handlers.onStaged('b2');
+    await flushMicrotasks();
     expect(rig.apply).toHaveBeenCalledTimes(1);
+    expect(rig.apply).toHaveBeenCalledWith({ bundleId: 'b2' });
   });
 
-  it('falls back silently to apply-on-background when the reload path is unavailable', async () => {
+  it('applies a staged bundle with no id by letting the apply ask the plugin', async () => {
+    const rig = makeRig();
+    rig.handlers.onStaged(null);
+    await flushMicrotasks();
+    expect(rig.apply).toHaveBeenCalledWith({ bundleId: null });
+  });
+
+  it('applies a bundle the plugin staged before this context existed (boot probe)', async () => {
+    const rig = makeRig({ pending: vi.fn(async () => 'b7') });
+    await flushMicrotasks();
+    expect(rig.apply).toHaveBeenCalledTimes(1);
+    expect(rig.apply).toHaveBeenCalledWith({ bundleId: 'b7' });
+    expect(rig.render).toHaveBeenLastCalledWith({
+      phase: 'applying',
+      percent: 100,
+      fatal: false,
+    });
+  });
+
+  it('the boot probe defers to backgrounding when the player is already in-world', async () => {
+    const rig = makeRig({ pending: vi.fn(async () => 'b7') });
+    rig.setInWorld(true);
+    await flushMicrotasks();
+    expect(rig.apply).not.toHaveBeenCalled();
+    expect(rig.gate.state()).toMatchObject({ phase: 'ready', staged: true, stagedId: 'b7' });
+  });
+
+  it('falls back silently to apply-on-background when nothing could be switched', async () => {
     const rig = makeRig({ apply: vi.fn(async () => false) });
-    rig.handlers.onComplete();
+    rig.handlers.onStaged('b2');
     await flushMicrotasks();
     expect(rig.hide).toHaveBeenCalled();
     expect(rig.onFatalRecoveryFailed).not.toHaveBeenCalled();
   });
 
-  it('claims the incompatible-version disconnect only while an update is in flight', () => {
+  it('claims the incompatible-version disconnect while an update is in flight', () => {
     const idle = makeRig();
     expect(idle.gate.handleIncompatibleDisconnect(ONLINE_WORLD_INCOMPATIBLE_MESSAGE)).toBe(false);
     expect(idle.gate.handleIncompatibleDisconnect('rejected by server')).toBe(false);
@@ -197,18 +299,58 @@ describe('installOtaUpdateGate', () => {
     rig.handlers.onProgress(60);
     expect(rig.gate.handleIncompatibleDisconnect('message rate exceeded')).toBe(false);
     expect(rig.gate.handleIncompatibleDisconnect(undefined)).toBe(false);
+    expect(rig.pending).toHaveBeenCalledTimes(1); // the boot probe only; no re-probe
   });
 
   it('a staged bundle applies immediately when the incompatible rejection lands', async () => {
     const rig = makeRig();
-    rig.setInWorld(true); // completed mid-session: apply deferred to backgrounding
+    rig.setInWorld(true); // staged mid-session: apply deferred to backgrounding
     rig.handlers.onComplete();
+    rig.handlers.onStaged('b2');
     await flushMicrotasks();
     expect(rig.apply).not.toHaveBeenCalled();
     rig.setInWorld(false); // the rejection ends the session
     expect(rig.gate.handleIncompatibleDisconnect(ONLINE_WORLD_INCOMPATIBLE_MESSAGE)).toBe(true);
     await flushMicrotasks();
     expect(rig.apply).toHaveBeenCalledTimes(1);
+    expect(rig.apply).toHaveBeenCalledWith({ bundleId: 'b2' });
+  });
+
+  it('with nothing in flight, the rejection re-probes the plugin and applies what it finds, fatal', async () => {
+    // The download finished before this context booted AND the boot probe
+    // missed it (raced the plugin's own bookkeeping): the player taps Play,
+    // the server rejects the stale bundle, and the plugin is asked again.
+    let probes = 0;
+    const rig = makeRig({
+      pending: vi.fn(async () => (++probes === 1 ? null : 'b9')),
+    });
+    await flushMicrotasks();
+    expect(rig.apply).not.toHaveBeenCalled();
+    rig.setInWorld(true); // whatever body still says after the session died
+    expect(rig.gate.handleIncompatibleDisconnect(ONLINE_WORLD_INCOMPATIBLE_MESSAGE)).toBe(false);
+    await flushMicrotasks();
+    expect(rig.pending).toHaveBeenCalledTimes(2);
+    expect(rig.apply).toHaveBeenCalledTimes(1);
+    expect(rig.apply).toHaveBeenCalledWith({ bundleId: 'b9' });
+    expect(rig.render).toHaveBeenLastCalledWith({ phase: 'applying', percent: 100, fatal: true });
+  });
+
+  it('a miss on that re-probe leaves the caller overlay alone but keeps fatal for a later download', async () => {
+    const rig = makeRig();
+    await flushMicrotasks();
+    expect(rig.gate.handleIncompatibleDisconnect(ONLINE_WORLD_INCOMPATIBLE_MESSAGE)).toBe(false);
+    await flushMicrotasks();
+    expect(rig.apply).not.toHaveBeenCalled();
+    expect(rig.render).not.toHaveBeenCalled();
+    expect(rig.onFatalRecoveryFailed).not.toHaveBeenCalled();
+    // The plugin re-checks on the next foreground; that download now paints
+    // and applies over the dead end without another rejection round trip.
+    rig.setInWorld(true);
+    rig.handlers.onProgress(40);
+    expect(rig.render).toHaveBeenLastCalledWith({ phase: 'downloading', percent: 40, fatal: true });
+    rig.handlers.onStaged('b3');
+    await flushMicrotasks();
+    expect(rig.apply).toHaveBeenCalledWith({ bundleId: 'b3' });
   });
 
   it('fatal-mode dead ends hand the screen back through onFatalRecoveryFailed', async () => {
@@ -216,6 +358,7 @@ describe('installOtaUpdateGate', () => {
     applyFails.handlers.onProgress(80);
     applyFails.gate.handleIncompatibleDisconnect(ONLINE_WORLD_INCOMPATIBLE_MESSAGE);
     applyFails.handlers.onComplete();
+    applyFails.handlers.onStaged('b2');
     await flushMicrotasks();
     expect(applyFails.onFatalRecoveryFailed).toHaveBeenCalledTimes(1);
     // Handing the screen back means actually hiding this overlay: the caller's
@@ -229,5 +372,57 @@ describe('installOtaUpdateGate', () => {
     downloadFails.handlers.onFailed();
     expect(downloadFails.hide).toHaveBeenCalled();
     expect(downloadFails.onFatalRecoveryFailed).toHaveBeenCalledTimes(1);
+  });
+
+  it('a completed download the plugin never stages is released after the grace window', async () => {
+    const rig = makeRig();
+    rig.handlers.onComplete();
+    expect(rig.timers.map((t) => t.ms)).toEqual([OTA_STAGING_GRACE_MS]);
+    rig.fireTimers();
+    await flushMicrotasks();
+    // One last look at the plugin's record, then step aside (the plugin's own
+    // apply-on-background is still armed); no dead-end "applying" forever.
+    expect(rig.pending).toHaveBeenCalledTimes(2);
+    expect(rig.apply).not.toHaveBeenCalled();
+    expect(rig.hide).toHaveBeenCalled();
+    expect(rig.gate.state().phase).toBe('failed');
+  });
+
+  it('the grace-window probe applies a bundle the plugin staged without telling us', async () => {
+    let probes = 0;
+    const rig = makeRig({ pending: vi.fn(async () => (++probes === 1 ? null : 'b4')) });
+    rig.handlers.onComplete();
+    rig.fireTimers();
+    await flushMicrotasks();
+    expect(rig.apply).toHaveBeenCalledWith({ bundleId: 'b4' });
+  });
+
+  it('the grace window is disarmed once the bundle is staged or the download fails', async () => {
+    const staged = makeRig();
+    staged.handlers.onComplete();
+    staged.handlers.onStaged('b2');
+    await flushMicrotasks();
+    staged.fireTimers();
+    await flushMicrotasks();
+    expect(staged.apply).toHaveBeenCalledTimes(1);
+    expect(staged.pending).toHaveBeenCalledTimes(1); // boot probe only
+
+    const failed = makeRig();
+    failed.handlers.onComplete();
+    failed.handlers.onFailed();
+    failed.fireTimers();
+    await flushMicrotasks();
+    expect(failed.pending).toHaveBeenCalledTimes(1);
+  });
+
+  it('in fatal mode, a grace-window miss hands the screen back exactly once', async () => {
+    const rig = makeRig();
+    rig.handlers.onProgress(80);
+    rig.gate.handleIncompatibleDisconnect(ONLINE_WORLD_INCOMPATIBLE_MESSAGE);
+    rig.handlers.onComplete();
+    rig.fireTimers();
+    await flushMicrotasks();
+    expect(rig.onFatalRecoveryFailed).toHaveBeenCalledTimes(1);
+    expect(rig.hide).toHaveBeenCalled();
   });
 });

--- a/tests/ota_update_gate.test.ts
+++ b/tests/ota_update_gate.test.ts
@@ -277,9 +277,9 @@ describe('installOtaUpdateGate', () => {
     expect(rig.onFatalRecoveryFailed).not.toHaveBeenCalled();
   });
 
-  it('claims the incompatible-version disconnect while an update is in flight', () => {
+  it('claims the incompatible-version disconnect, in flight or not, and never another reason', () => {
     const idle = makeRig();
-    expect(idle.gate.handleIncompatibleDisconnect(ONLINE_WORLD_INCOMPATIBLE_MESSAGE)).toBe(false);
+    expect(idle.gate.handleIncompatibleDisconnect(ONLINE_WORLD_INCOMPATIBLE_MESSAGE)).toBe(true);
     expect(idle.gate.handleIncompatibleDisconnect('rejected by server')).toBe(false);
 
     const downloading = makeRig();
@@ -327,22 +327,29 @@ describe('installOtaUpdateGate', () => {
     await flushMicrotasks();
     expect(rig.apply).not.toHaveBeenCalled();
     rig.setInWorld(true); // whatever body still says after the session died
-    expect(rig.gate.handleIncompatibleDisconnect(ONLINE_WORLD_INCOMPATIBLE_MESSAGE)).toBe(false);
+    expect(rig.gate.handleIncompatibleDisconnect(ONLINE_WORLD_INCOMPATIBLE_MESSAGE)).toBe(true);
     await flushMicrotasks();
     expect(rig.pending).toHaveBeenCalledTimes(2);
     expect(rig.apply).toHaveBeenCalledTimes(1);
     expect(rig.apply).toHaveBeenCalledWith({ bundleId: 'b9' });
     expect(rig.render).toHaveBeenLastCalledWith({ phase: 'applying', percent: 100, fatal: true });
+    // The caller's dead-end overlay never painted, so the resume marker it
+    // clears survives and the reload lands back in the world on the new bundle.
+    expect(rig.onFatalRecoveryFailed).not.toHaveBeenCalled();
   });
 
-  it('a miss on that re-probe leaves the caller overlay alone but keeps fatal for a later download', async () => {
+  it('a miss on that re-probe hands the screen back exactly once and keeps fatal for a later download', async () => {
     const rig = makeRig();
     await flushMicrotasks();
-    expect(rig.gate.handleIncompatibleDisconnect(ONLINE_WORLD_INCOMPATIBLE_MESSAGE)).toBe(false);
+    expect(rig.gate.handleIncompatibleDisconnect(ONLINE_WORLD_INCOMPATIBLE_MESSAGE)).toBe(true);
+    // Claimed but nothing painted yet: the hand-back waits for the plugin's
+    // answer because the caller's overlay is what clears the resume marker.
+    expect(rig.render).not.toHaveBeenCalled();
+    expect(rig.onFatalRecoveryFailed).not.toHaveBeenCalled();
     await flushMicrotasks();
     expect(rig.apply).not.toHaveBeenCalled();
     expect(rig.render).not.toHaveBeenCalled();
-    expect(rig.onFatalRecoveryFailed).not.toHaveBeenCalled();
+    expect(rig.onFatalRecoveryFailed).toHaveBeenCalledTimes(1);
     // The plugin re-checks on the next foreground; that download now paints
     // and applies over the dead end without another rejection round trip.
     rig.setInWorld(true);
@@ -351,6 +358,30 @@ describe('installOtaUpdateGate', () => {
     rig.handlers.onStaged('b3');
     await flushMicrotasks();
     expect(rig.apply).toHaveBeenCalledWith({ bundleId: 'b3' });
+  });
+
+  it('a download that starts while the re-probe runs keeps the screen instead of handing back', async () => {
+    const probe: { answer: ((id: string | null) => void) | null } = { answer: null };
+    let probes = 0;
+    const rig = makeRig({
+      pending: vi.fn(
+        () =>
+          new Promise<string | null>((resolve) => {
+            if (++probes === 1)
+              resolve(null); // the boot probe
+            else probe.answer = resolve;
+          }),
+      ),
+    });
+    await flushMicrotasks();
+    expect(rig.gate.handleIncompatibleDisconnect(ONLINE_WORLD_INCOMPATIBLE_MESSAGE)).toBe(true);
+    rig.handlers.onProgress(20); // the plugin's foreground re-check started a download
+    probe.answer?.(null);
+    await flushMicrotasks();
+    expect(rig.onFatalRecoveryFailed).not.toHaveBeenCalled();
+    expect(rig.render).toHaveBeenLastCalledWith({ phase: 'downloading', percent: 20, fatal: true });
+    rig.handlers.onFailed(); // that download's own failure is what hands back
+    expect(rig.onFatalRecoveryFailed).toHaveBeenCalledTimes(1);
   });
 
   it('fatal-mode dead ends hand the screen back through onFatalRecoveryFailed', async () => {


### PR DESCRIPTION
## Summary

Players on iOS (and Android) who receive an auto-downloaded OTA bundle still hit
"Game and server versions are incompatible" when they tap Play, and only a full
force-quit fixes it. The update was downloaded, but it was never applied.

**Root cause.** The visible OTA gate (`src/net/ota_update_gate.ts`) applied a
finished download by calling the plugin's `reload()` on the `downloadComplete`
event. In `@capgo/capacitor-updater` 8.51.2 that event is emitted from inside the
download routine, before the bundle is verified and before the plugin records it
as the next bundle; even `updateAvailable` fires one statement before
`setNextBundle` (same order on iOS and Android). `reload()` only applies a bundle
the plugin has already recorded as next, so it found nothing and reloaded the
bundle already running. The player booted into the same stale client, the server
rejected its world-layout epoch, and the gate (now in a fresh JS context with no
download events) could not claim the rejection, so the dead-end overlay showed.
A force-quit worked because the plugin applies the next bundle on backgrounding.

**Fix** (client only, no plugin or server change):

- The apply now keys on the plugin's `updateAvailable` (staged) signal, not
  `downloadComplete`, and switches to the bundle **by id** through the plugin's
  `set({ id })` instead of trusting the next marker to be in place. `reload()`
  remains only as the fallback for a plugin without `set()`.
- A download can finish before the JS context exists (cold start, or the context
  an earlier apply reloaded) and no event replays, so the gate asks the plugin
  for an already-staged bundle at install (`getNextBundle()` + `current()`) and
  applies it pre-world. It asks again when the incompatible rejection lands with
  nothing in flight: the gate claims the screen first, applies a bundle that turns
  up in fatal mode (the resume marker survives, so the reload lands back in the
  world on the new bundle), and hands the dead-end overlay back only on a miss.
- `downloadComplete` alone only holds the "applying" screen; a completed download
  the plugin never stages is released after a bounded grace window (30 s) so the
  gate can never dead-end on its own overlay.
- Reload-loop guards: the probe returns nothing unless it can prove the next
  bundle differs from the running one, and the apply refuses to switch to the
  bundle already running (`set()` leaves the next marker pointing at what is now
  current, which the plugin itself tolerates by the same id comparison).

Docs: `docs/ota-updates.md` steps 4 and 5 describe the event order and the new
apply contract; `docs/release-notes/unreleased.md` carries the player-facing line.

## Related issues

Ships on release/v0.41.2 (the hotfix line; originally opened against release/v0.42.0, tracked by #3780). Hardens the OTA rollout on the native shells.

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [x] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx vitest run tests/ota_update_gate.test.ts tests/native_ota.test.ts` (59 tests green)
  - `npx tsc --noEmit` (clean)
  - `npx @biomejs/biome check --write` on the changed files
  - `node scripts/gate_select.mjs`: 1,046 of 1,073 suites green (20,464 tests). The three
    red suites are environmental and import nothing from this change:
    `tests/desktop_publish_guard.test.ts` and `tests/ci_leg_runner.test.ts` fail identically
    on an untouched `main` checkout on macOS (CI on Ubuntu is the authoritative run), and
    `tests/voice_manifest.test.ts` hit its 20 s timeout hashing every clip under the 7-worker
    floor run; it passes alone in about a second.
- Manual steps:
  - Plugin behavior verified against the installed `@capgo/capacitor-updater` 8.51.2
    sources for both platforms: `reload()` applies only a recorded next bundle;
    `downloadComplete` is emitted inside `notifyDownload(percent: 100)`;
    `updateAvailable` precedes `setNextBundle` in the `atBackground` branch of
    `backgroundDownload`; `set(id)` switches the current bundle and reloads.
  - New unit coverage pins the regression (no apply on `downloadComplete` alone;
    apply on staged with the bundle id), the boot and rejection-time probes, the
    grace window, and the never-guess rules of the probe.
  - Not yet exercised on a device against a published bundle; the runbook's
    "Verifying an update end to end" step 3 (launch, background, foreground, then
    tap Play on the stale bundle) is the on-device check for this change.

## Screenshots / recordings

N/A: no new UI; the existing OTA overlay is reused.

---

## Checklist

### Quality

- [x] **The gate passes** apart from the three environment-only suites detailed above;
      CI is the authoritative run. I added or updated decisive tests for changed behavior
      and recorded any manual checks above.

### Cross-platform

- [ ] ~Tested on desktop and mobile.~ Native shells only; the gate is inert on web and desktop.
- [ ] ~Accessible.~ No UI added or edited.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

