### PR TITLE
fix(ci): own the macOS signing keychain in the desktop publish job

### DIFF
--- a/.github/workflows/desktop-publish.yml
+++ b/.github/workflows/desktop-publish.yml
@@ -346,8 +346,10 @@ jobs:
           existing="$(security list-keychains -d user | tr -d '" ')"
           # shellcheck disable=SC2086
           security list-keychains -d user -s "$keychain" "$RUNNER_TEMP/electron-builder-root-certs.keychain" $existing
+          # electron-builder wants the name WITHOUT the "Developer ID Application:"
+          # prefix (it refuses the prefixed form and picks the certificate type itself).
           identity="$(security find-identity -v -p codesigning "$keychain" \
-            | sed -n 's/.*"\(Developer ID Application: [^"]*\)".*/\1/p' | head -n 1)"
+            | sed -n 's/.*"Developer ID Application: \([^"]*\)".*/\1/p' | head -n 1)"
           if [ -z "$identity" ]; then
             echo "No valid Developer ID Application identity in the imported certificate" >&2
             security find-identity -p codesigning "$keychain" >&2 || true

--- a/.github/workflows/desktop-publish.yml
+++ b/.github/workflows/desktop-publish.yml
@@ -297,15 +297,71 @@ jobs:
           restore-keys: |
             electron-builder-${{ runner.os }}-
 
-      # CSC_LINK is the base64 .p12 (electron-builder consumes it directly);
-      # the App Store Connect API key must be a file on disk, so the .p8
-      # secret content is written to the runner temp dir and APPLE_API_KEY
-      # points at it. Signing and notarization then activate automatically in
-      # scripts/electron-build.mjs / electron-builder.
-      - name: Build signed and notarized macOS desktop artifacts
+      # electron-builder 26.15.7 imports CSC_LINK into a keychain of its own and
+      # then runs `security set-key-partition-list -k` with the CERTIFICATE
+      # password instead of the keychain password. The macOS 26.6 runner image
+      # (20260831) rejects that call ("SecKeychainUnlock: The user name or
+      # passphrase you entered is not correct") where 26.5 let it through;
+      # electron-builder fixed it in 26.16.1 ("use keychain password for
+      # set-key-partition-list"). Until that bump lands (it moves pnpm-lock.yaml,
+      # which re-mints every GLB seal), this step owns the keychain: it imports
+      # the .p12 with the right passwords, adds electron-builder's bundled Apple
+      # root keychain to the search list exactly as its createKeychain would, and
+      # hands electron-builder the result through CSC_KEYCHAIN plus the identity
+      # name through CSC_NAME (scripts/electron-build.mjs treats CSC_NAME as the
+      # real-signing signal). The build step deliberately does NOT receive
+      # CSC_LINK: with it set, electron-builder would create its own keychain
+      # again and fail the same way.
+      - name: Import the signing certificate into a temporary keychain
         env:
           CSC_LINK: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          keychain="$RUNNER_TEMP/woc-signing.keychain-db"
+          keychain_password="$(openssl rand -base64 24)"
+          cert="$RUNNER_TEMP/csc.p12"
+          # CSC_LINK is the base64 .p12 (docs/desktop-release.md, "Publishing from
+          # CI"); an optional data: URI prefix is stripped, and the path/URL forms
+          # electron-builder also accepts are refused because this step does not fetch.
+          case "$CSC_LINK" in
+            http://*|https://*|file:*|/*)
+              echo "CSC_LINK must be the base64 .p12 for the keychain import step" >&2
+              exit 1 ;;
+          esac
+          printf '%s' "${CSC_LINK#data:*;base64,}" | base64 --decode > "$cert"
+          security create-keychain -p "$keychain_password" "$keychain"
+          security set-keychain-settings -lut 21600 "$keychain"
+          security unlock-keychain -p "$keychain_password" "$keychain"
+          security import "$cert" -k "$keychain" -P "$CSC_KEY_PASSWORD" \
+            -T /usr/bin/codesign -T /usr/bin/productbuild -T /usr/bin/security
+          security set-key-partition-list -S apple-tool:,apple: -s -k "$keychain_password" "$keychain"
+          rm -f "$cert"
+          root_certs="$(find node_modules/.pnpm -path '*/app-builder-lib/certs/root_certs.keychain' -print -quit)"
+          if [ -z "$root_certs" ]; then
+            echo "app-builder-lib's bundled root_certs.keychain was not found under node_modules" >&2
+            exit 1
+          fi
+          cp "$root_certs" "$RUNNER_TEMP/electron-builder-root-certs.keychain"
+          existing="$(security list-keychains -d user | tr -d '" ')"
+          # shellcheck disable=SC2086
+          security list-keychains -d user -s "$keychain" "$RUNNER_TEMP/electron-builder-root-certs.keychain" $existing
+          identity="$(security find-identity -v -p codesigning "$keychain" \
+            | sed -n 's/.*"\(Developer ID Application: [^"]*\)".*/\1/p' | head -n 1)"
+          if [ -z "$identity" ]; then
+            echo "No valid Developer ID Application identity in the imported certificate" >&2
+            security find-identity -p codesigning "$keychain" >&2 || true
+            exit 1
+          fi
+          echo "CSC_KEYCHAIN=$keychain" >> "$GITHUB_ENV"
+          echo "CSC_NAME=$identity" >> "$GITHUB_ENV"
+
+      # The App Store Connect API key must be a file on disk, so the .p8 secret
+      # content is written to the runner temp dir and APPLE_API_KEY points at it.
+      # Signing (CSC_KEYCHAIN and CSC_NAME from the step above) and notarization
+      # then activate automatically in scripts/electron-build.mjs / electron-builder.
+      - name: Build signed and notarized macOS desktop artifacts
+        env:
           APPLE_API_KEY_P8: ${{ secrets.APPLE_API_KEY_P8 }}
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}

--- a/.github/workflows/desktop-publish.yml
+++ b/.github/workflows/desktop-publish.yml
@@ -337,7 +337,7 @@ jobs:
             -T /usr/bin/codesign -T /usr/bin/productbuild -T /usr/bin/security
           security set-key-partition-list -S apple-tool:,apple: -s -k "$keychain_password" "$keychain"
           rm -f "$cert"
-          root_certs="$(find node_modules/.pnpm -path '*/app-builder-lib/certs/root_certs.keychain' -print -quit)"
+          root_certs="$(find node_modules -name root_certs.keychain -path '*/app-builder-lib/certs/*' -print -quit)"
           if [ -z "$root_certs" ]; then
             echo "app-builder-lib's bundled root_certs.keychain was not found under node_modules" >&2
             exit 1


### PR DESCRIPTION
## Summary

The v0.42.0 tag run of the desktop publish workflow ([34343984848](https://github.com/levy-street/world-of-claudecraft/actions/runs/34343984848)) published Linux and Windows but failed the macOS job twice, both attempts at the same line inside electron-builder's keychain setup:

```
Command failed: /usr/bin/security set-key-partition-list -S apple-tool:,apple: -s -k *** <tmp>.keychain
security: SecKeychainUnlock: The user name or passphrase you entered is not correct.
```

Root cause: app-builder-lib 26.15.7 (`out/codeSign/macCodeSign.js`, `importCerts`) passes the CERTIFICATE password to `set-key-partition-list -k`, where the keychain password belongs. The GitHub macOS runner image moved from build 20260728 (macOS 26.5.2, the green v0.41.4 run) to 20260831 (macOS 26.6.2), and the newer `security` rejects the wrong passphrase instead of ignoring it. electron-builder fixed this in 26.16.1 on 7 September ("fix(mac): use keychain password for set-key-partition-list", the v26 backport of #10101). The toolchain pinned here (electron-builder 26.15.7, Electron 43.3.0) is unchanged since v0.41.4.

Bumping electron-builder moves `pnpm-lock.yaml`, which is a source-fingerprint input for every sealed GLB (48 files, ten seal suites), so this PR fixes the workflow instead and leaves the dependency bump for a normal cycle. The macOS job now owns the signing keychain:

- a new step decodes the base64 `.p12` from `CSC_LINK`, creates a temporary keychain with its own random password, imports the certificate with `CSC_KEY_PASSWORD`, runs `set-key-partition-list` with the KEYCHAIN password, adds electron-builder's bundled `certs/root_certs.keychain` (the Apple root and intermediate chain) to the user search list exactly as `createKeychain` does, and exports `CSC_KEYCHAIN` plus the `Developer ID Application` identity name as `CSC_NAME`;
- the build step no longer receives `CSC_LINK` or `CSC_KEY_PASSWORD`, so app-builder-lib takes its `keychainFile = process.env.CSC_KEYCHAIN` arm (`out/macPackager.js`) instead of creating a keychain of its own; `scripts/electron-build.mjs` already treats `CSC_NAME` as the real-signing signal, so the ad-hoc fallback stays off.

Nothing else in the workflow changes: the secrets check, the notarization inputs, the signature and notarization verification, the artifact checks, and the R2 upload are as before. Linux and Windows are untouched.

## Related issues

Unblocks the v0.42.0 desktop publish (release https://github.com/levy-street/world-of-claudecraft/releases/tag/v0.42.0). After merge, the macOS artifacts are backfilled with a manual dispatch on main with `publish` ticked (the documented backfill path in the workflow header).

## Type of change

- [x] Bug fix
- [x] Build, CI, or tooling

## How was this tested?

- Commands: the edited workflow parses (Ruby YAML: mac job steps in order, build env reduced to the three Apple notarization inputs, import step env `CSC_LINK` + `CSC_KEY_PASSWORD`); the copy scan is clean. A `workflow_dispatch` dry run of this exact branch (build, sign, notarize, verify, checksum, attach; no upload) is running as [34348675480](https://github.com/levy-street/world-of-claudecraft/actions/runs/34348675480); its result is recorded in the PR conversation.
- Manual steps: confirmed the failing command and the wrong password argument in the app-builder-lib 26.15.7 tarball (`npm pack`), confirmed the `CSC_KEYCHAIN` arm in `out/macPackager.js`, and compared the runner image builds and toolchain versions between the green v0.41.4 run and the failing v0.42.0 run.

## Checklist

### Quality

- [x] Workflow-only change; the pinned tests that read `desktop-publish.yml` (`tests/desktop_publish_guard.test.ts`, `tests/deploy_node_version.test.ts`, `tests/deploy_ota_updates.test.ts`, `tests/ci_workflow.test.ts`) pin the version-lockstep step, the Node 22 line, the tag trigger, and the secret references, none of which move. CI on this PR runs them.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wfqh37xBASQ9cekRWT32Qs
