### PR TITLE
fix(raid): retune Heroic Varkhul intermission add health to 0.7x

### DIFF
--- a/src/sim/content/dungeon_difficulty.ts
+++ b/src/sim/content/dungeon_difficulty.ts
@@ -311,6 +311,12 @@ export const HEROIC_MOB_TUNING: Record<string, HeroicMobTuning> = {
   },
 };
 
+// Heroic Varkhul, Master's Assembly (the 50% add intermission): the factor on
+// the three summoned add pools, on top of the per-role progression below.
+// 1 restores the 2026-08-24 tuning that no live raid has cleared; 0.7 is the
+// 2026-09 "very difficult, not impossible" line (rationale on the record).
+export const VARKHUL_HEROIC_ADD_HEALTH_RETUNE = 0.7;
+
 export const HEROIC_DUNGEON_TUNING: Record<string, HeroicDungeonTuning> = {
   hollow_crypt: {
     id: 'hollow_crypt',
@@ -464,13 +470,29 @@ export const HEROIC_DUNGEON_TUNING: Record<string, HeroicDungeonTuning> = {
     difficulty: 'heroic',
     level: 22,
     healthMultiplier: 5 / 3,
-    // Boss: 120k -> 200k. Add overrides pin the requested per-role Heroic
-    // progression after the shared level transform: Sentinel +20%, Warden
-    // +25%, Artificer +30%.
+    // Boss: 120k -> 200k. Add overrides pin the per-role Heroic progression
+    // after the shared level transform (Sentinel +20%, Warden +25%, Artificer
+    // +30% over their level-22 pools), then apply the 2026-09 adds-phase retune.
+    // The 1200 / 1395 / 2170 figures are pre-elite: createMob multiplies every
+    // elite pool by 2.3, so the spawned Heroic adds were 3,312 / 4,011 / 6,488
+    // (88,500 HP across the 20 wave adds and 3 Artificers of the Master's
+    // Assembly, 1,264 raid DPS with zero downtime inside the 70 s cap).
+    // Live raids realize a median 696 DPS on those adds (best pull 865), and
+    // no Heroic Varkhul pull has finished the intermission; a Monte Carlo of
+    // the shipped encounter (tmp study, 2026-09-06) needed about 1,240 realized
+    // add DPS for a coin flip even with perfect beam soaks and interrupts.
+    // VARKHUL_HEROIC_ADD_HEALTH_RETUNE scales the three intermission adds to
+    // 0.7x (2,318 / 2,807 / 4,542, 61,950 HP, 885 zero-downtime DPS, still
+    // above Normal's 824 and still a hard check where Normal's meltdown is
+    // survivable). Measured with perfect execution: the raid wiping today
+    // clears about one pull in eight, a raid at its Heroic Ignivar output
+    // about four in five. Timers, wave count, heat and the meltdown are
+    // deliberately untouched: a longer cap alone spawns more Artificers and
+    // more heat, and did not help. Pinned by tests/ignivar_varkhul_health.test.ts.
     healthMultiplierByMob: {
-      ignivar_ember_sentinel: (1200 * 1.2) / 1300,
-      ignivar_crucible_warden: (1395 * 1.25) / 1505,
-      ignivar_cinder_artificer: (2170 * 1.3) / 2330,
+      ignivar_ember_sentinel: ((1200 * 1.2) / 1300) * VARKHUL_HEROIC_ADD_HEALTH_RETUNE,
+      ignivar_crucible_warden: ((1395 * 1.25) / 1505) * VARKHUL_HEROIC_ADD_HEALTH_RETUNE,
+      ignivar_cinder_artificer: ((2170 * 1.3) / 2330) * VARKHUL_HEROIC_ADD_HEALTH_RETUNE,
     },
     damageMultiplier: (251.5 * 1.35) / 272.5,
     addDamageMultiplier: 1,

--- a/tests/ignivar_raid_trash_tuning.test.ts
+++ b/tests/ignivar_raid_trash_tuning.test.ts
@@ -3,6 +3,7 @@ import {
   HEROIC_DUNGEON_TUNING,
   HEROIC_MOB_TUNING,
   NORMAL_DUNGEON_TUNING,
+  VARKHUL_HEROIC_ADD_HEALTH_RETUNE,
 } from '../src/sim/content/dungeon_difficulty';
 import { DUNGEONS } from '../src/sim/data';
 import {
@@ -77,10 +78,12 @@ describe('Ignivar raid trash tuning', () => {
     expect(NORMAL_DUNGEON_TUNING[IGNIVAR_SECOND_WING_ID]).toBeUndefined();
     expect(HEROIC_DUNGEON_TUNING[IGNIVAR_SECOND_WING_ID]).toMatchObject({
       healthMultiplier: 5 / 3,
+      // The per-role progression times the 2026-09 adds-phase retune; the
+      // spawned pools are pinned in tests/ignivar_varkhul_health.test.ts.
       healthMultiplierByMob: {
-        ignivar_ember_sentinel: (1_200 * 1.2) / 1_300,
-        ignivar_crucible_warden: (1_395 * 1.25) / 1_505,
-        ignivar_cinder_artificer: (2_170 * 1.3) / 2_330,
+        ignivar_ember_sentinel: ((1_200 * 1.2) / 1_300) * VARKHUL_HEROIC_ADD_HEALTH_RETUNE,
+        ignivar_crucible_warden: ((1_395 * 1.25) / 1_505) * VARKHUL_HEROIC_ADD_HEALTH_RETUNE,
+        ignivar_cinder_artificer: ((2_170 * 1.3) / 2_330) * VARKHUL_HEROIC_ADD_HEALTH_RETUNE,
       },
       damageMultiplierByMob: {
         ignivar_ember_sentinel: (101.8 * 1.25) / 110.2,

--- a/tests/ignivar_varkhul_health.test.ts
+++ b/tests/ignivar_varkhul_health.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import { HEROIC_DUNGEON_TUNING } from '../src/sim/content/dungeon_difficulty';
+import {
+  HEROIC_DUNGEON_TUNING,
+  VARKHUL_HEROIC_ADD_HEALTH_RETUNE,
+} from '../src/sim/content/dungeon_difficulty';
 import { DUNGEON_MOBS } from '../src/sim/content/dungeons';
 import { createMob } from '../src/sim/entity';
 import {
@@ -38,15 +41,25 @@ describe('Ignivar and Varkhul raid health bands', () => {
   });
 
   it('scales Heroic automata after compensating for their level 20 to 22 jump', () => {
+    // The Heroic pools are the per-role progression (+20% / +25% / +30% over
+    // the level-22 transform, elite x2.3 included) times the 2026-09 adds-phase
+    // retune. At 1x they were 3,312 / 4,011 / 6,488 and no live raid finished
+    // the Master's Assembly; 0.7x is the "very difficult, not impossible" line.
+    expect(VARKHUL_HEROIC_ADD_HEALTH_RETUNE).toBe(0.7);
     const rows = [
-      [IGNIVAR_EMBER_SENTINEL_ID, 2_760, 3_312],
-      [IGNIVAR_CRUCIBLE_WARDEN_ID, 3_208, 4_011],
-      [IGNIVAR_CINDER_ARTIFICER_ID, 4_991, 6_488],
+      [IGNIVAR_EMBER_SENTINEL_ID, 2_760, 2_318],
+      [IGNIVAR_CRUCIBLE_WARDEN_ID, 3_208, 2_807],
+      [IGNIVAR_CINDER_ARTIFICER_ID, 4_991, 4_542],
     ] as const;
     for (const [templateId, normalHp, heroicHp] of rows) {
       expect(spawned(templateId, 'ignivar_inner_crucible', 'normal').maxHp).toBe(normalHp);
       expect(spawned(templateId, 'ignivar_inner_crucible', 'heroic').maxHp).toBe(heroicHp);
     }
+    // The whole intermission (16 Sentinels, 4 Wardens, 3 Artificers) must stay
+    // a harder throughput check than Normal's 12 + 3 inside its 60 s cap.
+    const heroicPool = 16 * 2_318 + 4 * 2_807 + 3 * 4_542;
+    const normalPool = 9 * 2_760 + 3 * 3_208 + 3 * 4_991;
+    expect(heroicPool / 70).toBeGreaterThan(normalPool / 60);
   });
 
   it('raises Heroic tank and add melee without multiplying support damage wildly', () => {

--- a/tests/varkhul_forge_encounter.test.ts
+++ b/tests/varkhul_forge_encounter.test.ts
@@ -382,7 +382,7 @@ describe('Varkhul forge pillars and add intermission', () => {
       .map((id) => sim.entities.get(id))
       .find((add) => add?.templateId === VARKHUL_CINDER_ARTIFICER_ID);
     if (!artificer) throw new Error('Cinder Artificer did not emerge');
-    expect(artificer.maxHp).toBe(6_488);
+    expect(artificer.maxHp).toBe(4_542);
     expect(artificer.mechanicDamageMult).toBe(1);
     expect(artificer.rangedDamageMult).toBeUndefined();
     expect(artificer.ccImmune).not.toBe(true);
@@ -2737,7 +2737,7 @@ describe('Varkhul forge pillars and add intermission', () => {
       .map((id) => sim.entities.get(id))
       .find((add) => add?.templateId === VARKHUL_CRUCIBLE_WARDEN_ID);
     if (!warden) throw new Error('Crucible Warden did not emerge');
-    expect(warden.maxHp).toBe(4_011);
+    expect(warden.maxHp).toBe(2_807);
     expect(warden.mechanicDamageMult).toBeCloseTo((92.2 * 1.25) / 99.8, 12);
     state.assemblyForgeBeamWarmupRemaining = 999;
 


### PR DESCRIPTION
## Summary

Retunes the Heroic Varkhul intermission (the Master's Assembly at 50%) by scaling the three summoned add pools to 0.7x. Timers, wave count, portal cadence, forge heat, beam soaks and the meltdown are deliberately untouched.

**Why.** No live raid has finished the Heroic intermission. All 23 logged Heroic pulls (one team, 2026-09-01) reached 50% and wiped inside it; the best pull killed 11 of 20 wave adds; median realized DPS on the adds was 696 (best 865). The shipped pools are Sentinel 3,312 / Warden 4,011 / Artificer 6,488 (the per-role table times the 2.3x elite multiplier `createMob` applies), which is 88,500 HP across the 20 wave adds and 3 Artificers inside the 70 s cap: 1,264 raid DPS with zero downtime. A Monte Carlo of the real encounter (real `Sim`, real Inner Crucible instance, real tank and healer bots, synthetic post-mitigation DPS, perfect beam soaks and interrupts, 24 seeds per point) needed about 1,240 realized add DPS for a coin flip and 1,400 for a reliable clear; the harness reproduces the live team at their DPS (696 realized, 7 of 20 adds versus 696 and 6 of 20 in the logs).

**What changes.** `VARKHUL_HEROIC_ADD_HEALTH_RETUNE = 0.7` multiplies the three `healthMultiplierByMob` entries for `ignivar_inner_crucible`:

| Add | Shipped Heroic | This PR | Normal (unchanged) |
|---|---|---|---|
| Ember Sentinel | 3,312 | 2,318 | 2,760 |
| Crucible Warden | 4,011 | 2,807 | 3,208 |
| Cinder Artificer | 6,488 | 4,542 | 4,991 |
| Whole intermission | 88,500 HP, 1,264 DPS zero-downtime in 70 s | 61,950 HP, 885 DPS | 49,434 HP, 824 DPS in 60 s |

Heroic stays a harder throughput check than Normal and stays a hard enrage (Normal's 140% meltdown is survived by 30 of 35 kills; Heroic's 175% by none of 23 pulls). Measured with perfect execution: the raid wiping today clears about one pull in eight (so it still has to fix its soaking and interrupts, which is what its logged heat meltdowns at a median 52 s say it is not doing), a raid at its Heroic Ignivar output about four in five, a very strong raid every time. 0.8x left a geared raid under one in three; 0.6x handed the current raid a coin flip. The target brief was "very difficult, not impossible".

**Why not the timer.** Measured: raising the 70 s cap alone does not help, because the Artificer portal (every 18 s) and forge heat (never cools, +10% per completed quake) keep running with it; a 130 s cap gave the current raid 12% with seven Artificers to kill. A 120 s cap only works with the Artificer repeat stretched to 36 s (67%), and that was rejected in favour of keeping every timer as designed.

Study report (parse mining plus the Monte Carlo, all numbers above): `VARKHUL-ADDS-PHASE-DPS-2026-09-06` (maintainer-local, not in the repo). Tooling is untracked study scaffolding in the `wt-varkhul-dps-study` worktree.

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx tsc --noEmit` (clean)
  - `npx @biomejs/biome check` on the four changed files (clean)
  - `npx vitest run tests/ignivar_varkhul_health.test.ts tests/varkhul_forge_encounter.test.ts tests/ignivar_raid_trash_tuning.test.ts tests/parity tests/guide.test.ts tests/heroic_difficulty_floors.test.ts` (green; the parity goldens do not hash the add pools, no re-mint)
  - `GATE_SELECT_BASE=origin/release/v0.42.0 node scripts/gate_select.mjs` (see the gate line below)
- Manual steps: none. The retune is pinned by `tests/ignivar_varkhul_health.test.ts` (spawned pools on both difficulties, the 0.7 factor, and the Heroic-harder-than-Normal throughput inequality), plus the re-pinned Artificer and Warden `maxHp` checks in `tests/varkhul_forge_encounter.test.ts` and the multiplier shape in `tests/ignivar_raid_trash_tuning.test.ts`.

---

## Checklist

### Quality

- [x] **The gate passes.** `node scripts/gate_select.mjs` is green. I added or updated decisive tests for changed behavior and recorded any manual checks above.

### Cross-platform

- [ ] ~Tested on desktop and mobile.~ N/A, sim tuning only.
- [ ] ~Accessible.~ N/A, no UI.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] No generated files hand-edited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WeTbH3xygrhhA1BTyxqpfh
