### PR TITLE
fix(items): restore Crucible drop trading and the BoP party-trade flow (PRs #3789/#3791 lost in the v0.42 hotfix sync)

### DIFF
--- a/docs/prd/ignivar-raid-loot-items.md
+++ b/docs/prd/ignivar-raid-loot-items.md
@@ -14,8 +14,10 @@ budgets that tests/item_level.test.ts enforces (35 x slot mult x 0.7,
 epic quality), so what is reviewed here is what the budget sweep will pin.
 
 Shared by every gear item below: item level 35 (source 26 + epic 6 + raid
-3), epic quality, requiredLevel 20, soulbound. Set pieces are class-locked
-to their set's class. Armor values by slot:
+3), epic quality, requiredLevel 20. Set pieces are class-locked to their
+set's class and soulbound, like the redemption sigils that buy them; the
+ordinary boss drops (offset, jewelry, held, weapons) are transferable.
+Armor values by slot:
 
 | Slot | Mail | Leather | Cloth |
 |---|---|---|---|
@@ -365,7 +367,7 @@ design targets for the tuning pass.
 
 ## The 15 sigils
 
-Tokens are kind tool, epic, soulbound, noDiscard, stack 20, class-locked
+Tokens are kind tool, epic, soulbound, discardable, stack 20, class-locked
 to their group. One sigil buys any one matching-slot set piece for the
 holder's class at the Crucible Quartermaster.
 

--- a/docs/prd/ignivar-raid-loot.md
+++ b/docs/prd/ignivar-raid-loot.md
@@ -707,7 +707,7 @@ contested across the whole raid rather than inside one armor class:
 Token items: "Helm Sigil of the Anvil", "Mantle Sigil of the Ember", "Robe
 Sigil of the Tempest", and so on for all 15 (slot nouns Helm, Mantle, Robe,
 Grip, Legging). Ids follow `sigil_<group>_<slot>`. Each token is kind 'tool',
-epic quality, soulbound, noDiscard, stackSize 20, requiredClass locked to its
+epic quality, soulbound, discardable, stackSize 20, requiredClass locked to its
 three classes, exactly the heroic_mark pattern.
 
 ### Redemption
@@ -1018,9 +1018,12 @@ Each phase is a reviewable commit (or small commit series) with its tests:
    catalog of 58 bonuses lives in the set tables above and in the item
    catalog; implementation rides the TalentEffect seam.
 
-## Binding rules: the party trade window (maintainer directives, 2026-08-29)
+## Binding rules: sigils and tier pieces bind, ordinary drops trade
 
-Implemented alongside the soulbound rulings above:
+The 15 class-tier redemption sigils and the 145 redeemed tier set pieces
+are soulbound. The ordinary boss drops (offset, jewelry, held, weapons)
+are transferable. The party trade window applies when a soulbound item,
+in this tier a sigil, is awarded from party loot:
 
 - Every SOULBOUND item awarded from party boss loot (need/greed win,
   master-loot assignment, round-robin, or a shared direct pickup) is

--- a/src/sim/content/ignivar_loot.ts
+++ b/src/sim/content/ignivar_loot.ts
@@ -32,6 +32,11 @@
 // trade, mail, market, and sale). One sigil buys any one matching-slot set
 // piece for the holder's class at the Crucible Quartermaster
 // (CRUCIBLE_VENDOR_STOCK).
+//
+// Binding policy (PRs #3788 and #3789): the 15 sigils and the 145 sigil-redeemed
+// tier set pieces are soulbound, matching the tokens that buy them; the 41
+// ordinary boss drops (offset, jewelry, held, weapons) carry no `soulbound`
+// flag and trade freely. Pinned by tests/ignivar_loot.test.ts.
 
 import type { ItemDef, NpcDef } from '../types';
 import { CRUCIBLE_PATTERN_VENDOR_STOCK } from './crucible_collections';
@@ -2634,7 +2639,6 @@ export const IGNIVAR_OFFSET_ITEMS: Record<string, ItemDef> = {
     hitRating: 60,
     critRating: 25,
     sellValue: 10000,
-    soulbound: true,
     requiredClass: ['mage', 'priest', 'warlock'],
   },
   cindersoaked_slippers: {
@@ -2650,7 +2654,6 @@ export const IGNIVAR_OFFSET_ITEMS: Record<string, ItemDef> = {
     critRating: 60,
     hasteRating: 25,
     sellValue: 10000,
-    soulbound: true,
     requiredClass: ['mage', 'priest', 'warlock'],
   },
   // ---- Cloth healing ----
@@ -2667,7 +2670,6 @@ export const IGNIVAR_OFFSET_ITEMS: Record<string, ItemDef> = {
     hasteRating: 25,
     hitRating: 60,
     sellValue: 10000,
-    soulbound: true,
     requiredClass: ['mage', 'priest'],
   },
   steps_of_quiet_water: {
@@ -2683,7 +2685,6 @@ export const IGNIVAR_OFFSET_ITEMS: Record<string, ItemDef> = {
     hasteRating: 60,
     critRating: 25,
     sellValue: 10000,
-    soulbound: true,
     requiredClass: ['mage', 'priest'],
   },
   // ---- Leather tanking ----
@@ -2699,7 +2700,6 @@ export const IGNIVAR_OFFSET_ITEMS: Record<string, ItemDef> = {
     hitRating: 60,
     critRating: 25,
     sellValue: 10000,
-    soulbound: true,
     requiredClass: ['druid'],
   },
   ashenbark_treads: {
@@ -2714,7 +2714,6 @@ export const IGNIVAR_OFFSET_ITEMS: Record<string, ItemDef> = {
     critRating: 60,
     hasteRating: 25,
     sellValue: 10000,
-    soulbound: true,
     requiredClass: ['druid'],
   },
   // ---- Leather dps ----
@@ -2730,7 +2729,6 @@ export const IGNIVAR_OFFSET_ITEMS: Record<string, ItemDef> = {
     hitRating: 60,
     critRating: 25,
     sellValue: 10000,
-    soulbound: true,
     requiredClass: ['rogue', 'hunter', 'druid'],
   },
   ashrunner_boots: {
@@ -2745,7 +2743,6 @@ export const IGNIVAR_OFFSET_ITEMS: Record<string, ItemDef> = {
     critRating: 60,
     hasteRating: 25,
     sellValue: 10000,
-    soulbound: true,
     requiredClass: ['rogue', 'hunter', 'druid'],
   },
   // ---- Leather spell damage ----
@@ -2762,7 +2759,6 @@ export const IGNIVAR_OFFSET_ITEMS: Record<string, ItemDef> = {
     hitRating: 60,
     critRating: 25,
     sellValue: 10000,
-    soulbound: true,
     requiredClass: ['druid'],
   },
   scorchgrove_striders: {
@@ -2778,7 +2774,6 @@ export const IGNIVAR_OFFSET_ITEMS: Record<string, ItemDef> = {
     critRating: 60,
     hasteRating: 25,
     sellValue: 10000,
-    soulbound: true,
     requiredClass: ['druid'],
   },
   // ---- Leather healing ----
@@ -2795,7 +2790,6 @@ export const IGNIVAR_OFFSET_ITEMS: Record<string, ItemDef> = {
     hasteRating: 25,
     hitRating: 60,
     sellValue: 10000,
-    soulbound: true,
     requiredClass: ['druid'],
   },
   dewfall_moccasins: {
@@ -2811,7 +2805,6 @@ export const IGNIVAR_OFFSET_ITEMS: Record<string, ItemDef> = {
     hasteRating: 60,
     critRating: 25,
     sellValue: 10000,
-    soulbound: true,
     requiredClass: ['druid'],
   },
   // ---- Mail tanking ----
@@ -2827,7 +2820,6 @@ export const IGNIVAR_OFFSET_ITEMS: Record<string, ItemDef> = {
     hitRating: 60,
     critRating: 25,
     sellValue: 10000,
-    soulbound: true,
     requiredClass: ['warrior', 'paladin', 'shaman'],
   },
   anvilstance_sabatons: {
@@ -2842,7 +2834,6 @@ export const IGNIVAR_OFFSET_ITEMS: Record<string, ItemDef> = {
     critRating: 60,
     hasteRating: 25,
     sellValue: 10000,
-    soulbound: true,
     requiredClass: ['warrior', 'paladin', 'shaman'],
   },
   // ---- Mail dps ----
@@ -2858,7 +2849,6 @@ export const IGNIVAR_OFFSET_ITEMS: Record<string, ItemDef> = {
     hitRating: 60,
     critRating: 25,
     sellValue: 10000,
-    soulbound: true,
     requiredClass: ['warrior', 'paladin', 'shaman'],
   },
   furnace_march_greaves: {
@@ -2873,7 +2863,6 @@ export const IGNIVAR_OFFSET_ITEMS: Record<string, ItemDef> = {
     critRating: 60,
     hasteRating: 25,
     sellValue: 10000,
-    soulbound: true,
     requiredClass: ['warrior', 'paladin', 'shaman'],
   },
   // ---- Mail spell damage ----
@@ -2890,7 +2879,6 @@ export const IGNIVAR_OFFSET_ITEMS: Record<string, ItemDef> = {
     hitRating: 60,
     critRating: 25,
     sellValue: 10000,
-    soulbound: true,
     requiredClass: ['shaman'],
   },
   thundershock_treads: {
@@ -2906,7 +2894,6 @@ export const IGNIVAR_OFFSET_ITEMS: Record<string, ItemDef> = {
     critRating: 60,
     hasteRating: 25,
     sellValue: 10000,
-    soulbound: true,
     requiredClass: ['shaman'],
   },
   // ---- Mail healing ----
@@ -2923,7 +2910,6 @@ export const IGNIVAR_OFFSET_ITEMS: Record<string, ItemDef> = {
     hasteRating: 25,
     hitRating: 60,
     sellValue: 10000,
-    soulbound: true,
     requiredClass: ['paladin', 'shaman'],
   },
   springwarden_sabatons: {
@@ -2939,7 +2925,6 @@ export const IGNIVAR_OFFSET_ITEMS: Record<string, ItemDef> = {
     hasteRating: 60,
     critRating: 25,
     sellValue: 10000,
-    soulbound: true,
     requiredClass: ['paladin', 'shaman'],
   },
 };
@@ -2957,7 +2942,6 @@ export const IGNIVAR_JEWELRY_ITEMS: Record<string, ItemDef> = {
     stats: { str: 7, sta: 9 },
     critRating: 25,
     sellValue: 8000,
-    soulbound: true,
   },
   // ---- physical dps ----
   ignivars_ember_choker: {
@@ -2970,7 +2954,6 @@ export const IGNIVAR_JEWELRY_ITEMS: Record<string, ItemDef> = {
     stats: { str: 8, agi: 8 },
     hitRating: 25,
     sellValue: 8000,
-    soulbound: true,
   },
   // ---- spell damage ----
   locket_of_the_last_flame: {
@@ -2984,7 +2967,6 @@ export const IGNIVAR_JEWELRY_ITEMS: Record<string, ItemDef> = {
     spellPower: 4,
     critRating: 25,
     sellValue: 8000,
-    soulbound: true,
   },
   // ---- healing ----
   heartspring_amulet: {
@@ -2998,7 +2980,6 @@ export const IGNIVAR_JEWELRY_ITEMS: Record<string, ItemDef> = {
     healPower: 8,
     hasteRating: 25,
     sellValue: 8000,
-    soulbound: true,
   },
   // ---- tank ----
   seal_of_the_forgewall: {
@@ -3011,7 +2992,6 @@ export const IGNIVAR_JEWELRY_ITEMS: Record<string, ItemDef> = {
     stats: { str: 7, sta: 8 },
     hitRating: 25,
     sellValue: 8000,
-    soulbound: true,
   },
   // ---- physical dps ----
   band_of_marked_strikes: {
@@ -3024,7 +3004,6 @@ export const IGNIVAR_JEWELRY_ITEMS: Record<string, ItemDef> = {
     stats: { str: 8, agi: 7 },
     hitRating: 25,
     sellValue: 8000,
-    soulbound: true,
   },
   // ---- spell damage ----
   circle_of_cinders: {
@@ -3038,7 +3017,6 @@ export const IGNIVAR_JEWELRY_ITEMS: Record<string, ItemDef> = {
     spellPower: 4,
     hitRating: 25,
     sellValue: 8000,
-    soulbound: true,
   },
   // ---- healing ----
   loop_of_quiet_springs: {
@@ -3052,7 +3030,6 @@ export const IGNIVAR_JEWELRY_ITEMS: Record<string, ItemDef> = {
     healPower: 8,
     hitRating: 25,
     sellValue: 8000,
-    soulbound: true,
   },
 };
 
@@ -3071,7 +3048,6 @@ export const IGNIVAR_HELD_ITEMS: Record<string, ItemDef> = {
     blockValue: 30,
     critRating: 25,
     sellValue: 12000,
-    soulbound: true,
     requiredClass: ['warrior', 'paladin', 'shaman'],
   },
   ember_wardens_barrier: {
@@ -3088,7 +3064,6 @@ export const IGNIVAR_HELD_ITEMS: Record<string, ItemDef> = {
     healPower: 18,
     hasteRating: 25,
     sellValue: 12000,
-    soulbound: true,
     requiredClass: ['paladin', 'shaman'],
   },
   orb_of_the_last_spring: {
@@ -3102,7 +3077,6 @@ export const IGNIVAR_HELD_ITEMS: Record<string, ItemDef> = {
     healPower: 28,
     hasteRating: 25,
     sellValue: 12000,
-    soulbound: true,
     requiredClass: ['priest', 'mage', 'druid', 'paladin', 'shaman'],
   },
   cinder_of_the_first_design: {
@@ -3116,7 +3090,6 @@ export const IGNIVAR_HELD_ITEMS: Record<string, ItemDef> = {
     spellPower: 14,
     critRating: 25,
     sellValue: 12000,
-    soulbound: true,
     requiredClass: ['mage', 'priest', 'warlock', 'druid'],
   },
 };
@@ -3140,7 +3113,6 @@ export const IGNIVAR_WEAPON_ITEMS: Record<string, ItemDef> = {
     critRating: 70,
     hitRating: 30,
     sellValue: 14000,
-    soulbound: true,
     requiredClass: ['warrior', 'rogue', 'hunter', 'shaman', 'paladin'],
   },
   cinderfang_kris: {
@@ -3155,7 +3127,6 @@ export const IGNIVAR_WEAPON_ITEMS: Record<string, ItemDef> = {
     critRating: 70,
     hitRating: 30,
     sellValue: 14000,
-    soulbound: true,
     requiredClass: ['rogue', 'hunter'],
   },
   slagrender_cleaver: {
@@ -3170,7 +3141,6 @@ export const IGNIVAR_WEAPON_ITEMS: Record<string, ItemDef> = {
     critRating: 70,
     hitRating: 30,
     sellValue: 14000,
-    soulbound: true,
     requiredClass: ['warrior', 'rogue', 'hunter', 'shaman', 'paladin'],
   },
   anvilguard_blade: {
@@ -3185,7 +3155,6 @@ export const IGNIVAR_WEAPON_ITEMS: Record<string, ItemDef> = {
     critRating: 70,
     hitRating: 30,
     sellValue: 14000,
-    soulbound: true,
     requiredClass: ['warrior', 'rogue', 'hunter', 'shaman', 'paladin'],
   },
   heart_of_the_end_greatblade: {
@@ -3201,7 +3170,6 @@ export const IGNIVAR_WEAPON_ITEMS: Record<string, ItemDef> = {
     critRating: 70,
     hitRating: 30,
     sellValue: 16000,
-    soulbound: true,
     // No rogue: the equipment boundary hard-blocks rogues from two-handers,
     // and requiredClass must list exactly who canEquipItem admits
     // (tests/equipment_proficiency.test.ts).
@@ -3221,7 +3189,6 @@ export const IGNIVAR_WEAPON_ITEMS: Record<string, ItemDef> = {
     hasteRating: 70,
     hitRating: 30,
     sellValue: 16000,
-    soulbound: true,
     requiredClass: ['mage', 'priest', 'warlock', 'shaman', 'paladin', 'druid'],
   },
   forgefire_spire: {
@@ -3238,7 +3205,6 @@ export const IGNIVAR_WEAPON_ITEMS: Record<string, ItemDef> = {
     critRating: 70,
     hitRating: 30,
     sellValue: 16000,
-    soulbound: true,
     requiredClass: ['mage', 'priest', 'warlock', 'shaman', 'paladin', 'druid'],
   },
   springtouched_crozier: {
@@ -3254,7 +3220,6 @@ export const IGNIVAR_WEAPON_ITEMS: Record<string, ItemDef> = {
     hasteRating: 70,
     hitRating: 30,
     sellValue: 14000,
-    soulbound: true,
     requiredClass: ['mage', 'priest', 'warlock', 'shaman', 'paladin', 'druid'],
   },
   wand_of_quenched_sparks: {
@@ -3270,7 +3235,6 @@ export const IGNIVAR_WEAPON_ITEMS: Record<string, ItemDef> = {
     critRating: 70,
     hitRating: 30,
     sellValue: 12000,
-    soulbound: true,
     requiredClass: ['mage', 'priest', 'warlock', 'shaman', 'paladin', 'druid'],
   },
 };

--- a/src/sim/item_instance_load.ts
+++ b/src/sim/item_instance_load.ts
@@ -116,6 +116,25 @@ export function boundCraftedRecipeIdOnLoad(
   }
 }
 
+/**
+ * The per-slot payload bound for a loaded container row (bags, buyback): the
+ * whole-payload sanitize below, the dropped-path report under `containerLabel`,
+ * and the empty-payload removal (an empty `{}` payload can never stack again,
+ * so the field goes rather than the copy), one arm shared by the sim.ts load
+ * loops instead of restated per container. Mutates the caller-owned clone.
+ */
+export function sanitizeSlotInstanceOnLoad(
+  slot: { itemId: string; instance?: unknown },
+  dropped: string[],
+  containerLabel: string,
+): void {
+  if (!slot.instance) return;
+  const { payload, dropped: droppedKeys } = sanitizeItemInstancePayloadOnLoad(slot.instance);
+  for (const d of droppedKeys) dropped.push(`${containerLabel}.${slot.itemId}.${d}`);
+  if (payload) slot.instance = payload;
+  else delete slot.instance;
+}
+
 export interface SanitizedItemInstancePayload {
   /** The cleaned payload, or undefined when nothing usable survives (the
    *  caller then removes the field entirely: an empty `{}` payload is worse

--- a/src/sim/loot/bop_trade_cleanup.ts
+++ b/src/sim/loot/bop_trade_cleanup.ts
@@ -1,0 +1,154 @@
+// Retires bind-on-pickup party-trade markers after they stop authorizing a
+// transfer, then restores ordinary stack behavior. The clock is supplied by
+// the caller so this leaf stays deterministic and host-neutral.
+
+import { stackSizeOf } from '../bags';
+import { ITEMS } from '../data';
+import { canStackInstancePayloads, isMergeableInstancePayload } from '../item_instance_merge';
+import { cloneItemInstancePayload, type InvSlot } from '../types';
+import { partyTradeActive, withoutPartyTradeMarker } from './bop_trade_window';
+
+export interface PartyTradeContainerOwner {
+  inventory: InvSlot[];
+  bank: { inventory: InvSlot[] };
+  vendorBuyback: InvSlot[];
+}
+
+export interface PartyTradeContainerChanges {
+  inventory: boolean;
+  bank: boolean;
+  buyback: boolean;
+}
+
+export interface PersistedPartyTradeContainers {
+  inventory: InvSlot[];
+  bank?: { inventory: InvSlot[] };
+  vendorBuyback?: InvSlot[];
+}
+
+function markerMustRetire(slot: InvSlot, nowMs: number): boolean {
+  if (!slot.instance?.partyTrade) return false;
+  return !partyTradeActive(slot.instance, nowMs);
+}
+
+function slotWithoutPartyTrade(slot: InvSlot): InvSlot {
+  const { instance: _instance, ...plain } = slot;
+  const instance = withoutPartyTradeMarker(slot.instance as NonNullable<InvSlot['instance']>);
+  return instance ? { ...plain, instance } : plain;
+}
+
+function freshSlot(source: InvSlot, count: number, keepPosition: boolean): InvSlot {
+  const slot: InvSlot = {
+    itemId: source.itemId,
+    count,
+    ...(source.instance ? { instance: cloneItemInstancePayload(source.instance) } : {}),
+    ...(source.craftedRecipeId === undefined ? {} : { craftedRecipeId: source.craftedRecipeId }),
+    ...(keepPosition && source.slot !== undefined ? { slot: source.slot } : {}),
+  };
+  return slot;
+}
+
+/**
+ * Returns the original array when no marker needs retirement. Otherwise it
+ * returns new slots with total counts conserved, unrelated payload fields
+ * preserved, and newly identical rows coalesced up to the live stack cap.
+ */
+export function normalizePartyTradeSlots(slots: InvSlot[], nowMs: number): InvSlot[] {
+  return normalizePartyTradeSlotsWithPolicy(slots, nowMs, true);
+}
+
+interface IndexedSlot {
+  sourceIndex: number;
+  splitIndex: number;
+  slot: InvSlot;
+}
+
+function normalizePartyTradeSlotsWithPolicy(
+  slots: InvSlot[],
+  nowMs: number,
+  restack: boolean,
+): InvSlot[] {
+  const retiring = slots.map((slot) => markerMustRetire(slot, nowMs));
+  if (!retiring.some(Boolean)) return slots;
+
+  // Seed the result with unaffected rows. Expired rows may fill those stacks,
+  // but two unrelated pre-existing partial stacks are never merged together.
+  const result: IndexedSlot[] = slots.flatMap((slot, sourceIndex) =>
+    retiring[sourceIndex] ? [] : [{ sourceIndex, splitIndex: 0, slot }],
+  );
+  for (let sourceIndex = 0; sourceIndex < slots.length; sourceIndex++) {
+    if (!retiring[sourceIndex]) continue;
+    const source = slotWithoutPartyTrade(slots[sourceIndex]);
+    let remaining = source.count;
+    const stackCap = stackSizeOf(ITEMS[source.itemId]);
+    const mergeable = isMergeableInstancePayload(source.instance);
+    if (restack && mergeable) {
+      for (const target of result) {
+        if (remaining <= 0) break;
+        if (
+          target.slot.itemId !== source.itemId ||
+          target.slot.craftedRecipeId !== source.craftedRecipeId ||
+          !canStackInstancePayloads(target.slot.instance, source.instance) ||
+          target.slot.count >= stackCap
+        ) {
+          continue;
+        }
+        const moved = Math.min(stackCap - target.slot.count, remaining);
+        target.slot = { ...target.slot, count: target.slot.count + moved };
+        remaining -= moved;
+      }
+    }
+    let splitIndex = 0;
+    while (remaining > 0) {
+      // A non-mergeable payload (for example a player-locked counted stack) is
+      // already one legal persisted row. Never fan it out into one row per unit.
+      const count = !restack || !mergeable ? remaining : Math.min(stackCap, remaining);
+      result.push({
+        sourceIndex,
+        splitIndex,
+        slot: freshSlot(source, count, splitIndex === 0),
+      });
+      splitIndex++;
+      remaining -= count;
+    }
+  }
+  result.sort((a, b) => a.sourceIndex - b.sourceIndex || a.splitIndex - b.splitIndex);
+  return result.map((entry) => entry.slot);
+}
+
+/** Normalize general persisted per-character item containers with one clock read. */
+export function normalizePartyTradeContainers(
+  owner: PartyTradeContainerOwner,
+  nowMs: number,
+): PartyTradeContainerChanges {
+  const inventory = normalizePartyTradeSlots(owner.inventory, nowMs);
+  const bank = normalizePartyTradeSlots(owner.bank.inventory, nowMs);
+  // Buyback is recency/index ordered and intentionally permits rows above the
+  // live stack cap. Strip only the marker; never reorder, split, or coalesce it.
+  const buyback = normalizePartyTradeSlotsWithPolicy(owner.vendorBuyback, nowMs, false);
+  const changes = {
+    inventory: inventory !== owner.inventory,
+    bank: bank !== owner.bank.inventory,
+    buyback: buyback !== owner.vendorBuyback,
+  };
+  owner.inventory = inventory;
+  owner.bank.inventory = bank;
+  owner.vendorBuyback = buyback;
+  return changes;
+}
+
+/** Normalize the optional JSONB container shape without growing Sim's save coordinator. */
+export function normalizePersistedPartyTradeContainers(
+  owner: PersistedPartyTradeContainers,
+  nowMs: number,
+): void {
+  const containers = {
+    inventory: owner.inventory,
+    bank: { inventory: owner.bank?.inventory ?? [] },
+    vendorBuyback: owner.vendorBuyback ?? [],
+  };
+  normalizePartyTradeContainers(containers, nowMs);
+  owner.inventory = containers.inventory;
+  if (owner.bank) owner.bank.inventory = containers.bank.inventory;
+  owner.vendorBuyback = containers.vendorBuyback;
+}

--- a/src/sim/loot/bop_trade_persistence.ts
+++ b/src/sim/loot/bop_trade_persistence.ts
@@ -1,0 +1,35 @@
+// The two persistence-boundary hooks for the bind-on-pickup party-trade marker
+// (bop_trade_cleanup.ts owns the slot walk): a character's item containers and
+// Materials Vault retire expired markers when the character loads and again
+// when it serializes, so stale metadata never survives a save/load cycle and
+// the simulation tick never needs a realm-wide container sweep. The clock is
+// the caller's (the raid-lockout clock, which is what stamped `untilMs`), so
+// this leaf stays deterministic and host-neutral.
+
+import {
+  normalizeSavedVaultPartyTradeState,
+  normalizeVaultPartyTradeState,
+  type SavedMaterialsVaultState,
+} from '../materials_vault';
+import type { PlayerMeta } from '../sim';
+import {
+  normalizePartyTradeContainers,
+  normalizePersistedPartyTradeContainers,
+  type PersistedPartyTradeContainers,
+} from './bop_trade_cleanup';
+
+/** Load side: the live PlayerMeta containers (bags, bank, buyback) plus its vault. */
+export function retirePartyTradeOnLoad(meta: PlayerMeta, nowMs: number): void {
+  normalizePartyTradeContainers(meta, nowMs);
+  normalizeVaultPartyTradeState(meta.vault, nowMs);
+}
+
+/** Save side: the serialized character, returned so the caller can chain the
+ *  save sanitizers. The vault stays absent-while-empty (the save-shape contract). */
+export function retirePartyTradeOnSave<
+  T extends PersistedPartyTradeContainers & { vault?: SavedMaterialsVaultState },
+>(state: T, nowMs: number): T {
+  normalizePersistedPartyTradeContainers(state, nowMs);
+  if (state.vault) normalizeSavedVaultPartyTradeState(state.vault, nowMs);
+  return state;
+}

--- a/src/sim/loot/loot_roll.ts
+++ b/src/sim/loot/loot_roll.ts
@@ -355,6 +355,17 @@ export function rollLoot(
     }
   }
   if (copper > 0 || items.length > 0) {
+    // A soulbound drop pins its bind-on-pickup trade group NOW, from the
+    // kill-time `eligible` set, so a member who disconnects before the roll
+    // resolves still counts (killSnapshotEligibility prefers this snapshot).
+    if (items.some((slot) => ITEMS[slot.itemId]?.soulbound)) {
+      mob.lootPartyTradeEligibility = {
+        names: eligible.map((candidate) => candidate.name),
+        characterIds: eligible.flatMap((candidate) =>
+          candidate.characterId === undefined ? [] : [candidate.characterId],
+        ),
+      };
+    }
     mob.loot = { copper, items };
     mob.lootable = true;
     // start the owner-lock countdown: after LOOT_FFA_DELAY the tap opens to all.
@@ -512,6 +523,12 @@ export function killSnapshotEligibility(
   ctx: SimContext,
   mob: Entity,
 ): { names: string[]; characterIds: number[] } {
+  if (mob.lootPartyTradeEligibility) {
+    return {
+      names: [...mob.lootPartyTradeEligibility.names],
+      characterIds: [...mob.lootPartyTradeEligibility.characterIds],
+    };
+  }
   if (!mob.lootRecipientIds || mob.lootRecipientIds.length === 0) {
     return { names: [], characterIds: [] };
   }

--- a/src/sim/materials_vault.ts
+++ b/src/sim/materials_vault.ts
@@ -90,6 +90,7 @@ import { addStacked, bagPools, bagsFullError, countFit } from './bags';
 import { nearBanker } from './bank';
 import { warnDroppedInstanceKeys } from './item_instance_load';
 import { itemInstancePayloadsEqual } from './item_instance_merge';
+import { normalizePartyTradeSlots } from './loot/bop_trade_cleanup';
 import { materialItemIds } from './material_ids';
 import { applyMaterialInventoryTake } from './material_inventory_take';
 import { resolveMaterialSourceTransferSelection } from './material_source_transfer_selection';
@@ -187,6 +188,24 @@ export function savedVaultState(state: MaterialsVaultState): SavedMaterialsVault
       : {}),
     upgrades: state.upgrades,
   };
+}
+
+/** Retire expired party-trade markers while keeping this module the sole vault writer. */
+export function normalizeVaultPartyTradeState(state: MaterialsVaultState, nowMs: number): boolean {
+  const special = normalizePartyTradeSlots(state.special, nowMs);
+  if (special === state.special) return false;
+  state.special = special;
+  return true;
+}
+
+/** Save-shape variant that preserves the absent-while-empty `special` contract. */
+export function normalizeSavedVaultPartyTradeState(
+  state: SavedMaterialsVaultState,
+  nowMs: number,
+): void {
+  if (!state.special) return;
+  const special = normalizePartyTradeSlots(state.special, nowMs);
+  if (special !== state.special) state.special = special;
 }
 
 /** True when a slot must retain its full identity in `special` rather than

--- a/src/sim/mob/lifecycle.ts
+++ b/src/sim/mob/lifecycle.ts
@@ -63,6 +63,7 @@ export function respawnMob(ctx: SimContext, mob: Entity): void {
   mob.lootable = false;
   mob.loot = null;
   mob.lootRecipientIds = undefined;
+  mob.lootPartyTradeEligibility = undefined;
   mob.tappedById = null;
   mob.harvestClaimedBy = null;
   mob.ownerId = null;

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -288,6 +288,7 @@ import { foldNamedSlotTarget, type NamedSlotTarget } from './item_copy_ref';
 import {
   boundCraftedRecipeIdOnLoad,
   sanitizeItemInstancePayloadOnLoad,
+  sanitizeSlotInstanceOnLoad,
   warnDroppedInstanceKeys,
 } from './item_instance_load';
 import { isMergeableInstancePayload } from './item_instance_merge';
@@ -309,6 +310,7 @@ import {
 } from './leaderboard_page';
 import { entityLineOfSightClear } from './line_of_sight_elevation';
 import type { Ante, PickAction } from './lockpick';
+import { retirePartyTradeOnLoad, retirePartyTradeOnSave } from './loot/bop_trade_persistence';
 import { withoutPartyTradeMarker } from './loot/bop_trade_window';
 // L1: the loot-distribution layer (party-loot strategy, the rollLoot roller, copper
 // split, need-greed roll lifecycle, corpse-loot helpers) moved to ./loot/loot_roll.ts;
@@ -3199,12 +3201,7 @@ export class Sim {
         // equipment-only clamp missed the container that carries most of
         // them). Same shared rule as the equip arm above, on the clone
         // cloneInvSlot just made (or the fresh rift rebuild).
-        if (slot.instance) {
-          const { payload, dropped } = sanitizeItemInstancePayloadOnLoad(slot.instance);
-          for (const d of dropped) droppedInstanceJunk.push(`bag.${slot.itemId}.${d}`);
-          if (payload) slot.instance = payload;
-          else delete slot.instance;
-        }
+        sanitizeSlotInstanceOnLoad(slot, droppedInstanceJunk, 'bag');
       }
       meta.inventory = meta.inventory.map(normalizeLoadedMaterialSlot);
       if (s.bags === undefined) {
@@ -3256,12 +3253,7 @@ export class Sim {
         // as bags and equipment; the first cut reached neither this list nor
         // the bank. Before the charges clamp below, which reads the payload
         // this leaves behind.
-        if (slot.instance) {
-          const { payload, dropped } = sanitizeItemInstancePayloadOnLoad(slot.instance);
-          for (const d of dropped) droppedInstanceJunk.push(`buyback.${slot.itemId}.${d}`);
-          if (payload) slot.instance = payload;
-          else delete slot.instance;
-        }
+        sanitizeSlotInstanceOnLoad(slot, droppedInstanceJunk, 'buyback');
         if (
           !preservesMaterialCountOnLoad(slot) &&
           slot.instance &&
@@ -3279,6 +3271,8 @@ export class Sim {
       // save sanitizes to the empty locked vault): restoreVaultStateOnLoad owns the
       // whole-record replacement AND its vaultWireRev bump (the rationale sits there).
       vaultMod.restoreVaultStateOnLoad(meta, s.vault, droppedInstanceJunk, player.id);
+      // Expired bind-on-pickup party-trade markers retire here and at serialize.
+      retirePartyTradeOnLoad(meta, this.lockoutNowMs());
       warnDroppedInstanceKeys(meta.name, droppedInstanceJunk);
       let questRevReset = false;
       for (const q of s.questLog) {
@@ -4334,7 +4328,8 @@ export class Sim {
       // pre-feature save stay byte-equal.
       ...materialGathererIdentitySaveFragment(meta.gathererIdentity),
     };
-    return sanitizeRemovedZone1Content(state).state;
+    // Expired party-trade markers retire at this persistence boundary, never by tick sweep.
+    return sanitizeRemovedZone1Content(retirePartyTradeOnSave(state, this.lockoutNowMs())).state;
   }
 
   /** Set a player's appearance skin (meta + entity). Bounded; the renderer

--- a/src/sim/social/trade.ts
+++ b/src/sim/social/trade.ts
@@ -27,7 +27,13 @@ import {
 import { partyTradeWindowAllows } from '../loot/bop_trade_window';
 import type { PlayerMeta, TradeSession } from '../sim';
 import type { SimContext } from '../sim_context';
-import { cloneItemInstancePayload, dist2d, type InvSlot, type ItemInstancePayload } from '../types';
+import {
+  cloneItemInstancePayload,
+  dist2d,
+  type InvSlot,
+  type ItemInstancePayload,
+  TICK_RATE,
+} from '../types';
 import {
   carriersReadable,
   mergedUnitSources,
@@ -991,6 +997,10 @@ export function updateTradesAndInvites(ctx: SimContext): void {
   }
   // cancel trades when the parties drift apart
   const seen = new Set<TradeSession>();
+  // Once a second, re-check every staged bind-on-pickup copy against the
+  // lockout clock: a window can expire while the offer sits on the table.
+  const revalidatePartyTradeOffers = ctx.tickCount % TICK_RATE === 0;
+  const nowMs = revalidatePartyTradeOffers ? ctx.lockoutNowMs() : 0;
   for (const session of ctx.trades.values()) {
     if (seen.has(session)) continue;
     seen.add(session);
@@ -998,6 +1008,19 @@ export function updateTradesAndInvites(ctx: SimContext): void {
     const eb = ctx.entities.get(session.b);
     if (!ea || !eb || dist2d(ea.pos, eb.pos) > TRADE_RANGE + 4 || ea.dead || eb.dead) {
       tradeCancel(ctx, session.a);
+      continue;
+    }
+    if (!revalidatePartyTradeOffers) continue;
+    for (const [pid, otherPid, offer] of [
+      [session.a, session.b, session.offerA],
+      [session.b, session.a, session.offerB],
+    ] as const) {
+      if (!offer.items.some((slot) => ITEMS[slot.itemId]?.soulbound)) continue;
+      if (offerCovered(ctx, offer.items, pid, otherPid, () => nowMs)) continue;
+      // Re-run the authoritative staging walk to remove only copies that are
+      // no longer valid. This also resets both acceptances, so a reconnecting
+      // client never sees an expired line as already agreed.
+      tradeSetOffer(ctx, offer.items, offer.copper, pid);
     }
   }
 }

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -5427,6 +5427,10 @@ export interface Entity extends ClientMirroredEntityFields {
   lootable: boolean;
   loot: CorpseLoot | null;
   lootRecipientIds?: number[];
+  /** Runtime-only stable identity for a soulbound drop's party-trade window.
+   *  Captured synchronously when loot rolls, so a later disconnect cannot
+   *  erase a kill-eligible character from the copy's transfer group. */
+  lootPartyTradeEligibility?: { names: string[]; characterIds: number[] };
   xpValue: number;
   // npc
   questIds: string[];

--- a/src/ui/bags_view.ts
+++ b/src/ui/bags_view.ts
@@ -193,7 +193,12 @@ export function bagItemAction(
    *  by the bank socket arm (bank sockets store bare ids, so a marked bag
    *  deposits instead). The vault preserves it, so it never blocks there. */
   craftedRecipeId?: string,
+  /** Host-clock verdict for the copy's bind-on-pickup marker. The server still
+   *  authorizes the recipient; this only prevents an expired client affordance. */
+  partyTradeWindowActive = instance?.partyTrade !== undefined,
 ): BagAction {
+  if (item.soulbound && mode.tradeOpen && instance?.partyTrade && partyTradeWindowActive)
+    return 'trade';
   if (item.soulbound && (mode.tradeOpen || mode.mailAttach || mode.marketSell || mode.vendorOpen))
     return 'transferBlockedSoulbound';
   if (mode.tradeOpen) return 'trade';
@@ -469,7 +474,10 @@ export function bagTooltipHintKey(
   /** The slot's crafting provenance marker, the bagItemAction twin: read only
    *  by the vaultDeposit arm. */
   craftedRecipeId?: string,
+  partyTradeWindowActive = instance?.partyTrade !== undefined,
 ): BagTooltipHintKey {
+  if (item.soulbound && mode.tradeOpen && instance?.partyTrade && partyTradeWindowActive)
+    return 'itemUi.tooltip.clickTradeOffer';
   if (item.soulbound && (mode.tradeOpen || mode.mailAttach || mode.marketSell || mode.vendorOpen))
     return 'hudChrome.itemSoulbound';
   if (mode.tradeOpen) return 'itemUi.tooltip.clickTradeOffer';

--- a/src/ui/bags_window.ts
+++ b/src/ui/bags_window.ts
@@ -1703,6 +1703,7 @@ export class BagsWindow {
       this.bagMode(),
       s.instance,
       s.craftedRecipeId,
+      this.partyTradeWindowActive(s.instance),
     );
     switch (action) {
       case 'transferBlockedSoulbound':
@@ -1903,6 +1904,7 @@ export class BagsWindow {
         mode,
         s.instance,
         s.craftedRecipeId,
+        this.partyTradeWindowActive(s.instance),
       );
       const extra = key ? `<div class="tt-sub">${esc(t(key))}</div>` : '';
       // Advertise the shift-click partial deposit on a splittable stack, the bank
@@ -2031,6 +2033,19 @@ export class BagsWindow {
       vaultDeposit: this.deps.isVaultBankTab(),
       petFeed: this.deps.pendingPetFeed(),
     };
+  }
+
+  // Whether a bind-on-pickup party-trade marker on this copy is still live
+  // on the host clock (the world owns which clock stamped `untilMs`), so the
+  // bag click and hint stage a still-tradable soulbound copy instead of
+  // refusing it before the authoritative trade path ever sees it.
+  private partyTradeWindowActive(instance: ItemInstancePayload | undefined): boolean {
+    const untilMs = instance?.partyTrade?.untilMs;
+    return (
+      typeof untilMs === 'number' &&
+      Number.isFinite(untilMs) &&
+      this.deps.world().partyTradeMsRemaining(untilMs) > 0
+    );
   }
 
   // Whether the action menu should open for this item. Offered ONLY in

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -6569,11 +6569,11 @@ export class Hud {
     // classic "Soulbound" line so a player can see it cannot be traded or destroyed.
     if (item.soulbound) {
       html += `<div class="tt-sub" style="color:var(--gold)">${esc(t('hudChrome.itemSoulbound'))}</div>`;
+      // BoP party trade window: qualifies the Soulbound line while this copy can
+      // still be traded to the players who shared its drop; def-gated, so a legacy
+      // marker on a since-freed drop renders nothing (the world owns the clock).
+      html += instancePartyTradeLine(instance, (ms) => this.sim.partyTradeMsRemaining(ms));
     }
-    // BoP party trade window: qualifies the Soulbound line above while this
-    // copy can still be traded to the players who shared its drop
-    // (item_instance_tooltip.ts owns the copy rules; the world owns the clock).
-    html += instancePartyTradeLine(instance, (untilMs) => this.sim.partyTradeMsRemaining(untilMs));
     // Maker's Bond lines (Professions 2.0): the commission
     // binds-on-first-trade warning or the bound lock, beside the def-level
     // soulbound line it parallels (item_instance_tooltip.ts owns the copy

--- a/src/ui/item_instance_tooltip.ts
+++ b/src/ui/item_instance_tooltip.ts
@@ -191,7 +191,9 @@ export function instanceBindingLines(
  *  this builder stays a Node-testable pure string function. Renders nothing
  *  for an absent, malformed, or expired window, and never on WORN gear
  *  (equip strips the payload field, and wornTooltipInstance would trim it
- *  anyway). */
+ *  anyway). The caller gates on the DEF's soulbound flag (hud.ts renders this
+ *  inside its Soulbound block), so a legacy marker on a drop that has since
+ *  become freely tradable never shows a stale window line. */
 export function instancePartyTradeLine(
   instance: ItemInstancePayload | undefined,
   msRemainingFor: (untilMs: number) => number,

--- a/tests/bags_view.test.ts
+++ b/tests/bags_view.test.ts
@@ -505,6 +505,48 @@ describe('transfer-locked instanced copies (issue 1165)', () => {
 });
 
 describe('soulbound transfer affordances', () => {
+  const PARTY_WINDOW = {
+    partyTrade: { untilMs: 10_000, eligible: ['Alice', 'Bob'] },
+  };
+
+  it('stages a marked soulbound copy for player trade while keeping every anonymous pipe blocked', () => {
+    expect([
+      bagItemAction(ITEMS.mark, { ...NO_MODE, tradeOpen: true }, PARTY_WINDOW),
+      bagItemAction(ITEMS.mark, { ...NO_MODE, mailAttach: true }, PARTY_WINDOW),
+      bagItemAction(ITEMS.mark, { ...NO_MODE, marketSell: true }, PARTY_WINDOW),
+      bagItemAction(ITEMS.mark, { ...NO_MODE, vendorOpen: true }, PARTY_WINDOW),
+    ]).toEqual([
+      'trade',
+      'transferBlockedSoulbound',
+      'transferBlockedSoulbound',
+      'transferBlockedSoulbound',
+    ]);
+  });
+
+  it('advertises player trade only for a marked soulbound copy', () => {
+    expect([
+      bagTooltipHintKey(ITEMS.mark, { ...NO_MODE, tradeOpen: true }, PARTY_WINDOW),
+      bagTooltipHintKey(ITEMS.mark, { ...NO_MODE, mailAttach: true }, PARTY_WINDOW),
+      bagTooltipHintKey(ITEMS.mark, { ...NO_MODE, marketSell: true }, PARTY_WINDOW),
+      bagTooltipHintKey(ITEMS.mark, { ...NO_MODE, vendorOpen: true }, PARTY_WINDOW),
+    ]).toEqual([
+      'itemUi.tooltip.clickTradeOffer',
+      'hudChrome.itemSoulbound',
+      'hudChrome.itemSoulbound',
+      'hudChrome.itemSoulbound',
+    ]);
+  });
+
+  it('blocks the trade action and hint once the host clock says the marker expired', () => {
+    const tradeMode = { ...NO_MODE, tradeOpen: true };
+    expect(bagItemAction(ITEMS.mark, tradeMode, PARTY_WINDOW, undefined, false)).toBe(
+      'transferBlockedSoulbound',
+    );
+    expect(bagTooltipHintKey(ITEMS.mark, tradeMode, PARTY_WINDOW, undefined, false)).toBe(
+      'hudChrome.itemSoulbound',
+    );
+  });
+
   it('blocks trade, mail, market, and vendor clicks instead of staging a Heroic Mark transfer', () => {
     expect([
       bagItemAction(ITEMS.mark, { ...NO_MODE, tradeOpen: true }),

--- a/tests/bags_window_party_trade.test.ts
+++ b/tests/bags_window_party_trade.test.ts
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 // Drives the real bags painter through the player click that originally
 // rejected every soulbound copy before the authoritative trade path could see
 // its temporary bind-on-pickup party-trade marker (PR #3791): a still-live

--- a/tests/bags_window_party_trade.test.ts
+++ b/tests/bags_window_party_trade.test.ts
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+// Drives the real bags painter through the player click that originally
+// rejected every soulbound copy before the authoritative trade path could see
+// its temporary bind-on-pickup party-trade marker (PR #3791): a still-live
+// marker stages the copy, an expired one (by the host clock) shows the
+// Soulbound refusal.
+import { describe, expect, it } from 'vitest';
+import type { InvSlot } from '../src/sim/types';
+import { BagsWindow, type BagsWindowDeps } from '../src/ui/bags_window';
+import { ItemDragState } from '../src/ui/item_drag_state';
+import type { IWorld } from '../src/world_api';
+
+function clickHarness(
+  inventory: InvSlot[],
+  partyTradeMsRemaining = 1,
+): {
+  root: HTMLElement;
+  staged: string[];
+  errors: string[];
+} {
+  document.body.innerHTML = '';
+  const staged: string[] = [];
+  const errors: string[] = [];
+  const root = document.createElement('div');
+  document.body.appendChild(root);
+  const world = {
+    inventory,
+    bags: [null, null, null, null],
+    bagCapacity: 16,
+    copper: 0,
+    questLog: new Map(),
+    partyTradeMsRemaining: () => partyTradeMsRemaining,
+  } as unknown as IWorld;
+  const noop = (): void => {};
+  const deps: BagsWindowDeps = {
+    itemIcon: () => '<span class="item-icon"></span>',
+    moneyHtml: () => '',
+    itemTooltip: () => '',
+    attachTooltip: noop,
+    root: () => root,
+    world: () => world,
+    wocBalanceHtml: () => '',
+    claudiumLauncherHtml: () => '',
+    openClaudium: noop,
+    openWallet: noop,
+    hideTooltip: noop,
+    consumePeek: () => false,
+    cancelPetFeed: noop,
+    captureFocus: () => null,
+    restoreFocus: noop,
+    renderCharIfOpen: noop,
+    vendorOpen: () => false,
+    tradeOpen: () => true,
+    isMarketSell: () => false,
+    isMailAttach: () => false,
+    isBankOpen: () => false,
+    isPersonalBankTab: () => false,
+    isGuildBankTab: () => false,
+    isVaultBankTab: () => false,
+    pendingPetFeed: () => false,
+    closeVendor: noop,
+    closeBank: noop,
+    onClosed: noop,
+    addItemToTrade: (itemId) => staged.push(itemId),
+    stageMarketSell: noop,
+    stageMailParcel: noop,
+    insertItemChatLink: noop,
+    showError: (message) => errors.push(message),
+    setPendingPetFeed: noop,
+    resetPetBarSig: noop,
+    isHotbarItemId: () => false,
+    useGatherTool: () => false,
+    setDragAction: noop,
+    clearActionDropTargets: noop,
+    dragState: new ItemDragState(),
+    isTouchHud: () => false,
+    confirmVendorSell: () => true,
+    markEquipDropTargets: noop,
+    dropOnEquipSlot: noop,
+    dropOnActionSlot: noop,
+    dropOnActionRingSlot: noop,
+    openItemActionMenu: noop,
+  };
+  new BagsWindow(deps).render();
+  return { root, staged, errors };
+}
+
+function clickFirstCell(root: HTMLElement): void {
+  const cell = root.querySelector('button.bag-item');
+  expect(cell).not.toBeNull();
+  cell?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+}
+
+const WINDOWED_SIGIL: InvSlot = {
+  itemId: 'sigil_anvil_helmet',
+  count: 1,
+  instance: {
+    partyTrade: { untilMs: 10_000, eligible: ['Alice', 'Bob'] },
+  },
+};
+
+describe('bags party-trade click path', () => {
+  it('stages a windowed soulbound sigil instead of showing the Soulbound refusal', () => {
+    const { root, staged, errors } = clickHarness([WINDOWED_SIGIL]);
+
+    clickFirstCell(root);
+
+    expect(staged).toEqual(['sigil_anvil_helmet']);
+    expect(errors).toEqual([]);
+  });
+
+  it('shows the Soulbound refusal after the host clock expires the same marker', () => {
+    const { root, staged, errors } = clickHarness([WINDOWED_SIGIL], 0);
+
+    clickFirstCell(root);
+
+    expect(staged).toEqual([]);
+    expect(errors).toHaveLength(1);
+  });
+});

--- a/tests/bop_party_trade.test.ts
+++ b/tests/bop_party_trade.test.ts
@@ -7,7 +7,7 @@ import { describe, expect, it } from 'vitest';
 import { BOP_PARTY_TRADE_MS } from '../src/sim/loot/bop_trade_window';
 import { grantAwardedLootItem } from '../src/sim/loot/loot_roll';
 import { type PlayerMeta, Sim } from '../src/sim/sim';
-import type { ItemInstancePayload } from '../src/sim/types';
+import { type ItemInstancePayload, TICK_RATE } from '../src/sim/types';
 import { expectDefined } from './helpers/defined';
 
 const HELM = 'slagbreaker_helmet'; // soulbound epic warrior tier piece
@@ -85,6 +85,34 @@ describe('BoP party trade window: the trade path', () => {
 
     expect(sim.countItem(HELM, alice)).toBe(1);
     expect(sim.countItem(HELM, bob)).toBe(0);
+  });
+
+  it('prunes a staged copy when its window expires and resets both acceptances', () => {
+    const { sim, alice, bob } = tradeSim();
+    const expiring = { partyTrade: { untilMs: 25, eligible: ['Alice', 'Bob'] } };
+    sim.addItemInstance(HELM, expiring, alice);
+    sim.addItemInstance(HELM, expiring, bob);
+    openTrade(sim, alice, bob);
+    sim.tradeSetOffer([{ itemId: HELM, count: 1 }], 0, alice);
+    sim.tradeSetOffer([{ itemId: HELM, count: 1 }], 0, bob);
+    const session = expectDefined(sim.ctx.trades.get(alice));
+    session.acceptedA = true;
+    session.acceptedB = true;
+
+    for (let i = 0; i < TICK_RATE - 1; i++) sim.tick();
+    expect(session.offerA.items).toHaveLength(1);
+    expect(session.offerB.items).toHaveLength(1);
+    expect(session.acceptedA).toBe(true);
+    expect(session.acceptedB).toBe(true);
+
+    sim.tick();
+
+    expect(session.offerA.items).toEqual([]);
+    expect(session.offerB.items).toEqual([]);
+    expect(session.acceptedA).toBe(false);
+    expect(session.acceptedB).toBe(false);
+    expect(sim.countItem(HELM, alice)).toBe(1);
+    expect(sim.countItem(HELM, bob)).toBe(1);
   });
 
   it('never offers a plain soulbound copy that carries no window at all', () => {

--- a/tests/bop_trade_cleanup.test.ts
+++ b/tests/bop_trade_cleanup.test.ts
@@ -1,0 +1,302 @@
+import { describe, expect, it } from 'vitest';
+import {
+  normalizePartyTradeContainers,
+  normalizePartyTradeSlots,
+} from '../src/sim/loot/bop_trade_cleanup';
+import {
+  normalizeSavedVaultPartyTradeState,
+  normalizeVaultPartyTradeState,
+} from '../src/sim/materials_vault';
+import { Sim } from '../src/sim/sim';
+import { type InvSlot, TICK_RATE } from '../src/sim/types';
+
+describe('bind-on-pickup party trade marker cleanup', () => {
+  it('retires expired sigil markers and restacks copies that are otherwise identical', () => {
+    const slots: InvSlot[] = [
+      {
+        itemId: 'sigil_anvil_helmet',
+        count: 1,
+        instance: { partyTrade: { untilMs: 100, eligible: ['Alice', 'Bob'] } },
+        slot: 4,
+      },
+      {
+        itemId: 'sigil_anvil_helmet',
+        count: 1,
+        instance: { partyTrade: { untilMs: 200, eligible: ['Alice', 'Bob'] } },
+        slot: 8,
+      },
+    ];
+
+    const normalized = normalizePartyTradeSlots(slots, 200);
+
+    expect(normalized).toEqual([{ itemId: 'sigil_anvil_helmet', count: 2, slot: 4 }]);
+    expect(slots).toHaveLength(2);
+    expect(slots[0].instance?.partyTrade).toBeDefined();
+  });
+
+  it('keeps active markers distinct and returns the original collection', () => {
+    const slots: InvSlot[] = [
+      {
+        itemId: 'sigil_anvil_helmet',
+        count: 1,
+        instance: { partyTrade: { untilMs: 201, eligible: ['Alice', 'Bob'] } },
+      },
+    ];
+
+    expect(normalizePartyTradeSlots(slots, 200)).toBe(slots);
+  });
+
+  it('preserves an active legacy marker on a currently tradable item for rollback safety', () => {
+    const slots: InvSlot[] = [
+      { itemId: 'heartspring_amulet', count: 1 },
+      {
+        itemId: 'heartspring_amulet',
+        count: 1,
+        instance: { partyTrade: { untilMs: 1_000, eligible: ['Alice', 'Bob'] } },
+      },
+    ];
+
+    expect(normalizePartyTradeSlots(slots, 0)).toBe(slots);
+  });
+
+  it('preserves unrelated payload fields and crafting provenance while restacking', () => {
+    const slots: InvSlot[] = [
+      {
+        itemId: 'sigil_anvil_helmet',
+        count: 1,
+        instance: {
+          signer: 'Alice',
+          partyTrade: { untilMs: 100, eligible: ['Alice', 'Bob'] },
+        },
+        craftedRecipeId: 'recipe_a',
+      },
+      {
+        itemId: 'sigil_anvil_helmet',
+        count: 1,
+        instance: {
+          signer: 'Alice',
+          partyTrade: { untilMs: 100, eligible: ['Alice', 'Bob'] },
+        },
+        craftedRecipeId: 'recipe_a',
+      },
+    ];
+
+    expect(normalizePartyTradeSlots(slots, 100)).toEqual([
+      {
+        itemId: 'sigil_anvil_helmet',
+        count: 2,
+        instance: { signer: 'Alice' },
+        craftedRecipeId: 'recipe_a',
+      },
+    ]);
+  });
+
+  it('keeps different crafting provenance and sibling payloads in separate rows', () => {
+    const expired = (craftedRecipeId: string, signer: string): InvSlot => ({
+      itemId: 'sigil_anvil_helmet',
+      count: 1,
+      instance: {
+        signer,
+        partyTrade: { untilMs: 100, eligible: ['Alice', 'Bob'] },
+      },
+      craftedRecipeId,
+    });
+
+    expect(
+      normalizePartyTradeSlots(
+        [expired('recipe_a', 'Alice'), expired('recipe_b', 'Alice'), expired('recipe_a', 'Bob')],
+        100,
+      ),
+    ).toHaveLength(3);
+  });
+
+  it('does not merge unrelated partial stacks when another item marker expires', () => {
+    const slots: InvSlot[] = [
+      { itemId: 'wolf_pelt', count: 2, slot: 1 },
+      {
+        itemId: 'sigil_anvil_helmet',
+        count: 1,
+        instance: { partyTrade: { untilMs: 100, eligible: ['Alice', 'Bob'] } },
+      },
+      { itemId: 'wolf_pelt', count: 3, slot: 7 },
+    ];
+
+    expect(normalizePartyTradeSlots(slots, 100)).toEqual([
+      { itemId: 'wolf_pelt', count: 2, slot: 1 },
+      { itemId: 'sigil_anvil_helmet', count: 1 },
+      { itemId: 'wolf_pelt', count: 3, slot: 7 },
+    ]);
+  });
+
+  it('preserves one counted non-mergeable row without increasing serialized bytes', () => {
+    const slots: InvSlot[] = [
+      {
+        itemId: 'sigil_anvil_helmet',
+        count: 20,
+        instance: {
+          locked: true,
+          partyTrade: { untilMs: 100, eligible: ['Alice', 'Bob'] },
+        },
+      },
+    ];
+
+    const normalized = normalizePartyTradeSlots(slots, 100);
+    expect(normalized).toEqual([
+      { itemId: 'sigil_anvil_helmet', count: 20, instance: { locked: true } },
+    ]);
+    expect(JSON.stringify(normalized).length).toBeLessThanOrEqual(JSON.stringify(slots).length);
+  });
+
+  it('splits a normalized stack at the live item cap and is idempotent', () => {
+    const slots: InvSlot[] = [
+      {
+        itemId: 'sigil_anvil_helmet',
+        count: 20,
+        instance: { partyTrade: { untilMs: 100, eligible: ['Alice', 'Bob'] } },
+      },
+      {
+        itemId: 'sigil_anvil_helmet',
+        count: 1,
+        instance: { partyTrade: { untilMs: 100, eligible: ['Alice', 'Bob'] } },
+      },
+    ];
+
+    const normalized = normalizePartyTradeSlots(slots, 100);
+    expect(normalized.map((slot) => slot.count)).toEqual([20, 1]);
+    expect(normalizePartyTradeSlots(normalized, 100)).toBe(normalized);
+  });
+
+  it('normalizes every persisted player item container through its owning boundary', () => {
+    const expired = (): InvSlot => ({
+      itemId: 'sigil_anvil_helmet',
+      count: 1,
+      instance: { partyTrade: { untilMs: 100, eligible: ['Alice', 'Bob'] } },
+    });
+    const owner = {
+      inventory: [expired()],
+      bank: { inventory: [expired()] },
+      vault: { stock: { copper_ore: 7 }, special: [expired()], upgrades: 2 },
+      vendorBuyback: [expired()],
+    };
+
+    expect(normalizePartyTradeContainers(owner, 100)).toEqual({
+      inventory: true,
+      bank: true,
+      buyback: true,
+    });
+    expect(normalizeVaultPartyTradeState(owner.vault, 100)).toBe(true);
+    expect(owner.vault.stock).toEqual({ copper_ore: 7 });
+    expect(owner.vault.upgrades).toBe(2);
+    expect(
+      [
+        ...owner.inventory,
+        ...owner.bank.inventory,
+        ...owner.vault.special,
+        ...owner.vendorBuyback,
+      ].every((slot) => slot.instance?.partyTrade === undefined),
+    ).toBe(true);
+  });
+
+  it('does not materialize an absent optional vault special list at save time', () => {
+    const vault = { stock: {}, upgrades: 0 };
+    normalizeSavedVaultPartyTradeState(vault, 100);
+    expect(vault).toEqual({ stock: {}, upgrades: 0 });
+  });
+
+  it('preserves buyback row order and oversized counts while stripping an expired marker', () => {
+    const expired: InvSlot = {
+      itemId: 'sigil_anvil_helmet',
+      count: 20,
+      instance: { partyTrade: { untilMs: 100, eligible: ['Alice', 'Bob'] } },
+    };
+    const owner = {
+      inventory: [],
+      bank: { inventory: [] },
+      vault: { special: [] },
+      vendorBuyback: [
+        { itemId: 'wolf_pelt', count: 40 },
+        expired,
+        { itemId: 'wolf_pelt', count: 60 },
+      ],
+    };
+
+    normalizePartyTradeContainers(owner, 100);
+
+    expect(owner.vendorBuyback).toEqual([
+      { itemId: 'wolf_pelt', count: 40 },
+      { itemId: 'sigil_anvil_helmet', count: 20 },
+      { itemId: 'wolf_pelt', count: 60 },
+    ]);
+  });
+
+  it('normalizes the saved character without a realm-wide tick sweep', () => {
+    const sim = new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+    const pid = sim.addPlayer('warrior', 'Alice');
+    const meta = sim.ctx.players.get(pid);
+    expect(meta).toBeDefined();
+    if (!meta) return;
+    const expired = (): InvSlot => ({
+      itemId: 'sigil_anvil_helmet',
+      count: 1,
+      instance: { partyTrade: { untilMs: 1, eligible: ['Alice', 'Bob'] } },
+    });
+    meta.inventory = [expired()];
+    meta.bank.inventory = [expired()];
+    meta.vault.special = [expired()];
+    meta.vendorBuyback = [expired()];
+    for (let i = 0; i < TICK_RATE; i++) sim.tick();
+
+    const saved = sim.serializeCharacter(pid);
+
+    expect(saved?.inventory[0].instance).toBeUndefined();
+    expect(saved?.bank?.inventory[0].instance).toBeUndefined();
+    expect(saved?.vault?.special?.[0].instance).toBeUndefined();
+    expect(saved?.vendorBuyback?.[0].instance).toBeUndefined();
+    expect(meta.inventory[0].instance?.partyTrade).toBeDefined();
+  });
+
+  it('retires and restacks expired persisted copies during load and resave', () => {
+    const seed = new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+    const seedPid = seed.addPlayer('warrior', 'Alice');
+    const state = seed.serializeCharacter(seedPid);
+    expect(state).toBeDefined();
+    if (!state) return;
+    state.inventory = [
+      {
+        itemId: 'sigil_anvil_helmet',
+        count: 1,
+        instance: { partyTrade: { untilMs: 1, eligible: ['Alice', 'Bob'] } },
+      },
+      {
+        itemId: 'sigil_anvil_helmet',
+        count: 1,
+        instance: { partyTrade: { untilMs: 2, eligible: ['Alice', 'Bob'] } },
+      },
+    ];
+    state.vault = {
+      stock: { copper_ore: 7 },
+      special: [
+        {
+          itemId: 'sigil_anvil_helmet',
+          count: 1,
+          instance: { partyTrade: { untilMs: 1, eligible: ['Alice', 'Bob'] } },
+        },
+      ],
+      upgrades: 2,
+    };
+    const loaded = new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+    loaded.tick();
+
+    const loadedPid = loaded.addPlayer('warrior', 'Alice', { state });
+    const meta = loaded.ctx.players.get(loadedPid);
+
+    expect(meta?.inventory).toEqual([{ itemId: 'sigil_anvil_helmet', count: 2 }]);
+    expect(meta?.vault).toEqual({
+      stock: { copper_ore: 7 },
+      special: [{ itemId: 'sigil_anvil_helmet', count: 1 }],
+      upgrades: 2,
+    });
+    const resaved = loaded.serializeCharacter(loadedPid);
+    expect(resaved?.inventory).toEqual([{ itemId: 'sigil_anvil_helmet', count: 2 }]);
+  });
+});

--- a/tests/ignivar_loot.test.ts
+++ b/tests/ignivar_loot.test.ts
@@ -106,7 +106,6 @@ describe('ignivar loot: every gear piece is item level 35 and budget-exact', () 
       expect(item.quality, item.id).toBe('epic');
       expect(itemLevel(item), `${item.id} ilvl`).toBe(35);
       expect(item.requiredLevel, item.id).toBe(20);
-      expect(item.soulbound, item.id).toBe(true);
     }
   });
 
@@ -135,6 +134,77 @@ describe('ignivar loot: every gear piece is item level 35 and budget-exact', () 
       );
       expect(primaryStatSum(item), `${item.id} stat sum == budget`).toBe(want);
     }
+  });
+});
+
+describe('ignivar loot: binding policy (sigils and tier pieces bind, drops trade)', () => {
+  it('keeps every class-tier redemption sigil soulbound', () => {
+    for (const sigil of Object.values(IGNIVAR_SIGIL_ITEMS)) {
+      expect(sigil.soulbound, sigil.id).toBe(true);
+    }
+  });
+
+  it('keeps every redeemed tier set piece soulbound', () => {
+    for (const item of Object.values(IGNIVAR_SET_ITEMS)) {
+      expect(item.soulbound, item.id).toBe(true);
+    }
+  });
+
+  it('keeps every ordinary raid gear drop transferable', () => {
+    const droppedGear = [
+      ...Object.values(IGNIVAR_OFFSET_ITEMS),
+      ...Object.values(IGNIVAR_JEWELRY_ITEMS),
+      ...Object.values(IGNIVAR_HELD_ITEMS),
+      ...Object.values(IGNIVAR_WEAPON_ITEMS),
+    ];
+    expect(droppedGear.length).toBe(41);
+    for (const item of droppedGear) {
+      expect(item.soulbound, item.id).toBeFalsy();
+    }
+  });
+
+  function partyOfTwo(playerClass: 'warrior' | 'priest') {
+    const sim = new Sim({ seed: 7, playerClass, noPlayer: true });
+    const recipient = sim.addPlayer(playerClass, 'Recipient');
+    const partyMember = sim.addPlayer(playerClass, 'PartyMember');
+    for (const pid of [recipient, partyMember]) {
+      const entity = sim.entities.get(pid);
+      if (!entity) throw new Error(`missing player ${pid}`);
+      entity.pos = { x: 0, y: 0, z: 0 };
+      entity.prevPos = { x: 0, y: 0, z: 0 };
+      sim.rebucket(entity);
+    }
+    sim.partyInvite(partyMember, recipient);
+    sim.partyAccept(partyMember);
+    return { sim, recipient, partyMember };
+  }
+
+  function tradeOne(sim: Sim, from: number, to: number, itemId: string): void {
+    sim.tradeRequest(to, from);
+    sim.tradeAccept(to);
+    sim.tradeSetOffer([{ itemId, count: 1 }], 0, from);
+    sim.tradeConfirm(from);
+    sim.tradeConfirm(to);
+  }
+
+  it('refuses trading a redeemed tier piece even inside the party', () => {
+    const { sim, recipient, partyMember } = partyOfTwo('warrior');
+    sim.addItem('slagbreaker_helmet', 1, recipient);
+
+    tradeOne(sim, recipient, partyMember, 'slagbreaker_helmet');
+
+    expect(sim.countItem('slagbreaker_helmet', recipient)).toBe(1);
+    expect(sim.countItem('slagbreaker_helmet', partyMember)).toBe(0);
+  });
+
+  it('lets a Heartspring Amulet recipient trade it to a party member', () => {
+    const { sim, recipient, partyMember } = partyOfTwo('priest');
+    sim.addItem('heartspring_amulet', 1, recipient);
+
+    tradeOne(sim, recipient, partyMember, 'heartspring_amulet');
+
+    expect(sim.countItem('heartspring_amulet', recipient)).toBe(0);
+    expect(sim.countItem('heartspring_amulet', partyMember)).toBe(1);
   });
 });
 

--- a/tests/item_instance_load.test.ts
+++ b/tests/item_instance_load.test.ts
@@ -17,6 +17,7 @@ import {
   MAX_INSTANCE_SUBTREE_JSON_LENGTH,
   MAX_LEGENDARY_NAME_LOAD_LENGTH,
   sanitizeItemInstancePayloadOnLoad,
+  sanitizeSlotInstanceOnLoad,
   warnDroppedInstanceKeys,
 } from '../src/sim/item_instance_load';
 import { PERFECTING_RANKS } from '../src/sim/professions/perfecting';
@@ -453,6 +454,50 @@ describe('boundCraftedRecipeIdOnLoad: the slot-level sibling bound', () => {
     boundCraftedRecipeIdOnLoad(nonString, dropped, 'buyback');
     expect('craftedRecipeId' in nonString).toBe(false);
     expect(dropped).toEqual(['bag.hide.craftedRecipeId', 'buyback.hide.craftedRecipeId']);
+  });
+});
+
+describe('sanitizeSlotInstanceOnLoad: the per-slot bound the container load loops share', () => {
+  it('leaves a slot without a payload alone and reports nothing', () => {
+    const slot = { itemId: 'tough_jerky', count: 3 };
+    const dropped: string[] = [];
+    sanitizeSlotInstanceOnLoad(slot, dropped, 'bag');
+    expect(slot).toEqual({ itemId: 'tough_jerky', count: 3 });
+    expect(dropped).toEqual([]);
+  });
+
+  it('keeps a legal payload by identity and reports nothing', () => {
+    const instance = legalPayload();
+    const slot = { itemId: 'tough_jerky', count: 1, instance };
+    const dropped: string[] = [];
+    sanitizeSlotInstanceOnLoad(slot, dropped, 'bag');
+    expect(slot.instance).toBe(instance);
+    expect(dropped).toEqual([]);
+  });
+
+  it('labels each dropped key under the container and item: bag.<id>.<key>', () => {
+    const slot = {
+      itemId: 'tough_jerky',
+      count: 1,
+      instance: { ...legalPayload(), signer: 'x'.repeat(MAX_INSTANCE_STRING_LENGTH + 1) },
+    };
+    const dropped: string[] = [];
+    sanitizeSlotInstanceOnLoad(slot, dropped, 'bag');
+    expect(dropped).toEqual(['bag.tough_jerky.signer']);
+    const { signer: _signer, ...rest } = legalPayload();
+    expect(slot.instance).toEqual(rest);
+  });
+
+  it('deletes the field outright when the payload sanitizes to nothing (never leaves `{}`)', () => {
+    const slot: { itemId: string; count: number; instance?: unknown } = {
+      itemId: 'tough_jerky',
+      count: 1,
+      instance: { signer: 'x'.repeat(MAX_INSTANCE_STRING_LENGTH + 1) },
+    };
+    const dropped: string[] = [];
+    sanitizeSlotInstanceOnLoad(slot, dropped, 'buyback');
+    expect('instance' in slot).toBe(false);
+    expect(dropped).toEqual(['buyback.tough_jerky.signer', 'buyback.tough_jerky.payload']);
   });
 });
 

--- a/tests/item_instance_tooltip.test.ts
+++ b/tests/item_instance_tooltip.test.ts
@@ -757,15 +757,22 @@ describe('instancePartyTradeLine (the BoP party trade window line)', () => {
     ).toBe('');
   });
 
-  it('composes in hud.itemTooltip right after the Soulbound line, before the bond lines', () => {
+  it('composes in hud.itemTooltip inside the Soulbound block, before the bond lines', () => {
     const hud = readFileSync(new URL('../src/ui/hud.ts', import.meta.url), 'utf8');
     const soulbound = hud.indexOf("t('hudChrome.itemSoulbound')");
     const partyTrade = hud.indexOf('instancePartyTradeLine(instance,');
     const binding = hud.indexOf('instanceBindingLines(instance, item.kind)');
+    // The window line rides INSIDE the def-level `if (item.soulbound)` block
+    // (no block close between the Soulbound line and the call, and the call
+    // sits at the block's indent), so a legacy marker on a drop that has since
+    // become freely tradable (the Crucible boss drops, PR #3789) renders nothing.
+    expect(hud.slice(soulbound, partyTrade)).not.toContain('\n    }\n');
+    const callLineStart = hud.lastIndexOf('\n', partyTrade) + 1;
+    expect(hud.slice(callLineStart, partyTrade)).toBe('      html += ');
     expect(partyTrade).toBeGreaterThan(soulbound);
     expect(binding).toBeGreaterThan(partyTrade);
     expect(hud.indexOf('instancePartyTradeLine(', partyTrade + 1)).toBe(-1);
     // The remaining span resolves through the IWorld clock, never Date.now().
-    expect(hud).toContain('this.sim.partyTradeMsRemaining(untilMs)');
+    expect(hud).toContain('this.sim.partyTradeMsRemaining(ms)');
   });
 });

--- a/tests/item_instance_tooltip.test.ts
+++ b/tests/item_instance_tooltip.test.ts
@@ -762,13 +762,19 @@ describe('instancePartyTradeLine (the BoP party trade window line)', () => {
     const soulbound = hud.indexOf("t('hudChrome.itemSoulbound')");
     const partyTrade = hud.indexOf('instancePartyTradeLine(instance,');
     const binding = hud.indexOf('instanceBindingLines(instance, item.kind)');
-    // The window line rides INSIDE the def-level `if (item.soulbound)` block
-    // (no block close between the Soulbound line and the call, and the call
-    // sits at the block's indent), so a legacy marker on a drop that has since
-    // become freely tradable (the Crucible boss drops, PR #3789) renders nothing.
-    expect(hud.slice(soulbound, partyTrade)).not.toContain('\n    }\n');
-    const callLineStart = hud.lastIndexOf('\n', partyTrade) + 1;
-    expect(hud.slice(callLineStart, partyTrade)).toBe('      html += ');
+    // The window line rides INSIDE the def-level `if (item.soulbound)` block,
+    // so a legacy marker on a drop that has since become freely tradable (the
+    // Crucible boss drops, PR #3789) renders nothing. Pinned by braces, not
+    // whitespace, so a reformat of the block cannot break it: no `}` between
+    // the block's open and the Soulbound line, and none between the end of the
+    // Soulbound statement and the call (the template's `${...}` sits inside
+    // that statement, which is why the second span starts after it).
+    const blockOpen = hud.lastIndexOf('if (item.soulbound)', soulbound);
+    expect(blockOpen).toBeGreaterThan(-1);
+    expect(hud.slice(blockOpen, soulbound)).not.toContain('}');
+    const soulboundEnd = hud.indexOf('`;', soulbound);
+    expect(soulboundEnd).toBeGreaterThan(soulbound);
+    expect(hud.slice(soulboundEnd, partyTrade)).not.toContain('}');
     expect(partyTrade).toBeGreaterThan(soulbound);
     expect(binding).toBeGreaterThan(partyTrade);
     expect(hud.indexOf('instancePartyTradeLine(', partyTrade + 1)).toBe(-1);

--- a/tests/loot_roll.test.ts
+++ b/tests/loot_roll.test.ts
@@ -8,6 +8,7 @@ import {
   awardSharedLootItem,
   CORPSE_INTERACT_GRACE_SECONDS,
   distributeLootCopper,
+  killSnapshotEligibility,
   lootRollGroupStatus,
   lootSlotVisibleTo,
   partyLootCandidatesForMob,
@@ -818,6 +819,30 @@ describe('loot_roll: heroic-append cross-group dedup arm', () => {
 });
 
 describe('loot_roll: bind-on-pickup party trade window on soulbound awards', () => {
+  it('keeps the exact drop group eligible when a member disconnects before distribution', () => {
+    const { sim, a, b, c } = partyOfThree();
+    playerMeta(sim, a).characterId = 101;
+    playerMeta(sim, b).characterId = 102;
+    playerMeta(sim, c).characterId = 103;
+    const mob = createMob(sim.nextId++, MOBS.ignivar_herald_of_the_last_flame, 20, {
+      x: 0,
+      y: 0,
+      z: 0,
+    });
+    mob.lootRecipientIds = [a, b, c];
+    rollLoot(sim.ctx, mob, playerMeta(sim, a), [
+      playerMeta(sim, a),
+      playerMeta(sim, b),
+      playerMeta(sim, c),
+    ]);
+    playerMeta(sim, b).leaving = true;
+
+    expect(killSnapshotEligibility(sim.ctx, mob)).toEqual({
+      names: ['Aaa', 'Bbb', 'Ccc'],
+      characterIds: [101, 102, 103],
+    });
+  });
+
   it('stamps the drop-moment candidate snapshot onto a need/greed win of a soulbound item', () => {
     const { sim, a, b, c } = partyOfThree();
     const mob = deadCorpse(sim, a, [a, b, c], {

--- a/tests/mob_lifecycle.test.ts
+++ b/tests/mob_lifecycle.test.ts
@@ -188,7 +188,7 @@ describe('mob_lifecycle module: respawnMob + despawnSummonedAdds', () => {
 // so the tapping player keeps a bounded, classic-faithful window before the loot
 // decays with the corpse. Both facets were previously unpinned.
 describe('mob_lifecycle module: un-looted corpse loot on respawn (issue #1539)', () => {
-  it('respawnMob wipes the reused corpse loot state (lootable/loot/tappedById/lootRecipientIds)', () => {
+  it('respawnMob wipes the reused corpse loot state and party-trade eligibility snapshot', () => {
     const sim = makeSim();
     const p = sim.player as any;
     const mob = spawn(sim, 'forest_wolf', 5, 40, 40);
@@ -200,6 +200,7 @@ describe('mob_lifecycle module: un-looted corpse loot on respawn (issue #1539)',
     mob.loot = { copper: 120, items: [{ itemId: 'wolf_pelt', count: 1 }] };
     mob.tappedById = p.id;
     mob.lootRecipientIds = [p.id];
+    mob.lootPartyTradeEligibility = { names: ['Tester'], characterIds: [101] };
 
     respawnMob(ctxOf(sim), mob);
 
@@ -207,6 +208,7 @@ describe('mob_lifecycle module: un-looted corpse loot on respawn (issue #1539)',
     expect(mob.loot).toBe(null);
     expect(mob.tappedById).toBe(null);
     expect(mob.lootRecipientIds).toBeUndefined();
+    expect(mob.lootPartyTradeEligibility).toBeUndefined();
   });
 
   it('the in-place respawn is deferred while the corpse is lootable, then wipes the loot when the corpse decays', () => {

--- a/tests/monolith_budget.test.ts
+++ b/tests/monolith_budget.test.ts
@@ -1013,7 +1013,12 @@ const MONOLITHS: MonolithRow[] = [
     // measures 11923, below both arms, so the ceiling follows it down. Exact
     // merged count, zero slack: any further growth reds again.
     // Main hotfix integration: combined extractions, exact merged count.
-    ceiling: 11879,
+    // Down 11879 -> 11874 at the Crucible binding restore (PRs #3788/#3789/#3791
+    // re-applied for v0.42.1): the two per-slot payload-bound blocks in the
+    // character load loops (bags, buyback) moved to item_instance_load.ts's
+    // sanitizeSlotInstanceOnLoad, paying for the party-trade retire hooks that
+    // now live in src/sim/loot/bop_trade_persistence.ts. Exact count, zero slack.
+    ceiling: 11874,
     seam: 'a sim system module behind SimContext (src/sim/CLAUDE.md)',
   },
   {

--- a/tests/parity/coverage_c.test.ts
+++ b/tests/parity/coverage_c.test.ts
@@ -1900,4 +1900,12 @@ describe('coverage: each scenario fires its subsystem', { timeout: 90_000 }, () 
     // shed the aura rather than leaving a stale second one behind.
     expect((p.auras as any[]).filter((a) => a.kind === 'buff_sta')).toEqual([]);
   });
+
+  it('bop_party_trade_eligibility: a leaving drop-mate stays on the awarded copy', () => {
+    const rec = run('bop_party_trade_eligibility');
+    expect(rec.notes.eligibleCharacterIds).toEqual([101, 102]);
+    const alice = [...rec.sim.ctx.players.values()].find((meta) => meta.name === 'AliceParity');
+    const awarded = alice?.inventory.find((slot) => slot.itemId === 'sigil_anvil_helmet');
+    expect(awarded?.instance?.partyTrade?.eligibleIds).toEqual([101, 102]);
+  });
 });

--- a/tests/parity/golden/bop_party_trade_eligibility.json
+++ b/tests/parity/golden/bop_party_trade_eligibility.json
@@ -1,0 +1,1169 @@
+{
+  "scenario": "bop_party_trade_eligibility",
+  "seed": 1173,
+  "sampleEvery": 1,
+  "ticks": 0,
+  "coverage": [
+    "soulbound raid loot captures stable party-trade identity at roll time",
+    "a leaving member remains eligible during delayed distribution",
+    "class:warrior",
+    "class:mage"
+  ],
+  "draws": 7,
+  "drawDigest": "284731db",
+  "frames": [
+    {
+      "tick": 0,
+      "time": 0,
+      "nextId": 1006,
+      "state": "5bc471b0",
+      "events": "741638a5",
+      "rng": {
+        "draws": 0,
+        "digest": "811c9dc5"
+      },
+      "label": "init",
+      "players": [],
+      "entities": []
+    },
+    {
+      "tick": 0,
+      "time": 0,
+      "nextId": 1009,
+      "state": "69a38adb",
+      "events": "741638a5",
+      "rng": {
+        "draws": 7,
+        "digest": "284731db"
+      },
+      "label": "loot-identity-captured",
+      "players": [
+        {
+          "activeLoadout": -1,
+          "archetype": {},
+          "arena2v2Rating": 1500,
+          "arenaRating": 1500,
+          "bags": [
+            null,
+            null,
+            null,
+            null
+          ],
+          "bank": {
+            "socketBags": [
+              null,
+              null,
+              null,
+              null
+            ]
+          },
+          "bgRating": 1500,
+          "cls": "warrior",
+          "companionUpgrades": {},
+          "counters": {},
+          "craftDaily": {},
+          "craftSkills": {},
+          "deedStats": {
+            "counters": {},
+            "dungeonClears": {},
+            "itemsDiscovered": [
+              "baked_bread",
+              "eastbrook_buckler",
+              "recruit_tunic",
+              "worn_sword"
+            ]
+          },
+          "delveClears": {},
+          "delveDaily": {},
+          "entityId": 1006,
+          "equipment": {
+            "chest": "recruit_tunic",
+            "mainhand": "worn_sword",
+            "offhand": "eastbrook_buckler"
+          },
+          "equipmentInstance": {},
+          "gathererIdentity": {
+            "id": 101,
+            "kind": "character"
+          },
+          "gatheringProficiency": {},
+          "harvestPreference": {
+            "kind": "all"
+          },
+          "heroicDaily": {},
+          "inventory": [
+            {
+              "count": 5,
+              "itemId": "baked_bread"
+            }
+          ],
+          "mailWelcomed": true,
+          "nodeHarvestReadyAt": {},
+          "recipesGrandfathered": true,
+          "reliquary": {
+            "counts": {},
+            "firstFind": {}
+          },
+          "talents": {
+            "rows": {}
+          },
+          "townFocus": {},
+          "vault": {
+            "stock": {}
+          },
+          "wyrmfallDaily": {}
+        },
+        {
+          "activeLoadout": -1,
+          "archetype": {},
+          "arena2v2Rating": 1500,
+          "arenaRating": 1500,
+          "bags": [
+            null,
+            null,
+            null,
+            null
+          ],
+          "bank": {
+            "socketBags": [
+              null,
+              null,
+              null,
+              null
+            ]
+          },
+          "bgRating": 1500,
+          "cls": "mage",
+          "companionUpgrades": {},
+          "counters": {},
+          "craftDaily": {},
+          "craftSkills": {},
+          "deedStats": {
+            "counters": {},
+            "dungeonClears": {},
+            "itemsDiscovered": [
+              "apprentice_robe",
+              "baked_bread",
+              "gnarled_staff",
+              "spring_water"
+            ]
+          },
+          "delveClears": {},
+          "delveDaily": {},
+          "entityId": 1007,
+          "equipment": {
+            "chest": "apprentice_robe",
+            "mainhand": "gnarled_staff"
+          },
+          "equipmentInstance": {},
+          "gathererIdentity": {
+            "id": 102,
+            "kind": "character"
+          },
+          "gatheringProficiency": {},
+          "harvestPreference": {
+            "kind": "all"
+          },
+          "heroicDaily": {},
+          "inventory": [
+            {
+              "count": 5,
+              "itemId": "baked_bread"
+            },
+            {
+              "count": 5,
+              "itemId": "spring_water"
+            }
+          ],
+          "mailWelcomed": true,
+          "nodeHarvestReadyAt": {},
+          "recipesGrandfathered": true,
+          "reliquary": {
+            "counts": {},
+            "firstFind": {}
+          },
+          "talents": {
+            "rows": {}
+          },
+          "townFocus": {},
+          "vault": {
+            "stock": {}
+          },
+          "wyrmfallDaily": {}
+        }
+      ],
+      "entities": [
+        {
+          "aiState": "idle",
+          "attackPower": 46,
+          "auras": [
+            {
+              "duration": 3600,
+              "id": "battle_stance",
+              "kind": "battle_stance",
+              "name": "Battle Stance",
+              "remaining": 3600,
+              "school": "physical",
+              "sourceId": 1006
+            }
+          ],
+          "blockChance": 0.05,
+          "blockValue": 6,
+          "combatTimer": 99,
+          "comboUntil": -1,
+          "critChance": 0.06,
+          "detonateTimer": "Infinity",
+          "dodgeChance": 0.06,
+          "fallStartY": -2,
+          "fiveSecondRule": 99,
+          "healPower": 5,
+          "hp": 100,
+          "id": 1006,
+          "kind": "player",
+          "level": 1,
+          "lootFfaTimer": "Infinity",
+          "maxHp": 100,
+          "maxResource": 100,
+          "moveSpeed": 7,
+          "offhandItemId": "eastbrook_buckler",
+          "onGround": true,
+          "overpowerUntil": -1,
+          "petMode": "defensive",
+          "pos": {
+            "x": -94,
+            "y": -2,
+            "z": -58
+          },
+          "potionCooldownUntil": -1,
+          "resourceType": "rage",
+          "spawnPos": {
+            "x": -94,
+            "y": -2,
+            "z": -58
+          },
+          "spellPower": 5,
+          "stats": {
+            "agi": 20,
+            "armor": 144,
+            "int": 10,
+            "spi": 11,
+            "sta": 23,
+            "str": 23
+          },
+          "templateId": "warrior",
+          "weapon": {
+            "max": 5,
+            "min": 2,
+            "speed": 2
+          }
+        },
+        {
+          "aiState": "idle",
+          "attackPower": 10,
+          "combatTimer": 99,
+          "comboUntil": -1,
+          "critChance": 0.056,
+          "detonateTimer": "Infinity",
+          "dodgeChance": 0.056,
+          "fallStartY": -2,
+          "fiveSecondRule": 99,
+          "healPower": 13,
+          "hp": 54,
+          "id": 1007,
+          "kind": "player",
+          "level": 1,
+          "lootFfaTimer": "Infinity",
+          "maxHp": 54,
+          "maxResource": 195,
+          "moveSpeed": 7,
+          "onGround": true,
+          "overpowerUntil": -1,
+          "petMode": "defensive",
+          "pos": {
+            "x": -94,
+            "y": -2,
+            "z": -58
+          },
+          "potionCooldownUntil": -1,
+          "resource": 195,
+          "resourceType": "mana",
+          "spawnPos": {
+            "x": -94,
+            "y": -2,
+            "z": -58
+          },
+          "spellPower": 13,
+          "stats": {
+            "agi": 12,
+            "armor": 57,
+            "int": 25,
+            "spi": 22,
+            "sta": 14,
+            "str": 10
+          },
+          "templateId": "mage",
+          "weapon": {
+            "max": 6,
+            "min": 3,
+            "speed": 2.9
+          }
+        },
+        {
+          "aiState": "idle",
+          "combatTimer": 99,
+          "comboUntil": -1,
+          "critChance": 0.05,
+          "detonateTimer": "Infinity",
+          "dodgeChance": 0.05,
+          "fallStartY": 0.413537,
+          "fiveSecondRule": 99,
+          "hostile": true,
+          "hp": 120000,
+          "id": 1008,
+          "kind": "mob",
+          "level": 20,
+          "loot": {
+            "copper": 112735,
+            "items": [
+              {
+                "count": 1,
+                "itemId": "sigil_anvil_gloves"
+              },
+              {
+                "count": 1,
+                "itemId": "cinderfang_kris"
+              },
+              {
+                "count": 1,
+                "itemId": "lastflame_core"
+              },
+              {
+                "count": 1,
+                "itemId": "lastflame_core"
+              },
+              {
+                "count": 1,
+                "itemId": "pattern_crucible_healer_mail"
+              }
+            ]
+          },
+          "lootFfaTimer": 60,
+          "lootPartyTradeEligibility": {
+            "characterIds": [
+              101,
+              102
+            ],
+            "names": [
+              "AliceParity",
+              "BobParity"
+            ]
+          },
+          "lootRecipientIds": [
+            1006,
+            1007
+          ],
+          "lootable": true,
+          "maxHp": 120000,
+          "moveSpeed": 7,
+          "onGround": true,
+          "overpowerUntil": -1,
+          "petMode": "defensive",
+          "pos": {
+            "x": 20,
+            "y": 0.413537,
+            "z": 22
+          },
+          "potionCooldownUntil": -1,
+          "spawnPos": {
+            "x": 20,
+            "y": 0.413537,
+            "z": 22
+          },
+          "stats": {
+            "armor": 798
+          },
+          "templateId": "ignivar_herald_of_the_last_flame",
+          "weapon": {
+            "max": 446,
+            "min": 286,
+            "speed": 2.6
+          }
+        }
+      ]
+    },
+    {
+      "tick": 0,
+      "time": 0,
+      "nextId": 1009,
+      "state": "9174a945",
+      "events": "397551ea",
+      "rng": {
+        "draws": 7,
+        "digest": "284731db"
+      },
+      "label": "leaver-remains-eligible",
+      "players": [
+        {
+          "activeLoadout": -1,
+          "archetype": {},
+          "arena2v2Rating": 1500,
+          "arenaRating": 1500,
+          "bags": [
+            null,
+            null,
+            null,
+            null
+          ],
+          "bank": {
+            "socketBags": [
+              null,
+              null,
+              null,
+              null
+            ]
+          },
+          "bgRating": 1500,
+          "cls": "warrior",
+          "companionUpgrades": {},
+          "counters": {},
+          "craftDaily": {},
+          "craftSkills": {},
+          "deedStats": {
+            "counters": {},
+            "dungeonClears": {},
+            "itemsDiscovered": [
+              "baked_bread",
+              "eastbrook_buckler",
+              "recruit_tunic",
+              "sigil_anvil_helmet",
+              "worn_sword"
+            ],
+            "visited": [
+              "quality:epic"
+            ]
+          },
+          "delveClears": {},
+          "delveDaily": {},
+          "entityId": 1006,
+          "equipment": {
+            "chest": "recruit_tunic",
+            "mainhand": "worn_sword",
+            "offhand": "eastbrook_buckler"
+          },
+          "equipmentInstance": {},
+          "gathererIdentity": {
+            "id": 101,
+            "kind": "character"
+          },
+          "gatheringProficiency": {},
+          "harvestPreference": {
+            "kind": "all"
+          },
+          "heroicDaily": {},
+          "inventory": [
+            {
+              "count": 5,
+              "itemId": "baked_bread"
+            },
+            {
+              "count": 1,
+              "instance": {
+                "partyTrade": {
+                  "eligible": [
+                    "AliceParity",
+                    "BobParity"
+                  ],
+                  "eligibleIds": [
+                    101,
+                    102
+                  ],
+                  "untilMs": 7200000
+                }
+              },
+              "itemId": "sigil_anvil_helmet"
+            }
+          ],
+          "mailWelcomed": true,
+          "nodeHarvestReadyAt": {},
+          "recipesGrandfathered": true,
+          "reliquary": {
+            "counts": {},
+            "firstFind": {}
+          },
+          "talents": {
+            "rows": {}
+          },
+          "townFocus": {},
+          "vault": {
+            "stock": {}
+          },
+          "wyrmfallDaily": {}
+        },
+        {
+          "activeLoadout": -1,
+          "archetype": {},
+          "arena2v2Rating": 1500,
+          "arenaRating": 1500,
+          "bags": [
+            null,
+            null,
+            null,
+            null
+          ],
+          "bank": {
+            "socketBags": [
+              null,
+              null,
+              null,
+              null
+            ]
+          },
+          "bgRating": 1500,
+          "cls": "mage",
+          "companionUpgrades": {},
+          "counters": {},
+          "craftDaily": {},
+          "craftSkills": {},
+          "deedStats": {
+            "counters": {},
+            "dungeonClears": {},
+            "itemsDiscovered": [
+              "apprentice_robe",
+              "baked_bread",
+              "gnarled_staff",
+              "spring_water"
+            ]
+          },
+          "delveClears": {},
+          "delveDaily": {},
+          "entityId": 1007,
+          "equipment": {
+            "chest": "apprentice_robe",
+            "mainhand": "gnarled_staff"
+          },
+          "equipmentInstance": {},
+          "gathererIdentity": {
+            "id": 102,
+            "kind": "character"
+          },
+          "gatheringProficiency": {},
+          "harvestPreference": {
+            "kind": "all"
+          },
+          "heroicDaily": {},
+          "inventory": [
+            {
+              "count": 5,
+              "itemId": "baked_bread"
+            },
+            {
+              "count": 5,
+              "itemId": "spring_water"
+            }
+          ],
+          "leaving": true,
+          "mailWelcomed": true,
+          "nodeHarvestReadyAt": {},
+          "recipesGrandfathered": true,
+          "reliquary": {
+            "counts": {},
+            "firstFind": {}
+          },
+          "talents": {
+            "rows": {}
+          },
+          "townFocus": {},
+          "vault": {
+            "stock": {}
+          },
+          "wyrmfallDaily": {}
+        }
+      ],
+      "entities": [
+        {
+          "aiState": "idle",
+          "attackPower": 46,
+          "auras": [
+            {
+              "duration": 3600,
+              "id": "battle_stance",
+              "kind": "battle_stance",
+              "name": "Battle Stance",
+              "remaining": 3600,
+              "school": "physical",
+              "sourceId": 1006
+            }
+          ],
+          "blockChance": 0.05,
+          "blockValue": 6,
+          "combatTimer": 99,
+          "comboUntil": -1,
+          "critChance": 0.06,
+          "detonateTimer": "Infinity",
+          "dodgeChance": 0.06,
+          "fallStartY": -2,
+          "fiveSecondRule": 99,
+          "healPower": 5,
+          "hp": 100,
+          "id": 1006,
+          "kind": "player",
+          "level": 1,
+          "lootFfaTimer": "Infinity",
+          "maxHp": 100,
+          "maxResource": 100,
+          "moveSpeed": 7,
+          "offhandItemId": "eastbrook_buckler",
+          "onGround": true,
+          "overpowerUntil": -1,
+          "petMode": "defensive",
+          "pos": {
+            "x": -94,
+            "y": -2,
+            "z": -58
+          },
+          "potionCooldownUntil": -1,
+          "resourceType": "rage",
+          "spawnPos": {
+            "x": -94,
+            "y": -2,
+            "z": -58
+          },
+          "spellPower": 5,
+          "stats": {
+            "agi": 20,
+            "armor": 144,
+            "int": 10,
+            "spi": 11,
+            "sta": 23,
+            "str": 23
+          },
+          "templateId": "warrior",
+          "weapon": {
+            "max": 5,
+            "min": 2,
+            "speed": 2
+          }
+        },
+        {
+          "aiState": "idle",
+          "attackPower": 10,
+          "combatTimer": 99,
+          "comboUntil": -1,
+          "critChance": 0.056,
+          "detonateTimer": "Infinity",
+          "dodgeChance": 0.056,
+          "fallStartY": -2,
+          "fiveSecondRule": 99,
+          "healPower": 13,
+          "hp": 54,
+          "id": 1007,
+          "kind": "player",
+          "level": 1,
+          "lootFfaTimer": "Infinity",
+          "maxHp": 54,
+          "maxResource": 195,
+          "moveSpeed": 7,
+          "onGround": true,
+          "overpowerUntil": -1,
+          "petMode": "defensive",
+          "pos": {
+            "x": -94,
+            "y": -2,
+            "z": -58
+          },
+          "potionCooldownUntil": -1,
+          "resource": 195,
+          "resourceType": "mana",
+          "spawnPos": {
+            "x": -94,
+            "y": -2,
+            "z": -58
+          },
+          "spellPower": 13,
+          "stats": {
+            "agi": 12,
+            "armor": 57,
+            "int": 25,
+            "spi": 22,
+            "sta": 14,
+            "str": 10
+          },
+          "templateId": "mage",
+          "weapon": {
+            "max": 6,
+            "min": 3,
+            "speed": 2.9
+          }
+        },
+        {
+          "aiState": "idle",
+          "combatTimer": 99,
+          "comboUntil": -1,
+          "critChance": 0.05,
+          "detonateTimer": "Infinity",
+          "dodgeChance": 0.05,
+          "fallStartY": 0.413537,
+          "fiveSecondRule": 99,
+          "hostile": true,
+          "hp": 120000,
+          "id": 1008,
+          "kind": "mob",
+          "level": 20,
+          "loot": {
+            "copper": 112735,
+            "items": [
+              {
+                "count": 1,
+                "itemId": "sigil_anvil_gloves"
+              },
+              {
+                "count": 1,
+                "itemId": "cinderfang_kris"
+              },
+              {
+                "count": 1,
+                "itemId": "lastflame_core"
+              },
+              {
+                "count": 1,
+                "itemId": "lastflame_core"
+              },
+              {
+                "count": 1,
+                "itemId": "pattern_crucible_healer_mail"
+              }
+            ]
+          },
+          "lootFfaTimer": 60,
+          "lootPartyTradeEligibility": {
+            "characterIds": [
+              101,
+              102
+            ],
+            "names": [
+              "AliceParity",
+              "BobParity"
+            ]
+          },
+          "lootRecipientIds": [
+            1006,
+            1007
+          ],
+          "lootable": true,
+          "maxHp": 120000,
+          "moveSpeed": 7,
+          "onGround": true,
+          "overpowerUntil": -1,
+          "petMode": "defensive",
+          "pos": {
+            "x": 20,
+            "y": 0.413537,
+            "z": 22
+          },
+          "potionCooldownUntil": -1,
+          "spawnPos": {
+            "x": 20,
+            "y": 0.413537,
+            "z": 22
+          },
+          "stats": {
+            "armor": 798
+          },
+          "templateId": "ignivar_herald_of_the_last_flame",
+          "weapon": {
+            "max": 446,
+            "min": 286,
+            "speed": 2.6
+          }
+        }
+      ]
+    },
+    {
+      "tick": 0,
+      "time": 0,
+      "nextId": 1009,
+      "state": "9174a945",
+      "events": "741638a5",
+      "rng": {
+        "draws": 7,
+        "digest": "284731db"
+      },
+      "label": "final",
+      "players": [
+        {
+          "activeLoadout": -1,
+          "archetype": {},
+          "arena2v2Rating": 1500,
+          "arenaRating": 1500,
+          "bags": [
+            null,
+            null,
+            null,
+            null
+          ],
+          "bank": {
+            "socketBags": [
+              null,
+              null,
+              null,
+              null
+            ]
+          },
+          "bgRating": 1500,
+          "cls": "warrior",
+          "companionUpgrades": {},
+          "counters": {},
+          "craftDaily": {},
+          "craftSkills": {},
+          "deedStats": {
+            "counters": {},
+            "dungeonClears": {},
+            "itemsDiscovered": [
+              "baked_bread",
+              "eastbrook_buckler",
+              "recruit_tunic",
+              "sigil_anvil_helmet",
+              "worn_sword"
+            ],
+            "visited": [
+              "quality:epic"
+            ]
+          },
+          "delveClears": {},
+          "delveDaily": {},
+          "entityId": 1006,
+          "equipment": {
+            "chest": "recruit_tunic",
+            "mainhand": "worn_sword",
+            "offhand": "eastbrook_buckler"
+          },
+          "equipmentInstance": {},
+          "gathererIdentity": {
+            "id": 101,
+            "kind": "character"
+          },
+          "gatheringProficiency": {},
+          "harvestPreference": {
+            "kind": "all"
+          },
+          "heroicDaily": {},
+          "inventory": [
+            {
+              "count": 5,
+              "itemId": "baked_bread"
+            },
+            {
+              "count": 1,
+              "instance": {
+                "partyTrade": {
+                  "eligible": [
+                    "AliceParity",
+                    "BobParity"
+                  ],
+                  "eligibleIds": [
+                    101,
+                    102
+                  ],
+                  "untilMs": 7200000
+                }
+              },
+              "itemId": "sigil_anvil_helmet"
+            }
+          ],
+          "mailWelcomed": true,
+          "nodeHarvestReadyAt": {},
+          "recipesGrandfathered": true,
+          "reliquary": {
+            "counts": {},
+            "firstFind": {}
+          },
+          "talents": {
+            "rows": {}
+          },
+          "townFocus": {},
+          "vault": {
+            "stock": {}
+          },
+          "wyrmfallDaily": {}
+        },
+        {
+          "activeLoadout": -1,
+          "archetype": {},
+          "arena2v2Rating": 1500,
+          "arenaRating": 1500,
+          "bags": [
+            null,
+            null,
+            null,
+            null
+          ],
+          "bank": {
+            "socketBags": [
+              null,
+              null,
+              null,
+              null
+            ]
+          },
+          "bgRating": 1500,
+          "cls": "mage",
+          "companionUpgrades": {},
+          "counters": {},
+          "craftDaily": {},
+          "craftSkills": {},
+          "deedStats": {
+            "counters": {},
+            "dungeonClears": {},
+            "itemsDiscovered": [
+              "apprentice_robe",
+              "baked_bread",
+              "gnarled_staff",
+              "spring_water"
+            ]
+          },
+          "delveClears": {},
+          "delveDaily": {},
+          "entityId": 1007,
+          "equipment": {
+            "chest": "apprentice_robe",
+            "mainhand": "gnarled_staff"
+          },
+          "equipmentInstance": {},
+          "gathererIdentity": {
+            "id": 102,
+            "kind": "character"
+          },
+          "gatheringProficiency": {},
+          "harvestPreference": {
+            "kind": "all"
+          },
+          "heroicDaily": {},
+          "inventory": [
+            {
+              "count": 5,
+              "itemId": "baked_bread"
+            },
+            {
+              "count": 5,
+              "itemId": "spring_water"
+            }
+          ],
+          "leaving": true,
+          "mailWelcomed": true,
+          "nodeHarvestReadyAt": {},
+          "recipesGrandfathered": true,
+          "reliquary": {
+            "counts": {},
+            "firstFind": {}
+          },
+          "talents": {
+            "rows": {}
+          },
+          "townFocus": {},
+          "vault": {
+            "stock": {}
+          },
+          "wyrmfallDaily": {}
+        }
+      ],
+      "entities": [
+        {
+          "aiState": "idle",
+          "attackPower": 46,
+          "auras": [
+            {
+              "duration": 3600,
+              "id": "battle_stance",
+              "kind": "battle_stance",
+              "name": "Battle Stance",
+              "remaining": 3600,
+              "school": "physical",
+              "sourceId": 1006
+            }
+          ],
+          "blockChance": 0.05,
+          "blockValue": 6,
+          "combatTimer": 99,
+          "comboUntil": -1,
+          "critChance": 0.06,
+          "detonateTimer": "Infinity",
+          "dodgeChance": 0.06,
+          "fallStartY": -2,
+          "fiveSecondRule": 99,
+          "healPower": 5,
+          "hp": 100,
+          "id": 1006,
+          "kind": "player",
+          "level": 1,
+          "lootFfaTimer": "Infinity",
+          "maxHp": 100,
+          "maxResource": 100,
+          "moveSpeed": 7,
+          "offhandItemId": "eastbrook_buckler",
+          "onGround": true,
+          "overpowerUntil": -1,
+          "petMode": "defensive",
+          "pos": {
+            "x": -94,
+            "y": -2,
+            "z": -58
+          },
+          "potionCooldownUntil": -1,
+          "resourceType": "rage",
+          "spawnPos": {
+            "x": -94,
+            "y": -2,
+            "z": -58
+          },
+          "spellPower": 5,
+          "stats": {
+            "agi": 20,
+            "armor": 144,
+            "int": 10,
+            "spi": 11,
+            "sta": 23,
+            "str": 23
+          },
+          "templateId": "warrior",
+          "weapon": {
+            "max": 5,
+            "min": 2,
+            "speed": 2
+          }
+        },
+        {
+          "aiState": "idle",
+          "attackPower": 10,
+          "combatTimer": 99,
+          "comboUntil": -1,
+          "critChance": 0.056,
+          "detonateTimer": "Infinity",
+          "dodgeChance": 0.056,
+          "fallStartY": -2,
+          "fiveSecondRule": 99,
+          "healPower": 13,
+          "hp": 54,
+          "id": 1007,
+          "kind": "player",
+          "level": 1,
+          "lootFfaTimer": "Infinity",
+          "maxHp": 54,
+          "maxResource": 195,
+          "moveSpeed": 7,
+          "onGround": true,
+          "overpowerUntil": -1,
+          "petMode": "defensive",
+          "pos": {
+            "x": -94,
+            "y": -2,
+            "z": -58
+          },
+          "potionCooldownUntil": -1,
+          "resource": 195,
+          "resourceType": "mana",
+          "spawnPos": {
+            "x": -94,
+            "y": -2,
+            "z": -58
+          },
+          "spellPower": 13,
+          "stats": {
+            "agi": 12,
+            "armor": 57,
+            "int": 25,
+            "spi": 22,
+            "sta": 14,
+            "str": 10
+          },
+          "templateId": "mage",
+          "weapon": {
+            "max": 6,
+            "min": 3,
+            "speed": 2.9
+          }
+        },
+        {
+          "aiState": "idle",
+          "combatTimer": 99,
+          "comboUntil": -1,
+          "critChance": 0.05,
+          "detonateTimer": "Infinity",
+          "dodgeChance": 0.05,
+          "fallStartY": 0.413537,
+          "fiveSecondRule": 99,
+          "hostile": true,
+          "hp": 120000,
+          "id": 1008,
+          "kind": "mob",
+          "level": 20,
+          "loot": {
+            "copper": 112735,
+            "items": [
+              {
+                "count": 1,
+                "itemId": "sigil_anvil_gloves"
+              },
+              {
+                "count": 1,
+                "itemId": "cinderfang_kris"
+              },
+              {
+                "count": 1,
+                "itemId": "lastflame_core"
+              },
+              {
+                "count": 1,
+                "itemId": "lastflame_core"
+              },
+              {
+                "count": 1,
+                "itemId": "pattern_crucible_healer_mail"
+              }
+            ]
+          },
+          "lootFfaTimer": 60,
+          "lootPartyTradeEligibility": {
+            "characterIds": [
+              101,
+              102
+            ],
+            "names": [
+              "AliceParity",
+              "BobParity"
+            ]
+          },
+          "lootRecipientIds": [
+            1006,
+            1007
+          ],
+          "lootable": true,
+          "maxHp": 120000,
+          "moveSpeed": 7,
+          "onGround": true,
+          "overpowerUntil": -1,
+          "petMode": "defensive",
+          "pos": {
+            "x": 20,
+            "y": 0.413537,
+            "z": 22
+          },
+          "potionCooldownUntil": -1,
+          "spawnPos": {
+            "x": 20,
+            "y": 0.413537,
+            "z": 22
+          },
+          "stats": {
+            "armor": 798
+          },
+          "templateId": "ignivar_herald_of_the_last_flame",
+          "weapon": {
+            "max": 446,
+            "min": 286,
+            "speed": 2.6
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/parity/scenarios.ts
+++ b/tests/parity/scenarios.ts
@@ -48,7 +48,12 @@ import {
 } from '../../src/sim/ignivar_raid_ids';
 import { enterDungeon } from '../../src/sim/instances/dungeons';
 import { solveLockActions } from '../../src/sim/lockpick';
-import type { PendingLootRoll } from '../../src/sim/loot/loot_roll';
+import {
+  grantAwardedLootItem,
+  killSnapshotEligibility,
+  type PendingLootRoll,
+  rollLoot,
+} from '../../src/sim/loot/loot_roll';
 import { RIFT_MECHANIC_SPACING_SEC } from '../../src/sim/mob/mechanic_spacing';
 import { NYTHRAXIS_BONE_SPIKE_ID } from '../../src/sim/nythraxis_bone_spike';
 import { NYTHRAXIS_GRAVE_ERUPTION_TELEGRAPH_SECONDS } from '../../src/sim/nythraxis_grave_eruption';
@@ -7582,6 +7587,50 @@ function varkhulRaidTuning(): Scenario {
   };
 }
 
+// The bind-on-pickup party-trade eligibility snapshot (PR #3791): a soulbound
+// Crucible drop pins its kill-time trade group at roll time, so a member who
+// leaves before distribution stays on the awarded copy.
+function bopPartyTradeEligibility(): Scenario {
+  return {
+    name: 'bop_party_trade_eligibility',
+    coverage: [
+      'soulbound raid loot captures stable party-trade identity at roll time',
+      'a leaving member remains eligible during delayed distribution',
+      'class:warrior',
+      'class:mage',
+    ],
+    sampleEvery: 1,
+    build: () => new Sim({ seed: 1173, playerClass: 'warrior', noPlayer: true }),
+    drive(rec: Recorder) {
+      const sim = rec.sim;
+      const aliceId = sim.addPlayer('warrior', 'AliceParity', { characterId: 101 });
+      const bobId = sim.addPlayer('mage', 'BobParity', { characterId: 102 });
+      const alice = requireValue(sim.meta(aliceId), 'BoP parity Alice metadata');
+      const bob = requireValue(sim.meta(bobId), 'BoP parity Bob metadata');
+      const mob = createMob(sim.nextId++, MOBS.ignivar_herald_of_the_last_flame, 20, {
+        x: 20,
+        y: terrainHeight(20, 22, sim.cfg.seed),
+        z: 22,
+      }) as AnyEntity;
+      mob.lootRecipientIds = [aliceId, bobId];
+      sim.addEntity(mob);
+      rec.track(mob.id);
+
+      rollLoot(sim.ctx, mob, alice, [alice, bob]);
+      if (!mob.lootPartyTradeEligibility) {
+        throw new Error('BoP parity seed did not roll a soulbound Ignivar drop');
+      }
+      rec.snapshot('loot-identity-captured');
+
+      bob.leaving = true;
+      const eligibility = killSnapshotEligibility(sim.ctx, mob);
+      grantAwardedLootItem(sim.ctx, 'sigil_anvil_helmet', aliceId, eligibility);
+      rec.notes.eligibleCharacterIds = eligibility.characterIds;
+      rec.snapshot('leaver-remains-eligible');
+    },
+  };
+}
+
 export const SCENARIOS: Scenario[] = [
   soloWarrior(),
   soloMage(),
@@ -7688,4 +7737,5 @@ export const SCENARIOS: Scenario[] = [
   // between shards.
   heroicFiveManClear(),
   flaskConsumables(),
+  bopPartyTradeEligibility(),
 ];


### PR DESCRIPTION
## Summary

The Crucible raid items regressed to all-soulbound on the v0.42 line, and the bind-on-pickup party-trade supporting flow went with them. Two v0.41.x hotfix PRs never survived into release/v0.42.0:

- #3788 / #3789: only the 15 sigils and the 145 sigil-redeemed tier set pieces are soulbound; the 41 ordinary boss drops (offset, jewelry, held, weapons) trade freely
- #3791: the party-trade flow (kill-time eligibility snapshot on the corpse, bag-click staging of a marked copy, expired-offer pruning, marker retirement at the persistence boundaries)

Both merged into release/v0.41.1 on 2026-09-01, but release/v0.42.0 had already branched. The 2026-09-09 hotfix sync (30f32ba7f8 "merge main hotfixes into v0.42.0", and the OSSBrain candidate merge 8e3f838021 before it) resolved every one of those files to the v0.42 side: `ignivar_loot.ts` went back to 201 `soulbound: true` (should be 160), `src/sim/loot/bop_trade_cleanup.ts` and its tests vanished, and the loot/trade/bags/tooltip edits from #3791 were dropped. v0.42.1, v0.43.0 and main all inherit that state.

This PR re-applies both on release/v0.42.1 (retargeted from release/v0.43.0 at Jamie's request; the two branches differ only in version surfaces and Fenbridge fingerprints), adapted to the code that has moved since (the award grant now lives in `awarded_loot_hold.ts`; the snapshot only touches `rollLoot` and `killSnapshotEligibility`).

### Binding policy (#3788 / #3789)

- `src/sim/content/ignivar_loot.ts`: `soulbound` removed from the 41 drops; header comment states the policy
- `tests/ignivar_loot.test.ts`: the three-way binding pins (sigils bind, tier pieces bind, 41 drops trade) plus the two end-to-end trades (a redeemed tier piece refused inside the party, a Heartspring Amulet accepted)
- `docs/prd/ignivar-raid-loot*.md`: the binding section and the shared-attributes paragraph read the corrected rules again

### Party-trade flow (#3791)

- `src/sim/loot/bop_trade_cleanup.ts` restored verbatim; `src/sim/loot/bop_trade_persistence.ts` is the new leaf Sim calls at load and serialize (one line each)
- `loot_roll.ts`: `Entity.lootPartyTradeEligibility` pins the kill-time group at roll time so a member who leaves before distribution still counts; `lifecycle.ts` wipes it on respawn
- `trade.ts`: once a second, a staged copy whose window expired is pruned and both acceptances reset
- `bags_view.ts` / `bags_window.ts`: a marked soulbound copy stages for trade while the host clock says its window is live; every other transfer pipe stays blocked
- `hud.ts` / `item_instance_tooltip.ts`: the window line renders inside the def-level Soulbound block, so a legacy marker on a since-freed drop shows nothing
- tests: `bop_trade_cleanup`, `bags_window_party_trade`, the prune / disconnect / respawn / affordance pins, and the `bop_party_trade_eligibility` parity scenario with its golden (minted with `UPDATE_PARITY=1`; no existing golden moved)

### Monolith ratchet

`sim.ts` and `hud.ts` sat at zero slack. The two per-slot payload-bound blocks in the character load loops (bags, buyback) moved to `item_instance_load.ts` `sanitizeSlotInstanceOnLoad` (a pure move), paying for the two retire hooks; `sim.ts` lands at 11874 and its ceiling follows it down. `hud.ts` keeps its size (the window call moved inside the Soulbound block).

## Type of change

- [x] Bug fix
- [x] Documentation
- [x] Tests

## How was this tested?

- `npx tsc --noEmit`, `npx @biomejs/biome check` on the changed files (warnings only, all pre-existing `any`), `npm run ci:changed`
- `npx vitest run` over the 21 touched suites (ignivar_loot, loot_roll, bop_trade_window, bop_party_trade, bop_party_trade_load, bop_trade_cleanup, bags_view, bags_window_party_trade, item_instance_tooltip, mob_lifecycle, crucible_vendor, crucible_vendor_online, trade, awarded_loot_hold, monolith_budget, world_api_parity, architecture, item_instance_load, materials_vault, parity coverage_c / parity_g): 1148 passed
- all 12 parity shards: 265 passed, 1 skipped
- `GATE_SELECT_BASE=origin/release/v0.43.0 node scripts/gate_select.mjs` (run before the retarget; the rebase onto v0.42.1 was conflict-free and the touched suites were rerun green after it): every non-test stage passed (build, typecheck, freshness, sfx, malware); the vitest floor stopped on `tests/bank_sockets.test.ts`, which compares a `src/sim/...` path against a Windows backslash path and is environmentally red on this native Windows host, unrelated to the change
- full `npx vitest run` on this native Windows host: 60966 passed, 141 failed across 69 files. Every failure is either a Windows path-separator / symlink / docker / Electron-Linux / CI-script assertion (bank_sockets, material_taxonomy, professions_farming_state, sfx_*, deploy_*, electron_*, ci_*, helpers/*_under, ...) or a heavy balance / encounter probe timing out under full-suite load; the ten timed-out gameplay suites (ignivar_encounter, ignivar_forge_judgment, corpse_harvest_sim, destruction_warlock, gravewyrm_boss_gold, varkhul_forge_encounter, priest_vespers, wand_swing_between_queued_casts, professions_deeds_playthrough, paladin_devotion_balance) pass when rerun in isolation (357 passed). None touch the changed behavior; CI runs the suite on Linux.
- Manual steps: N/A, declarative item policy plus the restored flow's own pins

## Checklist

### Quality

- [x] **The gate passes.** Decisive tests cover the changed behavior.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files (the parity golden was minted by the harness).

Generated with [Claude Code](https://claude.com/claude-code)
