### PR TITLE
feat(chat): add /all and /gen as General chat command aliases

### DIFF
--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -2,3 +2,7 @@
 
 - Backgrounded movement v2 sessions stop accruing playtime and daily-reward activity after
   their consumed input frames become stale.
+- General chat gains two new command aliases: /all and /gen (for short) now work alongside
+  /general and the classic /1 shortcut, so you can reach the realm-wide channel without the
+  /g-versus-guild ambiguity. Nothing else changed: the channel, its tab, its colour, and who
+  hears you are all the same.

--- a/server/game.ts
+++ b/server/game.ts
@@ -1728,7 +1728,7 @@ function chatChannelHint(session: ClientSession, text: string): string {
   if (/^\/(?:w|whisper|t|tell|r|reply)\s/i.test(text)) return 'whisper';
   if (/^\/(?:y|yell)\s/i.test(text)) return 'yell';
   if (/^\/(?:p|party)\s/i.test(text)) return 'party';
-  if (/^\/(?:general|world)\s/i.test(text)) return 'general';
+  if (/^\/(?:general|all|gen|world)\s/i.test(text)) return 'general';
   if (/^\/(?:s|say)\s/i.test(text)) return 'say';
   return session.rememberedChat.channel;
 }

--- a/server/general_chat_quota.ts
+++ b/server/general_chat_quota.ts
@@ -16,8 +16,9 @@ export interface OnlineGeneralChat {
 }
 
 /**
- * Classify only the online server's General spellings. In particular, `/g` is
- * guild online even though the offline sim retains it as a General alias.
+ * Classify only the online server's General spellings (`/general`, its `/all`
+ * and `/gen` aliases, and the numbered `/1`). In particular, `/g` is guild
+ * online even though the offline sim retains it as a General alias.
  */
 export function classifyOnlineGeneralChat(
   rawText: string,
@@ -25,7 +26,7 @@ export function classifyOnlineGeneralChat(
 ): OnlineGeneralChat | null {
   const text = rawText.trim();
   if (!text) return null;
-  const explicit = /^\/(?:general|1)\s+([\s\S]+)$/i.exec(text);
+  const explicit = /^\/(?:general|all|gen|1)\s+([\s\S]+)$/i.exec(text);
   if (explicit) {
     const body = explicit[1].trim();
     return body ? { canonicalText: `/general ${body}` } : null;

--- a/src/guide/pages/commands.ts
+++ b/src/guide/pages/commands.ts
@@ -47,7 +47,10 @@ const GROUPS: Group[] = [
     heading: 'guide.commandsPage.groupChannels',
     intro: 'guide.commandsPage.channelsIntro',
     rows: [
-      { cmds: ['/general <message>', '/1 <message>'], desc: 'guide.commandsPage.general' },
+      {
+        cmds: ['/general <message>', '/all <message>', '/gen <message>', '/1 <message>'],
+        desc: 'guide.commandsPage.general',
+      },
       { cmds: ['/g <message>'], desc: 'guide.commandsPage.gAlias' },
       { cmds: ['/guild <message>', '/gu <message>'], desc: 'guide.commandsPage.guild' },
       { cmds: ['/officer <message>', '/o <message>'], desc: 'guide.commandsPage.officer' },

--- a/src/sim/social/chat.ts
+++ b/src/sim/social/chat.ts
@@ -829,8 +829,10 @@ export function chat(ctx: SimContext, text: string, pid?: number): SentChat | nu
   // "/g message" / "/1 message": world-wide general channel (no pid = broadcast to
   // all). "/1" is the classic numbered-channel shortcut for General; unlike "/g" it
   // is never claimed by the online guild router, so it always reaches General.
-  if (/^\/(?:g(?:eneral)?|1)\s/i.test(raw)) {
-    const clean = raw.replace(/^\/(?:g(?:eneral)?|1)\s+/i, '').trim();
+  // "/all" and its short form "/gen" are newer aliases for the same channel,
+  // added so the channel can be addressed without the /g-vs-guild ambiguity.
+  if (/^\/(?:g(?:eneral)?|all|gen|1)\s/i.test(raw)) {
+    const clean = raw.replace(/^\/(?:g(?:eneral)?|all|gen|1)\s+/i, '').trim();
     if (!clean) return null;
     ctx.emit({
       type: 'chat',
@@ -1079,7 +1081,7 @@ export function playEmote(ctx: SimContext, emoteId: OverheadEmoteId, pid?: numbe
 // in sync with the commands handled in chat() above.
 export function helpLines(): string[] {
   return [
-    'Chat channels: /s say, /y yell, /general, /p party, /bg battleground, /world, /lfg.',
+    'Chat channels: /s say, /y yell, /general (also /all or /gen), /p party, /bg battleground, /world, /lfg.',
     'Whisper a player with /w <name> <message>, reply with /r.',
     'Other commands: /join <world|lfg>, /roll, /invite <name>, /inspect <name>, /follow <name>, /unfollow, /assist <name>, /ready, /afk, /dnd, /who.',
     'Recovery: /unstuck starts a stationary countdown, then moves you to the nearest graveyard, reviving you if you had fallen. It leaves you with Unstuck Sickness for up to 5 minutes.',

--- a/src/ui/hud/chat/chat_channels.ts
+++ b/src/ui/hud/chat/chat_channels.ts
@@ -197,9 +197,10 @@ export function sentLineChannel(line: string): ChatTabChannel | null {
   if (/^\/s(ay)?\s/i.test(text)) return 'say';
   if (/^\/gu(ild)?\s/i.test(text)) return 'guild';
   if (/^\/o(fficer)?\s/i.test(text)) return 'officer';
-  // "/1" is the numbered-channel shortcut for General (see sentLineTarget below and
-  // the sim router); "/g" is intentionally NOT here because it routes to guild online.
-  if (/^\/(?:general|1)\s/i.test(text)) return 'general';
+  // "/1" is the numbered-channel shortcut for General and "/all"/"/gen" its newer
+  // aliases (see sentLineTarget below and the sim router); "/g" is intentionally
+  // NOT here because it routes to guild online.
+  if (/^\/(?:general|all|gen|1)\s/i.test(text)) return 'general';
   if (/^\/world\s/i.test(text)) return 'world';
   if (/^\/lfg\s/i.test(text)) return 'lfg';
   return null;

--- a/tests/chat.test.ts
+++ b/tests/chat.test.ts
@@ -221,6 +221,46 @@ describe('chat channels', () => {
     expect(msgs[0].text).toBe('anyone for crypt');
   });
 
+  it('the /all and /gen aliases reach the General channel, like /general', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const far = sim.addPlayer('mage', 'Bet');
+    teleport(sim, a, 0, -40);
+    teleport(sim, far, 0, -900);
+    sim.tick();
+
+    expect(sim.chat('/all anyone for crypt', a)).toEqual({
+      channel: 'general',
+      message: 'anyone for crypt',
+    });
+    const allMsgs = chatEvents(sim.tick());
+    expect(allMsgs).toHaveLength(1);
+    expect(allMsgs[0].channel).toBe('general');
+    expect(allMsgs[0].pid).toBeUndefined(); // no pid = routed to everyone
+
+    expect(sim.chat('/gen still looking', a)).toEqual({
+      channel: 'general',
+      message: 'still looking',
+    });
+    const genMsgs = chatEvents(sim.tick());
+    expect(genMsgs).toHaveLength(1);
+    expect(genMsgs[0].channel).toBe('general');
+    expect(genMsgs[0].text).toBe('still looking');
+  });
+
+  it('/help lists the /all and /gen aliases beside /general', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    sim.chat('/help', a);
+    const lines = sim.tick().flatMap((e) => (e.type === 'error' && e.pid === a ? [e.text] : []));
+    const channels = lines.find((text) => /^Chat channels:/.test(text));
+    expect(channels).toBeDefined();
+    expect(channels).toContain('/general');
+    expect(channels).toContain('/all');
+    expect(channels).toContain('/gen');
+  });
+
   it('unknown slash commands error instead of being said out loud', () => {
     const sim = makeWorld();
     const a = sim.addPlayer('warrior', 'Aleph');

--- a/tests/chat_channels.test.ts
+++ b/tests/chat_channels.test.ts
@@ -387,6 +387,8 @@ describe('chat channel tabs — pure model', () => {
   it('sentLineChannel maps the /1 shortcut to General (but never /g, which is guild online)', () => {
     expect(sentLineChannel('/1 hey everyone')).toBe('general');
     expect(sentLineChannel('/general hey everyone')).toBe('general');
+    expect(sentLineChannel('/all hey everyone')).toBe('general');
+    expect(sentLineChannel('/gen hey everyone')).toBe('general');
     expect(sentLineChannel('/p on my way')).toBe('party');
     expect(sentLineChannel('/w Bob hi')).toBeNull();
     expect(sentLineChannel('/r sure')).toBeNull();
@@ -416,6 +418,8 @@ describe('chat channel tabs — pure model', () => {
       for (const online of [true, false]) {
         expect(sentLineTargetForHost('/1 hey', { online })).toBe('general');
         expect(sentLineTargetForHost('/general hey', { online })).toBe('general');
+        expect(sentLineTargetForHost('/all hey', { online })).toBe('general');
+        expect(sentLineTargetForHost('/gen hey', { online })).toBe('general');
         expect(sentLineTargetForHost('/gu ready', { online })).toBe('guild');
         expect(sentLineTargetForHost('/p on my way', { online })).toBe('party');
         expect(sentLineTargetForHost('/r sure', { online })).toBe(WHISPER_TAB);

--- a/tests/general_chat_quota.test.ts
+++ b/tests/general_chat_quota.test.ts
@@ -17,6 +17,10 @@ describe('classifyOnlineGeneralChat', () => {
   it.each([
     ['/general hello', 'say', '/general hello'],
     ['/GENERAL   hello there ', 'guild', '/general hello there'],
+    ['/all hello', 'say', '/general hello'],
+    ['/ALL   hello there ', 'guild', '/general hello there'],
+    ['/gen hello', 'say', '/general hello'],
+    ['/GEN   hello there ', 'guild', '/general hello there'],
     ['/1 hello', 'say', '/general hello'],
     ['sticky hello', 'general', '/general sticky hello'],
   ] as const)('classifies %j with sticky %s as General', (text, remembered, canonicalText) => {

--- a/tests/general_chat_quota_game.test.ts
+++ b/tests/general_chat_quota_game.test.ts
@@ -213,6 +213,24 @@ describe('GameServer General quota authority', () => {
     await vi.waitFor(() => expect(sender.session.rememberedChat).toEqual({ channel: 'general' }));
   });
 
+  it('routes the /all and /gen aliases through the same quota-gated General path', async () => {
+    consumeQuota.mockResolvedValue({ status: 'allowed' });
+    const server = new GameServer();
+    const sender = joinConfigured(server, 11, 'Aleph');
+    const simChat = vi.spyOn(server.sim, 'chat');
+    vi.spyOn(server.chatLog, 'log').mockImplementation(() => {});
+
+    send(server, sender.session, '/all hello everyone');
+    await vi.waitFor(() =>
+      expect(simChat).toHaveBeenCalledWith('/general hello everyone', sender.session.pid),
+    );
+    send(server, sender.session, '/gen short form too');
+    await vi.waitFor(() =>
+      expect(simChat).toHaveBeenCalledWith('/general short form too', sender.session.pid),
+    );
+    expect(consumeQuota).toHaveBeenCalledTimes(2);
+  });
+
   it('does not rewrite a newer sticky channel selected while the send was in flight', async () => {
     let resolve!: (result: { status: 'allowed' }) => void;
     consumeQuota.mockReturnValue(

--- a/tests/guide_commands_page.test.ts
+++ b/tests/guide_commands_page.test.ts
@@ -1,0 +1,24 @@
+// @vitest-environment happy-dom
+
+import { describe, expect, it } from 'vitest';
+import { pageFor } from '../src/guide/pages';
+import { setLanguage } from '../src/ui/i18n';
+
+// The General channel gained /all and /gen as command aliases beside /general
+// and the classic /1 shortcut; the guide's command reference is the
+// player-facing list of record, so pin all four spellings on the General row.
+describe('Guide commands page: General channel row', () => {
+  it('lists /general with its /all, /gen, and /1 aliases', () => {
+    setLanguage('en');
+    const html =
+      pageFor('commands')?.render({
+        params: [],
+        sub: 'reference/commands',
+        titleKey: 'guide.nav.commands',
+      }) ?? '';
+    expect(html).toContain('<kbd>/general &lt;message&gt;</kbd>');
+    expect(html).toContain('<kbd>/all &lt;message&gt;</kbd>');
+    expect(html).toContain('<kbd>/gen &lt;message&gt;</kbd>');
+    expect(html).toContain('<kbd>/1 &lt;message&gt;</kbd>');
+  });
+});

--- a/tests/parity/golden/chat_social.json
+++ b/tests/parity/golden/chat_social.json
@@ -1213,7 +1213,7 @@
       "time": 0,
       "nextId": 1001,
       "state": "7de04c7b",
-      "events": "261a1c23",
+      "events": "13a6f01d",
       "rng": {
         "draws": 0,
         "digest": "811c9dc5"


### PR DESCRIPTION
## Summary

General chat gains two additional command aliases: /all and its short form /gen now route to the realm-wide General channel everywhere /general does. Nothing existing moves: /general, the classic /1 shortcut, and the host-ambiguous /g all behave exactly as before, and the channel's id, tab, colour, and persistence are untouched.

Why: General has no unambiguous short command. /g is guild online (and General only offline), which makes it unsafe to teach or autocomplete, and /1 is a numbered convention newer players do not guess. /all and /gen are free on every host and read naturally.

What routes where:

- Sim router (`src/sim/social/chat.ts`): the General branch accepts /all and /gen beside /g, /general, and /1.
- Online quota classifier (`server/general_chat_quota.ts`): /all and /gen are classified as General and normalized to the same `/general <body>` canonical text, so the async quota admission, sticky-channel fencing, and chat logging are byte-identical for every spelling.
- Violation-log channel hint (`server/game.ts`): the aliases label as `general`.
- Client sticky map (`src/ui/hud/chat/chat_channels.ts`): an aliased send keeps the input in General, like /general.
- Discovery: /help now reads "/general (also /all or /gen)" and the wiki command reference lists all four spellings on the General row.

Deliberately unchanged: every translated UI string (no rewording means no stale overlay translations), the chat placeholder, the /join channel list, moderation commands, and the E2E scripts (which keep speaking /general and still pass by definition of an additive change).

The parity golden for the chat_social scenario is re-minted in its own commit per `tests/parity/CLAUDE.md`: the /help wording moves that scenario's event digest for one readout window, and the diff is that single events hash, with every rng fingerprint and state sample byte-identical.

## Type of change

- [x] Feature: new functionality

## How was this tested?

- Commands:
  - `npx tsc --noEmit` clean.
  - `npx vitest run tests/chat.test.ts tests/chat_channels.test.ts tests/chat_log.test.ts tests/chat_flair.test.ts tests/chat_hud_client_seam.test.ts tests/general_chat_quota.test.ts tests/general_chat_quota_game.test.ts tests/guide_commands_page.test.ts tests/localization_fixes.test.ts tests/i18n_completeness.test.ts tests/architecture.test.ts tests/guide.test.ts`: all green (484 passed).
  - `npx vitest run tests/parity`: green after the deliberate `UPDATE_PARITY=1` re-mint of `chat_social.json`, except `tests/parity/coverage_c.test.ts` (druid_engines), which fails identically on the pristine `release/v0.42.0` base on this machine and is unrelated to this change.
  - The selective gate legs (`scripts/gate_select.mjs` plan, run individually because this machine's standing environment failures abort the combined run at floor leg 1): every red file reproduces on the pristine base (ci_shard_plan, ci_stall_rerun, deploy_*, gate_preflight, electron_*, icon/art audits, path-helper suites, material_taxonomy, prod_cpu_monitor, parse_shipper, server/new_endpoint, auth_guard_bust_coverage), none chat-related.
- New tests: /all and /gen deliver to General offline; the online path consumes the quota and replays the `/general` canonical through the sim for both aliases; the classifier spellings (case and whitespace variants); the client sticky map; the /help listing; the guide command row.

## Checklist

### Quality

- [x] **The gate passes** per the leg-by-leg runs above; the only reds are this machine's standing environment failures, each verified against the pristine base.

### Cross-platform

- [x] N/A: no layout, styling, or input-surface change (two new kbd tokens in an existing wiki table row and one reworded /help line).

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings: slash-command tokens in the guide's kbd row are untranslated command spellings, and the /help readout is on the English-by-design V07 command-reference backstop. `npx vitest run tests/localization_fixes.test.ts` passes.

Generated with [Claude Code](https://claude.com/claude-code)
