### PR TITLE
perf(render): merge a prop bucket's shadow casters with its non-casters

### DIFF
--- a/src/render/props.ts
+++ b/src/render/props.ts
@@ -67,6 +67,7 @@ import {
   updatePropCullables,
 } from './prop_cull_core';
 import type { RevealGateCore } from './reveal_gate_core';
+import { mergeBandDepth, mergeStaticMeshes, normalizedStaticGeometry } from './static_merge';
 import { applySurfaceDetail, type WornFamilyPick, wornFamilyFor } from './worn_stone';
 
 // Static world props: buildings, tents, campfires, mines, ruins, docks,
@@ -132,8 +133,6 @@ export interface PropsResult {
    *  cullable key. */
   revealRoots(key: string): readonly THREE.Object3D[];
 }
-
-const mergeBandDepth = (): number => (GFX.standardMaterials ? 180 : 90);
 
 // ---------------------------------------------------------------------------
 // Asset registry — loads kick off at module import; main.ts awaits
@@ -2941,65 +2940,6 @@ function buildFarPropCells(group: THREE.Group, hideables: Hideable[]): FarPropCe
     out.push(cell);
   }
   return out;
-}
-
-// Bake every static prop mesh into world space and merge per
-// (material, castShadow, z-band). Flames (animated) and InstancedMeshes
-// survive untouched, as do the PointLights (not meshes). The merged meshes
-// replace the originals on the same group; emptied sub-groups are left in
-// place (they carry lights). Non-indexed procedural shapes receive exact tuple
-// indices so they can share indexed glTF buckets without expanding either.
-function mergeStaticMeshes(group: THREE.Group, keep: Set<THREE.Object3D>): THREE.Mesh[] {
-  group.updateMatrixWorld(true);
-  interface Bucket {
-    material: THREE.Material;
-    castShadow: boolean;
-    geoms: THREE.BufferGeometry[];
-  }
-  const buckets = new Map<string, Bucket>();
-  const merged: THREE.Mesh[] = [];
-  group.traverse((o) => {
-    const mesh = o as THREE.Mesh;
-    if (!mesh.isMesh || keep.has(mesh) || (mesh as THREE.InstancedMesh).isInstancedMesh) return;
-    const material = mesh.material as THREE.Material;
-    const worldX = mesh.matrixWorld.elements[12];
-    const worldZ = mesh.matrixWorld.elements[14];
-    const band = Math.floor((worldZ - WORLD_MIN_Z) / mergeBandDepth());
-    // x-halved like the instance batches above: world-wide merged bands
-    // defeat shadow-frustum culling (their bounds always intersect it).
-    const key = `${material.uuid}:${mesh.castShadow ? 1 : 0}:${worldX < 0 ? 'w' : 'e'}:${band}`;
-    let bucket = buckets.get(key);
-    if (!bucket) {
-      bucket = { material, castShadow: mesh.castShadow, geoms: [] };
-      buckets.set(key, bucket);
-    }
-    // Extracted geometries are shared across placements, so the bake must
-    // never mutate them in place. Preserve source index reuse and normalize
-    // procedural streams with byte-exact full-tuple indices.
-    const geo = normalizedStaticGeometry(mesh.geometry);
-    bucket.geoms.push(geo.applyMatrix4(mesh.matrixWorld));
-    merged.push(mesh);
-  });
-  for (const mesh of merged) mesh.removeFromParent();
-  const out: THREE.Mesh[] = [];
-  for (const bucket of buckets.values()) {
-    const geo = mergeGeometries(bucket.geoms, false);
-    if (!geo) continue;
-    geo.computeBoundingBox();
-    geo.computeBoundingSphere();
-    const mesh = new THREE.Mesh(geo, bucket.material);
-    mesh.castShadow = bucket.castShadow;
-    mesh.receiveShadow = true;
-    group.add(mesh);
-    out.push(mesh);
-  }
-  return out;
-}
-
-function normalizedStaticGeometry(source: THREE.BufferGeometry): THREE.BufferGeometry {
-  const normalized = source.clone();
-  deinterleaveGeometry(normalized);
-  return normalized.index ? normalized : indexExactVertexTuples(normalized);
 }
 
 export const propStaticMergeInternalsForTest = { mergeStaticMeshes };

--- a/src/render/static_merge.ts
+++ b/src/render/static_merge.ts
@@ -1,0 +1,105 @@
+// The static prop merge: the props view's build-time draw-call collapse.
+//
+// Every static prop mesh is baked into world space and merged per
+// (material, attribute signature, x-half, z-band), so a village's hundreds of
+// small boxes reach the GPU as a handful of draws. Lives beside props.ts
+// rather than inside it because the merge is self-contained build-time
+// geometry work with its own tests (tests/props_static_merge.test.ts), and
+// props.ts is a coordinator this repo keeps from growing.
+//
+// The shadow half of the decision (and why castShadow is not in the key) is
+// the pure static_merge_shadow_core.ts; this module is its Three.js consumer.
+
+import * as THREE from 'three';
+import {
+  deinterleaveGeometry,
+  mergeGeometries,
+} from 'three/examples/jsm/utils/BufferGeometryUtils.js';
+import { WORLD_MIN_Z } from '../sim/data';
+import { indexExactVertexTuples } from './exact_index_geometry';
+import { GFX } from './gfx';
+import {
+  attachShadowRangeGate,
+  planStaticMergeShadow,
+  staticMergeAttributeSignature,
+} from './static_merge_shadow_core';
+
+/** Merge band depth in world units. Shallower without PBR: the low tier's
+ *  cheaper materials make more, smaller bands the better cull trade. */
+export const mergeBandDepth = (): number => (GFX.standardMaterials ? 180 : 90);
+
+// Bake every static prop mesh into world space and merge per
+// (material, attribute signature, z-band). Flames (animated) and
+// InstancedMeshes survive untouched, as do the PointLights (not meshes). The
+// merged meshes replace the originals on the same group; emptied sub-groups
+// are left in place (they carry lights). Non-indexed procedural shapes receive
+// exact tuple indices so they can share indexed glTF buckets without expanding
+// either. castShadow is NOT part of the key: a bucket's casters and its
+// non-casters share a material and therefore a program, so splitting them
+// bought a second draw and a second uniform upload per bucket on exactly the
+// tiers that pay for a shadow pass. They merge casters-first instead and the
+// shadow pass is clipped to that prefix (static_merge_shadow_core.ts).
+export function mergeStaticMeshes(group: THREE.Group, keep: Set<THREE.Object3D>): THREE.Mesh[] {
+  group.updateMatrixWorld(true);
+  interface Bucket {
+    material: THREE.Material;
+    geoms: THREE.BufferGeometry[];
+    casts: boolean[];
+  }
+  const buckets = new Map<string, Bucket>();
+  const merged: THREE.Mesh[] = [];
+  group.traverse((o) => {
+    const mesh = o as THREE.Mesh;
+    if (!mesh.isMesh || keep.has(mesh) || (mesh as THREE.InstancedMesh).isInstancedMesh) return;
+    const material = mesh.material as THREE.Material;
+    const worldX = mesh.matrixWorld.elements[12];
+    const worldZ = mesh.matrixWorld.elements[14];
+    const band = Math.floor((worldZ - WORLD_MIN_Z) / mergeBandDepth());
+    // Extracted geometries are shared across placements, so the bake must
+    // never mutate them in place. Preserve source index reuse and normalize
+    // procedural streams with byte-exact full-tuple indices.
+    const geo = normalizedStaticGeometry(mesh.geometry);
+    // x-halved like the instance batches above: world-wide merged bands
+    // defeat shadow-frustum culling (their bounds always intersect it).
+    const half = worldX < 0 ? 'w' : 'e';
+    const key = `${material.uuid}:${staticMergeAttributeSignature(geo)}:${half}:${band}`;
+    let bucket = buckets.get(key);
+    if (!bucket) {
+      bucket = { material, geoms: [], casts: [] };
+      buckets.set(key, bucket);
+    }
+    bucket.geoms.push(geo.applyMatrix4(mesh.matrixWorld));
+    bucket.casts.push(mesh.castShadow);
+    merged.push(mesh);
+  });
+  for (const mesh of merged) mesh.removeFromParent();
+  const out: THREE.Mesh[] = [];
+  for (const bucket of buckets.values()) {
+    const plan = planStaticMergeShadow(
+      bucket.geoms.map((g, i) => ({
+        castShadow: bucket.casts[i],
+        indexCount: g.getIndex()?.count ?? 0,
+      })),
+    );
+    const geo = mergeGeometries(
+      plan.order.map((i) => bucket.geoms[i]),
+      false,
+    );
+    if (!geo) continue;
+    geo.computeBoundingBox();
+    geo.computeBoundingSphere();
+    const mesh = new THREE.Mesh(geo, bucket.material);
+    mesh.castShadow = plan.castShadow;
+    mesh.receiveShadow = true;
+    if (plan.needsShadowRangeGate) attachShadowRangeGate(mesh, plan.casterIndexCount);
+    group.add(mesh);
+    out.push(mesh);
+  }
+  return out;
+}
+
+export function normalizedStaticGeometry(source: THREE.BufferGeometry): THREE.BufferGeometry {
+  const normalized = source.clone();
+  deinterleaveGeometry(normalized);
+  return normalized.index ? normalized : indexExactVertexTuples(normalized);
+}

--- a/src/render/static_merge_shadow_core.ts
+++ b/src/render/static_merge_shadow_core.ts
@@ -1,0 +1,129 @@
+// Static-merge shadow core: the decisions the props static merge makes once
+// castShadow stops being part of its bucket key.
+//
+// props.ts merges every static prop mesh of a (material, x-half, z-band)
+// bucket into one draw. castShadow used to be part of that key, which doubled
+// the bucket count on exactly the tiers that run a shadow pass: a bucket's
+// casters and its non-casters are the same material and the same program, so
+// the split bought a second draw and a second full uniform upload per bucket
+// for nothing but a per-mesh boolean.
+//
+// One bucket instead, ordered casters first, with the shadow pass clipped to
+// the caster prefix through geometry.drawRange. three clamps every draw to
+// drawRange (WebGLRenderer.renderBufferDirect) and calls the per-object
+// onBeforeShadow / onAfterShadow hooks around each shadow draw, so the prefix
+// costs the shadow pass nothing while the colour pass, which runs after it
+// inside the same render(), still draws the whole merged range. This is the
+// merged-mesh twin of shadow_pass_gate_core.ts's count-zero trick: drawRange
+// is to a merged Mesh what count is to an InstancedMesh.
+//
+// The signature helper is the safety half of the same change. Merging is only
+// defined over geometries that carry the same attribute set, and a bucket that
+// used to be split by castShadow could keep two such sets apart by luck; a
+// mismatch makes three's mergeGeometries return null, which would drop the
+// whole bucket from the scene. The signature keeps them in separate buckets on
+// purpose instead.
+//
+// Pure core contract: no three import, no DOM, no clocks, no randomness.
+// Registered in RENDER_PURE_CORES (tests/architecture.test.ts); tested by
+// tests/static_merge_shadow_core.test.ts.
+
+/** One mesh about to be merged into a bucket. */
+export interface StaticMergeShadowPart {
+  readonly castShadow: boolean;
+  /** Index elements this part contributes to the merged geometry. */
+  readonly indexCount: number;
+}
+
+export interface StaticMergeShadowPlan {
+  /** Part indices in merge order: casters first, source order kept in each half. */
+  readonly order: readonly number[];
+  /** Index elements the shadow pass draws (the caster prefix). */
+  readonly casterIndexCount: number;
+  /** The merged mesh's castShadow flag. */
+  readonly castShadow: boolean;
+  /** True only for a mixed bucket, the one case that needs the range gate. */
+  readonly needsShadowRangeGate: boolean;
+}
+
+/**
+ * Order a bucket's parts so every shadow caster comes first, and report the
+ * index prefix the shadow pass must be clipped to. A bucket that is all
+ * casters or all non-casters keeps its source order and needs no gate.
+ */
+export function planStaticMergeShadow(
+  parts: readonly StaticMergeShadowPart[],
+): StaticMergeShadowPlan {
+  const casters: number[] = [];
+  const rest: number[] = [];
+  let casterIndexCount = 0;
+  for (let i = 0; i < parts.length; i++) {
+    if (parts[i].castShadow) {
+      casters.push(i);
+      casterIndexCount += parts[i].indexCount;
+    } else {
+      rest.push(i);
+    }
+  }
+  const castShadow = casters.length > 0;
+  return {
+    order: [...casters, ...rest],
+    casterIndexCount,
+    castShadow,
+    needsShadowRangeGate: castShadow && rest.length > 0,
+  };
+}
+
+/** The geometry half a merged static mesh exposes to the range gate. */
+export interface ShadowRangeGeometry {
+  setDrawRange(start: number, count: number): void;
+}
+
+/** The merged static mesh the range gate is attached to. */
+export interface ShadowRangeGatedMesh {
+  geometry: ShadowRangeGeometry;
+  onBeforeShadow: unknown;
+  onAfterShadow: unknown;
+  /** The caster prefix, for cost telemetry and for the tests. */
+  shadowRangeIndexCount?: number;
+}
+
+/**
+ * Clip a merged static mesh to its caster prefix for the duration of each
+ * shadow draw. Attach only to a bucket that mixes casters and non-casters:
+ * the range is restored to the full geometry after every shadow draw, and a
+ * frame whose shadow pass never runs simply keeps the full range.
+ *
+ * CALLER CONTRACT: the merged geometry must be indexed and ordered by
+ * planStaticMergeShadow, and its bounding volumes computed over the WHOLE
+ * geometry (the shadow frustum test reads the object's bounds, not its
+ * draw range, so a caster-only bound would be wrong for the colour pass).
+ */
+export function attachShadowRangeGate(mesh: ShadowRangeGatedMesh, casterIndexCount: number): void {
+  mesh.shadowRangeIndexCount = casterIndexCount;
+  mesh.onBeforeShadow = () => {
+    mesh.geometry.setDrawRange(0, casterIndexCount);
+  };
+  mesh.onAfterShadow = () => {
+    mesh.geometry.setDrawRange(0, Number.POSITIVE_INFINITY);
+  };
+}
+
+/** The geometry shape the merge signature is read off. */
+export interface StaticMergeSignatureGeometry {
+  readonly attributes: Readonly<Record<string, unknown>>;
+  readonly morphAttributes?: Readonly<Record<string, unknown>>;
+}
+
+/**
+ * The attribute identity two geometries must share to be mergeable, as a
+ * bucket-key fragment. Order-independent, so two geometries that declare the
+ * same attributes in a different order still land in one bucket.
+ */
+export function staticMergeAttributeSignature(geometry: StaticMergeSignatureGeometry): string {
+  const attributes = Object.keys(geometry.attributes).sort().join(',');
+  const morphs = Object.keys(geometry.morphAttributes ?? {})
+    .sort()
+    .join(',');
+  return morphs ? `${attributes}|${morphs}` : attributes;
+}

--- a/tests/architecture.test.ts
+++ b/tests/architecture.test.ts
@@ -154,9 +154,12 @@ describe('live graphics profile architecture', () => {
       readFileSync(join(repoRoot, 'src', 'render', relativePath), 'utf8');
     const props = renderSource('props.ts');
     const foliage = renderSource('foliage.ts');
+    // The merge band depth moved out of props.ts with the static merge itself
+    // (src/render/static_merge.ts); the live-GFX rule follows the code.
+    const staticMerge = renderSource('static_merge.ts');
 
-    expect(props).not.toMatch(/\bconst\s+MERGE_BAND_DEPTH\s*=\s*GFX\b/);
-    expect(props).toContain('const mergeBandDepth = ():');
+    expect(staticMerge).not.toMatch(/\bconst\s+MERGE_BAND_DEPTH\s*=\s*GFX\b/);
+    expect(staticMerge).toContain('export const mergeBandDepth = ():');
     expect(props).toContain('deferredPropKeys ??= preloadPropKeys(GFX.standardMaterials)');
     expect(foliage).not.toMatch(/\bconst\s+MODEL_URLS\s*=\s*GFX\b/);
     expect(foliage).toContain('const foliageModelUrls = ():');
@@ -714,6 +717,7 @@ const RENDER_PURE_CORES = [
   'src/render/self_render_position_core.ts',
   'src/render/shadow_pass_gate_core.ts',
   'src/render/shore_water_gate_core.ts',
+  'src/render/static_merge_shadow_core.ts',
   'src/render/terrain_region_core.ts',
   'src/render/texture_prep_core.ts',
   'src/render/terrain_splat_presence_core.ts',

--- a/tests/props_static_merge.test.ts
+++ b/tests/props_static_merge.test.ts
@@ -103,7 +103,7 @@ describe('static prop merging', () => {
     expect(Array.from(sharedGeometry.getIndex()?.array ?? [])).toEqual(sourceIndex);
   });
 
-  it('keeps material and shadow buckets separate and ordered', () => {
+  it('keeps material buckets separate but merges casters with non-casters', () => {
     const group = new THREE.Group();
     const stone = new THREE.MeshStandardMaterial();
     const wood = new THREE.MeshStandardMaterial();
@@ -115,7 +115,7 @@ describe('static prop merging', () => {
 
     const merged = propStaticMergeInternalsForTest.mergeStaticMeshes(group, new Set());
 
-    expect(merged).toHaveLength(3);
+    expect(merged).toHaveLength(2);
     expect(
       merged.map((mesh) => ({
         material: mesh.material,
@@ -123,10 +123,80 @@ describe('static prop merging', () => {
         receiveShadow: mesh.receiveShadow,
       })),
     ).toEqual([
-      { material: stone, castShadow: false, receiveShadow: true },
-      { material: wood, castShadow: false, receiveShadow: true },
       { material: stone, castShadow: true, receiveShadow: true },
+      { material: wood, castShadow: false, receiveShadow: true },
     ]);
+  });
+
+  it('draws only the caster prefix in the shadow pass of a mixed bucket', () => {
+    const group = new THREE.Group();
+    const stone = new THREE.MeshStandardMaterial();
+    const unshadowed = new THREE.Mesh(indexedQuad(), stone);
+    unshadowed.position.x = 4;
+    const shadowed = new THREE.Mesh(indexedQuad(), stone);
+    shadowed.castShadow = true;
+    // Source order deliberately puts the non-caster first: the merge has to
+    // reorder, or the shadow prefix would clip the wrong half.
+    group.add(unshadowed, shadowed);
+
+    const merged = propStaticMergeInternalsForTest.mergeStaticMeshes(group, new Set());
+
+    expect(merged).toHaveLength(1);
+    const mesh = merged[0];
+    expect(mesh.castShadow).toBe(true);
+    expect((mesh as unknown as { shadowRangeIndexCount?: number }).shadowRangeIndexCount).toBe(6);
+    expect(mesh.geometry.getIndex()?.count).toBe(12);
+    // The caster's triangles come first, so its world position leads the
+    // merged position stream.
+    expect(Array.from(mesh.geometry.getAttribute('position').array).slice(0, 3)).toEqual([0, 0, 0]);
+
+    expect(mesh.geometry.drawRange).toEqual({ start: 0, count: Number.POSITIVE_INFINITY });
+    (mesh as unknown as { onBeforeShadow: () => void }).onBeforeShadow();
+    expect(mesh.geometry.drawRange).toEqual({ start: 0, count: 6 });
+    (mesh as unknown as { onAfterShadow: () => void }).onAfterShadow();
+    expect(mesh.geometry.drawRange).toEqual({ start: 0, count: Number.POSITIVE_INFINITY });
+  });
+
+  it('leaves a single-sided bucket ungated', () => {
+    const group = new THREE.Group();
+    const stone = new THREE.MeshStandardMaterial();
+    const a = new THREE.Mesh(indexedQuad(), stone);
+    a.castShadow = true;
+    const b = new THREE.Mesh(indexedQuad(), stone);
+    b.castShadow = true;
+    b.position.x = 4;
+    group.add(a, b);
+
+    const merged = propStaticMergeInternalsForTest.mergeStaticMeshes(group, new Set());
+
+    expect(merged).toHaveLength(1);
+    const mesh = merged[0];
+    expect(mesh.castShadow).toBe(true);
+    expect((mesh as unknown as { shadowRangeIndexCount?: number }).shadowRangeIndexCount).toBe(
+      undefined,
+    );
+    // three's own no-op hook survives on the prototype; the decisive check is
+    // that the shadow pass still draws the whole bucket.
+    (mesh as unknown as { onBeforeShadow: () => void }).onBeforeShadow();
+    expect(mesh.geometry.drawRange).toEqual({ start: 0, count: Number.POSITIVE_INFINITY });
+  });
+
+  it('never merges geometries whose attribute sets disagree', () => {
+    const group = new THREE.Group();
+    const stone = new THREE.MeshStandardMaterial();
+    const full = new THREE.Mesh(indexedQuad(), stone);
+    const sparse = indexedQuad();
+    sparse.deleteAttribute('color');
+    const partial = new THREE.Mesh(sparse, stone);
+    partial.position.x = 4;
+    group.add(full, partial);
+
+    const merged = propStaticMergeInternalsForTest.mergeStaticMeshes(group, new Set());
+
+    // Both survive: a single bucket would make three's mergeGeometries return
+    // null and drop the whole bucket out of the scene.
+    expect(merged).toHaveLength(2);
+    expect(merged.map((m) => m.geometry.getIndex()?.count)).toEqual([6, 6]);
   });
 
   it('de-interleaves indexed source attributes without mutating the shared geometry', () => {

--- a/tests/static_merge_shadow_core.test.ts
+++ b/tests/static_merge_shadow_core.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+import {
+  attachShadowRangeGate,
+  planStaticMergeShadow,
+  type ShadowRangeGatedMesh,
+  staticMergeAttributeSignature,
+} from '../src/render/static_merge_shadow_core';
+
+function fakeMesh(): ShadowRangeGatedMesh & { ranges: [number, number][] } {
+  const ranges: [number, number][] = [];
+  return {
+    ranges,
+    geometry: {
+      setDrawRange(start: number, count: number): void {
+        ranges.push([start, count]);
+      },
+    },
+    onBeforeShadow: null,
+    onAfterShadow: null,
+  };
+}
+
+describe('planStaticMergeShadow', () => {
+  it('orders casters first and reports their index prefix', () => {
+    const plan = planStaticMergeShadow([
+      { castShadow: false, indexCount: 6 },
+      { castShadow: true, indexCount: 12 },
+      { castShadow: false, indexCount: 3 },
+      { castShadow: true, indexCount: 9 },
+    ]);
+
+    expect(plan.order).toEqual([1, 3, 0, 2]);
+    expect(plan.casterIndexCount).toBe(21);
+    expect(plan.castShadow).toBe(true);
+    expect(plan.needsShadowRangeGate).toBe(true);
+  });
+
+  it('keeps source order and needs no gate when every part casts', () => {
+    const plan = planStaticMergeShadow([
+      { castShadow: true, indexCount: 6 },
+      { castShadow: true, indexCount: 6 },
+    ]);
+
+    expect(plan.order).toEqual([0, 1]);
+    expect(plan.casterIndexCount).toBe(12);
+    expect(plan.castShadow).toBe(true);
+    expect(plan.needsShadowRangeGate).toBe(false);
+  });
+
+  it('keeps source order and does not cast when no part casts', () => {
+    const plan = planStaticMergeShadow([
+      { castShadow: false, indexCount: 6 },
+      { castShadow: false, indexCount: 4 },
+    ]);
+
+    expect(plan.order).toEqual([0, 1]);
+    expect(plan.casterIndexCount).toBe(0);
+    expect(plan.castShadow).toBe(false);
+    expect(plan.needsShadowRangeGate).toBe(false);
+  });
+
+  it('answers an empty bucket without a gate', () => {
+    const plan = planStaticMergeShadow([]);
+
+    expect(plan.order).toEqual([]);
+    expect(plan.casterIndexCount).toBe(0);
+    expect(plan.castShadow).toBe(false);
+    expect(plan.needsShadowRangeGate).toBe(false);
+  });
+});
+
+describe('attachShadowRangeGate', () => {
+  it('clips to the caster prefix for the shadow draw and restores the full range', () => {
+    const mesh = fakeMesh();
+
+    attachShadowRangeGate(mesh, 21);
+
+    // Attaching must not clip anything: the colour pass of a frame whose
+    // shadow pass never runs still draws the whole merged range.
+    expect(mesh.ranges).toEqual([]);
+    expect(mesh.shadowRangeIndexCount).toBe(21);
+
+    (mesh.onBeforeShadow as () => void)();
+    expect(mesh.ranges).toEqual([[0, 21]]);
+
+    (mesh.onAfterShadow as () => void)();
+    expect(mesh.ranges).toEqual([
+      [0, 21],
+      [0, Number.POSITIVE_INFINITY],
+    ]);
+  });
+
+  it('restores the full range after every shadow draw of a multi-draw frame', () => {
+    const mesh = fakeMesh();
+    attachShadowRangeGate(mesh, 8);
+
+    for (let draw = 0; draw < 3; draw++) {
+      (mesh.onBeforeShadow as () => void)();
+      (mesh.onAfterShadow as () => void)();
+    }
+
+    expect(mesh.ranges).toEqual([
+      [0, 8],
+      [0, Number.POSITIVE_INFINITY],
+      [0, 8],
+      [0, Number.POSITIVE_INFINITY],
+      [0, 8],
+      [0, Number.POSITIVE_INFINITY],
+    ]);
+  });
+});
+
+describe('staticMergeAttributeSignature', () => {
+  it('is order-independent over the attribute names', () => {
+    expect(staticMergeAttributeSignature({ attributes: { position: 1, normal: 1, uv: 1 } })).toBe(
+      staticMergeAttributeSignature({ attributes: { uv: 1, position: 1, normal: 1 } }),
+    );
+  });
+
+  it('separates geometries that do not carry the same attributes', () => {
+    expect(staticMergeAttributeSignature({ attributes: { position: 1, normal: 1 } })).not.toBe(
+      staticMergeAttributeSignature({ attributes: { position: 1, normal: 1, color: 1 } }),
+    );
+  });
+
+  it('separates a morph-carrying geometry from a plain one', () => {
+    expect(
+      staticMergeAttributeSignature({
+        attributes: { position: 1 },
+        morphAttributes: { position: [1] },
+      }),
+    ).not.toBe(staticMergeAttributeSignature({ attributes: { position: 1 } }));
+  });
+});


### PR DESCRIPTION
## Summary

**The problem.** The static prop merge keyed its buckets on `castShadow`. Two
props sharing a material, and therefore a program, were merged into two meshes
instead of one purely because one of them cast a shadow and the other did not,
and that split fired on exactly the tiers that pay for a shadow pass in the first
place. The bucket key also did not carry the attribute signature that merging
actually requires, so a bucket mixing two attribute sets reached `mergeGeometries`
and was dropped by its null return, silently losing the merge.

**The fix.** The key drops `castShadow` and the merge orders casters first, then
clips the shadow pass to that prefix through `geometry.drawRange` in
`onBeforeShadow`. That is the merged-mesh twin of the count-zero trick the
instanced shadow proxies already use: one mesh, one colour draw over the whole
bucket, one shadow draw over the caster prefix. The bucket key gains the attribute
signature, so a bucket that mixes two attribute sets is kept apart deliberately
rather than dropped by a failed merge.

The merge moved out of `props.ts` into `static_merge.ts` beside the new pure core
`static_merge_shadow_core.ts`, which is where the ordering and the draw-range
arithmetic are unit-tested without a scene.

## Numbers

Measured in the offline world on Linux, RTX 3090 through ANGLE, 1920x1080. This
step is a structural change to how buckets are formed; no frame capture is
recorded for it, and the table states only what is counted in the merge itself.

| Measure | Before | After |
| --- | --- | --- |
| Merged meshes per material bucket, on a shadow-casting tier | 2 (casters, non-casters) | 1 |
| Shadow submission for that bucket | the caster half's own mesh | the caster prefix via `drawRange` |
| Bucket key inputs | material, `castShadow` | material, attribute signature |
| Buckets silently dropped by a null `mergeGeometries` | possible (mixed attribute sets) | none (kept apart by the key) |

## Related issues

N/A.

## Type of change

- [x] Refactor or performance (no behavior change)
- [x] Tests

## How was this tested?

- Commands: `npm run gate:fast` green against `release/v0.42.0`;
  `npx tsc --noEmit`; `npx vitest run tests/static_merge_shadow_core.test.ts
  tests/props_static_merge.test.ts tests/architecture.test.ts`.
- Manual steps: none beyond the suite.

## Screenshots / recordings

None. The change alters how prop geometry is bucketed and which prefix the shadow
pass draws, not what is drawn: the same casters cast, the same non-casters do not,
and the colour pass covers the same set. There is no frame in which a player-
visible difference could appear, so a before/after pair would show two identical
images and prove nothing. The behaviour is pinned by
`tests/static_merge_shadow_core.test.ts` instead, which asserts the caster
ordering and the exact draw range.

## Checklist

### Quality

- [x] **The gate passes.** The caster ordering and the shadow draw range are
      pinned in the pure core, and the bucket key's new attribute-signature arm
      has its own negative.

### Cross-platform

- [x] **Tested on desktop and mobile.** Verified in the offline world on a desktop
      (Eastbrook, Fenbridge and the Thornpeak hub on High and Ultra: every static
      prop present with its shadow, emissive glass and lanterns still shadowless)
      and on a phone in landscape on Low. Renderer-internal, no UI.
- [x] **Accessible.** N/A: no UI added or edited.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.
