### PR TITLE
fix(game): judge an entry crash by a frame-loop heartbeat, not a probe that outlived a background reload

### DIFF
--- a/src/game/entry_crash_guard.ts
+++ b/src/game/entry_crash_guard.ts
@@ -18,6 +18,19 @@
 // - Once entry is stable the probe stays armed for explicit high-risk runtime UI
 //   checkpoints. Normal lifecycle transitions clear it, so a silent foreground
 //   WebContent termination remains distinguishable from backgrounding or navigation.
+// - stampEntryHeartbeat() refreshes a liveness stamp (aliveAt) from the frame loop
+//   every ENTRY_HEARTBEAT_MS while the page is armed and foregrounded. Once a probe
+//   carries that stamp, a crash verdict also needs it to be younger than
+//   ENTRY_ALIVE_WINDOW_MS: a page that was provably running the frame loop right up
+//   to the reload was killed in the foreground; one whose heartbeat stopped long
+//   before the reload was backgrounded first, and a reload after that is the OS
+//   reclaiming a background WebView (or an OTA bundle switch), never an entry crash.
+//   This is what makes the verdict robust when the hidden-lifecycle clear below is
+//   lost (WebKit persists localStorage asynchronously, so a probe removal written
+//   in the last instant before a background purge may never reach disk) and when a
+//   boot starts hidden (the controller then arms without persisting until the first
+//   foreground). Before the first frame there is no heartbeat, and the synchronous
+//   scene build cannot produce one, so that phase keeps the wider window below.
 // - On the NEXT boot, a probe that is still present and fresh means the previous entry
 //   died mid-build: planEntryCrashRecovery() names the preset that crashed and the next
 //   tier down to retry with. The caller persists the lowered preset, drops the resume
@@ -40,6 +53,19 @@ export const ENTRY_RECOVERY_LOG_KEY = 'woc_entry_last_recovery';
 // world entry the player is attempting NOW - e.g. a phone that died mid-entry and was
 // booted again days later should not silently lose a graphics tier.
 export const ENTRY_CRASH_WINDOW_MS = 10 * 60 * 1000;
+
+// Liveness heartbeat cadence (frame loop, foreground only) and the longest a probe's
+// heartbeat may lag this boot for the previous session to count as killed in the
+// foreground. The window covers the heartbeat gap plus the crash-to-reload and
+// reload-to-check latency of a slow phone boot; anything longer means the page
+// stopped running BEFORE the reload, i.e. it was backgrounded, not crashed.
+// The window is a two-sided trade, deliberately: a background reclaim that reloads
+// within it still reads as a crash (narrowed from the 10 minute window, not gone),
+// and a real foreground kill whose frame loop had already stalled for longer than
+// it (a memory death spiral that hangs the main thread before the OS kills the
+// process) now reads as backgrounded. Widen it only with both sides in view.
+export const ENTRY_HEARTBEAT_MS = 5 * 1000;
+export const ENTRY_ALIVE_WINDOW_MS = 45 * 1000;
 
 // How long after the synchronous scene build the entry is considered stable. The
 // controller then stops periodic render writes but keeps the probe armed for named
@@ -98,6 +124,8 @@ export interface EntryProbe {
   checkpointAt?: number;
   /** bounded, non-sensitive render and device evidence for the checkpoint */
   diagnostics?: EntryDiagnostics;
+  /** wall-clock ms of the last frame-loop liveness heartbeat (absent before the first frame) */
+  aliveAt?: number;
 }
 
 export interface EntryCrashRecovery {
@@ -113,6 +141,8 @@ export interface EntryCrashRecovery {
   checkpointAgeMs?: number;
   /** render/device evidence captured at the last checkpoint */
   diagnostics?: EntryDiagnostics;
+  /** ms between the last liveness heartbeat and this boot (absent before the first frame) */
+  aliveAgeMs?: number;
 }
 
 export interface EntryRecoveryLog extends EntryCrashRecovery {
@@ -181,6 +211,9 @@ export function parseEntryRecoveryLog(raw: string | null): EntryRecoveryLog | nu
       const diagnostics = sanitizeDiagnostics(value.diagnostics);
       if (diagnostics) log.diagnostics = diagnostics;
     }
+    if (typeof value.aliveAgeMs === 'number' && Number.isFinite(value.aliveAgeMs)) {
+      log.aliveAgeMs = value.aliveAgeMs;
+    }
     return log;
   } catch {
     return null;
@@ -212,6 +245,9 @@ export function parseProbe(raw: string | null): EntryProbe | null {
       const diagnostics = sanitizeDiagnostics(value.diagnostics);
       if (diagnostics) probe.diagnostics = diagnostics;
     }
+    if (typeof value.aliveAt === 'number' && Number.isFinite(value.aliveAt)) {
+      probe.aliveAt = value.aliveAt;
+    }
     return probe;
   } catch {
     return null;
@@ -234,7 +270,15 @@ export function checkpointEntryProbe(
     checkpoint,
     checkpointAt: now,
     ...(sanitized ? { diagnostics: sanitized } : {}),
+    ...(probe.aliveAt !== undefined ? { aliveAt: probe.aliveAt } : {}),
   });
+}
+
+/** Pure heartbeat transition: refresh aliveAt, keep every breadcrumb as it is. */
+export function heartbeatEntryProbe(raw: string | null, now: number): string | null {
+  const probe = parseProbe(raw);
+  if (!probe || !Number.isFinite(now)) return null;
+  return serializeProbe({ ...probe, aliveAt: now });
 }
 
 /** One tier down, clamped to the settings range; the floor retries at the floor. */
@@ -253,13 +297,24 @@ export function planEntryCrashRecovery(raw: string | null, now: number): EntryCr
   const probe = parseProbe(raw);
   if (!probe) return null;
   const ageMs = now - probe.at;
-  const evidenceAgeMs = now - (probe.checkpointAt ?? probe.at);
+  // The heartbeat is evidence of life like any checkpoint: a long quiet session with
+  // a fresh heartbeat is still inside the window even when its last named
+  // checkpoint is hours old.
+  const evidenceAt = Math.max(probe.checkpointAt ?? probe.at, probe.aliveAt ?? probe.at);
+  const evidenceAgeMs = now - evidenceAt;
   if (ageMs < 0 || evidenceAgeMs < 0 || evidenceAgeMs > ENTRY_CRASH_WINDOW_MS) return null;
+  // A page that reached the frame loop proves it was still running right before a
+  // foreground kill; a heartbeat that stopped earlier than the alive window means
+  // the page was backgrounded before the reload (see the module header).
+  // (A heartbeat from the future already failed the evidence guard above.)
+  const aliveAgeMs = probe.aliveAt === undefined ? undefined : now - probe.aliveAt;
+  if (aliveAgeMs !== undefined && aliveAgeMs > ENTRY_ALIVE_WINDOW_MS) return null;
   const recovery: EntryCrashRecovery = {
     from: probe.preset,
     to: stepDownPreset(probe.preset),
     ageMs,
   };
+  if (aliveAgeMs !== undefined) recovery.aliveAgeMs = aliveAgeMs;
   if (probe.checkpoint && probe.checkpointAt !== undefined) {
     const checkpointAgeMs = now - probe.checkpointAt;
     if (checkpointAgeMs >= 0) {
@@ -296,6 +351,16 @@ export function stampEntryCheckpoint(
     if (next !== null) localStorage.setItem(ENTRY_PROBE_KEY, next);
   } catch {
     // Blocked storage only loses diagnostic detail; crash recovery still fails soft.
+  }
+}
+
+export function stampEntryHeartbeat(now: number): void {
+  try {
+    const next = heartbeatEntryProbe(localStorage.getItem(ENTRY_PROBE_KEY), now);
+    if (next !== null) localStorage.setItem(ENTRY_PROBE_KEY, next);
+  } catch {
+    // Blocked storage only loses the liveness stamp; the verdict falls back to the
+    // wider entry window, exactly as before the heartbeat existed.
   }
 }
 

--- a/src/game/entry_diagnostics.ts
+++ b/src/game/entry_diagnostics.ts
@@ -1,8 +1,10 @@
 import {
   clearEntryProbe,
+  ENTRY_HEARTBEAT_MS,
   type EntryCheckpoint,
   type EntryDiagnostics,
   stampEntryCheckpoint,
+  stampEntryHeartbeat,
   stampEntryProbe,
 } from './entry_crash_guard';
 
@@ -50,6 +52,8 @@ export interface EntryDiagnosticPersistence {
   start: (preset: number, now: number) => void;
   checkpoint: (checkpoint: EntryCheckpoint, now: number, diagnostics: EntryDiagnostics) => void;
   clear: () => void;
+  // Liveness stamp from the frame loop (entry_crash_guard.ts stampEntryHeartbeat).
+  heartbeat?: (now: number) => void;
 }
 
 export interface EntryDiagnosticsController {
@@ -66,7 +70,17 @@ const defaultPersistence: EntryDiagnosticPersistence = {
   start: stampEntryProbe,
   checkpoint: stampEntryCheckpoint,
   clear: clearEntryProbe,
+  heartbeat: stampEntryHeartbeat,
 };
+
+// A boot that starts hidden (an OTA bundle switch reloads the WebView while the app
+// is backgrounded, and the auto-resume enters the world from there) must not leave
+// a persisted probe behind: a later reload of that never-foregrounded page is not a
+// foreground crash. The controller arms in the suspended state instead and persists
+// on the first foreground, through the same resume() path a hidden tab uses.
+function documentHidden(): boolean {
+  return typeof document !== 'undefined' && document.visibilityState === 'hidden';
+}
 
 let activeController: EntryDiagnosticsController | null = null;
 
@@ -76,13 +90,17 @@ export function createEntryDiagnosticsController(options: {
   persistence?: EntryDiagnosticPersistence;
   wallNow?: () => number;
   log?: (message: string, diagnostics?: EntryDiagnostics) => void;
+  isHidden?: () => boolean;
 }): EntryDiagnosticsController {
   const persistence = options.persistence ?? defaultPersistence;
   const wallNow = options.wallNow ?? Date.now;
+  const isHidden = options.isHidden ?? documentHidden;
   const log = options.log ?? ((message, diagnostics) => console.info(message, diagnostics ?? ''));
   let armed = false;
   let frame = 0;
   let nextRenderCheckpointAt = 0;
+  let nextHeartbeatAt = 0;
+  let heartbeatStarted = false;
   let stickyCheckpoint: EntryCheckpoint | null = null;
   let stable = false;
   let suspended = false;
@@ -126,6 +144,8 @@ export function createEntryDiagnosticsController(options: {
       activePreset = preset;
       frame = 0;
       nextRenderCheckpointAt = 0;
+      nextHeartbeatAt = 0;
+      heartbeatStarted = false;
       stickyCheckpoint = null;
       stable = false;
       lastCheckpoint = null;
@@ -133,12 +153,32 @@ export function createEntryDiagnosticsController(options: {
       stableOnResume = false;
       stableOnResumeMessage = undefined;
       activeController = controller;
+      if (isHidden()) {
+        // Armed but unpersisted (see documentHidden): resume() stamps the probe and
+        // this breadcrumb on the first foreground. Checkpoints reached while still
+        // hidden are dropped like any suspended checkpoint, so a recovery log from
+        // this path names the entry start rather than the last hidden phase; the
+        // verdict is unaffected (no heartbeat yet, so the wide window applies).
+        suspended = true;
+        lastCheckpoint = 'scene-build-start';
+        lastDiagnostics = options.baseSnapshot();
+        log('[entry-diag] entry started hidden; probe persists on foreground');
+        return;
+      }
       persistence.start(preset, wallNow());
       checkpoint('scene-build-start', options.baseSnapshot());
     },
     checkpoint,
     renderedFrame(now): void {
-      if (!armed || suspended || stable) return;
+      if (!armed || suspended) return;
+      // Liveness heartbeat, before and after stable alike: the crash verdict on the
+      // next boot needs a stamp from the last seconds the page was actually running.
+      if (now >= nextHeartbeatAt) {
+        persistence.heartbeat?.(wallNow());
+        heartbeatStarted = true;
+        nextHeartbeatAt = now + ENTRY_HEARTBEAT_MS;
+      }
+      if (stable) return;
       frame++;
       if (frame !== 1 && now < nextRenderCheckpointAt) return;
       checkpoint(frame === 1 ? 'first-frame' : 'rendering', {
@@ -171,6 +211,11 @@ export function createEntryDiagnosticsController(options: {
       if (lastCheckpoint) {
         persistence.checkpoint(lastCheckpoint, wallNow(), lastDiagnostics);
       }
+      // A page that had reached the frame loop is alive again right now; stamp it
+      // so a kill in the first seconds after foregrounding still reads as one, and
+      // let the next frame start the cadence over.
+      nextHeartbeatAt = 0;
+      if (heartbeatStarted) persistence.heartbeat?.(wallNow());
       if (stableOnResume) {
         const message = stableOnResumeMessage;
         stableOnResume = false;

--- a/tests/entry_crash_guard.test.ts
+++ b/tests/entry_crash_guard.test.ts
@@ -2,10 +2,13 @@ import { readFileSync } from 'node:fs';
 import { beforeEach, describe, expect, it } from 'vitest';
 import {
   checkpointEntryProbe,
+  ENTRY_ALIVE_WINDOW_MS,
   ENTRY_CRASH_WINDOW_MS,
+  ENTRY_HEARTBEAT_MS,
   ENTRY_PRESET_MIN,
   ENTRY_PROBE_KEY,
   ENTRY_RECOVERY_LOG_KEY,
+  heartbeatEntryProbe,
   parseEntryRecoveryLog,
   parseProbe,
   persistEntryRecoveryLog,
@@ -13,6 +16,7 @@ import {
   serializeEntryRecoveryLog,
   serializeProbe,
   stampEntryCheckpoint,
+  stampEntryHeartbeat,
   stampEntryProbe,
   stepDownPreset,
 } from '../src/game/entry_crash_guard';
@@ -203,6 +207,76 @@ describe('entry crash guard: diagnostic checkpoints', () => {
   });
 });
 
+describe('entry crash guard: liveness heartbeat', () => {
+  it('pins the cadence inside the alive window with room for a slow phone boot', () => {
+    expect(ENTRY_ALIVE_WINDOW_MS).toBeGreaterThanOrEqual(ENTRY_HEARTBEAT_MS * 3);
+    expect(ENTRY_ALIVE_WINDOW_MS).toBeLessThan(ENTRY_CRASH_WINDOW_MS);
+  });
+
+  it('round-trips aliveAt and drops an invalid one without losing the probe', () => {
+    expect(parseProbe(serializeProbe({ preset: 2, at: NOW, aliveAt: NOW + 5 }))).toEqual({
+      preset: 2,
+      at: NOW,
+      aliveAt: NOW + 5,
+    });
+    expect(parseProbe(JSON.stringify({ preset: 2, at: NOW, aliveAt: 'soon' }))).toEqual({
+      preset: 2,
+      at: NOW,
+    });
+  });
+
+  it('refreshes only aliveAt and keeps every breadcrumb', () => {
+    const raw = checkpointEntryProbe(
+      serializeProbe({ preset: 2, at: NOW }),
+      'first-frame',
+      NOW + 10,
+      {
+        frame: 1,
+      },
+    );
+    expect(parseProbe(heartbeatEntryProbe(raw, NOW + 20))).toEqual({
+      preset: 2,
+      at: NOW,
+      checkpoint: 'first-frame',
+      checkpointAt: NOW + 10,
+      diagnostics: { frame: 1 },
+      aliveAt: NOW + 20,
+    });
+    // A later checkpoint keeps the heartbeat it does not own.
+    expect(
+      parseProbe(checkpointEntryProbe(heartbeatEntryProbe(raw, NOW + 20), 'rendering', NOW + 30)),
+    ).toMatchObject({
+      checkpoint: 'rendering',
+      aliveAt: NOW + 20,
+    });
+    expect(heartbeatEntryProbe(null, NOW)).toBeNull();
+    expect(heartbeatEntryProbe(raw, Number.NaN)).toBeNull();
+  });
+
+  it('stamps the heartbeat into storage only while a probe is armed', () => {
+    const store = new Map<string, string>();
+    const prev = Object.getOwnPropertyDescriptor(globalThis, 'localStorage');
+    Object.defineProperty(globalThis, 'localStorage', {
+      configurable: true,
+      value: {
+        getItem: (k: string) => store.get(k) ?? null,
+        setItem: (k: string, v: string) => store.set(k, v),
+        removeItem: (k: string) => store.delete(k),
+      },
+    });
+    try {
+      stampEntryHeartbeat(NOW);
+      expect(store.has(ENTRY_PROBE_KEY)).toBe(false);
+      store.set(ENTRY_PROBE_KEY, serializeProbe({ preset: 2, at: NOW }));
+      stampEntryHeartbeat(NOW + 5_000);
+      expect(parseProbe(store.get(ENTRY_PROBE_KEY) ?? null)?.aliveAt).toBe(NOW + 5_000);
+    } finally {
+      if (prev) Object.defineProperty(globalThis, 'localStorage', prev);
+      else Reflect.deleteProperty(globalThis, 'localStorage');
+    }
+  });
+});
+
 describe('entry crash guard: stepDownPreset', () => {
   it('steps each tier down one', () => {
     expect(stepDownPreset(5)).toBe(4);
@@ -293,6 +367,71 @@ describe('entry crash guard: planEntryCrashRecovery', () => {
       checkpointAgeMs: 750,
       diagnostics: { calls: 411, triangles: 2_872_588 },
     });
+  });
+
+  it('recovers when the heartbeat ran until the last seconds before the reload (foreground kill)', () => {
+    const raw = serializeProbe({
+      preset: 2,
+      at: NOW - ENTRY_CRASH_WINDOW_MS * 3,
+      checkpoint: 'runtime-stable',
+      checkpointAt: NOW - ENTRY_CRASH_WINDOW_MS * 3 + 20_000,
+      aliveAt: NOW - 8_000,
+    });
+    expect(planEntryCrashRecovery(raw, NOW)).toEqual({
+      from: 2,
+      to: 1,
+      ageMs: ENTRY_CRASH_WINDOW_MS * 3,
+      checkpoint: 'runtime-stable',
+      checkpointAgeMs: ENTRY_CRASH_WINDOW_MS * 3 - 20_000,
+      aliveAgeMs: 8_000,
+    });
+  });
+
+  it('ignores a probe whose heartbeat stopped before the reload: the page was backgrounded, not killed', () => {
+    // The reported iOS case: the player backgrounded the app (heartbeat stops), the
+    // hidden-lifecycle probe removal never reached disk, iOS reclaimed the WebView
+    // minutes later and the foreground reload found a probe with a recent dialog
+    // checkpoint inside the 10-minute window. Before the heartbeat this read as an
+    // entry crash and cost the player the resume marker on every such cycle.
+    const raw = serializeProbe({
+      preset: 1,
+      at: NOW - 30 * 60_000,
+      checkpoint: 'mobile-more-closed',
+      checkpointAt: NOW - 4 * 60_000,
+      aliveAt: NOW - ENTRY_ALIVE_WINDOW_MS - 1,
+    });
+    expect(planEntryCrashRecovery(raw, NOW)).toBeNull();
+  });
+
+  it('honors a heartbeat exactly at the alive window edge', () => {
+    const raw = serializeProbe({
+      preset: 3,
+      at: NOW - 60_000,
+      aliveAt: NOW - ENTRY_ALIVE_WINDOW_MS,
+    });
+    expect(planEntryCrashRecovery(raw, NOW)).toEqual({
+      from: 3,
+      to: 2,
+      ageMs: 60_000,
+      aliveAgeMs: ENTRY_ALIVE_WINDOW_MS,
+    });
+  });
+
+  it('keeps the wide entry window for a probe that never reached the frame loop', () => {
+    // No heartbeat means the synchronous scene build (which cannot heartbeat) was
+    // still running: the original crash-at-entry rule stands unchanged.
+    const raw = serializeProbe({
+      preset: 3,
+      at: NOW - ENTRY_CRASH_WINDOW_MS + 1_000,
+      checkpoint: 'renderer-built',
+      checkpointAt: NOW - ENTRY_CRASH_WINDOW_MS + 1_000,
+    });
+    expect(planEntryCrashRecovery(raw, NOW)).not.toBeNull();
+  });
+
+  it('ignores a heartbeat from the future (clock went backwards)', () => {
+    const raw = serializeProbe({ preset: 3, at: NOW - 5_000, aliveAt: NOW + 1 });
+    expect(planEntryCrashRecovery(raw, NOW)).toBeNull();
   });
 
   it('ignores a probe from the future (clock went backwards)', () => {

--- a/tests/entry_diagnostics.test.ts
+++ b/tests/entry_diagnostics.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { ENTRY_HEARTBEAT_MS } from '../src/game/entry_crash_guard';
 import {
   checkpointActiveEntryDiagnostics,
   createEntryDiagnosticsController,
@@ -8,7 +9,7 @@ import {
   suspendActiveEntryDiagnostics,
 } from '../src/game/entry_diagnostics';
 
-function harness() {
+function harness(opts: { heartbeat?: boolean; hidden?: () => boolean } = {}) {
   let wallNow = 1_000;
   const events: string[] = [];
   const logged: string[] = [];
@@ -16,6 +17,7 @@ function harness() {
     start: vi.fn((preset) => events.push(`start:${preset}`)),
     checkpoint: vi.fn((checkpoint) => events.push(checkpoint)),
     clear: vi.fn(() => events.push('clear')),
+    ...(opts.heartbeat ? { heartbeat: vi.fn((now: number) => events.push(`alive:${now}`)) } : {}),
   };
   const controller = createEntryDiagnosticsController({
     baseSnapshot: () => ({ phase: 'base' }),
@@ -23,6 +25,7 @@ function harness() {
     persistence,
     wallNow: () => wallNow,
     log: vi.fn((message: string) => logged.push(message)),
+    isHidden: opts.hidden ?? (() => false),
   });
   return {
     controller,
@@ -223,6 +226,97 @@ describe('entry diagnostics controller', () => {
       'start:4',
       'runtime-stable',
     ]);
+  });
+
+  it('heartbeats from the frame loop at the cadence, before and after stable alike', () => {
+    const { controller, events, setWallNow } = harness({ heartbeat: true });
+    controller.start(2);
+    setWallNow(5_000);
+    controller.renderedFrame(100); // first frame: immediate heartbeat
+    setWallNow(6_000);
+    controller.renderedFrame(2_000); // inside the cadence: no stamp
+    setWallNow(11_000);
+    controller.renderedFrame(100 + ENTRY_HEARTBEAT_MS); // cadence elapsed
+    controller.markStable();
+    setWallNow(30_000);
+    controller.renderedFrame(100 + ENTRY_HEARTBEAT_MS * 3); // still heartbeating after stable
+    expect(events).toEqual([
+      'start:2',
+      'scene-build-start',
+      'alive:5000',
+      'first-frame',
+      'alive:11000',
+      'rendering',
+      'runtime-stable',
+      'alive:30000',
+    ]);
+  });
+
+  it('does not heartbeat while suspended, and re-stamps on foreground once the frame loop had run', () => {
+    const { controller, events, setWallNow } = harness({ heartbeat: true });
+    controller.start(2);
+    setWallNow(2_000);
+    controller.renderedFrame(50);
+    suspendActiveEntryDiagnostics();
+    setWallNow(60_000);
+    controller.renderedFrame(50 + ENTRY_HEARTBEAT_MS * 10); // hidden: nothing persists
+    setWallNow(61_000);
+    resumeActiveEntryDiagnostics();
+    expect(events).toEqual([
+      'start:2',
+      'scene-build-start',
+      'alive:2000',
+      'first-frame',
+      'clear',
+      'start:2',
+      'first-frame',
+      'alive:61000',
+    ]);
+  });
+
+  it('does not claim liveness on foreground when no frame had ever rendered', () => {
+    const { controller, events } = harness({ heartbeat: true });
+    controller.start(2);
+    controller.checkpoint('assets-await');
+    suspendActiveEntryDiagnostics();
+    resumeActiveEntryDiagnostics();
+    expect(events).toEqual([
+      'start:2',
+      'scene-build-start',
+      'assets-await',
+      'clear',
+      'start:2',
+      'assets-await',
+    ]);
+  });
+
+  it('arms without persisting when the boot starts hidden, then persists on the first foreground', () => {
+    let hidden = true;
+    const { controller, events, logged } = harness({ heartbeat: true, hidden: () => hidden });
+    controller.start(3);
+    controller.checkpoint('assets-await');
+    controller.renderedFrame(100);
+    expect(events).toEqual([]);
+    expect(logged.at(-1)).toContain('started hidden');
+    hidden = false;
+    resumeActiveEntryDiagnostics();
+    expect(events).toEqual(['start:3', 'scene-build-start']);
+    controller.renderedFrame(200);
+    expect(events.slice(2)).toEqual(['alive:1000', 'first-frame']);
+  });
+
+  it('keeps heartbeating while a sticky dialog checkpoint is held', () => {
+    // The reported iOS shape: the More dialog is open (sticky, so routine checkpoints
+    // are refused) for minutes before the reload. Liveness must keep flowing anyway,
+    // or the verdict would read every such session as backgrounded.
+    const { controller, events, setWallNow } = harness({ heartbeat: true });
+    controller.start(2);
+    controller.renderedFrame(100);
+    controller.markStable();
+    checkpointActiveEntryDiagnostics('mobile-more-open');
+    setWallNow(90_000);
+    controller.renderedFrame(100 + ENTRY_HEARTBEAT_MS * 20);
+    expect(events.slice(-2)).toEqual(['mobile-more-open', 'alive:90000']);
   });
 
   it('uses wall time for persisted checkpoints rather than animation time', () => {


### PR DESCRIPTION
## Summary

iOS players in-world were being dropped to character select with the "Graphics lowered: the game closed unexpectedly while entering the world" banner, on the Low preset already, and lost their active-play resume marker each time.

That banner is the entry-crash guard (`src/game/entry_crash_guard.ts` + `src/game/entry_diagnostics.ts`). Its probe stays armed for the whole play session and is cleared only by the page-hidden handler, so at the next boot any probe with evidence under 10 minutes old counts as a foreground WebContent crash. Two ordinary reloads on the native shell defeat that:

- iOS reclaims the backgrounded WebView, and the hidden handler's localStorage removal never reached disk (WebKit persists localStorage asynchronously). The foreground reload finds the probe.
- An OTA bundle switch reloads the WebView while backgrounded. The auto-resume enters the world from a page that boots hidden and arms the probe, and a later rollback or purge reload reads it as a crash.

The fix judges the crash by liveness instead of by a removal that may never land:

- The probe carries a heartbeat (`aliveAt`) stamped from the frame loop every `ENTRY_HEARTBEAT_MS` (5 s) while armed and foregrounded, before and after `runtime-stable`, and through sticky dialog checkpoints. Once a probe has one, the boot verdict also requires it to be within `ENTRY_ALIVE_WINDOW_MS` (45 s): a page still running right before the reload was killed in the foreground; one whose heartbeat stopped earlier was backgrounded first. A probe with no heartbeat is the pre-first-frame synchronous build and keeps the 10-minute rule, so real entry crashes are still caught.
- The heartbeat also counts as evidence of life alongside checkpoints, so a long quiet session no longer ages out of the window.
- A boot that starts hidden arms the controller without persisting; the first foreground persists through the existing resume path.
- `src/main.ts` is untouched. Legacy probes and retained recovery logs parse as before (`aliveAt` / `aliveAgeMs` are optional).

Trade-off, documented in the module header: a real foreground kill whose frame loop had already hung for longer than the alive window now reads as backgrounded.

## Type of change

- [x] Bug fix
- [x] Tests

## How was this tested?

- Commands:
  - `npx vitest run tests/entry_crash_guard.test.ts tests/entry_diagnostics.test.ts tests/ios_entry_diagnostics.test.ts tests/settings_transfer_core.test.ts tests/pr_shot_targets.test.ts`
  - The new pins were run against the unfixed modules first: all 10 behavioral pins red, including the reported shape (recent `mobile-more-closed` checkpoint, heartbeat older than the alive window).
  - `npx tsc --noEmit`
  - `node scripts/gate_select.mjs`: every step green except one browser click-timeout under load (`tests/browser/stale_focus_space.browser.test.ts`), which passed standalone and in a full `npm run test:browser` re-run (410/410).
- Manual steps: none. The device-only reproduction (background reclaim on iOS) is modeled by the pins above.

## Checklist

### Quality

- [x] **The gate passes.** `node scripts/gate_select.mjs` is green (browser step re-run green after a timing flake). I added decisive tests for the changed behavior.

### Cross-platform

- ~Tested on desktop and mobile.~ No UI change.
- ~Accessible.~ No UI change.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
