### PR TITLE
fix(nythraxis): give heroic Bone Spikes the normal 1,000 health pool

### DIFF
--- a/src/sim/content/dungeon_difficulty.ts
+++ b/src/sim/content/dungeon_difficulty.ts
@@ -217,7 +217,9 @@ export const NORMAL_DUNGEON_TUNING: Record<string, NormalDungeonTuning> = {
     healthMultiplier: 2.0,
     // The boss alone: 160,000 on the 60,000 template (owner call for the
     // mechanics redo, 2026-09-04; was the shared 2.0 for 120,000). Adds and
-    // the Bone Spikes keep the shared multiplier.
+    // the Bone Spikes keep the shared multiplier; the heroic row's
+    // nythraxis_bone_spike override deliberately MIRRORS this 2.0 (same
+    // 1,000 pool on both difficulties), so retune the two together.
     healthMultiplierByMob: {
       // 120,000 after the first playtest (2026-09-04; the redo tried 160,000).
       nythraxis_scourge_of_thornpeak: 120_000 / 60_000,
@@ -474,10 +476,14 @@ export const HEROIC_DUNGEON_TUNING: Record<string, HeroicDungeonTuning> = {
     // and its respawn gate (only after the previous court dies) self-limits.
     healthMultiplierByMob: {
       nythraxis_skeleton_warrior: 2.22,
-      // Bone Spikes are a DPS target-switch check, not a health sponge: 1.5x
-      // their normal pool (1,500 vs 1,000) so three spikes still shatter inside
-      // the impale drain window when the raid splits onto them.
-      nythraxis_bone_spike: 3.0,
+      // Bone Spikes are a DPS target-switch check, not a health sponge: the
+      // SAME 1,000 pool as normal (owner call, 2026-09-10; the redo shipped
+      // 1.5x at 1,500). Heroic already stacks one more victim per cast, a
+      // shorter cadence, a faster drain, and level-22 spikes the level-20 raid
+      // misses more often, so a bigger pool on top compounded into an
+      // overtuned check. The 2.0 mirrors the normal table's shared multiplier
+      // instead of falling through to the raid-wide 3.2x.
+      nythraxis_bone_spike: 2.0,
       // The boss alone: 192,000 on the 60,000 template (owner call after the
       // first playtest, 2026-09-04; the redo tried 230,000).
       nythraxis_scourge_of_thornpeak: 192_000 / 60_000,

--- a/src/sim/content/dungeons.ts
+++ b/src/sim/content/dungeons.ts
@@ -1202,9 +1202,12 @@ export const DUNGEON_MOBS: Record<string, MobTemplate> = {
   // Bone Spike: the stationary pillar Nythraxis impales a raider on
   // (src/sim/nythraxis_bone_spike.ts). It never moves, aggroes, or swings; the
   // impaled raider drains until the raid kills it, so its health IS the
-  // mechanic's timer (about four seconds of two DPS on normal after the arena's
-  // 2.0x, 1.5x that on heroic via healthMultiplierByMob). xpMult 0: shattering a
-  // spike is the counterplay, never a kill worth experience.
+  // mechanic's timer: 1,000 on both difficulties (normal through the arena's
+  // shared 2.0x, heroic through a per-mob 2.0 override that mirrors it), about
+  // four seconds of two DPS on normal and a little longer on heroic against
+  // the level-22 miss gap. Heroic scales the victim count, cadence, and drain
+  // instead of the pool. xpMult 0: shattering a spike is the counterplay,
+  // never a kill worth experience.
   nythraxis_bone_spike: {
     id: 'nythraxis_bone_spike',
     name: 'Bone Spike',

--- a/tests/nythraxis_bone_spike.test.ts
+++ b/tests/nythraxis_bone_spike.test.ts
@@ -4,6 +4,10 @@
 // their driver by hand and assert on entities, auras, events, and readouts.
 
 import { describe, expect, it } from 'vitest';
+import {
+  HEROIC_DUNGEON_TUNING,
+  NORMAL_DUNGEON_TUNING,
+} from '../src/sim/content/dungeon_difficulty';
 import * as nythraxis from '../src/sim/encounters/nythraxis';
 import {
   isNythraxisImpaled,
@@ -217,14 +221,25 @@ describe('Nythraxis Bone Spike', () => {
     expect(inst?.mobIds).not.toContain(spike.id);
   });
 
-  it('pins the spike health pool the tuning tables promise: 1000 normal, 1500 heroic', () => {
+  it('pins the spike health pool the tuning tables promise: 1000 on both difficulties', () => {
+    // Heroic spikes carry the NORMAL pool (owner call, 2026-09-10): heroic
+    // already pins one more raider, casts sooner, drains faster, and spawns at
+    // level 22, so a bigger pool compounded into an overtuned check.
     for (const difficulty of ['normal', 'heroic'] as const) {
       const { ctx, boss, st, room, spikes } = setup({ difficulty });
       nythraxis.castNythraxisBoneSpike(ctx, boss, st, room(), difficulty);
       const spike = spikes()[0];
-      expect(spike.maxHp, difficulty).toBe(difficulty === 'heroic' ? 1500 : 1000);
+      expect(spike.maxHp, difficulty).toBe(1000);
       expect(spike.hp, difficulty).toBe(spike.maxHp);
     }
+    // The heroic pool comes from an explicit per-mob override that mirrors the
+    // normal table's shared multiplier: a deleted override would fall through
+    // to the raid-wide 3.2x, so the literal is pinned beside the spawn check.
+    const heroicArena = HEROIC_DUNGEON_TUNING.nythraxis_boss_arena;
+    expect(heroicArena.healthMultiplierByMob?.nythraxis_bone_spike).toBe(
+      NORMAL_DUNGEON_TUNING.nythraxis_boss_arena.healthMultiplier,
+    );
+    expect(NORMAL_DUNGEON_TUNING.nythraxis_boss_arena.healthMultiplier).toBe(2.0);
   });
 
   it('frees a victim who dies impaled, so a resurrection never brings the pin back', () => {


### PR DESCRIPTION
## Summary

Heroic Nythraxis was overtuned on the Bone Spike mechanic. Heroic spikes spawned with 1,500 health (a 3.0x per-mob override on the 500 template) while normal spikes spawn with 1,000 (the shared 2.0x). That extra pool sat on top of every other heroic knob the mechanic already carries, and the combination was too much for a live raid:

| Knob | Normal | Heroic before | Heroic after |
|---|---|---|---|
| Spike health | 1,000 | 1,500 | **1,000** |
| Victims per cast | 2 | 3 | 3 |
| Total spike HP per wave | 2,000 | 4,500 | **3,000** |
| Cast cadence | every 24 s | every 20 s | every 20 s |
| Impale drain | 8% max HP / s | 10% max HP / s | 10% max HP / s |
| Spike level vs level-20 raiders | 20 | 22 | 22 |

This PR sets the heroic `nythraxis_bone_spike` entry in `healthMultiplierByMob` to 2.0 so both difficulties shatter a 1,000 health spike. Victim count, cadence, and drain are unchanged: heroic still asks the raid to split onto three spikes inside a shorter window, it just no longer asks for 1.5x the damage per spike while doing so. The level-22 spawn (and its miss/resist tax on a level-20 raid) is also unchanged.

The 2.0 is an explicit entry rather than a removed one because a missing entry would fall through to the raid-wide 3.2x (1,600), not to normal's 2.0.

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx vitest run tests/nythraxis_bone_spike.test.ts -t 'pins the spike health pool'` RED first against the 3.0 override (heroic 1500 vs expected 1000), GREEN after the change.
  - `npx vitest run tests/nythraxis_bone_spike.test.ts tests/nythraxis_bone_spike_model.test.ts tests/heroic_difficulty_floors.test.ts tests/raid_avoidable_damage_tuning.test.ts tests/nythraxis_spike_fire_rules.test.ts tests/gravewyrm_normal_tuning.test.ts` (6 files, 58 tests green).
  - `npx tsc --noEmit` clean; `npx @biomejs/biome check` on the three changed files clean.
  - `GATE_SELECT_BASE=origin/release/v0.42.1 node scripts/gate_select.mjs`: run on the first commit: 3,019 of 3,052 test files green; the 2 red files (`tests/ci_shard_partition.test.ts`, `tests/scripts_windows_paths.test.ts`) were 20 s timeouts in whole-tree filesystem walks while a reviewer agent ran vitest in the same worktree, and both pass in isolation. A second gate run on the final SHA follows as a comment.
- Manual steps: none (pure tuning-table change; no rng draw, tick order, wire, or UI change).

## Checklist

### Quality

- [x] **The gate passes.** `node scripts/gate_select.mjs` on the final SHA is reported in the first comment below (the first run is described above). The pin test in `tests/nythraxis_bone_spike.test.ts` now expects 1,000 on both difficulties.

### Cross-platform

- ~Tested on desktop and mobile.~ N/A, no UI change.
- ~Accessible.~ N/A, no UI change.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings. The Bone Spike guide prose and Impaled tooltip describe victims, cadence, and drain, none of which changed.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018zMxupj6T2xFvCN7FKNxrv
