### PR TITLE
fix(render): snap the self pose across a teleport when prediction hands off

### DIFF
--- a/src/net/CLAUDE.md
+++ b/src/net/CLAUDE.md
@@ -253,7 +253,9 @@ failure, kept as stable English that `main.ts` re-localizes.
   is really on the wire, never an outcome guess; (c) corrections exist only on
   server override epochs (`ovE`/`ovA`) and genuine reconcile mismatches, and
   the display absorbs them through the handoff offset bounded by
-  `MAX_SELF_REWIND_YD_PER_SEC`; (d) the feel bar is
+  `MAX_SELF_REWIND_YD_PER_SEC`, except that a gap past the shared six-yard
+  teleport rule (`SELF_MOTION_SNAP_DIST_SQ`) is an authoritative relocation
+  and snaps outright instead of gliding; (d) the feel bar is
   `tests/movement_latency_baseline.test.ts` in strict mode, and any change here
   must keep it green. Changing this model is a maintainer decision. The legacy
   display extrapolator (`src/render/self_motion.ts`, leash + servo + block

--- a/src/render/self_render_position_core.ts
+++ b/src/render/self_render_position_core.ts
@@ -6,6 +6,7 @@
 
 import type { Entity } from '../sim/types';
 import {
+  SELF_MOTION_SNAP_DIST_SQ,
   type SelfMotionFrame,
   SelfMotionPredictor,
   updateSelfRenderFallback,
@@ -16,6 +17,38 @@ import {
 // takes over from the lead-smoothing path (gone in ~0.3 s, no camera step).
 const SELF_MOTION_HANDOFF_RATE = 15;
 export const MAX_SELF_REWIND_YD_PER_SEC = 12;
+
+/**
+ * Capture the gap between the drawn pose and the pose the incoming path wants
+ * as the handoff offset, unless it is a teleport. A handoff gap is at most a
+ * few yards (predictor lead, a reconcile residual); anything past the shared
+ * six-yard snap rule is an authoritative relocation that landed on the same
+ * frame the paths swapped: a delve or dungeon entry closes the prediction gate
+ * and teleports the body at once. Gliding that gap would pin the drawn body
+ * (and the camera) at the old spot and creep it toward the new one, which
+ * inside an instance reads as floating through the void. Zeroing the offset
+ * lets the fallback snap exactly as it would for a teleport with no handoff.
+ */
+function captureHandoffOffset(
+  offset: Vec3Like,
+  from: Vec3Like,
+  toX: number,
+  toY: number,
+  toZ: number,
+): void {
+  const dx = from.x - toX;
+  const dy = from.y - toY;
+  const dz = from.z - toZ;
+  if (dx * dx + dy * dy + dz * dz > SELF_MOTION_SNAP_DIST_SQ) {
+    offset.x = 0;
+    offset.y = 0;
+    offset.z = 0;
+    return;
+  }
+  offset.x = dx;
+  offset.y = dy;
+  offset.z = dz;
+}
 
 function decayOffset(offset: Vec3Like, dt: number, maxDistance = Number.POSITIVE_INFINITY): void {
   const decayShare = 1 - Math.exp(-SELF_MOTION_HANDOFF_RATE * Math.max(0, dt));
@@ -121,9 +154,7 @@ export function updateSelfRenderPosition(
         state.offset.y = 0;
         state.offset.z = 0;
       } else if (state.ready && !state.active) {
-        state.offset.x = state.position.x - predicted.x;
-        state.offset.y = state.position.y - predicted.y;
-        state.offset.z = state.position.z - predicted.z;
+        captureHandoffOffset(state.offset, state.position, predicted.x, predicted.y, predicted.z);
       }
       if (reconciled.kind === 'reconciled' && reconciled.residual) {
         state.offset.x += reconciled.residual.x;
@@ -150,9 +181,7 @@ export function updateSelfRenderPosition(
     state.offset.y = 0;
     state.offset.z = 0;
   } else if (state.ready && predictorWasActive) {
-    state.offset.x = state.position.x - px;
-    state.offset.y = state.position.y - py;
-    state.offset.z = state.position.z - pz;
+    captureHandoffOffset(state.offset, state.position, px, py, pz);
   }
   if (
     !authoritativeDiscontinuity &&

--- a/tests/self_render_position_core.test.ts
+++ b/tests/self_render_position_core.test.ts
@@ -289,6 +289,76 @@ describe('updateSelfRenderPosition predictor path', () => {
     expect(state.position.x).toBeCloseTo(-0.02, 10);
   });
 
+  it('snaps to a teleported authoritative pose when the gate closes on the same frame', () => {
+    // A delve entry: the predictor owned the pose at the board door, then one
+    // snapshot both closes the prediction gate (delves never predict) and
+    // relocates the body ~104,000 yards into the instance band. The drawn pose
+    // must land on the new body at once; a captured handoff gap would pin it
+    // at the door and creep it east at the rewind ceiling for hours.
+    const state = createSelfRenderPositionState();
+    const door = playerAt({ x: -136, y: 1.67, z: 109 }, { x: -136, y: 1.67, z: 109 });
+    noteSelfIdentity(state, 1);
+    updateSelfRenderPosition(state, door, SEED, 1, FRAME_DT, 0.2, null, false);
+    state.predictor = stubPredictor(() => ({ x: -139.4, y: 1.56, z: 106 }));
+    runPredicted(state, door);
+    expect(state.active).toBe(true);
+
+    state.predictor = stubPredictor(() => null);
+    const inDelve = playerAt({ x: 104200, y: 0, z: -633 }, { x: 104200, y: 0, z: -633 });
+    runPredicted(state, inDelve);
+    expect(state.active).toBe(false);
+    expect(state.offset).toEqual({ x: 0, y: 0, z: 0 });
+    expect(state.position).toEqual({ x: 104200, y: 0, z: -633 });
+
+    runPredicted(state, inDelve);
+    expect(state.position).toEqual({ x: 104200, y: 0, z: -633 });
+  });
+
+  it('still glides a handoff gap just under the teleport threshold', () => {
+    const state = createSelfRenderPositionState();
+    const player = playerAt({ x: 0, y: 0, z: 0 }, { x: 0, y: 0, z: 0 });
+    noteSelfIdentity(state, 1);
+    updateSelfRenderPosition(state, player, SEED, 1, FRAME_DT, 0.2, null, false);
+    state.predictor = stubPredictor(() => ({ x: 5.9, y: 0, z: 0 }));
+    runPredicted(state, player);
+    state.predictor = stubPredictor(() => null);
+    runPredicted(state, player);
+    expect(state.offset.x).toBeGreaterThan(0);
+    // The predictor frame drew 5.9 minus the decayed gap; the closing frame
+    // then rewinds toward the authoritative 0 at the rewind ceiling.
+    expect(state.position.x).toBeCloseTo(
+      5.9 * (1 - Math.exp(-HANDOFF_RATE * FRAME_DT)) - MAX_SELF_REWIND_YD_PER_SEC * FRAME_DT,
+      10,
+    );
+  });
+
+  it('snaps to the predictor when it takes over across a teleport', () => {
+    // The mirror case: a dungeon door teleport lands while the predictor is
+    // suspended for the override epoch, then prediction resumes at the new
+    // body. The 0.3 s rate-15 glide from the old spot is the same void-flight
+    // in miniature, so the same six-yard rule snaps it.
+    const state = createSelfRenderPositionState();
+    const outside = playerAt({ x: 0, y: 0, z: 0 }, { x: 0, y: 0, z: 0 });
+    noteSelfIdentity(state, 1);
+    updateSelfRenderPosition(state, outside, SEED, 1, FRAME_DT, 0.2, null, false);
+    expect(state.position.x).toBe(0);
+
+    const inside = playerAt({ x: 5000, y: 0, z: 40 }, { x: 5000, y: 0, z: 40 });
+    updateSelfRenderPosition(
+      state,
+      inside,
+      SEED,
+      1,
+      FRAME_DT,
+      0.2,
+      { kind: 'reconciled', position: { x: 5000, y: 0, z: 40 }, residual: null },
+      false,
+    );
+    expect(state.offset).toEqual({ x: 0, y: 0, z: 0 });
+    expect(state.position).toEqual({ x: 5000, y: 0, z: 40 });
+    expect(state.active).toBe(true);
+  });
+
   it('captures no offset when the predictor is the first to place the body', () => {
     const state = createSelfRenderPositionState();
     state.predictor = stubPredictor(() => ({ x: 5, y: 1, z: 2 }));


### PR DESCRIPTION
## Summary

Entering a delve online left the character (and the chase camera) floating through the void, drifting slowly east from the board door instead of standing on the delve floor.

**Root cause (client, online only).** Delves never run self-motion prediction (`self_motion_gate.ts`, #3480), so the delve entry snapshot both closes the prediction gate and teleports the body ~104,000 yd into the instance band on the same frame. `updateSelfRenderPosition` captured that entire gap as the predictor "handoff offset" and drained it at the pinned 12 yd/s rewind ceiling, so the drawn pose stayed at the door and crept toward the delve for hours. The same capture on the predictor-takeover side gave dungeon doors and `dev_teleport` a short swoop from the old spot. Offline play was never affected (no predictor).

**Fix.** A handoff gap is a few yards at most; anything past the shared six-yard snap rule (`SELF_MOTION_SNAP_DIST_SQ`) is an authoritative relocation. Both capture sites now zero the offset in that case, so the fallback snaps exactly as it does for a teleport with no handoff. Small handoffs keep the pinned rewind ceiling untouched.

## Verification

- Reproduced against a local server with a puppeteer probe (register, `dev_teleport` to the reliquary door, hold W to arm the predictor, `enterDelve`): before the fix the self view sat at x≈-139 with a captured offset of ≈-104,336 yd creeping east at ≈12 yd/s while the authoritative body was at x=104,200; after the fix the view and camera snap into the delve within one snapshot.
- `tsc --noEmit` clean, biome clean.
- `vitest`: self_render_position_core, self_motion, self_prediction, teleport_arrival, movement_latency_baseline — 146 passed. Three new cases cover the teleport-sized handoff on both sides and a just-under-threshold gap that still glides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
