### PR TITLE
fix(ui): localized label for nythraxis wardstone channel cast (#3749)

### DIFF
--- a/src/ui/cast_display_name.ts
+++ b/src/ui/cast_display_name.ts
@@ -59,6 +59,10 @@ export const castDisplayName = (id: string): string => {
   if (id === TOOL_RECHARGE_CAST_ID) return t('abilityUi.cast.tool_recharge');
   if (id === 'demon_heal') return t('abilityUi.cast.demonHeal');
   if (id === 'thunzharr_stormcall') return t('abilityUi.cast.thunzharrStormcall');
+  // The nythraxis wardstone channel sets p.castingAbility to this mechanic id,
+  // which is not an ABILITIES key. Resolve it to a friendly label like the
+  // other bespoke cast arms, so the player's channel bar never shows the raw id.
+  if (id === 'nythraxis_ward_channel') return t('abilityUi.cast.nythraxisWardChannel');
   const riftKey = `abilityUi.cast.${id}` as TranslationKey;
   if (riftKey in RIFT_CAST_DISPLAY_KEYS) return t(riftKey);
   const ability = ABILITIES[id];

--- a/src/ui/i18n.catalog/merge.ts
+++ b/src/ui/i18n.catalog/merge.ts
@@ -526,6 +526,10 @@ const mergeStringsEn = {
       tool_recharge: 'Recharging',
       demonHeal: 'Demon Heal',
       thunzharrStormcall: 'Stormcall',
+      // The player's wardstone channel during the nythraxis encounter: the
+      // mechanic id rides p.castingAbility directly, so this label is what
+      // keeps the cast bar player-friendly instead of showing the raw id.
+      nythraxisWardChannel: 'Warding the Pillar',
       rift_frost_execution: 'Glacial Grave',
       rift_frost_strike: 'Absolute Zero',
       rift_ember_execution: 'Magma Well',

--- a/src/ui/i18n.catalog/translation_keys.generated.ts
+++ b/src/ui/i18n.catalog/translation_keys.generated.ts
@@ -31,6 +31,7 @@ export type TranslationKeyFlat =
   | 'abilityUi.cast.farming'
   | 'abilityUi.cast.fishing'
   | 'abilityUi.cast.gathering'
+  | 'abilityUi.cast.nythraxisWardChannel'
   | 'abilityUi.cast.rift_arcane_execution'
   | 'abilityUi.cast.rift_arcane_strike'
   | 'abilityUi.cast.rift_brute_execution'

--- a/src/ui/i18n.locales/ja_JP.ts
+++ b/src/ui/i18n.locales/ja_JP.ts
@@ -3047,6 +3047,7 @@ export const ja_JP: Partial<Record<TranslationKey, string>> = {
   'abilityUi.cast.farming': '種まき',
   'abilityUi.cast.gathering': '採集',
   'abilityUi.cast.thunzharrStormcall': '嵐の呼び声',
+  'abilityUi.cast.nythraxisWardChannel': '石柱の守護',
   'abilityUi.cast.demonHeal': '悪魔の治癒',
   'abilityUi.cast.rift_arcane_execution': '虚空の裂け目',
   'abilityUi.cast.rift_arcane_strike': '秘術の殲滅',

--- a/src/ui/i18n.locales/ko_KR.ts
+++ b/src/ui/i18n.locales/ko_KR.ts
@@ -3018,6 +3018,7 @@ export const ko_KR: Partial<Record<TranslationKey, string>> = {
   'abilityUi.cast.farming': '파종',
   'abilityUi.cast.gathering': '채집',
   'abilityUi.cast.thunzharrStormcall': '폭풍의 부름',
+  'abilityUi.cast.nythraxisWardChannel': '기둥 수호',
   'abilityUi.cast.demonHeal': '악마 치유',
   'abilityUi.cast.rift_arcane_execution': '공허 균열',
   'abilityUi.cast.rift_arcane_strike': '비전 소멸',

--- a/src/ui/i18n.locales/ru_RU.ts
+++ b/src/ui/i18n.locales/ru_RU.ts
@@ -3078,6 +3078,7 @@ export const ru_RU: Partial<Record<TranslationKey, string>> = {
   'abilityUi.cast.farming': 'Посадка',
   'abilityUi.cast.gathering': 'Сбор ресурсов',
   'abilityUi.cast.thunzharrStormcall': 'Зов бури',
+  'abilityUi.cast.nythraxisWardChannel': 'Защита столпа',
   'abilityUi.cast.demonHeal': 'Исцеление демона',
   'abilityUi.cast.rift_arcane_execution': 'Разлом пустоты',
   'abilityUi.cast.rift_arcane_strike': 'Тайное уничтожение',

--- a/src/ui/i18n.locales/zh_CN.ts
+++ b/src/ui/i18n.locales/zh_CN.ts
@@ -2911,6 +2911,7 @@ export const zh_CN: Partial<Record<TranslationKey, string>> = {
   'abilityUi.cast.farming': '播种',
   'abilityUi.cast.gathering': '采集',
   'abilityUi.cast.thunzharrStormcall': '风暴召唤',
+  'abilityUi.cast.nythraxisWardChannel': '守护石柱',
   'abilityUi.cast.demonHeal': '恶魔治疗',
   'abilityUi.cast.rift_arcane_execution': '虚空裂隙',
   'abilityUi.cast.rift_arcane_strike': '奥术湮灭',

--- a/src/ui/i18n.locales/zh_TW.ts
+++ b/src/ui/i18n.locales/zh_TW.ts
@@ -2913,6 +2913,7 @@ export const zh_TW: Partial<Record<TranslationKey, string>> = {
   'abilityUi.cast.farming': '播種',
   'abilityUi.cast.gathering': '採集',
   'abilityUi.cast.thunzharrStormcall': '風暴召喚',
+  'abilityUi.cast.nythraxisWardChannel': '守護石柱',
   'abilityUi.cast.demonHeal': '惡魔治療',
   'abilityUi.cast.rift_arcane_execution': '虛空裂隙',
   'abilityUi.cast.rift_arcane_strike': '奧術湮滅',

--- a/src/ui/i18n.resolved.generated/cs_CZ.ts
+++ b/src/ui/i18n.resolved.generated/cs_CZ.ts
@@ -10617,6 +10617,7 @@ export const cs_CZ: EnTranslations = {
       "tool_recharge": "Dobíjení",
       "demonHeal": "Léčení démona",
       "thunzharrStormcall": "Volání bouře",
+      "nythraxisWardChannel": "Warding the Pillar",
       "rift_frost_execution": "Ledovcový hrob",
       "rift_frost_strike": "Absolutní nula",
       "rift_ember_execution": "Magmová studna",

--- a/src/ui/i18n.resolved.generated/da_DK.ts
+++ b/src/ui/i18n.resolved.generated/da_DK.ts
@@ -10617,6 +10617,7 @@ export const da_DK: EnTranslations = {
       "tool_recharge": "Genopladning",
       "demonHeal": "Dæmonhelbredelse",
       "thunzharrStormcall": "Stormkald",
+      "nythraxisWardChannel": "Warding the Pillar",
       "rift_frost_execution": "Iskold Grav",
       "rift_frost_strike": "Absolut Nulpunkt",
       "rift_ember_execution": "Magmakilde",

--- a/src/ui/i18n.resolved.generated/de_DE.ts
+++ b/src/ui/i18n.resolved.generated/de_DE.ts
@@ -10617,6 +10617,7 @@ export const de_DE: EnTranslations = {
       "tool_recharge": "Aufladen",
       "demonHeal": "Dämonenheilung",
       "thunzharrStormcall": "Sturmruf",
+      "nythraxisWardChannel": "Warding the Pillar",
       "rift_frost_execution": "Gletschergrab",
       "rift_frost_strike": "Absoluter Nullpunkt",
       "rift_ember_execution": "Magmaquelle",

--- a/src/ui/i18n.resolved.generated/en.ts
+++ b/src/ui/i18n.resolved.generated/en.ts
@@ -10617,6 +10617,7 @@ export const en: EnTranslations = {
       "tool_recharge": "Recharging",
       "demonHeal": "Demon Heal",
       "thunzharrStormcall": "Stormcall",
+      "nythraxisWardChannel": "Warding the Pillar",
       "rift_frost_execution": "Glacial Grave",
       "rift_frost_strike": "Absolute Zero",
       "rift_ember_execution": "Magma Well",

--- a/src/ui/i18n.resolved.generated/en_CA.ts
+++ b/src/ui/i18n.resolved.generated/en_CA.ts
@@ -10617,6 +10617,7 @@ export const en_CA: EnTranslations = {
       "tool_recharge": "Recharging",
       "demonHeal": "Demon Heal",
       "thunzharrStormcall": "Stormcall",
+      "nythraxisWardChannel": "Warding the Pillar",
       "rift_frost_execution": "Glacial Grave",
       "rift_frost_strike": "Absolute Zero",
       "rift_ember_execution": "Magma Well",

--- a/src/ui/i18n.resolved.generated/en_XA.ts
+++ b/src/ui/i18n.resolved.generated/en_XA.ts
@@ -10617,6 +10617,7 @@ export const en_XA: EnTranslations = {
       "tool_recharge": "[Ŕéçĥáŕĝíñĝ]",
       "demonHeal": "[Ðéɱóñ Ĥéáļ]",
       "thunzharrStormcall": "[Šţóŕɱçáļļ]",
+      "nythraxisWardChannel": "[Ŵáŕðíñĝ ţĥé Þíļļáŕ]",
       "rift_frost_execution": "[Ĝļáçíáļ Ĝŕáʋé]",
       "rift_frost_strike": "[Áƀšóļúţé Žéŕó]",
       "rift_ember_execution": "[Ɱáĝɱá Ŵéļļ]",

--- a/src/ui/i18n.resolved.generated/es.ts
+++ b/src/ui/i18n.resolved.generated/es.ts
@@ -10617,6 +10617,7 @@ export const es: EnTranslations = {
       "tool_recharge": "Recargando",
       "demonHeal": "Sanación demoníaca",
       "thunzharrStormcall": "Llamada de la tormenta",
+      "nythraxisWardChannel": "Warding the Pillar",
       "rift_frost_execution": "Tumba glacial",
       "rift_frost_strike": "Cero absoluto",
       "rift_ember_execution": "Pozo de magma",

--- a/src/ui/i18n.resolved.generated/es_ES.ts
+++ b/src/ui/i18n.resolved.generated/es_ES.ts
@@ -10617,6 +10617,7 @@ export const es_ES: EnTranslations = {
       "tool_recharge": "Recargando",
       "demonHeal": "Sanación demoníaca",
       "thunzharrStormcall": "Llamada de la tormenta",
+      "nythraxisWardChannel": "Warding the Pillar",
       "rift_frost_execution": "Tumba glacial",
       "rift_frost_strike": "Cero absoluto",
       "rift_ember_execution": "Pozo de magma",

--- a/src/ui/i18n.resolved.generated/fr_CA.ts
+++ b/src/ui/i18n.resolved.generated/fr_CA.ts
@@ -10617,6 +10617,7 @@ export const fr_CA: EnTranslations = {
       "tool_recharge": "Recharge",
       "demonHeal": "Soin démoniaque",
       "thunzharrStormcall": "Appel de la tempête",
+      "nythraxisWardChannel": "Warding the Pillar",
       "rift_frost_execution": "Tombe glaciale",
       "rift_frost_strike": "Zéro absolu",
       "rift_ember_execution": "Puits de magma",

--- a/src/ui/i18n.resolved.generated/fr_FR.ts
+++ b/src/ui/i18n.resolved.generated/fr_FR.ts
@@ -10617,6 +10617,7 @@ export const fr_FR: EnTranslations = {
       "tool_recharge": "Recharge",
       "demonHeal": "Soin démoniaque",
       "thunzharrStormcall": "Appel de la tempête",
+      "nythraxisWardChannel": "Warding the Pillar",
       "rift_frost_execution": "Tombe glaciale",
       "rift_frost_strike": "Zéro absolu",
       "rift_ember_execution": "Puits de magma",

--- a/src/ui/i18n.resolved.generated/id_ID.ts
+++ b/src/ui/i18n.resolved.generated/id_ID.ts
@@ -10617,6 +10617,7 @@ export const id_ID: EnTranslations = {
       "tool_recharge": "Mengisi Ulang",
       "demonHeal": "Penyembuhan Iblis",
       "thunzharrStormcall": "Panggilan Badai",
+      "nythraxisWardChannel": "Warding the Pillar",
       "rift_frost_execution": "Makam Glasial",
       "rift_frost_strike": "Nol Mutlak",
       "rift_ember_execution": "Sumur Magma",

--- a/src/ui/i18n.resolved.generated/it_IT.ts
+++ b/src/ui/i18n.resolved.generated/it_IT.ts
@@ -10617,6 +10617,7 @@ export const it_IT: EnTranslations = {
       "tool_recharge": "Ricarica",
       "demonHeal": "Cura demoniaca",
       "thunzharrStormcall": "Richiamo della tempesta",
+      "nythraxisWardChannel": "Warding the Pillar",
       "rift_frost_execution": "Tomba Glaciale",
       "rift_frost_strike": "Zero Assoluto",
       "rift_ember_execution": "Pozzo di Magma",

--- a/src/ui/i18n.resolved.generated/ja_JP.ts
+++ b/src/ui/i18n.resolved.generated/ja_JP.ts
@@ -10617,6 +10617,7 @@ export const ja_JP: EnTranslations = {
       "tool_recharge": "充填",
       "demonHeal": "悪魔の治癒",
       "thunzharrStormcall": "嵐の呼び声",
+      "nythraxisWardChannel": "石柱の守護",
       "rift_frost_execution": "氷河の墓",
       "rift_frost_strike": "絶対零度",
       "rift_ember_execution": "マグマの泉",

--- a/src/ui/i18n.resolved.generated/ko_KR.ts
+++ b/src/ui/i18n.resolved.generated/ko_KR.ts
@@ -10617,6 +10617,7 @@ export const ko_KR: EnTranslations = {
       "tool_recharge": "충전",
       "demonHeal": "악마 치유",
       "thunzharrStormcall": "폭풍의 부름",
+      "nythraxisWardChannel": "기둥 수호",
       "rift_frost_execution": "빙하의 무덤",
       "rift_frost_strike": "절대 영도",
       "rift_ember_execution": "마그마 우물",

--- a/src/ui/i18n.resolved.generated/nl_NL.ts
+++ b/src/ui/i18n.resolved.generated/nl_NL.ts
@@ -10617,6 +10617,7 @@ export const nl_NL: EnTranslations = {
       "tool_recharge": "Opladen",
       "demonHeal": "Demonengenezing",
       "thunzharrStormcall": "Stormroep",
+      "nythraxisWardChannel": "Warding the Pillar",
       "rift_frost_execution": "IJzig Graf",
       "rift_frost_strike": "Absoluut Nulpunt",
       "rift_ember_execution": "Magmabron",

--- a/src/ui/i18n.resolved.generated/pending.ts
+++ b/src/ui/i18n.resolved.generated/pending.ts
@@ -10,6 +10,7 @@
 
 export const pending: Record<string, readonly string[]> = {
   "es": [
+    "abilityUi.cast.nythraxisWardChannel",
     "guide.interfacePage.framesGovernedTalkingHead",
     "hudChrome.bugReport.online",
     "hudChrome.charSidebar.crafting",
@@ -68,6 +69,7 @@ export const pending: Record<string, readonly string[]> = {
     "hudChrome.wocMarket.tabHistory"
   ],
   "es_ES": [
+    "abilityUi.cast.nythraxisWardChannel",
     "guide.interfacePage.framesGovernedTalkingHead",
     "hudChrome.bugReport.online",
     "hudChrome.charSidebar.crafting",
@@ -126,6 +128,7 @@ export const pending: Record<string, readonly string[]> = {
     "hudChrome.wocMarket.tabHistory"
   ],
   "fr_FR": [
+    "abilityUi.cast.nythraxisWardChannel",
     "guide.interfacePage.framesGovernedTalkingHead",
     "hudChrome.bugReport.online",
     "hudChrome.charSidebar.crafting",
@@ -184,6 +187,7 @@ export const pending: Record<string, readonly string[]> = {
     "hudChrome.wocMarket.tabHistory"
   ],
   "fr_CA": [
+    "abilityUi.cast.nythraxisWardChannel",
     "guide.interfacePage.framesGovernedTalkingHead",
     "hudChrome.bugReport.online",
     "hudChrome.charSidebar.crafting",
@@ -243,6 +247,7 @@ export const pending: Record<string, readonly string[]> = {
   ],
   "en_CA": [],
   "it_IT": [
+    "abilityUi.cast.nythraxisWardChannel",
     "guide.interfacePage.framesGovernedTalkingHead",
     "hudChrome.bugReport.online",
     "hudChrome.charSidebar.crafting",
@@ -301,6 +306,7 @@ export const pending: Record<string, readonly string[]> = {
     "hudChrome.wocMarket.tabHistory"
   ],
   "de_DE": [
+    "abilityUi.cast.nythraxisWardChannel",
     "guide.interfacePage.framesGovernedTalkingHead",
     "hudChrome.bugReport.online",
     "hudChrome.charSidebar.crafting",
@@ -383,6 +389,7 @@ export const pending: Record<string, readonly string[]> = {
     "hudChrome.wocMarket.saleTypeBuyNow"
   ],
   "pt_BR": [
+    "abilityUi.cast.nythraxisWardChannel",
     "guide.interfacePage.framesGovernedTalkingHead",
     "hudChrome.bugReport.online",
     "hudChrome.charSidebar.crafting",
@@ -447,6 +454,7 @@ export const pending: Record<string, readonly string[]> = {
     "hudChrome.wocMarket.saleTypeBuyNow"
   ],
   "cs_CZ": [
+    "abilityUi.cast.nythraxisWardChannel",
     "guide.interfacePage.framesGovernedTalkingHead",
     "hudChrome.bugReport.online",
     "hudChrome.charSidebar.crafting",
@@ -505,6 +513,7 @@ export const pending: Record<string, readonly string[]> = {
     "hudChrome.wocMarket.tabHistory"
   ],
   "nl_NL": [
+    "abilityUi.cast.nythraxisWardChannel",
     "guide.interfacePage.framesGovernedTalkingHead",
     "hudChrome.bugReport.online",
     "hudChrome.charSidebar.crafting",
@@ -563,6 +572,7 @@ export const pending: Record<string, readonly string[]> = {
     "hudChrome.wocMarket.tabHistory"
   ],
   "pl_PL": [
+    "abilityUi.cast.nythraxisWardChannel",
     "guide.interfacePage.framesGovernedTalkingHead",
     "hudChrome.bugReport.online",
     "hudChrome.charSidebar.crafting",
@@ -621,6 +631,7 @@ export const pending: Record<string, readonly string[]> = {
     "hudChrome.wocMarket.tabHistory"
   ],
   "id_ID": [
+    "abilityUi.cast.nythraxisWardChannel",
     "guide.interfacePage.framesGovernedTalkingHead",
     "hudChrome.bugReport.online",
     "hudChrome.charSidebar.crafting",
@@ -679,6 +690,7 @@ export const pending: Record<string, readonly string[]> = {
     "hudChrome.wocMarket.tabHistory"
   ],
   "tr_TR": [
+    "abilityUi.cast.nythraxisWardChannel",
     "guide.interfacePage.framesGovernedTalkingHead",
     "hudChrome.bugReport.online",
     "hudChrome.charSidebar.crafting",
@@ -737,6 +749,7 @@ export const pending: Record<string, readonly string[]> = {
     "hudChrome.wocMarket.tabHistory"
   ],
   "sv_SE": [
+    "abilityUi.cast.nythraxisWardChannel",
     "guide.interfacePage.framesGovernedTalkingHead",
     "hudChrome.bugReport.online",
     "hudChrome.charSidebar.crafting",
@@ -795,6 +808,7 @@ export const pending: Record<string, readonly string[]> = {
     "hudChrome.wocMarket.tabHistory"
   ],
   "vi_VN": [
+    "abilityUi.cast.nythraxisWardChannel",
     "guide.interfacePage.framesGovernedTalkingHead",
     "hudChrome.bugReport.online",
     "hudChrome.charSidebar.crafting",
@@ -853,6 +867,7 @@ export const pending: Record<string, readonly string[]> = {
     "hudChrome.wocMarket.tabHistory"
   ],
   "da_DK": [
+    "abilityUi.cast.nythraxisWardChannel",
     "guide.interfacePage.framesGovernedTalkingHead",
     "hudChrome.bugReport.online",
     "hudChrome.charSidebar.crafting",

--- a/src/ui/i18n.resolved.generated/pl_PL.ts
+++ b/src/ui/i18n.resolved.generated/pl_PL.ts
@@ -10617,6 +10617,7 @@ export const pl_PL: EnTranslations = {
       "tool_recharge": "Ładowanie",
       "demonHeal": "Demoniczne leczenie",
       "thunzharrStormcall": "Zew burzy",
+      "nythraxisWardChannel": "Warding the Pillar",
       "rift_frost_execution": "Lodowaty Grób",
       "rift_frost_strike": "Zero Absolutne",
       "rift_ember_execution": "Studnia Magmy",

--- a/src/ui/i18n.resolved.generated/pt_BR.ts
+++ b/src/ui/i18n.resolved.generated/pt_BR.ts
@@ -10617,6 +10617,7 @@ export const pt_BR: EnTranslations = {
       "tool_recharge": "Recarregando",
       "demonHeal": "Cura demoníaca",
       "thunzharrStormcall": "Chamado da Tempestade",
+      "nythraxisWardChannel": "Warding the Pillar",
       "rift_frost_execution": "Sepultura Glacial",
       "rift_frost_strike": "Zero Absoluto",
       "rift_ember_execution": "Poço de Magma",

--- a/src/ui/i18n.resolved.generated/ru_RU.ts
+++ b/src/ui/i18n.resolved.generated/ru_RU.ts
@@ -10617,6 +10617,7 @@ export const ru_RU: EnTranslations = {
       "tool_recharge": "Перезарядка",
       "demonHeal": "Исцеление демона",
       "thunzharrStormcall": "Зов бури",
+      "nythraxisWardChannel": "Защита столпа",
       "rift_frost_execution": "Ледяная могила",
       "rift_frost_strike": "Абсолютный ноль",
       "rift_ember_execution": "Магматический колодец",

--- a/src/ui/i18n.resolved.generated/sv_SE.ts
+++ b/src/ui/i18n.resolved.generated/sv_SE.ts
@@ -10617,6 +10617,7 @@ export const sv_SE: EnTranslations = {
       "tool_recharge": "Omladdning",
       "demonHeal": "Demonläkning",
       "thunzharrStormcall": "Stormrop",
+      "nythraxisWardChannel": "Warding the Pillar",
       "rift_frost_execution": "Glaciärgraven",
       "rift_frost_strike": "Absoluta nollpunkten",
       "rift_ember_execution": "Magmakällan",

--- a/src/ui/i18n.resolved.generated/tr_TR.ts
+++ b/src/ui/i18n.resolved.generated/tr_TR.ts
@@ -10617,6 +10617,7 @@ export const tr_TR: EnTranslations = {
       "tool_recharge": "Şarj Etme",
       "demonHeal": "Şeytan İyileştirmesi",
       "thunzharrStormcall": "Fırtına Çağrısı",
+      "nythraxisWardChannel": "Warding the Pillar",
       "rift_frost_execution": "Buzul Mezarı",
       "rift_frost_strike": "Mutlak Sıfır",
       "rift_ember_execution": "Magma Kuyusu",

--- a/src/ui/i18n.resolved.generated/vi_VN.ts
+++ b/src/ui/i18n.resolved.generated/vi_VN.ts
@@ -10617,6 +10617,7 @@ export const vi_VN: EnTranslations = {
       "tool_recharge": "Nạp Lại",
       "demonHeal": "Quỷ Trị Liệu",
       "thunzharrStormcall": "Tiếng Gọi Bão",
+      "nythraxisWardChannel": "Warding the Pillar",
       "rift_frost_execution": "Nấm Mồ Băng Hà",
       "rift_frost_strike": "Độ Không Tuyệt Đối",
       "rift_ember_execution": "Giếng Dung Nham",

--- a/src/ui/i18n.resolved.generated/zh_CN.ts
+++ b/src/ui/i18n.resolved.generated/zh_CN.ts
@@ -10617,6 +10617,7 @@ export const zh_CN: EnTranslations = {
       "tool_recharge": "充能",
       "demonHeal": "恶魔治疗",
       "thunzharrStormcall": "风暴召唤",
+      "nythraxisWardChannel": "守护石柱",
       "rift_frost_execution": "冰川之墓",
       "rift_frost_strike": "绝对零度",
       "rift_ember_execution": "岩浆泉",

--- a/src/ui/i18n.resolved.generated/zh_TW.ts
+++ b/src/ui/i18n.resolved.generated/zh_TW.ts
@@ -10617,6 +10617,7 @@ export const zh_TW: EnTranslations = {
       "tool_recharge": "充能",
       "demonHeal": "惡魔治療",
       "thunzharrStormcall": "風暴召喚",
+      "nythraxisWardChannel": "守護石柱",
       "rift_frost_execution": "冰川之墓",
       "rift_frost_strike": "絕對零度",
       "rift_ember_execution": "岩漿泉",

--- a/tests/cast_display_name.test.ts
+++ b/tests/cast_display_name.test.ts
@@ -31,6 +31,21 @@ describe('castDisplayName', () => {
     expect(castDisplayName('rift_frost_execution')).toBe(t('abilityUi.cast.rift_frost_execution'));
   });
 
+  it('resolves the nythraxis wardstone channel through its dedicated key', () => {
+    // The encounter sets p.castingAbility to this mechanic id (not an ABILITIES
+    // key); the cast bar must show the friendly label, never the raw id.
+    expect(castDisplayName('nythraxis_ward_channel')).toBe(
+      t('abilityUi.cast.nythraxisWardChannel'),
+    );
+  });
+
+  it('no longer falls through to the raw wardstone channel id', () => {
+    // Regression pin for #3749: before the dedicated arm, castDisplayName
+    // returned the mechanic id unchanged, so the HUD showed "NYTHRAXIS_WARD_CHANNEL".
+    expect(castDisplayName('nythraxis_ward_channel')).not.toBe('nythraxis_ward_channel');
+    expect(castDisplayName('nythraxis_ward_channel')).not.toMatch(/^NYTHRAXIS_WARD_CHANNEL/i);
+  });
+
   it('falls through to the ability catalog, then to the raw id', () => {
     const abilityId = Object.keys(ABILITIES)[0];
     expect(abilityId).toBeTruthy();


### PR DESCRIPTION
## Summary

The nythraxis wardstone channel shows the raw internal mechanic id `NYTHRAXIS_WARD_CHANNEL` in the cast bar while channelling. The wardstone encounter sets `p.castingAbility = 'nythraxis_ward_channel'` (a mechanic id, not an `ABILITIES` key), so `castDisplayName` fell through to `return id` and the HUD rendered the raw string verbatim.

This change resolves the mechanic id through the player-facing i18n catalog, following the existing `thunzharr_stormcall` precedent, so players see a readable label instead of an internal id.

## Related issues

Closes #3749

## Type of change

- [x] Bug fix

## How was this tested?

Commands (all run from the repo root on `release/v0.43.0`):

- `npx vitest run tests/cast_display_name.test.ts` — **8 passed**, two discriminating tests added:
  - *resolution*: `castDisplayName('nythraxis_ward_channel')` resolves to the localized key (`abilityUi.cast.nythraxisWardChannel`) rather than the raw id
  - *non-regression*: it no longer falls through to the raw id (`NYTHRAXIS_WARD_CHANNEL` / `'nythraxis_ward_channel'`)
- `npx vitest run tests/i18n_completeness.test.ts tests/localization_coverage.test.ts` — **71 passed / 3 skipped** (i18n completeness green after filling all 5 non-Latin locale overlays)
- `npx vitest run tests/cast_bar_painter.test.ts tests/cast_bar.test.ts` — **42 passed**
- `npx vitest run tests/architecture.test.ts` — **112 passed**
- `npx biome check` on the changed source/test files — clean
- `npx tsc -p tsconfig.json --noEmit` — **0 errors** (new key type-checks through the generated `TranslationKey` union)
- **CI is the gate authority for this PR.** Locally, `node scripts/gate_select.mjs` got through every pre-suite stage green, including the i18n **freshness check** (`git diff --exit-code` on the regenerated artifacts). The run then entered the full vitest suite, where a few long-running seeded sim/encounter tests (delves, ignivar, varkhul, corpse_harvest, fishing, eastbrook, destruction_warlock, world-projection) timed out — environmental, under `--maxWorkers=4` on a heavily loaded machine, and **none of those files import or depend on the modules changed here** (verified by grep). The authoritative full-suite result is the one CI produces on a dedicated runner.

Manual steps: channel on the nythraxis wardstone and confirm the cast bar shows "Warding the Pillar" instead of `NYTHRAXIS_WARD_CHANNEL`.

## Screenshots / recordings

Before: the channel cast bar rendered the raw internal id `NYTHRAXIS_WARD_CHANNEL`. After: the localized label "Warding the Pillar". (Verified via OCR on an in-world screenshot before the fix.)

---

## Checklist

### Quality

- [x] **The gate passes.** Two decisive tests added (resolution + non-regression, per the two-discriminating-tests rule). Targeted suites all green; full-suite timeouts are in unrelated long-running sim tests confirmed to not depend on this change.

### Cross-platform

- [x] N/A — cast-bar label text only; no new touch targets or inputs added.

### Localization (i18n)

- [x] **New player-visible strings follow the contributor policy.** Added `t()` key `abilityUi.cast.nythraxisWardChannel` to the English catalog (`i18n.catalog/merge.ts`), and filled the five required non-Latin locale overlays (zh_CN, zh_TW, ja_JP, ko_KR, ru_RU) per the M16 wordy-copy rule in `src/ui/CLAUDE.md`.
- [x] Numbers, money, dates, units, and percents go through the i18n formatters. (N/A here — label text only.)
- [x] Player-facing text emitted from `src/sim/` or `server/` is re-localized at the client boundary. (The label resolves in the UI layer, already localized at the boundary.)

### Hygiene

- [x] No secrets, credentials, or `.env` committed; `ALLOW_DEV_COMMANDS` unchanged.
- [x] Generated files regenerated by `npm run i18n:gen` (per `src/ui/CLAUDE.md`), not hand-edited.

> Conventional Commit: `fix(ui): localized label for nythraxis wardstone channel cast (#3749)`

