### PR TITLE
fix(ui): let a mouseover combat res reach a raid member who released

### DIFF
--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -643,6 +643,7 @@ import { MobileMoreDialogController } from './mobile_more_dialog';
 import { MOUNT_DESC_KEYS, mountSpecLines } from './mount_labels';
 import { MountRaceControls } from './mount_race_controls';
 import { MountRaceStrip } from './mount_race_strip';
+import { mouseoverCastTargetPid } from './mouseover_cast_core';
 import { type FrameDimension, MovableFrame } from './movable_frame';
 import { NoticeboardPopup } from './noticeboard_popup';
 import { NPC_WINDOW_CLOSE_RANGE } from './npc_service_range';
@@ -7491,16 +7492,17 @@ export class Hud {
           // Clique-style mouseover cast: a friendly (heal/buff) ability pressed
           // while hovering a party frame lands on the hovered member instead of
           // the current target; the sim validates and falls back if it went stale.
-          // Gated on the Interface option (mouseoverCast, on by default).
-          const def = resolved.def;
-          if (
-            this.hoveredPartyPid !== null &&
-            (this.optionsHooks?.settings.get('mouseoverCast') ?? true) &&
-            def.requiresTarget &&
-            def.targetType === 'friendly' &&
-            this.sim.entities.has(this.hoveredPartyPid)
-          ) {
-            this.sim.castAbilityOn(action.id, this.hoveredPartyPid);
+          // Gated on the Interface option (mouseoverCast, on by default). A member
+          // outside this client's interest scope (a RELEASED ghost waits at the
+          // graveyard) still redirects on the party roster alone: see
+          // mouseover_cast_core.ts.
+          const mouseoverPid = mouseoverCastTargetPid(this.hoveredPartyPid, resolved.def, {
+            enabled: this.optionsHooks?.settings.get('mouseoverCast') ?? true,
+            hasEntity: (pid) => this.sim.entities.has(pid),
+            partyMemberPids: localPartyMemberIds(this.sim.partyInfo),
+          });
+          if (mouseoverPid !== null) {
+            this.sim.castAbilityOn(action.id, mouseoverPid);
           } else {
             this.sim.castAbility(action.id);
           }

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -7499,7 +7499,7 @@ export class Hud {
           const mouseoverPid = mouseoverCastTargetPid(this.hoveredPartyPid, resolved.def, {
             enabled: this.optionsHooks?.settings.get('mouseoverCast') ?? true,
             hasEntity: (pid) => this.sim.entities.has(pid),
-            partyMemberPids: localPartyMemberIds(this.sim.partyInfo),
+            partyMemberPids: () => localPartyMemberIds(this.sim.partyInfo),
           });
           if (mouseoverPid !== null) {
             this.sim.castAbilityOn(action.id, mouseoverPid);

--- a/src/ui/mouseover_cast_core.ts
+++ b/src/ui/mouseover_cast_core.ts
@@ -1,0 +1,52 @@
+// Clique-style mouseover casting: which unit a friendly ability pressed while the
+// cursor sits over a party/raid frame actually lands on.
+//
+// The staleness guard used to be "the hovered member's ENTITY is in the client's
+// interest scope", which silently broke the one case a raid needs most. A member who
+// RELEASES stands as a ghost at the graveyard, far outside the ~120 yd snapshot
+// scope, so the caster's client drops their entity: every mouseover combat
+// resurrection (Temporal Reversal, Recall the Fallen) then fell through to the
+// current target, which in a raid is the boss, and answered "You must target a dead
+// ally in your group". The authoritative sim accepts the override for exactly this
+// case (a released ghost is still `dead`, and resurrection reach is measured to the
+// BODY, not to the spirit: src/sim/combat/resurrection_reach.ts), so the ROSTER is
+// the right guard instead: a pid on the local party/raid roster is a real, live
+// member whether or not this client can currently see them. Interest scope is a
+// rendering budget, never a targeting rule.
+//
+// Pure core: no DOM, no world type, both hosts drive it through the two callbacks
+// (the offline Sim knows every entity; ClientWorld knows the ones in scope).
+
+/** The only two ability fields the redirect decision reads. */
+export interface MouseoverCastAbility {
+  requiresTarget?: boolean;
+  targetType?: string;
+}
+
+export interface MouseoverCastInputs {
+  /** The Interface option (mouseoverCast, on by default). */
+  enabled: boolean;
+  /** Whether this client currently holds the entity (in interest scope). */
+  hasEntity: (pid: number) => boolean;
+  /** The local player's party/raid roster (pids, self included; null when solo). */
+  partyMemberPids: readonly number[] | null;
+}
+
+/**
+ * The pid a mouseover cast should be redirected to, or null to leave the press on
+ * the classic current-target-else-self path.
+ *
+ * Only friendly targeted abilities redirect (a hostile cast never rides a party
+ * frame), and only to a hovered unit this client can still vouch for: one it holds
+ * an entity for, or one the party wire still lists as a member.
+ */
+export function mouseoverCastTargetPid(
+  hoveredPid: number | null,
+  ability: MouseoverCastAbility | null | undefined,
+  inputs: MouseoverCastInputs,
+): number | null {
+  if (hoveredPid === null || !inputs.enabled) return null;
+  if (!ability?.requiresTarget || ability.targetType !== 'friendly') return null;
+  if (inputs.hasEntity(hoveredPid)) return hoveredPid;
+  return inputs.partyMemberPids?.includes(hoveredPid) ? hoveredPid : null;
+}

--- a/src/ui/mouseover_cast_core.ts
+++ b/src/ui/mouseover_cast_core.ts
@@ -28,8 +28,11 @@ export interface MouseoverCastInputs {
   enabled: boolean;
   /** Whether this client currently holds the entity (in interest scope). */
   hasEntity: (pid: number) => boolean;
-  /** The local player's party/raid roster (pids, self included; null when solo). */
-  partyMemberPids: readonly number[] | null;
+  /** The local player's party/raid roster (pids, self included; null when solo).
+   *  A callback, and read ONLY when the entity is out of scope: the offline Sim
+   *  rebuilds its whole party model (aura + aggro sweeps) on every partyInfo read,
+   *  and this runs on every ability press. */
+  partyMemberPids: () => readonly number[] | null;
 }
 
 /**
@@ -48,5 +51,5 @@ export function mouseoverCastTargetPid(
   if (hoveredPid === null || !inputs.enabled) return null;
   if (!ability?.requiresTarget || ability.targetType !== 'friendly') return null;
   if (inputs.hasEntity(hoveredPid)) return hoveredPid;
-  return inputs.partyMemberPids?.includes(hoveredPid) ? hoveredPid : null;
+  return inputs.partyMemberPids()?.includes(hoveredPid) ? hoveredPid : null;
 }

--- a/tests/architecture.test.ts
+++ b/tests/architecture.test.ts
@@ -538,6 +538,7 @@ const UI_PURE_CORES = [
   'src/ui/hud/rift/rift_floor_tracker_view.ts',
   'src/ui/hud/woc_trade/woc_trade_offer_view.ts',
   'src/ui/safe_local_storage.ts',
+  'src/ui/mouseover_cast_core.ts',
 ].map((rel) => join(repoRoot, rel));
 
 // The one pure core allowed to trip DOM_GLOBAL_VALUE_RE: the shared safeLocalStorage()

--- a/tests/combat_res_released_ghost.test.ts
+++ b/tests/combat_res_released_ghost.test.ts
@@ -1,0 +1,207 @@
+// A combat resurrection must reach a group/raid member who has RELEASED.
+//
+// Releasing does not undo the death: `dead` stays true and `ghost` goes true while
+// the body is left where it fell (src/sim/spirit.ts), and resurrection reach is
+// measured to that BODY (src/sim/combat/resurrection_reach.ts). So a released raider
+// is exactly as raisable as one who is still lying on the floor, and the caster
+// standing over the corpse is in reach even though the spirit is at a graveyard on
+// the other side of the zone.
+//
+// Pinned end to end here (offline Sim, the mouseover override, and the
+// authoritative online server), because the player-facing failure had NO sim
+// symptom: the online client dropped the ghost's entity out of interest scope and
+// its mouseover cast then fell through to the current target. See
+// tests/mouseover_cast_core.test.ts for that arm.
+
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../server/db', () => ({
+  pool: { query: vi.fn(async () => ({ rows: [] })) },
+  saveCharacterState: vi.fn(async () => {}),
+  openPlaySession: vi.fn(async () => 1),
+  touchCharacterLogin: vi.fn(async () => {}),
+  closePlaySession: vi.fn(async () => {}),
+  insertChatLogs: vi.fn(async () => {}),
+  markAccountQuestComplete: vi.fn(async () => ({ completedQuestIds: [], mechChromaIds: [] })),
+  grantAccountMechChroma: vi.fn(async () => ({ completedQuestIds: [], mechChromaIds: [] })),
+}));
+
+import { GameServer } from '../server/game';
+import { Sim } from '../src/sim/sim';
+import { dist2d, type Entity, type SimEvent, type Vec3 } from '../src/sim/types';
+
+type AnySim = Sim & Record<string, any>;
+
+const COMBAT_REZ = 'temporal_reversal';
+
+// An arcane mage of 20 owns the single-target combat resurrection.
+function chronomancer(seed = 91): { sim: AnySim; mage: Entity } {
+  const sim = new Sim({ seed, playerClass: 'mage' }) as AnySim;
+  sim.setPlayerLevel(20);
+  expect(sim.setSpec('arcane')).toBe(true);
+  sim.tick();
+  const mage = sim.player as Entity;
+  mage.resource = mage.maxResource;
+  return { sim, mage };
+}
+
+function addToGroup(sim: AnySim, leader: Entity, name: string): Entity {
+  const pid = sim.addPlayer('warrior', name);
+  sim.partyInvite(pid, leader.id);
+  sim.partyAccept(pid);
+  return sim.entities.get(pid) as Entity;
+}
+
+// Kill the member on top of the caster, then release: the spirit is teleported to a
+// graveyard and the corpse stays at the caster's feet.
+function killAndRelease(sim: AnySim, caster: Entity, member: Entity): void {
+  member.pos = { ...caster.pos };
+  member.prevPos = { ...member.pos };
+  member.dead = true;
+  member.hp = 0;
+  member.resource = 0;
+  member.corpsePos = { ...member.pos };
+  sim.releaseSpirit(member.id);
+  expect(member.ghost).toBe(true);
+  expect(member.dead).toBe(true);
+  // The spirit really did leave: the ghost is nowhere near its own body.
+  expect(dist2d(member.pos, member.corpsePos as Vec3)).toBeGreaterThan(30);
+}
+
+function errorTexts(events: SimEvent[]): string[] {
+  return events.filter((e) => e.type === 'error').map((e) => (e as { text: string }).text);
+}
+
+function runCast(sim: AnySim): SimEvent[] {
+  const events: SimEvent[] = [];
+  for (let i = 0; i < 60; i++) events.push(...sim.tick());
+  return events;
+}
+
+describe('combat resurrection on a released ghost', () => {
+  it('offers, and the accepted offer stands the ghost back up at the caster', () => {
+    const { sim, mage } = chronomancer();
+    const ally = addToGroup(sim, mage, 'Fallen');
+    killAndRelease(sim, mage, ally);
+
+    sim.targetEntity(ally.id, mage.id);
+    expect(mage.targetId).toBe(ally.id);
+    sim.castAbility(COMBAT_REZ, mage.id);
+    expect(mage.castingAbility).toBe(COMBAT_REZ);
+
+    const events = runCast(sim);
+    expect(errorTexts(events)).toEqual([]);
+    expect(events).toContainEqual(
+      expect.objectContaining({ type: 'resurrectionOffer', pid: ally.id }),
+    );
+    expect(sim.pendingResurrections.has(ally.id)).toBe(true);
+
+    sim.respondToResurrection(true, ally.id);
+    expect(ally.dead).toBe(false);
+    expect(ally.ghost).toBe(false);
+    expect(ally.hp).toBeGreaterThan(0);
+    expect(dist2d(ally.pos, mage.pos)).toBeLessThan(1);
+  });
+
+  it('accepts the mouseover override with no current target selected', () => {
+    // The path the party/raid frame drives (castAbilityOn): the caster never
+    // selects the ghost, the hovered member's pid rides the cast itself.
+    const { sim, mage } = chronomancer(92);
+    const ally = addToGroup(sim, mage, 'Fallen');
+    killAndRelease(sim, mage, ally);
+    mage.targetId = null;
+
+    sim.castAbilityOn(COMBAT_REZ, ally.id, mage.id);
+    expect(mage.castingAbility).toBe(COMBAT_REZ);
+    const events = runCast(sim);
+    expect(errorTexts(events)).toEqual([]);
+    expect(events).toContainEqual(
+      expect.objectContaining({ type: 'resurrectionOffer', pid: ally.id }),
+    );
+  });
+
+  it('still refuses a released member whose BODY is out of reach', () => {
+    // Reach is the body, not the spirit: moving the corpse (not the ghost) out of
+    // range must still refuse, so this fix never became a cross-map resurrection.
+    const { sim, mage } = chronomancer(93);
+    const ally = addToGroup(sim, mage, 'Fallen');
+    killAndRelease(sim, mage, ally);
+    ally.corpsePos = { x: mage.pos.x + 400, y: mage.pos.y, z: mage.pos.z };
+
+    sim.targetEntity(ally.id, mage.id);
+    sim.castAbility(COMBAT_REZ, mage.id);
+    expect(mage.castingAbility).toBe(null);
+    expect(errorTexts(sim.tick())).toContain('Out of range.');
+    expect(sim.pendingResurrections.has(ally.id)).toBe(false);
+  });
+});
+
+function fakeWs(): Parameters<GameServer['join']>[0] {
+  return {
+    readyState: 1,
+    send: vi.fn(),
+    on: vi.fn(),
+    once: vi.fn(),
+    close: vi.fn(),
+  } as unknown as Parameters<GameServer['join']>[0];
+}
+
+describe('combat resurrection on a released ghost, authoritative online path', () => {
+  it('raises a raider who released, straight off the target + cast commands', () => {
+    const server = new GameServer();
+    const mageWs = fakeWs();
+    const allyWs = fakeWs();
+    const mageSession = server.join(mageWs, 1, 1, 'Chrona', 'mage', null);
+    const allySession = server.join(allyWs, 2, 2, 'Fallen', 'priest', null);
+    if ('error' in mageSession || 'error' in allySession) throw new Error('join failed');
+
+    server.sim.setPlayerLevel(20, mageSession.pid);
+    expect(server.sim.setSpec('arcane', mageSession.pid)).toBe(true);
+    server.sim.tick();
+    const mage = server.sim.entities.get(mageSession.pid);
+    const ally = server.sim.entities.get(allySession.pid);
+    if (!mage || !ally) throw new Error('players missing');
+    mage.resource = mage.maxResource;
+    server.sim.partyInvite(ally.id, mage.id);
+    server.sim.partyAccept(ally.id);
+    killAndRelease(server.sim as unknown as AnySim, mage, ally);
+
+    server.handleMessage(mageSession, JSON.stringify({ t: 'cmd', cmd: 'target', id: ally.id }));
+    expect(mage.targetId).toBe(ally.id);
+    server.handleMessage(
+      mageSession,
+      JSON.stringify({ t: 'cmd', cmd: 'cast', ability: COMBAT_REZ }),
+    );
+    expect(mage.castingAbility).toBe(COMBAT_REZ);
+
+    for (let tick = 0; tick < 60; tick++) {
+      (
+        server as unknown as { routeEvents(events: ReturnType<typeof server.sim.tick>): void }
+      ).routeEvents(server.sim.tick());
+    }
+
+    const sent = (allyWs.send as ReturnType<typeof vi.fn>).mock.calls.map(([raw]) =>
+      JSON.parse(String(raw)),
+    );
+    expect(sent).toContainEqual(
+      expect.objectContaining({
+        t: 'events',
+        list: expect.arrayContaining([
+          expect.objectContaining({
+            type: 'resurrectionOffer',
+            pid: ally.id,
+            fromName: mage.name,
+          }),
+        ]),
+      }),
+    );
+
+    server.handleMessage(
+      allySession,
+      JSON.stringify({ t: 'cmd', cmd: 'resurrect_respond', accept: true }),
+    );
+    expect(ally.dead).toBe(false);
+    expect(ally.ghost).toBe(false);
+    expect(dist2d(ally.pos, mage.pos)).toBeLessThan(1);
+  });
+});

--- a/tests/mouseover_cast_core.test.ts
+++ b/tests/mouseover_cast_core.test.ts
@@ -26,7 +26,7 @@ describe('mouseoverCastTargetPid', () => {
       mouseoverCastTargetPid(7, HEAL, {
         enabled: true,
         hasEntity: simLikeEntities([1, 7]),
-        partyMemberPids: [1, 7],
+        partyMemberPids: () => [1, 7],
       }),
     ).toBe(7);
   });
@@ -38,7 +38,7 @@ describe('mouseoverCastTargetPid', () => {
       mouseoverCastTargetPid(7, RES, {
         enabled: true,
         hasEntity: () => false,
-        partyMemberPids: [1, 7],
+        partyMemberPids: () => [1, 7],
       }),
     ).toBe(7);
     // Same inputs on the Sim-shaped host (entity present) resolve to the same pid.
@@ -46,7 +46,7 @@ describe('mouseoverCastTargetPid', () => {
       mouseoverCastTargetPid(7, RES, {
         enabled: true,
         hasEntity: simLikeEntities([1, 7]),
-        partyMemberPids: [1, 7],
+        partyMemberPids: () => [1, 7],
       }),
     ).toBe(7);
   });
@@ -59,14 +59,14 @@ describe('mouseoverCastTargetPid', () => {
       mouseoverCastTargetPid(7, HEAL, {
         enabled: true,
         hasEntity: () => false,
-        partyMemberPids: [1, 2],
+        partyMemberPids: () => [1, 2],
       }),
     ).toBeNull();
     expect(
       mouseoverCastTargetPid(7, HEAL, {
         enabled: true,
         hasEntity: () => false,
-        partyMemberPids: null,
+        partyMemberPids: () => null,
       }),
     ).toBeNull();
   });
@@ -75,13 +75,43 @@ describe('mouseoverCastTargetPid', () => {
     const inScope = {
       enabled: true,
       hasEntity: simLikeEntities([7]),
-      partyMemberPids: [1, 7],
+      partyMemberPids: () => [1, 7],
     };
     expect(mouseoverCastTargetPid(7, BOLT, inScope)).toBeNull();
     expect(mouseoverCastTargetPid(7, ABILITIES.collective_reversal, inScope)).toBeNull();
     expect(mouseoverCastTargetPid(7, undefined, inScope)).toBeNull();
     expect(mouseoverCastTargetPid(null, HEAL, inScope)).toBeNull();
     expect(mouseoverCastTargetPid(7, HEAL, { ...inScope, enabled: false })).toBeNull();
+  });
+
+  it('reads the roster only when the entity is out of scope', () => {
+    // The offline Sim rebuilds its whole party model on every partyInfo read
+    // (aura + aggro sweeps over the world), and this runs on every ability press:
+    // the in-scope answer must never pay for it.
+    let rosterReads = 0;
+    const roster = () => {
+      rosterReads++;
+      return [1, 7];
+    };
+    expect(
+      mouseoverCastTargetPid(7, HEAL, {
+        enabled: true,
+        hasEntity: simLikeEntities([7]),
+        partyMemberPids: roster,
+      }),
+    ).toBe(7);
+    expect(rosterReads).toBe(0);
+    // No hover at all: neither callback is consulted.
+    expect(
+      mouseoverCastTargetPid(null, HEAL, {
+        enabled: true,
+        hasEntity: () => {
+          throw new Error('entity lookup on an unhovered press');
+        },
+        partyMemberPids: roster,
+      }),
+    ).toBeNull();
+    expect(rosterReads).toBe(0);
   });
 
   it('keeps the two resurrections on the friendly-targeted path the redirect covers', () => {
@@ -96,7 +126,7 @@ describe('mouseoverCastTargetPid', () => {
         mouseoverCastTargetPid(7, ability, {
           enabled: true,
           hasEntity: () => false,
-          partyMemberPids: [1, 7],
+          partyMemberPids: () => [1, 7],
         }),
       ).toBe(7);
     }

--- a/tests/mouseover_cast_core.test.ts
+++ b/tests/mouseover_cast_core.test.ts
@@ -1,0 +1,104 @@
+// Clique-style mouseover casting (src/ui/mouseover_cast_core.ts): which unit a
+// friendly ability pressed over a party/raid frame lands on.
+//
+// The regression this pins: a raid member who RELEASES waits as a ghost at the
+// graveyard, far outside the online client's ~120 yd interest scope, so
+// ClientWorld holds no entity for them. The old "entity must be in scope" gate
+// dropped the redirect there and the combat resurrection fell through to the
+// current target (the boss). Interest scope is a rendering budget, never a
+// targeting rule: the party roster is what vouches for the hovered member.
+
+import { describe, expect, it } from 'vitest';
+import { ABILITIES } from '../src/sim/data';
+import { mouseoverCastTargetPid } from '../src/ui/mouseover_cast_core';
+
+const RES = ABILITIES.temporal_reversal;
+const HEAL = ABILITIES.healing_wave;
+const BOLT = ABILITIES.lightning_bolt;
+
+// The two hosts the core has to serve identically: the offline Sim knows every
+// entity in the world, ClientWorld only the ones inside the interest scope.
+const simLikeEntities = (ids: number[]) => (pid: number) => ids.includes(pid);
+
+describe('mouseoverCastTargetPid', () => {
+  it('redirects a friendly cast to the hovered member the client can see', () => {
+    expect(
+      mouseoverCastTargetPid(7, HEAL, {
+        enabled: true,
+        hasEntity: simLikeEntities([1, 7]),
+        partyMemberPids: [1, 7],
+      }),
+    ).toBe(7);
+  });
+
+  it('redirects a combat resurrection to a RELEASED member outside interest scope', () => {
+    // The ClientWorld-shaped host: no entity for the ghost at the graveyard, but
+    // the party wire still lists them.
+    expect(
+      mouseoverCastTargetPid(7, RES, {
+        enabled: true,
+        hasEntity: () => false,
+        partyMemberPids: [1, 7],
+      }),
+    ).toBe(7);
+    // Same inputs on the Sim-shaped host (entity present) resolve to the same pid.
+    expect(
+      mouseoverCastTargetPid(7, RES, {
+        enabled: true,
+        hasEntity: simLikeEntities([1, 7]),
+        partyMemberPids: [1, 7],
+      }),
+    ).toBe(7);
+  });
+
+  it('refuses a hovered pid that is neither in scope nor on the roster', () => {
+    // A stale hover (the member left the group between the mouseenter and the
+    // keypress): fall back to the classic current-target-else-self path rather
+    // than casting at an ex-member.
+    expect(
+      mouseoverCastTargetPid(7, HEAL, {
+        enabled: true,
+        hasEntity: () => false,
+        partyMemberPids: [1, 2],
+      }),
+    ).toBeNull();
+    expect(
+      mouseoverCastTargetPid(7, HEAL, {
+        enabled: true,
+        hasEntity: () => false,
+        partyMemberPids: null,
+      }),
+    ).toBeNull();
+  });
+
+  it('never redirects a hostile cast, an untargeted cast, or a disabled option', () => {
+    const inScope = {
+      enabled: true,
+      hasEntity: simLikeEntities([7]),
+      partyMemberPids: [1, 7],
+    };
+    expect(mouseoverCastTargetPid(7, BOLT, inScope)).toBeNull();
+    expect(mouseoverCastTargetPid(7, ABILITIES.collective_reversal, inScope)).toBeNull();
+    expect(mouseoverCastTargetPid(7, undefined, inScope)).toBeNull();
+    expect(mouseoverCastTargetPid(null, HEAL, inScope)).toBeNull();
+    expect(mouseoverCastTargetPid(7, HEAL, { ...inScope, enabled: false })).toBeNull();
+  });
+
+  it('keeps the two resurrections on the friendly-targeted path the redirect covers', () => {
+    // Pinned against the real ability table: a combat res authored as anything
+    // other than a friendly targeted cast would silently leave this redirect.
+    for (const id of ['temporal_reversal', 'recall_the_fallen'] as const) {
+      const ability = ABILITIES[id];
+      expect(ability.targetsDead).toBe(true);
+      expect(ability.requiresTarget).toBe(true);
+      expect(ability.targetType).toBe('friendly');
+      expect(
+        mouseoverCastTargetPid(7, ability, {
+          enabled: true,
+          hasEntity: () => false,
+          partyMemberPids: [1, 7],
+        }),
+      ).toBe(7);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

A raider who **releases** could not be given a combat resurrection from their raid frame.

Releasing does not undo the death: the spirit rises at the graveyard while `dead` stays true and
the body is left where it fell, and resurrection reach is measured to that **body**
(`src/sim/combat/resurrection_reach.ts`). So the sim was already right, and a released member is
exactly as raisable as one still lying on the floor. The break was in the client: the ghost waits
far outside the ~120 yd interest scope, so `ClientWorld` drops their entity, and the Clique-style
mouseover cast required that entity to be in scope. Hovering their raid frame and pressing Temporal
Reversal (or Recall the Fallen) therefore fell through to the current target, which in a raid is the
boss, and answered "You must target a dead ally in your group".

Interest scope is a rendering budget, never a targeting rule. The redirect now vouches for the
hovered unit with the party/raid **roster** when the client holds no entity for them, which keeps
the stale-hover guard (someone who left the group is still refused) while letting every released
member be raised. The decision moves out of `hud.ts` into a pure core,
`src/ui/mouseover_cast_core.ts`, so it is unit-tested against both a Sim-shaped and a
ClientWorld-shaped host instead of living untestable inside the coordinator.

The roster arrives as a callback the core reads only when the entity is out of scope: the offline
`Sim` rebuilds its whole party model (aura + aggro sweeps) on every `partyInfo` read, and this path
runs on every ability press.

No new strings, no visual change, no sim or wire change.

## Related issues

N/A

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands (Windows 11, `pnpm install --frozen-lockfile`):
  - `node scripts/gate_select.mjs`
  - `npx vitest related --run src/ui/hud.ts src/ui/mouseover_cast_core.ts` (35 files, green)
  - `npx vitest run tests/mouseover_cast_core.test.ts tests/combat_res_released_ghost.test.ts tests/architecture.test.ts tests/hud_perf_budget.test.ts tests/localization_fixes.test.ts tests/resurrection_reach.test.ts tests/party_frames.test.ts` (green)
  - `npx vitest run tests/collective_reversal.test.ts tests/collective_reversal_online.test.ts tests/combat_casting_lifecycle.test.ts tests/paladin_rite_of_many.test.ts` (green)
  - `npx tsc -p tsconfig.json --noEmit` (clean), `npm run build` (all five entries, green)
  - `npx @biomejs/biome check --write` on the changed files
- Local gate caveat, stated plainly: the selective gate's vitest floor is RED on this Windows
  machine in three files, `tests/ci_stall_rerun.test.ts`, `tests/ci_shard_plan.test.ts`, and
  `tests/bank_sockets.test.ts` (8 tests, subprocess exit codes and a source tripwire). They fail
  IDENTICALLY on the untouched base commit (`origin/release/v0.42.0`, checked out and re-run to
  confirm: same 3 files, same 8 tests), so they are pre-existing and environmental, not this
  change. Everything else in that leg is green.
- New coverage:
  - `tests/mouseover_cast_core.test.ts`: the redirect resolves a released member outside interest
    scope, still refuses a hovered ex-member, never rides a hostile or untargeted cast, honors the
    Interface option, reads the roster only when it has to, and pins both combat resurrections as
    friendly targeted casts so a content change cannot quietly leave the path.
  - `tests/combat_res_released_ghost.test.ts`: end to end on the released ghost, offline Sim
    (target + cast, and the mouseover override with no target selected), the accepted offer standing
    them back up at the caster, the negative arm where the **corpse** is out of range, and the same
    flow driven through the authoritative server over the wire.

## Screenshots / recordings

N/A: no visual change (the fix is which unit a keypress addresses).

---

## Checklist

### Quality

- [x] **The gate passes**, with the one pre-existing local caveat recorded above (the three
      Windows-only red files fail the same way on the untouched base commit). Decisive tests
      were added for the changed behavior.

### Cross-platform

- [x] **Tested on desktop and mobile.** No layout or touch-target change; the party rows and their
      hover/press wiring are untouched.
- [x] **Accessible.** No UI structure, ARIA, focus, or motion change.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any
      production path.
- [x] No generated files were hand-edited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SCorMYsS9C8SUPv9Po87WT
