### PR TITLE
fix(render): snap the self pose across teleports instead of gliding it

### DIFF
--- a/src/render/self_render_position_core.ts
+++ b/src/render/self_render_position_core.ts
@@ -6,6 +6,7 @@
 
 import type { Entity } from '../sim/types';
 import {
+  SELF_MOTION_SNAP_DIST_SQ,
   type SelfMotionFrame,
   SelfMotionPredictor,
   updateSelfRenderFallback,
@@ -27,6 +28,26 @@ function decayOffset(offset: Vec3Like, dt: number, maxDistance = Number.POSITIVE
   offset.x *= 1 - appliedShare;
   offset.y *= 1 - appliedShare;
   offset.z *= 1 - appliedShare;
+}
+
+/**
+ * The handoff-offset teleport rule. The offset exists to hide a SMALL gap
+ * between the drawn pose and the pose that takes over (a predictor lead, a
+ * reconcile correction), decayed so the camera glides instead of stepping.
+ * A gap no real motion could open in one frame is a teleport (dungeon exit,
+ * hearth, graveyard release, rift or delve exit, unstuck) and must never be
+ * glided: decaying it drew the body flying across the map. Same six-yard rule
+ * every other display smoother applies (self_motion.ts SELF_MOTION_SNAP_DIST_SQ,
+ * camera_boom_core.ts BOOM_SNAP_DIST, step_smooth_core.ts STEP_SMOOTH_SNAP).
+ */
+export function isTeleportGap(dx: number, dy: number, dz: number): boolean {
+  return dx * dx + dy * dy + dz * dz > SELF_MOTION_SNAP_DIST_SQ;
+}
+
+function clearOffset(offset: Vec3Like): void {
+  offset.x = 0;
+  offset.y = 0;
+  offset.z = 0;
 }
 
 export interface ReconciledSelfPrediction {
@@ -116,19 +137,31 @@ export function updateSelfRenderPosition(
       // remove). The only discontinuity is the handoff frame from the
       // lead-smoothing path below: capture that gap once as an offset and
       // decay it, so the camera glides instead of stepping.
-      if (authoritativeDiscontinuity) {
-        state.offset.x = 0;
-        state.offset.y = 0;
-        state.offset.z = 0;
+      // A teleport is not a handoff: when the new pose sits a teleport away
+      // from the drawn one (the predictor re-adopted a jumped anchor, or a
+      // v2 reconcile replayed onto a jumped acknowledgement), adopt it
+      // outright, residual included, exactly like an authoritative
+      // discontinuity.
+      const discontinuity =
+        authoritativeDiscontinuity ||
+        (state.ready &&
+          isTeleportGap(
+            state.position.x - predicted.x,
+            state.position.y - predicted.y,
+            state.position.z - predicted.z,
+          ));
+      if (discontinuity) {
+        clearOffset(state.offset);
       } else if (state.ready && !state.active) {
         state.offset.x = state.position.x - predicted.x;
         state.offset.y = state.position.y - predicted.y;
         state.offset.z = state.position.z - predicted.z;
       }
-      if (reconciled.kind === 'reconciled' && reconciled.residual) {
-        state.offset.x += reconciled.residual.x;
-        state.offset.y += reconciled.residual.y;
-        state.offset.z += reconciled.residual.z;
+      const residual = reconciled.kind === 'reconciled' ? reconciled.residual : null;
+      if (residual && !discontinuity && !isTeleportGap(residual.x, residual.y, residual.z)) {
+        state.offset.x += residual.x;
+        state.offset.y += residual.y;
+        state.offset.z += residual.z;
       }
       decayOffset(state.offset, dt);
       state.position.x = predicted.x + state.offset.x;
@@ -145,17 +178,23 @@ export function updateSelfRenderPosition(
   const px = p.prevPos.x + (p.pos.x - p.prevPos.x) * playerAlpha;
   const py = p.prevPos.y + (p.pos.y - p.prevPos.y) * playerAlpha;
   const pz = p.prevPos.z + (p.pos.z - p.prevPos.z) * playerAlpha;
-  if (authoritativeDiscontinuity) {
-    state.offset.x = 0;
-    state.offset.y = 0;
-    state.offset.z = 0;
+  // The same teleport rule as the predictor path: a handoff gap (prediction
+  // suspending on the teleport frame) or a mid-decay target jump of teleport
+  // size adopts the authoritative pose outright instead of rewinding toward
+  // it at MAX_SELF_REWIND_YD_PER_SEC.
+  const discontinuity =
+    authoritativeDiscontinuity ||
+    (state.ready &&
+      isTeleportGap(state.position.x - px, state.position.y - py, state.position.z - pz));
+  if (discontinuity) {
+    clearOffset(state.offset);
   } else if (state.ready && predictorWasActive) {
     state.offset.x = state.position.x - px;
     state.offset.y = state.position.y - py;
     state.offset.z = state.position.z - pz;
   }
   if (
-    !authoritativeDiscontinuity &&
+    !discontinuity &&
     (predictorWasActive || state.offset.x !== 0 || state.offset.y !== 0 || state.offset.z !== 0)
   ) {
     const previousX = state.position.x;
@@ -194,7 +233,7 @@ export function updateSelfRenderPosition(
     state.ready,
     dt,
     selfAlphaLead > 0,
-    authoritativeDiscontinuity,
+    discontinuity,
   );
   state.ready = true;
   return state.position;

--- a/src/render/self_render_position_core.ts
+++ b/src/render/self_render_position_core.ts
@@ -38,10 +38,37 @@ function decayOffset(offset: Vec3Like, dt: number, maxDistance = Number.POSITIVE
  * hearth, graveyard release, rift or delve exit, unstuck) and must never be
  * glided: decaying it drew the body flying across the map. Same six-yard rule
  * every other display smoother applies (self_motion.ts SELF_MOTION_SNAP_DIST_SQ,
- * camera_boom_core.ts BOOM_SNAP_DIST, step_smooth_core.ts STEP_SMOOTH_SNAP).
+ * camera_boom_core.ts BOOM_SNAP_DIST, step_smooth_core.ts STEP_SMOOTH_SNAP), and
+ * the same margin: the fastest plausible mover (23.1 yd/s, entity_reanchor.ts)
+ * over the main loop's 0.25 s frame clamp covers 5.8 yd, so one frame of real
+ * motion never trips it.
  */
 export function isTeleportGap(dx: number, dy: number, dz: number): boolean {
   return dx * dx + dy * dy + dz * dz > SELF_MOTION_SNAP_DIST_SQ;
+}
+
+/**
+ * Did the pose the display is anchored to jump a teleport this frame? Both
+ * paths draw `position = target + offset`, so `position - offset` is last
+ * frame's target and the gap to the new one is the AUTHORITATIVE jump alone.
+ * Measuring from the drawn pose instead would count the decaying offset too,
+ * and a legitimately accumulated offset (handoff plus a run of reconcile
+ * residuals) could then read as a teleport and pop.
+ */
+function targetJumpedTeleport(
+  state: SelfRenderPositionState,
+  tx: number,
+  ty: number,
+  tz: number,
+): boolean {
+  return (
+    state.ready &&
+    isTeleportGap(
+      state.position.x - state.offset.x - tx,
+      state.position.y - state.offset.y - ty,
+      state.position.z - state.offset.z - tz,
+    )
+  );
 }
 
 function clearOffset(offset: Vec3Like): void {
@@ -144,12 +171,7 @@ export function updateSelfRenderPosition(
       // discontinuity.
       const discontinuity =
         authoritativeDiscontinuity ||
-        (state.ready &&
-          isTeleportGap(
-            state.position.x - predicted.x,
-            state.position.y - predicted.y,
-            state.position.z - predicted.z,
-          ));
+        targetJumpedTeleport(state, predicted.x, predicted.y, predicted.z);
       if (discontinuity) {
         clearOffset(state.offset);
       } else if (state.ready && !state.active) {
@@ -182,10 +204,7 @@ export function updateSelfRenderPosition(
   // suspending on the teleport frame) or a mid-decay target jump of teleport
   // size adopts the authoritative pose outright instead of rewinding toward
   // it at MAX_SELF_REWIND_YD_PER_SEC.
-  const discontinuity =
-    authoritativeDiscontinuity ||
-    (state.ready &&
-      isTeleportGap(state.position.x - px, state.position.y - py, state.position.z - pz));
+  const discontinuity = authoritativeDiscontinuity || targetJumpedTeleport(state, px, py, pz);
   if (discontinuity) {
     clearOffset(state.offset);
   } else if (state.ready && predictorWasActive) {

--- a/src/render/self_render_position_core.ts
+++ b/src/render/self_render_position_core.ts
@@ -37,11 +37,11 @@ function decayOffset(offset: Vec3Like, dt: number, maxDistance = Number.POSITIVE
  * A gap no real motion could open in one frame is a teleport (dungeon exit,
  * hearth, graveyard release, rift or delve exit, unstuck) and must never be
  * glided: decaying it drew the body flying across the map. Same six-yard rule
- * every other display smoother applies (self_motion.ts SELF_MOTION_SNAP_DIST_SQ,
- * camera_boom_core.ts BOOM_SNAP_DIST, step_smooth_core.ts STEP_SMOOTH_SNAP), and
- * the same margin: the fastest plausible mover (23.1 yd/s, entity_reanchor.ts)
- * over the main loop's 0.25 s frame clamp covers 5.8 yd, so one frame of real
- * motion never trips it.
+ * the other whole-pose smoothers apply (self_motion.ts SELF_MOTION_SNAP_DIST_SQ,
+ * camera_boom_core.ts BOOM_SNAP_DIST; the step smoother's STEP_SMOOTH_SNAP is a
+ * separate, tighter vertical-only rule), and the same margin: the fastest
+ * plausible mover (23.1 yd/s, entity_reanchor.ts) over the main loop's 0.25 s
+ * frame clamp covers 5.8 yd, so one frame of real motion never trips it.
  */
 export function isTeleportGap(dx: number, dy: number, dz: number): boolean {
   return dx * dx + dy * dy + dz * dz > SELF_MOTION_SNAP_DIST_SQ;
@@ -50,10 +50,14 @@ export function isTeleportGap(dx: number, dy: number, dz: number): boolean {
 /**
  * Did the pose the display is anchored to jump a teleport this frame? Both
  * paths draw `position = target + offset`, so `position - offset` is last
- * frame's target and the gap to the new one is the AUTHORITATIVE jump alone.
- * Measuring from the drawn pose instead would count the decaying offset too,
- * and a legitimately accumulated offset (handoff plus a run of reconcile
- * residuals) could then read as a teleport and pop.
+ * frame's target on x and z, and the gap to the new one is the AUTHORITATIVE
+ * jump alone. Measuring from the drawn pose instead would count the decaying
+ * offset too, and a legitimately accumulated offset (handoff plus a run of
+ * reconcile residuals) could then read as a teleport and pop. Two small
+ * display terms do ride along in `position`: the renderer writes the step
+ * smoother's y back into it (bounded by STEP_SMOOTH_MAX_LAG), and on the plain
+ * fallback path it is the lead-smoothed pose; both stay well inside the margin
+ * above, so neither can turn real motion into a snap.
  */
 function targetJumpedTeleport(
   state: SelfRenderPositionState,

--- a/tests/self_pose_teleport_online.test.ts
+++ b/tests/self_pose_teleport_online.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// Postgres is mocked before the server/game import the harness pulls in
+// (tests/CLAUDE.md, Server tests). Superset shape, copied from
+// tests/unstuck_online.test.ts.
+vi.mock('../server/db', () => ({
+  pool: { query: vi.fn(async () => ({ rows: [] })) },
+  saveCharacterState: vi.fn(async () => {}),
+  saveCharacterAndMarketState: vi.fn(async () => {}),
+  saveMarketState: vi.fn(async () => {}),
+  saveMailState: vi.fn(async () => {}),
+  openPlaySession: vi.fn(async () => 1),
+  touchCharacterLogin: vi.fn(async () => {}),
+  closePlaySession: vi.fn(async () => {}),
+  insertChatLogs: vi.fn(async () => {}),
+  loadAccountFlair: vi.fn(async () => ({ ai: false, streamer: false, links: {} })),
+  walletForAccount: vi.fn(async () => null),
+  markAccountQuestComplete: vi.fn(async () => ({ completedQuestIds: [], mechChromaIds: [] })),
+  grantAccountMechChroma: vi.fn(async () => ({ completedQuestIds: [], mechChromaIds: [] })),
+  revokeAccountMechChroma: vi.fn(async () => ({ completedQuestIds: [], mechChromaIds: [] })),
+  acquireCharacterLease: vi.fn(async () => true),
+  releaseCharacterLease: vi.fn(async () => {}),
+  heartbeatCharacterLeases: vi.fn(async () => {}),
+  releaseAllCharacterLeases: vi.fn(async () => {}),
+}));
+
+import type { LatencyLinkConfig } from './helpers/latency_link';
+import { COLLIDER_FREE_LANE, teleportEntity } from './helpers/movement_ground_truth';
+import { createOnlineHarness, type FrameRecord } from './helpers/online_harness';
+
+// The real-path pin for the post-teleport flight: one real ClientWorld against
+// one real GameServer over the simulated link, the drawn pose coming out of the
+// same updateSelfRenderPosition call renderer.ts makes (tests/helpers/
+// online_harness.ts). The server moves the authoritative body a teleport away
+// mid-run, the way a dungeon exit, hearth, or graveyard release does; the
+// mirror snaps (entity_reanchor.ts) and prediction suspends on the override
+// epoch bump, which is exactly the handoff frame where the display used to
+// capture the whole jump as a decaying offset and draw the body flying the
+// distance. The pinned property: once the mirror has arrived, the drawn pose is
+// at the destination within a frame, and no frame ever draws a pose out in the
+// gap between departure and arrival.
+
+const TELEPORT_AT_MS = 1200;
+const RUN_MS = 2600;
+const TELEPORT_DZ = 400;
+// Drawn-pose tolerance at the destination: the predictor's own display lead
+// plus the wire's centimeter rounding, far below the six-yard snap rule.
+const ARRIVAL_TOLERANCE_YD = 3;
+
+function link(rttMs: number, jitterMs: number): LatencyLinkConfig {
+  return {
+    toServer: { baseMs: rttMs / 2, jitterMs, seed: 1337 },
+    toClient: { baseMs: rttMs / 2, jitterMs, seed: 4242 },
+  };
+}
+
+function runTeleportScenario(movementWire: 1 | 2): {
+  frames: FrameRecord[];
+  destinationZ: number;
+} {
+  const harness = createOnlineHarness({ latency: link(120, 10), movementWire });
+  try {
+    const seed = harness.server.sim.cfg.seed;
+    const destinationZ = COLLIDER_FREE_LANE.z + TELEPORT_DZ;
+    const run = harness.runScript({
+      durationMs: RUN_MS,
+      // Held forward the whole run: the predictor owns the pose when the
+      // teleport lands, which is the shape the bug needed.
+      script: [{ atMs: 0, mi: { forward: true }, facing: 0 }],
+      actions: [
+        {
+          atMs: TELEPORT_AT_MS,
+          run: () => {
+            teleportEntity(harness.serverEntity, COLLIDER_FREE_LANE.x, destinationZ, seed);
+            harness.server.sim.rebucket(harness.serverEntity);
+          },
+        },
+      ],
+    });
+    return { frames: run.frames, destinationZ };
+  } finally {
+    harness.dispose();
+  }
+}
+
+describe.each([2, 1] as const)('online self pose across a server teleport (wire v%i)', (wire) => {
+  it('arrives with the mirror in one frame and never draws the body in the gap', () => {
+    const { frames, destinationZ } = runTeleportScenario(wire);
+    const departureZ = COLLIDER_FREE_LANE.z;
+    const arrivalIndex = frames.findIndex(
+      (frame) => frame.tMs >= TELEPORT_AT_MS && Math.abs(frame.mirrorZ - destinationZ) < 1,
+    );
+    expect(arrivalIndex).toBeGreaterThan(0);
+    const gapLow = departureZ + 40;
+    const gapHigh = destinationZ - 40;
+    const flying = frames.filter((frame) => frame.z > gapLow && frame.z < gapHigh);
+    expect(flying.map((frame) => ({ tMs: frame.tMs, z: frame.z }))).toEqual([]);
+    // The frame the mirror lands (or the very next one) draws the destination.
+    const arrived = frames
+      .slice(arrivalIndex, arrivalIndex + 2)
+      .some((frame) => Math.abs(frame.z - frame.mirrorZ) <= ARRIVAL_TOLERANCE_YD);
+    expect(arrived).toBe(true);
+    // ...and it stays there: every later frame tracks the mirror.
+    for (const frame of frames.slice(arrivalIndex + 2)) {
+      expect(Math.abs(frame.z - frame.mirrorZ)).toBeLessThanOrEqual(ARRIVAL_TOLERANCE_YD);
+    }
+  });
+});

--- a/tests/self_pose_teleport_online.test.ts
+++ b/tests/self_pose_teleport_online.test.ts
@@ -39,6 +39,11 @@ import { createOnlineHarness, type FrameRecord } from './helpers/online_harness'
 // distance. The pinned property: once the mirror has arrived, the drawn pose is
 // at the destination within a frame, and no frame ever draws a pose out in the
 // gap between departure and arrival.
+//
+// Only the wire v2 arm is the regression pin (the base core fails it with eight
+// in-gap frames). On wire v1 the predictor stays active across the teleport and
+// re-seats itself, so the base core never captured an offset there; that arm is
+// kept as a guard that the rule stays inert on the path that never needed it.
 
 const TELEPORT_AT_MS = 1200;
 const RUN_MS = 2600;

--- a/tests/self_render_position_core.test.ts
+++ b/tests/self_render_position_core.test.ts
@@ -356,3 +356,151 @@ describe('updateSelfRenderPosition predictor path', () => {
     expect(state.predictor).toBe(built);
   });
 });
+
+describe('updateSelfRenderPosition teleport rule', () => {
+  // The self pose handoff (predictor to fallback, fallback to predictor, a v2
+  // reconcile residual) captures the gap between the drawn pose and the new
+  // target and decays it so the camera glides instead of stepping. A gap only a
+  // teleport could explain (dungeon exit, hearth, graveyard release, rift or
+  // delve exit) must NOT glide: gliding it drew the body flying across the map
+  // for a third of a second. Same six-yard rule every other display smoother
+  // uses (self_motion.ts, camera_boom_core.ts, step_smooth_core.ts).
+  const TELEPORT = Math.sqrt(SELF_MOTION_SNAP_DIST_SQ) * 100;
+  const runPredicted = (state: SelfRenderPositionState, player: Entity): Vec3Like =>
+    updateSelfRenderPosition(state, player, SEED, 1, FRAME_DT, 0.2, frame(), false);
+
+  it('snaps when the predictor re-adopts a teleported anchor instead of capturing the gap', () => {
+    const state = createSelfRenderPositionState();
+    const player = playerAt({ x: 10, y: 0, z: 0 }, { x: 10, y: 0, z: 0 });
+    updateSelfRenderPosition(state, player, SEED, 1, FRAME_DT, 0.2, null, false);
+    expect(state.position.x).toBe(10);
+    state.predictor = stubPredictor(() => ({ x: 10 + TELEPORT, y: 3, z: -TELEPORT }));
+    runPredicted(
+      state,
+      playerAt({ x: 10 + TELEPORT, y: 3, z: -TELEPORT }, { x: 10 + TELEPORT, y: 3, z: -TELEPORT }),
+    );
+    expect(state.offset).toEqual({ x: 0, y: 0, z: 0 });
+    expect(state.position).toEqual({ x: 10 + TELEPORT, y: 3, z: -TELEPORT });
+    expect(state.active).toBe(true);
+  });
+
+  it('snaps an active predictor whose output jumps a teleport in one frame', () => {
+    const state = createSelfRenderPositionState();
+    const player = playerAt({ x: 0, y: 0, z: 0 }, { x: 0, y: 0, z: 0 });
+    let predicted: Vec3Like = { x: 1, y: 0, z: 0 };
+    state.predictor = stubPredictor(() => predicted);
+    runPredicted(state, player);
+    predicted = { x: 1.2, y: 0, z: 0 };
+    runPredicted(state, player);
+    expect(state.position.x).toBeCloseTo(1.2, 10);
+    predicted = { x: TELEPORT, y: 0, z: 0 };
+    runPredicted(state, player);
+    expect(state.position.x).toBe(TELEPORT);
+    expect(state.offset).toEqual({ x: 0, y: 0, z: 0 });
+  });
+
+  it('drops a teleport-sized v2 reconcile residual instead of decaying it', () => {
+    const state = createSelfRenderPositionState();
+    const player = playerAt({ x: 0, y: 0, z: 0 }, { x: 0, y: 0, z: 0 });
+    updateSelfRenderPosition(
+      state,
+      player,
+      SEED,
+      1,
+      FRAME_DT,
+      0,
+      { kind: 'reconciled', position: { x: 0, y: 0, z: 0 }, residual: null },
+      false,
+    );
+    updateSelfRenderPosition(
+      state,
+      player,
+      SEED,
+      1,
+      FRAME_DT,
+      0,
+      {
+        kind: 'reconciled',
+        position: { x: TELEPORT, y: 2, z: 0 },
+        residual: { x: -TELEPORT, y: -2, z: 0 },
+      },
+      false,
+    );
+    expect(state.offset).toEqual({ x: 0, y: 0, z: 0 });
+    expect(state.position).toEqual({ x: TELEPORT, y: 2, z: 0 });
+  });
+
+  it('still glides a sub-threshold reconcile residual', () => {
+    const state = createSelfRenderPositionState();
+    const player = playerAt({ x: 0, y: 0, z: 0 }, { x: 0, y: 0, z: 0 });
+    const decay = Math.exp(-HANDOFF_RATE * FRAME_DT);
+    updateSelfRenderPosition(
+      state,
+      player,
+      SEED,
+      1,
+      FRAME_DT,
+      0,
+      { kind: 'reconciled', position: { x: 0, y: 0, z: 0 }, residual: null },
+      false,
+    );
+    updateSelfRenderPosition(
+      state,
+      player,
+      SEED,
+      1,
+      FRAME_DT,
+      0,
+      { kind: 'reconciled', position: { x: 2, y: 0, z: 0 }, residual: { x: -2, y: 0, z: 0 } },
+      false,
+    );
+    expect(state.position.x).toBeCloseTo(2 - 2 * decay, 10);
+  });
+
+  it('snaps the fallback handoff when the predictor drops out across a teleport', () => {
+    const state = createSelfRenderPositionState();
+    state.predictor = stubPredictor(() => ({ x: 5, y: 0, z: 5 }));
+    runPredicted(state, playerAt({ x: 5, y: 0, z: 5 }, { x: 5, y: 0, z: 5 }));
+    expect(state.active).toBe(true);
+    // Prediction suspends on the teleport frame (override epoch bump) while the
+    // authoritative segment already sits at the destination.
+    state.predictor = stubPredictor(() => null);
+    const far = { x: 5 + TELEPORT, y: 1, z: 5 };
+    runPredicted(state, playerAt(far, far));
+    expect(state.active).toBe(false);
+    expect(state.offset).toEqual({ x: 0, y: 0, z: 0 });
+    expect(state.position).toEqual(far);
+  });
+
+  it('snaps a mid-decay fallback pose when the authoritative segment teleports', () => {
+    const state = createSelfRenderPositionState();
+    const player = playerAt({ x: 0, y: 0, z: 0 }, { x: 0, y: 0, z: 0 });
+    updateSelfRenderPosition(
+      state,
+      player,
+      SEED,
+      1,
+      FRAME_DT,
+      0.2,
+      { kind: 'reconciled', position: { x: 1.4, y: 0, z: 0 }, residual: null },
+      false,
+    );
+    updateSelfRenderPosition(state, player, SEED, 1, FRAME_DT, 0.2, null, false);
+    expect(state.offset.x).toBeGreaterThan(0);
+    const far = { x: -TELEPORT, y: 0, z: 0 };
+    updateSelfRenderPosition(state, playerAt(far, far), SEED, 1, FRAME_DT, 0.2, null, false);
+    expect(state.offset).toEqual({ x: 0, y: 0, z: 0 });
+    expect(state.position).toEqual(far);
+  });
+
+  it('keeps gliding a handoff gap under the threshold', () => {
+    const state = createSelfRenderPositionState();
+    const player = playerAt({ x: 10, y: 0, z: 0 }, { x: 10, y: 0, z: 0 });
+    updateSelfRenderPosition(state, player, SEED, 1, FRAME_DT, 0.2, null, false);
+    state.predictor = stubPredictor(() => ({ x: 5, y: 0, z: 0 }));
+    const decay = Math.exp(-HANDOFF_RATE * FRAME_DT);
+    runPredicted(state, player);
+    expect(state.offset.x).toBeCloseTo(5 * decay, 10);
+    expect(state.position.x).toBeCloseTo(5 + 5 * decay, 10);
+  });
+});

--- a/tests/self_render_position_core.test.ts
+++ b/tests/self_render_position_core.test.ts
@@ -365,13 +365,14 @@ describe('updateSelfRenderPosition teleport rule', () => {
   // target and decays it so the camera glides instead of stepping. A gap only a
   // teleport could explain (dungeon exit, hearth, graveyard release, rift or
   // delve exit) must NOT glide: gliding it drew the body flying across the map
-  // for a third of a second. Same six-yard rule every other display smoother
-  // uses (self_motion.ts, camera_boom_core.ts, step_smooth_core.ts).
+  // for a third of a second. Same six-yard rule the other whole-pose smoothers
+  // use (self_motion.ts, camera_boom_core.ts; step_smooth_core.ts keeps its own
+  // tighter vertical-only rule).
   const TELEPORT = Math.sqrt(SELF_MOTION_SNAP_DIST_SQ) * 100;
   const runPredicted = (state: SelfRenderPositionState, player: Entity): Vec3Like =>
     updateSelfRenderPosition(state, player, SEED, 1, FRAME_DT, 0.2, frame(), false);
 
-  it('snaps when the predictor re-adopts a teleported anchor instead of capturing the gap', () => {
+  it('snaps the fallback-to-predictor handoff across a teleport instead of capturing the gap', () => {
     const state = createSelfRenderPositionState();
     const player = playerAt({ x: 10, y: 0, z: 0 }, { x: 10, y: 0, z: 0 });
     updateSelfRenderPosition(state, player, SEED, 1, FRAME_DT, 0.2, null, false);
@@ -405,8 +406,10 @@ describe('updateSelfRenderPosition teleport rule', () => {
     expect(state.position).toEqual({ x: TELEPORT, y: 0, z: 0 });
   });
 
-  it('snaps the plain fallback pose (no predictor ever active) across a teleport', () => {
+  it('keeps the inherited plain-fallback snap (no predictor ever active) across a teleport', () => {
     // The offline / prediction-off shape: no offset in flight, smoothing on.
+    // updateSelfRenderFallback already snapped here before the rule existed;
+    // pinned so the shared `discontinuity` flag can never regress that arm.
     const state = createSelfRenderPositionState();
     const player = playerAt({ x: 0, y: 0, z: 0 }, { x: 0, y: 0, z: 0 });
     updateSelfRenderPosition(state, player, SEED, 1, FRAME_DT, 0.2, null, false);

--- a/tests/self_render_position_core.test.ts
+++ b/tests/self_render_position_core.test.ts
@@ -6,6 +6,7 @@ import {
   MAX_SELF_REWIND_YD_PER_SEC,
   noteSelfIdentity,
   type SelfRenderPositionState,
+  type SelfRenderPrediction,
   selfSnapshotAlpha,
   updateSelfRenderPosition,
 } from '../src/render/self_render_position_core';
@@ -491,6 +492,41 @@ describe('updateSelfRenderPosition teleport rule', () => {
     updateSelfRenderPosition(state, playerAt(far, far), SEED, 1, FRAME_DT, 0.2, null, false);
     expect(state.offset).toEqual({ x: 0, y: 0, z: 0 });
     expect(state.position).toEqual(far);
+  });
+
+  it('never mistakes an accumulated sub-threshold offset for a teleport', () => {
+    // A run of reconcile residuals stacks the shared offset well past six
+    // yards while the predicted pose itself barely moves: the rule measures
+    // the AUTHORITATIVE jump (last target to new target), never the drawn pose,
+    // so the offset keeps decaying instead of popping to zero.
+    const state = createSelfRenderPositionState();
+    const player = playerAt({ x: 0, y: 0, z: 0 }, { x: 0, y: 0, z: 0 });
+    const reconciled = (x: number, residualX: number | null): SelfRenderPrediction => ({
+      kind: 'reconciled',
+      position: { x, y: 0, z: 0 },
+      residual: residualX === null ? null : { x: residualX, y: 0, z: 0 },
+    });
+    updateSelfRenderPosition(state, player, SEED, 1, FRAME_DT, 0, reconciled(0, null), false);
+    let previous = state.position.x;
+    let peakOffset = 0;
+    for (let frameIndex = 1; frameIndex <= 12; frameIndex++) {
+      // The head is corrected 2 yd back each frame; the drawn pose leads it.
+      updateSelfRenderPosition(
+        state,
+        player,
+        SEED,
+        1,
+        FRAME_DT,
+        0,
+        reconciled(-2 * frameIndex, 2),
+        false,
+      );
+      expect(state.offset.x).toBeGreaterThan(0);
+      expect(Math.abs(state.position.x - previous)).toBeLessThan(2);
+      previous = state.position.x;
+      peakOffset = Math.max(peakOffset, state.offset.x);
+    }
+    expect(peakOffset).toBeGreaterThan(Math.sqrt(SELF_MOTION_SNAP_DIST_SQ));
   });
 
   it('keeps gliding a handoff gap under the threshold', () => {

--- a/tests/self_render_position_core.test.ts
+++ b/tests/self_render_position_core.test.ts
@@ -3,6 +3,7 @@ import type { SelfMotionFrame, SelfMotionPredictor, Vec3Like } from '../src/rend
 import { SELF_MOTION_SNAP_DIST_SQ } from '../src/render/self_motion';
 import {
   createSelfRenderPositionState,
+  isTeleportGap,
   MAX_SELF_REWIND_YD_PER_SEC,
   noteSelfIdentity,
   type SelfRenderPositionState,
@@ -385,19 +386,62 @@ describe('updateSelfRenderPosition teleport rule', () => {
     expect(state.active).toBe(true);
   });
 
-  it('snaps an active predictor whose output jumps a teleport in one frame', () => {
+  it('clears a still-decaying handoff offset when the active predictor jumps a teleport', () => {
     const state = createSelfRenderPositionState();
-    const player = playerAt({ x: 0, y: 0, z: 0 }, { x: 0, y: 0, z: 0 });
-    let predicted: Vec3Like = { x: 1, y: 0, z: 0 };
+    const player = playerAt({ x: 10, y: 0, z: 0 }, { x: 10, y: 0, z: 0 });
+    updateSelfRenderPosition(state, player, SEED, 1, FRAME_DT, 0.2, null, false);
+    // Sub-threshold handoff: the predictor takes over two yards behind the
+    // drawn pose, so a real offset is in flight.
+    let predicted: Vec3Like = { x: 8, y: 0, z: 0 };
     state.predictor = stubPredictor(() => predicted);
     runPredicted(state, player);
-    predicted = { x: 1.2, y: 0, z: 0 };
-    runPredicted(state, player);
-    expect(state.position.x).toBeCloseTo(1.2, 10);
+    expect(state.offset.x).toBeGreaterThan(1);
+    expect(state.position.x).toBeGreaterThan(8);
+    // The predictor re-adopts a teleported anchor while that offset is still
+    // decaying: without the rule the stale offset rides along to the destination.
     predicted = { x: TELEPORT, y: 0, z: 0 };
     runPredicted(state, player);
-    expect(state.position.x).toBe(TELEPORT);
     expect(state.offset).toEqual({ x: 0, y: 0, z: 0 });
+    expect(state.position).toEqual({ x: TELEPORT, y: 0, z: 0 });
+  });
+
+  it('snaps the plain fallback pose (no predictor ever active) across a teleport', () => {
+    // The offline / prediction-off shape: no offset in flight, smoothing on.
+    const state = createSelfRenderPositionState();
+    const player = playerAt({ x: 0, y: 0, z: 0 }, { x: 0, y: 0, z: 0 });
+    updateSelfRenderPosition(state, player, SEED, 1, FRAME_DT, 0.2, null, false);
+    updateSelfRenderPosition(state, player, SEED, 1, FRAME_DT, 0.2, null, false);
+    const far = { x: TELEPORT, y: 5, z: -TELEPORT };
+    updateSelfRenderPosition(state, playerAt(far, far), SEED, 1, FRAME_DT, 0.2, null, false);
+    expect(state.position).toEqual(far);
+    expect(state.offset).toEqual({ x: 0, y: 0, z: 0 });
+  });
+
+  it('pins the six-yard boundary: just past it snaps, just inside it glides', () => {
+    const snapDist = Math.sqrt(SELF_MOTION_SNAP_DIST_SQ);
+    expect(snapDist).toBe(6);
+    expect(isTeleportGap(snapDist + 1e-6, 0, 0)).toBe(true);
+    expect(isTeleportGap(snapDist, 0, 0)).toBe(false);
+    expect(isTeleportGap(0, snapDist - 1e-6, 0)).toBe(false);
+    expect(isTeleportGap(3, 3, 4.5)).toBe(true);
+    const decay = Math.exp(-HANDOFF_RATE * FRAME_DT);
+    for (const [gap, snaps] of [
+      [snapDist + 0.01, true],
+      [snapDist - 0.01, false],
+    ] as const) {
+      const state = createSelfRenderPositionState();
+      const player = playerAt({ x: gap, y: 0, z: 0 }, { x: gap, y: 0, z: 0 });
+      updateSelfRenderPosition(state, player, SEED, 1, FRAME_DT, 0.2, null, false);
+      state.predictor = stubPredictor(() => ({ x: 0, y: 0, z: 0 }));
+      runPredicted(state, player);
+      if (snaps) {
+        expect(state.offset.x).toBe(0);
+        expect(state.position.x).toBe(0);
+      } else {
+        expect(state.offset.x).toBeCloseTo(gap * decay, 10);
+        expect(state.position.x).toBeCloseTo(gap * decay, 10);
+      }
+    }
   });
 
   it('drops a teleport-sized v2 reconcile residual instead of decaying it', () => {


### PR DESCRIPTION
## Summary

Leaving a dungeon (or any other teleport: hearth, graveyard release, rift or delve
exit, unstuck) sometimes drew the local player **flying across the map** for a
fraction of a second before landing at the destination. The teleport is now
instant on the client, with no new per-frame cost.

**Root cause.** The other whole-pose display smoothers on the client already
snap when a position jumps more than six yards (`SELF_MOTION_SNAP_DIST_SQ` in
`self_motion.ts`, `BOOM_SNAP_DIST` in `camera_boom_core.ts`; the step smoother's
`STEP_SMOOTH_SNAP` is a separate 2 yd vertical-only rule). The one exception was
the self display pose in
`src/render/self_render_position_core.ts` (`updateSelfRenderPosition`). When the
movement predictor hands over to the lead-smoothing fallback (or back), or a v2
reconcile returns a residual, it captures the gap between the drawn pose and the
pose that takes over and decays it so the camera glides instead of stepping. That
offset had no teleport rule, so on the teleport frame the gap was the whole
teleport: it decayed over about 0.3 s on the predictor path (a visible flight),
or rewound at `MAX_SELF_REWIND_YD_PER_SEC` on the fallback path, and the camera
boom followed the gliding pose frame by frame. Which path the teleport frame
landed in depended on prediction timing, hence "sometimes".

**Fix.** `isTeleportGap` applies the same six-yard rule to the handoff offset on
both paths and to reconcile residuals: a teleport-sized gap clears the offset and
adopts the authoritative pose outright, exactly like the existing authoritative
discontinuity (unstuck) branch. Sub-threshold handoffs and residuals keep gliding
as before. Cost is one squared-distance compare per frame, no allocation, no new
state.

## Related issues

Part of #3966.

## Type of change

- [x] Bug fix

## How was this tested?

- Commands:
  - `node scripts/gate_select.mjs` — green
  - `npx vitest run tests/self_render_position_core.test.ts tests/self_motion.test.ts tests/self_prediction.test.ts tests/self_motion_wiring.test.ts tests/self_prediction_core.test.ts` — green
  - `npx tsc --noEmit` — clean
  - `npx @biomejs/biome check --write` on the two changed files — clean
- Tests:
  - `tests/self_pose_teleport_online.test.ts` (new): the real-path regression on
    the online harness (one real `ClientWorld` against one real `GameServer` over
    the simulated link, both movement wires). The server teleports the
    authoritative body mid-run; the drawn pose must never land in the gap and must
    arrive with the mirror within a frame. The wire v2 arm is the regression pin:
    on the previous core it fails with eight in-gap frames (about 120 ms of
    visible flight). The v1 arm passes on both cores (the predictor re-seats
    itself there) and is kept as a guard that the rule stays inert on that path.
  - `tests/self_render_position_core.test.ts`: a new `teleport rule` block covers
    the predictor-handoff, reconcile-residual, fallback-handoff, mid-decay,
    still-decaying-offset, and plain no-predictor paths, pins the six-yard
    boundary on both sides, and pins that sub-threshold handoffs, residuals, and
    a legitimately accumulated offset keep gliding.
- Review: `qa-checklist`, `render-performance-reviewer`, and
  `frontend-seam-reviewer` were dispatched on the diff; their findings (measure
  the jump from the anchored target rather than the drawn pose, one vacuous test,
  the unpinned boundary and fallback arm, the missing real-path test) are all
  addressed in the follow-up commits.
- Manual steps: ran the full local stack (authoritative server against the dev
  Postgres plus the Vite client) from this worktree for in-game verification of
  dungeon exit and hearth teleports.

## Screenshots / recordings

N/A: no UI change; the fix removes a transient motion artifact.

---

## Checklist

### Quality

- [x] **The gate passes.** `node scripts/gate_select.mjs` is green. I added
      decisive tests for the changed behavior and recorded the manual checks above.

### Cross-platform

- ~Tested on desktop and mobile.~ No UI or layout change; the pure core runs
  identically on every host.
- ~Accessible.~ No UI added or edited.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
