### PR TITLE
fix(vault): bound vault ledger reservations by the stack's identities

### DIFF
--- a/server/bank_ledger.ts
+++ b/server/bank_ledger.ts
@@ -735,7 +735,7 @@ export function vaultCountLedgerIdentity(
   return vaultSpecialLedgerIdentity({ instance, craftedRecipeId });
 }
 
-interface VaultCountGroup {
+export interface VaultCountGroup {
   readonly identity: VaultLedgerIdentity | null;
   readonly count: number;
 }
@@ -751,7 +751,7 @@ interface VaultCountGroup {
  * throws into the dispatch path, and an unreadable row keeps whatever identity
  * the pre-provenance ledger already gave it.
  */
-function vaultCountGroups(slot: VaultInfo['special'][number]): VaultCountGroup[] {
+export function vaultCountGroups(slot: VaultInfo['special'][number]): VaultCountGroup[] {
   const crafted = slot.craftedRecipeId ?? null;
   const normalized = isMaterialItemId(slot.itemId)
     ? normalizeMaterialStack(slot, materialItemIds())

--- a/server/bank_vault_ledger_guard.ts
+++ b/server/bank_vault_ledger_guard.ts
@@ -27,14 +27,21 @@
 // negative to show overload depth. Account refusals still ride the fixed
 // woc_ws_messages_dropped_total{cause="bank_vault"} series.
 //
-// vault_deposit_all is the legitimate bulk exception. Plain stacks collapse by
-// material id, but signed/crafted materials retain a distinct ledger identity
-// per carried slot. Its exact committed maximum is therefore the 112-slot
-// carried-inventory ceiling, not the smaller material-id set. The account row
-// burst admits nine ordinary single-row actions followed by a full sweep in the
-// same 10-command human burst. Both buckets reserve worst case before mutation,
-// then refund unused rows after the journal accepts the exact immutable batch.
-// Craft/enchant vault draws reserve their exact take count.
+// VAULT ROW SHAPES. The count ledger keys a vault row per distinct (material,
+// identity), and since carried material stacks combine while preserving their
+// per-unit sources, ONE stack can hold units signed by several premium
+// crafters beside unsigned units. So no vault command is a fixed-row action
+// any more: vault_wire.ts reserves, per command, the distinct ledger keys the
+// touched stack(s) can produce (server/vault_ledger_row_bound.ts), never below
+// the COMMAND_MAX_ROWS floor. The floor still records the legacy shape (one
+// row per targeted op, the 112-slot carried-inventory ceiling for the sweep),
+// and the account row burst is sized as nine single-row actions plus a full
+// sweep in one 10-command human burst; that burst is also the ceiling any one
+// reservation may ask for on the vault surface (reservationShapeIsKnown), and
+// a command whose bound exceeds it is refused before mutation. Both buckets
+// reserve worst case before mutation, then refund unused rows after the
+// journal accepts the exact immutable batch. Craft/enchant vault draws
+// reserve their exact take count.
 
 import type { VaultConsumptionReservation } from '../src/sim/types';
 import type {

--- a/server/bank_vault_ledger_guard.ts
+++ b/server/bank_vault_ledger_guard.ts
@@ -423,7 +423,15 @@ function reservationShapeIsKnown(
 ): boolean {
   if (maxGuildEffectDeltas !== 0) return false;
   if (surface === 'personal') return maxRows === 1 || maxRows === 2;
-  if (surface === 'vault') return maxRows === 1 || maxRows === VAULT_DEPOSIT_ALL_LEDGER_MAX_ROWS;
+  // Vault commands reserve a per-command bound read from the pre-mutation
+  // state (server/vault_ledger_row_bound.ts): one row per distinct ledger
+  // identity the command's stack(s) can touch, never below the table floor.
+  // So the known shape is a RANGE, positive up to the account row burst the
+  // bucket can hold at all; the dispatcher refuses anything above it before
+  // mutating rather than asking for a reservation that could never be granted.
+  if (surface === 'vault') {
+    return Number.isSafeInteger(maxRows) && maxRows >= 1 && maxRows <= BANK_VAULT_LEDGER_ROW_BURST;
+  }
   return false;
 }
 

--- a/server/http/game_signals.ts
+++ b/server/http/game_signals.ts
@@ -225,11 +225,16 @@ export type WocEscrowQueueOutcome = (typeof WOC_ESCROW_QUEUE_OUTCOMES)[number];
  *   rejected, so the audit trail (scripts/bank_audit.mjs) has a hole its
  *   replay cannot see: that character's vault will reconcile as a permanent
  *   ledger_state_mismatch and a real investigation would come up clean.
+ * - `row_bound_exceeded`: a vault command whose pre-mutation ledger row bound
+ *   (server/vault_ledger_row_bound.ts) exceeds what the account row burst can
+ *   ever reserve, refused BEFORE mutation with the busy line. Nothing is lost,
+ *   but the refusal repeats deterministically for that inventory, so a rising
+ *   rate is a player stuck behind a sweep the guard cannot admit.
  * This closed set IS the kind label's whole vocabulary; it never grows
  * per-player (character id is NEVER a label; the log line beside each
  * increment carries the identifying detail).
  */
-export const VAULT_LEDGER_INCIDENTS = ['ledger_write_failed'] as const;
+export const VAULT_LEDGER_INCIDENTS = ['ledger_write_failed', 'row_bound_exceeded'] as const;
 
 /** One of the fixed vault-ledger incident kinds. */
 export type VaultLedgerIncident = (typeof VAULT_LEDGER_INCIDENTS)[number];

--- a/server/vault_ledger_row_bound.ts
+++ b/server/vault_ledger_row_bound.ts
@@ -21,6 +21,15 @@
 // whole carried inventory) can touch, read from the SAME grouping the diff
 // uses so the two cannot drift.
 //
+// THE BOUND RESTS ON LOSSLESS BUCKET MERGING. A deposit that joins an existing
+// identity row can only change the keys the arriving stack itself carries
+// because src/sim/material_sources.ts coalesces buckets by identical descriptor
+// and refuses (count-overflow) rather than collapsing distinct buckets into
+// the unattributed one. A future bucket CAP that spilled a signer bucket into
+// the null identity would add an unbudgeted row on deposit and re-open the
+// kick; tests/server/vault_ledger_row_bound.test.ts pins rows <= bound over
+// randomized stacks so such a change reds there first.
+//
 // Every function here is a pure read over boundary snapshots: nothing is
 // mutated and no rng is drawn.
 

--- a/server/vault_ledger_row_bound.ts
+++ b/server/vault_ledger_row_bound.ts
@@ -1,0 +1,99 @@
+// Pre-mutation ledger row bounds for the Materials Vault commands.
+//
+// A vault command reserves its worst-case bank_ledger row count BEFORE the Sim
+// mutates (server/vault_wire.ts reserveLedgerRows), and the exact rows are
+// derived afterwards by diffing vaultInfoFor. A commit whose rows exceed the
+// reservation is a post-mutation projection failure, which the live host
+// treats as terminal: the session is quarantined and disconnected (game.ts
+// quarantineBankLedgerProjection). So the reservation MUST be a true upper
+// bound on the rows the diff can produce, or a legal command kicks its player.
+//
+// The count ledger keys a vault row per (itemId, identity), where the identity
+// is the EFFECTIVE payload of one source bucket: the row's instance payload
+// plus that bucket's legacy premium `signer` (bank_ledger.ts
+// vaultCountGroups). Since carried material stacks combine while preserving
+// their per-unit sources, ONE stack can hold units signed by several crafters
+// beside unsigned units, and a single deposit or withdrawal of that stack
+// diffs into one row per distinct identity. The fixed one-row table entry
+// (bank_vault_ledger_guard.ts COMMAND_MAX_ROWS) was written when a stack could
+// carry at most one payload; these bounds restore the invariant by counting
+// the distinct ledger keys the command's own stack (or, for the sweep, the
+// whole carried inventory) can touch, read from the SAME grouping the diff
+// uses so the two cannot drift.
+//
+// Every function here is a pure read over boundary snapshots: nothing is
+// mutated and no rng is drawn.
+
+import {
+  isVaultDepositableSlot,
+  resolveVaultSpecialIndex,
+  vaultMaterialIds,
+} from '../src/sim/materials_vault';
+import type { InvSlot } from '../src/sim/types';
+import type { VaultInfo, VaultSpecialRef } from '../src/world_api';
+import { vaultCountGroups } from './bank_ledger';
+import { BANK_VAULT_LEDGER_ROW_BURST } from './bank_vault_ledger_guard';
+
+/** A carried or stored material row as the ledger diff sees it: the InvSlot
+ *  fields minus the advisory bag cell. */
+type LedgerSlot = VaultInfo['special'][number];
+
+/** The most rows a vault command may ever reserve: the account row burst,
+ *  above which the guard refuses to reserve at all. A command whose bound
+ *  exceeds this is refused BEFORE mutation (the "You are busy." line) rather
+ *  than allowed to mutate and then fail its commit. */
+export const VAULT_LEDGER_ROW_BOUND_MAX = BANK_VAULT_LEDGER_ROW_BURST;
+
+/** Distinct (itemId, identity) ledger keys across `slots`: exactly the key
+ *  space bank_ledger.ts vaultMultiset builds for a diff, so the row count a
+ *  diff over these slots can produce is at most this number. */
+export function vaultLedgerKeyCount(slots: readonly LedgerSlot[]): number {
+  const keys = new Set<string>();
+  for (const slot of slots) {
+    for (const group of vaultCountGroups(slot)) {
+      keys.add(JSON.stringify([slot.itemId, group.identity]));
+    }
+  }
+  return keys.size;
+}
+
+function atLeastOne(count: number): number {
+  return Math.max(1, count);
+}
+
+/** Rows one targeted deposit of `slot` can write: one per distinct identity
+ *  the carried stack holds. A missing slot (an out-of-range index the Sim will
+ *  refuse) bounds to the single row the table always reserved. The fold of
+ *  compact stock into an identity row moves unrecorded units between two
+ *  representations that share the null identity, so it never adds a row. */
+export function vaultDepositLedgerRowBound(slot: InvSlot | undefined): number {
+  if (!slot) return 1;
+  return atLeastOne(vaultLedgerKeyCount([slot]));
+}
+
+/** Rows the deposit-all sweep can write: one per distinct (itemId, identity)
+ *  key across every carried stack the sweep would consider. Two stacks of the
+ *  same material signed by the same crafter share one key, so this is usually
+ *  far below the slot count. */
+export function vaultDepositAllLedgerRowBound(inventory: readonly InvSlot[]): number {
+  const materials = vaultMaterialIds();
+  return atLeastOne(
+    vaultLedgerKeyCount(inventory.filter((slot) => isVaultDepositableSlot(slot, materials))),
+  );
+}
+
+/** Rows one withdrawal can write. A compact (pooled) withdrawal moves the one
+ *  null-identity key. An identity-row withdrawal resolves its target row on
+ *  the pre-mutation snapshot with the SAME selector rule the Sim applies and
+ *  bounds to that row's distinct identities; a selector the Sim will not
+ *  resolve is a no-op that writes nothing, so it bounds to one. */
+export function vaultWithdrawLedgerRowBound(
+  before: VaultInfo | null,
+  itemId: string,
+  special: VaultSpecialRef | undefined,
+): number {
+  if (special === undefined || before === null) return 1;
+  const index = resolveVaultSpecialIndex(before.special, itemId, special);
+  if (index < 0) return 1;
+  return atLeastOne(vaultLedgerKeyCount([before.special[index]]));
+}

--- a/server/vault_wire.ts
+++ b/server/vault_wire.ts
@@ -46,16 +46,25 @@ import {
   materialSourceTransferSelectionMatches,
   readMaterialSourceTransferSelection,
 } from '../src/sim/material_source_transfer_selection';
+import type { InvSlot } from '../src/sim/types';
 import type { VaultInfo, VaultSpecialRef } from '../src/world_api';
 import { buildVaultLedgerRows, recordVaultOp } from './bank_ledger';
 import type { BankLedgerAdmission, BankLedgerAdmissionHandle } from './bank_ledger_admission';
 import { bankVaultLedgerMaxRows } from './bank_vault_ledger_guard';
+import {
+  VAULT_LEDGER_ROW_BOUND_MAX,
+  vaultDepositAllLedgerRowBound,
+  vaultDepositLedgerRowBound,
+  vaultWithdrawLedgerRowBound,
+} from './vault_ledger_row_bound';
 
 /** The slice of Sim the vault dispatch bodies call; a narrow host interface
- *  so a Vitest drives the bodies without a GameServer. */
+ *  so a Vitest drives the bodies without a GameServer. `inventory` is read
+ *  ONLY to bound a deposit's ledger rows before the reservation (see
+ *  vault_ledger_row_bound.ts); the Sim still owns every deposit rule. */
 export interface VaultSim {
   ctx: {
-    resolve(pid?: number): { meta: { entityId: number } } | null;
+    resolve(pid?: number): { meta: { entityId: number; inventory: readonly InvSlot[] } } | null;
     error(id: number, text: string): void;
   };
   vaultInfoFor(pid?: number): VaultInfo | null;
@@ -203,15 +212,28 @@ function refuseLedgerAdmission(sim: VaultSim, pid: number): void {
 }
 
 /** Undefined preserves the temporary legacy observer path. Null means the
- *  live session has no admission owner and must refuse before mutation. */
+ *  live session has no admission owner and must refuse before mutation.
+ *
+ *  `rowBound` is the command's OWN worst case, read from the pre-mutation state
+ *  (vault_ledger_row_bound.ts): one row per distinct ledger identity the
+ *  stack(s) it touches can produce. The table entry stays the floor. The two
+ *  must be combined here, because a commit whose rows exceed the reservation
+ *  is a post-mutation failure that quarantines and disconnects the session; a
+ *  bound the guard cannot reserve at all is refused up front instead. */
 function reserveLedgerRows(
   admission: BankLedgerAdmission | null | undefined,
   sim: VaultSim,
   pid: number,
   command: VaultCommandName,
+  rowBound: number,
 ): BankLedgerAdmissionHandle | null | undefined {
   if (admission === undefined) return undefined;
-  const reservation = admission?.tryReserve(bankVaultLedgerMaxRows(command), 0, 'vault') ?? null;
+  const maxRows = Math.max(bankVaultLedgerMaxRows(command), rowBound);
+  if (maxRows > VAULT_LEDGER_ROW_BOUND_MAX) {
+    refuseLedgerAdmission(sim, pid);
+    return null;
+  }
+  const reservation = admission?.tryReserve(maxRows, 0, 'vault') ?? null;
   if (!reservation) refuseLedgerAdmission(sim, pid);
   return reservation;
 }
@@ -275,7 +297,18 @@ export function dispatchVaultCommand(
         const transfer = readMaterialSourceTransferWire(msg, slot);
         if (transfer === null) break;
         const { count, selection } = transfer;
-        const reservation = reserveLedgerRows(admission, sim, pid, 'vault_deposit');
+        // The carried stack is read only to BOUND the rows; the Sim re-reads
+        // and validates it inside vaultDeposit. A slot index the Sim will
+        // refuse bounds to the table's single row.
+        const carried = sim.ctx.resolve(pid)?.meta.inventory;
+        const slotIndex = Number.isInteger(slot) && slot >= 0 ? slot : -1;
+        const reservation = reserveLedgerRows(
+          admission,
+          sim,
+          pid,
+          'vault_deposit',
+          vaultDepositLedgerRowBound(slotIndex < 0 ? undefined : carried?.[slotIndex]),
+        );
         if (reservation === null) break;
         const before = runReservedSimCall(
           reservation,
@@ -304,11 +337,22 @@ export function dispatchVaultCommand(
           })
         )
           break;
-        const reservation = reserveLedgerRows(admission, sim, pid, 'vault_withdraw');
+        // The pre-mutation snapshot is read ONCE, ahead of the reservation: it
+        // bounds the rows an identity-row withdrawal can write, then serves
+        // as the diff's before-state. Nothing mutates between the two uses
+        // (this whole dispatch is one synchronous turn).
+        const snapshot = sim.vaultInfoFor(pid);
+        const reservation = reserveLedgerRows(
+          admission,
+          sim,
+          pid,
+          'vault_withdraw',
+          vaultWithdrawLedgerRowBound(snapshot, itemId, special),
+        );
         if (reservation === null) break;
         const before = runReservedSimCall(
           reservation,
-          () => sim.vaultInfoFor(pid),
+          () => snapshot,
           () => {
             if (special === undefined) sim.vaultWithdraw(itemId, count, pid);
             else sim.vaultWithdraw(itemId, count, special, pid);
@@ -325,8 +369,16 @@ export function dispatchVaultCommand(
       // Argument-free (the sweep takes the whole carried inventory), so no
       // shape guard; the Sim owns every per-slot rule. ONE before/after diff
       // spans the whole batch, so recordVaultOp writes the sweep's rows (one
-      // per material moved) as ONE batched insert.
-      const reservation = reserveLedgerRows(admission, sim, pid, 'vault_deposit_all');
+      // per material moved) as ONE batched insert. The row bound is the
+      // distinct (material, identity) keys across the whole carried inventory,
+      // never below the table's 112-slot floor.
+      const reservation = reserveLedgerRows(
+        admission,
+        sim,
+        pid,
+        'vault_deposit_all',
+        vaultDepositAllLedgerRowBound(sim.ctx.resolve(pid)?.meta.inventory ?? []),
+      );
       if (reservation === null) break;
       const before = runReservedSimCall(
         reservation,
@@ -341,7 +393,8 @@ export function dispatchVaultCommand(
       break;
     }
     case 'vault_buy_upgrade': {
-      const reservation = reserveLedgerRows(admission, sim, pid, 'vault_buy_upgrade');
+      // A rung purchase writes exactly one copper row; the table floor is exact.
+      const reservation = reserveLedgerRows(admission, sim, pid, 'vault_buy_upgrade', 1);
       if (reservation === null) break;
       const before = runReservedSimCall(
         reservation,

--- a/server/vault_wire.ts
+++ b/server/vault_wire.ts
@@ -51,6 +51,7 @@ import type { VaultInfo, VaultSpecialRef } from '../src/world_api';
 import { buildVaultLedgerRows, recordVaultOp } from './bank_ledger';
 import type { BankLedgerAdmission, BankLedgerAdmissionHandle } from './bank_ledger_admission';
 import { bankVaultLedgerMaxRows } from './bank_vault_ledger_guard';
+import { gameMetricsCounters } from './http/game_signals';
 import {
   VAULT_LEDGER_ROW_BOUND_MAX,
   vaultDepositAllLedgerRowBound,
@@ -230,6 +231,11 @@ function reserveLedgerRows(
   if (admission === undefined) return undefined;
   const maxRows = Math.max(bankVaultLedgerMaxRows(command), rowBound);
   if (maxRows > VAULT_LEDGER_ROW_BOUND_MAX) {
+    // Refused before the guard ever sees it, so the guard's own refusal
+    // telemetry cannot record this arm; count it here or a player whose
+    // sweep is refused every time (more distinct material/signer keys carried
+    // than the burst can hold) leaves no server-side trace at all.
+    gameMetricsCounters().vaultLedgerIncident('row_bound_exceeded');
     refuseLedgerAdmission(sim, pid);
     return null;
   }
@@ -350,6 +356,9 @@ export function dispatchVaultCommand(
           vaultWithdrawLedgerRowBound(snapshot, itemId, special),
         );
         if (reservation === null) break;
+        // readBefore is inert here (the snapshot is already taken), so a
+        // future throwing read must NOT be slipped back into it expecting the
+        // reservation-cancel guard: take it before the reservation as above.
         const before = runReservedSimCall(
           reservation,
           () => snapshot,

--- a/server/vault_wire.ts
+++ b/server/vault_wire.ts
@@ -224,6 +224,7 @@ function refuseLedgerAdmission(sim: VaultSim, pid: number): void {
 function reserveLedgerRows(
   admission: BankLedgerAdmission | null | undefined,
   sim: VaultSim,
+  who: { characterId: number },
   pid: number,
   command: VaultCommandName,
   rowBound: number,
@@ -234,8 +235,15 @@ function reserveLedgerRows(
     // Refused before the guard ever sees it, so the guard's own refusal
     // telemetry cannot record this arm; count it here or a player whose
     // sweep is refused every time (more distinct material/signer keys carried
-    // than the burst can hold) leaves no server-side trace at all.
+    // than the burst can hold) leaves no server-side trace at all. The log
+    // line names the character because the metric never does (character id
+    // is unbounded, so it is banned as a label): it IS the identifying detail
+    // the counter's docblock promises an operator. Volume is bounded by the
+    // command lane, so no dedupe is needed.
     gameMetricsCounters().vaultLedgerIncident('row_bound_exceeded');
+    console.warn(
+      `bank_ledger vault ${command} refused for character ${who.characterId}: row bound ${maxRows} exceeds the ${VAULT_LEDGER_ROW_BOUND_MAX}-row reservation ceiling`,
+    );
     refuseLedgerAdmission(sim, pid);
     return null;
   }
@@ -311,6 +319,7 @@ export function dispatchVaultCommand(
         const reservation = reserveLedgerRows(
           admission,
           sim,
+          who,
           pid,
           'vault_deposit',
           vaultDepositLedgerRowBound(slotIndex < 0 ? undefined : carried?.[slotIndex]),
@@ -351,6 +360,7 @@ export function dispatchVaultCommand(
         const reservation = reserveLedgerRows(
           admission,
           sim,
+          who,
           pid,
           'vault_withdraw',
           vaultWithdrawLedgerRowBound(snapshot, itemId, special),
@@ -384,6 +394,7 @@ export function dispatchVaultCommand(
       const reservation = reserveLedgerRows(
         admission,
         sim,
+        who,
         pid,
         'vault_deposit_all',
         vaultDepositAllLedgerRowBound(sim.ctx.resolve(pid)?.meta.inventory ?? []),
@@ -403,7 +414,7 @@ export function dispatchVaultCommand(
     }
     case 'vault_buy_upgrade': {
       // A rung purchase writes exactly one copper row; the table floor is exact.
-      const reservation = reserveLedgerRows(admission, sim, pid, 'vault_buy_upgrade', 1);
+      const reservation = reserveLedgerRows(admission, sim, who, pid, 'vault_buy_upgrade', 1);
       if (reservation === null) break;
       const before = runReservedSimCall(
         reservation,

--- a/tests/bank_ledger_admission.test.ts
+++ b/tests/bank_ledger_admission.test.ts
@@ -158,7 +158,7 @@ function vaultSim(initial: VaultInfo = vaultInfo()): VaultSim & {
       info = next;
     },
     ctx: {
-      resolve: () => ({ meta: { entityId: 88 } }),
+      resolve: () => ({ meta: { entityId: 88, inventory: [] } }),
       error: (_id, text) => void errors.push(text),
     },
     vaultInfoFor: () => info,

--- a/tests/material_source_storage_selection_wire.test.ts
+++ b/tests/material_source_storage_selection_wire.test.ts
@@ -94,7 +94,7 @@ function bankSim(): BankSim {
 function vaultSim(): VaultSim {
   return {
     ctx: {
-      resolve: () => ({ meta: { entityId: 88 } }),
+      resolve: () => ({ meta: { entityId: 88, inventory: [] } }),
       error: vi.fn(),
     },
     vaultInfoFor: () => vaultInfo(),

--- a/tests/server/bank_vault_ledger_guard.test.ts
+++ b/tests/server/bank_vault_ledger_guard.test.ts
@@ -526,3 +526,37 @@ describe('resolveBankVaultLedgerMaxAccountStates', () => {
     );
   });
 });
+
+describe('vault surface reservation shape', () => {
+  // The vault surface reserves a per-command bound (vault_ledger_row_bound.ts)
+  // rather than one of two literals, so the guard's only self-check on that
+  // surface is a RANGE: any positive integer up to the account row burst. Pin
+  // both edges as literals: a widened range would silently admit a reservation
+  // the bucket can never hold, and a narrowed one would re-open the old
+  // budget-mismatch throw for a legal mixed-identity command.
+  const expected = 'bank-vault wire reservation does not match its command budget';
+
+  it('accepts every count from one row up to the 121-row burst', () => {
+    const coordinator = createBankVaultLedgerGuardCoordinator(() => 0);
+    const inner = fakeAdmission();
+    const runtime = coordinator.createRuntime(11, inner.admission, vi.fn());
+    expect(runtime.admission.tryReserve(1, 0, 'vault')?.commit([row])).toBe(true);
+    const full = coordinator.createRuntime(12, fakeAdmission().admission, vi.fn());
+    const burst = Array.from({ length: 121 }, () => row);
+    expect(full.admission.tryReserve(121, 0, 'vault')?.commit(burst)).toBe(true);
+    expect(BANK_VAULT_LEDGER_ROW_BURST).toBe(121);
+  });
+
+  it('throws the budget-mismatch error at 122, zero, a fraction, and a personal-surface widening', () => {
+    const coordinator = createBankVaultLedgerGuardCoordinator(() => 0);
+    const runtime = coordinator.createRuntime(13, fakeAdmission().admission, vi.fn());
+    expect(() => runtime.admission.tryReserve(122, 0, 'vault')).toThrow(expected);
+    expect(() => runtime.admission.tryReserve(0, 0, 'vault')).toThrow(expected);
+    expect(() => runtime.admission.tryReserve(1.5, 0, 'vault')).toThrow(expected);
+    expect(() => runtime.admission.tryReserve(3, 1, 'vault')).toThrow(expected);
+    // The personal bank keeps its two literals: the range is vault-only.
+    expect(() => runtime.admission.tryReserve(3, 0, 'personal')).toThrow(expected);
+    // Nothing above consumed a command token, so a legal reservation still admits.
+    expect(runtime.admission.tryReserve(2, 0, 'vault')?.commit([row, row])).toBe(true);
+  });
+});

--- a/tests/server/http/game_metrics.test.ts
+++ b/tests/server/http/game_metrics.test.ts
@@ -1124,7 +1124,7 @@ describe('registerGameStateMetrics: throughput counters via the returned sink', 
     expect(WOC_VAULT_LEDGER_INCIDENTS_TOTAL).not.toBe(WOC_GUILD_BANK_INCIDENTS_TOTAL);
     // The whole vocabulary, pinned as literals, for the guild set's reason: a
     // rename must fail here rather than silently retire an alert rule.
-    expect(VAULT_LEDGER_INCIDENTS).toEqual(['ledger_write_failed']);
+    expect(VAULT_LEDGER_INCIDENTS).toEqual(['ledger_write_failed', 'row_bound_exceeded']);
 
     // Scrape BEFORE any increment: an alert rule cannot fire on a series that
     // does not exist yet, so every kind must expose an explicit 0 from boot.

--- a/tests/server/vault_ledger_row_bound.test.ts
+++ b/tests/server/vault_ledger_row_bound.test.ts
@@ -1,0 +1,177 @@
+// The pre-mutation ledger row bounds for the Materials Vault commands
+// (server/vault_ledger_row_bound.ts). Every bound must be a TRUE upper bound
+// on the rows diffVaultOp can produce for that command, because a commit whose
+// rows exceed its reservation is a post-mutation failure that quarantines and
+// disconnects the live session. Each case here pins the bound against the real
+// diff over a fixture snapshot, so the two cannot drift apart silently.
+import { describe, expect, it } from 'vitest';
+import { diffVaultOp } from '../../server/bank_ledger';
+import { BANK_VAULT_LEDGER_ROW_BURST } from '../../server/bank_vault_ledger_guard';
+import {
+  VAULT_LEDGER_ROW_BOUND_MAX,
+  vaultDepositAllLedgerRowBound,
+  vaultDepositLedgerRowBound,
+  vaultLedgerKeyCount,
+  vaultWithdrawLedgerRowBound,
+} from '../../server/vault_ledger_row_bound';
+import {
+  canonicalMaterialComposition,
+  type MaterialComposition,
+  type MaterialSource,
+} from '../../src/sim/material_sources';
+import type { InvSlot } from '../../src/sim/types';
+import type { VaultInfo } from '../../src/world_api';
+
+const ana: MaterialSource = { gatherer: { kind: 'character', id: 11, name: 'Ana' } };
+const bob: MaterialSource = { gatherer: { kind: 'character', id: 12, name: 'Bob' } };
+const signedAna: MaterialSource = { signer: 'Ana' };
+const signedBob: MaterialSource = { signer: 'Bob' };
+
+function composition(rows: readonly { source: MaterialSource; count: number }[]) {
+  const total = rows.reduce((sum, row) => sum + row.count, 0);
+  const built = canonicalMaterialComposition(rows, total);
+  if (!built.ok) throw new Error(`bad fixture composition: ${built.error}`);
+  return built.value;
+}
+
+function slot(itemId: string, sources: MaterialComposition): InvSlot {
+  return {
+    itemId,
+    count: sources.reduce((sum, row) => sum + row.count, 0),
+    materialSources: sources,
+  };
+}
+
+function info(stock: Record<string, number>, special: InvSlot[]): VaultInfo {
+  return { stock, special, upgrades: 2, perMaterialCap: 80, nextUpgradeCost: 100_000 };
+}
+
+describe('vaultLedgerKeyCount', () => {
+  it('counts unsigned and gatherer-only units as ONE pooled identity', () => {
+    expect(vaultLedgerKeyCount([{ itemId: 'copper_ore', count: 5 }])).toBe(1);
+    expect(
+      vaultLedgerKeyCount([
+        slot(
+          'copper_ore',
+          composition([
+            { source: ana, count: 6 },
+            { source: bob, count: 4 },
+          ]),
+        ),
+      ]),
+    ).toBe(1);
+  });
+
+  it('counts one identity per distinct premium signer beside the pooled one', () => {
+    const mixed = slot(
+      'copper_ore',
+      composition([
+        { source: ana, count: 3 },
+        { source: signedAna, count: 2 },
+        { source: signedBob, count: 1 },
+      ]),
+    );
+    expect(vaultLedgerKeyCount([mixed])).toBe(3);
+  });
+
+  it('merges the same identity across stacks and separates materials', () => {
+    const a = slot('copper_ore', composition([{ source: signedAna, count: 2 }]));
+    const b = slot('copper_ore', composition([{ source: signedAna, count: 7 }]));
+    const c = slot('iron_ore', composition([{ source: signedAna, count: 7 }]));
+    expect(vaultLedgerKeyCount([a, b])).toBe(1);
+    expect(vaultLedgerKeyCount([a, b, c])).toBe(2);
+  });
+});
+
+describe('vaultDepositLedgerRowBound', () => {
+  it('bounds a missing slot to the one row the table reserves', () => {
+    expect(vaultDepositLedgerRowBound(undefined)).toBe(1);
+  });
+
+  it('is never below the rows the deposit diff really writes', () => {
+    const mixed = slot(
+      'copper_ore',
+      composition([
+        { source: ana, count: 6 },
+        { source: signedAna, count: 4 },
+      ]),
+    );
+    const before = info({ copper_ore: 10 }, []);
+    // The deposit folds the compact 10 into the identity row beside the arriving
+    // buckets: pooled 16 (null identity) and signed 4.
+    const after = info({}, [
+      slot(
+        'copper_ore',
+        composition([
+          { source: {}, count: 10 },
+          { source: ana, count: 6 },
+          { source: signedAna, count: 4 },
+        ]),
+      ),
+    ]);
+    const rows = diffVaultOp('deposit', before, after);
+    expect(rows).toHaveLength(2);
+    expect(vaultDepositLedgerRowBound(mixed)).toBe(2);
+    expect(vaultDepositLedgerRowBound(mixed)).toBeGreaterThanOrEqual(rows.length);
+  });
+});
+
+describe('vaultWithdrawLedgerRowBound', () => {
+  const row = slot(
+    'copper_ore',
+    composition([
+      { source: {}, count: 10 },
+      { source: signedAna, count: 4 },
+      { source: signedBob, count: 6 },
+    ]),
+  );
+  const before = info({ iron_ore: 3 }, [row]);
+
+  it('bounds a compact withdrawal to one row', () => {
+    expect(vaultWithdrawLedgerRowBound(before, 'iron_ore', undefined)).toBe(1);
+    expect(vaultWithdrawLedgerRowBound(null, 'iron_ore', { index: 0 })).toBe(1);
+  });
+
+  it('bounds an identity-row withdrawal to the distinct identities of that row', () => {
+    const after = info({ iron_ore: 3 }, []);
+    const rows = diffVaultOp('withdraw', before, after);
+    expect(rows).toHaveLength(3);
+    expect(vaultWithdrawLedgerRowBound(before, 'copper_ore', { index: 0 })).toBe(3);
+  });
+
+  it('recovers a stale index by fingerprint and bounds a miss to one', () => {
+    const shifted = info({}, [{ itemId: 'iron_ore', count: 1, craftedRecipeId: 'r' }, row]);
+    expect(vaultWithdrawLedgerRowBound(shifted, 'copper_ore', { index: 0 })).toBe(3);
+    expect(
+      vaultWithdrawLedgerRowBound(shifted, 'copper_ore', { index: 5, craftedRecipeId: 'x' }),
+    ).toBe(1);
+  });
+});
+
+describe('vaultDepositAllLedgerRowBound', () => {
+  it('counts distinct keys over depositable material stacks only', () => {
+    const inventory: InvSlot[] = [
+      { itemId: 'worn_sword', count: 1 },
+      { itemId: 'copper_ore', count: 20 },
+      slot('copper_ore', composition([{ source: signedAna, count: 5 }])),
+      slot(
+        'copper_ore',
+        composition([
+          { source: signedAna, count: 5 },
+          { source: ana, count: 5 },
+        ]),
+      ),
+      slot('iron_ore', composition([{ source: signedBob, count: 5 }])),
+    ];
+    // copper pooled, copper/Ana, iron/Bob.
+    expect(vaultDepositAllLedgerRowBound(inventory)).toBe(3);
+    expect(vaultDepositAllLedgerRowBound([])).toBe(1);
+  });
+});
+
+describe('VAULT_LEDGER_ROW_BOUND_MAX', () => {
+  it('is the account row burst the guard can reserve at most', () => {
+    expect(VAULT_LEDGER_ROW_BOUND_MAX).toBe(BANK_VAULT_LEDGER_ROW_BURST);
+    expect(VAULT_LEDGER_ROW_BOUND_MAX).toBe(121);
+  });
+});

--- a/tests/vault_ledger_row_bound_property.test.ts
+++ b/tests/vault_ledger_row_bound_property.test.ts
@@ -337,6 +337,9 @@ describe('over-bound refusal happens before mutation', () => {
     const tryReserve = vi.fn(() => {
       throw new Error('the guard must never see an over-bound reservation');
     });
+    // The metric never names a character (unbounded ids are banned as labels),
+    // so the log line beside the increment must carry the identifying detail.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const fake: VaultSim = {
       ctx: {
         resolve: () => ({ meta: { entityId: 5, inventory } }),
@@ -355,5 +358,10 @@ describe('over-bound refusal happens before mutation', () => {
     expect(tryReserve).not.toHaveBeenCalled();
     expect(incidents).toEqual(['row_bound_exceeded']);
     expect(gameMetricsCounters()).not.toBe(noopGameMetricsCounters);
+    expect(warn).toHaveBeenCalledTimes(1);
+    const line = String(warn.mock.calls[0]?.[0]);
+    expect(line).toContain('vault_deposit_all refused for character 1');
+    expect(line).toContain(`row bound ${bound} exceeds the 121-row reservation ceiling`);
+    warn.mockRestore();
   });
 });

--- a/tests/vault_ledger_row_bound_property.test.ts
+++ b/tests/vault_ledger_row_bound_property.test.ts
@@ -1,0 +1,359 @@
+// Property and edge pins for the Materials Vault ledger row bound
+// (server/vault_ledger_row_bound.ts) driven through the REAL dispatch and the
+// REAL session journal admission (server/bank_ledger_session.ts), which is
+// the path a live GameServer session takes. The fixed-fixture pins live in
+// tests/server/vault_ledger_row_bound.test.ts; this suite holds the invariant
+// the whole fix rests on, over randomized stacks: the rows a command commits
+// never exceed the rows it reserved, so the post-mutation commit can never
+// throw and quarantine the session again.
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createBankLedgerSessionJournal } from '../server/bank_ledger_session';
+import {
+  gameMetricsCounters,
+  noopGameMetricsCounters,
+  setGameMetricsCounters,
+  type VaultLedgerIncident,
+} from '../server/http/game_signals';
+import { REALM } from '../server/realm';
+import {
+  VAULT_LEDGER_ROW_BOUND_MAX,
+  vaultDepositAllLedgerRowBound,
+  vaultDepositLedgerRowBound,
+  vaultWithdrawLedgerRowBound,
+} from '../server/vault_ledger_row_bound';
+import { dispatchVaultCommand, type VaultSim } from '../server/vault_wire';
+import { materialStorageTransferPayload } from '../src/net/material_storage_command';
+import { vaultWithdrawPayload } from '../src/net/vault_snapshot_wire';
+import { BUILTIN_WORLD } from '../src/sim/data';
+import {
+  canonicalMaterialComposition,
+  type MaterialComposition,
+  type MaterialSource,
+} from '../src/sim/material_sources';
+import { vaultStoredCount } from '../src/sim/materials_vault';
+import { Rng } from '../src/sim/rng';
+import { Sim } from '../src/sim/sim';
+import type { Entity, InvSlot, WorldContent } from '../src/sim/types';
+import { vaultSpecialRef } from '../src/ui/vault_view';
+
+const BANKER_ID = 'bursar_fernando';
+const BANKER_WORLD: WorldContent = {
+  ...BUILTIN_WORLD,
+  camps: [],
+  npcs: { [BANKER_ID]: BUILTIN_WORLD.npcs[BANKER_ID] },
+  groundObjects: [],
+};
+const WHO = { characterId: 1, accountId: 1 };
+const wire = (value: unknown) => JSON.parse(JSON.stringify(value));
+
+const SIGNERS = ['Ana', 'Bob', 'Cyn', 'Dee', 'Eli'];
+// Members of the honest material set (src/sim/material_ids.ts); a non-material
+// id would make every deposit a silent refusal and hollow the property out.
+const MATERIALS = ['copper_ore', 'iron_ore', 'linen_scrap'];
+
+function composition(rows: readonly { source: MaterialSource; count: number }[]) {
+  const total = rows.reduce((sum, row) => sum + row.count, 0);
+  const built = canonicalMaterialComposition(rows, total);
+  if (!built.ok) throw new Error(`bad fixture composition: ${built.error}`);
+  return built.value;
+}
+
+/** A random stack of up to 20 units split across unsigned, gatherer-only and
+ *  premium-signed buckets: the shapes 0.42.0 stack combining produces. */
+function randomComposition(rng: Rng, units: number): MaterialComposition {
+  const rows: { source: MaterialSource; count: number }[] = [];
+  let left = units;
+  while (left > 0) {
+    const count = rng.int(1, left);
+    left -= count;
+    const roll = rng.int(0, 3);
+    const source: MaterialSource =
+      roll === 0
+        ? {}
+        : roll === 1
+          ? { gatherer: { kind: 'character', id: 100 + rng.int(0, 4), name: 'Gath' } }
+          : { signer: SIGNERS[rng.int(0, SIGNERS.length - 1)] };
+    rows.push({ source, count });
+  }
+  return composition(rows);
+}
+
+function bankerSim(): Sim {
+  const sim = new Sim({ seed: 73, playerClass: 'warrior', autoEquip: false, world: BANKER_WORLD });
+  const banker = [...sim.entities.values()].find(
+    (e): e is Entity => e.kind === 'npc' && e.templateId === BANKER_ID,
+  );
+  if (!banker) throw new Error('banker did not spawn');
+  sim.player.pos = { ...banker.pos };
+  sim.player.prevPos = { ...banker.pos };
+  sim.rebucket(sim.player);
+  return sim;
+}
+
+interface Harness {
+  sim: Sim;
+  pid: number;
+  failures: string[];
+  rowsCommitted(): number;
+  deposit(slot: number, count?: number): void;
+  withdraw(itemId: string, count?: number, special?: ReturnType<typeof vaultSpecialRef>): void;
+  depositAll(): void;
+}
+
+function harness(sim: Sim): Harness {
+  const failures: string[] = [];
+  const journal = createBankLedgerSessionJournal(
+    { realm: REALM, characterId: 1, accountId: 1 },
+    {
+      onProjectionFailure: (error, surface) => failures.push(`${surface}: ${String(error)}`),
+      onReservationFailure: (error) => failures.push(`reservation: ${String(error)}`),
+    },
+  );
+  const pid = sim.playerId;
+  const vs = sim as unknown as VaultSim;
+  const rowsCommitted = () =>
+    journal.outbox.snapshot().batches.reduce((sum, batch) => sum + batch.rows.length, 0);
+  return {
+    sim,
+    pid,
+    failures,
+    rowsCommitted,
+    deposit: (slot, count) =>
+      dispatchVaultCommand(
+        vs,
+        WHO,
+        'vault_deposit',
+        wire(materialStorageTransferPayload(slot, count)),
+        pid,
+        journal.admission,
+      ),
+    withdraw: (itemId, count, special) =>
+      dispatchVaultCommand(
+        vs,
+        WHO,
+        'vault_withdraw',
+        wire(vaultWithdrawPayload(itemId, count, special)),
+        pid,
+        journal.admission,
+      ),
+    depositAll: () =>
+      dispatchVaultCommand(vs, WHO, 'vault_deposit_all', {}, pid, journal.admission),
+  };
+}
+
+function resetPlayer(sim: Sim, upgrades: number): void {
+  const meta = sim.meta(sim.playerId);
+  if (!meta) throw new Error('missing player meta');
+  meta.inventory = [];
+  meta.vault = { stock: {}, special: [], upgrades };
+  meta.vaultWireRev++;
+}
+
+function carried(sim: Sim, itemId: string): number {
+  return (sim.meta(sim.playerId)?.inventory ?? [])
+    .filter((slot: InvSlot) => slot.itemId === itemId)
+    .reduce((sum: number, slot: InvSlot) => sum + slot.count, 0);
+}
+
+describe('vault ledger row bound property (real dispatch, real journal admission)', () => {
+  // One Sim for the whole sweep: construction dominates, and every case
+  // resets the carried inventory and the vault to a clean rung-3 state.
+  const sim = bankerSim();
+
+  it('rows committed by a deposit never exceed its bound, and nothing is ever quarantined', () => {
+    const rng = new Rng(4242);
+    for (let round = 0; round < 40; round++) {
+      resetPlayer(sim, 3);
+      const h = harness(sim);
+      const itemId = MATERIALS[rng.int(0, MATERIALS.length - 1)];
+      // A pre-existing vault holding of the same material in a random shape,
+      // so deposits exercise the fold and the merge-into-existing-row arms.
+      if (rng.int(0, 1) === 1) {
+        const seedUnits = rng.int(1, 20);
+        sim.addItem(itemId, seedUnits, sim.playerId, {
+          materialSources: randomComposition(rng, seedUnits),
+        });
+        h.deposit(0);
+        expect(h.failures).toEqual([]);
+      }
+      if (rng.int(0, 1) === 1) {
+        sim.addItem(itemId, rng.int(1, 20), sim.playerId);
+        h.deposit(0);
+        expect(h.failures).toEqual([]);
+      }
+      const units = rng.int(1, 20);
+      sim.addItem(itemId, units, sim.playerId, {
+        materialSources: randomComposition(rng, units),
+      });
+      const slot = (sim.meta(sim.playerId)?.inventory ?? []).findIndex((s) => s.itemId === itemId);
+      const stack = sim.meta(sim.playerId)?.inventory[slot];
+      const bound = vaultDepositLedgerRowBound(stack);
+      const rowsBefore = h.rowsCommitted();
+      const storedBefore = vaultStoredCount(sim.meta(sim.playerId)!.vault, itemId);
+      const carriedBefore = carried(sim, itemId);
+      // Random partial or whole deposit.
+      const partial = rng.int(0, 2) === 0 ? rng.int(1, units) : undefined;
+      h.deposit(slot, partial);
+      expect(h.failures).toEqual([]);
+      const rows = h.rowsCommitted() - rowsBefore;
+      expect(rows, `round ${round}`).toBeLessThanOrEqual(bound);
+      expect(rows).toBeGreaterThan(0);
+      // Conservation across the two containers.
+      expect(vaultStoredCount(sim.meta(sim.playerId)!.vault, itemId) + carried(sim, itemId)).toBe(
+        storedBefore + carriedBefore,
+      );
+    }
+  });
+
+  it('rows committed by an identity-row withdrawal never exceed its bound', () => {
+    const rng = new Rng(9001);
+    for (let round = 0; round < 40; round++) {
+      resetPlayer(sim, 3);
+      const h = harness(sim);
+      const itemId = MATERIALS[rng.int(0, MATERIALS.length - 1)];
+      // Build a random mixed identity row out of one to three deposits.
+      const stacks = rng.int(1, 3);
+      for (let i = 0; i < stacks; i++) {
+        const units = rng.int(1, 20);
+        sim.addItem(itemId, units, sim.playerId, {
+          materialSources: randomComposition(rng, units),
+        });
+        h.deposit(0);
+        expect(h.failures).toEqual([]);
+      }
+      const info = sim.vaultInfoFor(sim.playerId);
+      if (!info || info.special.length === 0) continue; // an all-unsigned draw pooled: not this arm
+      const index = rng.int(0, info.special.length - 1);
+      const row = info.special[index];
+      const ref = vaultSpecialRef(index, row);
+      const bound = vaultWithdrawLedgerRowBound(info, itemId, ref);
+      const rowsBefore = h.rowsCommitted();
+      const partial = rng.int(0, 1) === 0 && row.count > 1 ? rng.int(1, row.count - 1) : undefined;
+      h.withdraw(itemId, partial, ref);
+      expect(h.failures).toEqual([]);
+      const rows = h.rowsCommitted() - rowsBefore;
+      expect(rows, `round ${round}`).toBeLessThanOrEqual(bound);
+      expect(rows).toBeGreaterThan(0);
+    }
+  });
+
+  it('a compact withdrawal beside a mixed identity row of the same material writes exactly one row', () => {
+    resetPlayer(sim, 3);
+    const h = harness(sim);
+    // A mixed identity row first, then a dormant compact holding written
+    // straight into the record the way a pre-provenance save carries it.
+    sim.addItem('copper_ore', 10, sim.playerId, {
+      materialSources: composition([
+        { source: { signer: 'Ana' }, count: 6 },
+        { source: {}, count: 4 },
+      ]),
+    });
+    h.deposit(0);
+    sim.meta(sim.playerId)!.vault.stock.copper_ore = 15;
+    const info = sim.vaultInfoFor(sim.playerId);
+    expect(vaultWithdrawLedgerRowBound(info, 'copper_ore', undefined)).toBe(1);
+    const rowsBefore = h.rowsCommitted();
+    h.withdraw('copper_ore');
+    expect(h.failures).toEqual([]);
+    expect(h.rowsCommitted() - rowsBefore).toBe(1);
+    expect(sim.meta(sim.playerId)!.vault.stock).toEqual({});
+    expect(carried(sim, 'copper_ore')).toBe(15);
+  });
+
+  it('a legacy signer-on-payload stack deposits onto an unsigned row within its bound', () => {
+    resetPlayer(sim, 3);
+    const h = harness(sim);
+    sim.addItem('copper_ore', 10, sim.playerId);
+    h.deposit(0);
+    const meta = sim.meta(sim.playerId)!;
+    // The pre-provenance shape: the signer rides the instance payload and no
+    // bucket exists yet. Normalization projects it into a signer bucket.
+    meta.inventory.push({ itemId: 'copper_ore', count: 5, instance: { signer: 'Ana' } });
+    const bound = vaultDepositLedgerRowBound(meta.inventory[0]);
+    expect(bound).toBe(1);
+    const rowsBefore = h.rowsCommitted();
+    h.deposit(0);
+    expect(h.failures).toEqual([]);
+    expect(h.rowsCommitted() - rowsBefore).toBeLessThanOrEqual(bound);
+    expect(vaultStoredCount(meta.vault, 'copper_ore')).toBe(15);
+  });
+
+  it('a withdraw whose selector fingerprint misses writes nothing and quarantines nothing', () => {
+    resetPlayer(sim, 3);
+    const h = harness(sim);
+    sim.addItem('copper_ore', 10, sim.playerId, {
+      materialSources: composition([{ source: { signer: 'Ana' }, count: 10 }]),
+    });
+    h.deposit(0);
+    const rowsBefore = h.rowsCommitted();
+    h.withdraw('copper_ore', undefined, { index: 7, craftedRecipeId: 'not_this_row' });
+    expect(h.failures).toEqual([]);
+    expect(h.rowsCommitted() - rowsBefore).toBe(0);
+    expect(vaultStoredCount(sim.meta(sim.playerId)!.vault, 'copper_ore')).toBe(10);
+  });
+});
+
+describe('over-bound refusal happens before mutation', () => {
+  const incidents: VaultLedgerIncident[] = [];
+  afterEach(() => {
+    setGameMetricsCounters(noopGameMetricsCounters);
+    incidents.length = 0;
+  });
+
+  /** More distinct (material, signer) keys than the account row burst can
+   *  ever hold: seven materials, each a stack signed by eighteen crafters. */
+  function overBoundInventory(): InvSlot[] {
+    // Seven honest material ids (a non-material stack is skipped by the sweep
+    // and by the bound alike, so it could not push the count over).
+    const materials = [
+      'copper_ore',
+      'iron_ore',
+      'linen_scrap',
+      'rough_hide',
+      'spider_silk',
+      'silverleaf_herb',
+      'thorium_ore',
+    ];
+    return materials.map((itemId) => ({
+      itemId,
+      count: 18,
+      materialSources: composition(
+        Array.from({ length: 18 }, (_, i) => ({ source: { signer: `Crafter${i}` }, count: 1 })),
+      ),
+    }));
+  }
+
+  it('refuses a deposit-all whose key count exceeds the burst with the busy line, reserving and mutating nothing', () => {
+    setGameMetricsCounters({
+      ...noopGameMetricsCounters,
+      vaultLedgerIncident: (kind) => void incidents.push(kind),
+    });
+    const inventory = overBoundInventory();
+    const bound = vaultDepositAllLedgerRowBound(inventory);
+    expect(bound).toBeGreaterThan(VAULT_LEDGER_ROW_BOUND_MAX);
+
+    const errors: string[] = [];
+    const depositAll = vi.fn();
+    const tryReserve = vi.fn(() => {
+      throw new Error('the guard must never see an over-bound reservation');
+    });
+    const fake: VaultSim = {
+      ctx: {
+        resolve: () => ({ meta: { entityId: 5, inventory } }),
+        error: (_id, text) => void errors.push(text),
+      },
+      vaultInfoFor: () => null,
+      vaultDeposit: vi.fn(),
+      vaultWithdraw: vi.fn(),
+      vaultDepositAll: depositAll,
+      vaultBuyUpgrade: vi.fn(),
+    };
+    dispatchVaultCommand(fake, WHO, 'vault_deposit_all', {}, 5, { tryReserve });
+
+    expect(errors).toEqual(['You are busy.']);
+    expect(depositAll).not.toHaveBeenCalled();
+    expect(tryReserve).not.toHaveBeenCalled();
+    expect(incidents).toEqual(['row_bound_exceeded']);
+    expect(gameMetricsCounters()).not.toBe(noopGameMetricsCounters);
+  });
+});

--- a/tests/vault_wire.test.ts
+++ b/tests/vault_wire.test.ts
@@ -1901,7 +1901,7 @@ describe('vault_wire module units', () => {
   const withdrawArgs: unknown[][] = [];
   const unitSim = (): VaultSim => ({
     ctx: {
-      resolve: () => ({ meta: { entityId: 9 } }),
+      resolve: () => ({ meta: { entityId: 9, inventory: [] } }),
       error: (_id, text) => void calls.push(`error:${text}`),
     },
     vaultInfoFor: () => null,

--- a/tests/vault_wire_ledger_rows.test.ts
+++ b/tests/vault_wire_ledger_rows.test.ts
@@ -1,0 +1,261 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Postgres is mocked (hoisted above the server/game import), so GameServer runs
+// with no live DB; every vault command stages its rows in the session-owned
+// transactional journal exactly as production does.
+vi.mock('../server/db', () => ({
+  pool: { query: vi.fn(async () => ({ rows: [] })) },
+  saveCharacterState: vi.fn(async () => {}),
+  saveCharacterAndMarketState: vi.fn(async () => {}),
+  openPlaySession: vi.fn(async () => {}),
+  touchCharacterLogin: vi.fn(async () => {}),
+  closePlaySession: vi.fn(async () => {}),
+  releaseCharacterLease: vi.fn(async () => true),
+  insertChatLogs: vi.fn(async () => {}),
+  walletForAccount: vi.fn(async () => null),
+  markAccountQuestComplete: vi.fn(async () => ({ completedQuestIds: [], mechChromaIds: [] })),
+  grantAccountMechChroma: vi.fn(async () => ({ completedQuestIds: [], mechChromaIds: [] })),
+  loadAccountFlair: vi.fn(async () => ({ titleId: null, cosmetics: [] })),
+  insertBankLedgerRow: vi.fn(async () => {}),
+  insertBankLedgerRows: vi.fn(async () => {}),
+}));
+
+import { bankLedgerIdle } from '../server/bank_ledger';
+import type { GameServer as GameServerType } from '../server/game';
+import { GameServer } from '../server/game';
+import { decodeVaultInfoWire } from '../src/net/vault_snapshot_wire';
+import { canonicalMaterialComposition, type MaterialSource } from '../src/sim/material_sources';
+import { vaultStoredCount } from '../src/sim/materials_vault';
+import type { PlayerMeta, Sim } from '../src/sim/sim';
+import type { InvSlot } from '../src/sim/types';
+import { vaultSpecialRef } from '../src/ui/vault_view';
+import { type FakeClient, fakeWs, joinServer } from './helpers/bare_client';
+
+// The 0.42.0 regression (players kicked on an individual vault deposit or
+// withdraw, deposit-all unaffected): carried material stacks now combine while
+// keeping per-unit sources, so ONE stack can hold units signed by several
+// premium crafters beside unsigned units. The bank_ledger keys a vault row per
+// distinct (material, identity), so a single deposit or withdrawal of such a
+// stack diffs into several rows, while the command reserved exactly ONE row
+// before mutating. The commit then threw AFTER the Sim had moved the items,
+// which the live host treats as a lost ledger projection: it quarantines the
+// session and disconnects it ("character state could not be saved"). This
+// suite drives the REAL GameServer session path (guard, journal admission,
+// dispatch) and pins that the mixed-identity commands stay connected, write
+// their rows, and conserve every unit.
+
+const KICK_TEXT = 'character state could not be saved';
+
+const signedAna: MaterialSource = { signer: 'Ana' };
+const signedBob: MaterialSource = { signer: 'Bob' };
+const gatheredCal: MaterialSource = { gatherer: { kind: 'character', id: 31, name: 'Cal' } };
+
+function composition(rows: readonly { source: MaterialSource; count: number }[]) {
+  const total = rows.reduce((sum, row) => sum + row.count, 0);
+  const built = canonicalMaterialComposition(rows, total);
+  if (!built.ok) throw new Error(`bad fixture composition: ${built.error}`);
+  return built.value;
+}
+
+interface Seated {
+  // biome-ignore lint/suspicious/noExplicitAny: ClientSession is opaque to this suite
+  session: any;
+  sim: Sim;
+  pid: number;
+  meta: PlayerMeta;
+  fw: FakeClient;
+}
+
+function send(server: GameServerType, session: unknown, msg: Record<string, unknown>): void {
+  // biome-ignore lint/suspicious/noExplicitAny: ClientSession is opaque to this suite
+  server.handleMessage(session as any, JSON.stringify({ t: 'cmd', ...msg }));
+}
+
+/** Stand a fresh character at a banker with an unlocked vault at `upgrades`. */
+function seat(server: GameServerType, characterId: number, name: string, upgrades: number): Seated {
+  const fw = fakeWs();
+  const session = joinServer(server, fw, characterId, name);
+  // biome-ignore lint/suspicious/noExplicitAny: Sim internals the fixture reaches into
+  const sim = server.sim as any;
+  const pid = session.pid;
+  const banker = sim.entities.get(sim.bankerIds[0]);
+  const p = sim.entities.get(pid);
+  if (!banker || !p) throw new Error('missing banker/player test entity');
+  banker.pos = { ...p.pos };
+  banker.prevPos = { ...banker.pos };
+  const meta = sim.players.get(pid) as PlayerMeta;
+  meta.inventory.length = 0;
+  meta.vault.upgrades = upgrades;
+  return { session, sim, pid, meta, fw };
+}
+
+function journalRows(session: Seated['session']): Record<string, unknown>[] {
+  return session.bankLedgerJournal.outbox
+    .snapshot()
+    .batches.flatMap((batch: { rows: readonly Record<string, unknown>[] }) => batch.rows);
+}
+
+function kickFrames(fw: FakeClient): unknown[] {
+  return fw.sent.filter((frame) => {
+    try {
+      const parsed = JSON.parse(String(frame)) as { t?: string; error?: string };
+      return parsed.t === 'error' && parsed.error === KICK_TEXT;
+    } catch {
+      return false;
+    }
+  });
+}
+
+/** The quarantine kick fires on a microtask after the dispatch, so the
+ *  "still connected" claim must be checked after one turn of the loop. */
+async function settle(): Promise<void> {
+  await new Promise<void>((resolve) => setTimeout(resolve, 0));
+}
+
+function carried(meta: PlayerMeta, itemId: string): number {
+  return meta.inventory
+    .filter((s: InvSlot) => s.itemId === itemId)
+    .reduce((sum: number, s: InvSlot) => sum + s.count, 0);
+}
+
+beforeEach(async () => {
+  await bankLedgerIdle();
+});
+
+describe('materials vault ledger rows for mixed-identity stacks', () => {
+  it('an individual deposit of a stack signed by two crafters stays connected and writes one row per identity', async () => {
+    const server = new GameServer();
+    const { session, sim, pid, meta, fw } = seat(server, 1, 'Vaultmix', 2);
+    sim.addItem('copper_ore', 12, pid, {
+      materialSources: composition([
+        { source: gatheredCal, count: 5 },
+        { source: signedAna, count: 4 },
+        { source: signedBob, count: 3 },
+      ]),
+    });
+
+    send(server, session, { cmd: 'vault_deposit', slot: 0 });
+    await settle();
+
+    expect(session.escrowQuarantined).toBe(false);
+    expect(session.left).toBe(false);
+    expect(kickFrames(fw)).toEqual([]);
+    expect(carried(meta, 'copper_ore')).toBe(0);
+    expect(vaultStoredCount(meta.vault, 'copper_ore')).toBe(12);
+    const rows = journalRows(session);
+    expect(rows.map((row) => [row.op, row.itemId, row.count]).sort()).toEqual([
+      ['deposit', 'copper_ore', 3],
+      ['deposit', 'copper_ore', 4],
+      ['deposit', 'copper_ore', 5],
+    ]);
+    // The owner's snapshot still decodes on the client boundary.
+    expect(decodeVaultInfoWire(JSON.parse(JSON.stringify(sim.vaultInfoFor(pid))))).not.toBeNull();
+  });
+
+  it('an individual withdraw of a mixed identity row returns every unit without a kick', async () => {
+    const server = new GameServer();
+    const { session, sim, pid, meta, fw } = seat(server, 2, 'Vaultback', 2);
+    // Unsigned stock first (the pre-0.42 compact row), then a signed stack of
+    // the same material: the deposit folds the compact units into ONE identity
+    // row holding an unsigned bucket beside the signed one.
+    sim.addItem('copper_ore', 10, pid);
+    send(server, session, { cmd: 'vault_deposit', slot: 0 });
+    sim.addItem('copper_ore', 6, pid, {
+      materialSources: composition([{ source: signedAna, count: 6 }]),
+    });
+    send(server, session, { cmd: 'vault_deposit', slot: 0 });
+    await settle();
+    expect(session.escrowQuarantined).toBe(false);
+    expect(meta.vault.stock).toEqual({});
+    expect(meta.vault.special).toHaveLength(1);
+    const rowsBefore = journalRows(session).length;
+
+    const special = sim.vaultInfoFor(pid)?.special ?? [];
+    send(server, session, {
+      cmd: 'vault_withdraw',
+      itemId: 'copper_ore',
+      special: vaultSpecialRef(0, special[0]),
+    });
+    await settle();
+
+    expect(session.escrowQuarantined).toBe(false);
+    expect(session.left).toBe(false);
+    expect(kickFrames(fw)).toEqual([]);
+    expect(vaultStoredCount(meta.vault, 'copper_ore')).toBe(0);
+    expect(carried(meta, 'copper_ore')).toBe(16);
+    const withdrawRows = journalRows(session).slice(rowsBefore);
+    expect(withdrawRows.map((row) => [row.op, row.itemId, row.count]).sort()).toEqual([
+      ['withdraw', 'copper_ore', 10],
+      ['withdraw', 'copper_ore', 6],
+    ]);
+  });
+
+  it('a 120-ceiling vault stocked past 80 keeps taking mixed deposits and paying them back', async () => {
+    const server = new GameServer();
+    const { session, sim, pid, meta, fw } = seat(server, 3, 'Vaultwide', 3);
+    for (let i = 0; i < 5; i++) {
+      sim.addItem('copper_ore', 20, pid, {
+        materialSources: composition([
+          { source: i % 2 ? signedAna : signedBob, count: 12 },
+          { source: gatheredCal, count: 8 },
+        ]),
+      });
+      send(server, session, { cmd: 'vault_deposit', slot: 0 });
+    }
+    await settle();
+
+    expect(session.escrowQuarantined).toBe(false);
+    expect(kickFrames(fw)).toEqual([]);
+    expect(vaultStoredCount(meta.vault, 'copper_ore')).toBe(100);
+    expect(carried(meta, 'copper_ore')).toBe(0);
+    const info = sim.vaultInfoFor(pid);
+    expect(info?.perMaterialCap).toBe(120);
+    expect(decodeVaultInfoWire(JSON.parse(JSON.stringify(info)))).not.toBeNull();
+
+    // Shift-click partial: 20 units (one bag stack) out of the three-identity row.
+    const special = info?.special ?? [];
+    send(server, session, {
+      cmd: 'vault_withdraw',
+      itemId: 'copper_ore',
+      count: 20,
+      special: vaultSpecialRef(0, special[0]),
+    });
+    await settle();
+    expect(session.escrowQuarantined).toBe(false);
+    expect(session.left).toBe(false);
+    expect(kickFrames(fw)).toEqual([]);
+    expect(vaultStoredCount(meta.vault, 'copper_ore')).toBe(80);
+    expect(carried(meta, 'copper_ore')).toBe(20);
+  });
+
+  it('deposit-all over mixed stacks keeps its single batched receipt', async () => {
+    const server = new GameServer();
+    const { session, sim, pid, meta, fw } = seat(server, 4, 'Vaultsweep', 2);
+    sim.addItem('copper_ore', 8, pid, {
+      materialSources: composition([
+        { source: signedAna, count: 4 },
+        { source: signedBob, count: 4 },
+      ]),
+    });
+    sim.addItem('iron_ore', 5, pid);
+
+    send(server, session, { cmd: 'vault_deposit_all' });
+    await settle();
+
+    expect(session.escrowQuarantined).toBe(false);
+    expect(kickFrames(fw)).toEqual([]);
+    expect(vaultStoredCount(meta.vault, 'copper_ore')).toBe(8);
+    expect(vaultStoredCount(meta.vault, 'iron_ore')).toBe(5);
+    expect(session.bankLedgerJournal.outbox.snapshot().batches).toHaveLength(1);
+    expect(
+      journalRows(session)
+        .map((row) => [row.itemId, row.count])
+        .sort(),
+    ).toEqual([
+      ['copper_ore', 4],
+      ['copper_ore', 4],
+      ['iron_ore', 5],
+    ]);
+    expect(sim.meta(pid)).toBe(meta);
+  });
+});

--- a/tests/vault_wire_ledger_rows.test.ts
+++ b/tests/vault_wire_ledger_rows.test.ts
@@ -112,6 +112,12 @@ async function settle(): Promise<void> {
   await new Promise<void>((resolve) => setTimeout(resolve, 0));
 }
 
+/** Order journal row tuples by their trailing count, numerically: a bare
+ *  Array.sort compares the tuples as strings, where 10 sorts before 6. */
+function byCount(a: unknown[], b: unknown[]): number {
+  return Number(a[a.length - 1]) - Number(b[b.length - 1]);
+}
+
 function carried(meta: PlayerMeta, itemId: string): number {
   return meta.inventory
     .filter((s: InvSlot) => s.itemId === itemId)
@@ -143,7 +149,7 @@ describe('materials vault ledger rows for mixed-identity stacks', () => {
     expect(carried(meta, 'copper_ore')).toBe(0);
     expect(vaultStoredCount(meta.vault, 'copper_ore')).toBe(12);
     const rows = journalRows(session);
-    expect(rows.map((row) => [row.op, row.itemId, row.count]).sort()).toEqual([
+    expect(rows.map((row) => [row.op, row.itemId, row.count]).sort(byCount)).toEqual([
       ['deposit', 'copper_ore', 3],
       ['deposit', 'copper_ore', 4],
       ['deposit', 'copper_ore', 5],
@@ -184,9 +190,9 @@ describe('materials vault ledger rows for mixed-identity stacks', () => {
     expect(vaultStoredCount(meta.vault, 'copper_ore')).toBe(0);
     expect(carried(meta, 'copper_ore')).toBe(16);
     const withdrawRows = journalRows(session).slice(rowsBefore);
-    expect(withdrawRows.map((row) => [row.op, row.itemId, row.count]).sort()).toEqual([
-      ['withdraw', 'copper_ore', 10],
+    expect(withdrawRows.map((row) => [row.op, row.itemId, row.count]).sort(byCount)).toEqual([
       ['withdraw', 'copper_ore', 6],
+      ['withdraw', 'copper_ore', 10],
     ]);
   });
 


### PR DESCRIPTION
## Summary

Players on 0.42.0 were disconnected the moment they clicked an individual Materials Vault row to withdraw, and an individual deposit appeared to vanish, while the "Deposit all materials" button kept working. The same players reported "crashes" once a vault upgraded to the 120 ceiling started accepting stock past 80.

All three reports share one root cause on the server. A single `vault_deposit` or `vault_withdraw` reserves exactly ONE `bank_ledger` row before the sim mutates (`COMMAND_MAX_ROWS` in `server/bank_vault_ledger_guard.ts`), but the count ledger keys a vault row per distinct (material, identity), where the identity is each source bucket's premium `signer`. Since 0.42.0 combined carried material stacks while preserving their per-unit sources, one stack can hold units signed by several crafters beside unsigned units, so a single deposit or withdrawal of that stack diffs into several rows. The outbox commit then threw `bank ledger batch exceeds its reserved row limit` AFTER the items had moved, which the live host treats as a lost ledger projection: `quarantineBankLedgerProjection` refused the save and kicked the session with "character state could not be saved". Deposit-all was unaffected because it reserves the 112-slot sweep bound. At the 80 ceiling a full material simply refused new deposits with no mutation, so the fault only surfaced once the 120 rung let those mixed stacks in.

The fix:

- New module `server/vault_ledger_row_bound.ts`: a pre-mutation per-command row bound, one row per distinct ledger key the command's stack(s) can touch (deposit: the carried stack; withdraw: the resolved identity row or the single pooled row; deposit-all: distinct keys across every depositable carried stack; buy_upgrade: one). It counts through the exported `vaultCountGroups` grouping the diff itself uses, so the bound and the diff cannot drift.
- `server/vault_wire.ts` reserves `max(table floor, bound)`. A bound the guard could never grant (above the account row burst) is refused BEFORE mutation with the existing "You are busy." line instead of mutating and then failing the commit, and that arm counts a new `row_bound_exceeded` vault ledger incident so a permanently refused sweep is diagnosable. The withdraw arm reads the pre-mutation snapshot once and reuses it as the diff's before-state.
- `server/bank_vault_ledger_guard.ts`: the vault surface's known reservation shape becomes a range (1 to the account row burst) instead of the two literals 1 and 112. `COMMAND_MAX_ROWS` is unchanged and still the floor.

No sim, client, or wire-shape changes; no new player-visible strings.

Known limit, deliberately left as a refusal rather than a kick: a carried inventory holding more than 121 distinct (material, premium signer) keys can never complete deposit-all (it gets "You are busy." every time). That needs several dozen distinct signers spread across materials in one inventory; the new incident counter is what would show it happening.

## Related issues

Hotfix for the 0.42.0 Materials Vault reports (withdraw disconnects, individual deposit vanishes, "crash" past 80 stock at the 120 ceiling). Targets `release/v0.42.1`.

## Type of change

- [x] Bug fix
- [x] Tests

## How was this tested?

- Commands:
  - `npx vitest run tests/vault_wire_ledger_rows.test.ts tests/vault_ledger_row_bound_property.test.ts tests/server/vault_ledger_row_bound.test.ts` (new: the real GameServer session path with mixed-signer stacks stays connected, writes one row per identity, conserves every unit; a 120-ceiling vault holding 100 units keeps decoding on the client boundary and paying out; randomized stacks never commit more rows than they reserved; the over-bound refusal reserves and mutates nothing)
  - `npx vitest run tests/vault_wire.test.ts tests/bank_ledger_admission.test.ts tests/material_source_storage_selection_wire.test.ts tests/server/bank_vault_ledger_guard.test.ts tests/server/http/game_metrics.test.ts tests/materials_vault.test.ts tests/audit_conservation_vault.test.ts tests/bank_ledger.test.ts`
  - `npx tsc --noEmit`, biome on the changed files
  - `node scripts/gate_select.mjs`: on this Windows checkout it stops in `tests/bank_sockets.test.ts` on a pre-existing path-separator pin (`src\sim` vs `src/sim`) that is unrelated and Linux-green; the rest of the selection was run by hand (`npx vitest related` over the changed server files), where the only failures were the same pre-existing `static_sfx_serving` case and two status pins that read `ALLOW_DEV_COMMANDS=1` from the local `.env`. CI is the gate for this PR.
- Manual steps: reproduced the kick first with a scratch test driving the session journal admission (RangeError out of the outbox commit on a gatherer+signer stack deposit and on a mixed identity-row withdraw), then confirmed both pass after the fix. Ran the server and client locally, seeded a character with a copper stack signed by two crafters plus unsigned units in the bags and a mixed iron row in the vault at the 120 ceiling, and clicked the vault row to withdraw and the bag stack to deposit: both landed, no disconnect, no server error, the rows appeared in the session journal.

## Screenshots / recordings

N/A: server-side ledger fix, no UI change.

---

## Checklist

### Quality

- [x] **The gate passes.** CI runs the full gate; the local selective run is documented above, including the Windows-only pre-existing pin it stops on. I added decisive tests for changed behavior and recorded the manual checks above.

### Cross-platform

- ~Tested on desktop and mobile.~ N/A, no UI change.
- ~Accessible.~ N/A.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings (the pre-mutation refusal reuses the existing "You are busy." sim line).

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
