### PR TITLE
fix(render): guard the post chain against Mali NaN so Android frames stop going black

### DIFF
--- a/src/render/final_color_nan_guard_core.ts
+++ b/src/render/final_color_nan_guard_core.ts
@@ -1,11 +1,16 @@
+import { finiteGuardStatement } from './post_finite_guard_glsl';
+
 const OPAQUE_GUARD_MARKER = 'WOC_OPAQUE_NAN_GUARD';
 const FOG_GUARD_MARKER = 'WOC_FOG_NAN_GUARD';
 
 const OPAQUE_WRITE = 'gl_FragColor = vec4( outgoingLight, diffuseColor.a );';
 const FOG_WRITE = 'gl_FragColor.rgb = mix( gl_FragColor.rgb, fogColor, fogFactor );';
 
-// Every NaN comparison is false, so (x < 0.0 || x >= 0.0) keeps finite and
-// infinite values and rewrites only NaN to zero. This is generic hardening,
+// The scrub is the bit-exact exponent test from post_finite_guard_glsl.ts
+// (NaN and Inf to zero): the earlier comparison form, (x < 0.0 || x >= 0.0),
+// is implementation-defined for NaN in GLSL ES and evaluates as "finite" on
+// Mali (Android Chrome), which is how the phone rendered black frames through
+// a scrub that read as correct. This is generic hardening,
 // installed unconditionally on every tier and platform: GLES leaves the
 // conversion of a NaN fragment output into a fixed-point (UNSIGNED_BYTE)
 // render target undefined, so "the direct-to-canvas tiers clamp it away" is
@@ -21,14 +26,14 @@ const FOG_WRITE = 'gl_FragColor.rgb = mix( gl_FragColor.rgb, fogColor, fogFactor
 // depend on the answer.
 function scrubStatements(target: string): string {
   return (
-    `${target}.x = ( ${target}.x < 0.0 || ${target}.x >= 0.0 ) ? ${target}.x : 0.0;\n` +
-    `${target}.y = ( ${target}.y < 0.0 || ${target}.y >= 0.0 ) ? ${target}.y : 0.0;\n` +
-    `${target}.z = ( ${target}.z < 0.0 || ${target}.z >= 0.0 ) ? ${target}.z : 0.0;\n`
+    finiteGuardStatement(`${target}.x`) +
+    finiteGuardStatement(`${target}.y`) +
+    finiteGuardStatement(`${target}.z`)
   );
 }
 
 function scrubScalar(target: string): string {
-  return `${target} = ( ${target} < 0.0 || ${target} >= 0.0 ) ? ${target} : 0.0;\n`;
+  return finiteGuardStatement(target);
 }
 
 /**

--- a/src/render/post_bloom.ts
+++ b/src/render/post_bloom.ts
@@ -1,7 +1,8 @@
 import { type Texture, Vector2, type WebGLRenderer, type WebGLRenderTarget } from 'three';
 import type { FullScreenQuad } from 'three/examples/jsm/postprocessing/Pass.js';
 import { UnrealBloomPass } from 'three/examples/jsm/postprocessing/UnrealBloomPass.js';
-import { restoreClassicBloomComposite } from './post_bloom_shader_core';
+import { guardBloomHighPassInput, restoreClassicBloomComposite } from './post_bloom_shader_core';
+import { FINITE_GUARD_GLSL } from './post_finite_guard_glsl';
 
 const BLUR_X = new Vector2(1, 0);
 const BLUR_Y = new Vector2(0, 1);
@@ -59,6 +60,13 @@ export class PreparedBloomPass extends UnrealBloomPass {
     }
     this.materialHighPassFilter.depthTest = false;
     this.materialHighPassFilter.depthWrite = false;
+    // One NaN beauty texel must not become a frame-wide NaN bloom: guard the
+    // high-pass read, the one place every mip below descends from.
+    this.materialHighPassFilter.fragmentShader = guardBloomHighPassInput(
+      this.materialHighPassFilter.fragmentShader,
+      FINITE_GUARD_GLSL,
+    );
+    this.materialHighPassFilter.needsUpdate = true;
     for (const material of this.separableBlurMaterials) {
       material.depthTest = false;
       material.depthWrite = false;

--- a/src/render/post_bloom_shader_core.ts
+++ b/src/render/post_bloom_shader_core.ts
@@ -76,3 +76,27 @@ export function restoreClassicBloomComposite(shader: string, nMips: number): str
   }
   return patched;
 }
+
+/** The shipped LuminosityHighPassShader beauty read, whitespace-tolerant. */
+const HIGH_PASS_TEXEL = /vec4\s+texel\s*=\s*texture2D\s*\(\s*tDiffuse\s*,\s*vUv\s*\)\s*;/;
+const HIGH_PASS_MAIN = /void\s+main\s*\(\s*\)\s*\{/;
+const HIGH_PASS_SHAPE_ERROR = 'Pinned three LuminosityHighPassShader changed shape';
+
+/**
+ * Scrubs NaN and Inf out of the bloom high-pass input, so one bad beauty texel
+ * costs one bloom texel instead of the whole frame: every Gaussian mip below
+ * reads this target, and a single NaN in it reaches every pixel of the composite.
+ * The guard is the shared bit-exact snippet (post_finite_guard_glsl.ts); fails
+ * closed if three's shipped shader no longer has the pinned read.
+ */
+export function guardBloomHighPassInput(shader: string, guardGlsl: string): string {
+  if (!HIGH_PASS_TEXEL.test(shader)) throw new Error(`${HIGH_PASS_SHAPE_ERROR} (beauty read)`);
+  if (!HIGH_PASS_MAIN.test(shader)) throw new Error(`${HIGH_PASS_SHAPE_ERROR} (main)`);
+  const guarded = shader
+    .replace(HIGH_PASS_MAIN, `${guardGlsl}\n\t\tvoid main() {`)
+    .replace(HIGH_PASS_TEXEL, 'vec4 texel = wocSanitizeFinite4( texture2D( tDiffuse, vUv ) );');
+  if (!guarded.includes('wocSanitizeFinite4( texture2D( tDiffuse, vUv ) )')) {
+    throw new Error(`${HIGH_PASS_SHAPE_ERROR} (guard not applied)`);
+  }
+  return guarded;
+}

--- a/src/render/post_finite_guard_glsl.ts
+++ b/src/render/post_finite_guard_glsl.ts
@@ -1,0 +1,60 @@
+// The one non-finite guard the post chain splices into every fullscreen
+// shader that reads a HalfFloat target (the output grade, the bloom
+// high-pass). Shared as a snippet so the test is written once and every
+// consumer carries the same bit-exact form.
+//
+// Why bit-exact and not a comparison: GLSL ES leaves NaN comparisons
+// implementation-defined, and Mali (Android Chrome, Mali-G715, 2026-09) evaluates
+// `(x < 0.0 || x >= 0.0)` as true for NaN, so the comparison-based scrub that
+// stops ANGLE-GL's NaN on desktop let a NaN through on the phone. The tonemap's
+// saturate then collapsed it to 0 and the whole frame went black. A float is
+// NaN or Inf exactly when its exponent bits are all set; floatBitsToUint reads
+// those bits with no arithmetic and no comparison the driver can fold.
+//
+// Every integer here is qualified highp on purpose. GLSL ES 3.00 predeclares
+// `precision mediump int;` in the fragment language, a host that declares only
+// `precision highp float;` (the grade's RawShaderMaterial) leaves it there, and
+// mediump uint is allowed to be 16 bits wide: the mask 0x7f800000 would then
+// truncate to zero on exactly the mobile GPUs this guard exists for, and
+// equal(0, 0) would flag every texel.
+//
+// Inf is scrubbed as well: ACES of Inf is Inf/Inf = NaN, so an infinite sample
+// blacks the frame the same way a NaN does. Scrubbing to zero rather than to a
+// large finite value is a deliberate tradeoff: an Inf in a HalfFloat target is
+// a value past 65504 that no lit surface in this renderer produces, so the
+// choice only affects an already defective texel, and zero is the value that
+// cannot feed the bloom a frame-wide smear. (The grade's later quantizeHalf can
+// still mint an Inf from a finite sum past 65504; that one stays a single
+// pixel, nothing blurs after the grade.)
+//
+// Selection, never arithmetic: `mix(v, 0.0, weight)` is `v * (1 - w) + 0 * w`,
+// and NaN times zero stays NaN.
+export const FINITE_GUARD_GLSL = /* glsl */ `
+  bvec4 wocNonFinite(highp vec4 v) {
+    highp uvec4 exponentBits = floatBitsToUint(v) & uvec4(0x7f800000u);
+    return equal(exponentBits, uvec4(0x7f800000u));
+  }
+
+  vec4 wocSanitizeFinite4(highp vec4 v) {
+    bvec4 bad = wocNonFinite(v);
+    return vec4(
+      bad.x ? 0.0 : v.x,
+      bad.y ? 0.0 : v.y,
+      bad.z ? 0.0 : v.z,
+      bad.w ? 0.0 : v.w
+    );
+  }
+
+  vec3 wocSanitizeFinite(highp vec3 v) {
+    return wocSanitizeFinite4(vec4(v, 0.0)).xyz;
+  }
+`;
+
+/**
+ * The same test as a statement, for a chunk splice inside main() where no
+ * function can be declared (final_color_nan_guard_core.ts): `target` is
+ * rewritten to 0.0 when its exponent bits are all set.
+ */
+export function finiteGuardStatement(target: string): string {
+  return `${target} = ( ( floatBitsToUint( ${target} ) & 0x7f800000u ) == 0x7f800000u ) ? 0.0 : ${target};\n`;
+}

--- a/src/render/post_n8ao.ts
+++ b/src/render/post_n8ao.ts
@@ -214,6 +214,44 @@ function specializeStaticDenoise(material: ShaderMaterial): void {
   material.needsUpdate = true;
 }
 
+/**
+ * The depth-derived normal both the AO evaluation and the HALFRES compositer
+ * upsample reconstruct is normalize(cross(dpdx, dpdy)). Where the two position
+ * derivatives are parallel or one of them vanishes (a pixel whose neighbours
+ * reconstruct to the same world position), the cross product is zero and
+ * normalize returns NaN. In the compositer that NaN enters the bilateral weight
+ * (exp(NaN) times anything is NaN), so totalWeight is NaN, the divide guard is
+ * not taken, and a NaN texel is written into the composer beauty. Measured on
+ * Mali-G715 (Android Chrome): exactly one NaN pixel per affected frame, at a
+ * different place each time, on unrelated surfaces, while the raw beauty is
+ * finite; the bloom blur then spread it frame-wide. Guard with the same
+ * length-checked normalize n8ao itself uses elsewhere (its 1e-12 threshold is
+ * upstream's, not a derived bound); a zero-derivative pixel gets a screen-up
+ * normal in the view space these shaders work in, so its one weight is finite
+ * and bounded. The test is written so that its fallback branch is the one a
+ * NaN comparison lands on: GLSL ES leaves that comparison implementation
+ * defined, and a non-finite length squared must never reach the normalize.
+ * The depth downsample pass reconstructs the same normal into a HalfFloat
+ * attachment on the half-resolution tiers, so it carries the guard too.
+ */
+const DEGENERATE_NORMAL_RETURN = 'return normalize(cross(dpdx, dpdy));';
+const SAFE_NORMAL_RETURN = `vec3 faceNormal = cross(dpdx, dpdy);
+    float faceNormalLengthSq = dot(faceNormal, faceNormal);
+    return faceNormalLengthSq < 1e-12
+      ? vec3(0.0, 1.0, 0.0)
+      : faceNormal * inversesqrt(faceNormalLengthSq);`;
+
+function guardDegenerateNormal(material: ShaderMaterial): void {
+  if (material.fragmentShader.includes('faceNormalLengthSq')) return;
+  material.fragmentShader = replacePinned(
+    material.fragmentShader,
+    DEGENERATE_NORMAL_RETURN,
+    SAFE_NORMAL_RETURN,
+    1,
+  );
+  material.needsUpdate = true;
+}
+
 function suppressFullCoverageClear(quad: N8AOFullScreenTriangle | null | undefined): void {
   if (!quad || noClearQuads.has(quad)) return;
   const render = quad.render.bind(quad);
@@ -261,7 +299,10 @@ export class StaticOpaqueN8AOPass extends N8AOPass {
     assertStaticShaderConfiguration(this.configuration as unknown as N8AOStaticConfiguration);
     super.configureAOPass(depthBufferType, ortho);
     const state = this as unknown as N8AOStaticFrameInternals;
-    if (state.effectShaderQuad) specializeStaticEvaluation(state.effectShaderQuad.material);
+    if (state.effectShaderQuad) {
+      specializeStaticEvaluation(state.effectShaderQuad.material);
+      guardDegenerateNormal(state.effectShaderQuad.material);
+    }
     suppressFullCoverageClear(state.effectShaderQuad);
   }
 
@@ -277,6 +318,7 @@ export class StaticOpaqueN8AOPass extends N8AOPass {
     super.configureEffectCompositer(depthBufferType, ortho);
     const state = this as unknown as N8AOStaticFrameInternals;
     preserveAccumulationQuantization(state.effectCompositerQuad.material);
+    guardDegenerateNormal(state.effectCompositerQuad.material);
     suppressFullCoverageClear(state.effectCompositerQuad);
   }
 
@@ -284,6 +326,7 @@ export class StaticOpaqueN8AOPass extends N8AOPass {
     super.configureHalfResTargets();
     const state = this as unknown as N8AOStaticFrameInternals;
     if (state.depthDownsampleTarget) state.depthDownsampleTarget.depthBuffer = false;
+    if (state.depthDownsampleQuad) guardDegenerateNormal(state.depthDownsampleQuad.material);
     suppressFullCoverageClear(state.depthDownsampleQuad);
   }
 

--- a/src/render/post_output_grade.ts
+++ b/src/render/post_output_grade.ts
@@ -17,6 +17,7 @@ import {
   type WebGLRenderTarget,
 } from 'three';
 import { FullScreenQuad, Pass } from 'three/examples/jsm/postprocessing/Pass.js';
+import { FINITE_GUARD_GLSL } from './post_finite_guard_glsl';
 
 interface TimeUniform {
   value: number;
@@ -54,17 +55,16 @@ export const OUTPUT_GRADE_FRAGMENT_SHADER = /* glsl */ `
   // across every mip, so OutputGradePass adds a frame-wide NaN and the tonemap
   // maps it to black. NaN survives only in the float composer targets (the
   // direct-to-canvas UNSIGNED_BYTE tiers clamp it away), which is why low/medium
-  // are fine while the composer tiers go black. The IBL / PBR shader path emits
-  // those NaNs on some drivers (observed on ANGLE's OpenGL backend with NVIDIA on
-  // Linux). Every NaN comparison is false, so the (x < 0.0 || x >= 0.0) test
-  // keeps finite and infinite values and rewrites only NaN to zero. This must
-  // stay on the beauty AND the bloom read, since the blur already spread the NaN.
+  // are fine while the composer tiers go black. Sources seen so far: the IBL /
+  // PBR path on ANGLE's OpenGL backend (NVIDIA on Linux) and the N8AO
+  // compositer's depth-derived normal on Mali (Android Chrome). The scrub is the
+  // shared bit-exact guard (post_finite_guard_glsl.ts): the earlier comparison
+  // form let NaN through on Mali. It rewrites NaN and Inf to zero and must stay
+  // on the beauty AND the bloom read, since the blur already spread the NaN.
+  ${FINITE_GUARD_GLSL}
+
   vec3 sanitizeFinite(vec3 v) {
-    return vec3(
-      (v.x < 0.0 || v.x >= 0.0) ? v.x : 0.0,
-      (v.y < 0.0 || v.y >= 0.0) ? v.y : 0.0,
-      (v.z < 0.0 || v.z >= 0.0) ? v.z : 0.0
-    );
+    return wocSanitizeFinite(v);
   }
 
   // The display-referred image this pass grades: one scene sample with bloom

--- a/tests/browser/post_finite_guard.browser.test.ts
+++ b/tests/browser/post_finite_guard.browser.test.ts
@@ -1,0 +1,182 @@
+// Real-WebGL regression for the post chain's bit-exact non-finite guard. The
+// pure suites (post_finite_guard_glsl, post_output_grade, post_bloom_shader_core,
+// post_n8ao) pin only the STRING splices; production disables checkShaderErrors
+// unless ?shaderdebug is present (renderer.ts), so a syntax or semantic error
+// in the spliced GLSL would ship as an all-black frame with no error anywhere,
+// the exact symptom the guard exists to prevent. Same shape as
+// final_color_nan_guard.browser.test.ts: compile with errors wired to fail,
+// then prove the scrub on real NaN and Inf texels against a finite baseline.
+//
+// Read back through FloatType targets on purpose: an UNSIGNED_BYTE write
+// already converts NaN to 0 on some drivers, which would make a byte readback a
+// vacuous test of the guard itself. A float target keeps whatever the shader
+// wrote, so NaN-in equals NaN-out unless the spliced scrub runs.
+//
+// Lives under tests/browser/** and ends in .browser.test.ts, so a bare
+// `vitest run` skips it; `npm run test:browser` (chromium) runs it.
+
+import * as THREE from 'three';
+import { FullScreenQuad } from 'three/examples/jsm/postprocessing/Pass.js';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { PreparedBloomPass } from '../../src/render/post_bloom';
+import { StaticOpaqueN8AOPass } from '../../src/render/post_n8ao';
+import { OutputGradePass } from '../../src/render/post_output_grade';
+import { isSoftwareRendererName } from '../../src/render/software_renderer';
+
+let renderer: THREE.WebGLRenderer;
+let shaderError: string | null = null;
+
+// A 2x2 float texture: NaN, +Inf (with finite companions), a plain finite
+// texel, and black. The guarded shaders must map the first two exactly where
+// a zero texel would go and leave the finite ones untouched.
+const TEXELS: [number, number, number, number][] = [
+  [Number.NaN, Number.NaN, Number.NaN, 1],
+  [Number.POSITIVE_INFINITY, 2, 3, 1],
+  [2, 2, 2, 1],
+  [0, 0, 0, 1],
+];
+
+function floatTexture(texels: [number, number, number, number][]): THREE.DataTexture {
+  const data = new Float32Array(texels.flat());
+  const texture = new THREE.DataTexture(data, 2, 2, THREE.RGBAFormat, THREE.FloatType);
+  texture.minFilter = THREE.NearestFilter;
+  texture.magFilter = THREE.NearestFilter;
+  texture.generateMipmaps = false;
+  texture.needsUpdate = true;
+  return texture;
+}
+
+function readFloatTarget(target: THREE.WebGLRenderTarget): Float32Array {
+  const out = new Float32Array(target.width * target.height * 4);
+  renderer.readRenderTargetPixels(target, 0, 0, target.width, target.height, out);
+  return out;
+}
+
+function texel(pixels: Float32Array, index: number): number[] {
+  return Array.from(pixels.subarray(index * 4, index * 4 + 4));
+}
+
+beforeAll(() => {
+  const canvas = document.createElement('canvas');
+  canvas.width = 8;
+  canvas.height = 8;
+  renderer = new THREE.WebGLRenderer({ canvas, antialias: false });
+  renderer.debug.checkShaderErrors = true;
+  renderer.debug.onShaderError = (gl, program) => {
+    shaderError = gl.getProgramInfoLog(program) || 'shader compile/link failed';
+  };
+  renderer.toneMapping = THREE.ACESFilmicToneMapping;
+  const gl = renderer.getContext();
+  const dbg = gl.getExtension('WEBGL_debug_renderer_info');
+  const unmasked = String(
+    dbg ? gl.getParameter(dbg.UNMASKED_RENDERER_WEBGL) : gl.getParameter(gl.RENDERER),
+  );
+  console.log(
+    `[post_finite_guard.browser] adapter: ${unmasked} (software: ${isSoftwareRendererName(unmasked)})`,
+  );
+});
+
+afterEach(() => {
+  expect(shaderError).toBeNull();
+  shaderError = null;
+});
+
+afterAll(() => {
+  renderer.dispose();
+  renderer.forceContextLoss();
+});
+
+describe('bloom high-pass guard on a real driver', () => {
+  it('compiles, and scrubs NaN and Inf beauty texels to the zero texel result', () => {
+    const pass = new PreparedBloomPass(new THREE.Vector2(2, 2), 0.4, 0.6, 0);
+    const material = pass.materialHighPassFilter;
+    const input = floatTexture(TEXELS);
+    material.uniforms.tDiffuse.value = input;
+    material.uniforms.luminosityThreshold.value = 0;
+    material.uniforms.smoothWidth.value = 0.01;
+    const quad = new FullScreenQuad(material);
+    const target = new THREE.WebGLRenderTarget(2, 2, { type: THREE.FloatType, depthBuffer: false });
+    renderer.setRenderTarget(target);
+    quad.render(renderer);
+    renderer.setRenderTarget(null);
+    const pixels = readFloatTarget(target);
+
+    // NaN texel: scrubbed to black, luminance 0, so the high-pass emits its
+    // default colour (black, opacity 0), exactly what the black input texel gets.
+    expect(texel(pixels, 0)).toEqual(texel(pixels, 3));
+    expect(texel(pixels, 0).every(Number.isFinite)).toBe(true);
+    // Inf channel scrubbed to 0, finite companions kept, above threshold.
+    expect(texel(pixels, 1)).toEqual([0, 2, 3, 1]);
+    // Finite texel passes through unchanged.
+    expect(texel(pixels, 2)).toEqual([2, 2, 2, 1]);
+
+    quad.dispose();
+    target.dispose();
+    input.dispose();
+    pass.dispose();
+  });
+});
+
+describe('output grade guard on a real driver', () => {
+  // The grade is not uniform across the frame (vignette, grain), so a NaN
+  // texel cannot be compared with a black texel elsewhere: render the same
+  // frame twice, once from the NaN / Inf input and once from the input with
+  // those channels already at the scrub's 0.0, and require identical pixels.
+  function gradeFrame(texels: [number, number, number, number][]): Float32Array {
+    const pass = new OutputGradePass({ value: 0 }, null, { fxaa: false });
+    const input = floatTexture(texels);
+    const readBuffer = { texture: input } as unknown as THREE.WebGLRenderTarget;
+    const writeBuffer = new THREE.WebGLRenderTarget(2, 2, {
+      type: THREE.FloatType,
+      depthBuffer: false,
+    });
+    pass.render(renderer, writeBuffer, readBuffer);
+    renderer.setRenderTarget(null);
+    const pixels = readFloatTarget(writeBuffer);
+    writeBuffer.dispose();
+    input.dispose();
+    pass.dispose();
+    return pixels;
+  }
+
+  it('compiles, and grades a NaN or Inf beauty texel exactly like the scrubbed zero', () => {
+    const scrubbed: [number, number, number, number][] = [
+      [0, 0, 0, 1],
+      [0, 2, 3, 1],
+      [2, 2, 2, 1],
+      [0, 0, 0, 1],
+    ];
+    const pixels = gradeFrame(TEXELS);
+    const baseline = gradeFrame(scrubbed);
+
+    expect(Array.from(pixels).every(Number.isFinite)).toBe(true);
+    expect(Array.from(pixels)).toEqual(Array.from(baseline));
+    // Not vacuous: the frame carries a real graded image, the lit texel is
+    // brighter than the black one, and the scrubbed Inf texel keeps its
+    // finite companions (it is not the black result).
+    expect(texel(pixels, 2)[0]).toBeGreaterThan(texel(pixels, 3)[0]);
+    expect(texel(pixels, 1)[1]).toBeGreaterThan(texel(pixels, 3)[1]);
+  });
+});
+
+describe('N8AO guarded shaders on a real driver', () => {
+  it('compiles the guarded evaluation, downsample and compositer programs on the half-res path', () => {
+    const scene = new THREE.Scene();
+    scene.add(new THREE.Mesh(new THREE.BoxGeometry(1, 1, 1), new THREE.MeshBasicMaterial()));
+    const camera = new THREE.PerspectiveCamera(50, 1, 0.1, 100);
+    camera.position.set(0, 0, 3);
+    camera.lookAt(0, 0, 0);
+    camera.updateMatrixWorld();
+    const pass = new StaticOpaqueN8AOPass(scene, camera, 8, 8);
+    pass.setQualityMode('Low');
+    pass.configuration.halfRes = true;
+    pass.configuration.depthAwareUpsampling = true;
+    const a = new THREE.WebGLRenderTarget(8, 8, { type: THREE.HalfFloatType });
+    const b = new THREE.WebGLRenderTarget(8, 8, { type: THREE.HalfFloatType });
+    pass.render(renderer, a, b, 0, false);
+    renderer.setRenderTarget(null);
+    a.dispose();
+    b.dispose();
+    pass.dispose();
+  });
+});

--- a/tests/final_color_nan_guard.test.ts
+++ b/tests/final_color_nan_guard.test.ts
@@ -136,7 +136,9 @@ describe('patchOpaqueFragmentNanGuard coverage in stock shaders', () => {
       if (hasOpaque) withOpaque.push(name);
     }
     expect(withOpaque.length).toBeGreaterThan(0);
-    expect(THREE.ShaderChunk.opaque_fragment).toContain('outgoingLight.x = ( outgoingLight.x');
+    expect(THREE.ShaderChunk.opaque_fragment).toContain(
+      'outgoingLight.x = ( ( floatBitsToUint( outgoingLight.x )',
+    );
     expect(THREE.ShaderChunk.opaque_fragment).not.toContain('#ifndef USE_FOG');
   });
 

--- a/tests/final_color_nan_guard_core.test.ts
+++ b/tests/final_color_nan_guard_core.test.ts
@@ -50,7 +50,7 @@ describe('final color NaN guard core', () => {
     const patched = patchOpaqueFragmentNanGuard(SOURCE_OPAQUE_FRAGMENT);
     expect(patched).not.toBe(SOURCE_OPAQUE_FRAGMENT);
     const marker = patched.indexOf('// WOC_OPAQUE_NAN_GUARD');
-    const alphaScrub = patched.indexOf('diffuseColor.a = ( diffuseColor.a < 0.0');
+    const alphaScrub = patched.indexOf('diffuseColor.a = ( ( floatBitsToUint( diffuseColor.a )');
     const write = patched.indexOf(OPAQUE_WRITE);
     expect(marker).toBeGreaterThan(-1);
     expect(alphaScrub).toBeGreaterThan(marker);
@@ -69,11 +69,14 @@ describe('final color NaN guard core', () => {
 
   it('scrubs outgoingLight (rgb) unconditionally before opaque_fragment writes gl_FragColor', () => {
     const patched = patchOpaqueFragmentNanGuard(SOURCE_OPAQUE_FRAGMENT);
-    const alphaScrub = patched.indexOf('diffuseColor.a = ( diffuseColor.a < 0.0');
-    const scrubStart = patched.indexOf('outgoingLight.x = ( outgoingLight.x < 0.0');
+    const alphaScrub = patched.indexOf('diffuseColor.a = ( ( floatBitsToUint( diffuseColor.a )');
+    const scrubStart = patched.indexOf('outgoingLight.x = ( ( floatBitsToUint( outgoingLight.x )');
+    // Bit-exact (exponent bits all set), never a NaN comparison: see
+    // post_finite_guard_glsl.ts for why the comparison form is unsafe on Mali.
     const zScrub =
-      'outgoingLight.z = ( outgoingLight.z < 0.0 || outgoingLight.z >= 0.0 )' +
-      ' ? outgoingLight.z : 0.0;\n';
+      'outgoingLight.z = ( ( floatBitsToUint( outgoingLight.z ) & 0x7f800000u ) == 0x7f800000u )' +
+      ' ? 0.0 : outgoingLight.z;\n';
+    expect(patched).not.toMatch(/<\s*0\.0\s*\|\|/);
     const zScrubStart = patched.indexOf(zScrub);
     const scrubEnd = zScrubStart + zScrub.length;
     const write = patched.indexOf(OPAQUE_WRITE);

--- a/tests/post_bloom_shader_core.test.ts
+++ b/tests/post_bloom_shader_core.test.ts
@@ -3,7 +3,11 @@ import type { FullScreenQuad } from 'three/examples/jsm/postprocessing/Pass.js';
 import { UnrealBloomPass } from 'three/examples/jsm/postprocessing/UnrealBloomPass.js';
 import { describe, expect, it } from 'vitest';
 import { PreparedBloomPass } from '../src/render/post_bloom';
-import { restoreClassicBloomComposite } from '../src/render/post_bloom_shader_core';
+import {
+  guardBloomHighPassInput,
+  restoreClassicBloomComposite,
+} from '../src/render/post_bloom_shader_core';
+import { FINITE_GUARD_GLSL } from '../src/render/post_finite_guard_glsl';
 
 const NUM_MIPS = 5;
 // The real composite shader from the installed three, not a hand-written stand
@@ -215,6 +219,65 @@ describe('PreparedBloomPass internals against the installed three', () => {
     expect(last?.target).toBe(pass.renderTargetsHorizontal[0]);
     // render() restores the renderer's autoClear after the pass.
     expect(stub.autoClear).toBe(true);
+    pass.dispose();
+  });
+});
+
+describe('guardBloomHighPassInput', () => {
+  // The installed three high-pass, not a hand-written stand in: the guard has
+  // to find the pinned beauty read in the shader the pass really compiles.
+  const INSTALLED_HIGH_PASS: string = new UnrealBloomPass(new Vector2(64, 64), 0.4, 0.6, 1.32)
+    .materialHighPassFilter.fragmentShader;
+
+  it('wraps the beauty read in the shared bit-exact guard, declared before main', () => {
+    const guarded = guardBloomHighPassInput(INSTALLED_HIGH_PASS, FINITE_GUARD_GLSL);
+    const guardAt = guarded.indexOf('bvec4 wocNonFinite(highp vec4 v)');
+    const mainAt = guarded.indexOf('void main()');
+    const readAt = guarded.indexOf(
+      'vec4 texel = wocSanitizeFinite4( texture2D( tDiffuse, vUv ) );',
+    );
+    expect(guardAt).toBeGreaterThan(-1);
+    expect(mainAt).toBeGreaterThan(guardAt);
+    expect(readAt).toBeGreaterThan(mainAt);
+    // The bare read is gone: every high-pass texel now descends from the guard.
+    expect(guarded).not.toMatch(/vec4\s+texel\s*=\s*texture2D\s*\(\s*tDiffuse/);
+    // The rest of the high-pass (threshold, smoothstep mix) is untouched.
+    expect(guarded).toContain(
+      'smoothstep( luminosityThreshold, luminosityThreshold + smoothWidth, v )',
+    );
+  });
+
+  it('guards NaN AND Inf, by exponent bits, with a select and never a mix', () => {
+    expect(FINITE_GUARD_GLSL).toContain(
+      'highp uvec4 exponentBits = floatBitsToUint(v) & uvec4(0x7f800000u)',
+    );
+    expect(FINITE_GUARD_GLSL).toContain('equal(exponentBits, uvec4(0x7f800000u))');
+    expect(FINITE_GUARD_GLSL).toContain('bad.x ? 0.0 : v.x');
+    expect(FINITE_GUARD_GLSL).not.toMatch(/mix\s*\(/);
+    expect(FINITE_GUARD_GLSL).not.toMatch(/isnan|isinf|<\s*0\.0\s*\|\|/);
+  });
+
+  it('fails closed when the shipped high-pass read is not there', () => {
+    const noRead = INSTALLED_HIGH_PASS.replace(
+      /texture2D\s*\(\s*tDiffuse\s*,\s*vUv\s*\)/,
+      'vec4(0.0)',
+    );
+    expect(() => guardBloomHighPassInput(noRead, FINITE_GUARD_GLSL)).toThrow(
+      'Pinned three LuminosityHighPassShader changed shape (beauty read)',
+    );
+    expect(() =>
+      guardBloomHighPassInput('vec4 texel = texture2D(tDiffuse, vUv);', FINITE_GUARD_GLSL),
+    ).toThrow('Pinned three LuminosityHighPassShader changed shape (main)');
+  });
+
+  it('is applied to the live PreparedBloomPass high-pass material', () => {
+    const pass = new PreparedBloomPass(new Vector2(64, 64), 0.4, 0.6, 1.32);
+    expect(pass.materialHighPassFilter.fragmentShader).toContain(
+      'vec4 texel = wocSanitizeFinite4( texture2D( tDiffuse, vUv ) );',
+    );
+    expect(pass.materialHighPassFilter.fragmentShader).toContain(
+      'bvec4 wocNonFinite(highp vec4 v)',
+    );
     pass.dispose();
   });
 });

--- a/tests/post_finite_guard_glsl.test.ts
+++ b/tests/post_finite_guard_glsl.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { FINITE_GUARD_GLSL, finiteGuardStatement } from '../src/render/post_finite_guard_glsl';
+
+// The mask the snippet hard-codes, evaluated here in JavaScript over real IEEE
+// bit patterns: a wrong constant would otherwise only be caught by the
+// exact-string pins, which a careless edit updates in lockstep.
+const EXPONENT_MASK = 0x7f800000;
+
+function nonFinite(value: number): boolean {
+  const bits = new Uint32Array(new Float32Array([value]).buffer)[0];
+  return (bits & EXPONENT_MASK) >>> 0 === EXPONENT_MASK;
+}
+
+describe('post_finite_guard_glsl', () => {
+  it('flags exactly NaN and the two infinities under the exponent-bits rule', () => {
+    expect(nonFinite(Number.NaN)).toBe(true);
+    expect(nonFinite(Number.POSITIVE_INFINITY)).toBe(true);
+    expect(nonFinite(Number.NEGATIVE_INFINITY)).toBe(true);
+    // Every finite float, including the largest, half-float overflow
+    // candidates, zeros, and a denormal, keeps at least one exponent bit clear.
+    for (const finite of [0, -0, 1, -1, 65504, 65520, 3.4028234663852886e38, 1e-45, -1e-40]) {
+      expect(nonFinite(finite), String(finite)).toBe(false);
+    }
+  });
+
+  it('qualifies every integer highp so a highp-float-only host cannot truncate the mask', () => {
+    // GLSL ES 3.00 fragment shaders predeclare mediump int, which may be 16
+    // bits wide: 0x7f800000 would truncate to zero and flag every texel.
+    expect(FINITE_GUARD_GLSL).toContain('bvec4 wocNonFinite(highp vec4 v)');
+    expect(FINITE_GUARD_GLSL).toContain(
+      'highp uvec4 exponentBits = floatBitsToUint(v) & uvec4(0x7f800000u);',
+    );
+    expect(FINITE_GUARD_GLSL).toContain('return equal(exponentBits, uvec4(0x7f800000u));');
+    expect(FINITE_GUARD_GLSL).toContain('vec4 wocSanitizeFinite4(highp vec4 v)');
+    expect(FINITE_GUARD_GLSL).toContain('vec3 wocSanitizeFinite(highp vec3 v)');
+    // No integer declaration without the qualifier.
+    expect(FINITE_GUARD_GLSL).not.toMatch(/(?<!highp )\buvec4\s+\w+\s*=/);
+  });
+
+  it('selects, never mixes, and never compares a possibly-NaN value', () => {
+    expect(FINITE_GUARD_GLSL).toContain('bad.x ? 0.0 : v.x');
+    expect(FINITE_GUARD_GLSL).toContain('bad.w ? 0.0 : v.w');
+    expect(FINITE_GUARD_GLSL).not.toMatch(/mix\s*\(/);
+    expect(FINITE_GUARD_GLSL).not.toMatch(/isnan|isinf|<\s*0\.0\s*\|\||>=\s*0\.0/);
+  });
+
+  it('emits the same rule as one statement for chunk splices inside main()', () => {
+    expect(finiteGuardStatement('outgoingLight.x')).toBe(
+      'outgoingLight.x = ( ( floatBitsToUint( outgoingLight.x ) & 0x7f800000u ) == 0x7f800000u ) ? 0.0 : outgoingLight.x;\n',
+    );
+  });
+});

--- a/tests/post_n8ao.test.ts
+++ b/tests/post_n8ao.test.ts
@@ -153,3 +153,80 @@ describe('reversed-depth premises behind the dropped surgery arm', () => {
     }
   });
 });
+
+describe('degenerate depth-derived normal guard', () => {
+  // On Mali-G715 (Android Chrome) the HALFRES compositer wrote exactly one NaN
+  // texel per affected frame into the composer beauty while the raw scene target
+  // stayed finite: normalize(cross(dpdx, dpdy)) of a zero cross product. Both
+  // shaders that reconstruct that normal from depth carry the length-checked
+  // form, on the full-resolution and the half-resolution configurations alike.
+  // The fallback sits on the `<` branch on purpose: a NaN comparison is
+  // implementation-defined in GLSL ES, so the safe branch must be the one a
+  // non-finite length lands on wherever the driver sends it.
+  const SAFE_RETURN = 'return faceNormalLengthSq < 1e-12';
+  const BARE_RETURN = 'return normalize(cross(dpdx, dpdy));';
+
+  interface CompositerInternals {
+    effectShaderQuad: { material: THREE.ShaderMaterial };
+    effectCompositerQuad: { material: THREE.ShaderMaterial };
+    depthDownsampleQuad?: { material: THREE.ShaderMaterial } | null;
+  }
+
+  const expectGuarded = (shader: string): void => {
+    expect(shader).not.toContain(BARE_RETURN);
+    expect(shader.split(SAFE_RETURN)).toHaveLength(2);
+    expect(shader).toContain('vec3 faceNormal = cross(dpdx, dpdy);');
+    expect(shader).toContain('? vec3(0.0, 1.0, 0.0)');
+    expect(shader).toContain(': faceNormal * inversesqrt(faceNormalLengthSq);');
+  };
+
+  it.each([
+    ['full resolution', false],
+    ['half resolution with depth-aware upsampling', true],
+  ])('guards the evaluation and compositer normals at %s', (_label, halfRes) => {
+    const pass = new StaticOpaqueN8AOPass(
+      new THREE.Scene(),
+      new THREE.PerspectiveCamera(),
+      1279,
+      719,
+    );
+    pass.setQualityMode(halfRes ? 'Low' : 'Medium');
+    if (halfRes) {
+      pass.configuration.halfRes = true;
+      pass.configuration.depthAwareUpsampling = true;
+    }
+    const shaders = pass as unknown as CompositerInternals;
+    expectGuarded(shaders.effectShaderQuad.material.fragmentShader);
+    expectGuarded(shaders.effectCompositerQuad.material.fragmentShader);
+    if (halfRes) {
+      // The half-resolution tiers reconstruct the live normal in the depth
+      // downsample pass (a HalfFloat attachment, where a NaN survives), so it
+      // must carry the guard as well.
+      expect(shaders.depthDownsampleQuad).toBeTruthy();
+      expectGuarded(shaders.depthDownsampleQuad?.material.fragmentShader ?? '');
+    } else {
+      expect(shaders.depthDownsampleQuad ?? null).toBeNull();
+    }
+    pass.dispose();
+  });
+
+  it('applies once per material rebuild and never twice to the same source', () => {
+    const pass = new StaticOpaqueN8AOPass(
+      new THREE.Scene(),
+      new THREE.PerspectiveCamera(),
+      1279,
+      719,
+    );
+    pass.setQualityMode('Low');
+    pass.configuration.halfRes = true;
+    // A second reconfiguration rebuilds every material from the pristine
+    // n8ao source; the guard must be present exactly once afterwards.
+    pass.configuration.halfRes = false;
+    pass.configuration.halfRes = true;
+    const shaders = pass as unknown as CompositerInternals;
+    expectGuarded(shaders.effectShaderQuad.material.fragmentShader);
+    expectGuarded(shaders.effectCompositerQuad.material.fragmentShader);
+    expectGuarded(shaders.depthDownsampleQuad?.material.fragmentShader ?? '');
+    pass.dispose();
+  });
+});

--- a/tests/post_output_grade.test.ts
+++ b/tests/post_output_grade.test.ts
@@ -1,5 +1,6 @@
 import * as THREE from 'three';
 import { describe, expect, it, vi } from 'vitest';
+import { FINITE_GUARD_GLSL } from '../src/render/post_finite_guard_glsl';
 import { OUTPUT_GRADE_FRAGMENT_SHADER, OutputGradePass } from '../src/render/post_output_grade';
 
 describe('fused output and grade shader', () => {
@@ -99,7 +100,12 @@ describe('fused output and grade shader', () => {
     // so OutputGradePass must scrub NaN out of BOTH the beauty read and the
     // (already blur-spread) bloom read. Losing either scrub brings the black back.
     const shader = OUTPUT_GRADE_FRAGMENT_SHADER;
-    expect(shader).toContain('(v.x < 0.0 || v.x >= 0.0) ? v.x : 0.0');
+    // Bit-exact, never a comparison: Mali evaluates NaN comparisons as finite
+    // (see post_finite_guard_glsl.ts), which is how the phone went black with
+    // the comparison form in place.
+    expect(shader).toContain(FINITE_GUARD_GLSL);
+    expect(shader).toContain('return wocSanitizeFinite(v);');
+    expect(shader).not.toContain('v.x < 0.0 || v.x >= 0.0');
     const helperAt = shader.indexOf('vec3 sanitizeFinite(vec3 v) {');
     const beautyScrubAt = shader.indexOf('outputColor.rgb = sanitizeFinite(outputColor.rgb);');
     const diffuseSampleAt = shader.indexOf('vec4 outputColor = texture(tDiffuse, inputUv);');


### PR DESCRIPTION
## Summary

On Android Chrome (Mali-G715, Chrome 152) about 4 percent of frames rendered fully black on the composer tiers (high and above), one frame at a time, several times a minute. The low tier (direct render) never showed one.

**What goes wrong.** Three steps, each measured on the phone with a dev-only readback probe that classifies every presented frame and, on a black one, reads the post-chain targets back and raycasts the offending pixel:

1. The N8AO compositer writes exactly ONE NaN texel per affected frame into the composer beauty, at a different place each time, on unrelated surfaces (pine leaves, particle points, blade grass, a streetlamp), while the raw scene target N8AO rendered stays finite. Its half-resolution depth-aware upsample reconstructs a normal as `normalize(cross(dpdx, dpdy))`; where the two position derivatives give a zero cross product that normalize is NaN, `exp(NaN)` poisons the bilateral weight, `totalWeight` is NaN so its zero guard is not taken, and the divided texel is NaN.
2. The bloom's Gaussian mips smear that one texel over the whole bloom target (100 percent NaN on the frames captured).
3. `OutputGradePass` already scrubbed NaN with `(x < 0.0 || x >= 0.0) ? x : 0.0`, the fix that stopped the ANGLE-GL IBL NaN on desktop (#3426). GLSL ES leaves NaN comparisons implementation-defined and Mali evaluates that test as "finite", so the NaN reaches the ACES tonemap, whose saturate collapses it to 0: a uniformly black frame (the grade's lift is the only signal left, which is exactly what the readback measured).

**The fix, three guards plus the scene-level one they made suspect:**

- `post_n8ao.ts`: the depth-derived normal in the AO evaluation, the depth downsample and the compositer shaders uses a length-checked normalize (the form n8ao itself uses elsewhere) with a fallback on the branch a NaN comparison lands on, spliced through the existing `replacePinned` helper so a shader-shape change in a future n8ao bump fails closed.
- `post_finite_guard_glsl.ts` (new, shared snippet): a bit-exact non-finite test (`floatBitsToUint` exponent bits, every integer qualified `highp`, a select and never a `mix` since `NaN * 0.0` stays NaN) that no driver can fold, scrubbing Inf as well as NaN because ACES of Inf is NaN too. `post_output_grade.ts` now scrubs with it on both the beauty and the bloom read.
- `post_bloom_shader_core.ts` / `post_bloom.ts`: the same guard wraps the bloom high-pass beauty read, so any future stray NaN costs one bloom texel instead of the whole frame's bloom. Fails closed if three's `LuminosityHighPassShader` changes shape.
- `final_color_nan_guard_core.ts`: the unconditional scene-material scrub used the same comparison form, so it was silently inert on Mali; it now emits the bit-exact statement.

Two things the phone taught along the way, both pinned by tests: the grade is a `RawShaderMaterial` declaring only `precision highp float`, so an unqualified `uvec4` inherits GLSL ES 3.00's default `mediump int` and Mali truncates the 0x7f800000 mask to zero (a first build without `highp` flagged every texel and rendered every frame black); and the degenerate-normal fallback has to sit on the `<` branch so an implementation-defined NaN comparison cannot reach the normalize.

All guards are no-ops for finite inputs, so the look is unchanged on every tier.

## Related issues

N/A (reported directly by the maintainer from a phone session).

## Type of change

- [x] Bug fix

## How was this tested?

- Commands:
  - `npx vitest run tests/post_finite_guard_glsl.test.ts tests/post_output_grade.test.ts tests/post_bloom_shader_core.test.ts tests/post_n8ao.test.ts tests/final_color_nan_guard_core.test.ts tests/final_color_nan_guard.test.ts` (53 tests)
  - `npx vitest run --config vitest.browser.config.ts tests/browser/post_finite_guard.browser.test.ts` (Chromium: the guarded high-pass, grade and N8AO programs compile with `checkShaderErrors` on, and NaN / Inf texels grade pixel-identically to the scrubbed zero)
  - `GATE_SELECT_BASE=upstream/release/v0.42.0 node scripts/gate_select.mjs`: PASS, 12 steps
- Manual steps:
  - Before: on the phone (Mali-G715, Android Chrome 152), preset high, the readback probe counted 24 fully black frames in about 600 frames and 11 in about 280 over two sessions, each with the one-NaN-texel signature above; 0 in 1400 frames on the low tier.
  - After: same phone, same preset, 0 black frames in 1476 frames, and a full NaN / Inf census of the composer targets every 30 frames (49 scans) found 0 non-finite texels, so the N8AO guard removes the pixel at its source rather than the grade merely hiding it. A first build with the guard's integers left at the default `mediump` rendered every frame black on the same phone, which is what the `highp` pin guards against.
  - Desktop (Linux, Chrome): high and ultra presets render identically before and after.

## Screenshots / recordings

N/A: the change removes intermittent fully black frames; a still of a normal frame is identical before and after.

---

## Checklist

### Quality

- [x] **The gate passes.** `node scripts/gate_select.mjs` is green. Decisive tests: the guard module pins the mask against real IEEE bit patterns and the `highp` qualifiers; the grade shader pins the shared guard and rejects the comparison form; the bloom test wraps three's installed high-pass and fails closed on a changed shape; the N8AO test checks all three shaders at full and half resolution and across a rebuild; the browser suite proves the scrub on a real driver.

### Cross-platform

- [x] **Tested on desktop and mobile.** Phone (Android Chrome, landscape and portrait) and desktop Chrome.
- [ ] ~Accessible~ N/A, no UI change.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files.