### PR TITLE
fix(net): fix API calls (perf report, site presence, arena, BG) failing silently in electron client

### DIFF
--- a/src/game/perf_reporter.ts
+++ b/src/game/perf_reporter.ts
@@ -1,3 +1,4 @@
+import { apiUrl } from '../client_origin';
 import { graphicsPresetLabel } from '../render/gfx';
 import { isSoftwareRendererName } from '../render/software_renderer';
 import { crowdBucketLabel } from './crowd_bucket';
@@ -806,7 +807,7 @@ export function startPerfReporter(options: PerfReporterOptions): () => void {
         `final post too large for keepalive: ${status.lastBodyBytes} bytes`,
       );
     }
-    void fetch('/api/perf-report', {
+    void fetch(apiUrl('/api/perf-report'), {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/src/site_presence.ts
+++ b/src/site_presence.ts
@@ -1,3 +1,5 @@
+import { apiUrl } from './client_origin';
+
 const STORAGE_KEY = 'woc_site_visitor_id';
 const HEARTBEAT_MS = 45_000;
 
@@ -35,7 +37,7 @@ export function startSitePresence(fallbackPage = 'home'): void {
   const id = visitorId();
   const send = () => {
     if (document.visibilityState === 'hidden') return;
-    void fetch('/api/site-presence', {
+    void fetch(apiUrl('/api/site-presence'), {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ visitorId: id, page: pageName(fallbackPage) }),

--- a/src/ui/arena_window.ts
+++ b/src/ui/arena_window.ts
@@ -17,6 +17,7 @@
 // constants. The window redraws while open from hud.update()'s
 // mediumHud band, skipping the DOM rebuild when the content signature is unchanged.
 
+import { apiUrl } from '../client_origin';
 import { audio } from '../game/audio';
 import type { ArenaMapId } from '../sim/dungeon_layout';
 import { ARENA_MIN_LEVEL } from '../sim/social/arena';
@@ -187,7 +188,7 @@ export class ArenaWindow {
     const now = performance.now();
     if (now - (this.lbFetchedAt[format] ?? 0) < LEADERBOARD_REFETCH_MS) return;
     this.lbFetchedAt[format] = now;
-    fetch(`/api/arena/leaderboard?format=${encodeURIComponent(format)}`)
+    fetch(apiUrl(`/api/arena/leaderboard?format=${encodeURIComponent(format)}`))
       .then((r) => (r.ok ? r.json() : null))
       .then((d) => {
         if (d && Array.isArray(d.leaders)) {
@@ -204,7 +205,7 @@ export class ArenaWindow {
     const now = performance.now();
     if (now - this.bgLbFetchedAt < LEADERBOARD_REFETCH_MS) return;
     this.bgLbFetchedAt = now;
-    fetch('/api/battleground/leaderboard')
+    fetch(apiUrl('/api/battleground/leaderboard'))
       .then((r) => (r.ok ? r.json() : null))
       .then((d) => {
         if (d && Array.isArray(d.leaders)) {

--- a/tests/client_api_origin.test.ts
+++ b/tests/client_api_origin.test.ts
@@ -1,0 +1,90 @@
+// Guard: every client REST call resolves through `apiUrl()`, never a bare
+// root-relative '/api/...'.
+//
+// Why this is a guard and not a style note. The desktop shell serves the page
+// from `app://worldofclaudecraft` and its scheme handler falls back to
+// index.html for any path it does not recognise (electron/main.cjs). A bare
+// `fetch('/api/perf-report')` therefore resolved against THAT origin and came
+// back 200 with the homepage HTML, so the beacon never left the application.
+// `res.ok` was true, so the reporter counted a success and drained its retained
+// worst-10s window: the evidence was destroyed rather than retried, and no
+// desktop session had ever reached the perf telemetry (found 2026-09-12 on an
+// Electron 43 client, against a fleet whose Linux rows were therefore all
+// browsers). The same shape silently emptied the Arena and Battleground
+// all-time ladders in the client, where `r.json()` threw on the HTML into a
+// catch written for "offline or no server".
+//
+// `apiUrl()` (src/client_origin.ts) prefixes the configured origin in the shell
+// and returns the path unchanged in a browser, so the browser arm is untouched.
+//
+// src/admin is the one exemption, by rule rather than by oversight: the admin
+// dashboard is a separate entry served from the site origin itself, never from
+// app://, and src/admin/CLAUDE.md forbids any relative import resolving outside
+// that directory, so it cannot reach apiUrl at all.
+//
+// Known limit: the sweep matches the LITERAL shape, which is the shape that
+// shipped. A path assembled into a variable first is not caught; the pins below
+// cover the four call sites this was written for.
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { runtimeApiOrigin } from '../src/runtime';
+import { expectScansOnlyThroughSharedWalkers } from './helpers/scan_guard_self_audit';
+import { stripComments } from './helpers/strip_comments';
+import { tsFilesUnder } from './helpers/ts_files_under';
+
+const SRC_ROOT = fileURLToPath(new URL('../src', import.meta.url));
+
+/** The one exempt subtree, relative to SRC_ROOT. See the header. */
+const EXEMPT_DIR = 'admin/';
+
+/** `fetch()` handed a root-relative /api path directly, in any quote spelling. */
+const BARE_API_FETCH = /fetch\(\s*['"`]\/api\//;
+
+/** The call sites this guard was written for, each with the text it must carry. */
+const PINNED_CALLS: ReadonlyArray<readonly [string, string]> = [
+  ['game/perf_reporter.ts', "apiUrl('/api/perf-report')"],
+  ['site_presence.ts', "apiUrl('/api/site-presence')"],
+  ['ui/arena_window.ts', 'apiUrl(`/api/arena/leaderboard?format='],
+  ['ui/arena_window.ts', "apiUrl('/api/battleground/leaderboard')"],
+];
+
+/** The shell's real user agent, as the packaged client reports it. */
+const SHELL_USER_AGENT =
+  'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) world-of-claudecraft/0.42.2 Chrome/150.0.7871.212 Electron/43.3.0 Safari/537.36';
+const BROWSER_USER_AGENT =
+  'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/152.0.0.0 Safari/537.36';
+
+describe('client REST calls resolve through apiUrl', () => {
+  it('reads src through the shared walker, recursively', () => {
+    expectScansOnlyThroughSharedWalkers(import.meta.url, ['ts_files_under']);
+    const files = tsFilesUnder(SRC_ROOT).map((source) => source.file);
+    // src is genuinely deep, so the recursion is provable against the real
+    // tree: a single-level read would see neither of these.
+    expect(files).toContain('render/characters/halo.ts');
+    expect(files).toContain('sim/content/deeds.ts');
+    expect(files.length).toBeGreaterThan(2700);
+  });
+
+  it('has no bare root-relative /api fetch outside src/admin', () => {
+    const offenders = tsFilesUnder(SRC_ROOT)
+      .filter((source) => !source.file.startsWith(EXEMPT_DIR))
+      .filter((source) => BARE_API_FETCH.test(stripComments(readFileSync(source.full, 'utf8'))))
+      .map((source) => source.file);
+    expect(
+      offenders,
+      "a bare fetch('/api/...') resolves against app://worldofclaudecraft in the desktop shell and silently returns index.html: route it through apiUrl() from src/client_origin.ts",
+    ).toEqual([]);
+  });
+
+  it.each(PINNED_CALLS)('%s sends %s through apiUrl', (file, call) => {
+    expect(readFileSync(join(SRC_ROOT, file), 'utf8')).toContain(call);
+  });
+
+  it('resolves an absolute origin in the shell and stays relative in a browser', () => {
+    expect(runtimeApiOrigin(SHELL_USER_AGENT)).toBe('https://worldofclaudecraft.com');
+    expect(runtimeApiOrigin(BROWSER_USER_AGENT)).toBe('');
+  });
+});

--- a/tests/client_api_origin.test.ts
+++ b/tests/client_api_origin.test.ts
@@ -14,22 +14,34 @@
 // all-time ladders in the client, where `r.json()` threw on the HTML into a
 // catch written for "offline or no server".
 //
+// THE URL IS THE ONLY LINE OF DEFENCE, deliberately. A 200 carrying
+// `text/html` still counts as a delivered report in
+// src/game/perf_reporter.ts, and `r.ok ? r.json() : null` still absorbs one in
+// src/ui/arena_window.ts. Hardening those was considered and declined, so do
+// not read this guard as closing the silent-success class: it closes exactly
+// the misroute that triggered it.
+//
 // `apiUrl()` (src/client_origin.ts) prefixes the configured origin in the shell
-// and returns the path unchanged in a browser, so the browser arm is untouched.
+// and the native WebViews and returns the path unchanged in a browser, which is
+// what the resolution cases at the bottom pin, arm by arm.
 //
 // src/admin is the one exemption, by rule rather than by oversight: the admin
 // dashboard is a separate entry served from the site origin itself, never from
 // app://, and src/admin/CLAUDE.md forbids any relative import resolving outside
-// that directory, so it cannot reach apiUrl at all.
+// that directory, so it cannot reach apiUrl at all. The exemption is asserted
+// to still be load-bearing, so it has to be re-justified the day it stops being.
 //
 // Known limit: the sweep matches the LITERAL shape, which is the shape that
-// shipped. A path assembled into a variable first is not caught; the pins below
-// cover the four call sites this was written for.
+// shipped. A path assembled into a variable first is invisible to it, and has
+// two live instances: src/net/online.ts (`${this.base}/api/card`), correct
+// because `base` is already origin-resolved, and src/editor/net.ts, which is
+// genuinely bare but clean by REACHABILITY, editor.html having no link from the
+// game or the shell. Both would need a real defect to become one.
 
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { runtimeApiOrigin } from '../src/runtime';
 import { expectScansOnlyThroughSharedWalkers } from './helpers/scan_guard_self_audit';
 import { stripComments } from './helpers/strip_comments';
@@ -40,8 +52,14 @@ const SRC_ROOT = fileURLToPath(new URL('../src', import.meta.url));
 /** The one exempt subtree, relative to SRC_ROOT. See the header. */
 const EXEMPT_DIR = 'admin/';
 
-/** `fetch()` handed a root-relative /api path directly, in any quote spelling. */
-const BARE_API_FETCH = /fetch\(\s*['"`]\/api\//;
+/**
+ * A request minted straight onto a root-relative /api path, in any quote
+ * spelling. The whole request-mint family, not just `fetch`: `sendBeacon` is
+ * the idiomatic replacement for a page-hide beacon and would reintroduce this
+ * exact defect in this exact module. Trailing `(?![\w-])` so `/api?x=1` and
+ * `/api'` count too, while `/apiary/...` does not.
+ */
+const BARE_API_REQUEST = /(?:fetch|sendBeacon|EventSource|new Request)\(\s*['"`]\/api(?![\w-])/;
 
 /** The call sites this guard was written for, each with the text it must carry. */
 const PINNED_CALLS: ReadonlyArray<readonly [string, string]> = [
@@ -57,21 +75,72 @@ const SHELL_USER_AGENT =
 const BROWSER_USER_AGENT =
   'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/152.0.0.0 Safari/537.36';
 
+/**
+ * Every build flag the origin policy reads, blanked. Stubbed on EVERY arm
+ * rather than only where an arm needs a value: vitest populates
+ * `import.meta.env` through Vite's .env loading, and pointing
+ * VITE_DESKTOP_API_ORIGIN at a local server is a documented workflow, so an
+ * unstubbed arm would pass or fail depending on the developer's own .env.
+ */
+const BLANK_BUILD_ENV: Readonly<Record<string, string>> = {
+  VITE_DESKTOP_API_ORIGIN: '',
+  VITE_API_ORIGIN: '',
+  VITE_DESKTOP_RELATIVE_API: '',
+  VITE_DESKTOP_APP: '',
+  VITE_NATIVE_APP: '',
+};
+
+/**
+ * `apiUrl` as a given build and host would resolve it. Re-imported per arm
+ * because src/client_origin.ts captures DESKTOP_APP and DESKTOP_API_ORIGIN at
+ * module evaluation, so the navigator and the env must be in place first.
+ */
+async function apiUrlFor(
+  userAgent: string,
+  env: Readonly<Record<string, string>> = {},
+): Promise<(path: string, base?: string) => string> {
+  for (const [name, value] of Object.entries({ ...BLANK_BUILD_ENV, ...env })) {
+    vi.stubEnv(name, value);
+  }
+  vi.stubGlobal('navigator', { userAgent });
+  vi.resetModules();
+  return (await import('../src/client_origin')).apiUrl;
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+  vi.resetModules();
+});
+
 describe('client REST calls resolve through apiUrl', () => {
   it('reads src through the shared walker, recursively', () => {
     expectScansOnlyThroughSharedWalkers(import.meta.url, ['ts_files_under']);
     const files = tsFilesUnder(SRC_ROOT).map((source) => source.file);
     // src is genuinely deep, so the recursion is provable against the real
-    // tree: a single-level read would see neither of these.
+    // tree: a single-level read would see none of these. net/ is the third
+    // anchor on purpose, being the client REST layer this guard polices and
+    // the subtree the floor's slack would otherwise be wide enough to hide.
     expect(files).toContain('render/characters/halo.ts');
     expect(files).toContain('sim/content/deeds.ts');
-    expect(files.length).toBeGreaterThan(2700);
+    expect(files).toContain('net/online.ts');
+    expect(files.length).toBeGreaterThan(2800);
   });
 
-  it('has no bare root-relative /api fetch outside src/admin', () => {
+  it('matches the shape that shipped and not the fixed one', () => {
+    // The positive control. Without it the sweep below would pass vacuously
+    // forever the day the pattern is narrowed or mistyped.
+    expect(BARE_API_REQUEST.test("void fetch('/api/perf-report', { method: 'POST' })")).toBe(true);
+    expect(BARE_API_REQUEST.test('fetch(`/api/arena/leaderboard?format=${f}`)')).toBe(true);
+    expect(BARE_API_REQUEST.test("navigator.sendBeacon('/api/perf-report', body)")).toBe(true);
+    expect(BARE_API_REQUEST.test("fetch(apiUrl('/api/perf-report'))")).toBe(false);
+    expect(BARE_API_REQUEST.test("fetch('/apiary/bees')")).toBe(false);
+  });
+
+  it('has no bare root-relative /api request outside src/admin', () => {
     const offenders = tsFilesUnder(SRC_ROOT)
       .filter((source) => !source.file.startsWith(EXEMPT_DIR))
-      .filter((source) => BARE_API_FETCH.test(stripComments(readFileSync(source.full, 'utf8'))))
+      .filter((source) => BARE_API_REQUEST.test(stripComments(readFileSync(source.full, 'utf8'))))
       .map((source) => source.file);
     expect(
       offenders,
@@ -79,11 +148,73 @@ describe('client REST calls resolve through apiUrl', () => {
     ).toEqual([]);
   });
 
-  it.each(PINNED_CALLS)('%s sends %s through apiUrl', (file, call) => {
-    expect(readFileSync(join(SRC_ROOT, file), 'utf8')).toContain(call);
+  it('keeps the admin exemption load-bearing', () => {
+    const exempt = tsFilesUnder(SRC_ROOT)
+      .filter((source) => source.file.startsWith(EXEMPT_DIR))
+      .filter((source) => BARE_API_REQUEST.test(stripComments(readFileSync(source.full, 'utf8'))))
+      .map((source) => source.file);
+    expect(
+      exempt,
+      'the admin exemption no longer excuses anything: re-justify it against src/admin/CLAUDE.md or drop it',
+    ).toContain('admin/site_presence.ts');
   });
 
-  it('resolves an absolute origin in the shell and stays relative in a browser', () => {
+  it('pins every call site the fix touched', () => {
+    // Guards the it.each below against a row being quietly deleted, which
+    // would narrow the pin with no signal at all.
+    expect(PINNED_CALLS).toHaveLength(4);
+  });
+
+  it.each(PINNED_CALLS)('%s sends %s through apiUrl', (file, call) => {
+    // Through stripComments, or a stale comment quoting the fixed call would
+    // satisfy the pin over reverted code.
+    expect(stripComments(readFileSync(join(SRC_ROOT, file), 'utf8'))).toContain(call);
+  });
+});
+
+describe('apiUrl resolution per host', () => {
+  it('leaves a browser build relative', async () => {
+    const apiUrl = await apiUrlFor(BROWSER_USER_AGENT);
+    expect(apiUrl('/api/perf-report')).toBe('/api/perf-report');
+  });
+
+  it('resolves the packaged shell to the compiled-in production origin', async () => {
+    const apiUrl = await apiUrlFor(SHELL_USER_AGENT);
+    expect(apiUrl('/api/perf-report')).toBe('https://worldofclaudecraft.com/api/perf-report');
+  });
+
+  it('resolves the shell to a configured origin when the build sets one', async () => {
+    const apiUrl = await apiUrlFor(SHELL_USER_AGENT, {
+      VITE_DESKTOP_API_ORIGIN: 'http://127.0.0.1:9876',
+    });
+    expect(apiUrl('/api/site-presence')).toBe('http://127.0.0.1:9876/api/site-presence');
+  });
+
+  it('resolves a native WebView build to its configured API origin', async () => {
+    const apiUrl = await apiUrlFor(BROWSER_USER_AGENT, {
+      VITE_API_ORIGIN: 'https://api.example.test',
+    });
+    expect(apiUrl('/api/battleground/leaderboard')).toBe(
+      'https://api.example.test/api/battleground/leaderboard',
+    );
+  });
+
+  it('prefers the native origin over the desktop one', async () => {
+    const apiUrl = await apiUrlFor(SHELL_USER_AGENT, {
+      VITE_API_ORIGIN: 'https://api.example.test',
+    });
+    expect(apiUrl('/api/perf-report')).toBe('https://api.example.test/api/perf-report');
+  });
+
+  it('stays relative in an electron dev run', async () => {
+    const apiUrl = await apiUrlFor(SHELL_USER_AGENT, { VITE_DESKTOP_RELATIVE_API: '1' });
+    expect(apiUrl('/api/perf-report')).toBe('/api/perf-report');
+  });
+
+  it('resolves the origin from the user agent, not from the call site', () => {
+    // src/runtime.ts's own contract, which tests/runtime.test.ts does not
+    // cover. One level above apiUrl: it decides WHETHER to prefix, never where.
+    for (const [name, value] of Object.entries(BLANK_BUILD_ENV)) vi.stubEnv(name, value);
     expect(runtimeApiOrigin(SHELL_USER_AGENT)).toBe('https://worldofclaudecraft.com');
     expect(runtimeApiOrigin(BROWSER_USER_AGENT)).toBe('');
   });

--- a/tests/perf_reporter.test.ts
+++ b/tests/perf_reporter.test.ts
@@ -1544,6 +1544,13 @@ describe('perf reporter worst-window drain', () => {
       expect(fetchImpl).not.toHaveBeenCalled();
       await vi.advanceTimersByTimeAsync(1);
       expect(fetchImpl).toHaveBeenCalledTimes(1);
+      // The URL, not only the count and the body: this harness drives the real
+      // startPerfReporter, and the beacon posting to the wrong origin is what
+      // kept every desktop session out of the fleet (tests/client_api_origin.test.ts).
+      expect(fetchImpl).toHaveBeenCalledWith(
+        '/api/perf-report',
+        expect.objectContaining({ method: 'POST' }),
+      );
       await Promise.resolve();
       await Promise.resolve();
     } finally {


### PR DESCRIPTION
## Summary

In the desktop client, four REST calls never reached the server. They were written as bare
root-relative paths, so they resolved against the shell's own origin,
`app://worldofclaudecraft`, whose scheme handler answers any path it does not recognise with
`index.html` (`electron/main.cjs`). Each call came back `200 OK` with `text/html` and the
homepage markup.

Three consequences, in order of how long they went unnoticed:

- **The client perf beacon never arrived.** `POST /api/perf-report` got the 200, so `res.ok`
  was true: the reporter counted a success, then called `perf.drainWorstWindow()` and
  committed the prewarm-list fingerprint. The retained worst-10s window was discarded rather
  than retried. No desktop session has ever reached the perf telemetry, on any platform, so
  every client performance number we have describes browsers only.
- **The Arena and Battleground all-time ladders are empty in the client.** `r.ok` passes,
  then `r.json()` throws on the HTML, into a `catch` written for "offline or no server". A
  desktop player sees a blank ladder and no error.
- **Desktop players are never counted in site presence.** The `/api/site-presence` heartbeat
  lands on the same fallback every 45 seconds.

The rest of the client already routes through `apiUrl()` (`src/client_origin.ts`), which
prefixes the configured origin in the shell and returns the path unchanged in a browser.
These four call sites had simply been missed, so the browser arm is unaffected by the fix.

**The Capacitor android and ios shells are fixed by the same change**, which is worth
claiming rather than discovering later. They serve the page from `capacitor://localhost` or
`http://localhost`, so these four calls never reached the server there either; they now
resolve against `VITE_API_ORIGIN`, which `apiUrl` prefers over the desktop origin. Those
origins are already in `NATIVE_APP_ORIGINS` (`server/web_login_guard.ts`), so CORS covers
them too. Every other host is byte-identical, and the argument does not need a case list: on
any page served from an `http(s)` origin in a build that is neither native nor desktop, both
origin constants are empty and `apiUrl` is the identity function.

## What to expect after merge

Two readings change, neither of them a code defect, both easy to misinterpret on first sight:

- **The new desktop perf rows arrive labelled `chrome`.** `browserFamily()` in
  `src/game/perf_reporter.ts` matches `chrome/` first and the shell's user agent contains it,
  so the desktop population is not separable from browser Chrome in the fleet readouts. The
  gap existed before; it was simply inert while the desktop count was zero.
- **A new `index-html` bucket appears in site presence.** In the shell `location.pathname` is
  `/index.html`, so `pageName()` returns `index.html` and the server normalizes the dot to a
  dash. Nothing errors, the label passes validation, but it sits beside `home` and `play` as
  a new value.

Observed on a packaged Linux client at 0.42.2 (Electron 43): request URL
`app://worldofclaudecraft/api/perf-report`, method POST, status 200, `Content-Type:
text/html`, body `<!DOCTYPE html>`. The shell's own CSP already allows `connect-src`
to `https://worldofclaudecraft.com`, so no CSP change is needed.

`src/admin/site_presence.ts` keeps its relative path on purpose: the admin dashboard is a
separate entry served from the site origin, never from `app://`, and `src/admin/CLAUDE.md`
forbids a relative import resolving outside that directory, so it cannot reach `apiUrl` at
all. The new guard exempts exactly that subtree and records why.

The cross-origin POST works by construction and was checked, not assumed:
`app://worldofclaudecraft` is in `DESKTOP_APP_ORIGINS` (`server/web_login_guard.ts`), and
`maybeCors` answers the preflight with the reflected origin plus
`Access-Control-Allow-Headers: Authorization, Content-Type`, which is what a JSON POST
carrying a bearer needs.

## Known, and deliberately left alone

Two things a review raised that this PR does not change, recorded so the decision is visible
rather than implicit:

- **None of the four calls passes a `base`,** so on desktop they resolve to the configured
  main origin rather than the realm the player selected (`src/net/online.ts` threads
  `this.base` for its own calls). That is on purpose here: in a browser these four have
  always resolved against the PAGE origin, not the realm, and the main origin is the
  desktop equivalent of the page origin. Threading `base` would change the browser arm as
  well, which is a separate decision about where a beacon and a ladder should be read
  from, not part of restoring a call that never left the app.
- **`public/privacy.html` names neither a persistent visitor identifier nor the desktop
  client.** `src/site_presence.ts` sends a stable `localStorage` visitor id that
  `src/attribution.ts` later joins to a created account. The browser client has always sent
  it; this PR means the desktop installed base is counted too. No code change is proposed,
  but the policy text deserves a maintainer read before this ships.

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx tsc --noEmit`
  - `npx vitest run tests/client_api_origin.test.ts` (the new guard)
  - `npx vitest run tests/perf_reporter.test.ts tests/arena_window.test.ts
    tests/arena_window_view.test.ts tests/architecture.test.ts tests/homepage_foundation.test.ts`
  - `GATE_SELECT_BASE=upstream/release/v0.43.0 node scripts/gate_select.mjs`
- Manual steps:
  - Read the request in the packaged client's DevTools Network panel and confirmed the
    200 / `text/html` / homepage-body response quoted above.
  - **Confirmed fixed end to end on a packaged desktop client built from this branch.** The
    same request now reads:

    ```
    Request URL   https://worldofclaudecraft.com/api/perf-report
    Status        200 OK
    Content-Type  application/json        (11 bytes: {"ok":true})
    ```

    with the preflight answered as expected, `Access-Control-Allow-Origin:
    app://worldofclaudecraft` and `Access-Control-Allow-Headers: Authorization,
    Content-Type`. Two reports from that session then arrived in the fleet telemetry
    carrying `gl_backend = vulkan`, which are the first desktop rows the perf pipeline has
    ever received. This is the arm no Node test can reach: it needs the real custom scheme,
    the real CSP, and a real cross-origin preflight.
  - Checked the guard is decisive rather than decorative, twice. Reverting the perf-report
    call site to its bare path turns both the sweep and its pin red, naming
    `game/perf_reporter.ts`. Dropping `DESKTOP_API_ORIGIN` from the resolution chain in
    `src/client_origin.ts` turns exactly the two shell arms red, which is the regression a
    source-text pin alone would have let through.

One narrow arm stays unverified. The scheduled posts are confirmed above, and with them the
preflight (`Access-Control-Max-Age: 600` keeps it warm between the 5-minute reports). The
reporter's FINAL post at pagehide is the exception: both beacons send JSON with a bearer, so
they are non-simple requests that need a preflight cross-origin where same-origin they
needed none, and a session ending inside its first report interval pays that preflight
during document teardown with a cold cache. Worth one look after merge; it can only lose a
row from a very short session, which today loses every row anyway.

`tests/client_api_origin.test.ts` has two halves. The sweep is the repo-wide net: through
the shared walker (`helpers/ts_files_under` plus `expectScansOnlyThroughSharedWalkers`) it
looks for any request minted straight onto a root-relative `/api` path, across the whole
mint family rather than `fetch` alone, since `sendBeacon` is the idiomatic page-hide
replacement and would reintroduce this defect in this module. It carries a positive control,
so a narrowed regex fails instead of passing over nothing, and it pins the four call sites
through `stripComments`, so a stale comment quoting the fixed call cannot satisfy one.

The resolution cases are the decisive half: `apiUrl` is re-imported per arm and asserted
over six hosts (browser, packaged shell, shell with a configured origin, native WebView,
native winning over desktop, and the electron dev run), with every build flag the policy
reads stubbed on every arm so a developer `.env` cannot decide the verdict. Without them a
regression inside `apiUrl` would re-ship the original 200-HTML outcome with the guard green.

The file classifies as `partial` visibility, so the selective gate always runs it rather than
selecting it from a diff.

## Screenshots / recordings

N/A. Nothing changes in layout or appearance. The Arena and Battleground windows render
exactly as before; they now receive the ladder data they were already asking for.

## Checklist

### Quality

- [x] **The gate passes.** `node scripts/gate_select.mjs` is green, with a decisive new
      guard test and the manual check recorded above.

### Cross-platform

- [x] N/A. No UI is added or edited: the change is the origin a `fetch` resolves against.
- [x] N/A for accessibility, same reason.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled
      in any production path.
- [x] No generated file was hand-edited.