### PR TITLE
feat(parse): snapshot aura state and classify every event type

### DIFF
--- a/scripts/parse/gen_event_policy.cjs
+++ b/scripts/parse/gen_event_policy.cjs
@@ -53,7 +53,7 @@ if (names.size === 0) throw new Error('no event type literals found');
 const existing = new Map();
 if (fs.existsSync(policyPath)) {
   const current = fs.readFileSync(policyPath, 'utf8');
-  for (const m of current.matchAll(/^  ([A-Za-z0-9_]+): '(routed|record|skip)',/gm)) {
+  for (const m of current.matchAll(/^ {2}([A-Za-z0-9_]+): '(routed|record|skip)',/gm)) {
     existing.set(m[1], m[2]);
   }
 }

--- a/scripts/parse/gen_event_policy.cjs
+++ b/scripts/parse/gen_event_policy.cjs
@@ -1,0 +1,124 @@
+// Regenerates server/parse/event_policy.ts from the SimEvent union.
+//
+// Reads the union through the TypeScript checker (so members declared as
+// named aliases count, not just inline `{ type: '...' }` literals), keeps
+// every classification already present in the file, and adds new types as
+// 'skip' with a TODO marker so the diff shows exactly what needs a decision.
+// Typecheck is the real guard (the map is a Record over the union); this
+// script just saves the typing.
+//
+//   node scripts/parse/gen_event_policy.cjs
+const fs = require('node:fs');
+const path = require('node:path');
+const ts = require('typescript');
+
+const root = path.resolve(__dirname, '..', '..');
+const typesPath = path.join(root, 'src', 'sim', 'types.ts');
+const policyPath = path.join(root, 'server', 'parse', 'event_policy.ts');
+
+const program = ts.createProgram([typesPath], {
+  target: ts.ScriptTarget.ES2022,
+  module: ts.ModuleKind.ESNext,
+  moduleResolution: ts.ModuleResolutionKind.Bundler,
+  strict: true,
+  noEmit: true,
+  skipLibCheck: true,
+});
+const checker = program.getTypeChecker();
+const source = program.getSourceFile(typesPath);
+if (!source) throw new Error(`cannot load ${typesPath}`);
+
+let simEventType = null;
+ts.forEachChild(source, (node) => {
+  if (ts.isTypeAliasDeclaration(node) && node.name.text === 'SimEvent') {
+    simEventType = checker.getTypeAtLocation(node.name);
+  }
+});
+if (!simEventType) throw new Error('SimEvent alias not found');
+
+const names = new Set();
+const members = simEventType.isUnion() ? simEventType.types : [simEventType];
+for (const member of members) {
+  const prop = member.getProperty('type');
+  if (!prop) continue;
+  const propType = checker.getTypeOfSymbol(prop);
+  const literals = propType.isUnion() ? propType.types : [propType];
+  for (const literal of literals) {
+    if (literal.isStringLiteral()) names.add(literal.value);
+  }
+}
+if (names.size === 0) throw new Error('no event type literals found');
+
+// Keep existing decisions; only genuinely new types get the placeholder.
+const existing = new Map();
+if (fs.existsSync(policyPath)) {
+  const current = fs.readFileSync(policyPath, 'utf8');
+  for (const m of current.matchAll(/^  ([A-Za-z0-9_]+): '(routed|record|skip)',/gm)) {
+    existing.set(m[1], m[2]);
+  }
+}
+
+const sorted = [...names].sort();
+const added = [];
+const entries = sorted
+  .map((name) => {
+    const policy = existing.get(name);
+    if (policy !== undefined) return `  ${name}: '${policy}',`;
+    added.push(name);
+    return `  ${name}: 'skip', // TODO(parse): classify (new event type)`;
+  })
+  .join('\n');
+const removed = [...existing.keys()].filter((name) => !names.has(name));
+
+const out = `// Recording policy for every SimEvent type the drain can carry.
+//
+// The recorder used to route a hand-picked handful of event types and let a
+// bare \`default: break\` swallow the rest, which is how respawns and
+// resurrection offers stayed invisible to the parse: nothing forced a
+// decision when those events were added. This map is keyed by the FULL
+// SimEvent type union, so adding a type to the sim fails typecheck here until
+// someone classifies it. The classification is the decision record.
+//
+// - routed: the recorder has a bespoke handler (attribution, rollups, fight
+//   opening) in recorder.ts.
+// - record: shipped verbatim to the fight of the event's actor; no rollup.
+//   Combat-meaningful state changes with no bespoke handling live here.
+// - skip: cosmetic, UI-only, or non-combat (chat, loot, quests, cues, ...).
+//   Volume or privacy, never "nobody asked yet".
+//
+// Regenerate the key list with scripts/parse/gen_event_policy.cjs when the
+// union changes (existing decisions are kept, new types land as 'skip' with
+// a TODO), or add the new key by hand; typecheck enforces completeness.
+import type { SimEvent } from '../../src/sim/types';
+
+export type EventRecordPolicy = 'routed' | 'record' | 'skip';
+
+export const EVENT_RECORD_POLICY: Readonly<Record<SimEvent['type'], EventRecordPolicy>> = {
+${entries}
+};
+
+/** Event types the generic \`record\` path ships; exported for tests. */
+export const GENERIC_RECORDED_EVENT_TYPES: ReadonlySet<SimEvent['type']> = new Set(
+  (Object.keys(EVENT_RECORD_POLICY) as SimEvent['type'][]).filter(
+    (type) => EVENT_RECORD_POLICY[type] === 'record',
+  ),
+);
+
+/**
+ * The entity a generically recorded event belongs to, in the sim's own
+ * precedence: a personal event's pid, else the acting entity, else the
+ * target, else the source. Null when the event names nobody.
+ */
+export function eventActorId(ev: SimEvent): number | null {
+  const fields = ev as Record<string, unknown>;
+  for (const key of ['pid', 'entityId', 'targetId', 'sourceId']) {
+    const value = fields[key];
+    if (typeof value === 'number') return value;
+  }
+  return null;
+}
+`;
+fs.writeFileSync(policyPath, out);
+console.log(
+  `event_policy.ts: ${sorted.length} types, ${added.length} new (${added.join(', ') || 'none'}), ${removed.length} stale (${removed.join(', ') || 'none'})`,
+);

--- a/scripts/parse/gen_event_policy.mjs
+++ b/scripts/parse/gen_event_policy.mjs
@@ -7,12 +7,13 @@
 // Typecheck is the real guard (the map is a Record over the union); this
 // script just saves the typing.
 //
-//   node scripts/parse/gen_event_policy.cjs
-const fs = require('node:fs');
-const path = require('node:path');
-const ts = require('typescript');
+//   node scripts/parse/gen_event_policy.mjs
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
 
-const root = path.resolve(__dirname, '..', '..');
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
 const typesPath = path.join(root, 'src', 'sim', 'types.ts');
 const policyPath = path.join(root, 'server', 'parse', 'event_policy.ts');
 
@@ -86,7 +87,7 @@ const out = `// Recording policy for every SimEvent type the drain can carry.
 // - skip: cosmetic, UI-only, or non-combat (chat, loot, quests, cues, ...).
 //   Volume or privacy, never "nobody asked yet".
 //
-// Regenerate the key list with scripts/parse/gen_event_policy.cjs when the
+// Regenerate the key list with scripts/parse/gen_event_policy.mjs when the
 // union changes (existing decisions are kept, new types land as 'skip' with
 // a TODO), or add the new key by hand; typecheck enforces completeness.
 import type { SimEvent } from '../../src/sim/types';

--- a/server/parse/CLAUDE.md
+++ b/server/parse/CLAUDE.md
@@ -119,11 +119,36 @@ id-keyset batches, and projects only the state sub-paths it needs, never the
 whole JSONB blob. Rows enqueue in chunks per event-loop turn so a large realm
 never fans a whole snapshot into the shipper on the world-loop thread.
 
+## Completeness guards (what stops "used in-game, missing from the parse")
+The Ignivar Chains partner lived on the aura object (`value2`), was drawn by
+the renderer every tick, and never reached the parse because the aura EVENT
+carried only identity and the recorder hand-picked three fields off the
+object. Two structural guards now replace hand-picking:
+- **Event types are classified, not defaulted.** `event_policy.ts` maps the
+  FULL `SimEvent['type']` union to `routed` (bespoke handler in
+  `recorder.ts`), `record` (shipped verbatim to the actor's fight via
+  `routeRecorded`, e.g. `respawn`, `resurrectionOffer`) or `skip`. It is a
+  `Record` over the union, so adding an event type to the sim fails typecheck
+  until it is classified; `scripts/parse/gen_event_policy.cjs` regenerates
+  the key list. Classify by volume and privacy, never by "nobody asked yet".
+- **Aura state ships whole.** `aura_state.ts` snapshots EVERY scalar field
+  of the live aura on a gained event into `x.auraState`, minus a typed
+  omit list (`AURA_STATE_OMIT`, identity already carried beside it and
+  per-tick counters). A field added to `Aura` reaches the parse with no
+  recorder change; a field that must not ship is an explicit entry there.
+  `linkedEntityId` is the one reserved key (tether partner; the service
+  renders it as a link), so a new pairing mechanic that sets it is recorded
+  and shown with no per-mechanic wiring.
+
 ## Known capture limits (v1, deliberate)
 - Aura attribution: `Sim.applyAura` gained/displaced events carry
   sourceId/abilityId/stacks; the many scattered FADE emit sites elsewhere in
   the sim are not yet widened, so fades enrich only via the best-effort
   state-join fallback in `recorder.ts`.
+- Encounter code that strips an aura by filtering `entity.auras` directly
+  bypasses the aura system's fade emit; the parse then sees the aura as up
+  until the next natural expiry. Emit the fade at such sites (Ignivar Chains
+  does since the state-snapshot change).
 - Overheal: a periodic tick that FULLY overheals emits no heal2 at all (those
   sim sites gate on `healed > 0`, unchanged), so overheal totals undercount
   the at-full-health case; direct heals report it exactly.

--- a/server/parse/CLAUDE.md
+++ b/server/parse/CLAUDE.md
@@ -129,13 +129,17 @@ object. Two structural guards now replace hand-picking:
   `recorder.ts`), `record` (shipped verbatim to the actor's fight via
   `routeRecorded`, e.g. `respawn`, `resurrectionOffer`) or `skip`. It is a
   `Record` over the union, so adding an event type to the sim fails typecheck
-  until it is classified; `scripts/parse/gen_event_policy.cjs` regenerates
+  until it is classified; `scripts/parse/gen_event_policy.mjs` regenerates
   the key list. Classify by volume and privacy, never by "nobody asked yet".
 - **Aura state ships whole.** `aura_state.ts` snapshots EVERY scalar field
   of the live aura on a gained event into `x.auraState`, minus a typed
-  omit list (`AURA_STATE_OMIT`, identity already carried beside it and
-  per-tick counters). A field added to `Aura` reaches the parse with no
-  recorder change; a field that must not ship is an explicit entry there.
+  omit list (`AURA_STATE_OMIT`: identity already carried beside it, per-tick
+  counters, and the mechanics' own bookkeeping cursors). A field added to
+  `Aura` reaches the parse with no recorder change; a field that must not
+  ship is an explicit entry there. The defensive field cap cannot trip with
+  today's `Aura`; if it ever does, `ParseCounters.auraStateTruncated`
+  (`woc_parse_aura_state_truncated_total`) says so rather than losing fields
+  silently.
   `linkedEntityId` is the one reserved key (tether partner; the service
   renders it as a link), so a new pairing mechanic that sets it is recorded
   and shown with no per-mechanic wiring.
@@ -147,8 +151,8 @@ object. Two structural guards now replace hand-picking:
   state-join fallback in `recorder.ts`.
 - Encounter code that strips an aura by filtering `entity.auras` directly
   bypasses the aura system's fade emit; the parse then sees the aura as up
-  until the next natural expiry. Emit the fade at such sites (Ignivar Chains
-  does since the state-snapshot change).
+  until the next natural expiry. Emit the fade at such sites (every Ignivar
+  Chains strip does: pair release, encounter reset, and arena departure).
 - Overheal: a periodic tick that FULLY overheals emits no heal2 at all (those
   sim sites gate on `healed > 0`, unchanged), so overheal totals undercount
   the at-full-health case; direct heals report it exactly.

--- a/server/parse/aura_state.ts
+++ b/server/parse/aura_state.ts
@@ -13,10 +13,12 @@ import type { Aura } from '../../src/sim/types';
 import type { AuraStateSnapshot } from './contract';
 
 /**
- * Never snapshotted: identity the enrichment already carries beside the
- * snapshot (auraId / auraSourceId / auraStacks), and per-tick countdowns or
- * accruals whose value at application is either the duration (already
- * shipped) or zero.
+ * Never snapshotted. Three groups: identity the enrichment already carries
+ * beside the snapshot (auraId / auraSourceId / auraStacks); per-tick
+ * countdowns and accruals whose value at application is either the duration
+ * (already shipped) or zero; and per-application bookkeeping the owning
+ * mechanic keeps for itself (lockout and tick cursors, the extension ledger,
+ * the Chronomancy tick countdown), whose values are noise to a reader.
  */
 export const AURA_STATE_OMIT: ReadonlySet<keyof Aura> = new Set<keyof Aura>([
   'id',
@@ -27,6 +29,10 @@ export const AURA_STATE_OMIT: ReadonlySet<keyof Aura> = new Set<keyof Aura>([
   'tickTimer',
   'damageAccrued',
   'icd',
+  'actionGainLockout',
+  'gloomtitheTick',
+  'extendedBy',
+  'temporalHealTicksRemaining',
 ]);
 
 /** Defensive bounds: an aura is a handful of scalars, never a payload. */
@@ -37,12 +43,23 @@ export const MAX_AURA_STATE_STRING = 64;
  * Scalar (number / string / boolean) fields of a live aura, minus the omit
  * list, in the object's own key order (stable per construction site, which
  * keeps golden captures byte-identical). Undefined when nothing remains.
+ * `onTruncate` fires once when the field cap cuts the snapshot short, so a
+ * caller can count it (the recorder bumps ParseCounters.auraStateTruncated):
+ * the cap cannot trip with today's Aura, and if it ever does the loss must be
+ * visible, not silent, in the module whose point is completeness.
  */
-export function auraStateSnapshot(aura: object): AuraStateSnapshot | undefined {
+export function auraStateSnapshot(
+  aura: object,
+  onTruncate?: () => void,
+): AuraStateSnapshot | undefined {
   let out: AuraStateSnapshot | undefined;
   let count = 0;
-  for (const [key, value] of Object.entries(aura)) {
+  // for..in over own keys: same output as Object.entries with no tuple
+  // allocation per key on every gained aura event.
+  for (const key in aura) {
+    if (!Object.hasOwn(aura, key)) continue;
     if (AURA_STATE_OMIT.has(key as keyof Aura)) continue;
+    const value = (aura as Record<string, unknown>)[key];
     let scalar: number | string | boolean;
     if (typeof value === 'number') {
       if (!Number.isFinite(value)) continue;
@@ -54,7 +71,10 @@ export function auraStateSnapshot(aura: object): AuraStateSnapshot | undefined {
     } else {
       continue;
     }
-    if (count >= MAX_AURA_STATE_FIELDS) break;
+    if (count >= MAX_AURA_STATE_FIELDS) {
+      onTruncate?.();
+      break;
+    }
     out ??= {};
     out[key] = scalar;
     count++;

--- a/server/parse/aura_state.ts
+++ b/server/parse/aura_state.ts
@@ -1,0 +1,63 @@
+// Aura state snapshot: what a gained aura event ships beyond its identity.
+//
+// The sim's Aura object carries the mechanic's working state (value, value2,
+// kind, school, a tether partner, ...) and the aura EVENT carries none of it,
+// which is how the Ignivar Chains partner (value2) went unrecorded while the
+// renderer drew it every tick. Rather than hand-pick fields (the gap simply
+// moves to the next new field), the recorder snapshots EVERY scalar field on
+// the live aura at application and omits a typed denylist. A field added to
+// `Aura` therefore reaches the parse with no recorder change; a field that
+// must NOT ship is an explicit decision here, checked against the Aura type
+// so a rename cannot silently reopen the gap.
+import type { Aura } from '../../src/sim/types';
+import type { AuraStateSnapshot } from './contract';
+
+/**
+ * Never snapshotted: identity the enrichment already carries beside the
+ * snapshot (auraId / auraSourceId / auraStacks), and per-tick countdowns or
+ * accruals whose value at application is either the duration (already
+ * shipped) or zero.
+ */
+export const AURA_STATE_OMIT: ReadonlySet<keyof Aura> = new Set<keyof Aura>([
+  'id',
+  'name',
+  'sourceId',
+  'stacks',
+  'remaining',
+  'tickTimer',
+  'damageAccrued',
+  'icd',
+]);
+
+/** Defensive bounds: an aura is a handful of scalars, never a payload. */
+export const MAX_AURA_STATE_FIELDS = 32;
+export const MAX_AURA_STATE_STRING = 64;
+
+/**
+ * Scalar (number / string / boolean) fields of a live aura, minus the omit
+ * list, in the object's own key order (stable per construction site, which
+ * keeps golden captures byte-identical). Undefined when nothing remains.
+ */
+export function auraStateSnapshot(aura: object): AuraStateSnapshot | undefined {
+  let out: AuraStateSnapshot | undefined;
+  let count = 0;
+  for (const [key, value] of Object.entries(aura)) {
+    if (AURA_STATE_OMIT.has(key as keyof Aura)) continue;
+    let scalar: number | string | boolean;
+    if (typeof value === 'number') {
+      if (!Number.isFinite(value)) continue;
+      scalar = value;
+    } else if (typeof value === 'string') {
+      scalar = value.length > MAX_AURA_STATE_STRING ? value.slice(0, MAX_AURA_STATE_STRING) : value;
+    } else if (typeof value === 'boolean') {
+      scalar = value;
+    } else {
+      continue;
+    }
+    if (count >= MAX_AURA_STATE_FIELDS) break;
+    out ??= {};
+    out[key] = scalar;
+    count++;
+  }
+  return out;
+}

--- a/server/parse/contract.ts
+++ b/server/parse/contract.ts
@@ -109,6 +109,18 @@ export interface ParticipantJoinRecord {
   participant: FightParticipant;
 }
 
+/**
+ * The live aura's scalar state at application, joined by the recorder: every
+ * number/string/boolean field on the sim's Aura object except the identity
+ * fields already carried beside it and the per-tick counters
+ * (server/parse/aura_state.ts in the game repo owns the omit list). The set
+ * of keys is whatever the sim's Aura type carries at capture time, so a field
+ * added to the sim reaches the parse without a contract change; readers must
+ * treat every key as optional. `linkedEntityId` is the one key with reserved
+ * meaning: another entity this aura ties its holder to (a tether partner).
+ */
+export type AuraStateSnapshot = Record<string, number | string | boolean>;
+
 /** Capture-time enrichments only the recorder can compute (state joins). */
 export interface EventEnrichment {
   /** Pet attribution: the owning player's entityId, joined at drain time. */
@@ -117,6 +129,8 @@ export interface EventEnrichment {
   auraSourceId?: number;
   auraId?: string;
   auraStacks?: number;
+  /** Aura scalar state at application (gained events only). */
+  auraState?: AuraStateSnapshot;
 }
 
 export interface EventRecord {

--- a/server/parse/counters.ts
+++ b/server/parse/counters.ts
@@ -20,6 +20,11 @@ export interface ParseCounters {
   observeMsMax: number;
   /** Set once when the budget breaker disables capture; requires a restart. */
   captureDisabled: number;
+  /** Gained aura events whose state snapshot hit the field cap and was cut
+   * short (aura_state.ts): completeness is the module's whole point, so a
+   * truncation must be visible rather than silent. Zero unless Aura grows
+   * past the cap. */
+  auraStateTruncated: number;
   censusRuns: number;
   censusRows: number;
   censusFailures: number;
@@ -42,6 +47,7 @@ export function createParseCounters(): ParseCounters {
     observeMsLast: 0,
     observeMsMax: 0,
     captureDisabled: 0,
+    auraStateTruncated: 0,
     censusRuns: 0,
     censusRows: 0,
     censusFailures: 0,
@@ -120,6 +126,11 @@ export function registerParseMetrics(registry: Registry, counters: ParseCounters
     'woc_parse_capture_disabled',
     'Budget breaker tripped (1 = capture off)',
     () => counters.captureDisabled,
+  );
+  gauge(
+    'woc_parse_aura_state_truncated_total',
+    'Gained aura events whose state snapshot hit the field cap',
+    () => counters.auraStateTruncated,
   );
   gauge('woc_parse_census_runs_total', 'Census exports since boot', () => counters.censusRuns);
   gauge(

--- a/server/parse/event_policy.ts
+++ b/server/parse/event_policy.ts
@@ -1,0 +1,192 @@
+// Recording policy for every SimEvent type the drain can carry.
+//
+// The recorder used to route a hand-picked handful of event types and let a
+// bare `default: break` swallow the rest, which is how respawns and
+// resurrection offers stayed invisible to the parse: nothing forced a
+// decision when those events were added. This map is keyed by the FULL
+// SimEvent type union, so adding a type to the sim fails typecheck here until
+// someone classifies it. The classification is the decision record.
+//
+// - routed: the recorder has a bespoke handler (attribution, rollups, fight
+//   opening) in recorder.ts.
+// - record: shipped verbatim to the fight of the event's actor; no rollup.
+//   Combat-meaningful state changes with no bespoke handling live here.
+// - skip: cosmetic, UI-only, or non-combat (chat, loot, quests, cues, ...).
+//   Volume or privacy, never "nobody asked yet".
+//
+// Regenerate the key list with scripts/parse/gen_event_policy.cjs when the
+// union changes (existing decisions are kept, new types land as 'skip' with
+// a TODO), or add the new key by hand; typecheck enforces completeness.
+import type { SimEvent } from '../../src/sim/types';
+
+export type EventRecordPolicy = 'routed' | 'record' | 'skip';
+
+export const EVENT_RECORD_POLICY: Readonly<Record<SimEvent['type'], EventRecordPolicy>> = {
+  arenaCountdown: 'skip',
+  arenaEnd: 'skip',
+  arenaFound: 'skip',
+  arenaQueued: 'skip',
+  arenaStart: 'skip',
+  arenaUnqueued: 'skip',
+  attuned: 'skip',
+  attunedZone: 'skip',
+  augmentChosen: 'skip',
+  augmentOffer: 'skip',
+  aura: 'routed',
+  bank: 'skip',
+  bgCountdown: 'skip',
+  bgEnd: 'skip',
+  bgFlag: 'skip',
+  bgFound: 'skip',
+  bgKill: 'skip',
+  bgProposalUpdate: 'skip',
+  bgProposed: 'skip',
+  bgQueued: 'skip',
+  bgStart: 'skip',
+  bgTimeWarning: 'skip',
+  bgUnqueued: 'skip',
+  calendarResult: 'skip',
+  cardDuelMatchEnd: 'skip',
+  cardDuelMatchStart: 'skip',
+  cardPlayed: 'skip',
+  cardRoundResolved: 'skip',
+  castStart: 'routed',
+  castStop: 'routed',
+  chat: 'skip',
+  comboPoint: 'skip',
+  commissionOrderResult: 'skip',
+  companionBark: 'skip',
+  craftResult: 'skip',
+  damage: 'routed',
+  death: 'routed',
+  deedBroadcast: 'skip',
+  deedUnlocked: 'skip',
+  delveChestLoot: 'skip',
+  delveComplete: 'skip',
+  delveEntered: 'skip',
+  delveFailed: 'skip',
+  delveLoreUnlock: 'skip',
+  delveObjectiveComplete: 'skip',
+  delveRiteChoosePrompt: 'skip',
+  delveRiteFeedback: 'skip',
+  delveRitePulse: 'skip',
+  dfProposal: 'skip',
+  disenchantResult: 'skip',
+  duelCountdown: 'skip',
+  duelEnd: 'skip',
+  duelRequest: 'skip',
+  duelStart: 'skip',
+  enchantResult: 'skip',
+  error: 'skip',
+  ferryBellHome: 'skip',
+  ferryIslandArrival: 'skip',
+  fiestaDown: 'skip',
+  fiestaPowerup: 'skip',
+  fiestaScore: 'skip',
+  fiestaWave: 'skip',
+  fiestaWord: 'skip',
+  fishingBite: 'skip',
+  fishingEarlyReel: 'skip',
+  fishingEmptyHook: 'skip',
+  fishingGotAway: 'skip',
+  fishingResult: 'skip',
+  gatherDenied: 'skip',
+  gatherDowngrade: 'skip',
+  gatherRareEvent: 'skip',
+  gatherResult: 'skip',
+  gatherToolNoNode: 'skip',
+  guildInvite: 'skip',
+  guildInviteCancelled: 'skip',
+  guildRenamed: 'skip',
+  harvestResult: 'skip',
+  heal: 'routed',
+  heal2: 'routed',
+  honor: 'skip',
+  learnAbility: 'skip',
+  levelup: 'skip',
+  loadoutGearResult: 'skip',
+  lockpickBonus: 'skip',
+  lockpickEnd: 'skip',
+  lockpickOffer: 'skip',
+  lockpickSession: 'skip',
+  lockpickStep: 'skip',
+  log: 'skip',
+  loot: 'skip',
+  lootRoll: 'skip',
+  mailArrived: 'skip',
+  mailResult: 'skip',
+  mailbox: 'skip',
+  masterLoot: 'skip',
+  masterwork: 'skip',
+  masterworkZone: 'skip',
+  motdResult: 'skip',
+  mountRaceCountdown: 'skip',
+  mountRaceEnd: 'skip',
+  mountRaceJump: 'skip',
+  mountRaceStart: 'skip',
+  mountTrainEnd: 'skip',
+  mountTrainSession: 'skip',
+  noticeboard: 'skip',
+  partyInvite: 'skip',
+  playerDeath: 'skip',
+  prestige: 'skip',
+  profTierTutorial: 'skip',
+  profTrendNudge: 'skip',
+  questAccepted: 'skip',
+  questDone: 'skip',
+  questProgress: 'skip',
+  questReady: 'skip',
+  readyCheckStart: 'skip',
+  reliquaryIlluminationBroadcast: 'skip',
+  reliquaryUnlock: 'skip',
+  respawn: 'record',
+  resurrectionOffer: 'record',
+  riftDeathZoneClear: 'skip',
+  riftDeathZoneSpawn: 'skip',
+  riftForgeResult: 'skip',
+  riftRaceResult: 'skip',
+  riftRaceWorld: 'skip',
+  riftState: 'skip',
+  salvageResult: 'skip',
+  skinEvent: 'skip',
+  spellfx: 'skip',
+  spellfxAt: 'skip',
+  toolEffectResult: 'skip',
+  tradeDone: 'skip',
+  tradeRequest: 'skip',
+  trainResult: 'skip',
+  tutorialGreeting: 'skip',
+  unbindResult: 'skip',
+  unstuck: 'skip', // TODO(parse): classify (new event type)
+  varkhulCallout: 'skip',
+  vaultCraftConsume: 'skip',
+  vendor: 'skip',
+  virtualLevelUp: 'skip',
+  worldObjectBurning: 'skip',
+  xp: 'skip',
+  yumiDown: 'skip',
+  yumiStatus: 'skip',
+  yumiSuddenDeath: 'skip',
+  yumiTeleport: 'skip',
+};
+
+/** Event types the generic `record` path ships; exported for tests. */
+export const GENERIC_RECORDED_EVENT_TYPES: ReadonlySet<SimEvent['type']> = new Set(
+  (Object.keys(EVENT_RECORD_POLICY) as SimEvent['type'][]).filter(
+    (type) => EVENT_RECORD_POLICY[type] === 'record',
+  ),
+);
+
+/**
+ * The entity a generically recorded event belongs to, in the sim's own
+ * precedence: a personal event's pid, else the acting entity, else the
+ * target, else the source. Null when the event names nobody.
+ */
+export function eventActorId(ev: SimEvent): number | null {
+  const fields = ev as Record<string, unknown>;
+  for (const key of ['pid', 'entityId', 'targetId', 'sourceId']) {
+    const value = fields[key];
+    if (typeof value === 'number') return value;
+  }
+  return null;
+}

--- a/server/parse/event_policy.ts
+++ b/server/parse/event_policy.ts
@@ -14,7 +14,7 @@
 // - skip: cosmetic, UI-only, or non-combat (chat, loot, quests, cues, ...).
 //   Volume or privacy, never "nobody asked yet".
 //
-// Regenerate the key list with scripts/parse/gen_event_policy.cjs when the
+// Regenerate the key list with scripts/parse/gen_event_policy.mjs when the
 // union changes (existing decisions are kept, new types land as 'skip' with
 // a TODO), or add the new key by hand; typecheck enforces completeness.
 import type { SimEvent } from '../../src/sim/types';
@@ -157,7 +157,7 @@ export const EVENT_RECORD_POLICY: Readonly<Record<SimEvent['type'], EventRecordP
   trainResult: 'skip',
   tutorialGreeting: 'skip',
   unbindResult: 'skip',
-  unstuck: 'skip', // TODO(parse): classify (new event type)
+  unstuck: 'skip',
   varkhulCallout: 'skip',
   vaultCraftConsume: 'skip',
   vendor: 'skip',

--- a/server/parse/recorder.ts
+++ b/server/parse/recorder.ts
@@ -10,9 +10,9 @@
 // rather than ever degrading the tick loop.
 import type { SimEvent } from '../../src/sim/types';
 import { ArenaSegmenter } from './arena';
+import { auraStateSnapshot } from './aura_state';
 import { BattlegroundSegmenter } from './battleground';
 import { BossCastSynthesizer } from './boss_casts';
-import { auraStateSnapshot } from './aura_state';
 import type { EventEnrichment, FightParticipant, Surface } from './contract';
 import { EVENT_RECORD_POLICY, eventActorId } from './event_policy';
 import type { OpenFight, PendingClose } from './fights';

--- a/server/parse/recorder.ts
+++ b/server/parse/recorder.ts
@@ -326,21 +326,27 @@ export class ParseRecorder {
       // The live aura object: the event names it, the object holds its state.
       // A fresh application or refresh always appends to the end (applyAura
       // splices then pushes), so the backward scan finds the most recent
-      // match. Matching by id + source when the event carries them (fidelity
-      // round 1 emit sites) and by name otherwise (the un-widened sites);
-      // the name fallback is best-effort: with two same-named auras from
-      // different casters the older one is unreachable by name alone.
+      // match. The name always has to agree; when the event also carries
+      // source and ability id (fidelity round 1 emit sites) those must agree
+      // too, so a same-source decoy applied later cannot be mistaken for the
+      // named aura. The bare-name fallback (un-widened sites) is best-effort:
+      // with two same-named auras from different casters the older one is
+      // unreachable by name alone.
+      //
+      // Known miss, inherited from base: the Sunder/Expose stack-bump re-emit
+      // (effect_dispatch.ts) deliberately names the CURRENT caster while the
+      // live aura keeps the original one, so a bump from a second caster
+      // finds no live match and ships identity and stacks with no auraState.
       const auras = this.opts.sim.entities.get(ev.targetId)?.auras;
       let live: (typeof auras extends readonly (infer A)[] | undefined ? A : never) | undefined;
       if (auras !== undefined) {
         for (let i = auras.length - 1; i >= 0; i--) {
           const aura = auras[i];
-          if (aura === undefined) continue;
+          if (aura === undefined || aura.name !== ev.name) continue;
           const matches =
-            ev.sourceId !== undefined
-              ? aura.sourceId === ev.sourceId &&
-                (ev.abilityId === undefined || aura.id === ev.abilityId)
-              : aura.name === ev.name;
+            ev.sourceId === undefined ||
+            (aura.sourceId === ev.sourceId &&
+              (ev.abilityId === undefined || aura.id === ev.abilityId));
           if (matches) {
             live = aura;
             break;
@@ -363,11 +369,17 @@ export class ParseRecorder {
       }
       // The aura's scalar state rides along automatically (aura_state.ts):
       // whatever the sim keeps on the aura is what the parse gets.
-      const auraState = live !== undefined ? auraStateSnapshot(live) : undefined;
+      const auraState =
+        live !== undefined ? auraStateSnapshot(live, this.noteAuraStateTruncated) : undefined;
       if (auraState !== undefined) enrichment = { ...(enrichment ?? {}), auraState };
     }
     fight.recordEvent(tick, ev as Record<string, unknown>, enrichment);
   }
+
+  /** Bound once so the aura join passes a stable callback, no closure per event. */
+  private readonly noteAuraStateTruncated = (): void => {
+    this.opts.counters.auraStateTruncated++;
+  };
 
   private routeDeath(ev: SimEvent & { type: 'death' }, tick: number): void {
     const match = this.fightFor(ev.entityId) ?? this.fightFor(ev.killerId);

--- a/server/parse/recorder.ts
+++ b/server/parse/recorder.ts
@@ -12,7 +12,9 @@ import type { SimEvent } from '../../src/sim/types';
 import { ArenaSegmenter } from './arena';
 import { BattlegroundSegmenter } from './battleground';
 import { BossCastSynthesizer } from './boss_casts';
+import { auraStateSnapshot } from './aura_state';
 import type { EventEnrichment, FightParticipant, Surface } from './contract';
+import { EVENT_RECORD_POLICY, eventActorId } from './event_policy';
 import type { OpenFight, PendingClose } from './fights';
 import type { ParseFlags } from './flags';
 import { DungeonSegmenter } from './instances';
@@ -193,9 +195,23 @@ export class ParseRecorder {
           this.routeDeath(ev, tick);
           break;
         default:
+          // Everything else is classified in event_policy.ts (keyed by the full
+          // SimEvent union, so a new type cannot arrive here unclassified).
+          if (EVENT_RECORD_POLICY[ev.type] === 'record') this.routeRecorded(ev, tick);
           break;
       }
     }
+  }
+
+  /** Generic path for `record`-policy events: verbatim, to the actor's fight. */
+  private routeRecorded(ev: SimEvent, tick: number): void {
+    const actorId = eventActorId(ev);
+    if (actorId === null) return;
+    const match = this.fightFor(actorId);
+    if (match === null) return;
+    const enrichment: EventEnrichment | undefined =
+      match.ownerId !== null ? { ownerId: match.ownerId } : undefined;
+    match.fight.recordEvent(tick, ev as Record<string, unknown>, enrichment);
   }
 
   /** A pet's owner entity id, or the id itself for everything else. */
@@ -307,6 +323,30 @@ export class ParseRecorder {
     if (fight === undefined) return;
     let enrichment: EventEnrichment | undefined;
     if (ev.gained) {
+      // The live aura object: the event names it, the object holds its state.
+      // A fresh application or refresh always appends to the end (applyAura
+      // splices then pushes), so the backward scan finds the most recent
+      // match. Matching by id + source when the event carries them (fidelity
+      // round 1 emit sites) and by name otherwise (the un-widened sites);
+      // the name fallback is best-effort: with two same-named auras from
+      // different casters the older one is unreachable by name alone.
+      const auras = this.opts.sim.entities.get(ev.targetId)?.auras;
+      let live: (typeof auras extends readonly (infer A)[] | undefined ? A : never) | undefined;
+      if (auras !== undefined) {
+        for (let i = auras.length - 1; i >= 0; i--) {
+          const aura = auras[i];
+          if (aura === undefined) continue;
+          const matches =
+            ev.sourceId !== undefined
+              ? aura.sourceId === ev.sourceId &&
+                (ev.abilityId === undefined || aura.id === ev.abilityId)
+              : aura.name === ev.name;
+          if (matches) {
+            live = aura;
+            break;
+          }
+        }
+      }
       if (ev.sourceId !== undefined) {
         // Fidelity round 1 landed: the event itself carries attribution.
         enrichment = {
@@ -314,28 +354,17 @@ export class ParseRecorder {
           ...(ev.abilityId !== undefined ? { auraId: ev.abilityId } : {}),
           ...(ev.stacks !== undefined ? { auraStacks: ev.stacks } : {}),
         };
-      } else {
-        // Fallback state-join for un-widened emit sites: scan the live aura
-        // array backwards by name. A fresh application or refresh always
-        // appends to the end (applyAura splices then pushes), so the backward
-        // scan finds the most recent same-named aura. Best-effort only: with
-        // two same-named auras from different casters the older one is
-        // unreachable by name alone.
-        const auras = this.opts.sim.entities.get(ev.targetId)?.auras;
-        if (auras !== undefined) {
-          for (let i = auras.length - 1; i >= 0; i--) {
-            const aura = auras[i];
-            if (aura !== undefined && aura.name === ev.name) {
-              enrichment = {
-                auraSourceId: aura.sourceId,
-                auraId: aura.id,
-                ...(aura.stacks !== undefined ? { auraStacks: aura.stacks } : {}),
-              };
-              break;
-            }
-          }
-        }
+      } else if (live !== undefined) {
+        enrichment = {
+          auraSourceId: live.sourceId,
+          auraId: live.id,
+          ...(live.stacks !== undefined ? { auraStacks: live.stacks } : {}),
+        };
       }
+      // The aura's scalar state rides along automatically (aura_state.ts):
+      // whatever the sim keeps on the aura is what the parse gets.
+      const auraState = live !== undefined ? auraStateSnapshot(live) : undefined;
+      if (auraState !== undefined) enrichment = { ...(enrichment ?? {}), auraState };
     }
     fight.recordEvent(tick, ev as Record<string, unknown>, enrichment);
   }

--- a/src/sim/encounters/ignivar.ts
+++ b/src/sim/encounters/ignivar.ts
@@ -1510,7 +1510,7 @@ export function resetIgnivarEncounter(ctx: SimContext, boss: Entity): void {
   for (const meta of ctx.players.values()) {
     const player = ctx.entities.get(meta.entityId);
     if (player?.kind !== 'player') continue;
-    clearIgnivarEncounterAuras(player, boss.id);
+    clearIgnivarEncounterAuras(ctx, player, boss.id);
   }
   for (const conduit of conduitEntities(ctx, boss).values()) {
     conduit.templateId = IGNIVAR_WATER_CONDUIT_TEMPLATES.ready;
@@ -1536,8 +1536,12 @@ export function clearIgnivarBrand(player: Entity, sourceId?: number): void {
   );
 }
 
-export function clearIgnivarEncounterAuras(player: Entity, sourceId?: number): void {
-  clearIgnivarForgeChainAura(player, sourceId);
+export function clearIgnivarEncounterAuras(
+  ctx: SimContext,
+  player: Entity,
+  sourceId?: number,
+): void {
+  clearIgnivarForgeChainAura(ctx, player, sourceId);
   player.auras = player.auras.filter(
     (aura) =>
       (aura.id !== IGNIVAR_BRAND_AURA_ID &&

--- a/src/sim/ignivar_forge_chains.ts
+++ b/src/sim/ignivar_forge_chains.ts
@@ -69,12 +69,17 @@ function clearChainAura(ctx: SimContext, player: Entity | undefined, bossId: num
   }
 }
 
-export function clearIgnivarForgeChainAura(player: Entity, bossId?: number): void {
+/** Encounter reset and arena departure: the same strip, the same fade announcement. */
+export function clearIgnivarForgeChainAura(ctx: SimContext, player: Entity, bossId?: number): void {
+  const before = player.auras.length;
   player.auras = player.auras.filter(
     (aura) =>
       aura.id !== IGNIVAR_FORGE_CHAINS_AURA_ID ||
       (bossId !== undefined && aura.sourceId !== bossId),
   );
+  if (player.auras.length !== before) {
+    ctx.emit({ type: 'aura', targetId: player.id, name: IGNIVAR_FORGE_CHAINS_NAME, gained: false });
+  }
 }
 
 function closestChainPair(candidates: readonly Entity[]): [Entity, Entity] | null {

--- a/src/sim/ignivar_forge_chains.ts
+++ b/src/sim/ignivar_forge_chains.ts
@@ -54,11 +54,19 @@ export function movementCrossesIgnivarForgeChain(
   return passedThrough || landedOnChain;
 }
 
-function clearChainAura(player: Entity | undefined, bossId: number): void {
+// Strips the chain aura directly (no aura-kind hooks fire for it) but still
+// announces the fade: the parse recorder and the client's aura tracking only
+// learn about a removal from this event, and a silent strip left the parse
+// showing chains "up" long after the pair was released.
+function clearChainAura(ctx: SimContext, player: Entity | undefined, bossId: number): void {
   if (!player) return;
+  const before = player.auras.length;
   player.auras = player.auras.filter(
     (aura) => aura.id !== IGNIVAR_FORGE_CHAINS_AURA_ID || aura.sourceId !== bossId,
   );
+  if (player.auras.length !== before) {
+    ctx.emit({ type: 'aura', targetId: player.id, name: IGNIVAR_FORGE_CHAINS_NAME, gained: false });
+  }
 }
 
 export function clearIgnivarForgeChainAura(player: Entity, bossId?: number): void {
@@ -131,6 +139,7 @@ function applyChainAura(ctx: SimContext, boss: Entity, player: Entity, partner: 
     duration: IGNIVAR_FORGE_CHAINS_DURATION_SECONDS,
     value: 0,
     value2: partner.id,
+    linkedEntityId: partner.id,
     sourceId: boss.id,
     school: 'fire',
     encounterOwned: true,
@@ -158,7 +167,7 @@ function finishChainPair(
     }
   }
   for (const player of [first, second]) {
-    clearChainAura(player, boss.id);
+    clearChainAura(ctx, player, boss.id);
     if (!player) continue;
     ctx.emit({
       type: 'spellfx',

--- a/src/sim/instances/dungeons.ts
+++ b/src/sim/instances/dungeons.ts
@@ -540,7 +540,7 @@ export function enterDungeon(
       const player = ctx.entities.get(meta.entityId);
       if (player?.kind !== 'player') continue;
       for (const oldIgnivarId of oldIgnivarIds) {
-        clearIgnivarEncounterAuras(player, oldIgnivarId);
+        clearIgnivarEncounterAuras(ctx, player, oldIgnivarId);
       }
       for (const oldVarkhulId of oldVarkhulIds) {
         clearVarkhulEncounterAuras(player, oldVarkhulId);
@@ -846,7 +846,7 @@ export function leaveDungeon(ctx: SimContext, pid?: number): boolean {
       // The left room's teardown, exactly leaveDungeon's: departing scrubs the
       // leaver from its hate tables and sheds its encounter-owned auras.
       if (inst) scrubInstanceThreat(ctx, inst, p.id);
-      if (dungeon.id === IGNIVAR_RAID_ARENA_ID) clearIgnivarEncounterAuras(p);
+      if (dungeon.id === IGNIVAR_RAID_ARENA_ID) clearIgnivarEncounterAuras(ctx, p);
       if (dungeon.id === IGNIVAR_SECOND_WING_ID) clearVarkhulEncounterAuras(p);
       return true;
     }
@@ -890,7 +890,7 @@ export function detachFromDungeon(ctx: SimContext, p: Entity): { x: number; z: n
   if (!dungeon) return null;
   const inst = ctx.instances.find((i) => i.partyKey !== null && instanceClaimContains(i, p.pos));
   if (inst) scrubInstanceThreat(ctx, inst, p.id);
-  if (dungeon.id === IGNIVAR_RAID_ARENA_ID) clearIgnivarEncounterAuras(p);
+  if (dungeon.id === IGNIVAR_RAID_ARENA_ID) clearIgnivarEncounterAuras(ctx, p);
   if (dungeon.id === IGNIVAR_SECOND_WING_ID) clearVarkhulEncounterAuras(p);
   cancelProfessionSessionOnDisplacement(ctx, p);
   const drop = dungeon.leaveOffset ?? { x: 0, z: -DUNGEON_DOOR_RETURN_INSET };

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -635,6 +635,12 @@ export interface Aura {
   value: number; // dot/hot: per tick; slow/haste/speed: multiplier; absorb: remaining; buffs: amount
   value2?: number; // imbue: judgement min; Greater Invisibility: aftereffect DR
   value3?: number; // imbue: judgement max; Greater Invisibility: aftereffect duration
+  // Another entity this aura ties its holder to (a tether partner, a bond
+  // target). Self-describing where value2 is not: the parse recorder snapshots
+  // it with the rest of the aura's scalar state and the parse site renders it
+  // as a link, so any pairing mechanic that sets it is recorded and shown with
+  // no per-mechanic wiring.
+  linkedEntityId?: number;
   tickInterval?: number;
   tickTimer?: number;
   // Sim-only periodic ramp: after each resolved DoT tick, increase `stacks`

--- a/tests/ignivar_encounter.test.ts
+++ b/tests/ignivar_encounter.test.ts
@@ -71,6 +71,7 @@ import {
   IGNIVAR_FORGE_CHAINS_DURATION_SECONDS,
   IGNIVAR_FORGE_CHAINS_EVERY,
   IGNIVAR_FORGE_CHAINS_FIRST_SECONDS,
+  IGNIVAR_FORGE_CHAINS_NAME,
   IGNIVAR_FORGE_CHAINS_PAIR_COUNT,
   IGNIVAR_FORGE_CHAINS_STRAIN_SECONDS,
   updateIgnivarForgeChains,
@@ -633,6 +634,47 @@ describe('Ignivar encounter', () => {
     expect(second.hp).toBe(second.maxHp);
     expect(first.auras.some((aura) => aura.id === IGNIVAR_FORGE_CHAINS_AURA_ID)).toBe(false);
     expect(second.auras.some((aura) => aura.id === IGNIVAR_FORGE_CHAINS_AURA_ID)).toBe(false);
+  });
+
+  it('names the tether partner on the chain aura and announces the fade when a pair is released', () => {
+    // The parse recorder snapshots the aura's scalar state on the gained
+    // event (linkedEntityId is its reserved partner key) and only learns of a
+    // removal from the fade event, which the direct aura strip used to skip.
+    const { sim, boss } = claimedHeroicEncounter();
+    const first = addEncounterPlayer(sim, boss, 'Recorded Chain One');
+    const second = addEncounterPlayer(sim, boss, 'Recorded Chain Two');
+    updateIgnivarEncounter(sim.ctx, boss);
+    isolateForgeChains(boss);
+    updateIgnivarEncounter(sim.ctx, boss);
+
+    const firstChain = first.auras.find((aura) => aura.id === IGNIVAR_FORGE_CHAINS_AURA_ID);
+    const secondChain = second.auras.find((aura) => aura.id === IGNIVAR_FORGE_CHAINS_AURA_ID);
+    expect(firstChain?.linkedEntityId).toBe(second.id);
+    expect(secondChain?.linkedEntityId).toBe(first.id);
+    sim.drainEvents();
+
+    // A crossing releases the pair through the direct strip, not aura expiry.
+    const intruder = addEncounterPlayer(sim, boss, 'Recorded Chain Intruder');
+    first.pos = { x: boss.pos.x - 4, y: boss.pos.y, z: boss.pos.z + 2 };
+    second.pos = { x: boss.pos.x + 4, y: boss.pos.y, z: boss.pos.z + 2 };
+    intruder.pos = { x: boss.pos.x, y: boss.pos.y, z: boss.pos.z - 2 };
+    intruder.prevPos = { ...intruder.pos };
+    updateIgnivarEncounter(sim.ctx, boss);
+    intruder.pos = { x: boss.pos.x, y: boss.pos.y, z: boss.pos.z + 6 };
+    updateIgnivarEncounter(sim.ctx, boss);
+
+    expect(intruder.dead).toBe(true);
+    expect(first.auras.some((aura) => aura.id === IGNIVAR_FORGE_CHAINS_AURA_ID)).toBe(false);
+    expect(second.auras.some((aura) => aura.id === IGNIVAR_FORGE_CHAINS_AURA_ID)).toBe(false);
+    const fades = sim
+      .drainEvents()
+      .filter(
+        (ev): ev is SimEvent & { type: 'aura' } =>
+          ev.type === 'aura' && ev.gained === false && ev.name === IGNIVAR_FORGE_CHAINS_NAME,
+      )
+      .map((ev) => ev.targetId)
+      .sort((a, b) => a - b);
+    expect(fades).toEqual([first.id, second.id].sort((a, b) => a - b));
   });
 
   it('clears an active Heroic chain when the encounter resets', () => {

--- a/tests/parse_aura_state.test.ts
+++ b/tests/parse_aura_state.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from 'vitest';
+import {
+  AURA_STATE_OMIT,
+  auraStateSnapshot,
+  MAX_AURA_STATE_FIELDS,
+  MAX_AURA_STATE_STRING,
+} from '../server/parse/aura_state';
+
+// The snapshot's whole point is completeness, so these pin the only ways a
+// field can legitimately be left out: the typed omit list, non-scalars,
+// non-finite numbers, and the two defensive bounds (which must be visible
+// when they bite, never silent).
+
+describe('auraStateSnapshot', () => {
+  test('ships every scalar field except the omit list, in key order', () => {
+    const state = auraStateSnapshot({
+      id: 'x',
+      name: 'X',
+      sourceId: 1,
+      stacks: 2,
+      remaining: 3,
+      kind: 'dot',
+      value: 4,
+      value2: 5,
+      linkedEntityId: 6,
+      encounterOwned: true,
+      school: 'fire',
+    });
+    expect(state).toEqual({
+      kind: 'dot',
+      value: 4,
+      value2: 5,
+      linkedEntityId: 6,
+      encounterOwned: true,
+      school: 'fire',
+    });
+    expect(Object.keys(state ?? {})).toEqual([
+      'kind',
+      'value',
+      'value2',
+      'linkedEntityId',
+      'encounterOwned',
+      'school',
+    ]);
+  });
+
+  test('skips non-scalars and non-finite numbers, and answers undefined for nothing', () => {
+    expect(
+      auraStateSnapshot({
+        empowerAbilities: ['a'],
+        nested: { x: 1 },
+        fn: () => 1,
+        missing: undefined,
+        nothing: null,
+        inf: Number.POSITIVE_INFINITY,
+        nan: Number.NaN,
+      }),
+    ).toBeUndefined();
+    expect(auraStateSnapshot({ id: 'only-identity', name: 'n', sourceId: 1 })).toBeUndefined();
+  });
+
+  test('truncates a long string to the cap', () => {
+    const long = 'a'.repeat(MAX_AURA_STATE_STRING + 20);
+    expect(auraStateSnapshot({ label: long })).toEqual({
+      label: 'a'.repeat(MAX_AURA_STATE_STRING),
+    });
+  });
+
+  test('stops at the field cap and reports the truncation once', () => {
+    const aura: Record<string, number> = {};
+    for (let i = 0; i < MAX_AURA_STATE_FIELDS + 5; i++) aura[`f${i}`] = i;
+    let truncations = 0;
+    const state = auraStateSnapshot(aura, () => truncations++);
+    expect(Object.keys(state ?? {})).toHaveLength(MAX_AURA_STATE_FIELDS);
+    expect(state?.f0).toBe(0);
+    expect(state?.[`f${MAX_AURA_STATE_FIELDS - 1}`]).toBe(MAX_AURA_STATE_FIELDS - 1);
+    expect(state).not.toHaveProperty(`f${MAX_AURA_STATE_FIELDS}`);
+    expect(truncations).toBe(1);
+  });
+
+  test('an aura within the cap never reports a truncation', () => {
+    const aura: Record<string, number> = {};
+    for (let i = 0; i < MAX_AURA_STATE_FIELDS; i++) aura[`f${i}`] = i;
+    let truncations = 0;
+    auraStateSnapshot(aura, () => truncations++);
+    expect(truncations).toBe(0);
+  });
+
+  test('the omit list names identity, per-tick counters, and mechanic bookkeeping', () => {
+    for (const key of ['id', 'name', 'sourceId', 'stacks', 'remaining', 'tickTimer'] as const) {
+      expect(AURA_STATE_OMIT.has(key)).toBe(true);
+    }
+    // The fields a reader needs are never on it.
+    for (const key of [
+      'value',
+      'value2',
+      'linkedEntityId',
+      'duration',
+      'kind',
+      'school',
+    ] as const) {
+      expect(AURA_STATE_OMIT.has(key)).toBe(false);
+    }
+  });
+});

--- a/tests/parse_event_policy.test.ts
+++ b/tests/parse_event_policy.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from 'vitest';
+import {
+  EVENT_RECORD_POLICY,
+  eventActorId,
+  GENERIC_RECORDED_EVENT_TYPES,
+} from '../server/parse/event_policy';
+import type { SimEvent } from '../src/sim/types';
+
+// Completeness itself is enforced at typecheck: EVENT_RECORD_POLICY is a
+// Record over the full SimEvent type union, so a new event type fails the
+// build until it is classified. These tests pin the classification that the
+// recorder's routing depends on, so a reclassification is a deliberate diff.
+
+describe('EVENT_RECORD_POLICY', () => {
+  test('every type the recorder handles bespoke is marked routed', () => {
+    for (const type of [
+      'damage',
+      'heal2',
+      'heal',
+      'aura',
+      'castStart',
+      'castStop',
+      'death',
+    ] as const) {
+      expect(EVENT_RECORD_POLICY[type]).toBe('routed');
+    }
+  });
+
+  test('resurrection state changes ship through the generic record path', () => {
+    expect(EVENT_RECORD_POLICY.respawn).toBe('record');
+    expect(EVENT_RECORD_POLICY.resurrectionOffer).toBe('record');
+    expect([...GENERIC_RECORDED_EVENT_TYPES].sort()).toEqual(['respawn', 'resurrectionOffer']);
+  });
+
+  test('chatter and cosmetic cues never enter the parse', () => {
+    for (const type of [
+      'chat',
+      'log',
+      'spellfx',
+      'spellfxAt',
+      'loot',
+      'xp',
+      'mailArrived',
+    ] as const) {
+      expect(EVENT_RECORD_POLICY[type]).toBe('skip');
+    }
+  });
+
+  test('every classification is one of the three policies', () => {
+    for (const policy of Object.values(EVENT_RECORD_POLICY)) {
+      expect(['routed', 'record', 'skip']).toContain(policy);
+    }
+  });
+});
+
+describe('eventActorId', () => {
+  test('prefers the personal pid, then entity, target, source', () => {
+    expect(eventActorId({ type: 'respawn', pid: 7 } as SimEvent)).toBe(7);
+    expect(eventActorId({ type: 'castStop', entityId: 8, success: true } as SimEvent)).toBe(8);
+    expect(
+      eventActorId({ type: 'aura', targetId: 9, name: 'Rend', gained: true } as SimEvent),
+    ).toBe(9);
+    expect(eventActorId({ type: 'log', text: 'hi' } as SimEvent)).toBeNull();
+  });
+});

--- a/tests/parse_event_policy.test.ts
+++ b/tests/parse_event_policy.test.ts
@@ -45,12 +45,6 @@ describe('EVENT_RECORD_POLICY', () => {
       expect(EVENT_RECORD_POLICY[type]).toBe('skip');
     }
   });
-
-  test('every classification is one of the three policies', () => {
-    for (const policy of Object.values(EVENT_RECORD_POLICY)) {
-      expect(['routed', 'record', 'skip']).toContain(policy);
-    }
-  });
 });
 
 describe('eventActorId', () => {

--- a/tests/parse_recorder.test.ts
+++ b/tests/parse_recorder.test.ts
@@ -230,6 +230,102 @@ describe('ParseRecorder enrichment', () => {
     expect(ev.x).toMatchObject({ auraSourceId: 5, auraId: 'rend', auraStacks: 3 });
   });
 
+  test('gained aura events snapshot the live aura scalar state, tether partner included', () => {
+    const sim = fakeSim();
+    seedArena(sim, arenaMatch());
+    const target = sim.entities.get(7);
+    if (target !== undefined) {
+      (target as { auras: unknown }).auras = [
+        // An unrelated same-source aura first: the join must pick the named one.
+        { id: 'brand', name: 'Brand', sourceId: 5, value: 1, remaining: 9, duration: 9 },
+        {
+          id: 'forge_chains',
+          name: 'Chains',
+          sourceId: 5,
+          kind: 'vulnerability',
+          remaining: 8,
+          duration: 8,
+          value: 0,
+          value2: 8,
+          linkedEntityId: 8,
+          school: 'fire',
+          encounterOwned: true,
+          // Non-scalars never ship, and per-tick counters are omitted.
+          empowerAbilities: ['x'],
+          tickTimer: 0.35,
+        },
+      ];
+    }
+    const { recorder, records } = makeRecorder(sim);
+
+    sim.tickCount = 10;
+    recorder.observe([]);
+    sim.tickCount = 11;
+    recorder.observe([
+      {
+        type: 'aura',
+        targetId: 7,
+        name: 'Chains',
+        gained: true,
+        sourceId: 5,
+        abilityId: 'forge_chains',
+      },
+    ]);
+
+    const ev = records.find((r) => r.t === 'ev') as Record<string, unknown>;
+    expect(ev.x).toEqual({
+      auraSourceId: 5,
+      auraId: 'forge_chains',
+      auraState: {
+        kind: 'vulnerability',
+        duration: 8,
+        value: 0,
+        value2: 8,
+        linkedEntityId: 8,
+        school: 'fire',
+        encounterOwned: true,
+      },
+    });
+  });
+
+  test('faded aura events carry no state snapshot', () => {
+    const sim = fakeSim();
+    seedArena(sim, arenaMatch());
+    const { recorder, records } = makeRecorder(sim);
+
+    sim.tickCount = 10;
+    recorder.observe([]);
+    sim.tickCount = 11;
+    recorder.observe([{ type: 'aura', targetId: 7, name: 'Chains', gained: false }]);
+
+    const ev = records.find((r) => r.t === 'ev') as Record<string, unknown>;
+    expect(ev.x).toBeUndefined();
+  });
+
+  test("record-policy events ship verbatim to the actor's fight", () => {
+    const sim = fakeSim();
+    seedArena(sim, arenaMatch());
+    const { recorder, records } = makeRecorder(sim);
+
+    sim.tickCount = 10;
+    recorder.observe([]);
+    sim.tickCount = 11;
+    recorder.observe([
+      { type: 'respawn', pid: 7 },
+      { type: 'resurrectionOffer', fromName: 'Healer', pid: 8 },
+      // A player outside the fight: nothing to attach it to.
+      { type: 'respawn', pid: 99 },
+      // Skip policy: never recorded even for a participant.
+      { type: 'log', text: 'hello', pid: 7 },
+    ]);
+
+    const evs = records.filter((r) => r.t === 'ev').map((r) => r.ev as Record<string, unknown>);
+    expect(evs).toEqual([
+      { type: 'respawn', pid: 7 },
+      { type: 'resurrectionOffer', fromName: 'Healer', pid: 8 },
+    ]);
+  });
+
   test('cue-only heal2 events never enter the parse', () => {
     const sim = fakeSim();
     seedArena(sim, arenaMatch());

--- a/tests/parse_recorder.test.ts
+++ b/tests/parse_recorder.test.ts
@@ -236,8 +236,6 @@ describe('ParseRecorder enrichment', () => {
     const target = sim.entities.get(7);
     if (target !== undefined) {
       (target as { auras: unknown }).auras = [
-        // An unrelated same-source aura first: the join must pick the named one.
-        { id: 'brand', name: 'Brand', sourceId: 5, value: 1, remaining: 9, duration: 9 },
         {
           id: 'forge_chains',
           name: 'Chains',
@@ -254,6 +252,9 @@ describe('ParseRecorder enrichment', () => {
           empowerAbilities: ['x'],
           tickTimer: 0.35,
         },
+        // A same-source decoy applied LAST: the backward scan reaches it first,
+        // so the join must reject it by id (and name) to land on the chain.
+        { id: 'brand', name: 'Brand', sourceId: 5, value: 1, remaining: 9, duration: 9 },
       ];
     }
     const { recorder, records } = makeRecorder(sim);
@@ -288,9 +289,18 @@ describe('ParseRecorder enrichment', () => {
     });
   });
 
-  test('faded aura events carry no state snapshot', () => {
+  test('faded aura events carry no state snapshot even with a live matching aura', () => {
     const sim = fakeSim();
     seedArena(sim, arenaMatch());
+    const target = sim.entities.get(7);
+    if (target !== undefined) {
+      // The fade site strips after emitting in some paths and before in
+      // others, so a live same-named aura can still be present: the fade
+      // must not snapshot it (its state at removal is not the parse's business).
+      (target as { auras: unknown }).auras = [
+        { id: 'forge_chains', name: 'Chains', sourceId: 5, value: 0, linkedEntityId: 8 },
+      ];
+    }
     const { recorder, records } = makeRecorder(sim);
 
     sim.tickCount = 10;
@@ -299,6 +309,7 @@ describe('ParseRecorder enrichment', () => {
     recorder.observe([{ type: 'aura', targetId: 7, name: 'Chains', gained: false }]);
 
     const ev = records.find((r) => r.t === 'ev') as Record<string, unknown>;
+    expect(ev.ev).toEqual({ type: 'aura', targetId: 7, name: 'Chains', gained: false });
     expect(ev.x).toBeUndefined();
   });
 


### PR DESCRIPTION
## Summary

Closes a class of parse gap found while reading fight 69651 (Heroic Ignivar): Chains of the Forge stores its partner on the aura object (`value2`) and the renderer draws it every tick, but the partner never reached the parse because the aura EVENT carries only identity and the recorder hand-picked three fields off the live object. Two structural guards replace hand-picking so the next such field cannot go missing:

- **`server/parse/aura_state.ts`**: on a gained aura event the recorder snapshots EVERY scalar field of the live aura into `x.auraState`, minus a typed omit list (`AURA_STATE_OMIT`, identity already carried beside it plus per-tick counters). A field added to `Aura` reaches the parse with no recorder change; a field that must not ship is an explicit entry checked against the `Aura` type.
- **`server/parse/event_policy.ts`**: a `Record` over the FULL `SimEvent['type']` union mapping each type to `routed` (bespoke handler), `record` (verbatim to the actor's fight), or `skip`. A new event type fails typecheck until classified. `respawn` and `resurrectionOffer` now ship via the generic path (they were invisible before, which is how the same fight's revives could not be attributed). `scripts/parse/gen_event_policy.cjs` regenerates the key list through the TypeScript checker, keeping existing decisions.
- **`Aura.linkedEntityId`**: the self-describing tether-partner key. Chains sets it beside `value2`; the parse service renders it as a link (levy-street/woc-parse-service#10).
- **Chains fade emit**: `clearChainAura` stripped the aura silently, so the parse showed chains up until the next natural expiry (a 57 percent uptime on a player dead at 40 seconds). It now emits the fade like the aura system does.
- Contract re-vendored verbatim from the service (`auraState` is additive and optional; no `CONTRACT_VERSION` bump).

## Type of change

- [x] Feature: new functionality
- [x] Bug fix (the silent chain fade)
- [x] Tests

## How was this tested?

- Commands: `pnpm exec tsc --noEmit`; `npx vitest run tests/parse_recorder.test.ts tests/parse_event_policy.test.ts tests/parse_golden.test.ts tests/parse_pve.test.ts tests/parse_subsystem.test.ts tests/ignivar_encounter.test.ts tests/ignivar_forge_chains.test.ts tests/architecture.test.ts` (all green in isolation; one unrelated Ignivar timing test hits its 20 s budget only under parallel load on Windows and passes alone); `npx vitest run tests/parity/coverage_c.test.ts` (the Ignivar golden trace is unchanged); `node scripts/gate_select.mjs` (see the checklist line below).
- New tests: `tests/parse_event_policy.test.ts`; recorder cases for the state snapshot, the fade path, and the generic record path; an encounter case pinning `linkedEntityId` on both chain auras and the fade events on a crossing release.
- Manual steps: none; nothing in this change is player-visible.

## Screenshots / recordings

N/A, no UI change.

---

## Checklist

### Quality

- [ ] **The gate passes.** `node scripts/gate_select.mjs` on this Windows box: every step through the malware scan and biome is green, and the first vitest floor is 3182 passed with 8 failures that are all environmental and reproduce identically on an untouched worktree of the same base (`bank_sockets` compares a backslash path, `ci_shard_plan` and `ci_stall_rerun` spawn `npx` and fail with ENOENT). The gate stops at that floor, so the later floors are left to CI; the suites this change touches were run directly (listed above) and are green.

### Cross-platform

- N/A

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

