### PR TITLE
fix(ui): tolerate finger jitter in touch tooltip peek

### DIFF
--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -855,7 +855,7 @@ import {
 } from './tooltip_clamp_core';
 import { createTooltipLine } from './tooltip_line';
 import { SharedTooltipOwner } from './tooltip_owner';
-import { TOOLTIP_PEEK_MS, TouchPeekGuard } from './touch_peek';
+import { bindTooltipTouchPeek, TouchPeekGuard } from './touch_peek';
 import { bindTouchDoubleTap, bindTouchTap, CLICK_SUPPRESS_MS, TAP_SLOP_PX } from './touch_tap';
 import { buildTownFocusView, stepTownFocus, townFocusRenderSig } from './town_focus_view';
 import { renderTownFocusWindow } from './town_focus_window';
@@ -6110,17 +6110,12 @@ export class Hud {
   }
 
   attachTooltip(el: HTMLElement, html: () => string): void {
-    let touchTimer: number | undefined;
     // tooltip box size, measured once in showAt (right after the content is set)
     // and reused by every mousemove: the content cannot change between showAt
     // calls, so re-reading offsetWidth/Height per mousemove only forced a reflow
     let ttW = 0;
     let ttH = 0;
     const mobile = () => document.body.classList.contains('mobile-touch');
-    const clearTouchTimer = () => {
-      if (touchTimer !== undefined) window.clearTimeout(touchTimer);
-      touchTimer = undefined;
-    };
     const showAt = (x: number, y: number, trigger: 'touch' | 'mouse' | 'focus') => {
       // Touch-only path: showing the tooltip means the held control is being
       // inspected, so the release click should peek, not fire its action.
@@ -6137,6 +6132,14 @@ export class Hud {
       const rect = el.getBoundingClientRect();
       showAt(rect.right, rect.top + rect.height / 2, 'focus');
     };
+    const touchPeek = bindTooltipTouchPeek(el, {
+      isMobile: mobile,
+      press: () => this.peekGuard.press(),
+      hide: () => {
+        this.tooltipEl.style.display = 'none';
+      },
+      showAt: (x, y) => showAt(x, y, 'touch'),
+    });
     // A mouse click or a tap focuses the button as a side effect (the browser
     // moves focus to whatever was pressed), which used to fire showNearElement
     // on EVERY action-bar press, not just real keyboard (Tab) navigation. Flag
@@ -6185,35 +6188,25 @@ export class Hud {
       this.tooltipEl.style.top = `${at.top}px`;
     });
     el.addEventListener('mouseleave', () => {
-      clearTouchTimer();
+      touchPeek.clear();
       this.tooltipEl.style.display = 'none';
       // Box hidden: no element owns it, so the next move over any slot re-resolves.
       this.tooltipOwner.release();
     });
     el.addEventListener('focusout', () => {
-      clearTouchTimer();
+      touchPeek.clear();
       this.tooltipEl.style.display = 'none';
       this.tooltipOwner.release();
     });
-    el.addEventListener('pointerdown', (e) => {
-      if (!mobile() || e.pointerType === 'mouse') return;
-      clearTouchTimer();
-      // A fresh press: drop any stale peek and dismiss a lingering tooltip.
-      this.peekGuard.press();
-      this.tooltipEl.style.display = 'none';
-      const x = e.clientX,
-        y = e.clientY;
-      touchTimer = window.setTimeout(() => showAt(x, y, 'touch'), TOOLTIP_PEEK_MS);
-    });
     el.addEventListener('pointerup', () => {
-      clearTouchTimer();
+      touchPeek.clear();
       // Safari desktop never focuses a button on click, so pointerdown's flag
       // above would otherwise never get consumed by a focusin and could wrongly
       // swallow a later, real keyboard-focus tooltip; drop it once the press ends.
       pointerFocusPending = false;
     });
     el.addEventListener('pointercancel', () => {
-      clearTouchTimer();
+      touchPeek.clear();
       pointerFocusPending = false;
     });
   }

--- a/src/ui/touch_peek.ts
+++ b/src/ui/touch_peek.ts
@@ -11,6 +11,30 @@
 /** Default hold (ms) before a touch press is treated as a tooltip peek. */
 export const TOOLTIP_PEEK_MS = 950;
 
+// Movement (px) that cancels a pending peek, treating the press as the start
+// of a scroll instead of a held tap. Every element attachTooltip binds to
+// sits inside a touch-action: pan-y scroll container with no pointermove
+// listener of its own, so iOS Safari's gesture arbiter was free to read any
+// finger drift during the ~1s hold as scroll intent and fire pointercancel,
+// wiping the timer before it ever fired (the reported "never works on iOS"
+// failure). touch_item_drag.ts already solves this exact disambiguation for
+// its own long-press gesture on the same rows (TOUCH_DRAG_MOVE_TOLERANCE_PX);
+// this constant matches its value independently rather than importing it, so
+// the two gesture modules stay decoupled.
+export const TOOLTIP_PEEK_MOVE_TOLERANCE_PX = 9;
+
+/** Whether a finger has drifted far enough from where a peek press started to
+ *  treat it as scroll intent rather than a still-held tap. Pure so it is
+ *  unit-tested directly; the pointermove wiring lives in Hud.attachTooltip. */
+export function exceedsPeekMoveTolerance(
+  startX: number,
+  startY: number,
+  x: number,
+  y: number,
+): boolean {
+  return Math.hypot(x - startX, y - startY) > TOOLTIP_PEEK_MOVE_TOLERANCE_PX;
+}
+
 export type TooltipTriggerKind = 'touch' | 'mouse' | 'focus';
 
 export class TouchPeekGuard {
@@ -41,4 +65,54 @@ export class TouchPeekGuard {
     this.peeked = false;
     return wasPeek;
   }
+}
+
+export interface TooltipTouchPeekDeps {
+  /** True on a touch device (Hud.attachTooltip's own `mobile()` check). */
+  isMobile(): boolean;
+  /** A fresh press began: drop any stale peek state. */
+  press(): void;
+  /** Hide a lingering tooltip before arming a new peek. */
+  hide(): void;
+  /** The hold completed: show the tooltip at (x, y). */
+  showAt(x: number, y: number): void;
+}
+
+/** Binds the whole long-press-to-peek touch gesture to one attachTooltip
+ *  target: pointerdown arms the TOOLTIP_PEEK_MS timer, and pointerup /
+ *  pointercancel / a move past TOOLTIP_PEEK_MOVE_TOLERANCE_PX clear it.
+ *  Mirrors touch_item_drag.ts's own pointer-event shape (hold timer plus a
+ *  move-tolerance stand-down) for the identical scroll-vs-hold
+ *  disambiguation on the same scrollable rows. The caller's own
+ *  mouseleave/focusout/pointerup/pointercancel handlers call the returned
+ *  `clear()` to drop a pending timer on their own cleanup paths. */
+export function bindTooltipTouchPeek(
+  el: HTMLElement,
+  deps: TooltipTouchPeekDeps,
+): { clear(): void } {
+  let timer: number | undefined;
+  let startX = 0;
+  let startY = 0;
+  const clear = (): void => {
+    if (timer !== undefined) window.clearTimeout(timer);
+    timer = undefined;
+  };
+  el.addEventListener('pointerdown', (e) => {
+    if (!deps.isMobile() || e.pointerType === 'mouse') return;
+    clear();
+    deps.press();
+    deps.hide();
+    const x = e.clientX;
+    const y = e.clientY;
+    startX = x;
+    startY = y;
+    timer = window.setTimeout(() => deps.showAt(x, y), TOOLTIP_PEEK_MS);
+  });
+  el.addEventListener('pointermove', (e) => {
+    if (timer === undefined) return;
+    if (exceedsPeekMoveTolerance(startX, startY, e.clientX, e.clientY)) clear();
+  });
+  el.addEventListener('pointerup', clear);
+  el.addEventListener('pointercancel', clear);
+  return { clear };
 }

--- a/tests/architecture.test.ts
+++ b/tests/architecture.test.ts
@@ -2532,6 +2532,11 @@ const UI_DOM_MODULES = [
   'src/ui/target_swing_timer_bars.ts',
   'src/ui/theme.ts',
   'src/ui/touch_item_drag.ts',
+  // bindTooltipTouchPeek binds pointerdown/pointermove/pointerup/pointercancel
+  // to the caller's element and owns a window.setTimeout/clearTimeout peek
+  // timer: the same DOM-owning shape as touch_item_drag.ts's own long-press
+  // gesture above, for the identical scroll-vs-hold disambiguation.
+  'src/ui/touch_peek.ts',
   'src/ui/touch_tap.ts',
   'src/ui/town_focus_window.ts',
   // The tracker-stack seat applier: owns a resize listener and bounded

--- a/tests/monolith_budget.test.ts
+++ b/tests/monolith_budget.test.ts
@@ -433,7 +433,12 @@ const MONOLITHS: MonolithRow[] = [
     // `wc -l < src/ui/hud.ts` on the reconciled file measures 18577, below
     // both arms, so the ceiling follows it down. Exact merged count, zero
     // slack: any further growth reds again.
-    ceiling: 18577,
+    // LOWERED 18577 -> 18570 for the touch-peek jitter-tolerance fix: the whole
+    // long-press-to-peek touch gesture (the timer arm/clear plus the new
+    // move-tolerance stand-down) moved into src/ui/touch_peek.ts's
+    // bindTooltipTouchPeek, leaving attachTooltip a thin caller passing it
+    // isMobile/press/hide/showAt. Exact count, zero slack.
+    ceiling: 18570,
     seam: 'pure view core + thin painter on PainterHost (src/ui/CLAUDE.md)',
   },
   {

--- a/tests/touch_peek.test.ts
+++ b/tests/touch_peek.test.ts
@@ -1,5 +1,10 @@
-import { describe, it, expect } from 'vitest';
-import { TouchPeekGuard, TOOLTIP_PEEK_MS } from '../src/ui/touch_peek';
+import { describe, expect, it } from 'vitest';
+import {
+  exceedsPeekMoveTolerance,
+  TOOLTIP_PEEK_MOVE_TOLERANCE_PX,
+  TOOLTIP_PEEK_MS,
+  TouchPeekGuard,
+} from '../src/ui/touch_peek';
 
 describe('TouchPeekGuard', () => {
   it('a quick tap (no peek) activates the control', () => {
@@ -54,5 +59,29 @@ describe('TouchPeekGuard', () => {
   it('exposes a sane default hold threshold', () => {
     expect(TOOLTIP_PEEK_MS).toBeGreaterThan(300);
     expect(TOOLTIP_PEEK_MS).toBeLessThan(2000);
+  });
+});
+
+describe('exceedsPeekMoveTolerance', () => {
+  it('tolerates small jitter while the finger is effectively still', () => {
+    expect(exceedsPeekMoveTolerance(100, 100, 100, 100)).toBe(false);
+    expect(exceedsPeekMoveTolerance(100, 100, 103, 101)).toBe(false);
+    expect(exceedsPeekMoveTolerance(100, 100, 100 + TOOLTIP_PEEK_MOVE_TOLERANCE_PX, 100)).toBe(
+      false,
+    );
+  });
+
+  it('treats movement past the tolerance as scroll intent', () => {
+    expect(exceedsPeekMoveTolerance(100, 100, 100 + TOOLTIP_PEEK_MOVE_TOLERANCE_PX + 1, 100)).toBe(
+      true,
+    );
+    expect(exceedsPeekMoveTolerance(100, 100, 100, 250)).toBe(true);
+  });
+
+  it('measures straight-line distance, not per-axis drift', () => {
+    // A diagonal move whose per-axis components are each under tolerance can
+    // still exceed it in combined distance.
+    const half = TOOLTIP_PEEK_MOVE_TOLERANCE_PX;
+    expect(exceedsPeekMoveTolerance(0, 0, half, half)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Long-press on a bag/action-bar/crafting item to peek its tooltip essentially never worked on iOS Safari. Root cause: `Hud.attachTooltip`'s touch peek timer (`src/ui/hud.ts`, `TOOLTIP_PEEK_MS = 950`) had no `pointermove` listener at all. Every bound element sits inside a `touch-action: pan-y` scroll container (bag grid, bank scroll, market body, etc.), so with zero active listeners watching finger movement, iOS Safari's gesture arbiter is free to decide on the slightest drift during the ~1s hold that this is a scroll and fire `pointercancel`, wiping the pending timer before it ever shows the tooltip.

`src/ui/touch_item_drag.ts` already solves this exact scroll-vs-hold disambiguation for its own long-press-to-drag gesture on the same rows (`TOUCH_DRAG_MOVE_TOLERANCE_PX = 9`, hold timer plus a move-tolerance stand-down). This PR mirrors that established pattern for the tooltip peek instead of inventing a new idiom: `src/ui/touch_peek.ts` gains `exceedsPeekMoveTolerance` (pure, unit-tested) and `bindTooltipTouchPeek`, which owns the whole pointerdown/pointermove/pointerup/pointercancel wiring. Small jitter within tolerance leaves the peek timer running; a real drift cancels it and lets the browser's own pan take over, same as before.

`src/ui/hud.ts` was at its exact monolith-ratchet line-count ceiling, so rather than growing it, the whole touch-peek gesture (not just the new tolerance check) moved out of `attachTooltip` into `touch_peek.ts`'s `bindTooltipTouchPeek`, leaving `attachTooltip` a thin caller passing `isMobile`/`press`/`hide`/`showAt`. Net effect: `hud.ts` shrank by 7 lines, so the ceiling in `tests/monolith_budget.test.ts` was lowered to match (18577 -> 18570), per the ratchet's "extract, then lower" rule.

No visual change: the tooltip itself looks identical, only the trigger reliability changes.

## Related issues

N/A

## Type of change

- [x] Bug fix

## How was this tested?

- Commands:
  - `npx tsc --noEmit`
  - `npx vitest run tests/touch_peek.test.ts` (10 passed, including 3 new cases for the move-tolerance helper: within tolerance, past tolerance, and diagonal straight-line distance)
  - `npx vitest run tests/architecture.test.ts` (112 passed; `touch_peek.ts` now touches the DOM via `bindTooltipTouchPeek`, so it was registered in `UI_DOM_MODULES` alongside its sibling `touch_item_drag.ts`)
  - `npx vitest run tests/monolith_budget.test.ts` (22 passed, ceiling lowered to match the extraction)
  - `npx @biomejs/biome check --write` on every changed file
  - `git push` (the `.githooks/pre-push` floor: tsc, guard tests, whole-repo biome check, copy rules) ran green
- Manual steps: none on a real device (no iOS hardware available in this environment); the fix is verified by mirroring the exact working pattern of `touch_item_drag.ts` on the same DOM elements, plus the new unit tests pinning the tolerance math itself.
- **Honest gap:** the full local `node scripts/gate_select.mjs` merge-bar gate was started twice but not allowed to finish (the machine was under heavy memory pressure from other concurrent work, and it was killed intentionally to prioritize opening this PR promptly); the pre-push floor (tsc, the architecture/i18n guard suites, whole-repo biome, copy rules) did complete and passed. Real CI will run the full gate on this PR.

## Screenshots / recordings

N/A. No visual change (same tooltip appearance); only touch event-handling reliability changes.

---

## Checklist

### Quality

- [ ] The gate passes. `node scripts/gate_select.mjs` was not completed locally (see honest gap above); the pre-push floor (tsc, guard tests, biome, copy rules) is green, and targeted tests for the changed behavior were added.

### Cross-platform

- [ ] Tested on desktop and mobile. No real iOS device was available in this environment; verified via the existing working `touch_item_drag.ts` precedent and new unit tests. No visual/layout change.
- [x] Accessible. No UI/ARIA change; behavior-only fix.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files.