### PR TITLE
feat(perf): report the real 3D drawing buffer in the fleet perf report

### DIFF
--- a/server/perf_report.ts
+++ b/server/perf_report.ts
@@ -258,6 +258,25 @@ function sanitizeBrowserSummary(value: unknown): Record<string, unknown> | undef
   };
 }
 
+// rendererDrawingBuffer: the allocated 3D backing store and the CSS viewport it
+// covers, the only field that says what resolution a session rasterizes at
+// (viewport x dpr is not the allocation). Same JSONB-not-DDL treatment as the
+// longtask block above, and the same reason for a bound: it rides the compact
+// path, where every retained key is copied verbatim, so "four scalars" has to be
+// enforced here rather than trusted. The ceiling is generous against any real
+// panel and MAX_VIEWPORT_DIMS, and only defends the ingest.
+const DRAWING_BUFFER_RAW_PIXELS_MAX = 65_536;
+
+function sanitizeDrawingBuffer(value: unknown): Record<string, unknown> | undefined {
+  if (!isRecord(value)) return undefined;
+  return {
+    width: intIn(value.width, 0, DRAWING_BUFFER_RAW_PIXELS_MAX, 0),
+    height: intIn(value.height, 0, DRAWING_BUFFER_RAW_PIXELS_MAX, 0),
+    cssWidth: intIn(value.cssWidth, 0, DRAWING_BUFFER_RAW_PIXELS_MAX, 0),
+    cssHeight: intIn(value.cssHeight, 0, DRAWING_BUFFER_RAW_PIXELS_MAX, 0),
+  };
+}
+
 // rendererGpuQueue (issue #3167): the background GPU queue drains one unit at
 // a time (plus a small released-tail overlap), so the running unit, the
 // released tails, and the stalls they record are the only evidence a
@@ -732,6 +751,11 @@ function rawSummary(value: unknown, devTraceAllowed = false): Record<string, unk
     const gpuQueue = sanitizeGpuQueueSummary(parsed.rendererGpuQueue);
     if (gpuQueue) parsed.rendererGpuQueue = gpuQueue;
     else delete parsed.rendererGpuQueue;
+    // Field-shaped here, BEFORE the byte check, so the compact path's verbatim
+    // copy of the key is bounded by construction.
+    const drawingBuffer = sanitizeDrawingBuffer(parsed.rendererDrawingBuffer);
+    if (drawingBuffer) parsed.rendererDrawingBuffer = drawingBuffer;
+    else delete parsed.rendererDrawingBuffer;
     // The prewarm summary rides through verbatim on this path, bounded only by
     // the body cap, so its client-supplied LISTS are bounded here explicitly.
     // Without this the resume block's entries and failed-unit ids reach storage
@@ -891,6 +915,7 @@ export const perfReportInternalsForTest = {
   PERF_REPORT_SCHEMA_VERSION,
   LONG_TASK_RAW_MS_MAX,
   LONG_TASK_RAW_AGE_MS_MAX,
+  DRAWING_BUFFER_RAW_PIXELS_MAX,
   GPU_QUEUE_RAW_MS_MAX,
   GPU_QUEUE_RAW_AGE_MS_MAX,
   GPU_QUEUE_RAW_STALLS_MAX,

--- a/server/perf_report.ts
+++ b/server/perf_report.ts
@@ -264,7 +264,9 @@ function sanitizeBrowserSummary(value: unknown): Record<string, unknown> | undef
 // longtask block above, and the same reason for a bound: it rides the compact
 // path, where every retained key is copied verbatim, so "four scalars" has to be
 // enforced here rather than trusted. The ceiling is generous against any real
-// panel and MAX_VIEWPORT_DIMS, and only defends the ingest.
+// panel and MAX_VIEWPORT_DIMS, and only defends the ingest. The flag says
+// whether the governor rasterizes a sub-rect of that allocation, without which
+// a backed-off session reads as if it drew at full size.
 const DRAWING_BUFFER_RAW_PIXELS_MAX = 65_536;
 
 function sanitizeDrawingBuffer(value: unknown): Record<string, unknown> | undefined {
@@ -274,6 +276,7 @@ function sanitizeDrawingBuffer(value: unknown): Record<string, unknown> | undefi
     height: intIn(value.height, 0, DRAWING_BUFFER_RAW_PIXELS_MAX, 0),
     cssWidth: intIn(value.cssWidth, 0, DRAWING_BUFFER_RAW_PIXELS_MAX, 0),
     cssHeight: intIn(value.cssHeight, 0, DRAWING_BUFFER_RAW_PIXELS_MAX, 0),
+    dynamicResolution: Boolean(value.dynamicResolution),
   };
 }
 

--- a/server/perf_report.ts
+++ b/server/perf_report.ts
@@ -701,6 +701,9 @@ function compactRawSummary(value: Record<string, unknown>): Record<string, unkno
     'rendererFoliage',
     'rendererBudget',
     'rendererQualityBuckets',
+    // The allocated drawing buffer (four scalars): the only field that says what
+    // resolution a session rasterizes at, since viewport x dpr does not.
+    'rendererDrawingBuffer',
     'input',
     'hud',
     'netPipeline',

--- a/src/game/perf_reporter.ts
+++ b/src/game/perf_reporter.ts
@@ -615,17 +615,20 @@ function payloadFromSnapshot(
       rendererFoliage: renderer.foliage,
       rendererBudget: renderer.renderBudget,
       rendererQualityBuckets: renderer.qualityBuckets,
-      // The resolution the 3D scene is actually drawn at. The report already
-      // carries the CSS viewport and the DPR, but their product is not the
-      // allocation (the tier's DPR cap and the Render Quality slider both move
-      // the backing store under a fixed viewport), so without this the fleet
-      // cannot say what a Windows session renders. Four bounded scalars in
-      // rawSummary, the no-DDL home: no column, no metric.
+      // The resolution the 3D scene is drawn at. The columns above cannot say
+      // it: `dpr` is the raw window.devicePixelRatio, never the renderer's
+      // capped ratio, and the viewport columns are window.innerWidth/Height,
+      // never the canvas rect. `dynamicResolution` rides along because a
+      // governor-backed-off session allocates at the manual ceiling and
+      // rasterizes a sub-rect, so without the flag it would read as full size
+      // (the reconstruction rule is on DrawingBufferStats). Five bounded
+      // scalars in rawSummary, the no-DDL home: no column, no metric.
       rendererDrawingBuffer: {
         width: renderer.drawingBuffer.width,
         height: renderer.drawingBuffer.height,
         cssWidth: renderer.drawingBuffer.cssWidth,
         cssHeight: renderer.drawingBuffer.cssHeight,
+        dynamicResolution: renderer.drawingBuffer.dynamicResolution,
       },
       rendererDiagnostics: renderer.renderDiagnostics,
       // The summary above is the whole prewarm payload. The live stats object

--- a/src/game/perf_reporter.ts
+++ b/src/game/perf_reporter.ts
@@ -615,6 +615,18 @@ function payloadFromSnapshot(
       rendererFoliage: renderer.foliage,
       rendererBudget: renderer.renderBudget,
       rendererQualityBuckets: renderer.qualityBuckets,
+      // The resolution the 3D scene is actually drawn at. The report already
+      // carries the CSS viewport and the DPR, but their product is not the
+      // allocation (the tier's DPR cap and the Render Quality slider both move
+      // the backing store under a fixed viewport), so without this the fleet
+      // cannot say what a Windows session renders. Four bounded scalars in
+      // rawSummary, the no-DDL home: no column, no metric.
+      rendererDrawingBuffer: {
+        width: renderer.drawingBuffer.width,
+        height: renderer.drawingBuffer.height,
+        cssWidth: renderer.drawingBuffer.cssWidth,
+        cssHeight: renderer.drawingBuffer.cssHeight,
+      },
       rendererDiagnostics: renderer.renderDiagnostics,
       // The summary above is the whole prewarm payload. The live stats object
       // used to ride along beside it as `rendererPrewarm`, from before the

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -4370,6 +4370,15 @@ export class Renderer {
       pixelRatio: this.webgl.getPixelRatio(),
       width: this.viewport.width,
       height: this.viewport.height,
+      // The canvas backing store as allocated, beside the CSS viewport already
+      // cached above: no layout read on a path the 1 Hz sampler and the prewarm
+      // headroom poll both take.
+      drawingBuffer: {
+        width: this.webgl.domElement.width,
+        height: this.webgl.domElement.height,
+        cssWidth: this.viewport.width,
+        cssHeight: this.viewport.height,
+      },
       // Composer tiers serve the accumulated per-frame delta (the live counter is
       // monotonic there, so it already includes the off-screen water-simulation
       // passes); other profiles keep the live post-frame read, where three's

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -4370,14 +4370,14 @@ export class Renderer {
       pixelRatio: this.webgl.getPixelRatio(),
       width: this.viewport.width,
       height: this.viewport.height,
-      // The canvas backing store as allocated, beside the CSS viewport already
-      // cached above: no layout read on a path the 1 Hz sampler and the prewarm
-      // headroom poll both take.
+      // Attribute reads only, no layout: the 1 Hz sampler and the prewarm
+      // headroom poll both take this path (contract in DrawingBufferStats).
       drawingBuffer: {
         width: this.webgl.domElement.width,
         height: this.webgl.domElement.height,
         cssWidth: this.viewport.width,
         cssHeight: this.viewport.height,
+        dynamicResolution: this.post?.supportsDynamicResolution === true,
       },
       // Composer tiers serve the accumulated per-frame delta (the live counter is
       // monotonic there, so it already includes the off-screen water-simulation

--- a/src/render/renderer_perf_stats.ts
+++ b/src/render/renderer_perf_stats.ts
@@ -21,13 +21,23 @@ import type { ZoneStreamingStats } from './zone_prepare_stats';
 
 export type RendererPhase = 'setup' | 'entities' | 'world' | 'nameplates' | 'submit' | 'total';
 
-/** The buffer the 3D scene is actually rasterized into, beside the CSS viewport
- *  it covers. `pixelRatio` x `width`/`height` does NOT reconstruct it: the tier's
- *  DPR cap and the Render Quality slider both move the allocation under a fixed
- *  viewport, so the backing store is the only field that says what a session
- *  really renders. On the dynamic-resolution path (medium's composer) the
- *  allocation stands at the manual ceiling and the governor renders a sub-rect
- *  of it, scaled by the `effectiveRenderScale` this same block already carries. */
+/** The allocated 3D drawing buffer, beside the CSS viewport it covers.
+ *
+ *  Inside THIS block the pair is redundant (`width === floor(cssWidth *
+ *  pixelRatio)`: both canvas sizing sites go through one `setPixelRatio` plus
+ *  `setSize(viewport)`). It is reported because the FLEET REPORT cannot rebuild
+ *  it from its own columns: the beacon's `dpr` is the raw
+ *  `window.devicePixelRatio`, never the renderer's capped ratio, and its
+ *  viewport is `window.innerWidth`/`innerHeight`, never the canvas rect. So
+ *  this is the only field that says what a session rasterizes.
+ *
+ *  On the dynamic-resolution path (`dynamicResolution` true: the grade-only
+ *  composer, medium today) this is the ALLOCATION, held at the manual Render
+ *  Quality ceiling while the governor rasterizes a sub-rect of it. The live
+ *  extent is then this buffer times `effectiveRenderScale / renderScale`, both
+ *  of which the report already carries as their own columns; the factor is that
+ *  RATIO and not `effectiveRenderScale` alone, because the allocation already
+ *  contains the manual scale. Everywhere else the two are the same buffer. */
 export interface DrawingBufferStats {
   /** The canvas backing store, in device pixels (`canvas.width`/`canvas.height`). */
   width: number;
@@ -35,6 +45,11 @@ export interface DrawingBufferStats {
   /** The CSS viewport it covers, from the renderer's cached measurement. */
   cssWidth: number;
   cssHeight: number;
+  /** Whether the governor rasterizes a sub-rect of the allocation rather than
+   *  reallocating. Reported because it is NOT derivable downstream: it comes
+   *  from the post chain's pass list, not from the tier or the quality buckets,
+   *  and without it a backed-off session reads as if it drew at full size. */
+  dynamicResolution: boolean;
 }
 
 export type RendererPhaseStats = Record<

--- a/src/render/renderer_perf_stats.ts
+++ b/src/render/renderer_perf_stats.ts
@@ -21,6 +21,22 @@ import type { ZoneStreamingStats } from './zone_prepare_stats';
 
 export type RendererPhase = 'setup' | 'entities' | 'world' | 'nameplates' | 'submit' | 'total';
 
+/** The buffer the 3D scene is actually rasterized into, beside the CSS viewport
+ *  it covers. `pixelRatio` x `width`/`height` does NOT reconstruct it: the tier's
+ *  DPR cap and the Render Quality slider both move the allocation under a fixed
+ *  viewport, so the backing store is the only field that says what a session
+ *  really renders. On the dynamic-resolution path (medium's composer) the
+ *  allocation stands at the manual ceiling and the governor renders a sub-rect
+ *  of it, scaled by the `effectiveRenderScale` this same block already carries. */
+export interface DrawingBufferStats {
+  /** The canvas backing store, in device pixels (`canvas.width`/`canvas.height`). */
+  width: number;
+  height: number;
+  /** The CSS viewport it covers, from the renderer's cached measurement. */
+  cssWidth: number;
+  cssHeight: number;
+}
+
 export type RendererPhaseStats = Record<
   RendererPhase,
   { count: number; avg: number; p95: number; max: number }
@@ -91,6 +107,9 @@ export interface RendererPerfStats {
   pixelRatio: number;
   width: number;
   height: number;
+  /** The allocated drawing buffer (see DrawingBufferStats): what the fleet perf
+   *  report reads to say the resolution a session actually plays at. */
+  drawingBuffer: DrawingBufferStats;
   calls: number;
   triangles: number;
   geometries: number;

--- a/tests/dynamic_resolution_wiring.test.ts
+++ b/tests/dynamic_resolution_wiring.test.ts
@@ -67,12 +67,19 @@ describe('dynamic resolution renderer wiring', () => {
     expect(renderer).toContain('(-this.tmpV.y * 0.5 + 0.5) * this.viewport.height');
   });
 
-  it('reports the allocated drawing buffer from the canvas, with no layout read', () => {
-    // What perfStats says the scene is rasterized into: the canvas backing
-    // store beside the CSS viewport the renderer already caches. perfStats is
-    // read at boot, by the ~1 Hz metrics sampler and by the prewarm headroom
-    // poll, so a getBoundingClientRect here would be a layout read on a
-    // repeating path; the cached `this.viewport` is the sanctioned source.
+  it('reports the allocated drawing buffer, with the sub-rect flag and no layout read', () => {
+    // What perfStats says a session rasterizes: the canvas backing store beside
+    // the CSS viewport the renderer already caches. perfStats is read at boot,
+    // by the ~1 Hz metrics sampler and by the prewarm headroom poll, so a
+    // getBoundingClientRect here would be a layout read on a repeating path;
+    // the cached `this.viewport` is the sanctioned source.
+    //
+    // The flag is the load-bearing member. On this file's own subject, the
+    // dynamic path, `applyResolution` allocates at the manual ceiling and only
+    // `applyRenderRegion` moves the live extent, so the buffer alone reports a
+    // backed-off session at full size. Nothing downstream can recover the
+    // difference: supportsDynamicResolution comes from the post chain's pass
+    // list, not from the tier the report carries.
     expect(renderer).toContain(
       [
         'drawingBuffer: {',
@@ -80,8 +87,14 @@ describe('dynamic resolution renderer wiring', () => {
         '  height: this.webgl.domElement.height,',
         '  cssWidth: this.viewport.width,',
         '  cssHeight: this.viewport.height,',
+        '  dynamicResolution: this.post?.supportsDynamicResolution === true,',
         '},',
       ].join('\n      '),
+    );
+    // The same predicate the allocation branches on, so the flag cannot drift
+    // from the path it describes.
+    expect(methodSource('private applyRenderRegion(): void')).toContain(
+      'post?.supportsDynamicResolution',
     );
   });
 });

--- a/tests/dynamic_resolution_wiring.test.ts
+++ b/tests/dynamic_resolution_wiring.test.ts
@@ -66,4 +66,22 @@ describe('dynamic resolution renderer wiring', () => {
     expect(renderer).toContain('(this.tmpV.x * 0.5 + 0.5) * this.viewport.width');
     expect(renderer).toContain('(-this.tmpV.y * 0.5 + 0.5) * this.viewport.height');
   });
+
+  it('reports the allocated drawing buffer from the canvas, with no layout read', () => {
+    // What perfStats says the scene is rasterized into: the canvas backing
+    // store beside the CSS viewport the renderer already caches. perfStats is
+    // read at boot, by the ~1 Hz metrics sampler and by the prewarm headroom
+    // poll, so a getBoundingClientRect here would be a layout read on a
+    // repeating path; the cached `this.viewport` is the sanctioned source.
+    expect(renderer).toContain(
+      [
+        'drawingBuffer: {',
+        '  width: this.webgl.domElement.width,',
+        '  height: this.webgl.domElement.height,',
+        '  cssWidth: this.viewport.width,',
+        '  cssHeight: this.viewport.height,',
+        '},',
+      ].join('\n      '),
+    );
+  });
 });

--- a/tests/perf_diagnosis.test.ts
+++ b/tests/perf_diagnosis.test.ts
@@ -95,10 +95,13 @@ function baseSnapshot(): PerfSnapshot {
       pixelRatio: 1.5,
       width: 1440,
       height: 900,
-      // Deliberately NOT width x pixelRatio: the tier's DPR cap and the Render
-      // Quality slider move the backing store under a fixed CSS viewport, which
-      // is the whole reason the block is reported rather than derived.
-      drawingBuffer: { width: 1728, height: 1080, cssWidth: 1440, cssHeight: 900 },
+      drawingBuffer: {
+        width: 1728,
+        height: 1080,
+        cssWidth: 1440,
+        cssHeight: 900,
+        dynamicResolution: false,
+      },
       calls: 300,
       triangles: 1_000_000,
       geometries: 200,

--- a/tests/perf_diagnosis.test.ts
+++ b/tests/perf_diagnosis.test.ts
@@ -95,6 +95,10 @@ function baseSnapshot(): PerfSnapshot {
       pixelRatio: 1.5,
       width: 1440,
       height: 900,
+      // Deliberately NOT width x pixelRatio: the tier's DPR cap and the Render
+      // Quality slider move the backing store under a fixed CSS viewport, which
+      // is the whole reason the block is reported rather than derived.
+      drawingBuffer: { width: 1728, height: 1080, cssWidth: 1440, cssHeight: 900 },
       calls: 300,
       triangles: 1_000_000,
       geometries: 200,

--- a/tests/perf_report.test.ts
+++ b/tests/perf_report.test.ts
@@ -1325,6 +1325,38 @@ describe('perf report ingestion', () => {
     expect(compacted.oversized).toBeUndefined();
   });
 
+  it('field-shapes the drawing buffer rather than storing what was posted', () => {
+    const { rawSummary, DRAWING_BUFFER_RAW_PIXELS_MAX } = perfReportInternalsForTest;
+
+    // Every retained key of the compact path is copied verbatim, so "four
+    // scalars" has to be enforced at the ingest, not trusted. A hostile block
+    // keeps exactly four clamped integers and loses its extra members.
+    const hostile = rawSummary({
+      rendererDrawingBuffer: {
+        width: 1e308,
+        height: -5,
+        cssWidth: '1440.7',
+        cssHeight: { nested: 'x'.repeat(4000) },
+        extra: 'x'.repeat(4000),
+        list: new Array(500).fill('x'),
+      },
+    });
+    expect(hostile.rendererDrawingBuffer).toEqual({
+      width: DRAWING_BUFFER_RAW_PIXELS_MAX,
+      height: 0,
+      cssWidth: 1440,
+      cssHeight: 0,
+    });
+
+    // A non-record block is dropped, never stored as whatever was sent.
+    expect(rawSummary({ rendererDrawingBuffer: 'x'.repeat(4000) })).not.toHaveProperty(
+      'rendererDrawingBuffer',
+    );
+    expect(rawSummary({ rendererDrawingBuffer: [1, 2, 3] })).not.toHaveProperty(
+      'rendererDrawingBuffer',
+    );
+  });
+
   it('stores the GPU queue block bounded, and keeps it when raw summaries are truncated (#3167)', async () => {
     const {
       GPU_QUEUE_RAW_MS_MAX,

--- a/tests/perf_report.test.ts
+++ b/tests/perf_report.test.ts
@@ -1282,6 +1282,49 @@ describe('perf report ingestion', () => {
     expect((stored.rawSummary as Record<string, unknown>).oversized).toBeUndefined();
   });
 
+  it('keeps the drawing buffer block, verbatim and across truncation', async () => {
+    const drawingBuffer = { width: 1728, height: 1080, cssWidth: 1440, cssHeight: 900 };
+
+    const kept = fakeRes();
+    await handlePerfReport(
+      fakeReq({
+        sessionId: 'drawing-buffer-kept',
+        rawSummary: { seconds: 30, rendererDrawingBuffer: drawingBuffer },
+      }),
+      kept,
+    );
+    expect(kept.statusCode).toBe(200);
+    const stored = vi.mocked(insertClientPerfReport).mock.calls.at(-1)![0];
+    expect((stored.rawSummary as Record<string, unknown>).rendererDrawingBuffer).toEqual(
+      drawingBuffer,
+    );
+    expect((stored.rawSummary as Record<string, unknown>).truncated).toBeUndefined();
+
+    // The block is what says at what resolution a fleet actually plays, and an
+    // oversized report is exactly the session whose resolution is worth reading,
+    // so the compact path names it too.
+    const truncated = fakeRes();
+    await handlePerfReport(
+      fakeReq({
+        sessionId: 'drawing-buffer-truncated',
+        rawSummary: {
+          seconds: 30,
+          rendererDrawingBuffer: drawingBuffer,
+          oversized: 'x'.repeat(40_000),
+        },
+      }),
+      truncated,
+    );
+    expect(truncated.statusCode).toBe(200);
+    const compacted = vi.mocked(insertClientPerfReport).mock.calls.at(-1)![0].rawSummary as Record<
+      string,
+      unknown
+    >;
+    expect(compacted.truncated).toBe(true);
+    expect(compacted.rendererDrawingBuffer).toEqual(drawingBuffer);
+    expect(compacted.oversized).toBeUndefined();
+  });
+
   it('stores the GPU queue block bounded, and keeps it when raw summaries are truncated (#3167)', async () => {
     const {
       GPU_QUEUE_RAW_MS_MAX,

--- a/tests/perf_report.test.ts
+++ b/tests/perf_report.test.ts
@@ -1283,7 +1283,13 @@ describe('perf report ingestion', () => {
   });
 
   it('keeps the drawing buffer block, verbatim and across truncation', async () => {
-    const drawingBuffer = { width: 1728, height: 1080, cssWidth: 1440, cssHeight: 900 };
+    const drawingBuffer = {
+      width: 1728,
+      height: 1080,
+      cssWidth: 1440,
+      cssHeight: 900,
+      dynamicResolution: true,
+    };
 
     const kept = fakeRes();
     await handlePerfReport(
@@ -1346,6 +1352,7 @@ describe('perf report ingestion', () => {
       height: 0,
       cssWidth: 1440,
       cssHeight: 0,
+      dynamicResolution: false,
     });
 
     // A non-record block is dropped, never stored as whatever was sent.

--- a/tests/perf_reporter.test.ts
+++ b/tests/perf_reporter.test.ts
@@ -550,6 +550,10 @@ function snapshot(): PerfSnapshot {
       pixelRatio: 1.5,
       width: 1440,
       height: 900,
+      // Deliberately NOT width x pixelRatio (2160x1350): the tier's DPR cap and
+      // the Render Quality slider move the backing store under a fixed CSS
+      // viewport, so the fleet reads the allocation rather than deriving it.
+      drawingBuffer: { width: 1728, height: 1080, cssWidth: 1440, cssHeight: 900 },
       calls: 500,
       triangles: 300000,
       geometries: 120,
@@ -685,6 +689,17 @@ describe('perf reporter payload', () => {
     // rides in rawSummary (the no-DDL home), never as a top-level column.
     expect((body.rawSummary as { hiddenPresentSkips?: number }).hiddenPresentSkips).toBe(0);
     expect((body.rawSummary as { graphicsConfigVersion?: number }).graphicsConfigVersion).toBe(16);
+    // The 3D drawing buffer rides in rawSummary (the no-DDL home): the fleet
+    // cannot say what resolution a session plays at from the columns alone.
+    // The fixture's buffer is 1728x1080 while its viewport x pixelRatio is
+    // 2160x1350, so a regression that derived the block instead of reading the
+    // canvas backing store reds on these exact values.
+    expect((body.rawSummary as { rendererDrawingBuffer?: unknown }).rendererDrawingBuffer).toEqual({
+      width: 1728,
+      height: 1080,
+      cssWidth: 1440,
+      cssHeight: 900,
+    });
     // The entry reveal wait rides in rawSummary too (the fleet-side watch for the
     // establishing-shot bound): the counters verbatim, the waits from the ring.
     expect((body.rawSummary as { entryReveal?: unknown }).entryReveal).toEqual({

--- a/tests/perf_reporter.test.ts
+++ b/tests/perf_reporter.test.ts
@@ -550,10 +550,15 @@ function snapshot(): PerfSnapshot {
       pixelRatio: 1.5,
       width: 1440,
       height: 900,
-      // Deliberately NOT width x pixelRatio (2160x1350): the tier's DPR cap and
-      // the Render Quality slider move the backing store under a fixed CSS
-      // viewport, so the fleet reads the allocation rather than deriving it.
-      drawingBuffer: { width: 1728, height: 1080, cssWidth: 1440, cssHeight: 900 },
+      // A governor-backed-off medium session: the allocation stands at the
+      // manual ceiling and the flag says the scene rasterizes a sub-rect of it.
+      drawingBuffer: {
+        width: 1728,
+        height: 1080,
+        cssWidth: 1440,
+        cssHeight: 900,
+        dynamicResolution: true,
+      },
       calls: 500,
       triangles: 300000,
       geometries: 120,
@@ -689,16 +694,18 @@ describe('perf reporter payload', () => {
     // rides in rawSummary (the no-DDL home), never as a top-level column.
     expect((body.rawSummary as { hiddenPresentSkips?: number }).hiddenPresentSkips).toBe(0);
     expect((body.rawSummary as { graphicsConfigVersion?: number }).graphicsConfigVersion).toBe(16);
-    // The 3D drawing buffer rides in rawSummary (the no-DDL home): the fleet
-    // cannot say what resolution a session plays at from the columns alone.
-    // The fixture's buffer is 1728x1080 while its viewport x pixelRatio is
-    // 2160x1350, so a regression that derived the block instead of reading the
-    // canvas backing store reds on these exact values.
+    // The 3D drawing buffer rides in rawSummary (the no-DDL home): the report's
+    // own columns cannot say what a session rasterizes, because `dpr` is the raw
+    // window.devicePixelRatio and the viewport columns are window.innerWidth /
+    // innerHeight, neither of which is the renderer's capped ratio or the canvas
+    // rect. The dynamicResolution flag has to survive with the numbers: without
+    // it a governor-backed-off session reads as if it drew at full allocation.
     expect((body.rawSummary as { rendererDrawingBuffer?: unknown }).rendererDrawingBuffer).toEqual({
       width: 1728,
       height: 1080,
       cssWidth: 1440,
       cssHeight: 900,
+      dynamicResolution: true,
     });
     // The entry reveal wait rides in rawSummary too (the fleet-side watch for the
     // establishing-shot bound): the counters verbatim, the waits from the ring.


### PR DESCRIPTION
## Summary

The fleet performance report cannot say what resolution a session actually
renders at. It carries the Render Quality percentage, the graphics tier, a CSS
viewport and a device pixel ratio, but nothing that describes the buffer the 3D
scene is drawn into, and the columns it does carry cannot be multiplied into
one: the beacon's `dpr` is the raw `window.devicePixelRatio`, never the
renderer's per-tier capped ratio, and its viewport columns are
`window.innerWidth`/`innerHeight`, never the canvas rect. Two Windows clients
on the same reported columns can rasterize very different pixel counts. That is
the number the preset-ladder work needs, and today it is simply absent.

This adds it, as data only.

**`Renderer.perfStats()` gains `drawingBuffer`:**

- `width` / `height`: the canvas backing store in device pixels
  (`canvas.width` / `canvas.height`, a plain attribute read, no layout flush).
- `cssWidth` / `cssHeight`: the CSS viewport it covers, taken from the
  measurement the renderer already caches, so nothing on this path touches the
  DOM. `perfStats()` is read at boot, by the ~1 Hz metrics sampler and by the
  prewarm headroom poll, never per frame.
- `dynamicResolution`: whether the governor rasterizes a sub-rect of that
  allocation instead of reallocating.

That last flag is load-bearing rather than decorative. On the grade-only
composer path, `applyResolution` allocates at the manual Render Quality ceiling
and only the render region moves, so a backed-off session's backing store still
reads full size. Nothing downstream can recover the difference on its own:
`supportsDynamicResolution` is derived from the post chain's pass list, not from
the tier or the quality buckets the report already carries. With the flag, the
live extent is the reported buffer times `effectiveRenderScale / renderScale`,
both of which the report carries as their own columns. The ratio, not
`effectiveRenderScale` alone, because the allocation already contains the manual
scale; the contract on `DrawingBufferStats` states that rule.

**Where it lands.** `src/game/perf_reporter.ts` forwards the block into the
beacon as `rawSummary.rendererDrawingBuffer`. `server/perf_report.ts`
field-shapes it on ingest, in the sanitizer family beside the longtask and
GPU-queue blocks and before the byte check, so the four scalars are clamped
integers and the flag a real boolean whatever was posted; that also makes the
compact (truncated) path's verbatim copy bounded by construction, and the key is
on that path's retained list because an oversized report is exactly the session
whose resolution is worth reading.

The block rides the existing `raw_summary` JSONB: **no new Postgres column and
no new Prometheus metric**, deliberately. Nothing player-visible changes: no
overlay row, no Options readout, no dev flag, no new string.

## Related issues

N/A.

## Type of change

- [x] Feature: new functionality
- [ ] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change

## How was this tested?

- Commands:
  - `npx tsc --noEmit`, clean. The new field is required on
    `RendererPerfStats`, so every fixture that builds one had to be completed.
  - `npx vitest run tests/dynamic_resolution_wiring.test.ts
    tests/perf_diagnosis.test.ts tests/perf_reporter.test.ts
    tests/perf_report.test.ts tests/monolith_budget.test.ts
    tests/architecture.test.ts tests/renderer_frame_stats_snapshot.test.ts`
  - `npm run gate:fast` against `release/v0.42.0`: PASS.
- Tests added or extended:
  - `tests/dynamic_resolution_wiring.test.ts`, which already owns the
    resolution wiring pins, pins the renderer readout to its exact source (the
    canvas backing store and the cached viewport, so a `getBoundingClientRect`
    or a width/height transposition reds) and pins the flag to the same
    predicate `applyRenderRegion` branches on, so it cannot drift from the path
    it describes.
  - `tests/perf_reporter.test.ts` pins `rawSummary.rendererDrawingBuffer` as the
    exact block, on a governor-backed-off fixture, so dropping the flag reds.
  - `tests/perf_report.test.ts` pins the server on three arms: stored verbatim
    on the normal path, retained by the compact path under truncation, and
    field-shaped against a hostile block (a huge number, a negative, a numeric
    string, a nested object, extra keys and a list), which comes back as four
    clamped integers plus the boolean and nothing else. Both the retention and
    the clamp were checked decisive by reverting the server change and watching
    them go red.
  - `tests/perf_diagnosis.test.ts` carries the new field in its `perfStats`
    fixture.
- Manual steps: none. The change adds no visual or interactive surface.

Reviewed by the repo's `server-hot-path-reviewer` and
`render-performance-reviewer`. Both fed back into the branch: the ingest
sanitizer and its hostile-input test came from the first, and the
`dynamicResolution` flag plus two corrected claims in the field's contract came
from the second.

## Screenshots / recordings

N/A, nothing visual changes.

---

## Checklist

### Quality

- [x] **The gate passes.** `npm run gate:fast` is green on this branch against
      `release/v0.42.0`, with decisive tests on the renderer readout, the
      beacon payload, and the server ingest.

### Cross-platform

- [x] **Tested on desktop and mobile.** The owner played an online session on a
      phone (landscape and portrait) and on a desktop against a local server: the
      reports landed in `client_perf_reports.raw_summary.rendererDrawingBuffer`
      with the expected shape (phone 1366x608 for a 923x411 CSS view at the 1.48
      pixel-ratio cap, desktop 1920x1080 then 1854x961 after a window resize,
      `dynamicResolution: true` beside a governed resolution level under 1).
- [x] ~~Accessible.~~ N/A. No UI surface is added or changed.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] No generated file was hand-edited.

