### PR TITLE
fix(net): ignore late events from a superseded socket so they never drop a live session

### DIFF
--- a/src/net/guarded_socket.ts
+++ b/src/net/guarded_socket.ts
@@ -1,0 +1,48 @@
+// One socket, one owner: the handlers bound here fire only while the socket is
+// still its owner's CURRENT transport, so a socket the owner has replaced can
+// never speak to it again.
+//
+// Why: ClientWorld replaces its socket on every reconnect, and a mobile
+// foreground can find a "zombie" socket (the OS killed the transport while the
+// page was frozen, but the browser has not delivered its close event yet).
+// The zombie branch reports that drop by hand and schedules a fast retry. With
+// plain handlers the abandoned socket stayed wired to the same callbacks, so
+// when its real close event finally landed AFTER the replacement had already
+// connected, it was counted as a brand-new drop against a live transport: the
+// client opened a duplicate socket for the same character, the server refused
+// it with 'character already in world' because the replacement was alive, that
+// refusal's close scheduled another duplicate, and after the bounded run of
+// refusals the client ended a perfectly healthy session with the fatal
+// "Return to Login" overlay. The identity guard makes every late event from a
+// superseded socket a no-op.
+//
+// Client-only (src/net): touches the WebSocket API directly, never sim state.
+
+export interface GuardedSocketHandlers {
+  // The first frame to send once the socket opens (the world auth message).
+  auth: () => string;
+  message: (data: string) => void;
+  close: () => void;
+}
+
+// Open a socket whose handlers are gated on `current() === ws`: the owner must
+// assign the returned socket as its current one synchronously (no event can
+// fire before the caller's next turn), after which any event from a socket the
+// owner has since replaced is ignored.
+export function openGuardedSocket(
+  url: string,
+  current: () => WebSocket | undefined,
+  handlers: GuardedSocketHandlers,
+): WebSocket {
+  const ws = new WebSocket(url);
+  ws.onopen = () => {
+    if (current() === ws) ws.send(handlers.auth());
+  };
+  ws.onmessage = (ev) => {
+    if (current() === ws) handlers.message(String(ev.data));
+  };
+  ws.onclose = () => {
+    if (current() === ws) handlers.close();
+  };
+  return ws;
+}

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -211,6 +211,7 @@ import { dungeonEntrySnapshotFacing } from './dungeon_entry_facing';
 import { decodeEntityFlairWire } from './entity_flair_wire';
 import { reanchorDecision } from './entity_reanchor';
 import { applyGroundTelegraphSnapshot } from './ground_telegraph_wire';
+import { openGuardedSocket } from './guarded_socket';
 import { GuildBankLogMirror } from './guild_bank_log_mirror';
 import { foldInputAck } from './input_ack';
 import { INPUT_SEND_TIMER_INTERVAL_MS, inputFlushGateOpen } from './input_send_cadence';
@@ -1896,14 +1897,12 @@ export class ClientWorld extends ReconWireState implements IWorld {
     const wsUrl = this.base
       ? `${this.base.replace(/^http/, 'ws')}/ws`
       : buildWebSocketUrl(location.protocol, location.host);
-    this.ws = new WebSocket(wsUrl);
-    this.ws.onopen = () => {
-      this.ws.send(
+    this.ws = openGuardedSocket(wsUrl, () => this.ws, {
+      auth: () =>
         JSON.stringify(buildWebSocketAuthMessage(this.token, this.characterId, this.clientSeed)),
-      );
-    };
-    this.ws.onmessage = (ev) => this.onMessage(String(ev.data));
-    this.ws.onclose = () => this.socketClosed();
+      message: (data) => this.onMessage(data),
+      close: () => this.socketClosed(),
+    });
   }
 
   // A dropped socket schedules a reconnect with exponential backoff: the

--- a/tests/guarded_socket.test.ts
+++ b/tests/guarded_socket.test.ts
@@ -1,0 +1,78 @@
+// Pins src/net/guarded_socket.ts: handlers fire only while the socket is its
+// owner's current transport.
+import { afterEach, describe, expect, it } from 'vitest';
+import { openGuardedSocket } from '../src/net/guarded_socket';
+
+class StubWebSocket {
+  onopen: (() => void) | null = null;
+  onmessage: ((ev: { data: unknown }) => void) | null = null;
+  onclose: (() => void) | null = null;
+  sent: string[] = [];
+  constructor(public readonly url: string) {
+    StubWebSocket.instances.push(this);
+  }
+  send(data: string): void {
+    this.sent.push(data);
+  }
+  static instances: StubWebSocket[] = [];
+}
+
+function withStubWebSocket<T>(fn: () => T): T {
+  const g = globalThis as Record<string, unknown>;
+  const prev = g.WebSocket;
+  g.WebSocket = StubWebSocket as unknown;
+  try {
+    return fn();
+  } finally {
+    g.WebSocket = prev;
+  }
+}
+
+afterEach(() => {
+  StubWebSocket.instances = [];
+});
+
+function makeOwner() {
+  const log: string[] = [];
+  const owner = { ws: undefined as WebSocket | undefined };
+  const open = () =>
+    openGuardedSocket('ws://x/ws', () => owner.ws, {
+      auth: () => 'AUTH',
+      message: (data) => log.push(`message:${data}`),
+      close: () => log.push('close'),
+    });
+  return { log, owner, open };
+}
+
+describe('openGuardedSocket', () => {
+  it('routes open, message, and close from the current socket to the owner', () => {
+    withStubWebSocket(() => {
+      const { log, owner, open } = makeOwner();
+      owner.ws = open();
+      const ws = StubWebSocket.instances[0];
+      expect(ws.url).toBe('ws://x/ws');
+      ws.onopen?.();
+      expect(ws.sent).toEqual(['AUTH']);
+      ws.onmessage?.({ data: 42 });
+      ws.onclose?.();
+      expect(log).toEqual(['message:42', 'close']);
+    });
+  });
+
+  it('drops every event from a socket the owner has since replaced', () => {
+    withStubWebSocket(() => {
+      const { log, owner, open } = makeOwner();
+      owner.ws = open();
+      const stale = StubWebSocket.instances[0];
+      owner.ws = open();
+      stale.onopen?.();
+      stale.onmessage?.({ data: 'late' });
+      stale.onclose?.();
+      expect(stale.sent).toEqual([]);
+      expect(log).toEqual([]);
+      const live = StubWebSocket.instances[1];
+      live.onclose?.();
+      expect(log).toEqual(['close']);
+    });
+  });
+});

--- a/tests/monolith_budget.test.ts
+++ b/tests/monolith_budget.test.ts
@@ -1566,7 +1566,9 @@ const MONOLITHS: MonolithRow[] = [
     // OSSBrain integration: entity flair decoding moved to net/entity_flair_wire.ts.
     // Measured after formatting; lower the ratchet with the extraction.
     // Main hotfix integration: combined extractions, exact merged count.
-    ceiling: 5540,
+    // RE-PINNED when the guarded-socket sibling took the socket handler wiring
+    // (zombie late-close fix): the file measures 5539. Exact count, zero slack.
+    ceiling: 5539,
     seam: 'a src/net sibling module (the refactor/net-online split is the template)',
   },
   {

--- a/tests/net_online_visibility_reconnect.test.ts
+++ b/tests/net_online_visibility_reconnect.test.ts
@@ -330,6 +330,54 @@ describe('ClientWorld visibilitychange reconnect (mobile background/foreground)'
     });
   });
 
+  it('a late close from the zombie AFTER the replacement connected is a no-op: no second drop, no duplicate socket', () => {
+    withDomStubs((doc, harness) => {
+      vi.spyOn(Math, 'random').mockReturnValue(0.5);
+      const world = new ClientWorld('t', 1, PROBE_CLASS, 'http://localhost');
+      const w = world as unknown as {
+        connected: boolean;
+        reconnectAttempts: number;
+        sessionEnded: boolean;
+      };
+      let disconnected = '';
+      world.onDisconnect = (reason) => {
+        disconnected = reason;
+      };
+      const zombie = StubWebSocket.instances[0];
+      // Capture the handler the browser still holds a reference to, before the
+      // zombie branch detaches it: the late real close event fires THIS.
+      const lateClose = zombie.onclose;
+      w.connected = true;
+      zombie.readyState = StubWebSocket.CLOSED;
+
+      // Foreground: zombie branch, fast retry fires, replacement connects.
+      doc.setVisible(true);
+      harness.fire(harness.timers[0].id);
+      expect(StubWebSocket.instances.length).toBe(2);
+      const replacement = StubWebSocket.instances[1];
+      replacement.onopen?.();
+      replacement.onmessage?.({
+        data: JSON.stringify({ t: 'hello', pid: 7, seed: 1, realm: 'r' }),
+      });
+      expect(w.connected).toBe(true);
+      expect(w.reconnectAttempts).toBe(0);
+
+      // The zombie's real close lands late, after the fast retry already fired.
+      // Before the fix this counted a second drop against the LIVE replacement:
+      // a duplicate socket opened, the server refused it ('character already in
+      // world', the replacement being alive), each refusal re-scheduled another
+      // duplicate, and the bounded run ended the healthy session for good.
+      lateClose?.();
+      expect(w.connected).toBe(true);
+      expect(w.reconnectAttempts).toBe(0);
+      expect(harness.timers.length).toBe(0);
+      expect(StubWebSocket.instances.length).toBe(2);
+      expect(w.sessionEnded).toBe(false);
+      expect(disconnected).toBe('');
+      world.close();
+    });
+  });
+
   it('a late duplicate close at the attempt cap does not end the session while the final retry is pending', () => {
     withDomStubs((doc, harness) => {
       const world = new ClientWorld('t', 1, PROBE_CLASS, 'http://localhost');


### PR DESCRIPTION
## Summary

iOS players reported being "booted to the login screen" mid-session on a good connection. One concrete cause in the online client: a mobile foreground can find a zombie socket (the OS killed the transport while the page was frozen, but the browser has not delivered its close event yet). The zombie branch reports that drop by hand and schedules a fast retry, but the abandoned socket kept its handlers. When its real close event landed AFTER the replacement had already connected, it was counted as a brand-new drop against a live transport: a duplicate socket opened for the same character, the server refused it with `character already in world` (the replacement being alive), each refusal's close scheduled another duplicate, and after the bounded run of refusals the client ended a perfectly healthy session with the fatal "Return to Login" overlay.

This PR makes every event from a superseded socket a no-op:

- New sibling `src/net/guarded_socket.ts`: `openGuardedSocket` binds handlers gated on `current() === ws`.
- `ClientWorld.openSocket` opens through the guard. The coordinator shrinks by one line and the `src/net/online.ts` monolith ceiling follows it down (`tests/monolith_budget.test.ts`).

## Type of change

- [x] Bug fix
- [x] Tests

## How was this tested?

- Commands:
  - `npx vitest run tests/guarded_socket.test.ts tests/net_online_visibility_reconnect.test.ts tests/linkdead.test.ts tests/world_api_parity.test.ts tests/monolith_budget.test.ts tests/architecture.test.ts tests/corpse_harvest_info_transport.test.ts tests/net_interaction_outcome.test.ts tests/warlock_pet_wire_commands.test.ts`
  - The new pin in `tests/net_online_visibility_reconnect.test.ts` was run against the unfixed `online.ts` first: red (the unfixed client opened nine duplicate sockets and ended the session while the replacement stayed open).
  - `npx tsc --noEmit`
  - `node scripts/gate_select.mjs`
- Manual steps: none (client reconnect path, pinned by unit tests).

## Checklist

### Quality

- [x] **The gate passes.** `node scripts/gate_select.mjs` is green. I added decisive tests for the changed behavior.

### Cross-platform

- ~Tested on desktop and mobile.~ No UI change.
- ~Accessible.~ No UI change.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
