### PR TITLE
fix(render): fix monument impostor shader error

### DIFF
--- a/docs/screenshots/eastbrook-vale-rebuild/polish/metadata/after-desktop-ultra.json
+++ b/docs/screenshots/eastbrook-vale-rebuild/polish/metadata/after-desktop-ultra.json
@@ -11,7 +11,7 @@
     "mode": "composite-sha256",
     "algorithm": "sha256",
     "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-    "fingerprint": "5ae21044dd1b636f9c293ec628a7d316f740bb92a5962f848c6e58c80218ebbc",
+    "fingerprint": "9bac21494e4596b381a7e17363997ad5abee62078a7bb2b7ae63685100212d15",
     "components": {
       "townAsset": {
         "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -23,7 +23,7 @@
       },
       "civicShader": {
         "path": "src/render/realm_builder_monument_fx.ts",
-        "sha256": "d8db29ba7f4f433f645306fe732aeb3d59e8e7f81ce2e824a34b94042b0e3a2f"
+        "sha256": "58495d4a7dbc0a476302f17c652cf50a27fea3c8f08efa091477ba7be9314019"
       },
       "runtimeRender": {
         "town": {
@@ -89,7 +89,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5ae21044dd1b636f9c293ec628a7d316f740bb92a5962f848c6e58c80218ebbc",
+        "fingerprint": "9bac21494e4596b381a7e17363997ad5abee62078a7bb2b7ae63685100212d15",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -101,7 +101,7 @@
           },
           "civicShader": {
             "path": "src/render/realm_builder_monument_fx.ts",
-            "sha256": "d8db29ba7f4f433f645306fe732aeb3d59e8e7f81ce2e824a34b94042b0e3a2f"
+            "sha256": "58495d4a7dbc0a476302f17c652cf50a27fea3c8f08efa091477ba7be9314019"
           },
           "runtimeRender": {
             "town": {
@@ -1385,7 +1385,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5ae21044dd1b636f9c293ec628a7d316f740bb92a5962f848c6e58c80218ebbc",
+        "fingerprint": "9bac21494e4596b381a7e17363997ad5abee62078a7bb2b7ae63685100212d15",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -1397,7 +1397,7 @@
           },
           "civicShader": {
             "path": "src/render/realm_builder_monument_fx.ts",
-            "sha256": "d8db29ba7f4f433f645306fe732aeb3d59e8e7f81ce2e824a34b94042b0e3a2f"
+            "sha256": "58495d4a7dbc0a476302f17c652cf50a27fea3c8f08efa091477ba7be9314019"
           },
           "runtimeRender": {
             "town": {
@@ -2681,7 +2681,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5ae21044dd1b636f9c293ec628a7d316f740bb92a5962f848c6e58c80218ebbc",
+        "fingerprint": "9bac21494e4596b381a7e17363997ad5abee62078a7bb2b7ae63685100212d15",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -2693,7 +2693,7 @@
           },
           "civicShader": {
             "path": "src/render/realm_builder_monument_fx.ts",
-            "sha256": "d8db29ba7f4f433f645306fe732aeb3d59e8e7f81ce2e824a34b94042b0e3a2f"
+            "sha256": "58495d4a7dbc0a476302f17c652cf50a27fea3c8f08efa091477ba7be9314019"
           },
           "runtimeRender": {
             "town": {
@@ -3977,7 +3977,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5ae21044dd1b636f9c293ec628a7d316f740bb92a5962f848c6e58c80218ebbc",
+        "fingerprint": "9bac21494e4596b381a7e17363997ad5abee62078a7bb2b7ae63685100212d15",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -3989,7 +3989,7 @@
           },
           "civicShader": {
             "path": "src/render/realm_builder_monument_fx.ts",
-            "sha256": "d8db29ba7f4f433f645306fe732aeb3d59e8e7f81ce2e824a34b94042b0e3a2f"
+            "sha256": "58495d4a7dbc0a476302f17c652cf50a27fea3c8f08efa091477ba7be9314019"
           },
           "runtimeRender": {
             "town": {
@@ -5273,7 +5273,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5ae21044dd1b636f9c293ec628a7d316f740bb92a5962f848c6e58c80218ebbc",
+        "fingerprint": "9bac21494e4596b381a7e17363997ad5abee62078a7bb2b7ae63685100212d15",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -5285,7 +5285,7 @@
           },
           "civicShader": {
             "path": "src/render/realm_builder_monument_fx.ts",
-            "sha256": "d8db29ba7f4f433f645306fe732aeb3d59e8e7f81ce2e824a34b94042b0e3a2f"
+            "sha256": "58495d4a7dbc0a476302f17c652cf50a27fea3c8f08efa091477ba7be9314019"
           },
           "runtimeRender": {
             "town": {
@@ -6569,7 +6569,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5ae21044dd1b636f9c293ec628a7d316f740bb92a5962f848c6e58c80218ebbc",
+        "fingerprint": "9bac21494e4596b381a7e17363997ad5abee62078a7bb2b7ae63685100212d15",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -6581,7 +6581,7 @@
           },
           "civicShader": {
             "path": "src/render/realm_builder_monument_fx.ts",
-            "sha256": "d8db29ba7f4f433f645306fe732aeb3d59e8e7f81ce2e824a34b94042b0e3a2f"
+            "sha256": "58495d4a7dbc0a476302f17c652cf50a27fea3c8f08efa091477ba7be9314019"
           },
           "runtimeRender": {
             "town": {
@@ -7865,7 +7865,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5ae21044dd1b636f9c293ec628a7d316f740bb92a5962f848c6e58c80218ebbc",
+        "fingerprint": "9bac21494e4596b381a7e17363997ad5abee62078a7bb2b7ae63685100212d15",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -7877,7 +7877,7 @@
           },
           "civicShader": {
             "path": "src/render/realm_builder_monument_fx.ts",
-            "sha256": "d8db29ba7f4f433f645306fe732aeb3d59e8e7f81ce2e824a34b94042b0e3a2f"
+            "sha256": "58495d4a7dbc0a476302f17c652cf50a27fea3c8f08efa091477ba7be9314019"
           },
           "runtimeRender": {
             "town": {
@@ -9161,7 +9161,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5ae21044dd1b636f9c293ec628a7d316f740bb92a5962f848c6e58c80218ebbc",
+        "fingerprint": "9bac21494e4596b381a7e17363997ad5abee62078a7bb2b7ae63685100212d15",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -9173,7 +9173,7 @@
           },
           "civicShader": {
             "path": "src/render/realm_builder_monument_fx.ts",
-            "sha256": "d8db29ba7f4f433f645306fe732aeb3d59e8e7f81ce2e824a34b94042b0e3a2f"
+            "sha256": "58495d4a7dbc0a476302f17c652cf50a27fea3c8f08efa091477ba7be9314019"
           },
           "runtimeRender": {
             "town": {
@@ -10457,7 +10457,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5ae21044dd1b636f9c293ec628a7d316f740bb92a5962f848c6e58c80218ebbc",
+        "fingerprint": "9bac21494e4596b381a7e17363997ad5abee62078a7bb2b7ae63685100212d15",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -10469,7 +10469,7 @@
           },
           "civicShader": {
             "path": "src/render/realm_builder_monument_fx.ts",
-            "sha256": "d8db29ba7f4f433f645306fe732aeb3d59e8e7f81ce2e824a34b94042b0e3a2f"
+            "sha256": "58495d4a7dbc0a476302f17c652cf50a27fea3c8f08efa091477ba7be9314019"
           },
           "runtimeRender": {
             "town": {
@@ -11753,7 +11753,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5ae21044dd1b636f9c293ec628a7d316f740bb92a5962f848c6e58c80218ebbc",
+        "fingerprint": "9bac21494e4596b381a7e17363997ad5abee62078a7bb2b7ae63685100212d15",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -11765,7 +11765,7 @@
           },
           "civicShader": {
             "path": "src/render/realm_builder_monument_fx.ts",
-            "sha256": "d8db29ba7f4f433f645306fe732aeb3d59e8e7f81ce2e824a34b94042b0e3a2f"
+            "sha256": "58495d4a7dbc0a476302f17c652cf50a27fea3c8f08efa091477ba7be9314019"
           },
           "runtimeRender": {
             "town": {
@@ -13049,7 +13049,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5ae21044dd1b636f9c293ec628a7d316f740bb92a5962f848c6e58c80218ebbc",
+        "fingerprint": "9bac21494e4596b381a7e17363997ad5abee62078a7bb2b7ae63685100212d15",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -13061,7 +13061,7 @@
           },
           "civicShader": {
             "path": "src/render/realm_builder_monument_fx.ts",
-            "sha256": "d8db29ba7f4f433f645306fe732aeb3d59e8e7f81ce2e824a34b94042b0e3a2f"
+            "sha256": "58495d4a7dbc0a476302f17c652cf50a27fea3c8f08efa091477ba7be9314019"
           },
           "runtimeRender": {
             "town": {
@@ -14345,7 +14345,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5ae21044dd1b636f9c293ec628a7d316f740bb92a5962f848c6e58c80218ebbc",
+        "fingerprint": "9bac21494e4596b381a7e17363997ad5abee62078a7bb2b7ae63685100212d15",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -14357,7 +14357,7 @@
           },
           "civicShader": {
             "path": "src/render/realm_builder_monument_fx.ts",
-            "sha256": "d8db29ba7f4f433f645306fe732aeb3d59e8e7f81ce2e824a34b94042b0e3a2f"
+            "sha256": "58495d4a7dbc0a476302f17c652cf50a27fea3c8f08efa091477ba7be9314019"
           },
           "runtimeRender": {
             "town": {
@@ -15641,7 +15641,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5ae21044dd1b636f9c293ec628a7d316f740bb92a5962f848c6e58c80218ebbc",
+        "fingerprint": "9bac21494e4596b381a7e17363997ad5abee62078a7bb2b7ae63685100212d15",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -15653,7 +15653,7 @@
           },
           "civicShader": {
             "path": "src/render/realm_builder_monument_fx.ts",
-            "sha256": "d8db29ba7f4f433f645306fe732aeb3d59e8e7f81ce2e824a34b94042b0e3a2f"
+            "sha256": "58495d4a7dbc0a476302f17c652cf50a27fea3c8f08efa091477ba7be9314019"
           },
           "runtimeRender": {
             "town": {
@@ -16937,7 +16937,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5ae21044dd1b636f9c293ec628a7d316f740bb92a5962f848c6e58c80218ebbc",
+        "fingerprint": "9bac21494e4596b381a7e17363997ad5abee62078a7bb2b7ae63685100212d15",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -16949,7 +16949,7 @@
           },
           "civicShader": {
             "path": "src/render/realm_builder_monument_fx.ts",
-            "sha256": "d8db29ba7f4f433f645306fe732aeb3d59e8e7f81ce2e824a34b94042b0e3a2f"
+            "sha256": "58495d4a7dbc0a476302f17c652cf50a27fea3c8f08efa091477ba7be9314019"
           },
           "runtimeRender": {
             "town": {
@@ -19198,7 +19198,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5ae21044dd1b636f9c293ec628a7d316f740bb92a5962f848c6e58c80218ebbc",
+        "fingerprint": "9bac21494e4596b381a7e17363997ad5abee62078a7bb2b7ae63685100212d15",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -19210,7 +19210,7 @@
           },
           "civicShader": {
             "path": "src/render/realm_builder_monument_fx.ts",
-            "sha256": "d8db29ba7f4f433f645306fe732aeb3d59e8e7f81ce2e824a34b94042b0e3a2f"
+            "sha256": "58495d4a7dbc0a476302f17c652cf50a27fea3c8f08efa091477ba7be9314019"
           },
           "runtimeRender": {
             "town": {
@@ -20494,7 +20494,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5ae21044dd1b636f9c293ec628a7d316f740bb92a5962f848c6e58c80218ebbc",
+        "fingerprint": "9bac21494e4596b381a7e17363997ad5abee62078a7bb2b7ae63685100212d15",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -20506,7 +20506,7 @@
           },
           "civicShader": {
             "path": "src/render/realm_builder_monument_fx.ts",
-            "sha256": "d8db29ba7f4f433f645306fe732aeb3d59e8e7f81ce2e824a34b94042b0e3a2f"
+            "sha256": "58495d4a7dbc0a476302f17c652cf50a27fea3c8f08efa091477ba7be9314019"
           },
           "runtimeRender": {
             "town": {
@@ -21790,7 +21790,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5ae21044dd1b636f9c293ec628a7d316f740bb92a5962f848c6e58c80218ebbc",
+        "fingerprint": "9bac21494e4596b381a7e17363997ad5abee62078a7bb2b7ae63685100212d15",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -21802,7 +21802,7 @@
           },
           "civicShader": {
             "path": "src/render/realm_builder_monument_fx.ts",
-            "sha256": "d8db29ba7f4f433f645306fe732aeb3d59e8e7f81ce2e824a34b94042b0e3a2f"
+            "sha256": "58495d4a7dbc0a476302f17c652cf50a27fea3c8f08efa091477ba7be9314019"
           },
           "runtimeRender": {
             "town": {
@@ -23086,7 +23086,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5ae21044dd1b636f9c293ec628a7d316f740bb92a5962f848c6e58c80218ebbc",
+        "fingerprint": "9bac21494e4596b381a7e17363997ad5abee62078a7bb2b7ae63685100212d15",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -23098,7 +23098,7 @@
           },
           "civicShader": {
             "path": "src/render/realm_builder_monument_fx.ts",
-            "sha256": "d8db29ba7f4f433f645306fe732aeb3d59e8e7f81ce2e824a34b94042b0e3a2f"
+            "sha256": "58495d4a7dbc0a476302f17c652cf50a27fea3c8f08efa091477ba7be9314019"
           },
           "runtimeRender": {
             "town": {
@@ -24382,7 +24382,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5ae21044dd1b636f9c293ec628a7d316f740bb92a5962f848c6e58c80218ebbc",
+        "fingerprint": "9bac21494e4596b381a7e17363997ad5abee62078a7bb2b7ae63685100212d15",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -24394,7 +24394,7 @@
           },
           "civicShader": {
             "path": "src/render/realm_builder_monument_fx.ts",
-            "sha256": "d8db29ba7f4f433f645306fe732aeb3d59e8e7f81ce2e824a34b94042b0e3a2f"
+            "sha256": "58495d4a7dbc0a476302f17c652cf50a27fea3c8f08efa091477ba7be9314019"
           },
           "runtimeRender": {
             "town": {
@@ -25678,7 +25678,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5ae21044dd1b636f9c293ec628a7d316f740bb92a5962f848c6e58c80218ebbc",
+        "fingerprint": "9bac21494e4596b381a7e17363997ad5abee62078a7bb2b7ae63685100212d15",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -25690,7 +25690,7 @@
           },
           "civicShader": {
             "path": "src/render/realm_builder_monument_fx.ts",
-            "sha256": "d8db29ba7f4f433f645306fe732aeb3d59e8e7f81ce2e824a34b94042b0e3a2f"
+            "sha256": "58495d4a7dbc0a476302f17c652cf50a27fea3c8f08efa091477ba7be9314019"
           },
           "runtimeRender": {
             "town": {
@@ -26974,7 +26974,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5ae21044dd1b636f9c293ec628a7d316f740bb92a5962f848c6e58c80218ebbc",
+        "fingerprint": "9bac21494e4596b381a7e17363997ad5abee62078a7bb2b7ae63685100212d15",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -26986,7 +26986,7 @@
           },
           "civicShader": {
             "path": "src/render/realm_builder_monument_fx.ts",
-            "sha256": "d8db29ba7f4f433f645306fe732aeb3d59e8e7f81ce2e824a34b94042b0e3a2f"
+            "sha256": "58495d4a7dbc0a476302f17c652cf50a27fea3c8f08efa091477ba7be9314019"
           },
           "runtimeRender": {
             "town": {
@@ -28323,7 +28323,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5ae21044dd1b636f9c293ec628a7d316f740bb92a5962f848c6e58c80218ebbc",
+        "fingerprint": "9bac21494e4596b381a7e17363997ad5abee62078a7bb2b7ae63685100212d15",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -28335,7 +28335,7 @@
           },
           "civicShader": {
             "path": "src/render/realm_builder_monument_fx.ts",
-            "sha256": "d8db29ba7f4f433f645306fe732aeb3d59e8e7f81ce2e824a34b94042b0e3a2f"
+            "sha256": "58495d4a7dbc0a476302f17c652cf50a27fea3c8f08efa091477ba7be9314019"
           },
           "runtimeRender": {
             "town": {
@@ -29619,7 +29619,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5ae21044dd1b636f9c293ec628a7d316f740bb92a5962f848c6e58c80218ebbc",
+        "fingerprint": "9bac21494e4596b381a7e17363997ad5abee62078a7bb2b7ae63685100212d15",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -29631,7 +29631,7 @@
           },
           "civicShader": {
             "path": "src/render/realm_builder_monument_fx.ts",
-            "sha256": "d8db29ba7f4f433f645306fe732aeb3d59e8e7f81ce2e824a34b94042b0e3a2f"
+            "sha256": "58495d4a7dbc0a476302f17c652cf50a27fea3c8f08efa091477ba7be9314019"
           },
           "runtimeRender": {
             "town": {

--- a/docs/screenshots/eastbrook-vale-rebuild/polish/metadata/after-mobile-low.json
+++ b/docs/screenshots/eastbrook-vale-rebuild/polish/metadata/after-mobile-low.json
@@ -11,7 +11,7 @@
     "mode": "composite-sha256",
     "algorithm": "sha256",
     "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-    "fingerprint": "5ae21044dd1b636f9c293ec628a7d316f740bb92a5962f848c6e58c80218ebbc",
+    "fingerprint": "9bac21494e4596b381a7e17363997ad5abee62078a7bb2b7ae63685100212d15",
     "components": {
       "townAsset": {
         "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -23,7 +23,7 @@
       },
       "civicShader": {
         "path": "src/render/realm_builder_monument_fx.ts",
-        "sha256": "d8db29ba7f4f433f645306fe732aeb3d59e8e7f81ce2e824a34b94042b0e3a2f"
+        "sha256": "58495d4a7dbc0a476302f17c652cf50a27fea3c8f08efa091477ba7be9314019"
       },
       "runtimeRender": {
         "town": {
@@ -89,7 +89,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5ae21044dd1b636f9c293ec628a7d316f740bb92a5962f848c6e58c80218ebbc",
+        "fingerprint": "9bac21494e4596b381a7e17363997ad5abee62078a7bb2b7ae63685100212d15",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -101,7 +101,7 @@
           },
           "civicShader": {
             "path": "src/render/realm_builder_monument_fx.ts",
-            "sha256": "d8db29ba7f4f433f645306fe732aeb3d59e8e7f81ce2e824a34b94042b0e3a2f"
+            "sha256": "58495d4a7dbc0a476302f17c652cf50a27fea3c8f08efa091477ba7be9314019"
           },
           "runtimeRender": {
             "town": {
@@ -1368,7 +1368,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5ae21044dd1b636f9c293ec628a7d316f740bb92a5962f848c6e58c80218ebbc",
+        "fingerprint": "9bac21494e4596b381a7e17363997ad5abee62078a7bb2b7ae63685100212d15",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -1380,7 +1380,7 @@
           },
           "civicShader": {
             "path": "src/render/realm_builder_monument_fx.ts",
-            "sha256": "d8db29ba7f4f433f645306fe732aeb3d59e8e7f81ce2e824a34b94042b0e3a2f"
+            "sha256": "58495d4a7dbc0a476302f17c652cf50a27fea3c8f08efa091477ba7be9314019"
           },
           "runtimeRender": {
             "town": {
@@ -2647,7 +2647,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5ae21044dd1b636f9c293ec628a7d316f740bb92a5962f848c6e58c80218ebbc",
+        "fingerprint": "9bac21494e4596b381a7e17363997ad5abee62078a7bb2b7ae63685100212d15",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -2659,7 +2659,7 @@
           },
           "civicShader": {
             "path": "src/render/realm_builder_monument_fx.ts",
-            "sha256": "d8db29ba7f4f433f645306fe732aeb3d59e8e7f81ce2e824a34b94042b0e3a2f"
+            "sha256": "58495d4a7dbc0a476302f17c652cf50a27fea3c8f08efa091477ba7be9314019"
           },
           "runtimeRender": {
             "town": {
@@ -3926,7 +3926,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5ae21044dd1b636f9c293ec628a7d316f740bb92a5962f848c6e58c80218ebbc",
+        "fingerprint": "9bac21494e4596b381a7e17363997ad5abee62078a7bb2b7ae63685100212d15",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -3938,7 +3938,7 @@
           },
           "civicShader": {
             "path": "src/render/realm_builder_monument_fx.ts",
-            "sha256": "d8db29ba7f4f433f645306fe732aeb3d59e8e7f81ce2e824a34b94042b0e3a2f"
+            "sha256": "58495d4a7dbc0a476302f17c652cf50a27fea3c8f08efa091477ba7be9314019"
           },
           "runtimeRender": {
             "town": {
@@ -5205,7 +5205,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5ae21044dd1b636f9c293ec628a7d316f740bb92a5962f848c6e58c80218ebbc",
+        "fingerprint": "9bac21494e4596b381a7e17363997ad5abee62078a7bb2b7ae63685100212d15",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -5217,7 +5217,7 @@
           },
           "civicShader": {
             "path": "src/render/realm_builder_monument_fx.ts",
-            "sha256": "d8db29ba7f4f433f645306fe732aeb3d59e8e7f81ce2e824a34b94042b0e3a2f"
+            "sha256": "58495d4a7dbc0a476302f17c652cf50a27fea3c8f08efa091477ba7be9314019"
           },
           "runtimeRender": {
             "town": {
@@ -6484,7 +6484,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5ae21044dd1b636f9c293ec628a7d316f740bb92a5962f848c6e58c80218ebbc",
+        "fingerprint": "9bac21494e4596b381a7e17363997ad5abee62078a7bb2b7ae63685100212d15",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -6496,7 +6496,7 @@
           },
           "civicShader": {
             "path": "src/render/realm_builder_monument_fx.ts",
-            "sha256": "d8db29ba7f4f433f645306fe732aeb3d59e8e7f81ce2e824a34b94042b0e3a2f"
+            "sha256": "58495d4a7dbc0a476302f17c652cf50a27fea3c8f08efa091477ba7be9314019"
           },
           "runtimeRender": {
             "town": {
@@ -7763,7 +7763,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5ae21044dd1b636f9c293ec628a7d316f740bb92a5962f848c6e58c80218ebbc",
+        "fingerprint": "9bac21494e4596b381a7e17363997ad5abee62078a7bb2b7ae63685100212d15",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -7775,7 +7775,7 @@
           },
           "civicShader": {
             "path": "src/render/realm_builder_monument_fx.ts",
-            "sha256": "d8db29ba7f4f433f645306fe732aeb3d59e8e7f81ce2e824a34b94042b0e3a2f"
+            "sha256": "58495d4a7dbc0a476302f17c652cf50a27fea3c8f08efa091477ba7be9314019"
           },
           "runtimeRender": {
             "town": {
@@ -9042,7 +9042,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5ae21044dd1b636f9c293ec628a7d316f740bb92a5962f848c6e58c80218ebbc",
+        "fingerprint": "9bac21494e4596b381a7e17363997ad5abee62078a7bb2b7ae63685100212d15",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -9054,7 +9054,7 @@
           },
           "civicShader": {
             "path": "src/render/realm_builder_monument_fx.ts",
-            "sha256": "d8db29ba7f4f433f645306fe732aeb3d59e8e7f81ce2e824a34b94042b0e3a2f"
+            "sha256": "58495d4a7dbc0a476302f17c652cf50a27fea3c8f08efa091477ba7be9314019"
           },
           "runtimeRender": {
             "town": {
@@ -10321,7 +10321,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5ae21044dd1b636f9c293ec628a7d316f740bb92a5962f848c6e58c80218ebbc",
+        "fingerprint": "9bac21494e4596b381a7e17363997ad5abee62078a7bb2b7ae63685100212d15",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -10333,7 +10333,7 @@
           },
           "civicShader": {
             "path": "src/render/realm_builder_monument_fx.ts",
-            "sha256": "d8db29ba7f4f433f645306fe732aeb3d59e8e7f81ce2e824a34b94042b0e3a2f"
+            "sha256": "58495d4a7dbc0a476302f17c652cf50a27fea3c8f08efa091477ba7be9314019"
           },
           "runtimeRender": {
             "town": {
@@ -11600,7 +11600,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5ae21044dd1b636f9c293ec628a7d316f740bb92a5962f848c6e58c80218ebbc",
+        "fingerprint": "9bac21494e4596b381a7e17363997ad5abee62078a7bb2b7ae63685100212d15",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -11612,7 +11612,7 @@
           },
           "civicShader": {
             "path": "src/render/realm_builder_monument_fx.ts",
-            "sha256": "d8db29ba7f4f433f645306fe732aeb3d59e8e7f81ce2e824a34b94042b0e3a2f"
+            "sha256": "58495d4a7dbc0a476302f17c652cf50a27fea3c8f08efa091477ba7be9314019"
           },
           "runtimeRender": {
             "town": {
@@ -12879,7 +12879,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5ae21044dd1b636f9c293ec628a7d316f740bb92a5962f848c6e58c80218ebbc",
+        "fingerprint": "9bac21494e4596b381a7e17363997ad5abee62078a7bb2b7ae63685100212d15",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -12891,7 +12891,7 @@
           },
           "civicShader": {
             "path": "src/render/realm_builder_monument_fx.ts",
-            "sha256": "d8db29ba7f4f433f645306fe732aeb3d59e8e7f81ce2e824a34b94042b0e3a2f"
+            "sha256": "58495d4a7dbc0a476302f17c652cf50a27fea3c8f08efa091477ba7be9314019"
           },
           "runtimeRender": {
             "town": {
@@ -14158,7 +14158,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5ae21044dd1b636f9c293ec628a7d316f740bb92a5962f848c6e58c80218ebbc",
+        "fingerprint": "9bac21494e4596b381a7e17363997ad5abee62078a7bb2b7ae63685100212d15",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -14170,7 +14170,7 @@
           },
           "civicShader": {
             "path": "src/render/realm_builder_monument_fx.ts",
-            "sha256": "d8db29ba7f4f433f645306fe732aeb3d59e8e7f81ce2e824a34b94042b0e3a2f"
+            "sha256": "58495d4a7dbc0a476302f17c652cf50a27fea3c8f08efa091477ba7be9314019"
           },
           "runtimeRender": {
             "town": {
@@ -15437,7 +15437,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5ae21044dd1b636f9c293ec628a7d316f740bb92a5962f848c6e58c80218ebbc",
+        "fingerprint": "9bac21494e4596b381a7e17363997ad5abee62078a7bb2b7ae63685100212d15",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -15449,7 +15449,7 @@
           },
           "civicShader": {
             "path": "src/render/realm_builder_monument_fx.ts",
-            "sha256": "d8db29ba7f4f433f645306fe732aeb3d59e8e7f81ce2e824a34b94042b0e3a2f"
+            "sha256": "58495d4a7dbc0a476302f17c652cf50a27fea3c8f08efa091477ba7be9314019"
           },
           "runtimeRender": {
             "town": {
@@ -16716,7 +16716,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5ae21044dd1b636f9c293ec628a7d316f740bb92a5962f848c6e58c80218ebbc",
+        "fingerprint": "9bac21494e4596b381a7e17363997ad5abee62078a7bb2b7ae63685100212d15",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -16728,7 +16728,7 @@
           },
           "civicShader": {
             "path": "src/render/realm_builder_monument_fx.ts",
-            "sha256": "d8db29ba7f4f433f645306fe732aeb3d59e8e7f81ce2e824a34b94042b0e3a2f"
+            "sha256": "58495d4a7dbc0a476302f17c652cf50a27fea3c8f08efa091477ba7be9314019"
           },
           "runtimeRender": {
             "town": {
@@ -18960,7 +18960,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5ae21044dd1b636f9c293ec628a7d316f740bb92a5962f848c6e58c80218ebbc",
+        "fingerprint": "9bac21494e4596b381a7e17363997ad5abee62078a7bb2b7ae63685100212d15",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -18972,7 +18972,7 @@
           },
           "civicShader": {
             "path": "src/render/realm_builder_monument_fx.ts",
-            "sha256": "d8db29ba7f4f433f645306fe732aeb3d59e8e7f81ce2e824a34b94042b0e3a2f"
+            "sha256": "58495d4a7dbc0a476302f17c652cf50a27fea3c8f08efa091477ba7be9314019"
           },
           "runtimeRender": {
             "town": {
@@ -20239,7 +20239,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5ae21044dd1b636f9c293ec628a7d316f740bb92a5962f848c6e58c80218ebbc",
+        "fingerprint": "9bac21494e4596b381a7e17363997ad5abee62078a7bb2b7ae63685100212d15",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -20251,7 +20251,7 @@
           },
           "civicShader": {
             "path": "src/render/realm_builder_monument_fx.ts",
-            "sha256": "d8db29ba7f4f433f645306fe732aeb3d59e8e7f81ce2e824a34b94042b0e3a2f"
+            "sha256": "58495d4a7dbc0a476302f17c652cf50a27fea3c8f08efa091477ba7be9314019"
           },
           "runtimeRender": {
             "town": {
@@ -21518,7 +21518,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5ae21044dd1b636f9c293ec628a7d316f740bb92a5962f848c6e58c80218ebbc",
+        "fingerprint": "9bac21494e4596b381a7e17363997ad5abee62078a7bb2b7ae63685100212d15",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -21530,7 +21530,7 @@
           },
           "civicShader": {
             "path": "src/render/realm_builder_monument_fx.ts",
-            "sha256": "d8db29ba7f4f433f645306fe732aeb3d59e8e7f81ce2e824a34b94042b0e3a2f"
+            "sha256": "58495d4a7dbc0a476302f17c652cf50a27fea3c8f08efa091477ba7be9314019"
           },
           "runtimeRender": {
             "town": {
@@ -22797,7 +22797,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5ae21044dd1b636f9c293ec628a7d316f740bb92a5962f848c6e58c80218ebbc",
+        "fingerprint": "9bac21494e4596b381a7e17363997ad5abee62078a7bb2b7ae63685100212d15",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -22809,7 +22809,7 @@
           },
           "civicShader": {
             "path": "src/render/realm_builder_monument_fx.ts",
-            "sha256": "d8db29ba7f4f433f645306fe732aeb3d59e8e7f81ce2e824a34b94042b0e3a2f"
+            "sha256": "58495d4a7dbc0a476302f17c652cf50a27fea3c8f08efa091477ba7be9314019"
           },
           "runtimeRender": {
             "town": {
@@ -24076,7 +24076,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5ae21044dd1b636f9c293ec628a7d316f740bb92a5962f848c6e58c80218ebbc",
+        "fingerprint": "9bac21494e4596b381a7e17363997ad5abee62078a7bb2b7ae63685100212d15",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -24088,7 +24088,7 @@
           },
           "civicShader": {
             "path": "src/render/realm_builder_monument_fx.ts",
-            "sha256": "d8db29ba7f4f433f645306fe732aeb3d59e8e7f81ce2e824a34b94042b0e3a2f"
+            "sha256": "58495d4a7dbc0a476302f17c652cf50a27fea3c8f08efa091477ba7be9314019"
           },
           "runtimeRender": {
             "town": {
@@ -25355,7 +25355,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5ae21044dd1b636f9c293ec628a7d316f740bb92a5962f848c6e58c80218ebbc",
+        "fingerprint": "9bac21494e4596b381a7e17363997ad5abee62078a7bb2b7ae63685100212d15",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -25367,7 +25367,7 @@
           },
           "civicShader": {
             "path": "src/render/realm_builder_monument_fx.ts",
-            "sha256": "d8db29ba7f4f433f645306fe732aeb3d59e8e7f81ce2e824a34b94042b0e3a2f"
+            "sha256": "58495d4a7dbc0a476302f17c652cf50a27fea3c8f08efa091477ba7be9314019"
           },
           "runtimeRender": {
             "town": {
@@ -26634,7 +26634,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5ae21044dd1b636f9c293ec628a7d316f740bb92a5962f848c6e58c80218ebbc",
+        "fingerprint": "9bac21494e4596b381a7e17363997ad5abee62078a7bb2b7ae63685100212d15",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -26646,7 +26646,7 @@
           },
           "civicShader": {
             "path": "src/render/realm_builder_monument_fx.ts",
-            "sha256": "d8db29ba7f4f433f645306fe732aeb3d59e8e7f81ce2e824a34b94042b0e3a2f"
+            "sha256": "58495d4a7dbc0a476302f17c652cf50a27fea3c8f08efa091477ba7be9314019"
           },
           "runtimeRender": {
             "town": {
@@ -27966,7 +27966,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5ae21044dd1b636f9c293ec628a7d316f740bb92a5962f848c6e58c80218ebbc",
+        "fingerprint": "9bac21494e4596b381a7e17363997ad5abee62078a7bb2b7ae63685100212d15",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -27978,7 +27978,7 @@
           },
           "civicShader": {
             "path": "src/render/realm_builder_monument_fx.ts",
-            "sha256": "d8db29ba7f4f433f645306fe732aeb3d59e8e7f81ce2e824a34b94042b0e3a2f"
+            "sha256": "58495d4a7dbc0a476302f17c652cf50a27fea3c8f08efa091477ba7be9314019"
           },
           "runtimeRender": {
             "town": {
@@ -29245,7 +29245,7 @@
         "mode": "composite-sha256",
         "algorithm": "sha256",
         "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-        "fingerprint": "5ae21044dd1b636f9c293ec628a7d316f740bb92a5962f848c6e58c80218ebbc",
+        "fingerprint": "9bac21494e4596b381a7e17363997ad5abee62078a7bb2b7ae63685100212d15",
         "components": {
           "townAsset": {
             "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -29257,7 +29257,7 @@
           },
           "civicShader": {
             "path": "src/render/realm_builder_monument_fx.ts",
-            "sha256": "d8db29ba7f4f433f645306fe732aeb3d59e8e7f81ce2e824a34b94042b0e3a2f"
+            "sha256": "58495d4a7dbc0a476302f17c652cf50a27fea3c8f08efa091477ba7be9314019"
           },
           "runtimeRender": {
             "town": {

--- a/docs/screenshots/eastbrook-vale-rebuild/polish/performance/after-desktop-ultra-town.json
+++ b/docs/screenshots/eastbrook-vale-rebuild/polish/performance/after-desktop-ultra-town.json
@@ -14,7 +14,7 @@
     "mode": "composite-sha256",
     "algorithm": "sha256",
     "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-    "fingerprint": "5ae21044dd1b636f9c293ec628a7d316f740bb92a5962f848c6e58c80218ebbc",
+    "fingerprint": "9bac21494e4596b381a7e17363997ad5abee62078a7bb2b7ae63685100212d15",
     "components": {
       "townAsset": {
         "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -26,7 +26,7 @@
       },
       "civicShader": {
         "path": "src/render/realm_builder_monument_fx.ts",
-        "sha256": "d8db29ba7f4f433f645306fe732aeb3d59e8e7f81ce2e824a34b94042b0e3a2f"
+        "sha256": "58495d4a7dbc0a476302f17c652cf50a27fea3c8f08efa091477ba7be9314019"
       },
       "runtimeRender": {
         "town": {

--- a/docs/screenshots/eastbrook-vale-rebuild/polish/performance/after-mobile-low-town.json
+++ b/docs/screenshots/eastbrook-vale-rebuild/polish/performance/after-mobile-low-town.json
@@ -14,7 +14,7 @@
     "mode": "composite-sha256",
     "algorithm": "sha256",
     "baselineRevision": "3ab740db453bd8b5858a52c304edc811c9d520ca",
-    "fingerprint": "5ae21044dd1b636f9c293ec628a7d316f740bb92a5962f848c6e58c80218ebbc",
+    "fingerprint": "9bac21494e4596b381a7e17363997ad5abee62078a7bb2b7ae63685100212d15",
     "components": {
       "townAsset": {
         "source": "scripts/assets/eastbrook_town/source_fingerprint.mjs",
@@ -26,7 +26,7 @@
       },
       "civicShader": {
         "path": "src/render/realm_builder_monument_fx.ts",
-        "sha256": "d8db29ba7f4f433f645306fe732aeb3d59e8e7f81ce2e824a34b94042b0e3a2f"
+        "sha256": "58495d4a7dbc0a476302f17c652cf50a27fea3c8f08efa091477ba7be9314019"
       },
       "runtimeRender": {
         "town": {

--- a/scripts/assets/eastbrook_grand_armoury/capture_contract.mjs
+++ b/scripts/assets/eastbrook_grand_armoury/capture_contract.mjs
@@ -510,6 +510,26 @@ export const EASTBROOK_POLISH_BASELINE_REVISION = '3ab740db453bd8b5858a52c304edc
 // covers the renderer's own call sites. Add the module as a leaf at the next
 // legitimate re-mint only if a future capture's claims come to depend on
 // prewarm behavior.
+// SECOND DELIBERATE EXCLUSION (2026-09-12): the monument impostor's GLSL,
+// extracted out of the civicShader module into
+// src/render/realm_builder_monument_impostor_glsl.ts, is NOT a leaf here, and
+// this is the same shape as the exclusion above rather than a new judgement.
+// The extraction bought a real-context link of the shipped strings: importing
+// the fx module into a browser test cost +1.2 s of import time on a file whose
+// own assertions cost 110 ms, while a dependency-free source module costs
+// nothing. Applying the exclusion note's own test, do the polish evidence's
+// claims depend on these bytes: no. MONUMENT_IMPOSTOR_RANGE is 72
+// (realm_builder_monument_fx_core.ts) and the monument sits at (-14.75, -102)
+// (CIVIC_FEATURE_CENTER); every polish view that can contain it is within
+// 51 yd, the farthest being apothecary-lin at 50.6, so the captures show the
+// statue BODY and can never show the impostor card. The one polish view beyond
+// that range (camera (34, 15, 25), target (12.5, 4, -5.5)) is aimed at another
+// district, away from the monument. The civicShader leaf still seals the
+// wiring (which strings, which uniforms, fog: true), and the bytes themselves
+// now carry a stronger guard than a sha256: a real driver links them in
+// tests/browser/dry_compile_sources.browser.test.ts. Add the module as a leaf
+// at the next legitimate re-mint only if a future capture is retaken from
+// beyond 72 yd with the monument in frame.
 export const EASTBROOK_POLISH_PROVENANCE_INPUTS = Object.freeze({
   townAssetSourceFingerprint: 'scripts/assets/eastbrook_town/source_fingerprint.mjs',
   authoritativeLayout: 'src/sim/eastbrook_layout.ts',

--- a/src/render/realm_builder_monument_fx.ts
+++ b/src/render/realm_builder_monument_fx.ts
@@ -48,6 +48,10 @@ import {
   monumentPointWorld,
   monumentScale,
 } from './realm_builder_monument_fx_core';
+import {
+  MONUMENT_IMPOSTOR_FRAGMENT,
+  MONUMENT_IMPOSTOR_VERTEX,
+} from './realm_builder_monument_impostor_glsl';
 
 const GROUP_NAME = 'eastbrookRealmBuilderMonumentFx';
 const NAME_CANVAS_WIDTH = 1024;
@@ -386,49 +390,6 @@ interface MonumentImpostor {
   cell: number;
 }
 
-const IMPOSTOR_VERTEX = /* glsl */ `
-  #include <fog_pars_vertex>
-  uniform vec2 uCell;
-  uniform vec2 uCellSize;
-  varying vec2 vUv;
-  void main() {
-    vUv = uCell + uv * uCellSize;
-    // Billboard about the vertical axis ONLY: a statue that tips to face the
-    // camera reads as a card the moment you look down at it from a rise.
-    vec3 right = vec3(modelViewMatrix[0][0], modelViewMatrix[1][0], modelViewMatrix[2][0]);
-    vec3 flat = normalize(vec3(right.x, 0.0, right.z));
-    vec3 world = vec3(
-      flat.x * position.x,
-      position.y,
-      flat.z * position.x
-    );
-    vec4 mvPosition = modelViewMatrix * vec4(world, 1.0);
-    gl_Position = projectionMatrix * mvPosition;
-    #include <fog_vertex>
-  }
-`;
-
-// The atlas is sRGB-tagged, so the sample is linear like every lit surface,
-// and the tail is the one MeshStandardMaterial ends with (tonemapping,
-// colorspace, fog): a card that skipped it would stand un-fogged and
-// un-toned at the fog wall while every building around it fades, and would
-// shift colour against the body on the frame the two swap.
-const IMPOSTOR_FRAGMENT = /* glsl */ `
-  #include <fog_pars_fragment>
-  uniform sampler2D uAtlas;
-  varying vec2 vUv;
-  void main() {
-    vec4 texel = texture2D(uAtlas, vUv);
-    // Alpha-TEST, not blend: at this range the billboard has to sort against
-    // the town like the solid it stands in for, and a blended quad does not.
-    if (texel.a < 0.5) discard;
-    gl_FragColor = vec4(texel.rgb, 1.0);
-    #include <tonemapping_fragment>
-    #include <colorspace_fragment>
-    #include <fog_fragment>
-  }
-`;
-
 /**
  * The billboard that stands in for the statue past MONUMENT_IMPOSTOR_RANGE.
  *
@@ -443,8 +404,8 @@ function buildImpostor(placement: MonumentPlacement): MonumentImpostor | null {
   geometry.translate(0, size / 2, 0);
   const uvOffset = { value: new THREE.Vector2(0, 0) };
   const material = new THREE.ShaderMaterial({
-    vertexShader: IMPOSTOR_VERTEX,
-    fragmentShader: IMPOSTOR_FRAGMENT,
+    vertexShader: MONUMENT_IMPOSTOR_VERTEX,
+    fragmentShader: MONUMENT_IMPOSTOR_FRAGMENT,
     // Scene fog reaches a ShaderMaterial only when asked for, and only through
     // these uniforms (foliage_impostor.ts gets both from MeshStandardMaterial).
     // Cloned rather than merged so uCell stays the caller's own Vector2.

--- a/src/render/realm_builder_monument_impostor_glsl.ts
+++ b/src/render/realm_builder_monument_impostor_glsl.ts
@@ -1,0 +1,69 @@
+// The monument impostor's GLSL, alone in a module with NO imports.
+//
+// Why it is not inline in realm_builder_monument_fx.ts any more: a real-context
+// test has to link these exact strings (they shipped uncompilable for the whole
+// life of v0.42), and importing the fx module to reach them dragged its whole
+// dependency graph into the browser test bundle, measured at +1.2 s of import
+// time on a file whose assertions cost 110 ms. A dependency-free source module
+// costs nothing to import, so the gate that links the shipped shader is cheap
+// enough to keep and cheap enough to extend to the next shader.
+//
+// Data, not logic: no function and no state. It is still covered on two axes,
+// which is the point of splitting it out. tests/realm_builder_monument_impostor_glsl.test.ts
+// reads the text in Node for a millisecond (no reserved word used as an
+// identifier, the billboard's zeroed Y, the alpha test, the tail order), and
+// tests/browser/dry_compile_sources.browser.test.ts links these exact strings
+// against a real driver. The consumer is realm_builder_monument_fx.ts's
+// buildImpostor. The family is post_finite_guard_glsl.ts's.
+
+/**
+ * Billboards about the vertical axis ONLY: a statue that tips to face the
+ * camera reads as a card the moment you look down at it from a rise.
+ *
+ * No variable here may be named `flat`, `smooth`, `sample` or any other GLSL
+ * ES 3.00 qualifier. That is not style: `vec3 flat` is a syntax error, it made
+ * this shader fail to compile on every driver, and with three's link diagnostic
+ * off in production (renderer.ts, debug.checkShaderErrors) nothing reported it.
+ */
+export const MONUMENT_IMPOSTOR_VERTEX = /* glsl */ `
+  #include <fog_pars_vertex>
+  uniform vec2 uCell;
+  uniform vec2 uCellSize;
+  varying vec2 vUv;
+  void main() {
+    vUv = uCell + uv * uCellSize;
+    vec3 right = vec3(modelViewMatrix[0][0], modelViewMatrix[1][0], modelViewMatrix[2][0]);
+    vec3 flatRight = normalize(vec3(right.x, 0.0, right.z));
+    vec3 world = vec3(
+      flatRight.x * position.x,
+      position.y,
+      flatRight.z * position.x
+    );
+    vec4 mvPosition = modelViewMatrix * vec4(world, 1.0);
+    gl_Position = projectionMatrix * mvPosition;
+    #include <fog_vertex>
+  }
+`;
+
+/**
+ * The atlas is sRGB-tagged, so the sample is linear like every lit surface,
+ * and the tail is the one MeshStandardMaterial ends with (tonemapping,
+ * colorspace, fog): a card that skipped it would stand un-fogged and un-toned
+ * at the fog wall while every building around it fades, and would shift colour
+ * against the body on the frame the two swap.
+ */
+export const MONUMENT_IMPOSTOR_FRAGMENT = /* glsl */ `
+  #include <fog_pars_fragment>
+  uniform sampler2D uAtlas;
+  varying vec2 vUv;
+  void main() {
+    vec4 texel = texture2D(uAtlas, vUv);
+    // Alpha-TEST, not blend: at this range the billboard has to sort against
+    // the town like the solid it stands in for, and a blended quad does not.
+    if (texel.a < 0.5) discard;
+    gl_FragColor = vec4(texel.rgb, 1.0);
+    #include <tonemapping_fragment>
+    #include <colorspace_fragment>
+    #include <fog_fragment>
+  }
+`;

--- a/tests/browser/dry_compile_sources.browser.test.ts
+++ b/tests/browser/dry_compile_sources.browser.test.ts
@@ -4,15 +4,35 @@
 // hands the driver, under the same cache keys, and a second collection after
 // the link reports none of them. The browser's shared program cache is keyed
 // on that text, so this equality is what makes a worker's warm-up a hit.
+//
+// The scene also carries ONE real game shader, the monument impostor's
+// hand-written ShaderMaterial, and the link assertion below covers it. Two
+// reasons, and the second is why it rides here rather than in a file of its
+// own. First, the mirror has to hold for a hand-written ShaderMaterial too,
+// which reaches the assembly by a different path than three's stock materials.
+// Second, several browser files link shipped shaders, but none of them ASSERTS
+// the link succeeded, and nothing else does either: renderer.ts keeps three's
+// link diagnostic off outside ?shaderdebug (a synchronous info-log roundtrip
+// per link, a quarter of main-thread time on a streaming walk), so a shader
+// that never compiles ships silently and is drawn with on every frame. That is
+// exactly what the impostor did for all of v0.42. Adding it to this scene
+// costs one program link on a context this file already builds; a separate
+// browser file would have cost a whole context, measured at 0.65 s of the
+// 0.98 s this file takes.
 
 import * as THREE from 'three';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import type { DryCompileRenderer, DryProgramSource } from '../../src/render/program_sources';
+import {
+  MONUMENT_IMPOSTOR_FRAGMENT,
+  MONUMENT_IMPOSTOR_VERTEX,
+} from '../../src/render/realm_builder_monument_impostor_glsl';
 
 type PatchedRenderer = THREE.WebGLRenderer & Required<DryCompileRenderer>;
 
 interface MintedProgram {
   cacheKey: string;
+  program: WebGLProgram;
   vertexShader: WebGLShader;
   fragmentShader: WebGLShader;
 }
@@ -44,6 +64,23 @@ function scene(): { scene: THREE.Scene; camera: THREE.PerspectiveCamera; root: T
       new THREE.PlaneGeometry(),
       new THREE.MeshBasicMaterial({ transparent: true, side: THREE.DoubleSide }),
     ),
+    // The shipped monument impostor GLSL, uniforms shaped as buildImpostor
+    // shapes them (the atlas sampler may be null: a link needs the declaration,
+    // not the texture). See the header for why it rides in this scene.
+    new THREE.Mesh(
+      new THREE.PlaneGeometry(),
+      new THREE.ShaderMaterial({
+        vertexShader: MONUMENT_IMPOSTOR_VERTEX,
+        fragmentShader: MONUMENT_IMPOSTOR_FRAGMENT,
+        fog: true,
+        uniforms: {
+          ...THREE.UniformsUtils.clone(THREE.UniformsLib.fog),
+          uAtlas: { value: null },
+          uCell: { value: new THREE.Vector2(0, 0) },
+          uCellSize: { value: new THREE.Vector2(1, 1) },
+        },
+      }),
+    ),
   );
   world.add(root);
   return { scene: world, camera, root };
@@ -74,6 +111,18 @@ describe('the dry compile against the real link', () => {
     const linked = minted().filter((program) => !before.has(program.cacheKey));
     expect(linked.length).toBe(dry.length);
     for (const program of linked) {
+      // First: it linked at all. Three reports a failed link only under
+      // debug.checkShaderErrors, which production keeps off, so without this
+      // the driver's verdict is read by nobody and an uncompilable shader
+      // reaches players. The info logs name the line when it fails.
+      expect(
+        gl.getProgramParameter(program.program, gl.LINK_STATUS),
+        `link failed for ${program.cacheKey.slice(0, 40)}: program ${gl.getProgramInfoLog(
+          program.program,
+        )} vertex ${gl.getShaderInfoLog(program.vertexShader)} fragment ${gl.getShaderInfoLog(
+          program.fragmentShader,
+        )}`,
+      ).toBe(true);
       const entry = dryByKey.get(program.cacheKey);
       expect(entry, `announced key for ${program.cacheKey.slice(0, 40)}`).toBeDefined();
       if (!entry) continue;

--- a/tests/eastbrook_polish_artifact_integrity.test.ts
+++ b/tests/eastbrook_polish_artifact_integrity.test.ts
@@ -1362,10 +1362,12 @@ const ACCEPTED_POLISH_V2_METADATA_PATH = path.join(REPO_ROOT, POLISH_SEAL_PATH);
 // v0.42.0 dependency-floor bump (sharp, js-yaml, vitest): the lockfile is a
 // fingerprint input, so every shipping GLB was size-preserving re-minted and this
 // seal follows the swept evidence. No capture was retaken.
+// Re-minted for the monument impostor shader fix: renaming the illegal "flat"
+// variable moved the civicShader leaf. No capture was retaken.
 const ACCEPTED_POLISH_V2_METADATA_SHA256 =
-  'e3a555a9db84a550c92bf8443df1a20a64a96748dc7bd3159490b4ab93272770';
+  '7304024fd6217bc71fefeffd20cbf9a8e17f4af08a4f25c1eae3f5e4b538b49e';
 const ACCEPTED_POLISH_V2_COMPOSITE_PROVENANCE =
-  '5ae21044dd1b636f9c293ec628a7d316f740bb92a5962f848c6e58c80218ebbc';
+  '9bac21494e4596b381a7e17363997ad5abee62078a7bb2b7ae63685100212d15';
 const ACCEPTED_POLISH_V2_METADATA = readJsonFile<CaptureMetadata>(ACCEPTED_POLISH_V2_METADATA_PATH);
 const ACCEPTED_POLISH_V2_PROVENANCE = ACCEPTED_POLISH_V2_METADATA.polishProvenance;
 const ACCEPTED_POLISH_V2_TOWN_CONTRACT = ACCEPTED_POLISH_V2_METADATA.records[0]?.townContract;
@@ -2724,7 +2726,9 @@ describe('Eastbrook polish performance and contact evidence', () => {
       // canonical re-sealed evidence files. Capture pixels and scores did not change.
       // v0.42.0 dependency-floor bump: recomputed LAST over the swept evidence
       // after the lockfile-driven GLB re-mint. No capture was retaken.
-    ).toBe('eea4d7acbd5b80de9fcf51e9a24ba8218566cee1928111ef3723278b7036125b');
+      // Re-minted for the monument impostor shader fix: same order, the
+      // composite first, then this seal. No capture was retaken.
+    ).toBe('2f95727769426875d1328112b23a68cfd73dc55fda4bf6f6c5b507180e8fd795');
   });
 
   it('binds every historical after record to its accepted source and asset provenance', () => {

--- a/tests/eastbrook_polish_capture_contract.test.ts
+++ b/tests/eastbrook_polish_capture_contract.test.ts
@@ -668,8 +668,10 @@ interface AttributionTargetFixture {
 // v0.42.0 dependency-floor bump (sharp, js-yaml, vitest): the lockfile is a
 // fingerprint input, so every shipping GLB was size-preserving re-minted and this
 // seal follows the swept evidence. No capture was retaken.
+// Re-minted for the monument impostor shader fix: renaming the illegal "flat"
+// variable moved the civicShader leaf. No capture was retaken.
 const PINNED_POLISH_COMPOSITE_FINGERPRINT =
-  '5ae21044dd1b636f9c293ec628a7d316f740bb92a5962f848c6e58c80218ebbc';
+  '9bac21494e4596b381a7e17363997ad5abee62078a7bb2b7ae63685100212d15';
 
 function validPolishAttributionTargets(): AttributionTargetFixture[] {
   return [

--- a/tests/realm_builder_monument_impostor_glsl.test.ts
+++ b/tests/realm_builder_monument_impostor_glsl.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest';
+import {
+  MONUMENT_IMPOSTOR_FRAGMENT,
+  MONUMENT_IMPOSTOR_VERTEX,
+} from '../src/render/realm_builder_monument_impostor_glsl';
+
+// The Node half of the impostor's shader coverage, paired with the module the
+// way post_finite_guard_glsl.test.ts pairs with its own. It costs about a
+// millisecond and rides `vitest related`, so it is the cheap floor; the real
+// driver link lives in tests/browser/dry_compile_sources.browser.test.ts.
+//
+// The two halves fail on different axes ON PURPOSE, which is what makes the
+// pair worth having. This one reads the source text, so it catches ONE class
+// of defect (an identifier the language reserves) across the whole module
+// without a GL context. The browser one links against a driver, so it catches
+// EVERY class but only for a shader some scene actually instantiates.
+
+/**
+ * The GLSL ES 3.00 words that cannot name a variable. Deliberately NOT the
+ * whole specification list: these are the qualifiers and reserved words a
+ * shader author plausibly reaches for as a noun, which is how `vec3 flat`
+ * shipped and never compiled for the life of v0.42.
+ *
+ * `attribute` and `varying` are absent on purpose. The spec reserves both, but
+ * three's WebGL2 prefix defines them away (`#define attribute in`,
+ * `#define varying out`), and this module's own sources use `varying`.
+ */
+const RESERVED_AS_IDENTIFIER = [
+  // Interpolation and auxiliary qualifiers.
+  'flat',
+  'smooth',
+  'centroid',
+  'sample',
+  'patch',
+  // Storage, memory and layout qualifiers.
+  'layout',
+  'shared',
+  'invariant',
+  'precise',
+  'coherent',
+  'volatile',
+  'restrict',
+  'readonly',
+  'writeonly',
+  'subroutine',
+  // Reserved by the specification for future use.
+  'common',
+  'partition',
+  'active',
+  'filter',
+  'resource',
+  'namespace',
+  'using',
+  'cast',
+  'inline',
+  'noinline',
+  'sizeof',
+  'union',
+  'this',
+  'template',
+  'typedef',
+  'external',
+  'input',
+  'output',
+  'buffer',
+] as const;
+
+const DECLARED_TYPE =
+  '(?:vec[234]|ivec[234]|uvec[234]|bvec[234]|mat[234](?:x[234])?|float|int|uint|bool)';
+
+/** Every reserved word this source declares as a variable, in source order. */
+function reservedIdentifiers(source: string): string[] {
+  return RESERVED_AS_IDENTIFIER.filter((word) =>
+    new RegExp(`\\b${DECLARED_TYPE}\\s+${word}\\b`).test(source),
+  );
+}
+
+describe('realm_builder_monument_impostor_glsl', () => {
+  it('declares no reserved word as a variable', () => {
+    // The positive control first: without it this would be a negative pin on a
+    // token that is never present, and a broken matcher would pass over
+    // nothing. The string is the line that actually shipped.
+    expect(reservedIdentifiers('vec3 flat = normalize(vec3(right.x, 0.0, right.z));')).toEqual([
+      'flat',
+    ]);
+    expect(reservedIdentifiers('vec3 flatRight = normalize(right);')).toEqual([]);
+    // `varying vec2 vUv` must not trip it: three's prefix defines the word away.
+    expect(reservedIdentifiers('varying vec2 vUv;')).toEqual([]);
+
+    expect(reservedIdentifiers(MONUMENT_IMPOSTOR_VERTEX)).toEqual([]);
+    expect(reservedIdentifiers(MONUMENT_IMPOSTOR_FRAGMENT)).toEqual([]);
+  });
+
+  it('billboards about the vertical axis only', () => {
+    // The zeroed Y is the whole claim of the docblock: a statue that tips to
+    // face the camera reads as a card from a rise. A right vector taken whole
+    // would compile and look wrong, which no link test can catch.
+    expect(MONUMENT_IMPOSTOR_VERTEX).toContain(
+      'vec3 flatRight = normalize(vec3(right.x, 0.0, right.z));',
+    );
+    expect(MONUMENT_IMPOSTOR_VERTEX).toContain(
+      'vec3 right = vec3(modelViewMatrix[0][0], modelViewMatrix[1][0], modelViewMatrix[2][0]);',
+    );
+    // Only x and z ride the flattened basis; y passes through as authored.
+    expect(MONUMENT_IMPOSTOR_VERTEX).toContain('flatRight.x * position.x');
+    expect(MONUMENT_IMPOSTOR_VERTEX).toContain('flatRight.z * position.x');
+    expect(MONUMENT_IMPOSTOR_VERTEX).toContain('position.y');
+  });
+
+  it('alpha-tests rather than blending, so the card sorts like the solid', () => {
+    expect(MONUMENT_IMPOSTOR_FRAGMENT).toContain('if (texel.a < 0.5) discard;');
+    expect(MONUMENT_IMPOSTOR_FRAGMENT).toContain('gl_FragColor = vec4(texel.rgb, 1.0);');
+  });
+
+  it('ends on the tail a lit surface ends on, in order', () => {
+    // The docblock's promise: a card that skipped this would stand un-fogged
+    // and un-toned at the fog wall while the buildings around it fade.
+    const tail = ['tonemapping_fragment', 'colorspace_fragment', 'fog_fragment'].map((chunk) =>
+      MONUMENT_IMPOSTOR_FRAGMENT.indexOf(`#include <${chunk}>`),
+    );
+    expect(tail.every((at) => at >= 0)).toBe(true);
+    expect(tail).toEqual([...tail].sort((a, b) => a - b));
+    // Fog needs its declarations in both stages, or the tail does not compile.
+    expect(MONUMENT_IMPOSTOR_VERTEX).toContain('#include <fog_pars_vertex>');
+    expect(MONUMENT_IMPOSTOR_FRAGMENT).toContain('#include <fog_pars_fragment>');
+    expect(MONUMENT_IMPOSTOR_VERTEX).toContain('#include <fog_vertex>');
+  });
+
+  it('declares the uniforms and the varying the material wires', () => {
+    // buildImpostor supplies uAtlas, uCell and uCellSize; a rename on one side
+    // only leaves a silently unbound uniform rather than a failed link.
+    expect(MONUMENT_IMPOSTOR_VERTEX).toContain('uniform vec2 uCell;');
+    expect(MONUMENT_IMPOSTOR_VERTEX).toContain('uniform vec2 uCellSize;');
+    expect(MONUMENT_IMPOSTOR_FRAGMENT).toContain('uniform sampler2D uAtlas;');
+    expect(MONUMENT_IMPOSTOR_VERTEX).toContain('varying vec2 vUv;');
+    expect(MONUMENT_IMPOSTOR_FRAGMENT).toContain('varying vec2 vUv;');
+  });
+});


### PR DESCRIPTION
## Summary

The Realm Builder monument's impostor card has not drawn as authored since v0.42.0. Its
vertex shader declared `vec3 flat`, and `flat` is a GLSL ES 3.00 interpolation qualifier, so
it cannot name a variable. The shader never compiled, so the program never linked, and the
renderer went on drawing with the invalid program on every frame.

Nothing reported it, which is the part worth reading. Three logs a failed link only inside
`onFirstUse`, under `debug.checkShaderErrors`, and `src/render/renderer.ts` keeps that off
outside `?shaderdebug` on purpose: it costs a synchronous info-log roundtrip per link,
measured at a quarter of all main-thread time on a zone-streaming walk. So the failure
produced no error, no warning, and no missing-asset line. Its only visible trace was a flood
of `WebGL: INVALID_OPERATION: useProgram: program not valid`, 187 of them in one session
before the console mirror hit its cap, in any session that reached the monument.

It was found by reading a desktop client's console for an unrelated reason: of 382 programs,
exactly one was link-failed and still live (`usedTimes 1`), and its shader info log named the
line.

## Evidence

Both spellings compiled against a real driver, same prefix, same body:

```
renderer  ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (Subzero)), SwiftShader driver)
before    ok: false   ERROR: 0:16: 'flat' : syntax error
after     ok: true    (empty info log)
```

That driver is neither the hardware nor the backend the bug was found on, which is the point:
`flat` is reserved by the GLSL ES 3.00 specification, so the shader fails on every conformant
compiler. The impostor was broken everywhere, not on one card.

## The shader now has coverage, on two axes

A one-word fix with no test would leave the same line free to come back, so the shader gained
coverage that costs effectively nothing to run. The two halves fail on different axes, which
is why there are two:

- **Node, `tests/realm_builder_monument_impostor_glsl.test.ts`, tests in 5 ms.** Reads the
  source text: no GLSL ES 3.00 reserved word used as an identifier, anywhere in the module,
  plus the billboard's zeroed Y, the alpha test rather than a blend, and the tonemapping,
  colorspace, fog tail order the docblock promises. It catches ONE class of defect across
  EVERY string in the module, and carries a positive control so a broken matcher fails
  instead of passing over nothing.
- **Browser, `tests/browser/dry_compile_sources.browser.test.ts`.** The shipped impostor
  material now rides that file's existing scene, and its first case asserts `LINK_STATUS` on
  every program the link mints. It catches EVERY class of defect, for the shaders a scene
  actually instantiates. Several browser files already link shipped shaders; none of them
  asserted that the link succeeded.

The measured cost is what drove the shape. Importing `realm_builder_monument_fx.ts` into a
browser test to reach the strings cost **+1.2 s of import time on a file whose own assertions
cost 110 ms**, so the two GLSL constants moved into a dependency-free source module,
`src/render/realm_builder_monument_impostor_glsl.ts`, of the same family as
`src/render/post_finite_guard_glsl.ts` (zero imports, `/* glsl */` constants, a paired Node
test). With that, the file is back to 0.97 s against a 0.98 s baseline, import back to 96 ms:
the added program link is under the measurement noise. A separate browser file would have
cost a whole context, 0.65 s of the 0.98 s this one takes.

## The provenance seal, and why the extraction is an exclusion

`civicShader` seals `realm_builder_monument_fx.ts` for the Eastbrook polish evidence, so the
rename moved its leaf and reddened the capture pins by design;
`tests/eastbrook_polish_capture_contract.test.ts` named the moved leaf in its failure message.
Re-minted with `scripts/assets/eastbrook_grand_armoury/remint_polish_provenance.mjs`, the
composite first and the second-order performance seal last, which is the order the tool
enforces. `ACCEPTED_POLISH_V2_TOWN_SOURCE_FINGERPRINT` is untouched: it is the frozen identity
of the tree the captures were taken against, and it moves only when a capture is retaken. No
capture was retaken and no pixel changed.

The extracted GLSL is recorded as a **deliberate exclusion** from the provenance inputs rather
than added as a new leaf, in the same shape as the exclusion already recorded above that list,
and applying that note's own test. Do the polish evidence's claims depend on these bytes: no.
`MONUMENT_IMPOSTOR_RANGE` is 72 and the monument sits at `(-14.75, -102)`, while every polish
view that can contain it is within 51 yd, the farthest being `apothecary-lin` at 50.6. The
captures therefore show the statue body and can never show the impostor card. The one polish
view beyond that range is aimed at another district, away from the monument. The `civicShader`
leaf still seals the wiring (which strings, which uniforms, `fog: true`), and the bytes
themselves now carry a stronger guard than a sha256: a real driver links them.

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx tsc --noEmit`
  - `npx vitest run tests/realm_builder_monument_impostor_glsl.test.ts`
  - `npx vitest run --config vitest.browser.config.ts tests/browser/dry_compile_sources.browser.test.ts`
  - `npx vitest run tests/eastbrook_polish_capture_contract.test.ts
    tests/eastbrook_polish_artifact_integrity.test.ts` (the capture pins, green after the
    re-mint)
  - `npx vitest run tests/realm_builder_monument_fx.test.ts
    tests/realm_builder_monument_fx_core.test.ts tests/shader_pow_domain.test.ts
    tests/architecture.test.ts`
  - `GATE_SELECT_BASE=upstream/release/v0.43.0 node scripts/gate_select.mjs`
- Manual steps:
  - Compiled the old and the new spelling against a real WebGL2 driver and read the driver's
    own verdict, quoted above.
  - Read the failing program out of a live client: one link-failed program among 382, live on
    a material, `Vertex shader is not compiled.` as the program log and
    `ERROR: 0:84: 'flat' : syntax error` as the shader log.
  - Checked that both new tests are decisive rather than decorative, by reverting the
    identifier and confirming each one reds and names the cause. The Node test reports
    `expected [ 'flat' ] to deeply equal []`; the browser test reports the driver's own
    `ERROR: 0:80: 'flat' : syntax error` with the offending line.
  - Measured the added test time rather than counting lines, three runs per arm, numbers
    above.

## Screenshots / recordings

Realm builder monument (before): visible

<img width="2560" height="1440" alt="Screenshot from 2026-09-12 16-53-10" src="https://github.com/user-attachments/assets/18c402c9-f6d2-4018-8a95-ea9d88a8212a" />


Realm builder monument (after): visible

<img width="2560" height="1440" alt="Screenshot from 2026-09-12 20-37-36" src="https://github.com/user-attachments/assets/40e9b27a-45b9-4e4f-8d53-2207acd549a3" />


Realm builder monument impostor (before) : not rendered.

<img width="2560" height="1440" alt="Screenshot from 2026-09-12 16-53-14" src="https://github.com/user-attachments/assets/eb1865ee-dcd5-4d82-9a9d-265b0d8e09ab" />


Realm builder monument impostor (after) : visible

<img width="2560" height="1440" alt="Screenshot from 2026-09-12 20-37-39" src="https://github.com/user-attachments/assets/e947d85f-5377-4974-a8bc-b1d28a0f2ae1" />


## Checklist

### Quality

- [x] **The gate passes.** `node scripts/gate_select.mjs` is green, with two decisive new
      tests and the manual checks recorded above.

### Cross-platform

- [x] N/A. No UI is added or edited; the change is one identifier inside a shader.
- [x] N/A for accessibility, same reason.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled
      in any production path.
- [x] No generated file was hand-edited.