### PR TITLE
fix(moderation): let staff spectate other staff with /spectate

### DIFF
--- a/server/moderation_service.ts
+++ b/server/moderation_service.ts
@@ -272,7 +272,12 @@ export class ModerationService<TSession extends ModerationSession> {
       this.host.notice(actor, `No online player named '${name}'.`);
       return;
     }
-    if (target.pid === actor.pid || target.isAdmin) {
+    // Spectating is read-only observation, never a sanction, so staff may
+    // watch other staff (the sanction commands keep their staff guard in
+    // resolveNamedTarget). Watching your own account stays refused, and the
+    // account check (not the session) also covers a second character of the
+    // actor's account that is online at the same time.
+    if (target.accountId === actor.accountId) {
       this.host.notice(actor, "You can't moderate that player.");
       return;
     }

--- a/tests/moderation_game.test.ts
+++ b/tests/moderation_game.test.ts
@@ -856,6 +856,54 @@ describe('moderator spectate integration', () => {
     if (!restoredSnap?.self) throw new Error('restored snapshot missing');
     expect(restoredSnap.self.tal?.alloc).toEqual(moderatorMeta.talents);
   });
+
+  it('spectates another staff member like any player and restores the moderator', async () => {
+    const server = new GameServer();
+    const moderatorWs = fakeWs();
+    const moderator = joined(
+      server.join(moderatorWs, 1, 101, 'Watcher', 'mage', null, false, {
+        isAdmin: true,
+        adminPermissions: MOD_PERMS,
+      }),
+    );
+    const colleagueWs = fakeWs();
+    const colleague = joined(
+      server.join(colleagueWs, 2, 102, 'Colleague', 'priest', null, false, {
+        isAdmin: true,
+        adminPermissions: MOD_PERMS,
+      }),
+    );
+    const moderatorEntity = entity(server, moderator.pid);
+    const originalPos = { ...moderatorEntity.pos };
+    const colleaguePos = { ...entity(server, colleague.pid).pos };
+
+    command(server, moderator, '/spectate Colleague');
+    await vi.waitFor(() => expect(moderator.spectating).not.toBeNull());
+
+    expect(moderation.recordInGameAction).toHaveBeenCalledWith({
+      action: 'spectate',
+      accountId: 2,
+      adminAccountId: 1,
+      reason: 'Spectated via in-game moderator command',
+    });
+    expect(moderator.spectating?.characterId).toBe(colleague.characterId);
+    expect(frames(moderatorWs)).toContainEqual({ t: 'spectate', name: 'Colleague' });
+    // The watched staff member is not moved, flagged, or notified.
+    expect(entity(server, colleague.pid).pos).toEqual(colleaguePos);
+    expect(colleague.spectating).toBeNull();
+    expect(frames(colleagueWs).some((frame) => frame.t === 'spectate')).toBe(false);
+
+    moderatorWs.send.mockClear();
+    internals(server).broadcastSnapshots();
+    const snapshot = frames(moderatorWs).find((frame) => frame.t === 'snap');
+    if (!snapshot?.self) throw new Error('spectator snapshot missing');
+    expect(snapshot.self.id).toBe(colleague.pid);
+    expect(snapshot.self.nm).toBe('Colleague');
+
+    command(server, moderator, '/unspectate');
+    await vi.waitFor(() => expect(moderator.spectating).toBeNull());
+    expect(moderatorEntity.pos).toEqual(originalPos);
+  });
 });
 
 describe('server-side teleports end a live profession session', () => {

--- a/tests/moderation_service.test.ts
+++ b/tests/moderation_service.test.ts
@@ -519,15 +519,16 @@ describe('ModerationService', () => {
     expect(context.recordAction).not.toHaveBeenCalled();
   });
 
-  it('guards malformed, missing, self, admin, and offline targets', () => {
+  it('guards malformed, missing, self, own-account, and offline targets', () => {
     const actor = admin(1, 11);
-    const otherAdmin = admin(2, 22);
-    const context = setup({ actor, sessions: [otherAdmin] });
+    // A second character of the actor's own account, online at the same time.
+    const ownAlt = { ...admin(2, 11), name: 'OwnAlt' };
+    const context = setup({ actor, sessions: [ownAlt] });
 
     context.service.handleChatCommand(actor, '/spectate');
     context.service.handleChatCommand(actor, '/spectate Missing');
     context.service.handleChatCommand(actor, `/spectate ${actor.name}`);
-    context.service.handleChatCommand(actor, `/spectate ${otherAdmin.name}`);
+    context.service.handleChatCommand(actor, `/spectate ${ownAlt.name}`);
     context.service.handleChatCommand(actor, '/kick test');
     context.service.handleChatCommand(actor, '/kill "Missing" test');
 
@@ -539,7 +540,51 @@ describe('ModerationService', () => {
       'Enclose the character name in double quotes.',
       "No online player named 'Missing'.",
     ]);
+    expect(context.recordAction).not.toHaveBeenCalled();
     expect(context.spectated).toEqual([]);
     expect(context.kicked).toEqual([]);
+  });
+
+  it('lets staff spectate other staff while the sanction commands still refuse them', async () => {
+    const actor = admin(1, 11);
+    const otherAdmin = admin(2, 22);
+    const context = setup({ actor, sessions: [otherAdmin] });
+
+    expect(context.service.handleChatCommand(actor, `/spectate ${otherAdmin.name}`)).toBe(true);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(context.recordAction).toHaveBeenCalledTimes(1);
+    expect(context.recordAction).toHaveBeenCalledWith({
+      action: 'spectate',
+      accountId: 22,
+      adminAccountId: 11,
+      reason: 'Spectated via in-game moderator command',
+    });
+    expect(context.spectated).toEqual([{ moderator: actor, target: otherAdmin }]);
+    expect(context.notices).toEqual([]);
+
+    context.service.handleChatCommand(actor, `/kick "${otherAdmin.name}" test`);
+    context.service.handleChatCommand(actor, `/kill "${otherAdmin.name}" test`);
+    context.service.handleChatCommand(actor, `/mute "${otherAdmin.name}" 5 test`);
+    context.service.handleChatCommand(actor, `/ban "${otherAdmin.name}" test`);
+    context.service.handleChatCommand(actor, `/suspend "${otherAdmin.name}" 5 test`);
+    context.service.handleChatCommand(actor, `/forcerename "${otherAdmin.name}" test`);
+    context.service.handleChatCommand(actor, `/jail "${otherAdmin.name}" 5 test`);
+    context.service.handleChatCommand(actor, `/unjail "${otherAdmin.name}"`);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(context.notices.map((notice) => notice.text)).toEqual(
+      Array(8).fill("You can't moderate that player."),
+    );
+    expect(context.recordAction).toHaveBeenCalledTimes(1);
+    expect(context.mute).not.toHaveBeenCalled();
+    expect(context.ban).not.toHaveBeenCalled();
+    expect(context.suspend).not.toHaveBeenCalled();
+    expect(context.forceRename).not.toHaveBeenCalled();
+    expect(context.kicked).toEqual([]);
+    expect(context.killed).toEqual([]);
+    expect(context.jailed).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

`/spectate` reused the target guard of the sanction commands ("not yourself, not staff"), so a moderator could never watch another moderator: the command answered "You can't moderate that player." exactly as it does for `/kick` or `/ban` on a staff target.

Spectating is read-only observation, not a sanction, and it is already audited like every other moderation command (the audit row is written before the live effect applies). The staff half of that guard therefore only got in the way: two moderators looking at the same report together, or a lead reviewing how a junior moderator handles a session, had no way to do it in-game.

This PR drops the staff check for the `/spectate` branch only:

- `/spectate <staff name>` now works for any session holding `moderation.spectate`, with the same audit row (`spectate`, target account, acting account) as for a regular player.
- Spectating your own account is still refused. The self check now compares accounts rather than sessions: the server allows several characters of one account online at once, and the staff check used to cover that "own alt" case implicitly.
- `/kick`, `/kill`, `/mute`, `/ban`, `/suspend`, `/forcerename`, `/jail`, and `/unjail` keep the shared `resolveNamedTarget` guard unchanged: staff still cannot sanction staff from chat.

Two consequences worth stating explicitly, both accepted as the intended behavior:

- `moderation.spectate` is a flat permission, so there is no seniority rule: any staff session holding it can watch any other staff member, including an administrator. The audit row (acting account plus watched account) is the control, as it already is for regular players.
- Spectating a staff member who is themselves spectating (or on a jail visit) anchors on that staff member's own entity, exactly one level deep, the same as today for any target. The spectator does not see the nested target's data. That view is not useful, but it is also not new logic and needs no special case.

No new player-visible string, no wire change, no schema change.

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx vitest run tests/moderation_service.test.ts` (the new "lets staff spectate other staff while the sanction commands still refuse them" test fails on the previous guard and passes with this change; the existing guard test now covers malformed, missing, self, own-account, and offline targets)
  - `npx vitest run tests/moderation_game.test.ts` (new real-server case: a moderator spectates a staff colleague, the audit row names the colleague's account, the snapshot anchors on the colleague, the colleague is neither moved nor notified, and `/unspectate` restores the moderator; also fails on the previous guard)
  - `npx tsc --noEmit`
  - `npx @biomejs/biome check` on the two changed files
  - `node scripts/gate_select.mjs`: PASS, all 12 steps green
- Manual steps: none (server-only logic covered by the service unit tests).

## Checklist

### Quality

- [x] **The gate passes.** `node scripts/gate_select.mjs` is green (or `npm run gate` for
      the full suite). I added or updated decisive
      tests for changed behavior and recorded any manual checks above.

### Cross-platform

- ~Tested on desktop and mobile.~ N/A, no UI change.
- ~Accessible.~ N/A, no UI change.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.

